### PR TITLE
Fix entity armor not showing on death animation

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -72,8 +72,6 @@ public net.minecraft.server.level.ChunkMap getPoiManager()Lnet/minecraft/world/e
 # Improve death events
 public net.minecraft.world.entity.LivingEntity getDeathSound()Lnet/minecraft/sounds/SoundEvent;
 public net.minecraft.world.entity.LivingEntity getSoundVolume()F
-public net.minecraft.world.entity.Mob handItems
-public net.minecraft.world.entity.Mob armorItems
 
 # Add sun related api
 public net.minecraft.world.entity.Mob isSunBurnTick()Z

--- a/patches/server/0260-Improve-death-events.patch
+++ b/patches/server/0260-Improve-death-events.patch
@@ -70,7 +70,7 @@ index fd1937f49312204d38510996a5be43b731f38bde..a2e2b6ea166bf64fe5b49672a6c6f86a
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index c5d6e5c5c35fa3ab444f271c929ee88c30832dc9..a1850da0d11edfbaac5e799694ce12141aa5a92e 100644
+index c5d6e5c5c35fa3ab444f271c929ee88c30832dc9..cd3f18a7484817c5bc7c53585f6deb8889744c0b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -257,6 +257,7 @@ public abstract class LivingEntity extends Entity {
@@ -108,7 +108,7 @@ index c5d6e5c5c35fa3ab444f271c929ee88c30832dc9..a1850da0d11edfbaac5e799694ce1214
              if (this.deathScore >= 0 && entityliving != null) {
                  entityliving.awardKillScore(this, this.deathScore, source);
              }
-@@ -1606,20 +1606,52 @@ public abstract class LivingEntity extends Entity {
+@@ -1606,20 +1606,54 @@ public abstract class LivingEntity extends Entity {
              if (!this.level.isClientSide && this.hasCustomName()) {
                  if (org.spigotmc.SpigotConfig.logNamedDeaths) LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString()); // Spigot
              }
@@ -131,9 +131,11 @@ index c5d6e5c5c35fa3ab444f271c929ee88c30832dc9..a1850da0d11edfbaac5e799694ce1214
 +                        entityliving.awardKillScore(this, this.deathScore, source);
 +                    }
 +                    // Paper start - clear equipment if event is not cancelled
-+                    if (this instanceof Mob mob) {
-+                        java.util.Collections.fill(mob.handItems, ItemStack.EMPTY);
-+                        java.util.Collections.fill(mob.armorItems, ItemStack.EMPTY);
++                    if (this instanceof Mob) {
++                        for (EquipmentSlot slot : this.clearedEquipmentSlots) {
++                            this.setItemSlot(slot, ItemStack.EMPTY);
++                        }
++                        this.clearedEquipmentSlots.clear();
 +                    }
 +                    // Paper end
 +
@@ -164,7 +166,7 @@ index c5d6e5c5c35fa3ab444f271c929ee88c30832dc9..a1850da0d11edfbaac5e799694ce1214
          }
      }
  
-@@ -1627,7 +1659,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1627,7 +1661,7 @@ public abstract class LivingEntity extends Entity {
          if (!this.level.isClientSide) {
              boolean flag = false;
  
@@ -173,23 +175,30 @@ index c5d6e5c5c35fa3ab444f271c929ee88c30832dc9..a1850da0d11edfbaac5e799694ce1214
                  if (this.level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
                      BlockPos blockposition = this.blockPosition();
                      BlockState iblockdata = Blocks.WITHER_ROSE.defaultBlockState();
-@@ -1656,7 +1688,8 @@ public abstract class LivingEntity extends Entity {
+@@ -1656,7 +1690,11 @@ public abstract class LivingEntity extends Entity {
          }
      }
  
 -    protected void dropAllDeathLoot(DamageSource source) {
-+    protected boolean clearEquipmentSlots = true; // Paper
-+    protected org.bukkit.event.entity.EntityDeathEvent dropAllDeathLoot(DamageSource source) { // Paper
++    // Paper start
++    protected boolean clearEquipmentSlots = true;
++    protected Set<EquipmentSlot> clearedEquipmentSlots = new java.util.HashSet<>();
++    protected org.bukkit.event.entity.EntityDeathEvent dropAllDeathLoot(DamageSource source) {
++    // Paper end
          Entity entity = source.getEntity();
          int i;
  
-@@ -1671,18 +1704,23 @@ public abstract class LivingEntity extends Entity {
+@@ -1671,18 +1709,27 @@ public abstract class LivingEntity extends Entity {
          this.dropEquipment(); // CraftBukkit - from below
          if (this.shouldDropLoot() && this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
              this.dropFromLootTable(source, flag);
-+            this.clearEquipmentSlots = false; // Paper
++            // Paper start
++            final boolean prev = this.clearEquipmentSlots;
++            this.clearEquipmentSlots = false;
++            this.clearedEquipmentSlots.clear();
++            // Paper end
              this.dropCustomDeathLoot(source, i, flag);
-+            this.clearEquipmentSlots = true; // Paper
++            this.clearEquipmentSlots = prev; // Paper
          }
          // CraftBukkit start - Call death event
 -        CraftEventFactory.callEntityDeathEvent(this, this.drops);
@@ -209,16 +218,20 @@ index c5d6e5c5c35fa3ab444f271c929ee88c30832dc9..a1850da0d11edfbaac5e799694ce1214
      // CraftBukkit start
      public int getExpReward() {
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index b937ffef296beed853b47ded1672a2f408be674f..426b3afc7ba5229339f820062f17c1a0775a0df6 100644
+index b13e6bfa449599aafeb97d99c9dc1e0c3885c4be..ecd484a35f9401ffe8f0893749d8d05399166ac2 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1002,7 +1002,9 @@ public abstract class Mob extends LivingEntity {
+@@ -1002,7 +1002,13 @@ public abstract class Mob extends LivingEntity {
                  }
  
                  this.spawnAtLocation(itemstack);
 +                if (this.clearEquipmentSlots) { // Paper
                  this.setItemSlot(enumitemslot, ItemStack.EMPTY);
-+                } // Paper
++                // Paper start
++                } else {
++                    this.clearedEquipmentSlots.add(enumitemslot);
++                }
++                // Paper end
              }
          }
  

--- a/patches/server/0273-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0273-Add-LivingEntity-getTargetEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a1850da0d11edfbaac5e799694ce12141aa5a92e..7886d276e4919cb57372bd0475aaf83992cde360 100644
+index cd3f18a7484817c5bc7c53585f6deb8889744c0b..dc723e1a4d73e06c4b9f275c7b912de1a1cef070 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -113,6 +113,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
@@ -16,7 +16,7 @@ index a1850da0d11edfbaac5e799694ce12141aa5a92e..7886d276e4919cb57372bd0475aaf839
  import net.minecraft.world.phys.HitResult;
  import net.minecraft.world.phys.Vec3;
  import net.minecraft.world.scores.PlayerTeam;
-@@ -3744,6 +3745,38 @@ public abstract class LivingEntity extends Entity {
+@@ -3753,6 +3754,38 @@ public abstract class LivingEntity extends Entity {
          return level.clip(raytrace);
      }
  

--- a/patches/server/0293-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0293-force-entity-dismount-during-teleportation.patch
@@ -41,7 +41,7 @@ index db7f2715534ed71a2b285de095238586fe6a35b0..f51c416e7938b7905f7efb154ab14cad
  
          if (entity1 != entity && this.connection != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d53d968d92e7491c3802d6f9215710610ef11ce5..8018c9dae36335c2fb654269684445b6411450ee 100644
+index 37f337efb7ac164749c73974e4acfde93d649290..3a013ffe5feec6dab478684964f581c354f2a7ae 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2252,11 +2252,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -93,10 +93,10 @@ index d53d968d92e7491c3802d6f9215710610ef11ce5..8018c9dae36335c2fb654269684445b6
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 7886d276e4919cb57372bd0475aaf83992cde360..0031a3a4850e38039c37550d6f67e433b9143cfd 100644
+index dc723e1a4d73e06c4b9f275c7b912de1a1cef070..8587ac23b5c98ef2ee90445432da9db130d93464 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3343,9 +3343,15 @@ public abstract class LivingEntity extends Entity {
+@@ -3352,9 +3352,15 @@ public abstract class LivingEntity extends Entity {
  
      @Override
      public void stopRiding() {

--- a/patches/server/0338-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0338-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0031a3a4850e38039c37550d6f67e433b9143cfd..fa07a6f7ec215652861a62a0cb942522e0f4f655 100644
+index 8587ac23b5c98ef2ee90445432da9db130d93464..d3bb82817e595a946a8294a059982924226ebfa7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3565,9 +3565,14 @@ public abstract class LivingEntity extends Entity {
+@@ -3574,9 +3574,14 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void startUsingItem(InteractionHand hand) {
@@ -24,7 +24,7 @@ index 0031a3a4850e38039c37550d6f67e433b9143cfd..fa07a6f7ec215652861a62a0cb942522
              this.useItem = itemstack;
              this.useItemRemaining = itemstack.getUseDuration();
              if (!this.level.isClientSide) {
-@@ -3646,6 +3651,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3655,6 +3660,7 @@ public abstract class LivingEntity extends Entity {
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -32,7 +32,7 @@ index 0031a3a4850e38039c37550d6f67e433b9143cfd..fa07a6f7ec215652861a62a0cb942522
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
-@@ -3680,8 +3686,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3689,8 +3695,8 @@ public abstract class LivingEntity extends Entity {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0353-Lag-compensate-eating.patch
+++ b/patches/server/0353-Lag-compensate-eating.patch
@@ -7,10 +7,10 @@ When the server is lagging, players will wait longer when eating.
 Change to also use a time check instead if it passes.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index fa07a6f7ec215652861a62a0cb942522e0f4f655..4bdc5e2926ec78de0948b8469c72015c8fecb520 100644
+index d3bb82817e595a946a8294a059982924226ebfa7..77f79aa787aae0b146f84030d07df9d71e1637c5 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3508,6 +3508,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3517,6 +3517,11 @@ public abstract class LivingEntity extends Entity {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  
@@ -22,7 +22,7 @@ index fa07a6f7ec215652861a62a0cb942522e0f4f655..4bdc5e2926ec78de0948b8469c72015c
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameIgnoreDurability(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -3525,8 +3530,12 @@ public abstract class LivingEntity extends Entity {
+@@ -3534,8 +3539,12 @@ public abstract class LivingEntity extends Entity {
          if (this.shouldTriggerItemUseEffects()) {
              this.triggerItemUseEffects(stack, 5);
          }
@@ -37,7 +37,7 @@ index fa07a6f7ec215652861a62a0cb942522e0f4f655..4bdc5e2926ec78de0948b8469c72015c
              this.completeUsingItem();
          }
  
-@@ -3574,7 +3583,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3583,7 +3592,10 @@ public abstract class LivingEntity extends Entity {
  
          if (!itemstack.isEmpty() && !this.isUsingItem() || forceUpdate) { // Paper use override flag
              this.useItem = itemstack;
@@ -49,7 +49,7 @@ index fa07a6f7ec215652861a62a0cb942522e0f4f655..4bdc5e2926ec78de0948b8469c72015c
              if (!this.level.isClientSide) {
                  this.setLivingEntityFlag(1, true);
                  this.setLivingEntityFlag(2, hand == InteractionHand.OFF_HAND);
-@@ -3598,7 +3610,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3607,7 +3619,10 @@ public abstract class LivingEntity extends Entity {
                  }
              } else if (!this.isUsingItem() && !this.useItem.isEmpty()) {
                  this.useItem = ItemStack.EMPTY;
@@ -61,7 +61,7 @@ index fa07a6f7ec215652861a62a0cb942522e0f4f655..4bdc5e2926ec78de0948b8469c72015c
              }
          }
  
-@@ -3726,7 +3741,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3735,7 +3750,10 @@ public abstract class LivingEntity extends Entity {
          }
  
          this.useItem = ItemStack.EMPTY;

--- a/patches/server/0371-Entity-Jump-API.patch
+++ b/patches/server/0371-Entity-Jump-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4bdc5e2926ec78de0948b8469c72015c8fecb520..ae2ee484ab8b70226dd25386336c109a201a6450 100644
+index 77f79aa787aae0b146f84030d07df9d71e1637c5..a30f71d4558040e42f061d056a2ae26db3b9ce57 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3171,8 +3171,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3180,8 +3180,10 @@ public abstract class LivingEntity extends Entity {
              } else if (this.isInLava() && (!this.onGround || d7 > d8)) {
                  this.jumpInLiquid(FluidTags.LAVA);
              } else if ((this.onGround || flag && d7 <= d8) && this.noJumpDelay == 0) {

--- a/patches/server/0399-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0399-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -7,10 +7,10 @@ Will not run if max entity craming is disabled and
 the max collisions per entity is less than or equal to 0
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ae2ee484ab8b70226dd25386336c109a201a6450..4963f3b2e8d2889ef79a8c4fbc84548a0010b49d 100644
+index a30f71d4558040e42f061d056a2ae26db3b9ce57..16d9d4ff14d032e1793a482c57338839a5ab62fb 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3268,10 +3268,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3277,10 +3277,16 @@ public abstract class LivingEntity extends Entity {
      protected void serverAiStep() {}
  
      protected void pushEntities() {

--- a/patches/server/0407-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/server/0407-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4963f3b2e8d2889ef79a8c4fbc84548a0010b49d..ab02e0babf6289d64b44dc18f3f6f0bdd4b83c32 100644
+index 16d9d4ff14d032e1793a482c57338839a5ab62fb..843097979f45b8f99efbfdcf268eea4879c0239a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2046,7 +2046,16 @@ public abstract class LivingEntity extends Entity {
+@@ -2055,7 +2055,16 @@ public abstract class LivingEntity extends Entity {
  
              EntityDamageEvent event = CraftEventFactory.handleLivingEntityDamageEvent(this, damagesource, originalDamage, hardHatModifier, blockingModifier, armorModifier, resistanceModifier, magicModifier, absorptionModifier, hardHat, blocking, armor, resistance, magic, absorption);
              if (damagesource.getEntity() instanceof net.minecraft.world.entity.player.Player) {

--- a/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -80,7 +80,7 @@ index 6fa35e0acd966a9cfd3d5b3765c7d0130ea2de18..7bf62752b6604abe0bda6f5d0024f0e9
  
      public float getBlockExplosionResistance(Explosion explosion, BlockGetter world, BlockPos pos, BlockState blockState, FluidState fluidState, float max) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ab02e0babf6289d64b44dc18f3f6f0bdd4b83c32..198a0cfb222f40e792a9723eb25c514889ffe01f 100644
+index 843097979f45b8f99efbfdcf268eea4879c0239a..9d8912ff91932e5e3c9a708b4c850e8abaa1a605 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1619,9 +1619,9 @@ public abstract class LivingEntity extends Entity {
@@ -94,11 +94,11 @@ index ab02e0babf6289d64b44dc18f3f6f0bdd4b83c32..198a0cfb222f40e792a9723eb25c5148
 +                    //     entityliving.awardKillScore(this, this.deathScore, source);
 +                    // }
                      // Paper start - clear equipment if event is not cancelled
-                     if (this instanceof Mob mob) {
-                         java.util.Collections.fill(mob.handItems, ItemStack.EMPTY);
-@@ -1709,8 +1709,13 @@ public abstract class LivingEntity extends Entity {
+                     if (this instanceof Mob) {
+                         for (EquipmentSlot slot : this.clearedEquipmentSlots) {
+@@ -1718,8 +1718,13 @@ public abstract class LivingEntity extends Entity {
              this.dropCustomDeathLoot(source, i, flag);
-             this.clearEquipmentSlots = true; // Paper
+             this.clearEquipmentSlots = prev; // Paper
          }
 -        // CraftBukkit start - Call death event
 -        org.bukkit.event.entity.EntityDeathEvent deathEvent = CraftEventFactory.callEntityDeathEvent(this, this.drops); // Paper

--- a/patches/server/0469-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0469-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 198a0cfb222f40e792a9723eb25c514889ffe01f..345190be83c7c9a7f65d64a6905da872fc020abb 100644
+index 9d8912ff91932e5e3c9a708b4c850e8abaa1a605..371ae3291afa84a41821edc37cdcabe7723a45d0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3374,7 +3374,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3383,7 +3383,7 @@ public abstract class LivingEntity extends Entity {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - suppress

--- a/patches/server/0540-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0540-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -21,7 +21,7 @@ index f46d0d22b99582070747e2fde3c6328b0ab6d707..b9164fb28a49ccc3113f7010786960ec
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2c68dbfc38e9d9b7bb6cecb790d4d72fc2015a7f..1cf13735a8c5dbfa71011012b271b3dc409a5f15 100644
+index 56c138d69423cd7fc99003ff4ddf124ede1c5b95..925f9b57e347bb609c159bb9d750a528ad2b87dd 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1743,6 +1743,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -61,10 +61,10 @@ index 22f36cd3df49160f1b6668befdd05c2268edaa49..e39965c2e50bc8ee424ea07819346e06
              } else if (entity.level.isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 345190be83c7c9a7f65d64a6905da872fc020abb..cd7850fbfbd1997b42b93df15666b2f3f9948384 100644
+index 371ae3291afa84a41821edc37cdcabe7723a45d0..efc4ebcd1bb024ee7549047147bfe4da2b3fa3f8 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3288,7 +3288,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3297,7 +3297,7 @@ public abstract class LivingEntity extends Entity {
              return;
          }
          // Paper end - don't run getEntities if we're not going to use its result
@@ -73,7 +73,7 @@ index 345190be83c7c9a7f65d64a6905da872fc020abb..cd7850fbfbd1997b42b93df15666b2f3
  
          if (!list.isEmpty()) {
              // Paper - move up
-@@ -3459,9 +3459,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3468,9 +3468,16 @@ public abstract class LivingEntity extends Entity {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add dropLeash variable to EntityUnleashEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index e803af4d27f3f005a56696175d7ae8a51d7005a6..79c298334a1a2171ef6aca94114edf72ffb67ba1 100644
+index 94ec938800846ef79792b7fb800963f01677734e..6f47a27e9e48a4e49d5827ca3a3a2613680639aa 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1230,12 +1230,15 @@ public abstract class Mob extends LivingEntity {
+@@ -1234,12 +1234,15 @@ public abstract class Mob extends LivingEntity {
              return InteractionResult.PASS;
          } else if (this.getLeashHolder() == player) {
              // CraftBukkit start - fire PlayerUnleashEntityEvent
@@ -26,7 +26,7 @@ index e803af4d27f3f005a56696175d7ae8a51d7005a6..79c298334a1a2171ef6aca94114edf72
              return InteractionResult.sidedSuccess(this.level.isClientSide);
          } else {
              InteractionResult enuminteractionresult = this.checkAndHandleImportantInteractions(player, hand);
-@@ -1393,8 +1396,11 @@ public abstract class Mob extends LivingEntity {
+@@ -1397,8 +1400,11 @@ public abstract class Mob extends LivingEntity {
  
          if (this.leashHolder != null) {
              if (!this.isAlive() || !this.leashHolder.isAlive()) {
@@ -40,7 +40,7 @@ index e803af4d27f3f005a56696175d7ae8a51d7005a6..79c298334a1a2171ef6aca94114edf72
              }
  
          }
-@@ -1457,8 +1463,11 @@ public abstract class Mob extends LivingEntity {
+@@ -1461,8 +1467,11 @@ public abstract class Mob extends LivingEntity {
          boolean flag1 = super.startRiding(entity, force);
  
          if (flag1 && this.isLeashed()) {
@@ -54,7 +54,7 @@ index e803af4d27f3f005a56696175d7ae8a51d7005a6..79c298334a1a2171ef6aca94114edf72
          }
  
          return flag1;
-@@ -1630,8 +1639,11 @@ public abstract class Mob extends LivingEntity {
+@@ -1634,8 +1643,11 @@ public abstract class Mob extends LivingEntity {
      @Override
      protected void removeAfterChangingDimensions() {
          super.removeAfterChangingDimensions();

--- a/patches/server/0592-EntityMoveEvent.patch
+++ b/patches/server/0592-EntityMoveEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] EntityMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b5b7bb3c0147f95ac4036e7d2aa8f26ac755f4df..18830fa8e43c70c9da417eb771d553353b06bb48 100644
+index 88168eccb8224cb018afa40b7c391ce5814e8853..6f5047f97a1daa1ea6d30fac72a21f1ac5419371 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1505,6 +1505,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -17,7 +17,7 @@ index b5b7bb3c0147f95ac4036e7d2aa8f26ac755f4df..18830fa8e43c70c9da417eb771d55335
  
              this.profiler.push(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 1486f93a476ed9b887c8d2b2ab3b1671cc772aae..558a202fb147f4c466d5c8b958105cbf43be0788 100644
+index 753da2465d650d0889e0304b456ad754f4cd1c0b..3066d70a84eb3b23e16edf44f7540f6eb8da7eb2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -208,6 +208,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -29,10 +29,10 @@ index 1486f93a476ed9b887c8d2b2ab3b1671cc772aae..558a202fb147f4c466d5c8b958105cbf
          return new Throwable(entity + " Added to world at " + new java.util.Date());
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cd7850fbfbd1997b42b93df15666b2f3f9948384..aaea5020bf08b2dbc77cfd248dfe721b398c695e 100644
+index efc4ebcd1bb024ee7549047147bfe4da2b3fa3f8..8b9d61ee5384d530f80ea7496b93ceac24735e36 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3234,6 +3234,20 @@ public abstract class LivingEntity extends Entity {
+@@ -3243,6 +3243,20 @@ public abstract class LivingEntity extends Entity {
  
          this.pushEntities();
          this.level.getProfiler().pop();

--- a/patches/server/0626-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0626-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index aaea5020bf08b2dbc77cfd248dfe721b398c695e..510c2f0d47b593ac2bd60608c43cef8c069a5373 100644
+index 8b9d61ee5384d530f80ea7496b93ceac24735e36..f0d309ad128359c01e6723a462a27670cfd29751 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3720,6 +3720,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3729,6 +3729,7 @@ public abstract class LivingEntity extends Entity {
                          level.getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {

--- a/patches/server/0677-Line-Of-Sight-Changes.patch
+++ b/patches/server/0677-Line-Of-Sight-Changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 510c2f0d47b593ac2bd60608c43cef8c069a5373..3d197ddb412e7df6723be0e86db86d9326281bc1 100644
+index f0d309ad128359c01e6723a462a27670cfd29751..4dd329bc38272840b9b3c4a27978b88349dd2b89 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3445,7 +3445,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3454,7 +3454,8 @@ public abstract class LivingEntity extends Entity {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  

--- a/patches/server/0699-Improve-boat-collision-performance.patch
+++ b/patches/server/0699-Improve-boat-collision-performance.patch
@@ -17,7 +17,7 @@ index 6c87ad6e015729db5b10f795b59aa785dff4368a..4605e80bb7dc5408daafb5ccba52efa1
      };
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 73ff544665eed9d999b13462b9635e79866c927c..69e296de6f4dbbcacd516ee1707c1c315dd7f0a1 100644
+index 91b81a72f6bba408b7885ea23589746bc4c947b2..fba2239a33c5510581e9a09cf670499e51127479 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1315,7 +1315,7 @@ public abstract class LivingEntity extends Entity {
@@ -44,7 +44,7 @@ index 73ff544665eed9d999b13462b9635e79866c927c..69e296de6f4dbbcacd516ee1707c1c31
                          d0 = (Math.random() - Math.random()) * 0.01D;
                      }
  
-@@ -2097,7 +2098,7 @@ public abstract class LivingEntity extends Entity {
+@@ -2106,7 +2107,7 @@ public abstract class LivingEntity extends Entity {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/0710-Make-EntityUnleashEvent-cancellable.patch
+++ b/patches/server/0710-Make-EntityUnleashEvent-cancellable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make EntityUnleashEvent cancellable
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 79c298334a1a2171ef6aca94114edf72ffb67ba1..736b51e411b009db0482d9a72f179cc7b6241265 100644
+index 6f47a27e9e48a4e49d5827ca3a3a2613680639aa..818436a1f35d3c59d9776d4edff675e6896c302f 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1465,7 +1465,7 @@ public abstract class Mob extends LivingEntity {
+@@ -1469,7 +1469,7 @@ public abstract class Mob extends LivingEntity {
          if (flag1 && this.isLeashed()) {
              // Paper start - drop leash variable
              EntityUnleashEvent event = new EntityUnleashEvent(this.getBukkitEntity(), UnleashReason.UNKNOWN, true);

--- a/patches/server/0805-Prevent-excessive-velocity-through-repeated-crits.patch
+++ b/patches/server/0805-Prevent-excessive-velocity-through-repeated-crits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent excessive velocity through repeated crits
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 69e296de6f4dbbcacd516ee1707c1c315dd7f0a1..da6e1730f7309e820b8a11a9b362a16b45db0abf 100644
+index fba2239a33c5510581e9a09cf670499e51127479..a62d66121b7ff883bcad92f57adcc66adb5d868a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2582,14 +2582,27 @@ public abstract class LivingEntity extends Entity {
+@@ -2591,14 +2591,27 @@ public abstract class LivingEntity extends Entity {
          return this.hasEffect(MobEffects.JUMP) ? (double) (0.1F * (float) (this.getEffect(MobEffects.JUMP).getAmplifier() + 1)) : 0.0D;
      }
  

--- a/patches/server/0810-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0810-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -34,10 +34,10 @@ index 703ac671b19636859648f16a5431b2700791e7d5..d8ef6137133716b9ee519e6e4668d2e1
              }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index da6e1730f7309e820b8a11a9b362a16b45db0abf..45bad146283ebde8cc4a1d67a67d325f74417011 100644
+index a62d66121b7ff883bcad92f57adcc66adb5d868a..4f457aaebdc8100d69f6dd787e36bc40eb103c27 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3065,7 +3065,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3074,7 +3074,10 @@ public abstract class LivingEntity extends Entity {
          equipmentChanges.forEach((enumitemslot, itemstack) -> {
              ItemStack itemstack1 = itemstack.copy();
  
@@ -49,7 +49,7 @@ index da6e1730f7309e820b8a11a9b362a16b45db0abf..45bad146283ebde8cc4a1d67a67d325f
              switch (enumitemslot.getType()) {
                  case HAND:
                      this.setLastHandItem(enumitemslot, itemstack1);
-@@ -3078,6 +3081,34 @@ public abstract class LivingEntity extends Entity {
+@@ -3087,6 +3090,34 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  

--- a/patches/server/0811-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0811-Hide-unnecessary-itemmeta-from-clients.patch
@@ -36,10 +36,10 @@ index d8ef6137133716b9ee519e6e4668d2e1ae5d9ca3..9a6c67b614944f841813ec2892381c33
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 45bad146283ebde8cc4a1d67a67d325f74417011..44a32fd2c08a09af0bba01547847b8594a7cd077 100644
+index 4f457aaebdc8100d69f6dd787e36bc40eb103c27..a7f302a9d22e0475ec295ca69ba17770d668ae30 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3067,7 +3067,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3076,7 +3076,7 @@ public abstract class LivingEntity extends Entity {
  
              // Paper start - prevent oversized data
              ItemStack toSend = sanitizeItemStack(itemstack1, true);
@@ -48,7 +48,7 @@ index 45bad146283ebde8cc4a1d67a67d325f74417011..44a32fd2c08a09af0bba01547847b859
              // Paper end
              switch (enumitemslot.getType()) {
                  case HAND:
-@@ -3081,6 +3081,51 @@ public abstract class LivingEntity extends Entity {
+@@ -3090,6 +3090,51 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  

--- a/patches/server/0856-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0856-Freeze-Tick-Lock-API.patch
@@ -46,10 +46,10 @@ index 9b5bd68f328306e26eced7d3112b2c01301b543b..9ca080e2745686fc2e39485965ec54c5
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 44a32fd2c08a09af0bba01547847b8594a7cd077..25338fe4cfdc683ca4c01487e166a1649c6f640b 100644
+index a7f302a9d22e0475ec295ca69ba17770d668ae30..9822d163a9e4d6ac8240c18a7082e911788d0948 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3299,7 +3299,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3308,7 +3308,7 @@ public abstract class LivingEntity extends Entity {
          boolean flag1 = this.getType().is(EntityTypeTags.FREEZE_HURTS_EXTRA_TYPES);
          int i;
  


### PR DESCRIPTION
Was previously clearing all hand/armor slots on deaths when only slots that had their items dropped should be cleared so as to not update the client to the change in entity armor status.