### PR TITLE
Fix issues with LimitedRegion

### DIFF
--- a/patches/server/0680-Add-more-LimitedRegion-API.patch
+++ b/patches/server/0680-Add-more-LimitedRegion-API.patch
@@ -5,31 +5,10 @@ Subject: [PATCH] Add more LimitedRegion API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java
-index a98b39271123e3e7a595d74882f9c453645ee44b..bee7bded2aa5d91bc13ecdf3ad89680257b38701 100644
+index a98b39271123e3e7a595d74882f9c453645ee44b..5cc735c973d7c84475c82d93ee4339dd3be64873 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java
-@@ -175,7 +175,10 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
-     @Override
-     public BlockState getBlockState(int x, int y, int z) {
-         Preconditions.checkArgument(this.isInRegion(x, y, z), "Coordinates %s, %s, %s are not in the region", x, y, z);
--        return super.getBlockState(x, y, z);
-+        // Paper start
-+        net.minecraft.world.level.block.entity.BlockEntity entity = getHandle().getBlockEntity(new BlockPos(x, y, z));
-+        return org.bukkit.craftbukkit.inventory.CraftMetaBlockState.createBlockState(entity.getBlockState().getBukkitMaterial(), entity.saveWithFullMetadata());
-+        // Paper end
-     }
- 
-     @Override
-@@ -193,7 +196,7 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
-     @Override
-     public void setBlockData(int x, int y, int z, BlockData blockData) {
-         Preconditions.checkArgument(this.isInRegion(x, y, z), "Coordinates %s, %s, %s are not in the region", x, y, z);
--        super.setBlockData(x, y, z, blockData);
-+        getHandle().setBlock(new BlockPos(x, y, z), ((org.bukkit.craftbukkit.block.data.CraftBlockData) blockData).getState(), 3); // Paper
-     }
- 
-     @Override
-@@ -225,4 +228,45 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
+@@ -225,4 +225,45 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
      public void addEntityToWorld(net.minecraft.world.entity.Entity entity, CreatureSpawnEvent.SpawnReason reason) {
          this.entities.add(entity);
      }
@@ -47,7 +26,7 @@ index a98b39271123e3e7a595d74882f9c453645ee44b..bee7bded2aa5d91bc13ecdf3ad896802
 +    @Override
 +    public void scheduleBlockUpdate(int x, int y, int z) {
 +        BlockPos position = new BlockPos(x, y, z);
-+        getHandle().scheduleTick(position, getHandle().getBlockIfLoaded(position), 0);
++        getHandle().scheduleTick(position, getHandle().getBlockState(position).getBlock(), 0);
 +    }
 +
 +    @Override
@@ -75,42 +54,3 @@ index a98b39271123e3e7a595d74882f9c453645ee44b..bee7bded2aa5d91bc13ecdf3ad896802
 +    }
 +    // Paper end
  }
-diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-index 55dd618d8421271063843c6e65dbcaceba9a33de..56f65b49e0ce55ee5aa9d929a98ea055ce27a8a1 100644
---- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-+++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-@@ -214,11 +214,16 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
- 
-     @Override
-     public BlockState getBlockState() {
--        Material stateMaterial = (this.material != Material.SHIELD) ? this.material : CraftMetaBlockState.shieldToBannerHack(this.blockEntityTag); // Only actually used for jigsaws
--        if (this.blockEntityTag != null) {
--            switch (this.material) {
-+        // Paper start
-+        return createBlockState(this.material, this.blockEntityTag);
-+    }
-+    public static BlockState createBlockState(Material material, CompoundTag blockEntityTag) {
-+        Material stateMaterial = (material != Material.SHIELD) ? material : CraftMetaBlockState.shieldToBannerHack(blockEntityTag); // Only actually used for jigsaws
-+        if (blockEntityTag != null) {
-+            switch (material) {
-+                // Paper end
-                 case SHIELD:
--                    this.blockEntityTag.putString("id", "banner");
-+                    blockEntityTag.putString("id", "banner"); // Paper
-                     break;
-                 case SHULKER_BOX:
-                 case WHITE_SHULKER_BOX:
-@@ -237,11 +242,11 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
-                 case GREEN_SHULKER_BOX:
-                 case RED_SHULKER_BOX:
-                 case BLACK_SHULKER_BOX:
--                    this.blockEntityTag.putString("id", "shulker_box");
-+                    blockEntityTag.putString("id", "shulker_box"); // Paper
-                     break;
-                 case BEE_NEST:
-                 case BEEHIVE:
--                    this.blockEntityTag.putString("id", "beehive");
-+                    blockEntityTag.putString("id", "beehive"); // Paper
-                     break;
-             }
-         }


### PR DESCRIPTION
These issues stemmed from Paper integrating new upstream API
that was duplicated by a lot of existing Paper API

Fixes potential NPE if calling `CraftLimitedRegion#getBlockState(int,int,int)` and no BlockEntity is present.

No need to change implementation of CraftLimitedRegion#getBlockState(int,int,int) from `CraftRegionAccessor` because `CraftBlock` supports `WorldGenRegion`'s as its handle and `CraftBlockStates` (responsible for creating the API block states does as well)

No need to change implementation of `CraftLimitedRegion#setBlockData(int,int,int,BlockData)` either, if there is a need for different logic, it should be implemented in a separate method to keep API functionality consistent between upstream and Paper.

No need to change anything in `CraftMetaBlockState` to create block states since upstream added (and Paper fixed) the util class `CraftBlockStates`