### PR TITLE
Fix xp reward for baby zombies

### DIFF
--- a/patches/server/0852-Fix-xp-reward-for-baby-zombies.patch
+++ b/patches/server/0852-Fix-xp-reward-for-baby-zombies.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 16 Jan 2022 10:34:02 -0800
+Subject: [PATCH] Fix xp reward for baby zombies
+
+The field that tracks the xpReward was not
+getting reset if the death was cancelled
+so this resets it after each call to
+Zombie#getExperienceReward
+
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
+index e72e9b748b3f3e34baddf01366c703efba50c67c..35f0203d260c11b729c30e6241316fda4b70bfd7 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
+@@ -172,11 +172,16 @@ public class Zombie extends Monster {
+ 
+     @Override
+     protected int getExperienceReward(Player player) {
++        final int previousReward = this.xpReward; // Paper - store previous value to reset after calculating XP reward
+         if (this.isBaby()) {
+             this.xpReward = (int) ((float) this.xpReward * 2.5F);
+         }
+ 
+-        return super.getExperienceReward(player);
++        // Paper start - only change the XP reward for the calculations in the super method
++        int reward = super.getExperienceReward(player);
++        this.xpReward = previousReward;
++        return reward;
++        // Paper end
+     }
+ 
+     @Override


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/7352

The field that tracks the xpReward was not getting reset if the death was cancelled so this resets it after each call to `Zombie#getExperienceReward(Player)`