### PR TITLE
Add World Time API

### DIFF
--- a/patches/api/0357-Add-World-Time-API.patch
+++ b/patches/api/0357-Add-World-Time-API.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: DeJayDev <contact@dejaydev.com>
+Date: Mon, 17 Jan 2022 18:23:02 -0600
+Subject: [PATCH] Add World Time API
+
+Adds an enum with the constant phases of the daylight cycle, to be used as reference or with setTime and setFullTime
+
+diff --git a/src/main/java/io/papermc/paper/world/WorldTime.java b/src/main/java/io/papermc/paper/world/WorldTime.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..941cc14a058bf5c874609801e14eeb20f6b1e6b9
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/world/WorldTime.java
+@@ -0,0 +1,26 @@
++package io.papermc.paper.world;
++
++public enum WorldTime {
++
++    DAYTIME_START(0),
++    DAYTIME_MIDDAY(6000),
++    DAYTIME_END(12000),
++    SUNSET_START(12000),
++    SUNSET_END(13000),
++    NIGHTTIME_START(13000),
++    NIGHTTIME_MIDNIGHT(18000),
++    NIGHTTIME_END(23000),
++    SUNRISE_START(23000),
++    SUNRISE_END(24000);
++
++    private final int ticks;
++
++    WorldTime(int ticks) {
++        this.ticks = ticks;
++    }
++
++    public int getTicks() {
++        return ticks;
++    }
++
++}


### PR DESCRIPTION
Adds an enum with the constant phases of the daylight cycle, to be used as reference or with setTime and setFullTime.

I considered adding helpers to World for this, but wasn't sure if it'd be overstepping or doing too much. Decided it was best to get conversation started about it first.

These times are sourced from https://minecraft.fandom.com/wiki/Daylight_cycle#Daytime, and the overlapping time enums are on purpose.