### PR TITLE
Sync offhand slot in menus

### DIFF
--- a/patches/server/0950-Sync-offhand-slot-in-menus.patch
+++ b/patches/server/0950-Sync-offhand-slot-in-menus.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 14 Jan 2022 10:20:40 -0800
+Subject: [PATCH] Sync offhand slot in menus
+
+Menus don't add slots for the offhand, so on sendAllDataToRemote calls the
+offhand slot isn't sent. This is not correct because you *can* put stuff into the offhand
+by pressing the offhand swap item
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 3b122f521c166253f20d233c0fcebdede6660be5..9c9b4d7e0637348a94befce9377fdb69c1239694 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -287,6 +287,13 @@ public class ServerPlayer extends Player {
+ 
+             }
+ 
++            // Paper start
++            @Override
++            public void sendOffHandSlotChange() {
++                ServerPlayer.this.connection.send(new ClientboundContainerSetSlotPacket(ServerPlayer.this.inventoryMenu.containerId, ServerPlayer.this.inventoryMenu.incrementStateId(), net.minecraft.world.inventory.InventoryMenu.SHIELD_SLOT, ServerPlayer.this.inventoryMenu.getSlot(net.minecraft.world.inventory.InventoryMenu.SHIELD_SLOT).getItem().copy()));
++            }
++            // Paper end
++
+             @Override
+             public void sendSlotChange(AbstractContainerMenu handler, int slot, ItemStack stack) {
+                 ServerPlayer.this.connection.send(new ClientboundContainerSetSlotPacket(handler.containerId, handler.incrementStateId(), slot, stack));
+diff --git a/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java b/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java
+index 1ad44a49c1da9ede750984306960282f0df5844c..ec6c56c0564eae390de25f967d5d3d6443564ff2 100644
+--- a/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java
+@@ -199,6 +199,7 @@ public abstract class AbstractContainerMenu {
+ 
+         if (this.synchronizer != null) {
+             this.synchronizer.sendInitialData(this, this.remoteSlots, this.remoteCarried, this.remoteDataSlots.toIntArray());
++            this.synchronizer.sendOffHandSlotChange(); // Paper - update player's offhand since the offhand slot is not added to the slots for menus but can be changed by swapping from a menu slot
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/inventory/ContainerSynchronizer.java b/src/main/java/net/minecraft/world/inventory/ContainerSynchronizer.java
+index ff4fa86f9408e83e505f7e27692d3423f8570c48..db6c290dcbb8f5cb502f85e154b42ac89350a460 100644
+--- a/src/main/java/net/minecraft/world/inventory/ContainerSynchronizer.java
++++ b/src/main/java/net/minecraft/world/inventory/ContainerSynchronizer.java
+@@ -6,6 +6,7 @@ import net.minecraft.world.item.ItemStack;
+ public interface ContainerSynchronizer {
+     void sendInitialData(AbstractContainerMenu handler, NonNullList<ItemStack> stacks, ItemStack cursorStack, int[] properties);
+ 
++    default void sendOffHandSlotChange() {} // Paper
+     void sendSlotChange(AbstractContainerMenu handler, int slot, ItemStack stack);
+ 
+     void sendCarriedChange(AbstractContainerMenu handler, ItemStack stack);


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/4869

Menus don't add slots for the offhand, so on sendAllDataToRemote calls the
offhand slot isn't sent. This is not correct because you *can* put stuff into the offhand
by pressing the offhand swap item