### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0006-Timings-v2.patch
+++ b/patches/api/0006-Timings-v2.patch
@@ -3377,10 +3377,10 @@ index 2a145d851ce30360aa39549745bd87590c034584..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 709016bdc30d5502765af842d4fc83af53779a9e..c36e4ceb1094aa9469f976e0952e2725358ff761 100644
+index 6c8992a1a4c75c914e8aac16028cdfa0f39ac5eb..11f1b0df201272b158d403604c4f3c262ab011b7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1610,7 +1610,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1635,7 +1635,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           */
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");

--- a/patches/api/0008-Adventure.patch
+++ b/patches/api/0008-Adventure.patch
@@ -1133,7 +1133,7 @@ index efb97712cc9dc7c1e12a59f5b94e4f2ad7c6b7d8..3024468af4c073324e536c1cb26beffb
                  return warning == null || warning.value();
              }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 8ab8515c55ba5944469084b3b4f093cb9f9648fb..c58b1885662c6a234ffee75995051c9750c1a512 100644
+index f24f9391269cb80d1e7142369ca57d0e8e0606af..5d23c38758b4b9eb5802b6a22a094a3adb64e508 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -38,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
@@ -1596,7 +1596,7 @@ index 25a6f9313a1953def7470e411b53016f2ca14bef..10cb6088c4618f228c757f4e592b44ed
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dca1da9595 100644
+index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac6079bfd36c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -35,7 +35,28 @@ import org.jetbrains.annotations.Nullable;
@@ -1769,7 +1769,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      /**
       * Says a message (or runs a command).
       *
-@@ -473,6 +554,90 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -498,6 +579,90 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull EquipmentSlot slot, @NotNull ItemStack item);
  
@@ -1860,7 +1860,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      /**
       * Send a sign change. This fakes a sign change packet for a user at
       * a certain location. This will not actually change the world in any way.
-@@ -487,7 +652,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -512,7 +677,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param lines the new text on the sign or null to clear it
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -1870,7 +1870,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines) throws IllegalArgumentException;
  
      /**
-@@ -506,7 +673,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -531,7 +698,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -1880,7 +1880,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException;
  
      /**
-@@ -526,7 +695,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -551,7 +720,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -1890,7 +1890,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException;
  
      /**
-@@ -1008,6 +1179,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1033,6 +1204,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt);
  
@@ -1945,7 +1945,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      /**
       * Request that the player's client download and switch resource packs.
       * <p>
-@@ -1099,6 +1318,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1124,6 +1343,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt, boolean force);
  
@@ -2000,7 +2000,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      /**
       * Gets the Scoreboard displayed to this player
       *
-@@ -1192,7 +1459,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1217,7 +1484,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param title Title text
       * @param subtitle Subtitle text
@@ -2009,7 +2009,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
       */
      @Deprecated
      public void sendTitle(@Nullable String title, @Nullable String subtitle);
-@@ -1211,7 +1478,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1236,7 +1503,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param fadeIn time in ticks for titles to fade in. Defaults to 10.
       * @param stay time in ticks for titles to stay. Defaults to 70.
       * @param fadeOut time in ticks for titles to fade out. Defaults to 20.
@@ -2019,7 +2019,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      public void sendTitle(@Nullable String title, @Nullable String subtitle, int fadeIn, int stay, int fadeOut);
  
      /**
-@@ -1438,6 +1707,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1463,6 +1732,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -2034,7 +2034,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1463,8 +1740,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1488,8 +1765,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -2045,7 +2045,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      public String getLocale();
  
      /**
-@@ -1506,6 +1785,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1531,6 +1810,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public boolean isAllowingServerListings();
  
@@ -2060,7 +2060,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1560,11 +1847,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1585,11 +1872,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -2074,7 +2074,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1575,7 +1864,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1600,7 +1889,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -2084,7 +2084,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1585,7 +1876,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1610,7 +1901,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -2094,7 +2094,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1596,7 +1889,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1621,7 +1914,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -2104,7 +2104,7 @@ index c36e4ceb1094aa9469f976e0952e2725358ff761..e3cc40a54b48e8a90ccc93c272c1a2dc
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1607,7 +1902,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1632,7 +1927,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send

--- a/patches/api/0009-Player-affects-spawning-API.patch
+++ b/patches/api/0009-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index e3cc40a54b48e8a90ccc93c272c1a2dca1da9595..a6f6dea965eee2de2183f189580d1b7141a9308f 100644
+index 77db4c371ae6543435bde9247173ac6079bfd36c..768e93bf74f8176b6b9d146fac7c870af3ce7b95 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1746,6 +1746,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1771,6 +1771,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0014-Add-view-distance-API.patch
+++ b/patches/api/0014-Add-view-distance-API.patch
@@ -8,10 +8,10 @@ Add per player no-tick, tick, and send view distances.
 Also add send/no-tick view distance to World.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index c58b1885662c6a234ffee75995051c9750c1a512..7b1fb280a86ab44756fc233b085f878d2a27ad66 100644
+index 5d23c38758b4b9eb5802b6a22a094a3adb64e508..5e9f77a53bffed2e79200e9d8bb8685d3dd89901 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2450,6 +2450,52 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2475,6 +2475,52 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      int getSimulationDistance();
      // Spigot end
  
@@ -65,10 +65,10 @@ index c58b1885662c6a234ffee75995051c9750c1a512..7b1fb280a86ab44756fc233b085f878d
      public class Spigot {
  
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index a6f6dea965eee2de2183f189580d1b7141a9308f..bf60cc1beed41f6dc30b0df0bae9b937ddfa5553 100644
+index 768e93bf74f8176b6b9d146fac7c870af3ce7b95..3aa34138d90b206193fee0558939d8de52cd2a85 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1760,6 +1760,62 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1785,6 +1785,62 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0019-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0019-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -76,10 +76,10 @@ index 66211ef974b9e091983bfda108f6e420c01a9d78..8fb6545406ab6029d82c903856bda6c6
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 152f848d2f93a52999f093bd83b4732af9aab8d8..771682aa1c5e1bfb9670cc98ce99439014d0d31c 100644
+index 3aa34138d90b206193fee0558939d8de52cd2a85..77a3bb82f90a7779f98246ceecc150d4417043e7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -708,6 +708,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -733,6 +733,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  

--- a/patches/api/0023-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/api/0023-Player-Tab-List-and-Title-APIs.patch
@@ -432,7 +432,7 @@ index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb90
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b6a848261f7c136cbcb4a4f40223d2f248d546c2..1df2ff828aee7dac50d63fe1d51104e9fb2ed264 100644
+index 77a3bb82f90a7779f98246ceecc150d4417043e7..8c7c7ce6bf12d14300067cc64cbdeb9e7d984629 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -443,7 +443,7 @@ index b6a848261f7c136cbcb4a4f40223d2f248d546c2..1df2ff828aee7dac50d63fe1d51104e9
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -742,6 +743,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -767,6 +768,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }

--- a/patches/api/0025-Complete-resource-pack-API.patch
+++ b/patches/api/0025-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index cd2c4ff23cdbcc3e4e9ae94477a372d25ad31e39..422f322b9623dcb33472744ddfd91d7dba817471 100644
+index 8c7c7ce6bf12d14300067cc64cbdeb9e7d984629..7ff1c702348253cdee5c36045ceb57b8dc7da516 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1251,7 +1251,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1276,7 +1276,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the URL is null.
       * @throws IllegalArgumentException Thrown if the URL is too long. The
       *     length restriction is an implementation specific arbitrary value.
@@ -18,7 +18,7 @@ index cd2c4ff23cdbcc3e4e9ae94477a372d25ad31e39..422f322b9623dcb33472744ddfd91d7d
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -2025,6 +2027,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2050,6 +2052,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0045-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0045-Add-String-based-Action-Bar-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 422f322b9623dcb33472744ddfd91d7dba817471..9d9dd1f73b4c3ff143fbba87d8b5630017affd08 100644
+index 7ff1c702348253cdee5c36045ceb57b8dc7da516..632622b90696f0e1c8e33d897d8e14467691e760 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -3,6 +3,7 @@ package org.bukkit.entity;
@@ -16,7 +16,7 @@ index 422f322b9623dcb33472744ddfd91d7dba817471..9d9dd1f73b4c3ff143fbba87d8b56300
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -710,6 +711,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -735,6 +736,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start
@@ -56,7 +56,7 @@ index 422f322b9623dcb33472744ddfd91d7dba817471..9d9dd1f73b4c3ff143fbba87d8b56300
      /**
       * Sends the component to the player
       *
-@@ -737,9 +771,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -762,9 +796,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Sends an array of components as a single message to the specified screen position of this player
       *
@@ -68,7 +68,7 @@ index 422f322b9623dcb33472744ddfd91d7dba817471..9d9dd1f73b4c3ff143fbba87d8b56300
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }
-@@ -2216,6 +2252,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2241,6 +2277,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends the component to the specified screen position of this player
           *
@@ -76,7 +76,7 @@ index 422f322b9623dcb33472744ddfd91d7dba817471..9d9dd1f73b4c3ff143fbba87d8b56300
           * @param position the screen position
           * @param component the components to send
           * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
-@@ -2228,6 +2265,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2253,6 +2290,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends an array of components as a single message to the specified screen position of this player
           *

--- a/patches/api/0054-Fix-upstream-javadocs.patch
+++ b/patches/api/0054-Fix-upstream-javadocs.patch
@@ -76,10 +76,10 @@ index be9334a8b5fba9181ad63c211697e798be63da25..0514a141cb93a650be38c63d4336d46e
       * Instructs this Mob to set the specified LivingEntity as its target.
       * <p>
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d98029f01bc81c5bf33545fee54bdbce17960b50..dae5ffe9ed6ea43b269d14a6aaf08929fb90570f 100644
+index 632622b90696f0e1c8e33d897d8e14467691e760..b7a3da7a6ee0915449534f7f879eb2f40090b9dd 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -728,7 +728,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -753,7 +753,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * Use supplied alternative character to the section symbol to represent legacy color codes.
       *

--- a/patches/api/0080-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/api/0080-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b621f693379aedc23a90b03e724ba8a2ffeb283e..1e3a56ff656cdfe18cf665eecd8f126275f29715 100644
+index 9bbf1a9f3b848c26deac34435e71dd8558a80afd..1885a21b888b0a950a1f32bd587e6621522faef7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -986,12 +986,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1011,12 +1011,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void resetPlayerWeather();
  

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7e390f5d7438f292ddd849f47964282a1ad889d1..ac94189b7bc76e1de0ae7d46fe581af57594ef64 100644
+index 1885a21b888b0a950a1f32bd587e6621522faef7..8dc3472dac3215951ac11ae366a3d15314d956a5 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
@@ -17,7 +17,7 @@ index 7e390f5d7438f292ddd849f47964282a1ad889d1..ac94189b7bc76e1de0ae7d46fe581af5
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -2202,6 +2203,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2227,6 +2228,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
@@ -24,10 +24,10 @@ index 396092fd249928ca01133eeeeb61f0ad90b2e332..5cc025b69c4f405be8f7098d0dcef40f
      /**
       * Make the entity drop the item in their hand.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ac94189b7bc76e1de0ae7d46fe581af57594ef64..dbfd062792b0cc1d8fbfc8a30b0143467e7aaef7 100644
+index 8dc3472dac3215951ac11ae366a3d15314d956a5..5224cfe5d57ab62b52554336f325dae8829d1b30 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2058,7 +2058,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2083,7 +2083,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Open a Sign for editing by the Player.
       *

--- a/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
@@ -74,7 +74,7 @@ index 58313929f81509030216a0e5e3869da63e11108e..6cf05fed701c67a2c797a4e0839c7958
      /**
       * Checks if this player is whitelisted or not
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index da5dd22e75b998495258a482557221ebd52e0c39..07ae612268a5857cedf8c646a09eb30c9b0a036b 100644
+index 5224cfe5d57ab62b52554336f325dae8829d1b30..264a35cc33f40405e9ba10de850bb3142d984ee7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -5,6 +5,10 @@ import java.util.UUID;
@@ -88,7 +88,7 @@ index da5dd22e75b998495258a482557221ebd52e0c39..07ae612268a5857cedf8c646a09eb30c
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -712,6 +716,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -737,6 +741,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start

--- a/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -522,10 +522,10 @@ index dc5142460a711ee79aed30276382b92c82cbef00..40a3a54fc82252692fc8710cabb243d0
       * Options which can be applied to redstone dust particles - a particle
       * color and size.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index e8b94ae777cad907dbb31c9ea5a3c1690b178777..6156fb9827400cb6c1c0a96e0b6fed180a12d610 100644
+index 7e264881bb357b382b1b444982bbb1ed77788014..e06ab626c140988431022c9209266826c4994b0f 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2637,7 +2637,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2662,7 +2662,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
       */

--- a/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 62b41c809cec18b75ee83371f0ca97ccde141e30..fc44e75c52354d95fa7422e1d08ac4cba455be74 100644
+index 264a35cc33f40405e9ba10de850bb3142d984ee7..f99569b1f591ca89a6a69123293a8500caec3522 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2377,6 +2377,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2402,6 +2402,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull PlayerProfile profile);

--- a/patches/api/0194-Add-Player-Client-Options-API.patch
+++ b/patches/api/0194-Add-Player-Client-Options-API.patch
@@ -193,7 +193,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index fc44e75c52354d95fa7422e1d08ac4cba455be74..2404864227694e357350a8080b4f609b28ef0a47 100644
+index f99569b1f591ca89a6a69123293a8500caec3522..3de5c369d034d77d054e0fd620f0383baaee3272 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -204,7 +204,7 @@ index fc44e75c52354d95fa7422e1d08ac4cba455be74..2404864227694e357350a8080b4f609b
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import com.destroystokyo.paper.profile.PlayerProfile; // Paper
-@@ -2397,6 +2398,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2422,6 +2423,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0202-Spawn-Reason-API.patch
+++ b/patches/api/0202-Spawn-Reason-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Spawn Reason API
 
 
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index e285d54450471ed22e12e77c7b829fde6b564ede..35e407ec7bd8d5cd38069fe7f2cf3d9d3bc94cbe 100644
+index a89fff5c164881be0286ec2240e94dd5883ecc40..e55f6e2baf35dbd91c433ab9e62713eaac85435b 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
-@@ -9,6 +9,7 @@ import org.bukkit.block.data.BlockData;
+@@ -10,6 +10,7 @@ import org.bukkit.block.data.BlockData;
  import org.bukkit.entity.Entity;
  import org.bukkit.entity.EntityType;
  import org.bukkit.entity.LivingEntity;
@@ -16,7 +16,7 @@ index e285d54450471ed22e12e77c7b829fde6b564ede..35e407ec7bd8d5cd38069fe7f2cf3d9d
  import org.bukkit.util.Consumer;
  import org.jetbrains.annotations.NotNull;
  import org.jetbrains.annotations.Nullable;
-@@ -288,7 +289,34 @@ public interface RegionAccessor {
+@@ -309,7 +310,34 @@ public interface RegionAccessor {
       *     {@link Entity} requested cannot be spawned
       */
      @NotNull

--- a/patches/api/0218-Brand-support.patch
+++ b/patches/api/0218-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2404864227694e357350a8080b4f609b28ef0a47..c04572b87fc59b9cf92558653d06c449e2210233 100644
+index 3de5c369d034d77d054e0fd620f0383baaee3272..62a087be8695b3d4a226433fc3868ac5013cbcce 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2532,6 +2532,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2557,6 +2557,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0227-Player-elytra-boost-API.patch
+++ b/patches/api/0227-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c04572b87fc59b9cf92558653d06c449e2210233..116c75fa16fa544723c9a430ede3a46c3599d7e8 100644
+index 62a087be8695b3d4a226433fc3868ac5013cbcce..561084587e82b376cc583544b80c142bbf98480f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2404,6 +2404,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2429,6 +2429,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull ClientOption<T> option);

--- a/patches/api/0255-Add-sendOpLevel-API.patch
+++ b/patches/api/0255-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 116c75fa16fa544723c9a430ede3a46c3599d7e8..3b24457a1d25515132613b7e4fdaa7901d00ab78 100644
+index 561084587e82b376cc583544b80c142bbf98480f..3bb9b19ceeda5dd6a04ccfb8768766b7b8338138 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2417,6 +2417,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2442,6 +2442,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0284-More-World-API.patch
+++ b/patches/api/0284-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 82ca519c18e49fb4df1932e871a6c9d3dc7e86b2..facbf08b5427cf3841d58cfb946129bf7d7f8ea3 100644
+index 7a60ad315a092baed1e4c1f05f29a8f21ebad070..c19efb8beb3d13681ef1771849d74b96c9c28705 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3498,6 +3498,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3523,6 +3523,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public Location locateNearestStructure(@NotNull Location origin, @NotNull StructureType structureType, int radius, boolean findUnexplored);
  

--- a/patches/api/0342-Add-player-health-update-API.patch
+++ b/patches/api/0342-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ecd1a8c13137adc880067f9e911e8b1a08c5cd14..5e4a9ce5f899624255e806152c59f60664bcf701 100644
+index 1b53015ffe065782f1417d3567c6a89a47d66fab..7eda2ba17e39b8183e572c1cefa8afffbf17afcb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1821,6 +1821,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1846,6 +1846,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public double getHealthScale();
  

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -1918,10 +1918,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 55efa7cf942ece15ce5925c36aea5c33f67ced1e..bfb1ced180ff4943ba15eb16f01530cd1b5b8a90 100644
+index 9e9d62f168421bcb542f036f30515ef2ae374b45..2be5fd4be7b96c8215a3a65ecc799e3490e2e55d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1881,6 +1881,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1895,6 +1895,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              packet.components = components;
              CraftPlayer.this.getHandle().connection.send(packet);
          }

--- a/patches/server/0012-Adventure.patch
+++ b/patches/server/0012-Adventure.patch
@@ -1840,10 +1840,10 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b66b88475178f5a20a689f1af9a06f7f8e50ff9b..8df699de4ddde3089324f347a82d913f2208f5be 100644
+index d08836e06e13ba64298cc21d0e2e61f9334dddb9..83ad8c26a6152b4dd7ff9e432dabcc5fc17e3df0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -133,6 +133,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -135,6 +135,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      private int waterAmbientSpawn = -1;
      private int waterUndergroundCreatureSpawn = -1;
      private int ambientSpawn = -1;
@@ -1851,7 +1851,7 @@ index b66b88475178f5a20a689f1af9a06f7f8e50ff9b..8df699de4ddde3089324f347a82d913f
  
      private static final Random rand = new Random();
  
-@@ -1784,4 +1785,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1802,4 +1803,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.spigot;
      }
      // Spigot end
@@ -2348,10 +2348,10 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa220130e7 100644
+index 2be5fd4be7b96c8215a3a65ecc799e3490e2e55d..d4444384fae41b3c502e8a34ccd88041928de67d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -252,14 +252,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -253,14 +253,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getDisplayName() {
@@ -2391,7 +2391,7 @@ index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa
      @Override
      public String getPlayerListName() {
          return this.getHandle().listName == null ? getName() : CraftChatMessage.fromComponent(this.getHandle().listName);
-@@ -278,42 +303,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -279,42 +304,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2443,7 +2443,7 @@ index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa
          this.getHandle().connection.send(packet);
      }
  
-@@ -345,6 +370,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -346,6 +371,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.disconnect(message == null ? "" : message);
      }
  
@@ -2461,7 +2461,7 @@ index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa
      @Override
      public void setCompassTarget(Location loc) {
          if (this.getHandle().connection == null) return;
-@@ -587,6 +623,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -601,6 +637,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
@@ -2495,7 +2495,7 @@ index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa
      @Override
      public void sendSignChange(Location loc, String[] lines) {
          this.sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -614,14 +677,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -628,14 +691,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          Component[] components = CraftSign.sanitizeLines(lines);
@@ -2513,7 +2513,7 @@ index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa
      }
  
      @Override
-@@ -1305,7 +1369,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1319,7 +1383,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url) {
@@ -2522,7 +2522,7 @@ index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa
      }
  
      @Override
-@@ -1320,7 +1384,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1334,7 +1398,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url, byte[] hash, boolean force) {
@@ -2531,7 +2531,7 @@ index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa
      }
  
      @Override
-@@ -1336,6 +1400,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1350,6 +1414,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2553,7 +2553,7 @@ index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa
      public void addChannel(String channel) {
          Preconditions.checkState(this.channels.size() < 128, "Cannot register channel '%s'. Too many channels registered!", channel);
          channel = StandardMessenger.validateAndCorrectChannel(channel);
-@@ -1740,6 +1819,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1754,6 +1833,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -2566,7 +2566,7 @@ index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -1785,6 +1870,194 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1799,6 +1884,194 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  
@@ -2762,7 +2762,7 @@ index bfb1ced180ff4943ba15eb16f01530cd1b5b8a90..b62ddd41236b6561672eeedf4bbdd4fa
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 30325b83e044a0d6caf78a4953f9dde8bf440bae..4da8af129b8c4f61617348b292166b9b1e300ac8 100644
+index e5e2179e47cd0497b4a30e1bf99228953ec8d319..1e8c5b0194e1ba2f9a0f85dcaf6a3bcb632f6cbf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -807,9 +807,9 @@ public class CraftEventFactory {

--- a/patches/server/0023-Player-affects-spawning-API.patch
+++ b/patches/server/0023-Player-affects-spawning-API.patch
@@ -21,7 +21,7 @@ index 5c3b11f738c1ea19981cc878aa6c2323497391a0..b91a61be7c4829fce0ff8da290eab580
      public static Predicate<Entity> withinDistance(double x, double y, double z, double max) {
          double d4 = max * max;
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 92fdccbcf472d99989eb47c0dac1b8c557c37165..405ed6034c894bdff889307d9bbf8900f7085a94 100644
+index 07f37c1ca6a98ad8199c873556aac2e9de60fe81..0c0886fe46ad65678a6c6da89659e5991908ba7a 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -774,7 +774,7 @@ public abstract class Mob extends LivingEntity {
@@ -47,7 +47,7 @@ index 53106d7bbfeaaf52bbe69471e70670412e8bdfd3..195cdae3f3a9fe8ecab2895a6000f6f8
              return false;
          }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index b4e500a383d893b8de4ac800d035b581cd150af7..4d9b7fbb35d0c8f4fbb43b77a2e11a919614ab56 100644
+index ebe55b9c8e93fec1a1f7efca86d5d3968d1df200..90eb40ee3bf20dcbeb69ead753d424387a0ef42f 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -174,6 +174,9 @@ public abstract class Player extends LivingEntity {
@@ -117,10 +117,10 @@ index c65d1dc6eb0c1fc7c4a91faf0f1c6f26b3c2a76e..0dc46471f7247e5d36c3896a0c874730
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 37f6e5f0e9b31c10769ae06dc99395330b0a5c55..ef2001db09ca1ca3412aa01c09a8ee3bd70ed228 100644
+index d4444384fae41b3c502e8a34ccd88041928de67d..1195cf6c72cbf14d49ef709d54315ad998142656 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1833,8 +1833,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1847,8 +1847,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0026-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0026-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ef2001db09ca1ca3412aa01c09a8ee3bd70ed228..216c73d3b9f8c3e7f9c81a4349ac4989bb0209c3 100644
+index 1195cf6c72cbf14d49ef709d54315ad998142656..24ae5383543230b18a5f4aa66112f483850b39dc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1502,12 +1502,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1516,12 +1516,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0039-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0039-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index 88b6be62678fc09b5a39db28c6d71cc31b16dbcd..352bfe795aea26307de9c998d67a43af
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 216c73d3b9f8c3e7f9c81a4349ac4989bb0209c3..c29ca680f3c639d284488bfd95c44ccdcfada2ee 100644
+index 24ae5383543230b18a5f4aa66112f483850b39dc..8f5f26deeaf8c66af70e674922634b34eaa19831 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1833,8 +1833,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1847,8 +1847,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0040-Per-Player-View-Distance-API-placeholders.patch
+++ b/patches/server/0040-Per-Player-View-Distance-API-placeholders.patch
@@ -20,10 +20,10 @@ index 352bfe795aea26307de9c998d67a43af3e4845f0..4689d52cd314a607d17be3657099157e
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_XZ = 32;
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8df699de4ddde3089324f347a82d913f2208f5be..4a91e8ee26ec34f605828afa75eea8dd30a1f1ef 100644
+index 83ad8c26a6152b4dd7ff9e432dabcc5fc17e3df0..1fa945a6431b813edbdcd7cda9bd48b5c47598d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1753,6 +1753,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1771,6 +1771,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getSimulationDistance() {
          return world.spigotConfig.simulationDistance;
      }
@@ -56,10 +56,10 @@ index 8df699de4ddde3089324f347a82d913f2208f5be..4a91e8ee26ec34f605828afa75eea8dd
  
      // Spigot start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a3de0658c00175dedfbd1844e2c18082641b7072..bcb19b6885ab90046b1361e2a9e5f9e65c9be1d0 100644
+index 8f5f26deeaf8c66af70e674922634b34eaa19831..6dfbdc0279678e5a5dcf20a96fc638a77defb286 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -379,6 +379,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -380,6 +380,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              connection.disconnect(message == null ? net.kyori.adventure.text.Component.empty() : message);
          }
      }

--- a/patches/server/0052-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/server/0052-Player-Tab-List-and-Title-APIs.patch
@@ -63,7 +63,7 @@ index bd808eb312ade7122973a47f4b96505829511da5..bf0f9cab7c66c089f35b851e799ba4a4
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bcb19b6885ab90046b1361e2a9e5f9e65c9be1d0..7df097f1703e3e3a866ba041a736a34d8dcd77f8 100644
+index 6dfbdc0279678e5a5dcf20a96fc638a77defb286..8ffffe42d4e259da8cc2c15dc92f162e54d40355 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@
@@ -73,7 +73,7 @@ index bcb19b6885ab90046b1361e2a9e5f9e65c9be1d0..7df097f1703e3e3a866ba041a736a34d
  import com.google.common.base.Preconditions;
  import com.google.common.collect.ImmutableSet;
  import com.google.common.io.BaseEncoding;
-@@ -250,6 +251,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -251,6 +252,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0055-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0055-Configurable-inter-world-teleportation-safety.patch
@@ -30,10 +30,10 @@ index c248b66486044150c64eaddbef85fa6644494212..ada624b5f58381122e59568c2087cf38
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7df097f1703e3e3a866ba041a736a34d8dcd77f8..87a193e8f026166b5821710d5501eb11175744b0 100644
+index 8ffffe42d4e259da8cc2c15dc92f162e54d40355..c2e9f4609c70adf36425ee12bbbf47dd92bdbd0e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -907,7 +907,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -921,7 +921,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (fromWorld == toWorld) {
              entity.connection.teleport(to);
          } else {

--- a/patches/server/0061-Complete-resource-pack-API.patch
+++ b/patches/server/0061-Complete-resource-pack-API.patch
@@ -23,10 +23,10 @@ index a1fe02097f369a350de79d7eb94f4a6eb3d3530e..d64e7bbfda0ad2fd086fd918bf5fa31e
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 00e9f75a065b598358bc049027ee8896e168091f..4cb1cd3bd5905735daab669206d51ebcdecaea10 100644
+index c2e9f4609c70adf36425ee12bbbf47dd92bdbd0e..a332a025655219acdbbecb4ec86e280e4dd7dac3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -134,6 +134,7 @@ import org.bukkit.metadata.MetadataValue;
+@@ -135,6 +135,7 @@ import org.bukkit.metadata.MetadataValue;
  import org.bukkit.plugin.Plugin;
  import org.bukkit.plugin.messaging.StandardMessenger;
  import org.bukkit.scoreboard.Scoreboard;
@@ -34,7 +34,7 @@ index 00e9f75a065b598358bc049027ee8896e168091f..4cb1cd3bd5905735daab669206d51ebc
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
-@@ -150,6 +151,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -151,6 +152,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private double health = 20;
      private boolean scaledHealth = false;
      private double healthScale = 20;
@@ -45,7 +45,7 @@ index 00e9f75a065b598358bc049027ee8896e168091f..4cb1cd3bd5905735daab669206d51ebc
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -1973,6 +1978,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1987,6 +1992,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0069-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0069-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -44,10 +44,10 @@ index cb611587ad1b929627576a330e398d980595c48a..a1137e8602a2d2670df4ddff01d7aee5
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4cb1cd3bd5905735daab669206d51ebcdecaea10..6ca282bd204d3dbc4a63860f8603693fc2615f68 100644
+index a332a025655219acdbbecb4ec86e280e4dd7dac3..12985cf9731b70bb1811efb04afe25e5c9fdc851 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1778,6 +1778,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1792,6 +1792,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0084-Workaround-for-setting-passengers-on-players.patch
+++ b/patches/server/0084-Workaround-for-setting-passengers-on-players.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Workaround for setting passengers on players
 SPIGOT-1915 & GH-114
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 885d5dd984f2d7d8d662d6b6546eacd0879a2e54..1ac65af16a835f4c601d044412fc06ab9694eaf5 100644
+index 12985cf9731b70bb1811efb04afe25e5c9fdc851..19705e9771a96af6fc61262f73a8b393846af8f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -917,6 +917,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -931,6 +931,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return true;
      }
  

--- a/patches/server/0122-String-based-Action-Bar-API.patch
+++ b/patches/server/0122-String-based-Action-Bar-API.patch
@@ -26,10 +26,10 @@ index 32ef3edebe94a2014168b7e438752a80b2687e5f..ab6c58eed6707ab7b0aa3e7549a871ad
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1ac65af16a835f4c601d044412fc06ab9694eaf5..26ad8287e9ec74da99bdffe5de00f2e71ad571d0 100644
+index 19705e9771a96af6fc61262f73a8b393846af8f4..492b8b020d9536547f9e30a1ac356fd1f4cc969a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -257,6 +257,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -258,6 +258,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      // Paper start

--- a/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -7,7 +7,7 @@ Provides counts without the ineffeciency of using .getEntities().size()
 which creates copy of the collections.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index f51f41b19982736f3e095089eba17d0fab915e97..ea1e85fa125f2dd1a251e1589fff32d7083e2c13 100644
+index b40cdc7a49d005af6e142f6bc59e25dd29c96d5d..88b2681b15d2dca66b22d12b7dc7f854883793c8 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -111,7 +111,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -20,10 +20,10 @@ index f51f41b19982736f3e095089eba17d0fab915e97..ea1e85fa125f2dd1a251e1589fff32d7
      private boolean tickingBlockEntities;
      public final Thread thread;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4a91e8ee26ec34f605828afa75eea8dd30a1f1ef..306b949dc7b9a57d97373a309ee33820c523b86e 100644
+index 1fa945a6431b813edbdcd7cda9bd48b5c47598d1..cf051e821ec5969cafd815b95569e88d209e42e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -135,6 +135,57 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -137,6 +137,57 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      private int ambientSpawn = -1;
      private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  

--- a/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -301,10 +301,10 @@ index ba9f209c2674107fd5751cb28c4f80fcbbc0aaa2..6c33b524d81ccd8ed060c3a9067cb1b6
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index 01988598d9113a1e93f185bafb0db916b9519c00..1179fa40f4d23bb5d0308d4e8ef2ac16e4d09db2 100644
+index caccb8d7b30e616a4fb367e2e1c42845dd9a1880..ef3874fccb5d8b99c2b6753e7c60b83f5e3f316b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-@@ -875,7 +875,7 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+@@ -883,7 +883,7 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
          } else if (TNTPrimed.class.isAssignableFrom(clazz)) {
              entity = new PrimedTnt(world, x, y, z, null);
          } else if (ExperienceOrb.class.isAssignableFrom(clazz)) {

--- a/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
@@ -90,10 +90,10 @@ index 27d304316bec097fea4b950cb4e0ac80cb219f70..85fea9b0bf84a8b40098f35eac503070
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 26ad8287e9ec74da99bdffe5de00f2e71ad571d0..a469ab0056c133aa40f1c9f70782d6a8c40b6dfd 100644
+index 492b8b020d9536547f9e30a1ac356fd1f4cc969a..9090c1a400dcb23678ea15234e1517cd707b694c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -201,6 +201,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -202,6 +202,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
@@ -28,10 +28,10 @@ index 3a09ce6d0ea51436adcae4719d3f28d1868c283c..7bc5aa35b52de0027cf58a6127a99034
              return true;
          });
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a469ab0056c133aa40f1c9f70782d6a8c40b6dfd..f696e31ec286263c4d06d6897b3aef0fa50f8f34 100644
+index 9090c1a400dcb23678ea15234e1517cd707b694c..4061b79b55d0ef3221f74d5cb410f8a1574fd8d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1225,8 +1225,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1239,8 +1239,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return GameMode.getByValue(this.getHandle().gameMode.getGameModeForPlayer().getId());
      }
  

--- a/patches/server/0184-Player.setPlayerProfile-API.patch
+++ b/patches/server/0184-Player.setPlayerProfile-API.patch
@@ -26,10 +26,10 @@ index 00ef714294b6cce5fec7613eed4ba228a48e3e11..67b300574655854249c1f7440f56a6e8
                              uniqueId = gameProfile.getId();
                              // Paper end
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f696e31ec286263c4d06d6897b3aef0fa50f8f34..51839994999b22251bd9e813f1e05ef8d7e97c0d 100644
+index 4061b79b55d0ef3221f74d5cb410f8a1574fd8d2..b62925af7a2c9fda30b5d23ab12375ae1fd17ea2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -71,6 +71,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
+@@ -72,6 +72,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
  import net.minecraft.world.inventory.AbstractContainerMenu;
  import net.minecraft.world.level.GameType;
  import net.minecraft.world.level.block.Blocks;
@@ -37,7 +37,7 @@ index f696e31ec286263c4d06d6897b3aef0fa50f8f34..51839994999b22251bd9e813f1e05ef8
  import net.minecraft.world.level.block.entity.SignBlockEntity;
  import net.minecraft.world.level.saveddata.maps.MapDecoration;
  import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
-@@ -1358,8 +1359,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1372,8 +1373,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.hiddenEntities.put(entity.getUniqueId(), hidingPlugins);
  
          // Remove this entity from the hidden player's EntityTrackerEntry
@@ -52,7 +52,7 @@ index f696e31ec286263c4d06d6897b3aef0fa50f8f34..51839994999b22251bd9e813f1e05ef8
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1408,8 +1414,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1422,8 +1428,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          this.hiddenEntities.remove(entity.getUniqueId());
  
@@ -67,7 +67,7 @@ index f696e31ec286263c4d06d6897b3aef0fa50f8f34..51839994999b22251bd9e813f1e05ef8
  
          if (other instanceof ServerPlayer) {
              ServerPlayer otherPlayer = (ServerPlayer) other;
-@@ -1421,6 +1432,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1435,6 +1446,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entry.updatePlayer(this.getHandle());
          }
      }

--- a/patches/server/0190-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0190-Flag-to-disable-the-channel-limit.patch
@@ -9,10 +9,10 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 69b0566660b0ad8571782feddff7726dda474b4e..4c08a07b0f21e2f57c802a3b05142f4ad94fda9f 100644
+index b62925af7a2c9fda30b5d23ab12375ae1fd17ea2..eae0ec1c7165184a1a34510975ef62e9429a5777 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -155,6 +155,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -156,6 +156,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper start
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
@@ -20,7 +20,7 @@ index 69b0566660b0ad8571782feddff7726dda474b4e..4c08a07b0f21e2f57c802a3b05142f4a
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1675,7 +1676,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1689,7 +1690,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0197-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0197-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,7 +10,7 @@ Adds an option to control the force mode of the particle.
 This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 92fc07fb1a9dab0d44ac439287d10ae05a4e7043..377c8a43e063522478037c1368cefd71fec701cb 100644
+index 32253b7d4eec3cb0b7d047bb5ce05c46e9d3649d..11b0f1ef4aa02cf719e4d937c98d41b82ffca23a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1383,12 +1383,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -34,10 +34,10 @@ index 92fc07fb1a9dab0d44ac439287d10ae05a4e7043..377c8a43e063522478037c1368cefd71
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 306b949dc7b9a57d97373a309ee33820c523b86e..5d634f2bdab4f80cb2ccb3e60b9f3c96cfc7e875 100644
+index cf051e821ec5969cafd815b95569e88d209e42e0..d10ed2b2b547298580a8ae5fbe14526172cb5b7c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1751,11 +1751,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1769,11 +1769,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0202-Allow-spawning-Item-entities-with-World.spawnEntity.patch
+++ b/patches/server/0202-Allow-spawning-Item-entities-with-World.spawnEntity.patch
@@ -8,10 +8,10 @@ This API has more capabilities than .dropItem with the Consumer function
 Item can be set inside of the Consumer pre spawn function.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index 1179fa40f4d23bb5d0308d4e8ef2ac16e4d09db2..e9d6df8339dec597e646ab3e55fb7e032664908e 100644
+index ef3874fccb5d8b99c2b6753e7c60b83f5e3f316b..2c5ca6e91269aa27d18358b6f9b6e146a23ad933 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-@@ -535,6 +535,10 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+@@ -543,6 +543,10 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
          if (Boat.class.isAssignableFrom(clazz)) {
              entity = new net.minecraft.world.entity.vehicle.Boat(world, x, y, z);
              entity.moveTo(x, y, z, yaw, pitch);

--- a/patches/server/0214-Expand-Explosions-API.patch
+++ b/patches/server/0214-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5d634f2bdab4f80cb2ccb3e60b9f3c96cfc7e875..da66ab027f89f9d92efe58f14a35d758e4e30687 100644
+index d10ed2b2b547298580a8ae5fbe14526172cb5b7c..e611dba302344df257ecb0bcdff404444cfa5b72 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -691,6 +691,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -693,6 +693,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
          return !this.world.explode(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, breakBlocks ? Explosion.BlockInteraction.BREAK : Explosion.BlockInteraction.NONE).wasCanceled;
      }

--- a/patches/server/0218-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0218-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index da66ab027f89f9d92efe58f14a35d758e4e30687..0a2b445bffeb95854eb0e9fe009031d41ad1b2bb 100644
+index e611dba302344df257ecb0bcdff404444cfa5b72..bf3a5bfe15b630970553a67366bf6be24c57bcf0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1025,6 +1025,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1027,6 +1027,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return list;
      }
  

--- a/patches/server/0219-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0219-InventoryCloseEvent-Reason-API.patch
@@ -174,10 +174,10 @@ index 278f1f403c43a5c55a53ef8639bf2ea87a676498..c787bb69baa1b30fc513965fe4a9578c
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c66767e94cb123d9286b43a115ba4fda7727337f..9495c5c41b1671fbc3930fb374efd7c7a68073bf 100644
+index eae0ec1c7165184a1a34510975ef62e9429a5777..b77bb4a2439f8fae9a856edec889477c86d84a35 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -941,7 +941,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -955,7 +955,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {

--- a/patches/server/0256-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0256-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0a2b445bffeb95854eb0e9fe009031d41ad1b2bb..dafdfce21f6629d6f99bcf4e47e82e2fbf332f09 100644
+index bf3a5bfe15b630970553a67366bf6be24c57bcf0..63cbcd8d62d52ed485cbd923b405e0234173d2f0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -372,7 +372,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -374,7 +374,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0257-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0257-Asynchronous-chunk-IO-and-loading.patch
@@ -2771,7 +2771,7 @@ index 87c9a7ffc69206554cf37c7d2c9939eb3cbea3a9..7b391d6ab84eeaed7bdd27ea70d5e3f9
          } finally {
              chunkMap.callbackExecutor.run();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2d0e04cd2ab6403b3f5324cad130ec768a39d608..5abcae55b2dc37eea514d194803bc9a851f18c25 100644
+index cd11361cd2dc12c7b94f3e8505937b484ec19dff..8da73bd016b7da297e64383e2e6dc65a1dd3be87 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -309,6 +309,78 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -3571,10 +3571,10 @@ index 415ec2cb81e956526e7f4965b899c9aa04f62f2e..ff6cadec530dedf9efc5d6226e48a096
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index dafdfce21f6629d6f99bcf4e47e82e2fbf332f09..ab00e3a834c77e080a1ca4acf077c948a8287124 100644
+index 63cbcd8d62d52ed485cbd923b405e0234173d2f0..024fb684644bcebd42714abcfbba379bc6f68249 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1814,6 +1814,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1832,6 +1832,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public DragonBattle getEnderDragonBattle() {
          return (this.getHandle().dragonFight() == null) ? null : new CraftDragonBattle(this.getHandle().dragonFight());
      }

--- a/patches/server/0259-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0259-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9495c5c41b1671fbc3930fb374efd7c7a68073bf..e216c9a84efdf3f3eb7145d6136dbe8d92c0dcc3 100644
+index b77bb4a2439f8fae9a856edec889477c86d84a35..bdb7d9afe28b6576a95eac51f6ae9ebfbde93134 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2372,6 +2372,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2386,6 +2386,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0260-Improve-death-events.patch
+++ b/patches/server/0260-Improve-death-events.patch
@@ -295,10 +295,10 @@ index 91cf7728aee475cb36f2c02bbfb7e3d2e0d00576..a3a900d10440ed5ebe24370a77ccb6ca
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e216c9a84efdf3f3eb7145d6136dbe8d92c0dcc3..08093c890141fa146da00c413bd3509e2019cb59 100644
+index bdb7d9afe28b6576a95eac51f6ae9ebfbde93134..03b7da18cd28785f3a44c415ed45174c1fbf8778 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1935,7 +1935,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1949,7 +1949,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/patches/server/0274-Add-sun-related-API.patch
+++ b/patches/server/0274-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ab00e3a834c77e080a1ca4acf077c948a8287124..bbdeeb6bafde95cfffbafbe9fefb303d5593c498 100644
+index 024fb684644bcebd42714abcfbba379bc6f68249..1b3412c1cb9a90defcd3db7ef86a21d2bbe07bf4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -667,6 +667,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -669,6 +669,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
      }
  

--- a/patches/server/0298-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0298-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -106,10 +106,10 @@ index c7e4c6d29378675b76ebb179022ddbb02831a1dc..88bc0807e8bf66a65422f85f11123363
      public Location getBedSpawnLocation() {
          CompoundTag data = this.getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 08093c890141fa146da00c413bd3509e2019cb59..5beb5568c4c2a1ab8ac737e26a78178c788961d2 100644
+index 03b7da18cd28785f3a44c415ed45174c1fbf8778..468206c1a6cb3de1ffd07513127deff2d77df4c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -156,6 +156,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -157,6 +157,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
      private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
@@ -117,7 +117,7 @@ index 08093c890141fa146da00c413bd3509e2019cb59..5beb5568c4c2a1ab8ac737e26a78178c
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1547,6 +1548,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1561,6 +1562,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 08093c890141fa146da00c413bd3509e2019cb59..5beb5568c4c2a1ab8ac737e26a78178c
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1569,6 +1582,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1583,6 +1596,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index 08093c890141fa146da00c413bd3509e2019cb59..5beb5568c4c2a1ab8ac737e26a78178c
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1583,6 +1598,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1597,6 +1612,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0300-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0300-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5beb5568c4c2a1ab8ac737e26a78178c788961d2..b04aaab4f7cb7367d0fbc6268b0db269b55b2d17 100644
+index 468206c1a6cb3de1ffd07513127deff2d77df4c5..8ae3477fbe55e62a09c17e007ac8db3906965a48 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2419,6 +2419,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2433,6 +2433,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0320-Add-Heightmap-API.patch
+++ b/patches/server/0320-Add-Heightmap-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index bbdeeb6bafde95cfffbafbe9fefb303d5593c498..6f9e0560101662012a332c560ce51c00500ce20b 100644
+index 1b3412c1cb9a90defcd3db7ef86a21d2bbe07bf4..94e0284098f71613f37be8d65047a20420d2ddd1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -206,6 +206,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -208,6 +208,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.getHighestBlockYAt(x, z, org.bukkit.HeightMap.MOTION_BLOCKING);
      }
  

--- a/patches/server/0325-improve-CraftWorld-isChunkLoaded.patch
+++ b/patches/server/0325-improve-CraftWorld-isChunkLoaded.patch
@@ -9,10 +9,10 @@ waiting for the execution queue to get to our request; We can just query
 the chunk status and get a response now, vs having to wait
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6f9e0560101662012a332c560ce51c00500ce20b..29509d3ae956fd4da2bf12c6a352ab115fc75f5c 100644
+index 94e0284098f71613f37be8d65047a20420d2ddd1..3ba558e36cbb87e67736654bcd1d46474b6d4e2f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -277,13 +277,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -279,13 +279,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkLoaded(int x, int z) {

--- a/patches/server/0327-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0327-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -85,7 +85,7 @@ index bd8e654c1580a0ac7dd411b9f1dcad4a20d1d3e5..7576047ea9695434ca06ca8fefde0dce
          // CraftBukkit start
          // this.updateMobSpawningFlags();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2950ad995f322570cd647d3217f340327cc3e7c8..fef3846a978dcba95c5dbe5c528ac20cb4f56178 100644
+index d01f3207d4a7516d2eba9df44c44a7c41c354c84..bb6b8d123967850f5b305a94968648ca65ae6c75 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -60,6 +60,7 @@ import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
@@ -221,10 +221,10 @@ index 4185e6bcf9b2bb65b2a0fa5fcbeb5684615169a7..dbc29442f2b2ad3ea451910f4944e901
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 29509d3ae956fd4da2bf12c6a352ab115fc75f5c..255616aa45b06487c67aa6011dbe29e18d82bc68 100644
+index 3ba558e36cbb87e67736654bcd1d46474b6d4e2f..0816aa64d50b3144057024b998bc8dc4cd43b7a0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1340,15 +1340,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1342,15 +1342,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/patches/server/0332-Fix-World-isChunkGenerated-calls.patch
+++ b/patches/server/0332-Fix-World-isChunkGenerated-calls.patch
@@ -8,7 +8,7 @@ This patch also adds a chunk status cache on region files (note that
 its only purpose is to cache the status on DISK)
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 87f055f8338d4ce2f9ff76bdc6c0b7ffc266ce78..9dd2f5d7ea6a1d6744916c403bdd852bb66e45b8 100644
+index 8ccdaddcef1e5e83660e58075b039b124f36fce3..e78ad9330ae1b89aca9aef197f593156546138f0 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -87,6 +87,7 @@ import net.minecraft.world.level.chunk.ProtoChunk;
@@ -184,7 +184,7 @@ index 44de464b5f2190944c7a7316a76e13f9c3b954ab..293cce2c80fbdc18480977f5f6b24d6b
              this.padToFullSector();
          } finally {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java b/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
-index 2cbc17288b1dc52edb2bdad29976d0f551b1e176..2ee32657a49937418b352a138aca21fbb27857e6 100644
+index a1bfcdd713c47d8613eb4af7625a64d51161690b..4bc33c31d497aa7d69226ab870fd78902bedfd5b 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
 @@ -245,6 +245,7 @@ public class RegionFileStorage implements AutoCloseable {
@@ -196,7 +196,7 @@ index 2cbc17288b1dc52edb2bdad29976d0f551b1e176..2ee32657a49937418b352a138aca21fb
              } catch (Throwable throwable) {
                  if (dataoutputstream != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 255616aa45b06487c67aa6011dbe29e18d82bc68..706d5718997181279f7ec715526b4d8f2b6162a2 100644
+index 0816aa64d50b3144057024b998bc8dc4cd43b7a0..0ef9fc9cecdefcec3369c45643e474c16a588cea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -19,6 +19,7 @@ import java.util.Objects;
@@ -207,7 +207,7 @@ index 255616aa45b06487c67aa6011dbe29e18d82bc68..706d5718997181279f7ec715526b4d8f
  import java.util.function.Predicate;
  import java.util.stream.Collectors;
  import net.minecraft.core.BlockPos;
-@@ -282,8 +283,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -284,8 +285,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -231,7 +231,7 @@ index 255616aa45b06487c67aa6011dbe29e18d82bc68..706d5718997181279f7ec715526b4d8f
          } catch (IOException ex) {
              throw new RuntimeException(ex);
          }
-@@ -395,20 +410,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -397,20 +412,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0400-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0400-Implement-Player-Client-Options-API.patch
@@ -97,10 +97,10 @@ index 9cbca14b0a111e57a1d01bcbcf2164ab8b53b1a5..cdb0eb8e21299ca70ed7ed5c1195d07f
          if (getMainArm() != packet.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b04aaab4f7cb7367d0fbc6268b0db269b55b2d17..3f25e799ba13d8280c644a943ca0d191fde9eb7b 100644
+index 8ae3477fbe55e62a09c17e007ac8db3906965a48..ea307fad3f18f677d4e7c37d2d699f87e5f15699 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -546,6 +546,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -547,6 +547,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setSendViewDistance(int viewDistance) {
          throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }

--- a/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -44,10 +44,10 @@ index 52fabc8cd1b76a825a13d39f38ca982e252cb39b..54598af96488c47b613de8eb8eb0bf31
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 706d5718997181279f7ec715526b4d8f2b6162a2..c11bdc266434aa9d90e5ab25e185dc1a1ba57d9b 100644
+index 0ef9fc9cecdefcec3369c45643e474c16a588cea..bcb3a7e64f317732c8c758d4e743d84233bdafa6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -266,8 +266,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -268,8 +268,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -70,7 +70,7 @@ index 706d5718997181279f7ec715526b4d8f2b6162a2..c11bdc266434aa9d90e5ab25e185dc1a
  
      @Override
      public Chunk getChunkAt(Block block) {
-@@ -334,7 +347,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -336,7 +349,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (this.isChunkLoaded(x, z)) {
@@ -79,7 +79,7 @@ index 706d5718997181279f7ec715526b4d8f2b6162a2..c11bdc266434aa9d90e5ab25e185dc1a
          }
  
          return true;
-@@ -412,9 +425,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -414,9 +427,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -93,7 +93,7 @@ index 706d5718997181279f7ec715526b4d8f2b6162a2..c11bdc266434aa9d90e5ab25e185dc1a
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -422,7 +438,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -424,7 +440,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -102,7 +102,7 @@ index 706d5718997181279f7ec715526b4d8f2b6162a2..c11bdc266434aa9d90e5ab25e185dc1a
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -448,7 +464,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -450,7 +466,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -111,7 +111,7 @@ index 706d5718997181279f7ec715526b4d8f2b6162a2..c11bdc266434aa9d90e5ab25e185dc1a
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -1917,6 +1933,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1935,6 +1951,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);

--- a/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1151,7 +1151,7 @@ index 135337afa09f090847d26268fcb8e542b1535ef3..b164b43d9d61398231451162cfb07d11
              if (updatingChunk != null) {
                  return updatingChunk.getEntityTickingChunkFuture();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5a23c9fe4147c82ce2e6eda9690b158b030f71f6..e289c08936e0a3c5558e65f247406414d7fb0daa 100644
+index 5bf1b4ef94148a6108ad2f8cafdcedc412529ae1..998efab94fad3f5f5cbf17b29881ed2c3fc98f6f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -223,7 +223,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -1193,10 +1193,10 @@ index 6eaba33b7730d66bf631b6d5c6a7080f9f019f8b..8e03e63a00dd242791ba0d5a8a179222
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c11bdc266434aa9d90e5ab25e185dc1a1ba57d9b..eea11a2bf87d409f484f07f207c57c864079e43d 100644
+index bcb3a7e64f317732c8c758d4e743d84233bdafa6..336e65216f582a4393df07ace2eaf6ecc0c57e2e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1931,6 +1931,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1949,6 +1949,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return future;
          }
  
@@ -1210,10 +1210,10 @@ index c11bdc266434aa9d90e5ab25e185dc1a1ba57d9b..eea11a2bf87d409f484f07f207c57c86
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3f25e799ba13d8280c644a943ca0d191fde9eb7b..d22662c5d12f03196b00e8342b063f346d86f76a 100644
+index ea307fad3f18f677d4e7c37d2d699f87e5f15699..aa2875f9a82c3e57b4aeedf49ec65f860cb2102b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -909,6 +909,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -923,6 +923,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
      }
  

--- a/patches/server/0480-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/patches/server/0480-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index eea11a2bf87d409f484f07f207c57c864079e43d..b08bca3111a70edd329aac26b6f2763925081b60 100644
+index 336e65216f582a4393df07ace2eaf6ecc0c57e2e..2cd0185f607e39d445da3f5952d7f6f3b2cd7520 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2003,6 +2003,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2021,6 +2021,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
              lightning.visualOnly = true;
              lightning.isSilent = isSilent;

--- a/patches/server/0484-Brand-support.patch
+++ b/patches/server/0484-Brand-support.patch
@@ -72,10 +72,10 @@ index 4a17f98d06f061a2253dc75e313c618e550ed100..f9073eaa82c79f0b8ad738213b53f991
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d22662c5d12f03196b00e8342b063f346d86f76a..08d6dfbbf62e7adb801a7bf49dd1a1f611e768c6 100644
+index aa2875f9a82c3e57b4aeedf49ec65f860cb2102b..ffbff2a88237606986ed16b1223ca2b23fedcd31 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2563,6 +2563,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2577,6 +2577,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0488-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0488-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix SpawnChangeEvent not firing for all use-cases
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index be26327d31a3117cb7a5bf752c49c204738bc91e..230ee6dd71e55921960a81d7b3aedbc804f785e5 100644
+index b27fb07aacb66259f640de5c5aa6849eb7e8cc9c..74044db6497071debf8ad02829876e410ee4090e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1743,6 +1743,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -17,10 +17,10 @@ index be26327d31a3117cb7a5bf752c49c204738bc91e..230ee6dd71e55921960a81d7b3aedbc8
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig.keepLoadedRange, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b08bca3111a70edd329aac26b6f2763925081b60..81756e78acb1b9ea2a7e9b75ffe55a936cc79dce 100644
+index 2cd0185f607e39d445da3f5952d7f6f3b2cd7520..31e5ee79c92aa50182ccf4af5489ffa1407923af 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -247,11 +247,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -249,11 +249,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {
              Location previousLocation = this.getSpawnLocation();

--- a/patches/server/0489-Add-moon-phase-API.patch
+++ b/patches/server/0489-Add-moon-phase-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add moon phase API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 81756e78acb1b9ea2a7e9b75ffe55a936cc79dce..f850aefb042660e6df423a19907a096a3a7c1d77 100644
+index 31e5ee79c92aa50182ccf4af5489ffa1407923af..11f0c423c240b447af72b2a413164c15a36b52c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -185,6 +185,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -187,6 +187,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getPlayerCount() {
          return world.players().size();
      }

--- a/patches/server/0521-Player-elytra-boost-API.patch
+++ b/patches/server/0521-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 08d6dfbbf62e7adb801a7bf49dd1a1f611e768c6..3cb295a37f8cd1a84712a0b2b6b2c09dfafca162 100644
+index ffbff2a88237606986ed16b1223ca2b23fedcd31..0350eefdd5b76d60d3068f27be926009626db7ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -564,6 +564,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -565,6 +565,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/patches/server/0534-Expose-world-spawn-angle.patch
+++ b/patches/server/0534-Expose-world-spawn-angle.patch
@@ -18,10 +18,10 @@ index 3428f3014d9b8e9422a9f586268f5e82dcf1e33f..ba0596c0d6340492f2d4b017a8745945
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f850aefb042660e6df423a19907a096a3a7c1d77..4224f6c5d219285c10c1dae18375ee553052510b 100644
+index 11f0c423c240b447af72b2a413164c15a36b52c4..147276e051be53276d788b0b3d68f1df48ddf7d5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -238,7 +238,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -240,7 +240,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public Location getSpawnLocation() {
          BlockPos spawn = this.world.getSharedSpawnPos();

--- a/patches/server/0536-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0536-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3cb295a37f8cd1a84712a0b2b6b2c09dfafca162..a06fd29b6006459edf0069ce8d1dddcb36ca3104 100644
+index 0350eefdd5b76d60d3068f27be926009626db7ea..457f68048d9dab306555398480ba597289f75046 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2134,7 +2134,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2148,7 +2148,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0566-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0566-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 888d812118c15c212284687ae5842a94f5715d52..e7ca5d6fb8922e7e8065864f736b0605
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4224f6c5d219285c10c1dae18375ee553052510b..dc182b4ff748661b04e15578ac9e0e1a8062f2c8 100644
+index 147276e051be53276d788b0b3d68f1df48ddf7d5..7417b983b1c230e9a7f131bea978f0e0eaeb9e50 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1736,8 +1736,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1754,8 +1754,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index 4224f6c5d219285c10c1dae18375ee553052510b..dc182b4ff748661b04e15578ac9e0e1a
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1772,8 +1777,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1790,8 +1795,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0577-Add-sendOpLevel-API.patch
+++ b/patches/server/0577-Add-sendOpLevel-API.patch
@@ -32,10 +32,10 @@ index 201f36b0f8ae391b2efbad5cc38f115537a761a2..0052a9c5d19db44331bb7ee93544d783
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a06fd29b6006459edf0069ce8d1dddcb36ca3104..198731f323baee319100cb537afb9f5bb9a6af3c 100644
+index 457f68048d9dab306555398480ba597289f75046..bed138215387343c25d481ae3643499d5551d1e3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -578,6 +578,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -579,6 +579,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/patches/server/0613-Implement-Keyed-on-World.patch
+++ b/patches/server/0613-Implement-Keyed-on-World.patch
@@ -34,10 +34,10 @@ index 93faeef65f846fdb472204709093ebcdba790dce..28fb73ffd683a45b1d6be4b55116e861
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index dc182b4ff748661b04e15578ac9e0e1a8062f2c8..96d3f8a312ebe786fe21198d12d9f3294a86d865 100644
+index 7417b983b1c230e9a7f131bea978f0e0eaeb9e50..ecf67066669b7942f9373f760b75cfc36aab34e2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1959,6 +1959,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1977,6 +1977,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return java.util.concurrent.CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
          }, net.minecraft.server.MinecraftServer.getServer());
      }

--- a/patches/server/0628-Set-area-affect-cloud-rotation.patch
+++ b/patches/server/0628-Set-area-affect-cloud-rotation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Set area affect cloud rotation
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index e9d6df8339dec597e646ab3e55fb7e032664908e..15341c07f9e07ba1d875ef9de16476c07751cab6 100644
+index 2c5ca6e91269aa27d18358b6f9b6e146a23ad933..abd9429ece67fc1649750a77045c8157c57309a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-@@ -885,6 +885,7 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+@@ -893,6 +893,7 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
              entity.moveTo(location.getX(), location.getY(), location.getZ());
          } else if (AreaEffectCloud.class.isAssignableFrom(clazz)) {
              entity = new net.minecraft.world.entity.AreaEffectCloud(world, x, y, z);

--- a/patches/server/0637-More-World-API.patch
+++ b/patches/server/0637-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 96d3f8a312ebe786fe21198d12d9f3294a86d865..5e26484e0b4a72556e77d8b2035d4cc569826b42 100644
+index ecf67066669b7942f9373f760b75cfc36aab34e2..7119e59c228e6f3fa1cdb81a92a54a9e3dd1bc8e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1905,6 +1905,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1923,6 +1923,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0655-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0655-additions-to-PlayerGameModeChangeEvent.patch
@@ -139,10 +139,10 @@ index 9f93ce18a0406321462fb5e4c4dbfab720b87da8..b12d7f8ac2ac446eb0cdfa1e73de6690
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 198731f323baee319100cb537afb9f5bb9a6af3c..ffa49594d4a137be7476677488605ce74c607bba 100644
+index bed138215387343c25d481ae3643499d5551d1e3..32c700ae33f66844577dd2aaf4c38c6a264570e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1269,7 +1269,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1283,7 +1283,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0663-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0663-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add cause to Weather/ThunderChangeEvents
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 277f9c00c305a1e8b832bb48d9764a9d014612a6..2c8acd5610e873d64470b0e4b0373566357d885d 100644
+index d76668ab79d6afa0972fd54408a8475781b1c928..49640474611c4e1781a93c6eaa627a2865f5f72e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -471,8 +471,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -95,10 +95,10 @@ index d88003a29d382d8952964257601f93c5fe95fa8b..30cd6dc004ef1d1518c9a10304ea2a20
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5e26484e0b4a72556e77d8b2035d4cc569826b42..00aab4a9b4485fbecb98f2fb56370d3919b3a5f9 100644
+index 7119e59c228e6f3fa1cdb81a92a54a9e3dd1bc8e..9b7c49753a997ed04a6f588a99d896ece25578da 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1173,7 +1173,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1175,7 +1175,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index 5e26484e0b4a72556e77d8b2035d4cc569826b42..00aab4a9b4485fbecb98f2fb56370d39
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1195,7 +1195,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1197,7 +1197,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0666-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0666-Add-PlayerKickEvent-causes.patch
@@ -342,10 +342,10 @@ index ad7e4ec5ca3f2f874c916d7ee80f5b2b2ae03bf8..9b55968cb1db5f77a8e858e2a7aa66d5
          // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ffa49594d4a137be7476677488605ce74c607bba..43bfae712369c3c895a0007041d3821bb6257ccd 100644
+index 32c700ae33f66844577dd2aaf4c38c6a264570e0..9cc5531b7ed08f56b296e0fce92cf56d5ceb2730 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -504,16 +504,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -505,16 +505,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          org.spigotmc.AsyncCatcher.catchOp("player kick"); // Spigot
          if (this.getHandle().connection == null) return;
  

--- a/patches/server/0677-Line-Of-Sight-Changes.patch
+++ b/patches/server/0677-Line-Of-Sight-Changes.patch
@@ -19,10 +19,10 @@ index 4c9a6bb5456fe5fa35e37a18b3e577003d901d71..2d57ee46e66fe8962177a3a18c890f49
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 00aab4a9b4485fbecb98f2fb56370d3919b3a5f9..2e938d257de3df9ce571a6b850fc1a5ca5790cf7 100644
+index 9b7c49753a997ed04a6f588a99d896ece25578da..761f3f671ba23ab46b3c72ff488d0d43642cb2da 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -190,6 +190,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -192,6 +192,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public io.papermc.paper.world.MoonPhase getMoonPhase() {
          return io.papermc.paper.world.MoonPhase.getPhase(getFullTime() / 24000L);
      }

--- a/patches/server/0678-add-per-world-spawn-limits.patch
+++ b/patches/server/0678-add-per-world-spawn-limits.patch
@@ -44,10 +44,10 @@ index 478c93a4eae18047df037958720e56e94a131f1c..feaabc6d65845b81a3a184dc332d1152
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2e938d257de3df9ce571a6b850fc1a5ca5790cf7..b4a1346eb90864c1eeb46b22a61f3adcd352aa19 100644
+index 761f3f671ba23ab46b3c72ff488d0d43642cb2da..7821ebcbae8c63c3607d2ac8f92cb5a55a62bd97 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -212,6 +212,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -214,6 +214,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          this.biomeProvider = biomeProvider;
  
          this.environment = env;

--- a/patches/server/0702-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0702-Add-PlayerSetSpawnEvent.patch
@@ -93,10 +93,10 @@ index d620f559cdd1bd0e161a99123ef6c6f64e3302df..07e893f1859abe3c2a765694c21309d6
                      return InteractionResult.SUCCESS;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 43bfae712369c3c895a0007041d3821bb6257ccd..261a2b4d750c0b57c3c83a82ee41a2bb7d770d8a 100644
+index 9cc5531b7ed08f56b296e0fce92cf56d5ceb2730..d41d85f28e3eb7d6b9c9addc743e5bc09dd217c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1089,9 +1089,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1103,9 +1103,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0719-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0719-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4f3719e77e008cbd3d2bd9262a03a526000bc837..cd262cbe8f5f9588dd1d9fcd308eeb0418f54922 100644
+index d4129cb5ffa6bea474020c47b82d8905d1f4d9f5..df37739055bc705d9aebf8db4ee2007e366af7dd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -751,6 +751,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -29,10 +29,10 @@ index 4f3719e77e008cbd3d2bd9262a03a526000bc837..cd262cbe8f5f9588dd1d9fcd308eeb04
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b4a1346eb90864c1eeb46b22a61f3adcd352aa19..f7d94cb32a178247bbc5f59e5bc31e79f9fcdc4d 100644
+index 7821ebcbae8c63c3607d2ac8f92cb5a55a62bd97..246a25d76c26302833f86a2c329a9a0d738af707 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -693,6 +693,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -695,6 +695,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0750-Do-not-copy-visible-chunks.patch
+++ b/patches/server/0750-Do-not-copy-visible-chunks.patch
@@ -35,7 +35,7 @@ index b3516862d796c2d9fcc1c67a6073445403d73088..b61abf227a04b4565c2525e5f469db30
              List<ChunkHolder> allChunks = new ArrayList<>(visibleChunks.values());
              List<ServerPlayer> players = world.players;
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index ba5dab2d3bc8325e5678ef58fedac5b2bc7e38d3..7353b4e43503b371973c2de6a61e5ca91d613680 100644
+index fa458b35977b49fd5a7dabd826d6bf33a86319fe..26349902ea206d93cde94f0ed2741ba106e186e5 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -120,9 +120,11 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -166,10 +166,10 @@ index ba5dab2d3bc8325e5678ef58fedac5b2bc7e38d3..7353b4e43503b371973c2de6a61e5ca9
          while (objectbidirectionaliterator.hasNext()) {
              Entry<ChunkHolder> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f7d94cb32a178247bbc5f59e5bc31e79f9fcdc4d..ac41bc23d2f7e16bbacdc9b33fcf6c0d706fa023 100644
+index 246a25d76c26302833f86a2c329a9a0d738af707..a31da19c22d9fca4f5ed2bedf4210f661089da3f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -151,7 +151,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -153,7 +153,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public int getTileEntityCount() {
          // We don't use the full world tile entity list, so we must iterate chunks
@@ -178,7 +178,7 @@ index f7d94cb32a178247bbc5f59e5bc31e79f9fcdc4d..ac41bc23d2f7e16bbacdc9b33fcf6c0d
          int size = 0;
          for (ChunkHolder playerchunk : chunks.values()) {
              net.minecraft.world.level.chunk.LevelChunk chunk = playerchunk.getTickingChunk();
-@@ -172,7 +172,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -174,7 +174,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getChunkCount() {
          int ret = 0;
  
@@ -187,7 +187,7 @@ index f7d94cb32a178247bbc5f59e5bc31e79f9fcdc4d..ac41bc23d2f7e16bbacdc9b33fcf6c0d
              if (chunkHolder.getTickingChunk() != null) {
                  ++ret;
              }
-@@ -346,7 +346,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -348,7 +348,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {
@@ -207,7 +207,7 @@ index f7d94cb32a178247bbc5f59e5bc31e79f9fcdc4d..ac41bc23d2f7e16bbacdc9b33fcf6c0d
          return chunks.values().stream().map(ChunkHolder::getFullChunk).filter(Objects::nonNull).map(net.minecraft.world.level.chunk.LevelChunk::getBukkitChunk).toArray(Chunk[]::new);
      }
  
-@@ -422,7 +433,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -424,7 +435,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean refreshChunk(int x, int z) {

--- a/patches/server/0815-Add-player-health-update-API.patch
+++ b/patches/server/0815-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 261a2b4d750c0b57c3c83a82ee41a2bb7d770d8a..8de4ad9f2120d22b78202981624abd1d2fc70148 100644
+index d41d85f28e3eb7d6b9c9addc743e5bc09dd217c9..148e1985017f6955267b5c970730645394d700f6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2013,9 +2013,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2027,9 +2027,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index 261a2b4d750c0b57c3c83a82ee41a2bb7d770d8a..8de4ad9f2120d22b78202981624abd1d
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2023,7 +2025,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2037,7 +2039,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          // Paper end
      }

--- a/patches/server/0844-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0844-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -31,10 +31,10 @@ index ba7023e7ca5d29375ff53c2951892138d155f69f..54e8f0f367645f3aa8af5b1cb69c39c0
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ac41bc23d2f7e16bbacdc9b33fcf6c0d706fa023..c28f7074a07051ea9aee5dc67dfef9193426a42d 100644
+index a31da19c22d9fca4f5ed2bedf4210f661089da3f..5fb475b3ccaa98861e2c817b37cd1740e5bfed8d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -202,6 +202,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -204,6 +204,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.getHandle().clip(new ClipContext(vec3d, vec3d1, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, null)).getType() == HitResult.Type.MISS;
      }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
d924635c PR-704: Add generateTree method with a predicate
32563aa0 PR-706: Add playSound with Entity as source

CraftBukkit Changes:
34704504 PR-987: Add generateTree method with a predicate
312d007f PR-990: Add playSound with Entity as source