### PR TITLE
Remove redundant getRemoteAddress that can cause an NPE

### DIFF
--- a/patches/server/0405-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0405-Load-Chunks-for-Login-Asynchronously.patch
@@ -96,7 +96,7 @@ index bb767f5b626225e70a8af273384bb74dbd21430d..301042e7a0d372a914f27ec0988dd938
              try {
                  ServerPlayer entityplayer1 = this.server.getPlayerList().getPlayerForLogin(this.gameProfile, s); // CraftBukkit - add player reference
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f096fbe48d8cc70e3749f48bc9972def42b0068d..f3926ee149e5e42d48e33759202d8297e3afd1d4 100644
+index f096fbe48d8cc70e3749f48bc9972def42b0068d..b84124abaca401406fbffc8bc6bd21245c303156 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -39,6 +39,7 @@ import net.minecraft.network.protocol.Packet;
@@ -136,7 +136,24 @@ index f096fbe48d8cc70e3749f48bc9972def42b0068d..f3926ee149e5e42d48e33759202d8297
          // CraftBukkit end
  
          if (nbttagcompound != null) {
-@@ -259,6 +266,52 @@ public abstract class PlayerList {
+@@ -213,11 +220,15 @@ public abstract class PlayerList {
+         if (nbttagcompound == null) player.fudgeSpawnLocation(worldserver1); // Paper - only move to spawn on first login, otherwise, stay where you are....
+ 
+         player.setLevel(worldserver1);
+-        String s1 = "local";
++        // Paper start - make s1 final
++        final String s1;
+ 
+         if (connection.getRemoteAddress() != null) {
+             s1 = connection.getRemoteAddress().toString();
++        } else {
++            s1 = "local";
+         }
++        // Paper end
+ 
+         // Spigot start - spawn location event
+         Player spawnPlayer = player.getBukkitEntity();
+@@ -259,6 +270,52 @@ public abstract class PlayerList {
          player.getRecipeBook().sendInitialRecipeBook(player);
          this.updateEntireScoreboard(worldserver1.getScoreboard(), player);
          this.server.invalidateStatus();
@@ -160,7 +177,7 @@ index f096fbe48d8cc70e3749f48bc9972def42b0068d..f3926ee149e5e42d48e33759202d8297
 +            playerconnection.playerJoinReady = () -> {
 +                postChunkLoadJoin(
 +                    player, finalWorldserver, connection, playerconnection,
-+                    nbttagcompound, connection.getRemoteAddress().toString(), lastKnownName
++                    nbttagcompound, s1, lastKnownName
 +                );
 +            };
 +        });
@@ -189,7 +206,7 @@ index f096fbe48d8cc70e3749f48bc9972def42b0068d..f3926ee149e5e42d48e33759202d8297
          TranslatableComponent chatmessage;
  
          if (player.getGameProfile().getName().equalsIgnoreCase(s)) {
-@@ -502,6 +555,7 @@ public abstract class PlayerList {
+@@ -502,6 +559,7 @@ public abstract class PlayerList {
  
      protected void save(ServerPlayer player) {
          if (!player.getBukkitEntity().isPersistent()) return; // CraftBukkit
@@ -197,7 +214,7 @@ index f096fbe48d8cc70e3749f48bc9972def42b0068d..f3926ee149e5e42d48e33759202d8297
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -529,7 +583,7 @@ public abstract class PlayerList {
+@@ -529,7 +587,7 @@ public abstract class PlayerList {
          }
  
          PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
@@ -206,7 +223,7 @@ index f096fbe48d8cc70e3749f48bc9972def42b0068d..f3926ee149e5e42d48e33759202d8297
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  
          if (server.isSameThread()) entityplayer.doTick(); // SPIGOT-924 // Paper - don't tick during emergency shutdowns (Watchdog)
-@@ -574,6 +628,13 @@ public abstract class PlayerList {
+@@ -574,6 +632,13 @@ public abstract class PlayerList {
              // this.advancements.remove(uuid);
              // CraftBukkit end
          }
@@ -220,7 +237,7 @@ index f096fbe48d8cc70e3749f48bc9972def42b0068d..f3926ee149e5e42d48e33759202d8297
  
          // CraftBukkit start
          // this.broadcastAll(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, new EntityPlayer[]{entityplayer}));
-@@ -591,7 +652,7 @@ public abstract class PlayerList {
+@@ -591,7 +656,7 @@ public abstract class PlayerList {
          this.cserver.getScoreboardManager().removePlayer(entityplayer.getBukkitEntity());
          // CraftBukkit end
  
@@ -229,7 +246,7 @@ index f096fbe48d8cc70e3749f48bc9972def42b0068d..f3926ee149e5e42d48e33759202d8297
      }
  
      // CraftBukkit start - Whole method, SocketAddress to LoginListener, added hostname to signature, return EntityPlayer
-@@ -610,6 +671,13 @@ public abstract class PlayerList {
+@@ -610,6 +675,13 @@ public abstract class PlayerList {
                  list.add(entityplayer);
              }
          }

--- a/patches/server/0456-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0456-incremental-chunk-and-player-saving.patch
@@ -165,7 +165,7 @@ index 626bcbc6dd013260c3f8b38a1d14e7ba35dc1e01..9e96b0465717bfa761289c255fd8d2f1
          for (int i = 0; i < this.futures.length(); ++i) {
              CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> completablefuture = (CompletableFuture) this.futures.get(i);
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index d358bca3aa0407ede113b4ca6243043f75202267..326a3b312d3446b813e325867f852e0cf6786945 100644
+index e35a47e0c8eebbad7154a1357a6b868887bc4a0c..cac9c9ede6024653f4ae83cbbdd9939f75ccad48 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -101,6 +101,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureMana
@@ -301,7 +301,7 @@ index b327bd2f48166a4a0c831b0209695fe5935f6a68..73b1018b0aca377ed0ff188e74040cef
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 083772c2f71851b5521f0ec5c1ecb872e357e8f7..be26327d31a3117cb7a5bf752c49c204738bc91e 100644
+index 0d70647bdd08371beaf476bd4eb5a45d985e498d..b27fb07aacb66259f640de5c5aa6849eb7e8cc9c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1058,6 +1058,37 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -355,10 +355,10 @@ index 6b0cb662d9163c360035e19c5faad59fc72af3c1..d2280b9e9f107dca890bc76f0c58e707
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      public ServerGamePacketListenerImpl connection;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f3926ee149e5e42d48e33759202d8297e3afd1d4..8c0faa9ee28943c7750dc33947e3f096b45a2026 100644
+index b84124abaca401406fbffc8bc6bd21245c303156..ae921bfe9634f0fe41ef18db8da7bf00d536b59a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -556,6 +556,7 @@ public abstract class PlayerList {
+@@ -560,6 +560,7 @@ public abstract class PlayerList {
      protected void save(ServerPlayer player) {
          if (!player.getBukkitEntity().isPersistent()) return; // CraftBukkit
          if (!player.didPlayerJoinEvent) return; // Paper - If we never fired PJE, we disconnected during login. Data has not changed, and additionally, our saved vehicle is not loaded! If we save now, we will lose our vehicle (CraftBukkit bug)
@@ -366,7 +366,7 @@ index f3926ee149e5e42d48e33759202d8297e3afd1d4..8c0faa9ee28943c7750dc33947e3f096
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -1158,10 +1159,22 @@ public abstract class PlayerList {
+@@ -1162,10 +1163,22 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {

--- a/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1128,7 +1128,7 @@ index 8770fe0db46b01e8b608637df4f1a669a3f4cdde..3c1698ba0d3bc412ab957777d9b5211d
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 135337afa09f090847d26268fcb8e542b1535ef3..b164b43d9d61398231451162cfb07d118f2045ba 100644
+index d06e43bfaf8d22e0374bb6ed2e62c65e15699ef5..373f1c600ecdf75293dbe5ff6ef676a0e35e2e80 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -175,6 +175,7 @@ public abstract class PlayerList {
@@ -1139,7 +1139,7 @@ index 135337afa09f090847d26268fcb8e542b1535ef3..b164b43d9d61398231451162cfb07d11
          ServerPlayer prev = pendingPlayers.put(player.getUUID(), player);// Paper
          if (prev != null) {
              disconnectPendingPlayer(prev);
-@@ -285,8 +286,8 @@ public abstract class PlayerList {
+@@ -289,8 +290,8 @@ public abstract class PlayerList {
          net.minecraft.server.level.ChunkMap playerChunkMap = worldserver1.getChunkSource().chunkMap;
          net.minecraft.server.level.DistanceManager distanceManager = playerChunkMap.distanceManager;
          distanceManager.addTicketAtLevel(net.minecraft.server.level.TicketType.LOGIN, pos, 31, pos.toLong());

--- a/patches/server/0476-Fix-SPIGOT-5989.patch
+++ b/patches/server/0476-Fix-SPIGOT-5989.patch
@@ -10,7 +10,7 @@ This fixes that by checking if the modified spawn location is
 still at a respawn anchor.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b164b43d9d61398231451162cfb07d118f2045ba..98c70121c53e42e3c9bc7403eed83335f567bc74 100644
+index 373f1c600ecdf75293dbe5ff6ef676a0e35e2e80..8ed4d4bc6d08c8339aba57b17f068c7bef22787c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -78,6 +78,7 @@ import net.minecraft.world.level.GameRules;
@@ -21,7 +21,7 @@ index b164b43d9d61398231451162cfb07d118f2045ba..98c70121c53e42e3c9bc7403eed83335
  import net.minecraft.world.level.block.state.BlockState;
  import net.minecraft.world.level.border.BorderChangeListener;
  import net.minecraft.world.level.border.WorldBorder;
-@@ -830,6 +831,7 @@ public abstract class PlayerList {
+@@ -834,6 +835,7 @@ public abstract class PlayerList {
          // Paper start
          boolean isBedSpawn = false;
          boolean isRespawn = false;
@@ -29,7 +29,7 @@ index b164b43d9d61398231451162cfb07d118f2045ba..98c70121c53e42e3c9bc7403eed83335
          // Paper end
  
          // CraftBukkit start - fire PlayerRespawnEvent
-@@ -840,7 +842,7 @@ public abstract class PlayerList {
+@@ -844,7 +846,7 @@ public abstract class PlayerList {
                  Optional optional;
  
                  if (blockposition != null) {
@@ -38,7 +38,7 @@ index b164b43d9d61398231451162cfb07d118f2045ba..98c70121c53e42e3c9bc7403eed83335
                  } else {
                      optional = Optional.empty();
                  }
-@@ -884,7 +886,12 @@ public abstract class PlayerList {
+@@ -888,7 +890,12 @@ public abstract class PlayerList {
              }
              // Spigot End
  
@@ -52,7 +52,7 @@ index b164b43d9d61398231451162cfb07d118f2045ba..98c70121c53e42e3c9bc7403eed83335
              if (!flag) entityplayer.reset(); // SPIGOT-4785
              isRespawn = true; // Paper
          } else {
-@@ -922,8 +929,12 @@ public abstract class PlayerList {
+@@ -926,8 +933,12 @@ public abstract class PlayerList {
          }
          // entityplayer1.initInventoryMenu();
          entityplayer1.setHealth(entityplayer1.getHealth());

--- a/patches/server/0531-Add-API-for-quit-reason.patch
+++ b/patches/server/0531-Add-API-for-quit-reason.patch
@@ -49,10 +49,10 @@ index da130b7f0da73eb9868539911ba3157b88fc7199..c321f22af679cafd00be09a9212346b5
              this.connection.disconnect(ichatbasecomponent);
          });
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ba46e9eafab188455d49f1a555e38b0ebe66fcf9..3428f3014d9b8e9422a9f586268f5e82dcf1e33f 100644
+index 35cf9c8235534a5c59065718ff57873f9c00bfdc..e5ed9784b0e7d208604b41f51f1adf9c8f50fe08 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -596,7 +596,7 @@ public abstract class PlayerList {
+@@ -600,7 +600,7 @@ public abstract class PlayerList {
              entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  

--- a/patches/server/0534-Expose-world-spawn-angle.patch
+++ b/patches/server/0534-Expose-world-spawn-angle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose world spawn angle
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3428f3014d9b8e9422a9f586268f5e82dcf1e33f..ba0596c0d6340492f2d4b017a87459450ffdd77b 100644
+index e5ed9784b0e7d208604b41f51f1adf9c8f50fe08..8ce5f463f16857b5862b6e0a77c63d8118b34d67 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -874,7 +874,7 @@ public abstract class PlayerList {
+@@ -878,7 +878,7 @@ public abstract class PlayerList {
              if (location == null) {
                  worldserver1 = this.server.getLevel(Level.OVERWORLD);
                  blockposition = entityplayer1.getSpawnPoint(worldserver1);

--- a/patches/server/0576-Fix-villager-boat-exploit.patch
+++ b/patches/server/0576-Fix-villager-boat-exploit.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix villager boat exploit
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ba0596c0d6340492f2d4b017a87459450ffdd77b..201f36b0f8ae391b2efbad5cc38f115537a761a2 100644
+index 8ce5f463f16857b5862b6e0a77c63d8118b34d67..f4e74b0bc3d192d7f7c2bc1dbfef92a28863a57c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -621,6 +621,14 @@ public abstract class PlayerList {
+@@ -625,6 +625,14 @@ public abstract class PlayerList {
                  PlayerList.LOGGER.debug("Removing player mount");
                  entityplayer.stopRiding();
                  entity.getPassengersAndSelf().forEach((entity1) -> {

--- a/patches/server/0577-Add-sendOpLevel-API.patch
+++ b/patches/server/0577-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 201f36b0f8ae391b2efbad5cc38f115537a761a2..0052a9c5d19db44331bb7ee93544d783b471e70a 100644
+index f4e74b0bc3d192d7f7c2bc1dbfef92a28863a57c..b7f3be857d9ffb166e99f20753dbc671bb3b5451 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1119,6 +1119,11 @@ public abstract class PlayerList {
+@@ -1123,6 +1123,11 @@ public abstract class PlayerList {
      }
  
      private void sendPlayerPermissionLevel(ServerPlayer player, int permissionLevel) {
@@ -20,7 +20,7 @@ index 201f36b0f8ae391b2efbad5cc38f115537a761a2..0052a9c5d19db44331bb7ee93544d783
          if (player.connection != null) {
              byte b0;
  
-@@ -1133,8 +1138,10 @@ public abstract class PlayerList {
+@@ -1137,8 +1142,10 @@ public abstract class PlayerList {
              player.connection.send(new ClientboundEntityEventPacket(player, b0));
          }
  

--- a/patches/server/0618-Drop-carried-item-when-player-has-disconnected.patch
+++ b/patches/server/0618-Drop-carried-item-when-player-has-disconnected.patch
@@ -7,10 +7,10 @@ Fixes disappearance of held items, when a player gets disconnected and PlayerDro
 Closes #5036
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index bcdbdc648a76d2c57f4b0d86ae6f577fbc4be3d8..8e80783cd72eb7a07806f89341aff52a370ed87a 100644
+index 774db05fa19b1fc1d13481010e3135eba9593a3b..d591492c50ba8c4158199d4ff848ab5072c5d86d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -614,6 +614,14 @@ public abstract class PlayerList {
+@@ -618,6 +618,14 @@ public abstract class PlayerList {
          }
          // Paper end
  

--- a/patches/server/0640-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
+++ b/patches/server/0640-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix anchor respawn acting as a bed respawn from the end
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 8e80783cd72eb7a07806f89341aff52a370ed87a..d7e6baab6fd48e4126e1c333d997a8673b4c0139 100644
+index d591492c50ba8c4158199d4ff848ab5072c5d86d..b5c9c959de02430aee46bb8a1e55cef8fc6f69bd 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -847,6 +847,7 @@ public abstract class PlayerList {
+@@ -851,6 +851,7 @@ public abstract class PlayerList {
  
          // Paper start
          boolean isBedSpawn = false;
@@ -17,7 +17,7 @@ index 8e80783cd72eb7a07806f89341aff52a370ed87a..d7e6baab6fd48e4126e1c333d997a867
          boolean isRespawn = false;
          boolean isLocAltered = false; // Paper - Fix SPIGOT-5989
          // Paper end
-@@ -867,6 +868,7 @@ public abstract class PlayerList {
+@@ -871,6 +872,7 @@ public abstract class PlayerList {
                  if (optional.isPresent()) {
                      BlockState iblockdata = worldserver1.getBlockState(blockposition);
                      boolean flag3 = iblockdata.is(Blocks.RESPAWN_ANCHOR);
@@ -25,7 +25,7 @@ index 8e80783cd72eb7a07806f89341aff52a370ed87a..d7e6baab6fd48e4126e1c333d997a867
                      Vec3 vec3d = (Vec3) optional.get();
                      float f1;
  
-@@ -895,7 +897,7 @@ public abstract class PlayerList {
+@@ -899,7 +901,7 @@ public abstract class PlayerList {
              }
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();

--- a/patches/server/0642-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/server/0642-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -18,10 +18,10 @@ index e3d62889d7a985289d20ada6b42cc008aee7f353..9f93ce18a0406321462fb5e4c4dbfab7
                  } else {
                      if (this.player.getHealth() > 0.0F) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index d7e6baab6fd48e4126e1c333d997a8673b4c0139..ad7e4ec5ca3f2f874c916d7ee80f5b2b2ae03bf8 100644
+index b5c9c959de02430aee46bb8a1e55cef8fc6f69bd..3900e885988bc1f2865b95f825cba34d04919731 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -806,6 +806,12 @@ public abstract class PlayerList {
+@@ -810,6 +810,12 @@ public abstract class PlayerList {
      }
  
      public ServerPlayer respawn(ServerPlayer entityplayer, ServerLevel worldserver, boolean flag, Location location, boolean avoidSuffocation) {
@@ -34,7 +34,7 @@ index d7e6baab6fd48e4126e1c333d997a8673b4c0139..ad7e4ec5ca3f2f874c916d7ee80f5b2b
          entityplayer.stopRiding(); // CraftBukkit
          this.players.remove(entityplayer);
          this.playersByName.remove(entityplayer.getScoreboardName().toLowerCase(java.util.Locale.ROOT)); // Spigot
-@@ -897,7 +903,7 @@ public abstract class PlayerList {
+@@ -901,7 +907,7 @@ public abstract class PlayerList {
              }
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();

--- a/patches/server/0666-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0666-Add-PlayerKickEvent-causes.patch
@@ -318,10 +318,10 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
          }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ad7e4ec5ca3f2f874c916d7ee80f5b2b2ae03bf8..9b55968cb1db5f77a8e858e2a7aa66d518ddd00a 100644
+index 3900e885988bc1f2865b95f825cba34d04919731..cad8a98951795706b89ff3ea3985033f511da58b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -715,7 +715,7 @@ public abstract class PlayerList {
+@@ -719,7 +719,7 @@ public abstract class PlayerList {
          while (iterator.hasNext()) {
              entityplayer = (ServerPlayer) iterator.next();
              this.save(entityplayer); // CraftBukkit - Force the player's inventory to be saved
@@ -330,7 +330,7 @@ index ad7e4ec5ca3f2f874c916d7ee80f5b2b2ae03bf8..9b55968cb1db5f77a8e858e2a7aa66d5
          }
  
          // Instead of kicking then returning, we need to store the kick reason
-@@ -1346,8 +1346,8 @@ public abstract class PlayerList {
+@@ -1350,8 +1350,8 @@ public abstract class PlayerList {
          // Paper end
          // CraftBukkit start - disconnect safely
          for (ServerPlayer player : this.players) {

--- a/patches/server/0688-Fixes-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0688-Fixes-kick-event-leave-message-not-being-sent.patch
@@ -39,10 +39,10 @@ index a9f56903e7ef18dfa3c640510334dbf50110cf26..afed4675ebedb13bb313815580fe14c0
              this.server.getPlayerList().broadcastMessage(PaperAdventure.asVanilla(quitMessage), ChatType.SYSTEM, Util.NIL_UUID);
              // Paper end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 9b55968cb1db5f77a8e858e2a7aa66d518ddd00a..656c0235dfb8e7335fb7be4afc727eefb2a4188e 100644
+index cad8a98951795706b89ff3ea3985033f511da58b..5be363282ba6046c38794a3de3af845968d26296 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -587,6 +587,11 @@ public abstract class PlayerList {
+@@ -591,6 +591,11 @@ public abstract class PlayerList {
      }
  
      public net.kyori.adventure.text.Component remove(ServerPlayer entityplayer) { // Paper - return Component
@@ -54,7 +54,7 @@ index 9b55968cb1db5f77a8e858e2a7aa66d518ddd00a..656c0235dfb8e7335fb7be4afc727eef
          ServerLevel worldserver = entityplayer.getLevel();
  
          entityplayer.awardStat(Stats.LEAVE_GAME);
-@@ -597,7 +602,7 @@ public abstract class PlayerList {
+@@ -601,7 +606,7 @@ public abstract class PlayerList {
              entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  

--- a/patches/server/0702-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0702-Add-PlayerSetSpawnEvent.patch
@@ -67,10 +67,10 @@ index e87d4071604a642c0a08129b469e707a609bf83d..6c0c1f7f4f3407164ee39abf4c87ffcc
  
              this.respawnPosition = pos;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 656c0235dfb8e7335fb7be4afc727eefb2a4188e..81650be96a25f276c4df958dc4f339c75b39211e 100644
+index 5be363282ba6046c38794a3de3af845968d26296..8feadac9d9d4fb6c1ae290ca2ab2499b707bd56a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -891,7 +891,7 @@ public abstract class PlayerList {
+@@ -895,7 +895,7 @@ public abstract class PlayerList {
                          f1 = (float) Mth.wrapDegrees(Mth.atan2(vec3d1.z, vec3d1.x) * 57.2957763671875D - 90.0D);
                      }
  

--- a/patches/server/0798-Add-config-option-for-logging-player-ip-addresses.patch
+++ b/patches/server/0798-Add-config-option-for-logging-player-ip-addresses.patch
@@ -81,24 +81,15 @@ index d2dd8b802ecea7fd2efe5f07fcef65c26e1adfbc..33a29890435d6065a2cc4f8e8bf8209c
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 81650be96a25f276c4df958dc4f339c75b39211e..25b787d1b22e495fb6756e4ee909776ed8699492 100644
+index 8feadac9d9d4fb6c1ae290ca2ab2499b707bd56a..80888d5adf7d4377e17e6f530f35053cfcc9eed4 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -237,7 +237,7 @@ public abstract class PlayerList {
-         String s1 = "local";
+@@ -238,7 +238,7 @@ public abstract class PlayerList {
+         final String s1;
  
          if (connection.getRemoteAddress() != null) {
 -            s1 = connection.getRemoteAddress().toString();
 +            s1 = com.destroystokyo.paper.PaperConfig.logPlayerIpAddresses ? connection.getRemoteAddress().toString() : "<ip address withheld>"; // Paper
+         } else {
+             s1 = "local";
          }
- 
-         // Spigot start - spawn location event
-@@ -300,7 +300,7 @@ public abstract class PlayerList {
-             playerconnection.playerJoinReady = () -> {
-                 postChunkLoadJoin(
-                     player, finalWorldserver, connection, playerconnection,
--                    nbttagcompound, connection.getRemoteAddress().toString(), lastKnownName
-+                    nbttagcompound, com.destroystokyo.paper.PaperConfig.logPlayerIpAddresses ? connection.getRemoteAddress().toString() : "<ip address withheld>", lastKnownName // Paper
-                 );
-             };
-         });

--- a/patches/server/0818-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0818-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -942,10 +942,10 @@ index d626af3879e558cdfbe95b1e70e0b32e0f4d1170..7b23535a680d2a8534dcb8dd87770f66
              }
          }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 25b787d1b22e495fb6756e4ee909776ed8699492..042be2cf60a9d01698808d84f2e537a5eb952079 100644
+index 80888d5adf7d4377e17e6f530f35053cfcc9eed4..fe9810c3b908339ca050ed832c2e67d62cc97b0b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -932,7 +932,7 @@ public abstract class PlayerList {
+@@ -936,7 +936,7 @@ public abstract class PlayerList {
          // CraftBukkit end
  
          worldserver1.getChunkSource().addRegionTicket(net.minecraft.server.level.TicketType.POST_TELEPORT, new net.minecraft.world.level.ChunkPos(location.getBlockX() >> 4, location.getBlockZ() >> 4), 1, entityplayer.getId()); // Paper
@@ -955,7 +955,7 @@ index 25b787d1b22e495fb6756e4ee909776ed8699492..042be2cf60a9d01698808d84f2e537a5
          }
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e2c35ace138d7a6c41e7f07e9759f684b7152b71..9bb44918af119d9afae4a0a050c6a5381f028364 100644
+index 3638bdfdeb2b254e8378672f3ec897f3e8e1e5b2..f1ebd2d3a4efb04a4a85b3bbd0baff9676f19702 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1076,9 +1076,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i

--- a/patches/server/0841-Validate-usernames.patch
+++ b/patches/server/0841-Validate-usernames.patch
@@ -65,10 +65,10 @@ index 33a29890435d6065a2cc4f8e8bf8209c01d5d114..462d8c36166c63a4dc8fa74ac7f82859
              this.state = ServerLoginPacketListenerImpl.State.KEY;
              this.connection.send(new ClientboundHelloPacket("", this.server.getKeyPair().getPublic().getEncoded(), this.nonce));
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 042be2cf60a9d01698808d84f2e537a5eb952079..f55f8c0b2c748a5442199c0a7f772b02ed533753 100644
+index fe9810c3b908339ca050ed832c2e67d62cc97b0b..cd08f9b16c065be8f0eacaeba51d3e72d332daf9 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -703,7 +703,7 @@ public abstract class PlayerList {
+@@ -707,7 +707,7 @@ public abstract class PlayerList {
  
          for (int i = 0; i < this.players.size(); ++i) {
              entityplayer = (ServerPlayer) this.players.get(i);


### PR DESCRIPTION
Accidentally closed #6892, see it for the discussion that has taken place.

The original code for getting a player's ip address is as follows:
```java
String s1 = "local";

if (connection.getRemoteAddress() != null) {
    s1 = connection.getRemoteAddress().toString();
}
```

However, this s1 variable became unused and the following was used instead:
```java
postChunkLoadJoin( ... connection.getRemoteAddress().toString() ... )
```

This new code does not check if the `connection.getRemoteAddress()` is null, and throws a NullPointerException when it is null.

I have fixed this by replacing the new code with the original s1 variable. However, postChunkLoadJoin is run inside a lambda function, thus s1 was made final.