### PR TITLE
Added method to check snapshot state of TileStates

### DIFF
--- a/patches/api/0074-API-to-get-a-BlockState-without-a-snapshot.patch
+++ b/patches/api/0074-API-to-get-a-BlockState-without-a-snapshot.patch
@@ -29,3 +29,26 @@ index ce1e1e6cc6740d568fbf859c7e2c014fab5a59cd..62ab55729e69bfac8eb4b40d877b945d
      /**
       * Returns the biome that this block resides in
       *
+diff --git a/src/main/java/org/bukkit/block/TileState.java b/src/main/java/org/bukkit/block/TileState.java
+index 3b10fcc13893403b29f0260b8605144679e89b82..5c8517c5bcae10161952c104b6a4ff7c713bcdbd 100644
+--- a/src/main/java/org/bukkit/block/TileState.java
++++ b/src/main/java/org/bukkit/block/TileState.java
+@@ -36,4 +36,18 @@ public interface TileState extends BlockState, PersistentDataHolder {
+     @NotNull
+     @Override
+     PersistentDataContainer getPersistentDataContainer();
++
++    // Paper start
++    /**
++     * Checks if this TileState is a snapshot or a live
++     * representation of the underlying tile entity.
++     * <p>
++     * NOTE: You may still have to call {@link BlockState#update()} on
++     * live representations to update any visuals on the block.
++     *
++     * @return true if this is a snapshot
++     * @see Block#getState(boolean)
++     */
++    boolean isSnapshot();
++    // Paper end
+ }

--- a/patches/server/0164-API-to-get-a-BlockState-without-a-snapshot.patch
+++ b/patches/server/0164-API-to-get-a-BlockState-without-a-snapshot.patch
@@ -69,7 +69,7 @@ index 52fc42050d5df0882586c8f4bb4890ef1dbf979e..ba8f9ffed49bf377be8b37532d4f2bdc
      public Biome getBiome() {
          return this.getWorld().getBiome(this.getX(), this.getY(), this.getZ());
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index 7629a51ec284cab0db7e9238027d6acfa4f3083c..c2c0b4bfab64394e55f2832e37e49bccb7e955ab 100644
+index 7629a51ec284cab0db7e9238027d6acfa4f3083c..a76cce199acdcecfdd8b998ec08974c2ed0751cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 @@ -10,15 +10,26 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
@@ -101,6 +101,18 @@ index 7629a51ec284cab0db7e9238027d6acfa4f3083c..c2c0b4bfab64394e55f2832e37e49bcc
      }
  
      public void refreshSnapshot() {
+@@ -105,4 +116,11 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
+     public PersistentDataContainer getPersistentDataContainer() {
+         return this.getSnapshot().persistentDataContainer;
+     }
++
++    // Paper start
++    @Override
++    public boolean isSnapshot() {
++        return !this.snapshotDisabled;
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
 index 51ea68c433c4d530f8404d3174c5a121ce808a96..93a8aeb5545c794ac425c35f8af52a443cd060ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java


### PR DESCRIPTION
Currently no way of differentiating between BlockStates that are live representations of block entities, or snapshots that require a call to BlockState#update in order for their underlying nms BlockEntities to be updated.