### PR TITLE
Fix and deprecate ItemStack#getI18NDisplayName

### DIFF
--- a/patches/api/0064-Add-getI18NDisplayName-API.patch
+++ b/patches/api/0064-Add-getI18NDisplayName-API.patch
@@ -8,10 +8,10 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 6cc4bad2ecd19f44a680ff03cbfb99d48ea5c337..b1fbb931148a87f29e8b8796b13851d767cc1d68 100644
+index 6cc4bad2ecd19f44a680ff03cbfb99d48ea5c337..e301d477c4839c27854293998ae235b91c9c46e5 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -160,5 +160,16 @@ public interface ItemFactory {
+@@ -160,5 +160,19 @@ public interface ItemFactory {
       */
      @NotNull
      net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack);
@@ -23,16 +23,19 @@ index 6cc4bad2ecd19f44a680ff03cbfb99d48ea5c337..b1fbb931148a87f29e8b8796b13851d7
 +     *
 +     * @param item Item to return Display name of
 +     * @return Display name of Item
++     * @deprecated {@link ItemStack} implements {@link net.kyori.adventure.translation.Translatable}; use that and
++     * {@link net.kyori.adventure.text.Component#translatable(net.kyori.adventure.translation.Translatable)} instead.
 +     */
 +    @Nullable
++    @Deprecated
 +    String getI18NDisplayName(@Nullable ItemStack item);
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index a15abec467bac70116a6fc21a300d4930b909f15..de5bcdb7b84acdd5e22500e367df292f35a86e19 100644
+index a15abec467bac70116a6fc21a300d4930b909f15..dfd16531926e639231e93cb295de3d802d17413d 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -611,5 +611,17 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -611,5 +611,20 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public @NotNull net.kyori.adventure.text.Component displayName() {
          return Bukkit.getServer().getItemFactory().displayName(this);
      }
@@ -43,8 +46,11 @@ index a15abec467bac70116a6fc21a300d4930b909f15..de5bcdb7b84acdd5e22500e367df292f
 +     * You must replace the language file embedded in the server jar.
 +     *
 +     * @return Display name of Item
++     * @deprecated {@link ItemStack} implements {@link net.kyori.adventure.translation.Translatable}; use that and
++     * {@link net.kyori.adventure.text.Component#translatable(net.kyori.adventure.translation.Translatable)} instead.
 +     */
 +    @Nullable
++    @Deprecated
 +    public String getI18NDisplayName() {
 +        return Bukkit.getServer().getItemFactory().getI18NDisplayName(this);
 +    }

--- a/patches/api/0065-ensureServerConversions-API.patch
+++ b/patches/api/0065-ensureServerConversions-API.patch
@@ -7,12 +7,12 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index b1fbb931148a87f29e8b8796b13851d767cc1d68..71e5ee496a947fbd8e3ec579833b157c76b51833 100644
+index 28b410f4f68359281c9f9049639d97d38442f0ce..b0b43b3f42a11bb8fdb3d728f57b5fc462b0e9ab 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -171,5 +171,17 @@ public interface ItemFactory {
-      */
+@@ -174,5 +174,17 @@ public interface ItemFactory {
      @Nullable
+     @Deprecated
      String getI18NDisplayName(@Nullable ItemStack item);
 +
 +    /**

--- a/patches/api/0108-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/api/0108-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index e8783b0116f4efd5447a5f6f260506000983ffd2..9fee2f157ac5149cd65136bf8468deaca410fbf4 100644
+index 4b00a1833387f40a3771a254ad36f94a0c38a5eb..814854f08cce607004ad074d1f8efb44c7108f20 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -636,5 +636,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -639,5 +639,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public String getI18NDisplayName() {
          return Bukkit.getServer().getItemFactory().getI18NDisplayName(this);
      }

--- a/patches/api/0116-ItemStack-API-additions-for-quantity-flags-lore.patch
+++ b/patches/api/0116-ItemStack-API-additions-for-quantity-flags-lore.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ItemStack API additions for quantity/flags/lore
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 9fee2f157ac5149cd65136bf8468deaca410fbf4..686e2a0b9fe061816b41435ef2337870dbdca8e5 100644
+index 814854f08cce607004ad074d1f8efb44c7108f20..fbafd506f86a884a19b218e87ddc8720e83f993d 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -2,7 +2,9 @@ package org.bukkit.inventory;
@@ -18,7 +18,7 @@ index 9fee2f157ac5149cd65136bf8468deaca410fbf4..686e2a0b9fe061816b41435ef2337870
  import org.apache.commons.lang.Validate;
  import org.bukkit.Bukkit;
  import org.bukkit.Material;
-@@ -644,5 +646,185 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -647,5 +649,185 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
          // Requires access to NMS
          return ensureServerConversions().getMaxItemUseDuration();
      }

--- a/patches/api/0220-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0220-Add-methods-to-get-translation-keys.patch
@@ -337,7 +337,7 @@ index 511b96841f7342d0a6b38d7cff56252ea8ef9bfe..02ecc87a90bbd81e7d21279fac701ba4
  
      // Paper start - Add villager reputation API
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index b80ef2e5c23764ee68f809268185492bf5577913..e6eab5d8ca3fea8d2e0ccc1cd1c1a7a110b589db 100644
+index afe6d4877fa4f3c5b03f8bca68f59ff0885d21d4..ea94570cb7b8673962a8c1a735cfc7c80f85db31 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
@@ -349,7 +349,7 @@ index b80ef2e5c23764ee68f809268185492bf5577913..e6eab5d8ca3fea8d2e0ccc1cd1c1a7a1
      private Material type = Material.AIR;
      private int amount = 0;
      private MaterialData data = null;
-@@ -852,5 +852,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -855,5 +855,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
          ItemMeta itemMeta = getItemMeta();
          return itemMeta != null && itemMeta.hasItemFlag(flag);
      }

--- a/patches/api/0221-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/api/0221-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index d773e8594f91017bddd7ea8aada3a1ff2781d05b..0a4466c6ca519c3a5da76ff870fb2a4e3a06effd 100644
+index 0f6a3efc04214fd66cc5a0e9eea9d321ca7aac58..5793a02ff5ec9310c23c471529226b300d43ec7c 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -184,5 +184,62 @@ public interface ItemFactory {
+@@ -187,5 +187,62 @@ public interface ItemFactory {
       */
      @NotNull
      ItemStack ensureServerConversions(@NotNull ItemStack item);

--- a/patches/api/0277-Item-Rarity-API.patch
+++ b/patches/api/0277-Item-Rarity-API.patch
@@ -88,10 +88,10 @@ index a7a5eada1302dac046619d8a01c887965f22dd09..2392efea1b514671014c39d75407f59f
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index e6eab5d8ca3fea8d2e0ccc1cd1c1a7a110b589db..f46aeb59a5a1bde4011cd1d933afcc19c7d1b3bd 100644
+index ea94570cb7b8673962a8c1a735cfc7c80f85db31..45e656643f07e25ee4432786dea750b83abc95ae 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -877,5 +877,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -880,5 +880,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public @NotNull String translationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }

--- a/patches/api/0297-ItemStack-repair-check-API.patch
+++ b/patches/api/0297-ItemStack-repair-check-API.patch
@@ -26,10 +26,10 @@ index 8f85c41be166ea720a0bf5b6b58bc51a6d2c71cc..c1bda4dba319999261613d4aa45a280e
       * Returns the server's protocol version.
       *
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index f46aeb59a5a1bde4011cd1d933afcc19c7d1b3bd..86bd9f14de5c1ff3d797955be1af56e5efcac884 100644
+index 45e656643f07e25ee4432786dea750b83abc95ae..a1d332a5eafb88c2f5d95bea6dc7e528ea2047be 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -887,5 +887,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -890,5 +890,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public io.papermc.paper.inventory.ItemRarity getRarity() {
          return Bukkit.getUnsafe().getItemStackRarity(this);
      }

--- a/patches/api/0334-Add-ItemFactory-getMonsterEgg-API.patch
+++ b/patches/api/0334-Add-ItemFactory-getMonsterEgg-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ItemFactory#getMonsterEgg API
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 0a4466c6ca519c3a5da76ff870fb2a4e3a06effd..8677e273641a46aae7107361f23f6ded59a50dc0 100644
+index 5793a02ff5ec9310c23c471529226b300d43ec7c..bd2500068e984bd06b1121c34adbaaefda9c746a 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -241,5 +241,14 @@ public interface ItemFactory {
+@@ -244,5 +244,14 @@ public interface ItemFactory {
      @NotNull
      @Deprecated
      net.md_5.bungee.api.chat.hover.content.Content hoverContentOf(@NotNull org.bukkit.entity.Entity entity, @NotNull net.md_5.bungee.api.chat.BaseComponent[] customName);

--- a/patches/server/0150-Implement-getI18NDisplayName.patch
+++ b/patches/server/0150-Implement-getI18NDisplayName.patch
@@ -8,7 +8,7 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 73da393b26a7afd766b23716da454b0b68c26d5b..c50d3cee3dfebb62ad30f8d4efe23b5c7c9f2b57 100644
+index 73da393b26a7afd766b23716da454b0b68c26d5b..3e23fb314ec8c89643b900816075a3542b8bb890 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 @@ -362,5 +362,18 @@ public final class CraftItemFactory implements ItemFactory {
@@ -26,7 +26,7 @@ index 73da393b26a7afd766b23716da454b0b68c26d5b..c50d3cee3dfebb62ad30f8d4efe23b5c
 +            nms = CraftItemStack.asNMSCopy(item);
 +        }
 +
-+        return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId()) : null;
++        return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId(nms)) : null;
 +    }
      // Paper end
  }

--- a/patches/server/0501-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/server/0501-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index c50d3cee3dfebb62ad30f8d4efe23b5c7c9f2b57..fcbd28fdeab4815c005c7dca547aee246f52fd26 100644
+index 3e23fb314ec8c89643b900816075a3542b8bb890..def8caa7e991cc5f6e8aefcf9e9e3b18149bfdfa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 @@ -375,5 +375,40 @@ public final class CraftItemFactory implements ItemFactory {
  
-         return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId()) : null;
+         return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId(nms)) : null;
      }
 +
 +    @Override


### PR DESCRIPTION
Small change that fixes https://github.com/PaperMC/Paper/issues/7356

I also marked `ItemFactory#getI18NDisplayName(ItemStack)` and `ItemStack#getI18NDisplayName()` as deprecated with notices telling people to use `Component#translatable` with itemstacks since they implement `Translatable`

If we wanted to reduce patch counts, this patch could even be merged in with either Adventure or the patch that makes ItemStack implement Translatable.