### PR TITLE
Fix StoredEnchants reordering inconsistently

### DIFF
--- a/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
@@ -202,8 +202,28 @@ index e88df908377450964ae5b6ff97ee97bd2f09c05f..ba70ac49222c517a38e20e86cee1fd38
      }
  
      static Map<Enchantment, Integer> getEnchantments(net.minecraft.world.item.ItemStack item) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEnchantedBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEnchantedBook.java
+index ef6902466cce10d699d1541c968b0709654c57d0..2070f90eb4d9fab723c9da906e1fd72de21d896f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEnchantedBook.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaEnchantedBook.java
+@@ -39,13 +39,13 @@ class CraftMetaEnchantedBook extends CraftMetaItem implements EnchantmentStorage
+             return;
+         }
+ 
+-        this.enchantments = buildEnchantments(tag, CraftMetaEnchantedBook.STORED_ENCHANTMENTS);
++        this.enchantments = buildEnchantments(tag, CraftMetaEnchantedBook.STORED_ENCHANTMENTS, LinkedHashMap::new); // Paper
+     }
+ 
+     CraftMetaEnchantedBook(Map<String, Object> map) {
+         super(map);
+ 
+-        this.enchantments = buildEnchantments(map, CraftMetaEnchantedBook.STORED_ENCHANTMENTS);
++        this.enchantments = buildEnchantments(map, CraftMetaEnchantedBook.STORED_ENCHANTMENTS, LinkedHashMap::new); // Paper
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index b42527e0307811a3697f6e7b0afc9a10527acbaf..20d10e5b54edaf1c5212bbc33b8cd1aa426fa826 100644
+index b42527e0307811a3697f6e7b0afc9a10527acbaf..c22851932bc537e85f7ecc2aaab439c1b1e3e137 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
@@ -257,39 +277,50 @@ index b42527e0307811a3697f6e7b0afc9a10527acbaf..20d10e5b54edaf1c5212bbc33b8cd1aa
          }
  
          if (meta.hasAttributeModifiers()) {
-@@ -387,13 +390,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -387,13 +390,19 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
 -    static Map<Enchantment, Integer> buildEnchantments(CompoundTag tag, ItemMetaKey key) {
-+    static EnchantmentMap buildEnchantments(CompoundTag tag, ItemMetaKey key) { // Paper
++    // Paper start
++    static EnchantmentMap buildEnchantments(CompoundTag tag, ItemMetaKey key) {
++        return buildEnchantments(tag, key, ignored -> new EnchantmentMap());
++    }
++
++    static <M extends Map<Enchantment, Integer>> M buildEnchantments(CompoundTag tag, ItemMetaKey key, java.util.function.Function<Integer, M> mapCreator) {
++        // Paper end
          if (!tag.contains(key.NBT)) {
              return null;
          }
  
          ListTag ench = tag.getList(key.NBT, CraftMagicNumbers.NBT.TAG_COMPOUND);
 -        Map<Enchantment, Integer> enchantments = new LinkedHashMap<Enchantment, Integer>(ench.size());
-+        EnchantmentMap enchantments = new EnchantmentMap(); // Paper
++        M enchantments = mapCreator.apply(ench.size()); // Paper
  
          for (int i = 0; i < ench.size(); i++) {
              String id = ((CompoundTag) ench.get(i)).getString(ENCHANTMENTS_ID.NBT);
-@@ -546,13 +549,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -546,13 +555,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
 -    static Map<Enchantment, Integer> buildEnchantments(Map<String, Object> map, ItemMetaKey key) {
-+    static EnchantmentMap buildEnchantments(Map<String, Object> map, ItemMetaKey key) { // Paper
++    // Paper start
++    static EnchantmentMap buildEnchantments(Map<String, Object> map, ItemMetaKey key) {
++        return buildEnchantments(map, key, ignored -> new EnchantmentMap());
++    }
++    static <M extends Map<Enchantment, Integer>> M buildEnchantments(Map<String, Object> map, ItemMetaKey key, java.util.function.Function<Integer, M> mapCreator) {
++        // Paper end
          Map<?, ?> ench = SerializableMeta.getObject(Map.class, map, key.BUKKIT, true);
          if (ench == null) {
              return null;
          }
  
 -        Map<Enchantment, Integer> enchantments = new LinkedHashMap<Enchantment, Integer>(ench.size());
-+        EnchantmentMap enchantments = new EnchantmentMap(); // Paper
++        M enchantments = mapCreator.apply(ench.size()); // Paper
          for (Map.Entry<?, ?> entry : ench.entrySet()) {
              // Doctor older enchants
              String enchantKey = entry.getKey().toString();
-@@ -828,14 +831,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -828,14 +842,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public Map<Enchantment, Integer> getEnchants() {
@@ -306,7 +337,7 @@ index b42527e0307811a3697f6e7b0afc9a10527acbaf..20d10e5b54edaf1c5212bbc33b8cd1aa
          }
  
          if (ignoreRestrictions || level >= ench.getStartLevel() && level <= ench.getMaxLevel()) {
-@@ -1223,7 +1226,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1223,7 +1237,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.customModelData = this.customModelData;
              clone.blockData = this.blockData;
              if (this.enchantments != null) {
@@ -315,7 +346,7 @@ index b42527e0307811a3697f6e7b0afc9a10527acbaf..20d10e5b54edaf1c5212bbc33b8cd1aa
              }
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
-@@ -1458,4 +1461,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1458,4 +1472,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              return CraftMetaItem.HANDLED_TAGS;
          }
      }

--- a/patches/server/0173-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0173-Add-ArmorStand-Item-Meta.patch
@@ -258,7 +258,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b
 index 20d10e5b54edaf1c5212bbc33b8cd1aa426fa826..d5df6fc244ab82b94196be9c436ba77020716df2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1452,6 +1452,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1463,6 +1463,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaCrossbow.CHARGED.NBT,
                          CraftMetaCrossbow.CHARGED_PROJECTILES.NBT,
                          CraftMetaSuspiciousStew.EFFECTS.NBT,

--- a/patches/server/0259-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
+++ b/patches/server/0259-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement an API for CanPlaceOn and CanDestroy NBT values
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcdad8cd13b1 100644
+index 0174cbfeb49b646fda788fc974effb3d8c5008f4..d84b2e12605a1b1e60cb338798715215ca0677fd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -83,6 +83,12 @@ import org.bukkit.persistence.PersistentDataContainer;
@@ -91,7 +91,7 @@ index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcda
  
          Set<String> keys = tag.getAllKeys();
          for (String key : keys) {
-@@ -519,6 +567,34 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -525,6 +573,34 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              this.setDamage(damage);
          }
  
@@ -126,7 +126,7 @@ index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcda
          String internal = SerializableMeta.getString(map, "internal", true);
          if (internal != null) {
              ByteArrayInputStream buf = new ByteArrayInputStream(Base64.getDecoder().decode(internal));
-@@ -647,6 +723,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -658,6 +734,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          if (this.hasDamage()) {
              itemTag.putInt(DAMAGE.NBT, damage);
          }
@@ -150,7 +150,7 @@ index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcda
  
          for (Map.Entry<String, Tag> e : this.unhandledTags.entrySet()) {
              itemTag.put(e.getKey(), e.getValue());
-@@ -663,6 +756,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -674,6 +767,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -172,7 +172,7 @@ index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcda
      ListTag createStringList(List<String> list) {
          if (list == null) {
              return null;
-@@ -746,7 +854,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -757,7 +865,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
@@ -181,7 +181,7 @@ index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcda
      }
  
      // Paper start
-@@ -1177,7 +1285,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1188,7 +1296,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hideFlag == that.hideFlag)
                  && (this.isUnbreakable() == that.isUnbreakable())
                  && (this.hasDamage() ? that.hasDamage() && this.damage == that.damage : !that.hasDamage())
@@ -194,7 +194,7 @@ index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcda
      }
  
      /**
-@@ -1212,6 +1324,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1223,6 +1335,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
          hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
          hash = 61 * hash + this.version;
@@ -205,7 +205,7 @@ index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcda
          return hash;
      }
  
-@@ -1236,6 +1352,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1247,6 +1363,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.unbreakable = this.unbreakable;
              clone.damage = this.damage;
              clone.version = this.version;
@@ -220,7 +220,7 @@ index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcda
              return clone;
          } catch (CloneNotSupportedException e) {
              throw new Error(e);
-@@ -1293,6 +1417,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1304,6 +1428,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              builder.put(DAMAGE.BUKKIT, damage);
          }
  
@@ -244,7 +244,7 @@ index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcda
          final Map<String, Tag> internalTags = new HashMap<String, Tag>(this.unhandledTags);
          this.serializeInternal(internalTags);
          if (!internalTags.isEmpty()) {
-@@ -1459,6 +1600,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1470,6 +1611,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaArmorStand.SHOW_ARMS.NBT,
                          CraftMetaArmorStand.SMALL.NBT,
                          CraftMetaArmorStand.MARKER.NBT,
@@ -253,7 +253,7 @@ index d5df6fc244ab82b94196be9c436ba77020716df2..ac779f3cedb7ddd74f39a18f08afbcda
                          // Paper end
                          CraftMetaCompass.LODESTONE_DIMENSION.NBT,
                          CraftMetaCompass.LODESTONE_POS.NBT,
-@@ -1487,4 +1630,148 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1498,4 +1641,148 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
      // Paper end
  

--- a/patches/server/0456-Convert-legacy-attributes-in-Item-Meta.patch
+++ b/patches/server/0456-Convert-legacy-attributes-in-Item-Meta.patch
@@ -33,7 +33,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b
 index ac779f3cedb7ddd74f39a18f08afbcdad8cd13b1..389a0af8562bf7de6b8e52015286da06aef2f428 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -480,7 +480,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -486,7 +486,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
              AttributeModifier attribMod = CraftAttributeInstance.convert(nmsModifier);
  

--- a/patches/server/0459-Support-components-in-ItemMeta.patch
+++ b/patches/server/0459-Support-components-in-ItemMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 389a0af8562bf7de6b8e52015286da06aef2f428..24588933984cea75e983752ebd0c5643ff1e7846 100644
+index d2fdd613d36d15a8711785a42939b62d8470b416..68bff13c9b3761f15982803d93d4d3fc877131bb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -874,11 +874,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -885,11 +885,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return CraftChatMessage.fromJSONComponent(displayName);
      }
  
@@ -32,7 +32,7 @@ index 389a0af8562bf7de6b8e52015286da06aef2f428..24588933984cea75e983752ebd0c5643
      @Override
      public boolean hasDisplayName() {
          return this.displayName != null;
-@@ -1021,6 +1033,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1032,6 +1044,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromJSONComponent));
      }
  
@@ -47,7 +47,7 @@ index 389a0af8562bf7de6b8e52015286da06aef2f428..24588933984cea75e983752ebd0c5643
      @Override
      public void setLore(List<String> lore) {
          if (lore == null || lore.isEmpty()) {
-@@ -1035,6 +1055,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1046,6 +1066,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -69,7 +69,7 @@ index 389a0af8562bf7de6b8e52015286da06aef2f428..24588933984cea75e983752ebd0c5643
      @Override
      public boolean hasCustomModelData() {
          return this.customModelData != null;
-@@ -1502,6 +1537,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1513,6 +1548,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Object object : addFrom) {

--- a/patches/server/0895-Fix-NPE-for-BlockDataMeta-getBlockData.patch
+++ b/patches/server/0895-Fix-NPE-for-BlockDataMeta-getBlockData.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix NPE for BlockDataMeta#getBlockData
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 1fe46049cc33c24db04fbfcde36ab275c03177bf..5607dc10dc1c9d2dbf4e3007890e5e89a175605e 100644
+index 0b0e323bceea8a7f2197c61c98aefc8ed6d1ec24..c552b5f9fa32adf4f148eeaf932790333967890f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1093,7 +1093,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1104,7 +1104,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public BlockData getBlockData(Material material) {


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/6437

Tested using the reproduction steps outlined in above issue.

I think its better to not reorder stored enchants, as the order does have an effect on anvil usage. It's also a smaller diff, less to maintain, and will change 0 existing items, only newly created ones as LinkedHashSets keep the order from the EnchantmentMap but don't change it.