### PR TITLE
Change default for hoppers ignoring occluded blocks

### DIFF
--- a/patches/server/0346-Optimize-Hoppers.patch
+++ b/patches/server/0346-Optimize-Hoppers.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3e3a48a636c225ec113c1c64f6ffc8a37ad9169e..94336c6a644bf913d366baa71c2372eb67b6e2cd 100644
+index 3e3a48a636c225ec113c1c64f6ffc8a37ad9169e..98adf2fd1c2e9fe75456266ea1d7604fe64109b1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -511,5 +511,17 @@ public class PaperWorldConfig {
@@ -23,14 +23,14 @@ index 3e3a48a636c225ec113c1c64f6ffc8a37ad9169e..94336c6a644bf913d366baa71c2372eb
 +
 +    public boolean cooldownHopperWhenFull = true;
 +    public boolean disableHopperMoveEvents = false;
-+    public boolean hoppersIgnoreOccludingBlocks = true;
++    public boolean hoppersIgnoreOccludingBlocks = false;
 +    private void hopperOptimizations() {
 +        cooldownHopperWhenFull = getBoolean("hopper.cooldown-when-full", cooldownHopperWhenFull);
 +        log("Cooldown Hoppers when Full: " + (cooldownHopperWhenFull ? "enabled" : "disabled"));
 +        disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
 +        log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
 +        hoppersIgnoreOccludingBlocks = getBoolean("hopper.ignore-occluding-blocks", hoppersIgnoreOccludingBlocks);
-+        log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
++        log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
 +    }
  }
  

--- a/patches/server/0358-Increase-Light-Queue-Size.patch
+++ b/patches/server/0358-Increase-Light-Queue-Size.patch
@@ -14,12 +14,12 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 94336c6a644bf913d366baa71c2372eb67b6e2cd..723adafaf82a664b8bfff9d7d11e43e3eafafa6e 100644
+index 98adf2fd1c2e9fe75456266ea1d7604fe64109b1..d9c59ea6faa7155d415c89228c22da3311855c9d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -523,5 +523,10 @@ public class PaperWorldConfig {
          hoppersIgnoreOccludingBlocks = getBoolean("hopper.ignore-occluding-blocks", hoppersIgnoreOccludingBlocks);
-         log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
+         log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
 +
 +    public int lightQueueSize = 20;

--- a/patches/server/0372-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0372-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 88d140a03b6f28070b2f78588ee5ce4d5ac3cf0f..67dcc28e5c5f6bdcafaea4bfe317203ddee09454 100644
+index 6b0391743cd9e249c66796e7fe7a4da8c6b81b2e..5ba23152d2c7e45a824d49246706aa98c5d535ba 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -526,6 +526,11 @@ public class PaperWorldConfig {
-         log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
+         log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
  
 +    public boolean nerfNetherPortalPigmen = false;
@@ -21,7 +21,7 @@ index 88d140a03b6f28070b2f78588ee5ce4d5ac3cf0f..67dcc28e5c5f6bdcafaea4bfe317203d
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 306e23a788798dd0438a6a93cd55854c904eadbd..6fbbd591873d28dde1ff59ab0ae46f9ce4d6ae31 100644
+index e59364169c7ef5b8f9731e0f5db258b81acddae1..8d1cdf39d6512515e9f4d25d16ed347f14c1818a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -315,6 +315,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i

--- a/patches/server/0689-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0689-Add-config-for-mobs-immune-to-default-effects.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Add config for mobs immune to default effects
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3a83320bae86ba1acb189b9b2cf934ad0393c353..be7b7f9345a42007d6ccea6a31c93a4c874647b6 100644
+index 047d2b47b5af22087359e76362d84dc69ae26707..36730b851203602a49d5a76b25a9e3a11c005033 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -683,6 +683,21 @@ public class PaperWorldConfig {
-         log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
+         log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
  
 +    public boolean undeadImmuneToCertainEffects = true;
@@ -31,7 +31,7 @@ index 3a83320bae86ba1acb189b9b2cf934ad0393c353..be7b7f9345a42007d6ccea6a31c93a4c
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1879271ef55e07cd93ebab2d01bfeb7e7b247883..2b0ba27fbded68270421f31037f71bb81f98d139 100644
+index 2d57ee46e66fe8962177a3a18c890f4942752b33..d10edbda254e17a555e1ad00040e1693be7c5182 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1128,7 +1128,7 @@ public abstract class LivingEntity extends Entity {


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/5141

The default value for this setting should be vanilla behavior with a note in documentation that it improves performance if enabled.
Docs PR: https://github.com/PaperMC/PaperDocs/pull/148