### PR TITLE
Add configurable stronghold seed

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -298,3 +298,6 @@ public net.minecraft.world.entity.player.Player checkRidingStatistics(DDD)V
 
 # Fix NotePlayEvent
 public org.bukkit.craftbukkit.block.data.CraftBlockData toNMS(Ljava/lang/Enum;Ljava/lang/Class;)Ljava/lang/Enum;
+
+# Stronghold seed configuration
+public-f net.minecraft.world.level.chunk.ChunkGenerator strongholdSeed

--- a/patches/server/0858-Add-config-for-stronghold-seed.patch
+++ b/patches/server/0858-Add-config-for-stronghold-seed.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 13 Jan 2022 23:05:53 -0800
+Subject: [PATCH] Add config for stronghold seed
+
+
+diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
+index 3f0d83a90e1319baa0622b708b3ba940d3cee64a..0009af6e9c6a48a63736ada2653665f74ac396ca 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
++++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
+@@ -197,6 +197,7 @@ public abstract class ChunkGenerator implements BiomeManager.NoiseBiomeSource {
+         skipExistingChunks = event.shouldFindUnexplored();
+         structureFeature = StructureFeature.STRUCTURES_REGISTRY.get(event.getType().getName());
+         // Paper end
++        this.updateStructureSettings(world, this.settings); // Spigot // Paper - move up to include strongholds
+         if (structureFeature == StructureFeature.STRONGHOLD) {
+             this.generateStrongholds();
+             BlockPos blockposition1 = null;
+@@ -221,7 +222,6 @@ public abstract class ChunkGenerator implements BiomeManager.NoiseBiomeSource {
+ 
+             return blockposition1;
+         } else {
+-            this.updateStructureSettings(world, this.settings); // Spigot
+             StructureFeatureConfiguration structuresettingsfeature = this.settings.getConfig(structureFeature);
+             ImmutableMultimap<ConfiguredStructureFeature<?, ?>, ResourceKey<Biome>> immutablemultimap = this.settings.structures(structureFeature);
+ 
+@@ -528,6 +528,7 @@ public abstract class ChunkGenerator implements BiomeManager.NoiseBiomeSource {
+             java.util.Map<StructureFeature<?>, StructureFeatureConfiguration> original = settings.structureConfig();
+             java.util.Map<StructureFeature<?>, StructureFeatureConfiguration> updated = new java.util.HashMap<>();
+             org.spigotmc.SpigotWorldConfig conf = world.spigotConfig;
++            this.strongholdSeed = Objects.requireNonNullElse(conf.strongholdSeed, this.strongholdSeed); // Paper
+ 
+             for (java.util.Map.Entry<StructureFeature<?>, StructureFeatureConfiguration> entry : original.entrySet()) {
+                 String name = Registry.STRUCTURE_FEATURE.getKey(entry.getKey()).getPath();
+diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+index a7a0b94ed22e6e3b9063a17d086f96140c6e95cf..463010859c604812091399e6068e5c2e2daa99ce 100644
+--- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
++++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+@@ -365,6 +365,7 @@ public class SpigotWorldConfig
+     public int mansionSeed;
+     public int fossilSeed;
+     public int portalSeed;
++    public Long strongholdSeed; // Paper
+     private void initWorldGenSeeds()
+     {
+         this.villageSeed = this.getInt( "seed-village", 10387312 );
+@@ -383,6 +384,10 @@ public class SpigotWorldConfig
+         this.mansionSeed = this.getInt( "seed-mansion", 10387319 );
+         this.fossilSeed = this.getInt( "seed-fossil", 14357921 );
+         this.portalSeed = this.getInt( "seed-portal", 34222645 );
++        // Paper start
++        final String strongholdSeedString = this.getString("seed-stronghold", "default");
++        this.strongholdSeed = org.apache.commons.lang3.math.NumberUtils.isParsable(strongholdSeedString) ? Long.parseLong(strongholdSeedString) : null;
++        // Paper end
+         this.log( "Custom Map Seeds:  Village: " + this.villageSeed + " Desert: " + this.desertSeed + " Igloo: " + this.iglooSeed + " Jungle: " + this.jungleSeed + " Swamp: " + this.swampSeed + " Monument: " + this.monumentSeed
+                 + " Ocean: " + this.oceanSeed + " Shipwreck: " + this.shipwreckSeed + " End City: " + this.endCitySeed + " Slime: " + this.slimeSeed + " Bastion: " + this.bastionSeed + " Fortress: " + this.fortressSeed + " Mansion: " + this.mansionSeed + " Fossil: " + this.fossilSeed + " Portal: " + this.portalSeed );
+     }


### PR DESCRIPTION
Part of https://github.com/PaperMC/Paper/issues/6978

Seems to work with basic testing, used https://www.chunkbase.com/apps/stronghold-finder to find a stronghold, stopped server, deleted region files, set stronghold seed in spigot.yml, started server, re-joined and the stronghold was gone. stopped, deleted region files again, set the seed to `"default"` and then rejoined, and the stronghold generated.