### PR TITLE
Fix setting unplaced furnace cook speed multiplier

### DIFF
--- a/patches/server/0267-Implement-furnace-cook-speed-multiplier-API.patch
+++ b/patches/server/0267-Implement-furnace-cook-speed-multiplier-API.patch
@@ -11,7 +11,7 @@ to the nearest Integer when updating its current cook time.
 Modified by: Eric Su <ericsu@alumni.usc.edu>
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..fd1fb954ef1eb2624939a5c5d0d2c258d3398ff2 100644
+index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..0584c37824bb37ff546df956b82ffaaaafd30bfe 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 @@ -73,6 +73,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
@@ -70,9 +70,9 @@ index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..fd1fb954ef1eb2624939a5c5d0d2c258
 -    private static int getTotalCookTime(Level world, RecipeType<? extends AbstractCookingRecipe> recipeType, Container inventory) {
 -        return (world != null) ? (Integer) world.getRecipeManager().getRecipeFor((RecipeType<AbstractCookingRecipe>) recipeType, inventory, world).map(AbstractCookingRecipe::getCookingTime).orElse(200) : 200; // CraftBukkit - SPIGOT-4302 // Eclipse fail
 +    // Paper begin - Expose this function so CraftFurnace can correctly scale the total cooking time to a new multiplier
-+    public static int getTotalCookTime(Level world, RecipeType<? extends AbstractCookingRecipe> recipeType, Container inventory, final double cookSpeedMultiplier) {
++    public static int getTotalCookTime(@Nullable Level world, RecipeType<? extends AbstractCookingRecipe> recipeType, Container inventory, final double cookSpeedMultiplier) {
 +        /* Scale the recipe's cooking time to the current cookSpeedMultiplier */
-+        int cookTime = world != null ? world.getRecipeManager().getRecipeFor((RecipeType<AbstractCookingRecipe>) recipeType, inventory, world).map(AbstractCookingRecipe::getCookingTime).orElse(200) : 200; // CraftBukkit - SPIGOT-4302 // Eclipse fail
++        int cookTime = (world != null ? world.getRecipeManager() : net.minecraft.server.MinecraftServer.getServer().getRecipeManager()).getRecipeFor(recipeType, inventory, world /* passing a null level here is safe. world is only used for map extending recipes which won't happen here */).map(AbstractCookingRecipe::getCookingTime).orElse(200); // CraftBukkit - SPIGOT-4302 // Eclipse fail
 +        return (int) Math.ceil (cookTime / cookSpeedMultiplier);
      }
 +    // Paper end
@@ -89,7 +89,7 @@ index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..fd1fb954ef1eb2624939a5c5d0d2c258
              this.setChanged();
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java b/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
-index a5022dc1e2376e655bfa00f7c3ffb63788fa54d6..501e064d6b9b1970699e2724d1911125aa5ac143 100644
+index a5022dc1e2376e655bfa00f7c3ffb63788fa54d6..b6ee228d256e8dec0bcbd816a6dbaf53b47e5c8d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
 @@ -58,4 +58,20 @@ public abstract class CraftFurnace<T extends AbstractFurnaceBlockEntity> extends
@@ -109,7 +109,7 @@ index a5022dc1e2376e655bfa00f7c3ffb63788fa54d6..501e064d6b9b1970699e2724d1911125
 +        com.google.common.base.Preconditions.checkArgument(multiplier <= 200, "Furnace speed multiplier cannot more than 200");
 +        T snapshot = this.getSnapshot();
 +        snapshot.cookSpeedMultiplier = multiplier;
-+        snapshot.cookingTotalTime = AbstractFurnaceBlockEntity.getTotalCookTime(this.world.getHandle(), snapshot.recipeType, snapshot, snapshot.cookSpeedMultiplier); // Update the snapshot's current total cook time to scale with the newly set multiplier
++        snapshot.cookingTotalTime = AbstractFurnaceBlockEntity.getTotalCookTime(this.isPlaced() ? this.world.getHandle() : null, snapshot.recipeType, snapshot, snapshot.cookSpeedMultiplier); // Update the snapshot's current total cook time to scale with the newly set multiplier
 +    }
 +    // Paper end
  }


### PR DESCRIPTION
Previously got an NPE since the `world` field on `CraftBlockState` is null for unplaced BlockStates (such as the ones from `BlockStateMeta#getBlockState`). 