### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0006-Timings-v2.patch
+++ b/patches/api/0006-Timings-v2.patch
@@ -3377,10 +3377,10 @@ index 2a145d851ce30360aa39549745bd87590c034584..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6c8992a1a4c75c914e8aac16028cdfa0f39ac5eb..11f1b0df201272b158d403604c4f3c262ab011b7 100644
+index 5015386d4cd7209a598401932e276077861cea62..7b256be5b82e34a4591d0cc46a2d49aa1269e844 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1635,7 +1635,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1643,7 +1643,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           */
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");

--- a/patches/api/0008-Adventure.patch
+++ b/patches/api/0008-Adventure.patch
@@ -1596,7 +1596,7 @@ index 25a6f9313a1953def7470e411b53016f2ca14bef..10cb6088c4618f228c757f4e592b44ed
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac6079bfd36c 100644
+index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf9e5705ac 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -35,7 +35,28 @@ import org.jetbrains.annotations.Nullable;
@@ -1890,7 +1890,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException;
  
      /**
-@@ -1033,6 +1204,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1041,6 +1212,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt);
  
@@ -1945,7 +1945,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
      /**
       * Request that the player's client download and switch resource packs.
       * <p>
-@@ -1124,6 +1343,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1132,6 +1351,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt, boolean force);
  
@@ -2000,7 +2000,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
      /**
       * Gets the Scoreboard displayed to this player
       *
-@@ -1217,7 +1484,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1225,7 +1492,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param title Title text
       * @param subtitle Subtitle text
@@ -2009,7 +2009,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
       */
      @Deprecated
      public void sendTitle(@Nullable String title, @Nullable String subtitle);
-@@ -1236,7 +1503,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1244,7 +1511,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param fadeIn time in ticks for titles to fade in. Defaults to 10.
       * @param stay time in ticks for titles to stay. Defaults to 70.
       * @param fadeOut time in ticks for titles to fade out. Defaults to 20.
@@ -2019,7 +2019,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
      public void sendTitle(@Nullable String title, @Nullable String subtitle, int fadeIn, int stay, int fadeOut);
  
      /**
-@@ -1463,6 +1732,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1471,6 +1740,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -2034,7 +2034,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1488,8 +1765,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1496,8 +1773,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -2045,7 +2045,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
      public String getLocale();
  
      /**
-@@ -1531,6 +1810,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1539,6 +1818,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public boolean isAllowingServerListings();
  
@@ -2060,7 +2060,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1585,11 +1872,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1593,11 +1880,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -2074,7 +2074,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1600,7 +1889,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1608,7 +1897,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -2084,7 +2084,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1610,7 +1901,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1618,7 +1909,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -2094,7 +2094,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1621,7 +1914,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1629,7 +1922,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -2104,7 +2104,7 @@ index 11f1b0df201272b158d403604c4f3c262ab011b7..77db4c371ae6543435bde9247173ac60
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1632,7 +1927,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1640,7 +1935,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send

--- a/patches/api/0009-Player-affects-spawning-API.patch
+++ b/patches/api/0009-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 77db4c371ae6543435bde9247173ac6079bfd36c..768e93bf74f8176b6b9d146fac7c870af3ce7b95 100644
+index 23a5a2f6dc4f734606a9a6cb6c6f95bf9e5705ac..43d91f578b0aefd18f7f5ecd120a366af4ee98e6 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1771,6 +1771,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1779,6 +1779,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0014-Add-view-distance-API.patch
+++ b/patches/api/0014-Add-view-distance-API.patch
@@ -65,10 +65,10 @@ index 5d23c38758b4b9eb5802b6a22a094a3adb64e508..5e9f77a53bffed2e79200e9d8bb8685d
      public class Spigot {
  
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 768e93bf74f8176b6b9d146fac7c870af3ce7b95..3aa34138d90b206193fee0558939d8de52cd2a85 100644
+index 43d91f578b0aefd18f7f5ecd120a366af4ee98e6..2d93f5ad7f9c0df08bcd099a813c1d8e9b8c16eb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1785,6 +1785,62 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1793,6 +1793,62 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0025-Complete-resource-pack-API.patch
+++ b/patches/api/0025-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8c7c7ce6bf12d14300067cc64cbdeb9e7d984629..7ff1c702348253cdee5c36045ceb57b8dc7da516 100644
+index 5f5cde854dd7928e0b640ab1713f42194eab0833..09b5941bcd412420ffc6edfe62bc95cff426ba06 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1276,7 +1276,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1284,7 +1284,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the URL is null.
       * @throws IllegalArgumentException Thrown if the URL is too long. The
       *     length restriction is an implementation specific arbitrary value.
@@ -18,7 +18,7 @@ index 8c7c7ce6bf12d14300067cc64cbdeb9e7d984629..7ff1c702348253cdee5c36045ceb57b8
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -2050,6 +2052,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2058,6 +2060,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0045-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0045-Add-String-based-Action-Bar-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7ff1c702348253cdee5c36045ceb57b8dc7da516..632622b90696f0e1c8e33d897d8e14467691e760 100644
+index 09b5941bcd412420ffc6edfe62bc95cff426ba06..a0777f9dc7cb6d4274635d794cf66de714535cde 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -3,6 +3,7 @@ package org.bukkit.entity;
@@ -68,7 +68,7 @@ index 7ff1c702348253cdee5c36045ceb57b8dc7da516..632622b90696f0e1c8e33d897d8e1446
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }
-@@ -2241,6 +2277,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2249,6 +2285,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends the component to the specified screen position of this player
           *
@@ -76,7 +76,7 @@ index 7ff1c702348253cdee5c36045ceb57b8dc7da516..632622b90696f0e1c8e33d897d8e1446
           * @param position the screen position
           * @param component the components to send
           * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
-@@ -2253,6 +2290,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2261,6 +2298,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends an array of components as a single message to the specified screen position of this player
           *

--- a/patches/api/0080-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/api/0080-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9bbf1a9f3b848c26deac34435e71dd8558a80afd..1885a21b888b0a950a1f32bd587e6621522faef7 100644
+index d62f48e83e5e620d9dd9b82249e97f77509c0a0a..b68f2774e4f88e905cc195df6d1592d96103df7a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1011,12 +1011,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1019,12 +1019,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void resetPlayerWeather();
  

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 1885a21b888b0a950a1f32bd587e6621522faef7..8dc3472dac3215951ac11ae366a3d15314d956a5 100644
+index b68f2774e4f88e905cc195df6d1592d96103df7a..e64af8a5c6cfb1bb6493261c5a057364346d8608 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
@@ -17,7 +17,7 @@ index 1885a21b888b0a950a1f32bd587e6621522faef7..8dc3472dac3215951ac11ae366a3d153
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -2227,6 +2228,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2235,6 +2236,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
@@ -24,10 +24,10 @@ index 396092fd249928ca01133eeeeb61f0ad90b2e332..5cc025b69c4f405be8f7098d0dcef40f
      /**
       * Make the entity drop the item in their hand.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8dc3472dac3215951ac11ae366a3d15314d956a5..5224cfe5d57ab62b52554336f325dae8829d1b30 100644
+index e64af8a5c6cfb1bb6493261c5a057364346d8608..559d45ed0af80702d86eac20f01fcfb3104cc24c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2083,7 +2083,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2091,7 +2091,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Open a Sign for editing by the Player.
       *

--- a/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 264a35cc33f40405e9ba10de850bb3142d984ee7..f99569b1f591ca89a6a69123293a8500caec3522 100644
+index 9d742cdb669ea1d2cfd99ac25a2843a637bf9307..a5fa9ea0149de9bfd45617c782f0626079893d27 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2402,6 +2402,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2410,6 +2410,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull PlayerProfile profile);

--- a/patches/api/0194-Add-Player-Client-Options-API.patch
+++ b/patches/api/0194-Add-Player-Client-Options-API.patch
@@ -193,7 +193,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f99569b1f591ca89a6a69123293a8500caec3522..3de5c369d034d77d054e0fd620f0383baaee3272 100644
+index a5fa9ea0149de9bfd45617c782f0626079893d27..4466b78315008e460bf1c4204347d174921e68de 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -204,7 +204,7 @@ index f99569b1f591ca89a6a69123293a8500caec3522..3de5c369d034d77d054e0fd620f0383b
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import com.destroystokyo.paper.profile.PlayerProfile; // Paper
-@@ -2422,6 +2423,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2430,6 +2431,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0218-Brand-support.patch
+++ b/patches/api/0218-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3de5c369d034d77d054e0fd620f0383baaee3272..62a087be8695b3d4a226433fc3868ac5013cbcce 100644
+index 4466b78315008e460bf1c4204347d174921e68de..09fc2dda0ae9b1586bf33805f6dcb4a26a02f72b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2557,6 +2557,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2565,6 +2565,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0227-Player-elytra-boost-API.patch
+++ b/patches/api/0227-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 62a087be8695b3d4a226433fc3868ac5013cbcce..561084587e82b376cc583544b80c142bbf98480f 100644
+index 09fc2dda0ae9b1586bf33805f6dcb4a26a02f72b..df9b6031649b751ae737c6fb76761b1b42d54a93 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2429,6 +2429,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2437,6 +2437,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull ClientOption<T> option);

--- a/patches/api/0255-Add-sendOpLevel-API.patch
+++ b/patches/api/0255-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 561084587e82b376cc583544b80c142bbf98480f..3bb9b19ceeda5dd6a04ccfb8768766b7b8338138 100644
+index df9b6031649b751ae737c6fb76761b1b42d54a93..302f9fc837918dfa85660e00ae70e00fe0ba1780 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2442,6 +2442,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2450,6 +2450,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0342-Add-player-health-update-API.patch
+++ b/patches/api/0342-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 1b53015ffe065782f1417d3567c6a89a47d66fab..7eda2ba17e39b8183e572c1cefa8afffbf17afcb 100644
+index 9ccdb05d2be4547a3ed1d10479f10b58775336ef..c8fc528b5f9e7c898106bc5b30c245700ed17095 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1846,6 +1846,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1854,6 +1854,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public double getHealthScale();
  

--- a/patches/server/0006-MC-Utils.patch
+++ b/patches/server/0006-MC-Utils.patch
@@ -4414,7 +4414,7 @@ index 0000000000000000000000000000000000000000..4d3dc8fba51bf5c0dceb06744781d1df
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/Util.java b/src/main/java/net/minecraft/Util.java
-index 1851b36f978330651627f902f1c123337cdf9075..5c57a6607f1a95ac4d8770d0429d6848351f5452 100644
+index 0b73c98a880d535b615f89d47f4bc3a22348a195..2a06617cd484f378e87660b11a5eb78052348f39 100644
 --- a/src/main/java/net/minecraft/Util.java
 +++ b/src/main/java/net/minecraft/Util.java
 @@ -107,7 +107,7 @@ public class Util {
@@ -5291,7 +5291,7 @@ index 40dd2077f26a2c1fa15f21861204faa53748140e..45de5e508540b4ba622985d530f1aada
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 6628fd9cff01a3ddb736ec829566afcd08a7f95e..f3a2a5dcd18d8abe370779f75106eacab498c3b6 100644
+index 2fc246ca7ade62c0c2aff3f13f07bd376f032816..ae93a5bd184e084720400a44a3d9b14910343333 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -59,6 +59,7 @@ import net.minecraft.network.protocol.game.ClientboundSetChunkCacheCenterPacket;
@@ -5881,7 +5881,7 @@ index d672c467267ef4d96184e104c35d0379116880db..be11caf7c0dcdb11e24cfb053cda45ac
      @Override
      public ChunkAccess getChunk(int x, int z, ChunkStatus leastStatus, boolean create) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 5ee375a81164bbf18b8fc8e4fec5869187438078..ce9ff034a281cd9cc76c26713b6d1eab3f6c9fe2 100644
+index b9ef6e33e584099b77b966774e1ae6aa497dfca1..073cea951644f25c276ba05ff1fc48fda08593da 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -159,6 +159,7 @@ import org.bukkit.event.server.MapInitializeEvent;
@@ -6090,10 +6090,10 @@ index a4c5edee297af6d68d518b77f706732b5ccbe4de..7bf4bf5cb2c1b54a7e2733091f48f3a8
      @Override
      public void tell(R runnable) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2d530eababfe131942714e543ba305e3e32fd3c7..600cebdb6688ffef448d126233a329a6931ce37a 100644
+index a54b10896825ef61bd005bcd5a1232bd5f2ec132..52eb344feee9c3bc34a6d22a32de174c52736fb5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -302,6 +302,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -308,6 +308,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return this.level.hasChunk((int) Math.floor(this.getX()) >> 4, (int) Math.floor(this.getZ()) >> 4);
      }
      // CraftBukkit end
@@ -6106,10 +6106,10 @@ index 2d530eababfe131942714e543ba305e3e32fd3c7..600cebdb6688ffef448d126233a329a6
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e772ed45ba7cf366c6da0dc8b1bd3497d561473a..e9e97cf0b202c84252fb3bada97890198fcc6bb9 100644
+index 1c5f30b199904c74aa3e473b7696c416d93f0efe..a3b6883d7fc856ed8550ffb7aa8dd929922853e2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -256,6 +256,7 @@ public abstract class LivingEntity extends Entity {
+@@ -255,6 +255,7 @@ public abstract class LivingEntity extends Entity {
      public boolean collides = true;
      public Set<UUID> collidableExemptions = new HashSet<>();
      public boolean bukkitPickUpLoot;
@@ -7065,7 +7065,7 @@ index d40c0d8be1b0153d62021b8bcb6e8b37fd0acb4e..e38e57b1f9ef27020de35d7ddcb36a66
      public void clear() {
          // Create new array to reset memory usage to initial capacity
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index beea7aa621bc00d30a448fbbb684b05e229dc6ea..c90db55aadb1d16f6cc4e02e57a13a3c3fe6a420 100644
+index a96cb7a5f7c94cd9a46b31cf8ec90b544221557b..43aa6b0129892b8ab8ec25c16a131541c6607487 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -118,7 +118,11 @@ public class SpigotConfig

--- a/patches/server/0009-Add-MinecraftKey-Information-to-Objects.patch
+++ b/patches/server/0009-Add-MinecraftKey-Information-to-Objects.patch
@@ -36,7 +36,7 @@ index 0000000000000000000000000000000000000000..9f0c7fd903f085e70db1785fb8bcdb54
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 600cebdb6688ffef448d126233a329a6931ce37a..fdf607c91ee31206839b14212a20ee81ec751776 100644
+index 52eb344feee9c3bc34a6d22a32de174c52736fb5..0736454dea12d8ffe8ef6873c5d25d17a96504b0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -145,7 +145,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
@@ -48,7 +48,7 @@ index 600cebdb6688ffef448d126233a329a6931ce37a..fdf607c91ee31206839b14212a20ee81
  
      // CraftBukkit start
      private static final int CURRENT_LEVEL = 2;
-@@ -1949,12 +1949,32 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1963,12 +1963,32 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return true;
      }
  

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -1412,7 +1412,7 @@ index 8e4325abb2dda74c38b17bb27f9dcfcf97ba2de6..1be4b3ad18d314b0460ce61e01afd0d7
  
      public UserWhiteList getWhiteList() {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index efb347d1a8ac45b13e1abfa712cbd204c64501ae..668fcdf95c92b439612d98f224ae4ac9bd055bdf 100644
+index 0736454dea12d8ffe8ef6873c5d25d17a96504b0..68ccbc193ff6682f505928dc0a29ee990349d299 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -125,7 +125,6 @@ import org.bukkit.craftbukkit.event.CraftPortalEvent;
@@ -1423,7 +1423,7 @@ index efb347d1a8ac45b13e1abfa712cbd204c64501ae..668fcdf95c92b439612d98f224ae4ac9
  import org.bukkit.event.entity.EntityCombustByEntityEvent;
  import org.bukkit.event.hanging.HangingBreakByEntityEvent;
  import org.bukkit.event.vehicle.VehicleBlockCollisionEvent;
-@@ -286,7 +285,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -292,7 +291,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public boolean lastDamageCancelled; // SPIGOT-5339, SPIGOT-6252, SPIGOT-6777: Keep track if the event was canceled
      public boolean persistentInvisibility = false;
      public BlockPos lastLavaContact;
@@ -1431,7 +1431,7 @@ index efb347d1a8ac45b13e1abfa712cbd204c64501ae..668fcdf95c92b439612d98f224ae4ac9
      // Spigot start
      public final org.spigotmc.ActivationRange.ActivationType activationType = org.spigotmc.ActivationRange.initializeEntityActivationType(this);
      public final boolean defaultActivationState;
-@@ -734,7 +732,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -740,7 +738,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public void move(MoverType movementType, Vec3 movement) {
@@ -1439,7 +1439,7 @@ index efb347d1a8ac45b13e1abfa712cbd204c64501ae..668fcdf95c92b439612d98f224ae4ac9
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -887,7 +884,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -893,7 +890,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  this.level.getProfiler().pop();
              }
          }
@@ -1504,7 +1504,7 @@ index e688949fc2f3031dc9c9817bc59554e9f5a436af..20cfdba68c200e87d00995a6a4e25a5f
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5669d868f764dcdea8c510fc902cadea226ce473..46b40b08916369f8aa8b28144f07c48741c45101 100644
+index a3b6883d7fc856ed8550ffb7aa8dd929922853e2..59bb2aafcbc1a4a5c963ef0391b4e9b4f670ff72 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -137,7 +137,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -1516,7 +1516,7 @@ index 5669d868f764dcdea8c510fc902cadea226ce473..46b40b08916369f8aa8b28144f07c487
  
  public abstract class LivingEntity extends Entity {
  
-@@ -2760,7 +2760,6 @@ public abstract class LivingEntity extends Entity {
+@@ -2759,7 +2759,6 @@ public abstract class LivingEntity extends Entity {
  
      @Override
      public void tick() {
@@ -1524,7 +1524,7 @@ index 5669d868f764dcdea8c510fc902cadea226ce473..46b40b08916369f8aa8b28144f07c487
          super.tick();
          this.updatingUsingItem();
          this.updateSwimAmount();
-@@ -2801,9 +2800,7 @@ public abstract class LivingEntity extends Entity {
+@@ -2800,9 +2799,7 @@ public abstract class LivingEntity extends Entity {
              }
          }
  
@@ -1534,7 +1534,7 @@ index 5669d868f764dcdea8c510fc902cadea226ce473..46b40b08916369f8aa8b28144f07c487
          double d0 = this.getX() - this.xo;
          double d1 = this.getZ() - this.zo;
          float f = (float) (d0 * d0 + d1 * d1);
-@@ -2883,8 +2880,6 @@ public abstract class LivingEntity extends Entity {
+@@ -2882,8 +2879,6 @@ public abstract class LivingEntity extends Entity {
          if (this.isSleeping()) {
              this.setXRot(0.0F);
          }
@@ -1543,7 +1543,7 @@ index 5669d868f764dcdea8c510fc902cadea226ce473..46b40b08916369f8aa8b28144f07c487
      }
  
      public void detectEquipmentUpdates() {
-@@ -3066,7 +3061,6 @@ public abstract class LivingEntity extends Entity {
+@@ -3065,7 +3060,6 @@ public abstract class LivingEntity extends Entity {
  
          this.setDeltaMovement(d4, d5, d6);
          this.level.getProfiler().push("ai");
@@ -1551,7 +1551,7 @@ index 5669d868f764dcdea8c510fc902cadea226ce473..46b40b08916369f8aa8b28144f07c487
          if (this.isImmobile()) {
              this.jumping = false;
              this.xxa = 0.0F;
-@@ -3076,7 +3070,6 @@ public abstract class LivingEntity extends Entity {
+@@ -3075,7 +3069,6 @@ public abstract class LivingEntity extends Entity {
              this.serverAiStep();
              this.level.getProfiler().pop();
          }
@@ -1559,7 +1559,7 @@ index 5669d868f764dcdea8c510fc902cadea226ce473..46b40b08916369f8aa8b28144f07c487
  
          this.level.getProfiler().pop();
          this.level.getProfiler().push("jump");
-@@ -3111,9 +3104,9 @@ public abstract class LivingEntity extends Entity {
+@@ -3110,9 +3103,9 @@ public abstract class LivingEntity extends Entity {
          this.updateFallFlying();
          AABB axisalignedbb = this.getBoundingBox();
  
@@ -1571,7 +1571,7 @@ index 5669d868f764dcdea8c510fc902cadea226ce473..46b40b08916369f8aa8b28144f07c487
          this.level.getProfiler().pop();
          this.level.getProfiler().push("freezing");
          boolean flag1 = this.getType().is(EntityTypeTags.FREEZE_HURTS_EXTRA_TYPES);
-@@ -3142,9 +3135,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3141,9 +3134,7 @@ public abstract class LivingEntity extends Entity {
              this.checkAutoSpinAttack(axisalignedbb, this.getBoundingBox());
          }
  
@@ -1918,10 +1918,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9e9d62f168421bcb542f036f30515ef2ae374b45..2be5fd4be7b96c8215a3a65ecc799e3490e2e55d 100644
+index fef3a50c48d1548a6b39e60c3a1acb283d20dd74..42df05eb0f7fe1910433e4bfe53c17dc5f5cbdfe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1895,6 +1895,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1902,6 +1902,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              packet.components = components;
              CraftPlayer.this.getHandle().connection.send(packet);
          }

--- a/patches/server/0012-Adventure.patch
+++ b/patches/server/0012-Adventure.patch
@@ -2348,7 +2348,7 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2be5fd4be7b96c8215a3a65ecc799e3490e2e55d..d4444384fae41b3c502e8a34ccd88041928de67d 100644
+index 42df05eb0f7fe1910433e4bfe53c17dc5f5cbdfe..3869717bb9246cabf900840aac93eaa3e6b7fbf7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -253,14 +253,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2513,7 +2513,7 @@ index 2be5fd4be7b96c8215a3a65ecc799e3490e2e55d..d4444384fae41b3c502e8a34ccd88041
      }
  
      @Override
-@@ -1319,7 +1383,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1326,7 +1390,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url) {
@@ -2522,7 +2522,7 @@ index 2be5fd4be7b96c8215a3a65ecc799e3490e2e55d..d4444384fae41b3c502e8a34ccd88041
      }
  
      @Override
-@@ -1334,7 +1398,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1341,7 +1405,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url, byte[] hash, boolean force) {
@@ -2531,7 +2531,7 @@ index 2be5fd4be7b96c8215a3a65ecc799e3490e2e55d..d4444384fae41b3c502e8a34ccd88041
      }
  
      @Override
-@@ -1350,6 +1414,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1357,6 +1421,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2553,7 +2553,7 @@ index 2be5fd4be7b96c8215a3a65ecc799e3490e2e55d..d4444384fae41b3c502e8a34ccd88041
      public void addChannel(String channel) {
          Preconditions.checkState(this.channels.size() < 128, "Cannot register channel '%s'. Too many channels registered!", channel);
          channel = StandardMessenger.validateAndCorrectChannel(channel);
-@@ -1754,6 +1833,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1761,6 +1840,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -2566,7 +2566,7 @@ index 2be5fd4be7b96c8215a3a65ecc799e3490e2e55d..d4444384fae41b3c502e8a34ccd88041
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -1799,6 +1884,194 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1806,6 +1891,194 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  

--- a/patches/server/0016-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
+++ b/patches/server/0016-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
@@ -19,10 +19,10 @@ index 5896b4e4646d722db5622a424fa26f42d3f8d9ff..0a6e98ca5534430540044a32c280e568
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3eb1f5e422002a48651a24d0e70884bf54de717e..3efdf887ec70aa2d3486a1ddfc8e5e1c1e27829a 100644
+index 68ccbc193ff6682f505928dc0a29ee990349d299..3321df3bcc0b92277dc18b7f6efa42393e657a52 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1259,6 +1259,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1265,6 +1265,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          return this.isInWater() || this.isInRain();
      }
  
@@ -31,7 +31,7 @@ index 3eb1f5e422002a48651a24d0e70884bf54de717e..3efdf887ec70aa2d3486a1ddfc8e5e1c
          return this.isInWater() || this.isInRain() || this.isInBubbleColumn();
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index f6c93812c30bd1637219c22c1a903e2ec93a9d72..36a4214615a0acf0aa4a9dc4411afc130bcfdbc1 100644
+index 31f98763da600c34246d722cb92dda4442a3f046..1703bc12cd2c04fb34ebe025f305dc7fb2de1864 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -105,6 +105,7 @@ public abstract class Mob extends LivingEntity {

--- a/patches/server/0023-Player-affects-spawning-API.patch
+++ b/patches/server/0023-Player-affects-spawning-API.patch
@@ -117,10 +117,10 @@ index c65d1dc6eb0c1fc7c4a91faf0f1c6f26b3c2a76e..0dc46471f7247e5d36c3896a0c874730
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d4444384fae41b3c502e8a34ccd88041928de67d..1195cf6c72cbf14d49ef709d54315ad998142656 100644
+index 3869717bb9246cabf900840aac93eaa3e6b7fbf7..13d9bcb9ccc34bf81ba834365e511eabd4153aee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1847,8 +1847,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1854,8 +1854,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0026-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0026-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1195cf6c72cbf14d49ef709d54315ad998142656..24ae5383543230b18a5f4aa66112f483850b39dc 100644
+index 13d9bcb9ccc34bf81ba834365e511eabd4153aee..a0e5298abb15c11dc21ea09638a34ef11f253349 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1516,12 +1516,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1523,12 +1523,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0027-Entity-Origin-API.patch
+++ b/patches/server/0027-Entity-Origin-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity Origin API
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index ae090f58bec25270e55f8da37355351783e69a7f..50513abfb5009c22cfd6d8fcf20243f66bf2f53e 100644
+index c7fe4b6aa8d68bd5dc394752a5ae635eb46c5f31..a38fe84e9f8060640eb0c485957e8ceaef55c29b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2016,6 +2016,15 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -25,10 +25,10 @@ index ae090f58bec25270e55f8da37355351783e69a7f..50513abfb5009c22cfd6d8fcf20243f6
  
          public void onTrackingEnd(Entity entity) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3efdf887ec70aa2d3486a1ddfc8e5e1c1e27829a..228aa322f438c1c5f5bf655ff4c056aa01daed1a 100644
+index 3321df3bcc0b92277dc18b7f6efa42393e657a52..4e835004679b3f5ae0fc7103566b613a6766aefe 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -291,7 +291,27 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -297,7 +297,27 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public long activatedTick = Integer.MIN_VALUE;
      public void inactiveTick() { }
      // Spigot end
@@ -56,7 +56,7 @@ index 3efdf887ec70aa2d3486a1ddfc8e5e1c1e27829a..228aa322f438c1c5f5bf655ff4c056aa
      public float getBukkitYaw() {
          return this.yRot;
      }
-@@ -1807,6 +1827,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1817,6 +1837,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  this.bukkitEntity.storeBukkitValues(nbt);
              }
              // CraftBukkit end
@@ -72,7 +72,7 @@ index 3efdf887ec70aa2d3486a1ddfc8e5e1c1e27829a..228aa322f438c1c5f5bf655ff4c056aa
              return nbt;
          } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.forThrowable(throwable, "Saving entity NBT");
-@@ -1933,6 +1962,20 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1947,6 +1976,20 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              }
              // CraftBukkit end
  

--- a/patches/server/0029-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0029-Configurable-top-of-nether-void-damage.patch
@@ -29,10 +29,10 @@ index 6dec1bb96d695f28aae6517e4d78249169d2351a..1b090f2e38a8857ef74403e1f3db8c2b
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 228aa322f438c1c5f5bf655ff4c056aa01daed1a..5ae90cf6e786bf82bebd7914b4b65e87da2b6301 100644
+index 4e835004679b3f5ae0fc7103566b613a6766aefe..6cd4fecf8b6e49027cf8a523fb373db9a2708ed4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -638,7 +638,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -644,7 +644,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public void checkOutOfWorld() {

--- a/patches/server/0035-Disable-explosion-knockback.patch
+++ b/patches/server/0035-Disable-explosion-knockback.patch
@@ -19,10 +19,10 @@ index 2b0a75dc2e292e655ca3300f64bc1211b3adeceb..5cae4a5caf9aba8c0e99f1cb6badc5e8
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 46b40b08916369f8aa8b28144f07c48741c45101..7365ff9a52ddc302a68002a48c60ce526fcd547b 100644
+index 59bb2aafcbc1a4a5c963ef0391b4e9b4f670ff72..b14e9a629430070071b498f719b649af1d4bb926 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1374,6 +1374,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1373,6 +1373,7 @@ public abstract class LivingEntity extends Entity {
                  }
              }
  
@@ -30,7 +30,7 @@ index 46b40b08916369f8aa8b28144f07c48741c45101..7365ff9a52ddc302a68002a48c60ce52
              if (flag1) {
                  if (flag) {
                      this.level.broadcastEntityEvent(this, (byte) 29);
-@@ -1394,6 +1395,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1393,6 +1394,7 @@ public abstract class LivingEntity extends Entity {
                          b0 = 2;
                      }
  
@@ -38,7 +38,7 @@ index 46b40b08916369f8aa8b28144f07c48741c45101..7365ff9a52ddc302a68002a48c60ce52
                      this.level.broadcastEntityEvent(this, b0);
                  }
  
-@@ -1417,6 +1419,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1416,6 +1418,7 @@ public abstract class LivingEntity extends Entity {
                  }
              }
  

--- a/patches/server/0039-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0039-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index 88b6be62678fc09b5a39db28c6d71cc31b16dbcd..352bfe795aea26307de9c998d67a43af
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 24ae5383543230b18a5f4aa66112f483850b39dc..8f5f26deeaf8c66af70e674922634b34eaa19831 100644
+index a0e5298abb15c11dc21ea09638a34ef11f253349..3a3f9ef73c2ff39cf589b517b8b869f55edbe8ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1847,8 +1847,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1854,8 +1854,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0053-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0053-Add-configurable-portal-search-radius.patch
@@ -23,10 +23,10 @@ index 1e3c39f0eeeb07f8d49e3651b18a152db9ccba7b..c248b66486044150c64eaddbef85fa66
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5ae90cf6e786bf82bebd7914b4b65e87da2b6301..38b0923d47ee6a26325d559993f26367d7d81590 100644
+index 6cd4fecf8b6e49027cf8a523fb373db9a2708ed4..de15a2231057217fbbf723cf25e869998a1016f1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2900,7 +2900,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2914,7 +2914,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  double d0 = DimensionType.getTeleportationScale(this.level.dimensionType(), destination.dimensionType());
                  BlockPos blockposition = worldborder.clampToBounds(this.getX() * d0, this.getY(), this.getZ() * d0);
                  // CraftBukkit start

--- a/patches/server/0058-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/patches/server/0058-Disable-Scoreboards-for-non-players-by-default.patch
@@ -25,10 +25,10 @@ index ada624b5f58381122e59568c2087cf38fd2baf3e..5b55fce59db9ac3ab6030ebe8374c514
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 38b0923d47ee6a26325d559993f26367d7d81590..fd43c6053b14f60d77e902326df8957d272b944c 100644
+index de15a2231057217fbbf723cf25e869998a1016f1..69f820aa1f29e626c0ae0322281063efae53c470 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2547,6 +2547,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2561,6 +2561,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
  
      @Nullable
      public Team getTeam() {
@@ -37,10 +37,10 @@ index 38b0923d47ee6a26325d559993f26367d7d81590..fd43c6053b14f60d77e902326df8957d
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 181711ccb45ffaefddc846c374d5704696c31845..09cea6b92aa8a0b60716163b7bda61823268bed7 100644
+index b14e9a629430070071b498f719b649af1d4bb926..9168826ac85bc7cd355e73b2d02b7cce9c4c9cee 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -798,6 +798,7 @@ public abstract class LivingEntity extends Entity {
+@@ -797,6 +797,7 @@ public abstract class LivingEntity extends Entity {
          if (nbt.contains("Team", 8)) {
              String s = nbt.getString("Team");
              PlayerTeam scoreboardteam = this.level.getScoreboard().getPlayerTeam(s);

--- a/patches/server/0061-Complete-resource-pack-API.patch
+++ b/patches/server/0061-Complete-resource-pack-API.patch
@@ -23,7 +23,7 @@ index a1fe02097f369a350de79d7eb94f4a6eb3d3530e..d64e7bbfda0ad2fd086fd918bf5fa31e
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c2e9f4609c70adf36425ee12bbbf47dd92bdbd0e..a332a025655219acdbbecb4ec86e280e4dd7dac3 100644
+index a9fb93173266572acf4447e980859e5a2b6e9886..e81d8300ee80bfc20660b2c99a17703ad8d37701 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -135,6 +135,7 @@ import org.bukkit.metadata.MetadataValue;
@@ -45,7 +45,7 @@ index c2e9f4609c70adf36425ee12bbbf47dd92bdbd0e..a332a025655219acdbbecb4ec86e280e
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -1987,6 +1992,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1994,6 +1999,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0068-Custom-replacement-for-eaten-items.patch
+++ b/patches/server/0068-Custom-replacement-for-eaten-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom replacement for eaten items
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index c4bfeffbfefcb77c7727cb8466eb20c8ca0f2956..cb611587ad1b929627576a330e398d980595c48a 100644
+index 9168826ac85bc7cd355e73b2d02b7cce9c4c9cee..e94344170190ae9429b744ec7878c3aa093f01b6 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3563,9 +3563,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3562,9 +3562,10 @@ public abstract class LivingEntity extends Entity {
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
@@ -20,7 +20,7 @@ index c4bfeffbfefcb77c7727cb8466eb20c8ca0f2956..cb611587ad1b929627576a330e398d98
                          level.getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {
-@@ -3579,6 +3580,13 @@ public abstract class LivingEntity extends Entity {
+@@ -3578,6 +3579,13 @@ public abstract class LivingEntity extends Entity {
                      } else {
                          itemstack = this.useItem.finishUsingItem(this.level, this);
                      }
@@ -34,7 +34,7 @@ index c4bfeffbfefcb77c7727cb8466eb20c8ca0f2956..cb611587ad1b929627576a330e398d98
                      // CraftBukkit end
  
                      if (itemstack != this.useItem) {
-@@ -3586,6 +3594,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3585,6 +3593,11 @@ public abstract class LivingEntity extends Entity {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0069-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0069-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cb611587ad1b929627576a330e398d980595c48a..a1137e8602a2d2670df4ddff01d7aee5d3599991 100644
+index e94344170190ae9429b744ec7878c3aa093f01b6..e13808657e0c7dc94fcd2844690a31d0691b6a7b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -759,7 +759,13 @@ public abstract class LivingEntity extends Entity {
+@@ -758,7 +758,13 @@ public abstract class LivingEntity extends Entity {
  
      @Override
      public void readAdditionalSaveData(CompoundTag nbt) {
@@ -23,7 +23,7 @@ index cb611587ad1b929627576a330e398d980595c48a..a1137e8602a2d2670df4ddff01d7aee5
          if (nbt.contains("Attributes", 9) && this.level != null && !this.level.isClientSide) {
              this.getAttributes().load(nbt.getList("Attributes", 10));
          }
-@@ -1246,6 +1252,10 @@ public abstract class LivingEntity extends Entity {
+@@ -1245,6 +1251,10 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void setHealth(float health) {
@@ -34,7 +34,7 @@ index cb611587ad1b929627576a330e398d980595c48a..a1137e8602a2d2670df4ddff01d7aee5
          // CraftBukkit start - Handle scaled health
          if (this instanceof ServerPlayer) {
              org.bukkit.craftbukkit.entity.CraftPlayer player = ((ServerPlayer) this).getBukkitEntity();
-@@ -3397,7 +3407,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3396,7 +3406,7 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void setAbsorptionAmount(float amount) {
@@ -44,10 +44,10 @@ index cb611587ad1b929627576a330e398d980595c48a..a1137e8602a2d2670df4ddff01d7aee5
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a332a025655219acdbbecb4ec86e280e4dd7dac3..12985cf9731b70bb1811efb04afe25e5c9fdc851 100644
+index e81d8300ee80bfc20660b2c99a17703ad8d37701..c57a1e4f718d3a0ad644a432142110a397cd3ae6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1792,6 +1792,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1799,6 +1799,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0070-Use-a-Shared-Random-for-Entities.patch
+++ b/patches/server/0070-Use-a-Shared-Random-for-Entities.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use a Shared Random for Entities
 Reduces memory usage and provides ensures more randomness, Especially since a lot of garbage entity objects get created.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fd43c6053b14f60d77e902326df8957d272b944c..6ed53d50f395dc2a629d7393b01074d14f0a60d4 100644
+index 69f820aa1f29e626c0ae0322281063efae53c470..415c746b497d19f359705721874ed65d7e7ca817 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -152,6 +152,21 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -31,7 +31,7 @@ index fd43c6053b14f60d77e902326df8957d272b944c..6ed53d50f395dc2a629d7393b01074d1
      private CraftEntity bukkitEntity;
  
      public CraftEntity getBukkitEntity() {
-@@ -333,7 +348,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -339,7 +354,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          this.bb = Entity.INITIAL_AABB;
          this.stuckSpeedMultiplier = Vec3.ZERO;
          this.nextStep = 1.0F;

--- a/patches/server/0088-EntityRegainHealthEvent-isFastRegen-API.patch
+++ b/patches/server/0088-EntityRegainHealthEvent-isFastRegen-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] EntityRegainHealthEvent isFastRegen API
 Don't even get me started
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e5a0f6edbb1d43f8c918b9cee9a291db630663b4..88066799a0090d22a2e22df17e2967774089f8b7 100644
+index e13808657e0c7dc94fcd2844690a31d0691b6a7b..fcf9206ef317aa22cd644ccb415c2156fd9f2af2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1225,10 +1225,16 @@ public abstract class LivingEntity extends Entity {
+@@ -1224,10 +1224,16 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void heal(float f, EntityRegainHealthEvent.RegainReason regainReason) {

--- a/patches/server/0109-Add-EntityZapEvent.patch
+++ b/patches/server/0109-Add-EntityZapEvent.patch
@@ -28,10 +28,10 @@ index e2ac5290751b8c219add3823251e0131c0d2b52e..8785a112519de49e0d61eab5ab5325f9
              entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
              entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1e8c5b0194e1ba2f9a0f85dcaf6a3bcb632f6cbf..748989e26e57ab7606a355180a06e17e525df706 100644
+index 57c7ee1329d80fb441a4637f309d69fa120fae01..cad2a30665e059ab9f0be3f94876d332ccb29178 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1133,6 +1133,14 @@ public class CraftEventFactory {
+@@ -1142,6 +1142,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index 687904d3e1b3ee7b514c707d9b2eeccabbf56603..f7cbe6819b8c4f7eaca2389de8eaceb5
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 748989e26e57ab7606a355180a06e17e525df706..a16bc51215be1f3342bb2f47e203eb01359f294c 100644
+index cad2a30665e059ab9f0be3f94876d332ccb29178..16f1bac14758d5052effb3aadece9b00d8bc7752 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1092,6 +1092,17 @@ public class CraftEventFactory {
+@@ -1101,6 +1101,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0115-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0115-Add-ProjectileCollideEvent.patch
@@ -87,10 +87,10 @@ index 88181c59e604ba3b132b9e695cef5eaf5b836029..94d09b05737679b133ec462815b010b1
  
          this.checkInsideBlocks();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a16bc51215be1f3342bb2f47e203eb01359f294c..2b641a47f81c49dedc915d55dd43b7415f310582 100644
+index 16f1bac14758d5052effb3aadece9b00d8bc7752..d93e79ab1a3b16bfc75209cb0b5e2e9fade35d86 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1236,6 +1236,16 @@ public class CraftEventFactory {
+@@ -1245,6 +1245,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/patches/server/0128-Don-t-allow-entities-to-ride-themselves-572.patch
+++ b/patches/server/0128-Don-t-allow-entities-to-ride-themselves-572.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't allow entities to ride themselves - #572
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 493ddc76367226fa6344a1ee333378410e42b165..b1d86df7002d6f6398288bc24c0d92a6349e0dcb 100644
+index 31d5d69ba7e78158bf854a25e2bf43b119e0bf88..ebf9e06b4fdd64d22ad2b56c26b4c994c1a84833 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2242,6 +2242,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2256,6 +2256,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -129,10 +129,10 @@ index f7cbe6819b8c4f7eaca2389de8eaceb50bce4b15..90692df7e02346d4ba785d2eaf724d06
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e0f3687f3ca7af59ee305cf167f829300bbb6fb1..11244493242b04209c67b3a41814687b1d64cdf7 100644
+index fcf9206ef317aa22cd644ccb415c2156fd9f2af2..3490b9f1803ea852ad0682e22524b58c3b050510 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1698,7 +1698,8 @@ public abstract class LivingEntity extends Entity {
+@@ -1697,7 +1697,8 @@ public abstract class LivingEntity extends Entity {
      protected void dropExperience() {
          // CraftBukkit start - Update getExpReward() above if the removed if() changes!
          if (true) {
@@ -230,7 +230,7 @@ index 9001d627060b9691b703b4c0e157124b0cdee6bb..1101989e93758294c1adebbef0ab12a3
  
      }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
-index 4afc7ee0761733bbde66e6eed9c6964ddad783a0..0c21dbb304a31441f67ed4b008a145c1868da32c 100644
+index c4126c0ced9cd8f7f23f91e2d141c37ba85da6af..c51dbef3bf17405be368d4caec72b713e06bafbc 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 @@ -515,7 +515,7 @@ public class FishingHook extends Projectile {

--- a/patches/server/0130-Cap-Entity-Collisions.patch
+++ b/patches/server/0130-Cap-Entity-Collisions.patch
@@ -27,10 +27,10 @@ index f383f30b9dd1a7c6cf69d342f99118beec70b206..47b717e8741bb2b8f3aa776dcdc73a3e
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1deb8dd7cbf0486225bf0efbd92fe871d933bec2..d7fcf267853114ff3ca0b4ab784649f3166031e1 100644
+index ebf9e06b4fdd64d22ad2b56c26b4c994c1a84833..fb7487b52af00ae44e669242a4182a49e9b00428 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -308,6 +308,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -314,6 +314,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public void inactiveTick() { }
      // Spigot end
      // Paper start
@@ -39,10 +39,10 @@ index 1deb8dd7cbf0486225bf0efbd92fe871d933bec2..d7fcf267853114ff3ca0b4ab784649f3
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 11244493242b04209c67b3a41814687b1d64cdf7..ab95fd2a0a274f7f838ddcf28b84aee5d5df8d72 100644
+index 3490b9f1803ea852ad0682e22524b58c3b050510..9c175c28d152d4a6af9a720cfd95df7fdcc1be81 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3226,8 +3226,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3225,8 +3225,11 @@ public abstract class LivingEntity extends Entity {
                  }
              }
  

--- a/patches/server/0147-Entity-fromMobSpawner.patch
+++ b/patches/server/0147-Entity-fromMobSpawner.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d6e1860772724347d62fb6990304ec8f4cde4035..28d4202f0a9c6910e98d32f6c561ac25c73c186e 100644
+index fb7487b52af00ae44e669242a4182a49e9b00428..c2b24ad7ca280972f287cbb876dcc7011fb49db9 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -309,6 +309,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -315,6 +315,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      // Spigot end
      // Paper start
      protected int numCollisions = 0; // Paper
@@ -16,7 +16,7 @@ index d6e1860772724347d62fb6990304ec8f4cde4035..28d4202f0a9c6910e98d32f6c561ac25
      @javax.annotation.Nullable
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
-@@ -1856,6 +1857,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1866,6 +1867,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  }
                  nbt.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -27,7 +27,7 @@ index d6e1860772724347d62fb6990304ec8f4cde4035..28d4202f0a9c6910e98d32f6c561ac25
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -1995,6 +2000,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2009,6 +2014,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  this.originWorld = originWorld;
                  origin = new org.bukkit.util.Vector(originTag.getDouble(0), originTag.getDouble(1), originTag.getDouble(2));
              }

--- a/patches/server/0164-Add-PlayerArmorChangeEvent.patch
+++ b/patches/server/0164-Add-PlayerArmorChangeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ab95fd2a0a274f7f838ddcf28b84aee5d5df8d72..9319c33e21ac28aecc5171fc3fcc77d46e1d4b18 100644
+index 9c175c28d152d4a6af9a720cfd95df7fdcc1be81..0e1085dde127c943eda879b310182af60b8df16c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1,5 +1,6 @@
@@ -15,7 +15,7 @@ index ab95fd2a0a274f7f838ddcf28b84aee5d5df8d72..9319c33e21ac28aecc5171fc3fcc77d4
  import com.google.common.base.Objects;
  import com.google.common.collect.ImmutableList;
  import com.google.common.collect.ImmutableMap;
-@@ -2939,6 +2940,13 @@ public abstract class LivingEntity extends Entity {
+@@ -2938,6 +2939,13 @@ public abstract class LivingEntity extends Entity {
              ItemStack itemstack1 = this.getItemBySlot(enumitemslot);
  
              if (!ItemStack.matches(itemstack1, itemstack)) {

--- a/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
@@ -9,39 +9,22 @@ of giving the player experience points.
 
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
-diff --git a/src/main/java/net/minecraft/world/item/enchantment/EnchantmentHelper.java b/src/main/java/net/minecraft/world/item/enchantment/EnchantmentHelper.java
-index 3a09ce6d0ea51436adcae4719d3f28d1868c283c..7bc5aa35b52de0027cf58a6127a9903464ccaf47 100644
---- a/src/main/java/net/minecraft/world/item/enchantment/EnchantmentHelper.java
-+++ b/src/main/java/net/minecraft/world/item/enchantment/EnchantmentHelper.java
-@@ -270,8 +270,11 @@ public class EnchantmentHelper {
-         return getItemEnchantmentLevel(Enchantments.CHANNELING, stack) > 0;
-     }
- 
--    @Nullable
--    public static Entry<EquipmentSlot, ItemStack> getRandomItemWith(Enchantment enchantment, LivingEntity entity) {
-+    @Deprecated public static @javax.annotation.Nonnull ItemStack getRandomEquippedItemWithEnchant(Enchantment enchantment, LivingEntity entityliving) {
-+        Entry<EquipmentSlot, ItemStack> entry = getRandomItemWith(enchantment, entityliving);
-+        return entry != null ? entry.getValue() : ItemStack.EMPTY;
-+    } // Paper - OBFHELPER
-+    @Nullable public static Entry<EquipmentSlot, ItemStack> getRandomItemWith(Enchantment enchantment, LivingEntity entity) {
-         return getRandomItemWith(enchantment, entity, (stack) -> {
-             return true;
-         });
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9090c1a400dcb23678ea15234e1517cd707b694c..4061b79b55d0ef3221f74d5cb410f8a1574fd8d2 100644
+index d7a60f85362ef8416f323c075a0017cd4b544045..bc31a9d5f709362f986ce4132287746568bafa56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1239,8 +1239,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
-         return GameMode.getByValue(this.getHandle().gameMode.getGameModeForPlayer().getId());
+@@ -1247,7 +1247,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
+     @Override
+-    public void giveExp(int exp) {
 +    // Paper start
-+    @Override
 +    public int applyMending(int amount) {
-+        ServerPlayer handle = getHandle();
++        ServerPlayer handle = this.getHandle();
 +        // Logic copied from EntityExperienceOrb and remapped to unobfuscated methods/properties
-+        net.minecraft.world.item.ItemStack itemstack = net.minecraft.world.item.enchantment.EnchantmentHelper
-+            .getRandomEquippedItemWithEnchant(net.minecraft.world.item.enchantment.Enchantments.MENDING, handle);
++        final var stackEntry = net.minecraft.world.item.enchantment.EnchantmentHelper
++            .getRandomItemWith(net.minecraft.world.item.enchantment.Enchantments.MENDING, handle);
++        final net.minecraft.world.item.ItemStack itemstack = stackEntry != null ? stackEntry.getValue() : net.minecraft.world.item.ItemStack.EMPTY;
 +        if (!itemstack.isEmpty() && itemstack.getItem().canBeDepleted()) {
 +            net.minecraft.world.entity.ExperienceOrb orb = net.minecraft.world.entity.EntityType.EXPERIENCE_ORB.create(handle.level);
 +            orb.value = amount;
@@ -60,8 +43,7 @@ index 9090c1a400dcb23678ea15234e1517cd707b694c..4061b79b55d0ef3221f74d5cb410f8a1
 +        return amount;
 +    }
 +
-     @Override
--    public void giveExp(int exp) {
++    @Override
 +    public void giveExp(int exp, boolean applyMending) {
 +        if (applyMending) {
 +            exp = this.applyMending(exp);

--- a/patches/server/0184-Player.setPlayerProfile-API.patch
+++ b/patches/server/0184-Player.setPlayerProfile-API.patch
@@ -26,7 +26,7 @@ index 00ef714294b6cce5fec7613eed4ba228a48e3e11..67b300574655854249c1f7440f56a6e8
                              uniqueId = gameProfile.getId();
                              // Paper end
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4061b79b55d0ef3221f74d5cb410f8a1574fd8d2..b62925af7a2c9fda30b5d23ab12375ae1fd17ea2 100644
+index bc31a9d5f709362f986ce4132287746568bafa56..b808a8f5b1a2e663924b22aa0d65459abd9f865d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -72,6 +72,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -37,7 +37,7 @@ index 4061b79b55d0ef3221f74d5cb410f8a1574fd8d2..b62925af7a2c9fda30b5d23ab12375ae
  import net.minecraft.world.level.block.entity.SignBlockEntity;
  import net.minecraft.world.level.saveddata.maps.MapDecoration;
  import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
-@@ -1372,8 +1373,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1380,8 +1381,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.hiddenEntities.put(entity.getUniqueId(), hidingPlugins);
  
          // Remove this entity from the hidden player's EntityTrackerEntry
@@ -52,7 +52,7 @@ index 4061b79b55d0ef3221f74d5cb410f8a1574fd8d2..b62925af7a2c9fda30b5d23ab12375ae
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1422,8 +1428,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1430,8 +1436,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          this.hiddenEntities.remove(entity.getUniqueId());
  
@@ -67,7 +67,7 @@ index 4061b79b55d0ef3221f74d5cb410f8a1574fd8d2..b62925af7a2c9fda30b5d23ab12375ae
  
          if (other instanceof ServerPlayer) {
              ServerPlayer otherPlayer = (ServerPlayer) other;
-@@ -1435,6 +1446,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1443,6 +1454,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entry.updatePlayer(this.getHandle());
          }
      }

--- a/patches/server/0190-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0190-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b62925af7a2c9fda30b5d23ab12375ae1fd17ea2..eae0ec1c7165184a1a34510975ef62e9429a5777 100644
+index b808a8f5b1a2e663924b22aa0d65459abd9f865d..2a583f0db3dd9a64e843b63cd6a124074eb05e43 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -156,6 +156,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index b62925af7a2c9fda30b5d23ab12375ae1fd17ea2..eae0ec1c7165184a1a34510975ef62e9
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1689,7 +1690,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1697,7 +1698,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0210-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0210-Make-shield-blocking-delay-configurable.patch
@@ -19,10 +19,10 @@ index 8fc56818a2ba1aed73b8dda4da04ecac748c6ae6..1e9ffb5bc5c9d74c07be14435eb29ef9
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9319c33e21ac28aecc5171fc3fcc77d46e1d4b18..8abdc2807abe27c31c1f2c7316dad6c8457efbc4 100644
+index 0e1085dde127c943eda879b310182af60b8df16c..c347c4e6f957118198adb1de7633d369bd012b82 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3669,12 +3669,24 @@ public abstract class LivingEntity extends Entity {
+@@ -3668,12 +3668,24 @@ public abstract class LivingEntity extends Entity {
          if (this.isUsingItem() && !this.useItem.isEmpty()) {
              Item item = this.useItem.getItem();
  

--- a/patches/server/0213-Implement-EntityKnockbackByEntityEvent.patch
+++ b/patches/server/0213-Implement-EntityKnockbackByEntityEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement EntityKnockbackByEntityEvent
 This event is called when an entity receives knockback by another entity.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8abdc2807abe27c31c1f2c7316dad6c8457efbc4..8d6ff08f8546450a1fc746c3332bc427748cccb6 100644
+index c347c4e6f957118198adb1de7633d369bd012b82..9b6fcaaafa84853804f6183d02bd90b4f988d418 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1431,7 +1431,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1430,7 +1430,7 @@ public abstract class LivingEntity extends Entity {
                      }
  
                      this.hurtDir = (float) (Mth.atan2(d1, d0) * 57.2957763671875D - (double) this.getYRot());
@@ -18,7 +18,7 @@ index 8abdc2807abe27c31c1f2c7316dad6c8457efbc4..8d6ff08f8546450a1fc746c3332bc427
                  } else {
                      this.hurtDir = (float) ((int) (Math.random() * 2.0D) * 180);
                  }
-@@ -1479,7 +1479,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1478,7 +1478,7 @@ public abstract class LivingEntity extends Entity {
      }
  
      protected void blockedByShield(LivingEntity target) {
@@ -27,7 +27,7 @@ index 8abdc2807abe27c31c1f2c7316dad6c8457efbc4..8d6ff08f8546450a1fc746c3332bc427
      }
  
      private boolean checkTotemDeathProtection(DamageSource source) {
-@@ -1732,6 +1732,11 @@ public abstract class LivingEntity extends Entity {
+@@ -1731,6 +1731,11 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void knockback(double strength, double x, double z) {
@@ -39,7 +39,7 @@ index 8abdc2807abe27c31c1f2c7316dad6c8457efbc4..8d6ff08f8546450a1fc746c3332bc427
          strength *= 1.0D - this.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE);
          if (strength > 0.0D) {
              this.hasImpulse = true;
-@@ -1739,6 +1744,15 @@ public abstract class LivingEntity extends Entity {
+@@ -1738,6 +1743,15 @@ public abstract class LivingEntity extends Entity {
              Vec3 vec3d1 = (new Vec3(x, 0.0D, z)).normalize().scale(strength);
  
              this.setDeltaMovement(vec3d.x / 2.0D - vec3d1.x, this.onGround ? Math.min(0.4D, vec3d.y / 2.0D + strength) : vec3d.y, vec3d.z / 2.0D - vec3d1.z);

--- a/patches/server/0219-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0219-InventoryCloseEvent-Reason-API.patch
@@ -174,7 +174,7 @@ index 278f1f403c43a5c55a53ef8639bf2ea87a676498..c787bb69baa1b30fc513965fe4a9578c
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index eae0ec1c7165184a1a34510975ef62e9429a5777..b77bb4a2439f8fae9a856edec889477c86d84a35 100644
+index 2a583f0db3dd9a64e843b63cd6a124074eb05e43..8ef2df42573a4288b02c29f291d9aa65c2cf0e56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -955,7 +955,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -187,10 +187,10 @@ index eae0ec1c7165184a1a34510975ef62e9429a5777..b77bb4a2439f8fae9a856edec889477c
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2b641a47f81c49dedc915d55dd43b7415f310582..b3a2a865f7b7346566cf84bc20d845d1ca481711 100644
+index d93e79ab1a3b16bfc75209cb0b5e2e9fade35d86..f84669c550c7571fb3df431ab850b7d624739dcd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1205,7 +1205,7 @@ public class CraftEventFactory {
+@@ -1214,7 +1214,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -199,7 +199,7 @@ index 2b641a47f81c49dedc915d55dd43b7415f310582..b3a2a865f7b7346566cf84bc20d845d1
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1371,8 +1371,18 @@ public class CraftEventFactory {
+@@ -1380,8 +1380,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0224-add-more-information-to-Entity.toString.patch
+++ b/patches/server/0224-add-more-information-to-Entity.toString.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add more information to Entity.toString()
 UUID, ticks lived, valid, dead
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 28d4202f0a9c6910e98d32f6c561ac25c73c186e..2a11514554b6aea819046282cfcaeeb43d1ed920 100644
+index c2b24ad7ca280972f287cbb876dcc7011fb49db9..612478675192471ffcf937842d522bd179c43c51 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2813,7 +2813,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2827,7 +2827,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public String toString() {
          String s = this.level == null ? "~NULL~" : this.level.toString();
  

--- a/patches/server/0231-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0231-Vanished-players-don-t-have-rights.patch
@@ -99,10 +99,10 @@ index b91b2c2336b40c2332e59c3f24e36ca6083ce3bd..c239a71a9d864107c3a8e9537e4160c5
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b3a2a865f7b7346566cf84bc20d845d1ca481711..3cc200e2d83543d24c40e36d23f29e2b9888fea4 100644
+index f84669c550c7571fb3df431ab850b7d624739dcd..151039f67a2233d501bbe405f470bb38cabe390f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1241,6 +1241,14 @@ public class CraftEventFactory {
+@@ -1250,6 +1250,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0258-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/server/0258-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -28,10 +28,10 @@ index 0cf818fceddd76e7704fdc6625456787856b2815..ccdee183f02ab55723e16f41efce55dc
          switch (enumDirection) {
              case DOWN:
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8d6ff08f8546450a1fc746c3332bc427748cccb6..3582f2ebec124e0d56e478228946e2b7f6c7618b 100644
+index 9b6fcaaafa84853804f6183d02bd90b4f988d418..c5d6e5c5c35fa3ab444f271c929ee88c30832dc9 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3690,6 +3690,23 @@ public abstract class LivingEntity extends Entity {
+@@ -3689,6 +3689,23 @@ public abstract class LivingEntity extends Entity {
      }
  
      // Paper start

--- a/patches/server/0259-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0259-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b77bb4a2439f8fae9a856edec889477c86d84a35..bdb7d9afe28b6576a95eac51f6ae9ebfbde93134 100644
+index 8ef2df42573a4288b02c29f291d9aa65c2cf0e56..38d3f1b0769a73330abc04a5dcaab5e7844ada56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2386,6 +2386,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2394,6 +2394,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0260-Improve-death-events.patch
+++ b/patches/server/0260-Improve-death-events.patch
@@ -70,10 +70,10 @@ index fd1937f49312204d38510996a5be43b731f38bde..a2e2b6ea166bf64fe5b49672a6c6f86a
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3582f2ebec124e0d56e478228946e2b7f6c7618b..78b7b24c9f3ecef248bf45f4ae3624394d9b41a2 100644
+index c5d6e5c5c35fa3ab444f271c929ee88c30832dc9..a1850da0d11edfbaac5e799694ce12141aa5a92e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -258,6 +258,7 @@ public abstract class LivingEntity extends Entity {
+@@ -257,6 +257,7 @@ public abstract class LivingEntity extends Entity {
      public Set<UUID> collidableExemptions = new HashSet<>();
      public boolean bukkitPickUpLoot;
      public org.bukkit.craftbukkit.entity.CraftLivingEntity getBukkitLivingEntity() { return (org.bukkit.craftbukkit.entity.CraftLivingEntity) super.getBukkitEntity(); } // Paper
@@ -81,7 +81,7 @@ index 3582f2ebec124e0d56e478228946e2b7f6c7618b..78b7b24c9f3ecef248bf45f4ae362439
  
      @Override
      public float getBukkitYaw() {
-@@ -1440,13 +1441,12 @@ public abstract class LivingEntity extends Entity {
+@@ -1439,13 +1440,12 @@ public abstract class LivingEntity extends Entity {
              if (knockbackCancelled) this.level.broadcastEntityEvent(this, (byte) 2); // Paper - Disable explosion knockback
              if (this.isDeadOrDying()) {
                  if (!this.checkTotemDeathProtection(source)) {
@@ -99,7 +99,7 @@ index 3582f2ebec124e0d56e478228946e2b7f6c7618b..78b7b24c9f3ecef248bf45f4ae362439
                  }
              } else if (flag1) {
                  this.playHurtSound(source);
-@@ -1595,7 +1595,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1594,7 +1594,7 @@ public abstract class LivingEntity extends Entity {
          if (!this.isRemoved() && !this.dead) {
              Entity entity = source.getEntity();
              LivingEntity entityliving = this.getKillCredit();
@@ -108,7 +108,7 @@ index 3582f2ebec124e0d56e478228946e2b7f6c7618b..78b7b24c9f3ecef248bf45f4ae362439
              if (this.deathScore >= 0 && entityliving != null) {
                  entityliving.awardKillScore(this, this.deathScore, source);
              }
-@@ -1607,20 +1607,52 @@ public abstract class LivingEntity extends Entity {
+@@ -1606,20 +1606,52 @@ public abstract class LivingEntity extends Entity {
              if (!this.level.isClientSide && this.hasCustomName()) {
                  if (org.spigotmc.SpigotConfig.logNamedDeaths) LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString()); // Spigot
              }
@@ -164,7 +164,7 @@ index 3582f2ebec124e0d56e478228946e2b7f6c7618b..78b7b24c9f3ecef248bf45f4ae362439
          }
      }
  
-@@ -1628,7 +1660,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1627,7 +1659,7 @@ public abstract class LivingEntity extends Entity {
          if (!this.level.isClientSide) {
              boolean flag = false;
  
@@ -173,7 +173,7 @@ index 3582f2ebec124e0d56e478228946e2b7f6c7618b..78b7b24c9f3ecef248bf45f4ae362439
                  if (this.level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
                      BlockPos blockposition = this.blockPosition();
                      BlockState iblockdata = Blocks.WITHER_ROSE.defaultBlockState();
-@@ -1657,7 +1689,8 @@ public abstract class LivingEntity extends Entity {
+@@ -1656,7 +1688,8 @@ public abstract class LivingEntity extends Entity {
          }
      }
  
@@ -183,7 +183,7 @@ index 3582f2ebec124e0d56e478228946e2b7f6c7618b..78b7b24c9f3ecef248bf45f4ae362439
          Entity entity = source.getEntity();
          int i;
  
-@@ -1672,18 +1705,23 @@ public abstract class LivingEntity extends Entity {
+@@ -1671,18 +1704,23 @@ public abstract class LivingEntity extends Entity {
          this.dropEquipment(); // CraftBukkit - from below
          if (this.shouldDropLoot() && this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
              this.dropFromLootTable(source, flag);
@@ -295,10 +295,10 @@ index 91cf7728aee475cb36f2c02bbfb7e3d2e0d00576..a3a900d10440ed5ebe24370a77ccb6ca
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bdb7d9afe28b6576a95eac51f6ae9ebfbde93134..03b7da18cd28785f3a44c415ed45174c1fbf8778 100644
+index 38d3f1b0769a73330abc04a5dcaab5e7844ada56..18c565f79de56a90bc291b341f4b23844aadd802 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1949,7 +1949,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1957,7 +1957,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {
@@ -315,7 +315,7 @@ index bdb7d9afe28b6576a95eac51f6ae9ebfbde93134..03b7da18cd28785f3a44c415ed45174c
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 483d841e5a0cb52f96f23c18c3bccc9e58439240..8752f8ac5fdbab6184fc2718876c6e3a8f319391 100644
+index 016912c8b3fe0158d144b78f71b704972950f5b6..4b26540cda951cb46ac2833a60ce6cf06f483bff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -807,9 +807,16 @@ public class CraftEventFactory {

--- a/patches/server/0273-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0273-Add-LivingEntity-getTargetEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 78b7b24c9f3ecef248bf45f4ae3624394d9b41a2..0d4a1105345a56022fe92ca5077112fb96fed2fe 100644
+index a1850da0d11edfbaac5e799694ce12141aa5a92e..7886d276e4919cb57372bd0475aaf83992cde360 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -113,6 +113,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
@@ -16,7 +16,7 @@ index 78b7b24c9f3ecef248bf45f4ae3624394d9b41a2..0d4a1105345a56022fe92ca5077112fb
  import net.minecraft.world.phys.HitResult;
  import net.minecraft.world.phys.Vec3;
  import net.minecraft.world.scores.PlayerTeam;
-@@ -3745,6 +3746,38 @@ public abstract class LivingEntity extends Entity {
+@@ -3744,6 +3745,38 @@ public abstract class LivingEntity extends Entity {
          return level.clip(raytrace);
      }
  

--- a/patches/server/0293-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0293-force-entity-dismount-during-teleportation.patch
@@ -41,10 +41,10 @@ index db7f2715534ed71a2b285de095238586fe6a35b0..f51c416e7938b7905f7efb154ab14cad
  
          if (entity1 != entity && this.connection != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 37e5ef6b564ace0ae79c49f6474f2ce9fa21dd23..83698cbbe44405e80b787df6cd7a2921377e9bf7 100644
+index d53d968d92e7491c3802d6f9215710610ef11ce5..8018c9dae36335c2fb654269684445b6411450ee 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2238,11 +2238,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2252,11 +2252,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public void removeVehicle() {
@@ -62,7 +62,7 @@ index 37e5ef6b564ace0ae79c49f6474f2ce9fa21dd23..83698cbbe44405e80b787df6cd7a2921
          }
  
      }
-@@ -2305,7 +2310,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2319,7 +2324,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          return true; // CraftBukkit
      }
  
@@ -74,7 +74,7 @@ index 37e5ef6b564ace0ae79c49f6474f2ce9fa21dd23..83698cbbe44405e80b787df6cd7a2921
          if (entity.getVehicle() == this) {
              throw new IllegalStateException("Use x.stopRiding(y), not y.removePassenger(x)");
          } else {
-@@ -2315,7 +2323,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2329,7 +2337,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              if (this.getBukkitEntity() instanceof Vehicle && entity.getBukkitEntity() instanceof LivingEntity) {
                  VehicleExitEvent event = new VehicleExitEvent(
                          (Vehicle) this.getBukkitEntity(),
@@ -83,7 +83,7 @@ index 37e5ef6b564ace0ae79c49f6474f2ce9fa21dd23..83698cbbe44405e80b787df6cd7a2921
                  );
                  // Suppress during worldgen
                  if (this.valid) {
-@@ -2329,7 +2337,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2343,7 +2351,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              }
              // CraftBukkit end
              // Spigot start
@@ -93,10 +93,10 @@ index 37e5ef6b564ace0ae79c49f6474f2ce9fa21dd23..83698cbbe44405e80b787df6cd7a2921
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0d4a1105345a56022fe92ca5077112fb96fed2fe..f1d287f1fbb725a64e6252dedd4153199d0544a3 100644
+index 7886d276e4919cb57372bd0475aaf83992cde360..0031a3a4850e38039c37550d6f67e433b9143cfd 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3344,9 +3344,15 @@ public abstract class LivingEntity extends Entity {
+@@ -3343,9 +3343,15 @@ public abstract class LivingEntity extends Entity {
  
      @Override
      public void stopRiding() {

--- a/patches/server/0298-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0298-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -106,7 +106,7 @@ index c7e4c6d29378675b76ebb179022ddbb02831a1dc..88bc0807e8bf66a65422f85f11123363
      public Location getBedSpawnLocation() {
          CompoundTag data = this.getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 03b7da18cd28785f3a44c415ed45174c1fbf8778..468206c1a6cb3de1ffd07513127deff2d77df4c5 100644
+index 18c565f79de56a90bc291b341f4b23844aadd802..c553243dc5bb9dab6ca6d60994403b503653084a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -157,6 +157,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index 03b7da18cd28785f3a44c415ed45174c1fbf8778..468206c1a6cb3de1ffd07513127deff2
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1561,6 +1562,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1569,6 +1570,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 03b7da18cd28785f3a44c415ed45174c1fbf8778..468206c1a6cb3de1ffd07513127deff2
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1583,6 +1596,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1591,6 +1604,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index 03b7da18cd28785f3a44c415ed45174c1fbf8778..468206c1a6cb3de1ffd07513127deff2
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1597,6 +1612,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1605,6 +1620,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0300-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0300-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 468206c1a6cb3de1ffd07513127deff2d77df4c5..8ae3477fbe55e62a09c17e007ac8db3906965a48 100644
+index c553243dc5bb9dab6ca6d60994403b503653084a..6a92cc93b16780e1d1dc376b0c63a475e337f9a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2433,6 +2433,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2441,6 +2441,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0312-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0312-Entity-getEntitySpawnReason.patch
@@ -10,7 +10,7 @@ persistenting Living Entity, SPAWNER for spawners,
 or DEFAULT since data was not stored.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 5abcae55b2dc37eea514d194803bc9a851f18c25..2950ad995f322570cd647d3217f340327cc3e7c8 100644
+index 8da73bd016b7da297e64383e2e6dc65a1dd3be87..d01f3207d4a7516d2eba9df44c44a7c41c354c84 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1185,6 +1185,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -35,7 +35,7 @@ index 25da9e3252154415303db662286e89e3aa7cfcd8..eea7a625fb00af13944b21e1af4bf180
              });
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f015b1990a509071b6154a9eb7405fa2cbacb111..aa5fdc74a3b06b8d8b82b86fb4f1469ddd4c629e 100644
+index 8018c9dae36335c2fb654269684445b6411450ee..0f6ed83a866153864cb52e978645a7278473718d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -67,6 +67,8 @@ import net.minecraft.world.InteractionHand;
@@ -55,7 +55,7 @@ index f015b1990a509071b6154a9eb7405fa2cbacb111..aa5fdc74a3b06b8d8b82b86fb4f1469d
      // Paper end
  
      public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
-@@ -1859,6 +1862,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1869,6 +1872,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  }
                  nbt.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -65,7 +65,7 @@ index f015b1990a509071b6154a9eb7405fa2cbacb111..aa5fdc74a3b06b8d8b82b86fb4f1469d
              // Save entity's from mob spawner status
              if (spawnedViaMobSpawner) {
                  nbt.putBoolean("Paper.FromMobSpawner", true);
-@@ -2004,6 +2010,26 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2018,6 +2024,26 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0338-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0338-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f1d287f1fbb725a64e6252dedd4153199d0544a3..7bbb0415e8e22f3ca0d22ed21b68e963213d3e3c 100644
+index 0031a3a4850e38039c37550d6f67e433b9143cfd..fa07a6f7ec215652861a62a0cb942522e0f4f655 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3566,9 +3566,14 @@ public abstract class LivingEntity extends Entity {
+@@ -3565,9 +3565,14 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void startUsingItem(InteractionHand hand) {
@@ -24,7 +24,7 @@ index f1d287f1fbb725a64e6252dedd4153199d0544a3..7bbb0415e8e22f3ca0d22ed21b68e963
              this.useItem = itemstack;
              this.useItemRemaining = itemstack.getUseDuration();
              if (!this.level.isClientSide) {
-@@ -3647,6 +3652,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3646,6 +3651,7 @@ public abstract class LivingEntity extends Entity {
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -32,7 +32,7 @@ index f1d287f1fbb725a64e6252dedd4153199d0544a3..7bbb0415e8e22f3ca0d22ed21b68e963
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
-@@ -3681,8 +3687,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3680,8 +3686,8 @@ public abstract class LivingEntity extends Entity {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0353-Lag-compensate-eating.patch
+++ b/patches/server/0353-Lag-compensate-eating.patch
@@ -7,10 +7,10 @@ When the server is lagging, players will wait longer when eating.
 Change to also use a time check instead if it passes.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 7bbb0415e8e22f3ca0d22ed21b68e963213d3e3c..7694636ff03a303151ee59d83253cfeca502eca0 100644
+index fa07a6f7ec215652861a62a0cb942522e0f4f655..4bdc5e2926ec78de0948b8469c72015c8fecb520 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3509,6 +3509,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3508,6 +3508,11 @@ public abstract class LivingEntity extends Entity {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  
@@ -22,7 +22,7 @@ index 7bbb0415e8e22f3ca0d22ed21b68e963213d3e3c..7694636ff03a303151ee59d83253cfec
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameIgnoreDurability(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -3526,8 +3531,12 @@ public abstract class LivingEntity extends Entity {
+@@ -3525,8 +3530,12 @@ public abstract class LivingEntity extends Entity {
          if (this.shouldTriggerItemUseEffects()) {
              this.triggerItemUseEffects(stack, 5);
          }
@@ -37,7 +37,7 @@ index 7bbb0415e8e22f3ca0d22ed21b68e963213d3e3c..7694636ff03a303151ee59d83253cfec
              this.completeUsingItem();
          }
  
-@@ -3575,7 +3584,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3574,7 +3583,10 @@ public abstract class LivingEntity extends Entity {
  
          if (!itemstack.isEmpty() && !this.isUsingItem() || forceUpdate) { // Paper use override flag
              this.useItem = itemstack;
@@ -49,7 +49,7 @@ index 7bbb0415e8e22f3ca0d22ed21b68e963213d3e3c..7694636ff03a303151ee59d83253cfec
              if (!this.level.isClientSide) {
                  this.setLivingEntityFlag(1, true);
                  this.setLivingEntityFlag(2, hand == InteractionHand.OFF_HAND);
-@@ -3599,7 +3611,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3598,7 +3610,10 @@ public abstract class LivingEntity extends Entity {
                  }
              } else if (!this.isUsingItem() && !this.useItem.isEmpty()) {
                  this.useItem = ItemStack.EMPTY;
@@ -61,7 +61,7 @@ index 7bbb0415e8e22f3ca0d22ed21b68e963213d3e3c..7694636ff03a303151ee59d83253cfec
              }
          }
  
-@@ -3727,7 +3742,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3726,7 +3741,10 @@ public abstract class LivingEntity extends Entity {
          }
  
          this.useItem = ItemStack.EMPTY;

--- a/patches/server/0357-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0357-Entity-Activation-Range-2.0.patch
@@ -108,10 +108,10 @@ index 367e074dd5f85f824b7c4f5506d0ccac60580c1b..83c5b111b98e52f52b7e4cf607aac07b
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 71de08f60b9d9d0f132e2d3c60cd7b70e9ec3759..8b1e6961e2a60e17aa12ec949e3166e461d4fed7 100644
+index 0f6ed83a866153864cb52e978645a7278473718d..62f19eafbb650dfbfac31c320e4883149d327e43 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -313,6 +313,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -319,6 +319,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public void inactiveTick() { }
      // Spigot end
      // Paper start
@@ -120,7 +120,7 @@ index 71de08f60b9d9d0f132e2d3c60cd7b70e9ec3759..8b1e6961e2a60e17aa12ec949e3166e4
      protected int numCollisions = 0; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      @javax.annotation.Nullable
-@@ -784,6 +786,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -790,6 +792,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          } else {
              this.wasOnFire = this.isOnFire();
              if (movementType == MoverType.PISTON) {
@@ -129,7 +129,7 @@ index 71de08f60b9d9d0f132e2d3c60cd7b70e9ec3759..8b1e6961e2a60e17aa12ec949e3166e4
                  movement = this.limitPistonMovement(movement);
                  if (movement.equals(Vec3.ZERO)) {
                      return;
-@@ -796,6 +800,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -802,6 +806,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }

--- a/patches/server/0363-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0363-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ae454b12a0671f6698ff2b889988348e3a518b36..306e23a788798dd0438a6a93cd55854c904eadbd 100644
+index 62f19eafbb650dfbfac31c320e4883149d327e43..a9705e54b88339e2746348aee9ab1acdae5182b2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3011,6 +3011,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3026,6 +3026,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              BlockPos blockposition1;
  
              if (flag1) {

--- a/patches/server/0371-Entity-Jump-API.patch
+++ b/patches/server/0371-Entity-Jump-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 7694636ff03a303151ee59d83253cfeca502eca0..5fe23dc78d86f98c2952ff82f9502789d9009b8d 100644
+index 4bdc5e2926ec78de0948b8469c72015c8fecb520..ae2ee484ab8b70226dd25386336c109a201a6450 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3172,8 +3172,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3171,8 +3171,10 @@ public abstract class LivingEntity extends Entity {
              } else if (this.isInLava() && (!this.onGround || d7 > d8)) {
                  this.jumpInLiquid(FluidTags.LAVA);
              } else if ((this.onGround || flag && d7 <= d8) && this.noJumpDelay == 0) {
@@ -20,7 +20,7 @@ index 7694636ff03a303151ee59d83253cfeca502eca0..5fe23dc78d86f98c2952ff82f9502789
          } else {
              this.noJumpDelay = 0;
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Panda.java b/src/main/java/net/minecraft/world/entity/animal/Panda.java
-index 7b75f6863144b5f3307f72692529377aa61e7f43..29372c8a0c54e4bae518e09846f0e9caba263896 100644
+index 943a8d7c137feffcb1b06d7ddb4cb26378094675..a0cf2f28400bce6246c02e2fbe0d69bc6f7d46e2 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Panda.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Panda.java
 @@ -515,7 +515,9 @@ public class Panda extends Animal {

--- a/patches/server/0372-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0372-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -21,10 +21,10 @@ index 6b0391743cd9e249c66796e7fe7a4da8c6b81b2e..5ba23152d2c7e45a824d49246706aa98
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e59364169c7ef5b8f9731e0f5db258b81acddae1..8d1cdf39d6512515e9f4d25d16ed347f14c1818a 100644
+index a9705e54b88339e2746348aee9ab1acdae5182b2..aedb75bd1ca841ede6f71ba7bd3c69d393c4e07f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -315,6 +315,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -321,6 +321,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      // Paper start
      public long activatedImmunityTick = Integer.MIN_VALUE; // Paper
      public boolean isTemporarilyActive = false; // Paper
@@ -32,7 +32,7 @@ index e59364169c7ef5b8f9731e0f5db258b81acddae1..8d1cdf39d6512515e9f4d25d16ed347f
      protected int numCollisions = 0; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      @javax.annotation.Nullable
-@@ -1880,6 +1881,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1890,6 +1891,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              if (spawnedViaMobSpawner) {
                  nbt.putBoolean("Paper.FromMobSpawner", true);
              }
@@ -42,7 +42,7 @@ index e59364169c7ef5b8f9731e0f5db258b81acddae1..8d1cdf39d6512515e9f4d25d16ed347f
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2021,6 +2025,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2035,6 +2039,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0399-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0399-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -7,10 +7,10 @@ Will not run if max entity craming is disabled and
 the max collisions per entity is less than or equal to 0
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5fe23dc78d86f98c2952ff82f9502789d9009b8d..415c577983e03ccd419ea8d7391be77e44e07a19 100644
+index ae2ee484ab8b70226dd25386336c109a201a6450..4963f3b2e8d2889ef79a8c4fbc84548a0010b49d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3269,10 +3269,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3268,10 +3268,16 @@ public abstract class LivingEntity extends Entity {
      protected void serverAiStep() {}
  
      protected void pushEntities() {

--- a/patches/server/0406-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/patches/server/0406-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -7,10 +7,10 @@ The code following this has better support for null worlds to move
 them back to the world spawn.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a3a80ad047dfa9ba1c058eaaf95b76cd3e0ec490..3ef63d278464d4b4ebd5bd1b69b68bf0c818b9ab 100644
+index a7872994c3e48a2e27c31fab58a89593f8548d81..c8fb6387fb3ac2849a399b2ab1f30158aa734827 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1998,9 +1998,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2012,9 +2012,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                      bworld = server.getWorld(worldName);
                  }
  

--- a/patches/server/0407-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/server/0407-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 415c577983e03ccd419ea8d7391be77e44e07a19..873eaa14eccca2813d8ef99a0484d409201f9204 100644
+index 4963f3b2e8d2889ef79a8c4fbc84548a0010b49d..ab02e0babf6289d64b44dc18f3f6f0bdd4b83c32 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2047,7 +2047,16 @@ public abstract class LivingEntity extends Entity {
+@@ -2046,7 +2046,16 @@ public abstract class LivingEntity extends Entity {
  
              EntityDamageEvent event = CraftEventFactory.handleLivingEntityDamageEvent(this, damagesource, originalDamage, hardHatModifier, blockingModifier, armorModifier, resistanceModifier, magicModifier, absorptionModifier, hardHat, blocking, armor, resistance, magic, absorption);
              if (damagesource.getEntity() instanceof net.minecraft.world.entity.player.Player) {

--- a/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,10 +16,10 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 205102e43412c23bc7c4ead22c674e8c3cd6178b..f04c70c8d43a6a357f89aa7b8247d340c951de4c 100644
+index c8fb6387fb3ac2849a399b2ab1f30158aa734827..a02eb37845e0609ddf14a4214395e00443534b08 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2148,11 +2148,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2162,11 +2162,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          } else {
              // CraftBukkit start - Capture drops for death event
              if (this instanceof net.minecraft.world.entity.LivingEntity && !((net.minecraft.world.entity.LivingEntity) this).forceDrops) {
@@ -34,7 +34,7 @@ index 205102e43412c23bc7c4ead22c674e8c3cd6178b..f04c70c8d43a6a357f89aa7b8247d340
  
              entityitem.setDefaultPickUpDelay();
              // CraftBukkit start
-@@ -2905,6 +2906,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2919,6 +2920,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      @Nullable
      public Entity teleportTo(ServerLevel worldserver, BlockPos location) {
          // CraftBukkit end
@@ -47,7 +47,7 @@ index 205102e43412c23bc7c4ead22c674e8c3cd6178b..f04c70c8d43a6a357f89aa7b8247d340
          if (this.level instanceof ServerLevel && !this.isRemoved()) {
              this.level.getProfiler().push("changeDimension");
              // CraftBukkit start
-@@ -2925,6 +2932,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2939,6 +2946,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  // CraftBukkit end
  
                  this.level.getProfiler().popPush("reloading");
@@ -59,7 +59,7 @@ index 205102e43412c23bc7c4ead22c674e8c3cd6178b..f04c70c8d43a6a357f89aa7b8247d340
                  Entity entity = this.getType().create(worldserver);
  
                  if (entity != null) {
-@@ -2938,10 +2950,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2952,10 +2964,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index 205102e43412c23bc7c4ead22c674e8c3cd6178b..f04c70c8d43a6a357f89aa7b8247d340
                      // CraftBukkit end
                  }
  
-@@ -3062,7 +3070,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3077,7 +3085,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public boolean canChangeDimensions() {
@@ -80,10 +80,10 @@ index 205102e43412c23bc7c4ead22c674e8c3cd6178b..f04c70c8d43a6a357f89aa7b8247d340
  
      public float getBlockExplosionResistance(Explosion explosion, BlockGetter world, BlockPos pos, BlockState blockState, FluidState fluidState, float max) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 873eaa14eccca2813d8ef99a0484d409201f9204..3c27304ed44776e7256dc303a12eea5c0e5f2953 100644
+index ab02e0babf6289d64b44dc18f3f6f0bdd4b83c32..198a0cfb222f40e792a9723eb25c514889ffe01f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1620,9 +1620,9 @@ public abstract class LivingEntity extends Entity {
+@@ -1619,9 +1619,9 @@ public abstract class LivingEntity extends Entity {
                  // Paper start
                  org.bukkit.event.entity.EntityDeathEvent deathEvent = this.dropAllDeathLoot(source);
                  if (deathEvent == null || !deathEvent.isCancelled()) {
@@ -96,7 +96,7 @@ index 873eaa14eccca2813d8ef99a0484d409201f9204..3c27304ed44776e7256dc303a12eea5c
                      // Paper start - clear equipment if event is not cancelled
                      if (this instanceof Mob mob) {
                          java.util.Collections.fill(mob.handItems, ItemStack.EMPTY);
-@@ -1710,8 +1710,13 @@ public abstract class LivingEntity extends Entity {
+@@ -1709,8 +1709,13 @@ public abstract class LivingEntity extends Entity {
              this.dropCustomDeathLoot(source, i, flag);
              this.clearEquipmentSlots = true; // Paper
          }
@@ -135,7 +135,7 @@ index a3a900d10440ed5ebe24370a77ccb6cad911cfc9..0d468631b9c260091e732925da43c177
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a8b74b539eca41cb08cd79697a5732602401bb2f..de5f5856875fc4bfb051c7535344f18ded360ad3 100644
+index b7129aef8b08e8bd33f9f276bc2f97bbe8f5c894..624ed3d956a5614b723d32c6ad047248c5f5b038 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -810,6 +810,11 @@ public class CraftEventFactory {

--- a/patches/server/0433-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/patches/server/0433-Use-distance-map-to-optimise-entity-tracker.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use distance map to optimise entity tracker
 Use the distance map to find candidate players for tracking.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 4796e60ade3b576dbe0fe79bc9f0be6085dc7cc8..d358bca3aa0407ede113b4ca6243043f75202267 100644
+index d924dfe452244633bcf62e7ccefe3a5a1a3d7f37..e35a47e0c8eebbad7154a1357a6b868887bc4a0c 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -67,6 +67,7 @@ import net.minecraft.network.protocol.game.ClientboundSetEntityLinkPacket;
@@ -280,7 +280,7 @@ index 4796e60ade3b576dbe0fe79bc9f0be6085dc7cc8..d358bca3aa0407ede113b4ca6243043f
              return object instanceof ChunkMap.TrackedEntity ? ((ChunkMap.TrackedEntity) object).entity.getId() == this.entity.getId() : false;
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9336ad8bc5e11d6412869d597b5360c90be4df78..f7c783ad7ee5d29b489d20ed399076c4b4a9c496 100644
+index a02eb37845e0609ddf14a4214395e00443534b08..8e59a63e8c161e90ccff951ecb2b6530fadf3b80 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -51,6 +51,7 @@ import net.minecraft.network.syncher.EntityDataSerializers;
@@ -291,7 +291,7 @@ index 9336ad8bc5e11d6412869d597b5360c90be4df78..f7c783ad7ee5d29b489d20ed399076c4
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
-@@ -353,6 +354,39 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -359,6 +360,39 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
      // Paper end
  

--- a/patches/server/0449-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0449-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f7c783ad7ee5d29b489d20ed399076c4b4a9c496..59175679a2fae171b3d01fed5db8ac57d0a63a29 100644
+index 8e59a63e8c161e90ccff951ecb2b6530fadf3b80..df02a649ca99218745b7cd38e34edcabc2987255 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -589,8 +589,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -595,8 +595,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public void setPos(double x, double y, double z) {
@@ -19,7 +19,7 @@ index f7c783ad7ee5d29b489d20ed399076c4b4a9c496..59175679a2fae171b3d01fed5db8ac57
      }
  
      protected AABB makeBoundingBox() {
-@@ -3771,6 +3771,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3786,6 +3786,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public final void setPosRaw(double x, double y, double z) {
@@ -31,7 +31,7 @@ index f7c783ad7ee5d29b489d20ed399076c4b4a9c496..59175679a2fae171b3d01fed5db8ac57
          if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
-@@ -3793,6 +3798,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3808,6 +3813,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              }
          }
  

--- a/patches/server/0465-Add-entity-liquid-API.patch
+++ b/patches/server/0465-Add-entity-liquid-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 59175679a2fae171b3d01fed5db8ac57d0a63a29..5a23c9fe4147c82ce2e6eda9690b158b030f71f6 100644
+index df02a649ca99218745b7cd38e34edcabc2987255..cc60127472ce47659acc35caea5a924ce54bc06b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1353,7 +1353,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1359,7 +1359,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          return this.isInWater() || this.isInRain();
      }
  

--- a/patches/server/0468-Add-PrepareResultEvent.patch
+++ b/patches/server/0468-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index cdebd0cdf6eb901464cf4c16089b10ea0147b54d..221b6ffb426edc034183dbaf37de29c6
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0b054674aa97d9311b07889e2dc20ebc433c5718..e0e130052317bdd14349ef48ec44c1e31f90b24f 100644
+index 0d1524d6589a8055bcccd53f19bebc99553ccbe4..63f742a79e28e9e86eba01dc5a5029b5ea97158e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1574,19 +1574,44 @@ public class CraftEventFactory {
+@@ -1583,19 +1583,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0469-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0469-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3c27304ed44776e7256dc303a12eea5c0e5f2953..15e45ddd4b570b5ea3aff735163dcc62ca711686 100644
+index 198a0cfb222f40e792a9723eb25c514889ffe01f..345190be83c7c9a7f65d64a6905da872fc020abb 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3375,7 +3375,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3374,7 +3374,7 @@ public abstract class LivingEntity extends Entity {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - suppress

--- a/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1151,10 +1151,10 @@ index d06e43bfaf8d22e0374bb6ed2e62c65e15699ef5..373f1c600ecdf75293dbe5ff6ef676a0
              if (updatingChunk != null) {
                  return updatingChunk.getEntityTickingChunkFuture();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5bf1b4ef94148a6108ad2f8cafdcedc412529ae1..998efab94fad3f5f5cbf17b29881ed2c3fc98f6f 100644
+index cc60127472ce47659acc35caea5a924ce54bc06b..edea3cbfe1856df0f6d32a70cac5de16abc2018a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -223,7 +223,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -228,7 +228,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      private BlockPos blockPosition;
      private ChunkPos chunkPosition;
      private Vec3 deltaMovement;
@@ -1210,7 +1210,7 @@ index bcb3a7e64f317732c8c758d4e743d84233bdafa6..336e65216f582a4393df07ace2eaf6ec
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ea307fad3f18f677d4e7c37d2d699f87e5f15699..aa2875f9a82c3e57b4aeedf49ec65f860cb2102b 100644
+index 511757e42dba47cf5116bcc8c08ecb3814f65e1d..5921aea240f8dfcccac4164f7098120b6ae03a23 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -923,6 +923,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0484-Brand-support.patch
+++ b/patches/server/0484-Brand-support.patch
@@ -72,10 +72,10 @@ index 4a17f98d06f061a2253dc75e313c618e550ed100..f9073eaa82c79f0b8ad738213b53f991
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index aa2875f9a82c3e57b4aeedf49ec65f860cb2102b..ffbff2a88237606986ed16b1223ca2b23fedcd31 100644
+index 5921aea240f8dfcccac4164f7098120b6ae03a23..1be58e60a27dc829fd1a78ff651fa9c36f34116a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2577,6 +2577,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2585,6 +2585,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0503-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0503-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -31,7 +31,7 @@ index f9073eaa82c79f0b8ad738213b53f991d1b855a3..ff313dad1215762e2dc25d751f20aa71
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e289c08936e0a3c5558e65f247406414d7fb0daa..a35078c299c3c8d7e670d2ca82c110e62b374490 100644
+index edea3cbfe1856df0f6d32a70cac5de16abc2018a..707018a230e8f27e701c60bc7029d64c045d8bfc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -151,6 +151,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -42,7 +42,7 @@ index e289c08936e0a3c5558e65f247406414d7fb0daa..a35078c299c3c8d7e670d2ca82c110e6
      static boolean isLevelAtLeast(CompoundTag tag, int level) {
          return tag.contains("Bukkit.updateLevel") && tag.getInt("Bukkit.updateLevel") >= level;
      }
-@@ -1556,6 +1557,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1562,6 +1563,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public void moveTo(double x, double y, double z, float yaw, float pitch) {

--- a/patches/server/0508-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0508-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a35078c299c3c8d7e670d2ca82c110e62b374490..a6cc8d8691f314fe7d5499f525a45b1c2e7f31e5 100644
+index 707018a230e8f27e701c60bc7029d64c045d8bfc..2eb56ba2ecf49754e3b6229a798f837a4aa099da 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3971,4 +3971,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3986,4 +3986,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0510-Entity-isTicking.patch
+++ b/patches/server/0510-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a6cc8d8691f314fe7d5499f525a45b1c2e7f31e5..de984785361221dffece2a86c859ccf95a8b4af8 100644
+index 2eb56ba2ecf49754e3b6229a798f837a4aa099da..2c68dbfc38e9d9b7bb6cecb790d4d72fc2015a7f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -53,6 +53,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index a6cc8d8691f314fe7d5499f525a45b1c2e7f31e5..de984785361221dffece2a86c859ccf9
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -3976,5 +3977,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3991,5 +3992,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0536-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0536-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0350eefdd5b76d60d3068f27be926009626db7ea..457f68048d9dab306555398480ba597289f75046 100644
+index da6f0d8552d0be7d2d01a9eacdb9a6c18fe923be..92795e7d8d8ace473a4f49cbecfd0ed82f4da90a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2148,7 +2148,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2156,7 +2156,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0540-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0540-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f56992472665b59e3ae22fab74d994686dc767f4..8a266d1276595d5b2bd0b60f08d99d4cceea929a 100644
+index f46d0d22b99582070747e2fde3c6328b0ab6d707..b9164fb28a49ccc3113f7010786960ec36080df6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -94,6 +94,11 @@ public class PaperWorldConfig {
@@ -21,10 +21,10 @@ index f56992472665b59e3ae22fab74d994686dc767f4..8a266d1276595d5b2bd0b60f08d99d4c
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d394894ae506eafe6f363fa6c6592a92907d2492..6c32f51c649f0cdc56b672346a7ef6c15c899d12 100644
+index 2c68dbfc38e9d9b7bb6cecb790d4d72fc2015a7f..1cf13735a8c5dbfa71011012b271b3dc409a5f15 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1737,6 +1737,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1743,6 +1743,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public boolean isPushable() {
@@ -61,10 +61,10 @@ index 22f36cd3df49160f1b6668befdd05c2268edaa49..e39965c2e50bc8ee424ea07819346e06
              } else if (entity.level.isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 15e45ddd4b570b5ea3aff735163dcc62ca711686..d651746955a5b8ee225788fafb818264c1c6edbe 100644
+index 345190be83c7c9a7f65d64a6905da872fc020abb..cd7850fbfbd1997b42b93df15666b2f3f9948384 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3289,7 +3289,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3288,7 +3288,7 @@ public abstract class LivingEntity extends Entity {
              return;
          }
          // Paper end - don't run getEntities if we're not going to use its result
@@ -73,7 +73,7 @@ index 15e45ddd4b570b5ea3aff735163dcc62ca711686..d651746955a5b8ee225788fafb818264
  
          if (!list.isEmpty()) {
              // Paper - move up
-@@ -3460,9 +3460,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3459,9 +3459,16 @@ public abstract class LivingEntity extends Entity {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0546-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0546-MC-4-Fix-item-position-desync.patch
@@ -43,10 +43,10 @@ index b30c08bfb8c55161543a4ef09f2e462e0a1fe4ae..ec93f5300cc7d423ec0d292f0f8443f9
  
      public Vec3 updateEntityPosition(Vec3 orig) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 97bfbb01febae2cb4f9b4eb7b9540486d6eb94a2..755e9dbc4646314c3e666fb5d64a30178eaa155e 100644
+index 1cf13735a8c5dbfa71011012b271b3dc409a5f15..e64f17f859fc975fed07b86dfda2376018e97f6f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3790,6 +3790,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3805,6 +3805,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
          // Paper end

--- a/patches/server/0569-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0569-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 4ae21aa6fc91f527d3dca508588d8257961b8d24..b3203049eade7d11602fa2a12a8104a7
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index bae5e210cdc679189ad56a31e7734840c807c553..d7f865912feba5c88ed6d488554132edce0fb030 100644
+index ad095e2547bc247fb38f72a3197bb45d4e048824..7b3e709898f9da4e77c83485cd35633bc6cb5ed9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1848,4 +1848,12 @@ public class CraftEventFactory {
+@@ -1857,4 +1857,12 @@ public class CraftEventFactory {
          EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
      }

--- a/patches/server/0579-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0579-Collision-option-for-requiring-a-player-participant.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Collision option for requiring a player participant
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 95952806a544d38952b82f7078a46a5eeb622cd8..19ae4ae82be4a5a387b0f6e1b18e36b24d0cbbdb 100644
+index 797275dd2dc0f7c2ef24311ebdd9659e8b2fdf2f..55c997bc5fb41e16d965c6017128c90321d8457a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -81,6 +81,18 @@ public class PaperWorldConfig {
@@ -28,10 +28,10 @@ index 95952806a544d38952b82f7078a46a5eeb622cd8..19ae4ae82be4a5a387b0f6e1b18e36b2
      public int wanderingTraderSpawnDayTicks = 24000;
      public int wanderingTraderSpawnChanceFailureIncrement = 25;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 755e9dbc4646314c3e666fb5d64a30178eaa155e..56d8939c34e0edd74ee2980a41a889bb3ccf659e 100644
+index e64f17f859fc975fed07b86dfda2376018e97f6f..e0d1798b604b5977177714774da26a4d797ac448 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1620,6 +1620,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1626,6 +1626,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public void push(Entity entity) {
          if (!this.isPassengerOfSameVehicle(entity)) {
              if (!entity.noPhysics && !this.noPhysics) {

--- a/patches/server/0584-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0584-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 07d357b5fcb30ed9ff074a196a19de1481fe3738..83ac86b3c1e7b9233f2db8e5488f97c5
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 31fdf523fcb08d8fb6c146f7950838e753bfb447..068a14050d2512e88aeea81e6b0f8e5e1ce445b9 100644
+index 1a2a84c7044ab70de3fd632b0d04b33d827ce22e..5b9e76fbffa74b29f1a21374a74f46c917104fea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1866,5 +1866,11 @@ public class CraftEventFactory {
+@@ -1875,5 +1875,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index cf932116a0cafd315e44159fbf7c5d25d43782ff..03bda898a5a263053ecd79f74799d370
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 068a14050d2512e88aeea81e6b0f8e5e1ce445b9..3350575a5038de1185a636862df24e32f79e38c7 100644
+index 5b9e76fbffa74b29f1a21374a74f46c917104fea..7cde66a83f4abd4b25b7615139b1dd1cb2c746ce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1507,8 +1507,10 @@ public class CraftEventFactory {
+@@ -1516,8 +1516,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0592-EntityMoveEvent.patch
+++ b/patches/server/0592-EntityMoveEvent.patch
@@ -29,10 +29,10 @@ index 1486f93a476ed9b887c8d2b2ab3b1671cc772aae..558a202fb147f4c466d5c8b958105cbf
          return new Throwable(entity + " Added to world at " + new java.util.Date());
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d651746955a5b8ee225788fafb818264c1c6edbe..c01c349f872a6a7923e4b18c7f93ca3b8cf357dd 100644
+index cd7850fbfbd1997b42b93df15666b2f3f9948384..aaea5020bf08b2dbc77cfd248dfe721b398c695e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3235,6 +3235,20 @@ public abstract class LivingEntity extends Entity {
+@@ -3234,6 +3234,20 @@ public abstract class LivingEntity extends Entity {
  
          this.pushEntities();
          this.level.getProfiler().pop();

--- a/patches/server/0626-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0626-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index c01c349f872a6a7923e4b18c7f93ca3b8cf357dd..4c9a6bb5456fe5fa35e37a18b3e577003d901d71 100644
+index aaea5020bf08b2dbc77cfd248dfe721b398c695e..510c2f0d47b593ac2bd60608c43cef8c069a5373 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3721,6 +3721,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3720,6 +3720,7 @@ public abstract class LivingEntity extends Entity {
                          level.getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {

--- a/patches/server/0674-Fix-dangerous-end-portal-logic.patch
+++ b/patches/server/0674-Fix-dangerous-end-portal-logic.patch
@@ -11,10 +11,10 @@ Move the tick logic into the post tick, where portaling was
 designed to happen in the first place.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 56d8939c34e0edd74ee2980a41a889bb3ccf659e..6970bb9951e83d5e1a76bad8ca4a7cb16d7fdd92 100644
+index e0d1798b604b5977177714774da26a4d797ac448..7ba5761791bdbfdc924bdf8b1ed239c9fb640cac 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -388,6 +388,36 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -394,6 +394,36 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          return chunkMap.playerEntityTrackerTrackMaps[type.ordinal()].getObjectsInRange(MCUtil.getCoordinateKey(this));
      }
      // Paper end - optimise entity tracking
@@ -51,7 +51,7 @@ index 56d8939c34e0edd74ee2980a41a889bb3ccf659e..6970bb9951e83d5e1a76bad8ca4a7cb1
  
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
-@@ -2531,6 +2561,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2545,6 +2575,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              }
  
              this.processPortalCooldown();

--- a/patches/server/0677-Line-Of-Sight-Changes.patch
+++ b/patches/server/0677-Line-Of-Sight-Changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4c9a6bb5456fe5fa35e37a18b3e577003d901d71..2d57ee46e66fe8962177a3a18c890f4942752b33 100644
+index 510c2f0d47b593ac2bd60608c43cef8c069a5373..3d197ddb412e7df6723be0e86db86d9326281bc1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3446,7 +3446,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3445,7 +3445,8 @@ public abstract class LivingEntity extends Entity {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  

--- a/patches/server/0689-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0689-Add-config-for-mobs-immune-to-default-effects.patch
@@ -31,10 +31,10 @@ index 047d2b47b5af22087359e76362d84dc69ae26707..36730b851203602a49d5a76b25a9e3a1
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2d57ee46e66fe8962177a3a18c890f4942752b33..d10edbda254e17a555e1ad00040e1693be7c5182 100644
+index 3d197ddb412e7df6723be0e86db86d9326281bc1..73ff544665eed9d999b13462b9635e79866c927c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1128,7 +1128,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1127,7 +1127,7 @@ public abstract class LivingEntity extends Entity {
          if (this.getMobType() == MobType.UNDEAD) {
              MobEffect mobeffectlist = effect.getEffect();
  

--- a/patches/server/0699-Improve-boat-collision-performance.patch
+++ b/patches/server/0699-Improve-boat-collision-performance.patch
@@ -17,10 +17,10 @@ index 6c87ad6e015729db5b10f795b59aa785dff4368a..4605e80bb7dc5408daafb5ccba52efa1
      };
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d10edbda254e17a555e1ad00040e1693be7c5182..5a180c90d0704f1e1850bad07b863e9230866fcc 100644
+index 73ff544665eed9d999b13462b9635e79866c927c..69e296de6f4dbbcacd516ee1707c1c315dd7f0a1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1316,7 +1316,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1315,7 +1315,7 @@ public abstract class LivingEntity extends Entity {
                  if (!source.isProjectile()) {
                      Entity entity = source.getDirectEntity();
  
@@ -29,7 +29,7 @@ index d10edbda254e17a555e1ad00040e1693be7c5182..5a180c90d0704f1e1850bad07b863e92
                          this.blockUsingShield((LivingEntity) entity);
                      }
                  }
-@@ -1424,11 +1424,12 @@ public abstract class LivingEntity extends Entity {
+@@ -1423,11 +1423,12 @@ public abstract class LivingEntity extends Entity {
                  }
  
                  if (entity1 != null) {
@@ -44,7 +44,7 @@ index d10edbda254e17a555e1ad00040e1693be7c5182..5a180c90d0704f1e1850bad07b863e92
                          d0 = (Math.random() - Math.random()) * 0.01D;
                      }
  
-@@ -2098,7 +2099,7 @@ public abstract class LivingEntity extends Entity {
+@@ -2097,7 +2098,7 @@ public abstract class LivingEntity extends Entity {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/0707-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0707-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6970bb9951e83d5e1a76bad8ca4a7cb16d7fdd92..aa85a026b04f790dd9e4551f2ea3082bc076e04f 100644
+index 7ba5761791bdbfdc924bdf8b1ed239c9fb640cac..96fba810f9f6d105a844831de45ae1df174d1837 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3496,26 +3496,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3511,26 +3511,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      private Stream<Entity> getIndirectPassengersStream() {

--- a/patches/server/0718-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0718-Add-back-EntityPortalExitEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index aa85a026b04f790dd9e4551f2ea3082bc076e04f..1869eb6067da68e7c43b3749738c8376d18ed4cf 100644
+index 96fba810f9f6d105a844831de45ae1df174d1837..ddf315ab79dd42e18e73aba8b96ad33ae21073b7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3008,6 +3008,25 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3022,6 +3022,25 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              } else {
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
@@ -34,7 +34,7 @@ index aa85a026b04f790dd9e4551f2ea3082bc076e04f..1869eb6067da68e7c43b3749738c8376
                  this.unRide();
                  // CraftBukkit end
  
-@@ -3021,8 +3040,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3035,8 +3054,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
  
                  if (entity != null) {
                      entity.restoreFrom(this);

--- a/patches/server/0724-Add-critical-damage-API.patch
+++ b/patches/server/0724-Add-critical-damage-API.patch
@@ -72,7 +72,7 @@ index b436103957113bff5e553dacb869c775a3f8b059..3d3dcb47720055f550d17d1f106a2c0e
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cca472eb7c0df93e295125d35ede43b897e9d2b0..35cc150adf51f79e2fccef8b094c90554aafbee2 100644
+index db4a0f26ae528680b4e2ac395a6800c6d8f4124e..519b17fac445b7118f5493508bddccd368dadcde 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -970,7 +970,7 @@ public class CraftEventFactory {
@@ -93,7 +93,7 @@ index cca472eb7c0df93e295125d35ede43b897e9d2b0..35cc150adf51f79e2fccef8b094c9055
          } else if (source == DamageSource.OUT_OF_WORLD) {
              EntityDamageEvent event = new EntityDamageByBlockEvent(null, entity.getBukkitEntity(), DamageCause.VOID, modifiers, modifierFunctions);
              event.setCancelled(cancelled);
-@@ -1058,7 +1058,7 @@ public class CraftEventFactory {
+@@ -1067,7 +1067,7 @@ public class CraftEventFactory {
              } else {
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager.getHandle(), source.msgId));
              }
@@ -102,7 +102,7 @@ index cca472eb7c0df93e295125d35ede43b897e9d2b0..35cc150adf51f79e2fccef8b094c9055
              event.setCancelled(cancelled);
              CraftEventFactory.callEvent(event);
              if (!event.isCancelled()) {
-@@ -1103,20 +1103,28 @@ public class CraftEventFactory {
+@@ -1112,20 +1112,28 @@ public class CraftEventFactory {
          }
  
          if (cause != null) {

--- a/patches/server/0729-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0729-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1869eb6067da68e7c43b3749738c8376d18ed4cf..8963bc6cfd3edfd493cc73918513478a5bc03903 100644
+index ddf315ab79dd42e18e73aba8b96ad33ae21073b7..1d4a01b52f026d0610b49f1c2f048a6c68c54c4e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1826,6 +1826,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1832,6 +1832,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          }
      }
  

--- a/patches/server/0747-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0747-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -953,10 +953,10 @@ index de5e18a331178da8f7e82aa2419a0ee606e801ee..9b25d36fe5230e287d81b99be31b9edd
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8963bc6cfd3edfd493cc73918513478a5bc03903..a320816795fa9b2d4fc696b008222368b00c586e 100644
+index 1d4a01b52f026d0610b49f1c2f048a6c68c54c4e..688c606d8b01e24863849b5a7fede8dfa5cb6571 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -419,6 +419,56 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -425,6 +425,56 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
      // Paper end - make end portalling safe
  
@@ -1013,7 +1013,7 @@ index 8963bc6cfd3edfd493cc73918513478a5bc03903..a320816795fa9b2d4fc696b008222368
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
          this.passengers = ImmutableList.of();
-@@ -2280,11 +2330,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2294,11 +2344,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          return InteractionResult.PASS;
      }
  
@@ -1282,7 +1282,7 @@ index 9ab8159975f58a0014edbe3a368490b3590882ea..4c6cbfbcb5a7876e6b556b59c54e9a4c
 +    // Paper end
  }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 84880151abd193be5f02b5e9abb3fa78f2aa2cac..54a55cc05776af8de63b492bbda58182bb4c3726 100644
+index 88c3022abc5edde312573de4fe499f1f5ee9eeae..8bd8b85445b2b0b6517590baef33bb4234bb2a38 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -210,7 +210,13 @@ public class ActivationRange

--- a/patches/server/0753-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0753-Detail-more-information-in-watchdog-dumps.patch
@@ -77,7 +77,7 @@ index bcf53ec07b8eeec7a88fb67e6fb908362e6f51b0..acc12307f61e1e055896b68fe16654c9
              });
              throw RunningOnDifferentThreadException.RUNNING_ON_DIFFERENT_THREAD;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 7e837b2896cac64a982d9025c4e190dfa7ebc451..c353e41fa733b42350285861a5ddbdf304ec0e02 100644
+index cb327920cfa8d4eec626af1fe42ec1cc5e8953c7..3735b80c6f827500a9c474d4139d6e748b14863b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -976,7 +976,26 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -123,10 +123,10 @@ index 7e837b2896cac64a982d9025c4e190dfa7ebc451..c353e41fa733b42350285861a5ddbdf3
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a320816795fa9b2d4fc696b008222368b00c586e..ac6c0474fc05178d1efac7f5767066074def2f16 100644
+index 688c606d8b01e24863849b5a7fede8dfa5cb6571..a0ba2eb443c8ba63a813b97b69a80d77e7320867 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -898,7 +898,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -904,7 +904,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          return this.onGround;
      }
  
@@ -169,7 +169,7 @@ index a320816795fa9b2d4fc696b008222368b00c586e..ac6c0474fc05178d1efac7f576706607
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -1060,6 +1095,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1066,6 +1101,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  this.level.getProfiler().pop();
              }
          }
@@ -183,7 +183,7 @@ index a320816795fa9b2d4fc696b008222368b00c586e..ac6c0474fc05178d1efac7f576706607
      }
  
      protected boolean isHorizontalCollisionMinor(Vec3 adjustedMovement) {
-@@ -3850,7 +3892,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3865,7 +3907,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -193,7 +193,7 @@ index a320816795fa9b2d4fc696b008222368b00c586e..ac6c0474fc05178d1efac7f576706607
      }
  
      public void setDeltaMovement(double x, double y, double z) {
-@@ -3926,7 +3970,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3941,7 +3985,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          }
          // Paper end - fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {

--- a/patches/server/0789-Mark-fish-and-axolotls-from-buckets-as-persistent.patch
+++ b/patches/server/0789-Mark-fish-and-axolotls-from-buckets-as-persistent.patch
@@ -18,10 +18,10 @@ index 58428eebf24e328b3faf32ca473be8f19d4f6cca..3484defdfd5a487b11917310d7b1d154
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java b/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java
-index 67bb476693fa16aa391c120f8acae7c7279efc20..86acf89ce875e215da8469947b382f70e42314b0 100644
+index c2d5798cac21afab5133ce086f60bf54fa1b97b6..a3ad957a9131168656b8e30c82d762c77e96ae6e 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java
-@@ -237,7 +237,7 @@ public class Axolotl extends Animal implements LerpingModel, Bucketable {
+@@ -243,7 +243,7 @@ public class Axolotl extends Animal implements LerpingModel, Bucketable {
      @Override
      public void setFromBucket(boolean fromBucket) {
          this.entityData.set(Axolotl.FROM_BUCKET, fromBucket);

--- a/patches/server/0793-Update-head-rotation-in-missing-places.patch
+++ b/patches/server/0793-Update-head-rotation-in-missing-places.patch
@@ -8,10 +8,10 @@ This is because bukkit uses a separate head rotation field for yaw.
 This issue only applies to players.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ac6c0474fc05178d1efac7f5767066074def2f16..d4b553322712439bd4a459e7eaaa9df090e9cc6e 100644
+index a0ba2eb443c8ba63a813b97b69a80d77e7320867..2155c63e81ab241043deba30fef6f4c8482b9047 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1654,6 +1654,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1660,6 +1660,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          this.setXRot(Mth.clamp(pitch, -90.0F, 90.0F) % 360.0F);
          this.yRotO = this.getYRot();
          this.xRotO = this.getXRot();
@@ -19,7 +19,7 @@ index ac6c0474fc05178d1efac7f5767066074def2f16..d4b553322712439bd4a459e7eaaa9df0
      }
  
      public void absMoveTo(double x, double y, double z) {
-@@ -1692,6 +1693,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1698,6 +1699,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          this.setXRot(pitch);
          this.setOldPosAndRot();
          this.reapplyPosition();

--- a/patches/server/0803-don-t-attempt-to-teleport-dead-entities.patch
+++ b/patches/server/0803-don-t-attempt-to-teleport-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] don't attempt to teleport dead entities
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d4b553322712439bd4a459e7eaaa9df090e9cc6e..e2c35ace138d7a6c41e7f07e9759f684b7152b71 100644
+index 2155c63e81ab241043deba30fef6f4c8482b9047..26546c030710685cdc1c75b8018462cd424b9ed6 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -706,7 +706,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -712,7 +712,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      // CraftBukkit start
      public void postTick() {
          // No clean way to break out of ticking once the entity has been copied to a new world, so instead we move the portalling later in the tick cycle

--- a/patches/server/0805-Prevent-excessive-velocity-through-repeated-crits.patch
+++ b/patches/server/0805-Prevent-excessive-velocity-through-repeated-crits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent excessive velocity through repeated crits
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5a180c90d0704f1e1850bad07b863e9230866fcc..87993c38984906f06df926e0837294e642f7b845 100644
+index 69e296de6f4dbbcacd516ee1707c1c315dd7f0a1..da6e1730f7309e820b8a11a9b362a16b45db0abf 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2583,14 +2583,27 @@ public abstract class LivingEntity extends Entity {
+@@ -2582,14 +2582,27 @@ public abstract class LivingEntity extends Entity {
          return this.hasEffect(MobEffects.JUMP) ? (double) (0.1F * (float) (this.getEffect(MobEffects.JUMP).getAmplifier() + 1)) : 0.0D;
      }
  

--- a/patches/server/0810-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0810-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -34,10 +34,10 @@ index 703ac671b19636859648f16a5431b2700791e7d5..d8ef6137133716b9ee519e6e4668d2e1
              }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 87993c38984906f06df926e0837294e642f7b845..5e26b3ce1da37f9b93da91061f4e0aa92b80e2f2 100644
+index da6e1730f7309e820b8a11a9b362a16b45db0abf..45bad146283ebde8cc4a1d67a67d325f74417011 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3066,7 +3066,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3065,7 +3065,10 @@ public abstract class LivingEntity extends Entity {
          equipmentChanges.forEach((enumitemslot, itemstack) -> {
              ItemStack itemstack1 = itemstack.copy();
  
@@ -49,7 +49,7 @@ index 87993c38984906f06df926e0837294e642f7b845..5e26b3ce1da37f9b93da91061f4e0aa9
              switch (enumitemslot.getType()) {
                  case HAND:
                      this.setLastHandItem(enumitemslot, itemstack1);
-@@ -3079,6 +3082,34 @@ public abstract class LivingEntity extends Entity {
+@@ -3078,6 +3081,34 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  

--- a/patches/server/0811-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0811-Hide-unnecessary-itemmeta-from-clients.patch
@@ -36,10 +36,10 @@ index d8ef6137133716b9ee519e6e4668d2e1ae5d9ca3..9a6c67b614944f841813ec2892381c33
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5e26b3ce1da37f9b93da91061f4e0aa92b80e2f2..572f9ca81b78c6229725f6693940ac0a70ecdfd5 100644
+index 45bad146283ebde8cc4a1d67a67d325f74417011..44a32fd2c08a09af0bba01547847b8594a7cd077 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3068,7 +3068,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3067,7 +3067,7 @@ public abstract class LivingEntity extends Entity {
  
              // Paper start - prevent oversized data
              ItemStack toSend = sanitizeItemStack(itemstack1, true);
@@ -48,7 +48,7 @@ index 5e26b3ce1da37f9b93da91061f4e0aa92b80e2f2..572f9ca81b78c6229725f6693940ac0a
              // Paper end
              switch (enumitemslot.getType()) {
                  case HAND:
-@@ -3082,6 +3082,51 @@ public abstract class LivingEntity extends Entity {
+@@ -3081,6 +3081,51 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  

--- a/patches/server/0815-Add-player-health-update-API.patch
+++ b/patches/server/0815-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d41d85f28e3eb7d6b9c9addc743e5bc09dd217c9..148e1985017f6955267b5c970730645394d700f6 100644
+index e8daf648eada3f72f5e4fa28e08028efa95a60eb..d9c40138617ce73ae25d2175f1b4a70f47c32ea5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2027,9 +2027,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2035,9 +2035,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index d41d85f28e3eb7d6b9c9addc743e5bc09dd217c9..148e1985017f6955267b5c9707306453
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2037,7 +2039,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2045,7 +2047,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          // Paper end
      }

--- a/patches/server/0818-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0818-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -955,10 +955,10 @@ index 80888d5adf7d4377e17e6f530f35053cfcc9eed4..fe9810c3b908339ca050ed832c2e67d6
          }
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3638bdfdeb2b254e8378672f3ec897f3e8e1e5b2..f1ebd2d3a4efb04a4a85b3bbd0baff9676f19702 100644
+index 26546c030710685cdc1c75b8018462cd424b9ed6..2e61243b86ea1f21ec799a63badeae329e1ac3fa 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1076,9 +1076,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1082,9 +1082,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  float f2 = this.getBlockSpeedFactor();
  
                  this.setDeltaMovement(this.getDeltaMovement().multiply((double) f2, 1.0D, (double) f2));
@@ -1006,7 +1006,7 @@ index 3638bdfdeb2b254e8378672f3ec897f3e8e1e5b2..f1ebd2d3a4efb04a4a85b3bbd0baff96
                      if (this.remainingFireTicks <= 0) {
                          this.setRemainingFireTicks(-this.getFireImmuneTicks());
                      }
-@@ -1212,32 +1247,78 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -1218,32 +1253,78 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      private Vec3 collide(Vec3 movement) {
@@ -1106,7 +1106,7 @@ index 3638bdfdeb2b254e8378672f3ec897f3e8e1e5b2..f1ebd2d3a4efb04a4a85b3bbd0baff96
      }
  
      public static Vec3 collideBoundingBox(@Nullable Entity entity, Vec3 movement, AABB entityBoundingBox, Level world, List<VoxelShape> collisions) {
-@@ -2362,11 +2443,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2376,11 +2457,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              float f = this.dimensions.width * 0.8F;
              AABB axisalignedbb = AABB.ofSize(vec3d, (double) f, 1.0E-6D, (double) f);
  

--- a/patches/server/0828-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0828-Forward-CraftEntity-in-teleport-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9bb44918af119d9afae4a0a050c6a5381f028364..8ea81f6ac7503c68f0aea34802843bc545f46db0 100644
+index 2e61243b86ea1f21ec799a63badeae329e1ac3fa..eac13465c8c1827953a8b1bb2feb4d7f92c773fb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3154,6 +3154,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3168,6 +3168,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public void restoreFrom(Entity original) {
@@ -22,7 +22,7 @@ index 9bb44918af119d9afae4a0a050c6a5381f028364..8ea81f6ac7503c68f0aea34802843bc5
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3231,10 +3238,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3245,10 +3252,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                      if (worldserver.getTypeKey() == LevelStem.END) { // CraftBukkit
                          ServerLevel.makeObsidianPlatform(worldserver, this); // CraftBukkit
                      }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
2af60c80 Clarify documentation of Block#getBreakSpeed
368ad40b SPIGOT-6899: Add Player#getPreviousGameMode
b99d4c16 SPIGOT-6901: Make Random Nullable in LootTable
13b723fc Fix typo in CreatureSpawnEvent documentation
e9f9b5bd SPIGOT-6888: Add SpawnReason for Vex spawned by Evokers
aa908faf PR-713: Repairable should extend ItemMeta

CraftBukkit Changes:
30b4043e SPIGOT-6907: Oxygen does not restore up to value set by LivingEntity#setMaximumAir()
3a8161fe SPIGOT-6639: During an EntityDamageEvent with damage from blocks, damaging any entity throws an error
74a5cc8a PR-994: Fix changing world in portal events not updating used world border
7c3ac942 SPIGOT-6902: (Unsupported) Load server as child of system classloader
d10c35ea SPIGOT-6899: Add Player#getPreviousGameMode
e0a6aa36 SPIGOT-6901: Add Support for Random in methods for LootTable
2e61a5f8 SPIGOT-6888: Add SpawnReason for Vex spawned by Evokers

Spigot Changes:
862678ea Rebuild patches