### PR TITLE
Fix NPE for bucket empty result stack being null

### DIFF
--- a/patches/server/0668-Fix-PlayerBucketEmptyEvent-result-itemstack.patch
+++ b/patches/server/0668-Fix-PlayerBucketEmptyEvent-result-itemstack.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Fix PlayerBucketEmptyEvent result itemstack
 Fixes SPIGOT-2560: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-2560
 
 diff --git a/src/main/java/net/minecraft/world/item/BucketItem.java b/src/main/java/net/minecraft/world/item/BucketItem.java
-index 5406acd65d4e1146f3bd7340ff9a1954a5c39ddb..b5a5c56fbb66c17dd2e2d1f4d69d2b1826cd4951 100644
+index 5406acd65d4e1146f3bd7340ff9a1954a5c39ddb..a3f04f66c66f40068792da3ef0e75e7df102b0e0 100644
 --- a/src/main/java/net/minecraft/world/item/BucketItem.java
 +++ b/src/main/java/net/minecraft/world/item/BucketItem.java
 @@ -39,6 +39,8 @@ import org.bukkit.event.player.PlayerBucketFillEvent;
  
  public class BucketItem extends Item implements DispensibleContainerItem {
  
-+    private static ItemStack itemLeftInHandAfterPlayerBucketEmptyEvent = null; // Paper
++    private static @Nullable ItemStack itemLeftInHandAfterPlayerBucketEmptyEvent = null; // Paper
 +
      public final Fluid content;
  
@@ -32,13 +32,11 @@ index 5406acd65d4e1146f3bd7340ff9a1954a5c39ddb..b5a5c56fbb66c17dd2e2d1f4d69d2b18
          return !player.getAbilities().instabuild ? new ItemStack(Items.BUCKET) : stack;
      }
  
-@@ -152,6 +161,9 @@ public class BucketItem extends Item implements DispensibleContainerItem {
+@@ -152,6 +161,7 @@ public class BucketItem extends Item implements DispensibleContainerItem {
                      ((ServerPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
                      return false;
                  }
-+                // Paper start
-+                itemLeftInHandAfterPlayerBucketEmptyEvent = event.getItemStack().equals(CraftItemStack.asNewCraftStack(net.minecraft.world.item.Items.BUCKET)) ? null : CraftItemStack.asNMSCopy(event.getItemStack());
-+                // Paper end
++                itemLeftInHandAfterPlayerBucketEmptyEvent = event.getItemStack() != null ? event.getItemStack().equals(CraftItemStack.asNewCraftStack(net.minecraft.world.item.Items.BUCKET)) ? null : CraftItemStack.asNMSCopy(event.getItemStack()) : ItemStack.EMPTY; // Paper - fix empty event result itemstack
              }
              // CraftBukkit end
              if (!flag1) {


### PR DESCRIPTION
The result itemstack for PlayerBucketEmptyEvent can be set to null which the fix did not account for.

Just to clarify, the value of `itemLeftInHandAfterPlayerBucketEmptyEvent` being null, means that default behavior should be used when setting the result itemstack (not changing it in creative, setting to empty bucket in other mods), but if a value is present in that static field, that should override the vanilla logic.