### PR TITLE
Undeprecate Bed's tile entity interface

### DIFF
--- a/patches/api/0054-Fix-upstream-javadocs.patch
+++ b/patches/api/0054-Fix-upstream-javadocs.patch
@@ -46,6 +46,36 @@ index 5e4e6e83ac6b52493cb285561425bed53ffff2b6..2bfbb0ce71c8c5f8bd9bbd908488831b
       *
       * @return an array containing all previous players
       */
+diff --git a/src/main/java/org/bukkit/block/Bed.java b/src/main/java/org/bukkit/block/Bed.java
+index f9bd74f9ce6bd6650726e5a993f9b6e292cdc74d..f4c37ce1fe7aac3dde8485ee51fc8888ed56e79e 100644
+--- a/src/main/java/org/bukkit/block/Bed.java
++++ b/src/main/java/org/bukkit/block/Bed.java
+@@ -4,7 +4,22 @@ import org.bukkit.material.Colorable;
+ 
+ /**
+  * Represents a captured state of a bed.
+- * @deprecated does not provide useful information beyond the material itself
+  */
+-@Deprecated
+-public interface Bed extends TileState, Colorable { }
++// Paper start
++// @Deprecated
++public interface Bed extends TileState, Colorable {
++
++    @Override
++    @org.jetbrains.annotations.NotNull org.bukkit.DyeColor getColor();
++
++    /**
++     * <b>Unsupported</b>
++     *
++     * @throws UnsupportedOperationException not supported, set the block type
++     */
++    @Override
++    @org.jetbrains.annotations.Contract("_ -> fail")
++    @Deprecated(forRemoval = true)
++    void setColor(@org.bukkit.UndefinedNullability("not supported") org.bukkit.DyeColor color);
++// Paper end
++}
 diff --git a/src/main/java/org/bukkit/entity/ArmorStand.java b/src/main/java/org/bukkit/entity/ArmorStand.java
 index 91fc11dda99de506be83d40df8929bf7cd8e8d85..7dc631ebd009f5f5c3ac1699c3f3515c47609c05 100644
 --- a/src/main/java/org/bukkit/entity/ArmorStand.java


### PR DESCRIPTION
I think the ~~quickest~~simplest way currently to get the DyeColor of a bed, is
```java
if (block.getState() instanceof Bed bed) {
	DyeColor color = bed.getDyeColor()
}
```
which is just backed by a size 16 switch statement in CraftBed, but the method is still totally valid.

In addition, Beds **do still** have an associated tile entity, and I think it doesn't make sense to have it deprecated if it does in fact still exist. Take a look at the `Conduit` interface, which exists but has declared methods, and just extends `TileState`. 