### PR TITLE
1.18 misc performance dev branch

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -221,6 +221,8 @@ public net.minecraft.world.entity.animal.Fox isDefending()Z
 public net.minecraft.world.entity.animal.Fox setDefending(Z)V
 public net.minecraft.world.entity.animal.Fox isFaceplanted()Z
 public net.minecraft.world.entity.animal.Fox setFaceplanted(Z)V
+public net.minecraft.world.entity.animal.Panda getEatCounter()I
+public net.minecraft.world.entity.animal.Panda setEatCounter(I)V
 
 # Cook speed multipler API
 public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity recipeType

--- a/patches/api/0064-Add-getI18NDisplayName-API.patch
+++ b/patches/api/0064-Add-getI18NDisplayName-API.patch
@@ -8,10 +8,10 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 6cc4bad2ecd19f44a680ff03cbfb99d48ea5c337..b1fbb931148a87f29e8b8796b13851d767cc1d68 100644
+index 6cc4bad2ecd19f44a680ff03cbfb99d48ea5c337..e301d477c4839c27854293998ae235b91c9c46e5 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -160,5 +160,16 @@ public interface ItemFactory {
+@@ -160,5 +160,19 @@ public interface ItemFactory {
       */
      @NotNull
      net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack);
@@ -23,16 +23,19 @@ index 6cc4bad2ecd19f44a680ff03cbfb99d48ea5c337..b1fbb931148a87f29e8b8796b13851d7
 +     *
 +     * @param item Item to return Display name of
 +     * @return Display name of Item
++     * @deprecated {@link ItemStack} implements {@link net.kyori.adventure.translation.Translatable}; use that and
++     * {@link net.kyori.adventure.text.Component#translatable(net.kyori.adventure.translation.Translatable)} instead.
 +     */
 +    @Nullable
++    @Deprecated
 +    String getI18NDisplayName(@Nullable ItemStack item);
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index a15abec467bac70116a6fc21a300d4930b909f15..de5bcdb7b84acdd5e22500e367df292f35a86e19 100644
+index a15abec467bac70116a6fc21a300d4930b909f15..dfd16531926e639231e93cb295de3d802d17413d 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -611,5 +611,17 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -611,5 +611,20 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public @NotNull net.kyori.adventure.text.Component displayName() {
          return Bukkit.getServer().getItemFactory().displayName(this);
      }
@@ -43,8 +46,11 @@ index a15abec467bac70116a6fc21a300d4930b909f15..de5bcdb7b84acdd5e22500e367df292f
 +     * You must replace the language file embedded in the server jar.
 +     *
 +     * @return Display name of Item
++     * @deprecated {@link ItemStack} implements {@link net.kyori.adventure.translation.Translatable}; use that and
++     * {@link net.kyori.adventure.text.Component#translatable(net.kyori.adventure.translation.Translatable)} instead.
 +     */
 +    @Nullable
++    @Deprecated
 +    public String getI18NDisplayName() {
 +        return Bukkit.getServer().getItemFactory().getI18NDisplayName(this);
 +    }

--- a/patches/api/0065-ensureServerConversions-API.patch
+++ b/patches/api/0065-ensureServerConversions-API.patch
@@ -7,12 +7,12 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index b1fbb931148a87f29e8b8796b13851d767cc1d68..71e5ee496a947fbd8e3ec579833b157c76b51833 100644
+index 28b410f4f68359281c9f9049639d97d38442f0ce..b0b43b3f42a11bb8fdb3d728f57b5fc462b0e9ab 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -171,5 +171,17 @@ public interface ItemFactory {
-      */
+@@ -174,5 +174,17 @@ public interface ItemFactory {
      @Nullable
+     @Deprecated
      String getI18NDisplayName(@Nullable ItemStack item);
 +
 +    /**

--- a/patches/api/0108-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/api/0108-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index e8783b0116f4efd5447a5f6f260506000983ffd2..9fee2f157ac5149cd65136bf8468deaca410fbf4 100644
+index 4b00a1833387f40a3771a254ad36f94a0c38a5eb..814854f08cce607004ad074d1f8efb44c7108f20 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -636,5 +636,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -639,5 +639,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public String getI18NDisplayName() {
          return Bukkit.getServer().getItemFactory().getI18NDisplayName(this);
      }

--- a/patches/api/0116-ItemStack-API-additions-for-quantity-flags-lore.patch
+++ b/patches/api/0116-ItemStack-API-additions-for-quantity-flags-lore.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ItemStack API additions for quantity/flags/lore
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 9fee2f157ac5149cd65136bf8468deaca410fbf4..686e2a0b9fe061816b41435ef2337870dbdca8e5 100644
+index 814854f08cce607004ad074d1f8efb44c7108f20..fbafd506f86a884a19b218e87ddc8720e83f993d 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -2,7 +2,9 @@ package org.bukkit.inventory;
@@ -18,7 +18,7 @@ index 9fee2f157ac5149cd65136bf8468deaca410fbf4..686e2a0b9fe061816b41435ef2337870
  import org.apache.commons.lang.Validate;
  import org.bukkit.Bukkit;
  import org.bukkit.Material;
-@@ -644,5 +646,185 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -647,5 +649,185 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
          // Requires access to NMS
          return ensureServerConversions().getMaxItemUseDuration();
      }

--- a/patches/api/0150-Mob-Pathfinding-API.patch
+++ b/patches/api/0150-Mob-Pathfinding-API.patch
@@ -13,7 +13,7 @@ You can use EntityPathfindEvent to cancel new pathfinds from overriding your cur
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e2a6f9c3881ff9d7373ac30e60009200432555aa
+index 0000000000000000000000000000000000000000..43f062257472a06e9e64c2feef6c3b1012aee00e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
 @@ -0,0 +1,212 @@
@@ -214,7 +214,7 @@ index 0000000000000000000000000000000000000000..e2a6f9c3881ff9d7373ac30e60009200
 +
 +        /**
 +         * @return Returns the index of the current point along the points returned in {@link #getPoints()} the entity
-+         * is trying to reach, or null if we are done with this pathfinding.
++         * is trying to reach. This value will be higher than the maximum index of {@link #getPoints()} if this path finding is done.
 +         */
 +        int getNextPointIndex();
 +

--- a/patches/api/0220-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0220-Add-methods-to-get-translation-keys.patch
@@ -337,7 +337,7 @@ index 511b96841f7342d0a6b38d7cff56252ea8ef9bfe..02ecc87a90bbd81e7d21279fac701ba4
  
      // Paper start - Add villager reputation API
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index b80ef2e5c23764ee68f809268185492bf5577913..e6eab5d8ca3fea8d2e0ccc1cd1c1a7a110b589db 100644
+index afe6d4877fa4f3c5b03f8bca68f59ff0885d21d4..ea94570cb7b8673962a8c1a735cfc7c80f85db31 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
@@ -349,7 +349,7 @@ index b80ef2e5c23764ee68f809268185492bf5577913..e6eab5d8ca3fea8d2e0ccc1cd1c1a7a1
      private Material type = Material.AIR;
      private int amount = 0;
      private MaterialData data = null;
-@@ -852,5 +852,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -855,5 +855,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
          ItemMeta itemMeta = getItemMeta();
          return itemMeta != null && itemMeta.hasItemFlag(flag);
      }

--- a/patches/api/0221-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/api/0221-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index d773e8594f91017bddd7ea8aada3a1ff2781d05b..0a4466c6ca519c3a5da76ff870fb2a4e3a06effd 100644
+index 0f6a3efc04214fd66cc5a0e9eea9d321ca7aac58..5793a02ff5ec9310c23c471529226b300d43ec7c 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -184,5 +184,62 @@ public interface ItemFactory {
+@@ -187,5 +187,62 @@ public interface ItemFactory {
       */
      @NotNull
      ItemStack ensureServerConversions(@NotNull ItemStack item);

--- a/patches/api/0277-Item-Rarity-API.patch
+++ b/patches/api/0277-Item-Rarity-API.patch
@@ -88,10 +88,10 @@ index a7a5eada1302dac046619d8a01c887965f22dd09..2392efea1b514671014c39d75407f59f
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index e6eab5d8ca3fea8d2e0ccc1cd1c1a7a110b589db..f46aeb59a5a1bde4011cd1d933afcc19c7d1b3bd 100644
+index ea94570cb7b8673962a8c1a735cfc7c80f85db31..45e656643f07e25ee4432786dea750b83abc95ae 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -877,5 +877,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -880,5 +880,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public @NotNull String translationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }

--- a/patches/api/0297-ItemStack-repair-check-API.patch
+++ b/patches/api/0297-ItemStack-repair-check-API.patch
@@ -26,10 +26,10 @@ index 8f85c41be166ea720a0bf5b6b58bc51a6d2c71cc..c1bda4dba319999261613d4aa45a280e
       * Returns the server's protocol version.
       *
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index f46aeb59a5a1bde4011cd1d933afcc19c7d1b3bd..86bd9f14de5c1ff3d797955be1af56e5efcac884 100644
+index 45e656643f07e25ee4432786dea750b83abc95ae..a1d332a5eafb88c2f5d95bea6dc7e528ea2047be 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -887,5 +887,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -890,5 +890,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public io.papermc.paper.inventory.ItemRarity getRarity() {
          return Bukkit.getUnsafe().getItemStackRarity(this);
      }

--- a/patches/api/0312-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0312-Missing-Entity-Behavior-API.patch
@@ -175,3 +175,120 @@ index 498e182846b81d50b3a594254e8b341fb23e8763..3826363a1954afcddaadec7f96ac1830
 +    public boolean isFaceplanted();
 +    // Paper end - Add more fox behavior API
  }
+diff --git a/src/main/java/org/bukkit/entity/Panda.java b/src/main/java/org/bukkit/entity/Panda.java
+index a6a7429ed2e1eefb2b12b7480ed74fcc3963a864..9d065625be5931d970d7f34e1225fae1af960314 100644
+--- a/src/main/java/org/bukkit/entity/Panda.java
++++ b/src/main/java/org/bukkit/entity/Panda.java
+@@ -63,4 +63,112 @@ public interface Panda extends Animals {
+             return recessive;
+         }
+     }
++
++    // Paper start - Panda API
++    /**
++     * Sets the sneeze progress in this animation.
++     * This value counts up only if {@link Panda#isSneezing()} is true
++     *
++     * @param ticks sneeze progress
++     */
++    void setSneezeTicks(int ticks);
++
++    /**
++     * Gets the current sneeze progress, or how many ticks this panda will sneeze for.
++     *
++     * @return sneeze progress
++     */
++    int getSneezeTicks();
++
++    /**
++     * Sets if the panda is sneezing, which causes the sneeze counter to count.
++     * <p>
++     * When false, this will automatically set the sneeze ticks to 0.
++     *
++     * @param sneeze if the panda is sneezing or not
++     */
++    void setSneezing(boolean sneeze);
++
++    /**
++     * Gets if the panda is sneezing
++     *
++     * @return is sneezing
++     */
++    boolean isSneezing();
++
++    /**
++     * Sets the eating ticks for this panda.
++     * <p>
++     *
++     * This starts counting up as long as it is greater than 0.
++     *
++     * @param ticks eating ticks
++     */
++    void setEatingTicks(int ticks);
++
++    /**
++     * Gets the current eating progress, or how many ticks this panda has been eating for.
++     *
++     * @return eating progress
++     */
++    int getEatingTicks();
++
++    /**
++     * Sets the number of ticks this panda will be unhappy for.
++     * <p>
++     * This value counts down.
++     *
++     * @param ticks unhappy ticks
++     */
++    void setUnhappyTicks(int ticks);
++
++    /**
++     * Gets how many ticks this panda will be unhappy for.
++     *
++     * @return unhappy ticks
++     */
++    int getUnhappyTicks();
++
++    /**
++     * Sets if this panda is currently rolling.
++     *
++     * @param rolling should roll
++     */
++    void setRolling(boolean rolling);
++
++    /**
++     * Gets if this panda is currently rolling on the ground.
++     *
++     * @return is rolling
++     */
++    boolean isRolling();
++
++    /**
++     * Sets if this panda is currently on its back.
++     *
++     * @param onBack is on its back
++     */
++    void setIsOnBack(boolean onBack);
++
++    /**
++     * Gets if this panda is currently on its back.
++     *
++     * @return is on back
++     */
++    boolean isOnBack();
++
++    /**
++     * Sets if this panda is currently sitting.
++     *
++     * @param sitting is currently sitting
++     */
++    void setIsSitting(boolean sitting);
++
++    /**
++     * Gets if this panda is sitting.
++     *
++     * @return is sitting
++     */
++    boolean isSitting();
++    // Paper end - Panda API
+ }

--- a/patches/api/0334-Add-ItemFactory-getMonsterEgg-API.patch
+++ b/patches/api/0334-Add-ItemFactory-getMonsterEgg-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ItemFactory#getMonsterEgg API
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 0a4466c6ca519c3a5da76ff870fb2a4e3a06effd..8677e273641a46aae7107361f23f6ded59a50dc0 100644
+index 5793a02ff5ec9310c23c471529226b300d43ec7c..bd2500068e984bd06b1121c34adbaaefda9c746a 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -241,5 +241,14 @@ public interface ItemFactory {
+@@ -244,5 +244,14 @@ public interface ItemFactory {
      @NotNull
      @Deprecated
      net.md_5.bungee.api.chat.hover.content.Content hoverContentOf(@NotNull org.bukkit.entity.Entity entity, @NotNull net.md_5.bungee.api.chat.BaseComponent[] customName);

--- a/patches/server/0015-Configurable-fishing-time-ranges.patch
+++ b/patches/server/0015-Configurable-fishing-time-ranges.patch
@@ -22,7 +22,7 @@ index ec3fb557fa31b153de20c4990066182a774dd489..5896b4e4646d722db5622a424fa26f42
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
-index 73c5a0e6f1db6bf438fe516e213f40f0645ed954..dc248a0a91795fb67cc0e15cb0012364e739fbaa 100644
+index 73c5a0e6f1db6bf438fe516e213f40f0645ed954..b11f97e4ecc8d623d8a8a69e9e7a6205b96072f1 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 @@ -82,6 +82,10 @@ public class FishingHook extends Projectile {
@@ -36,3 +36,12 @@ index 73c5a0e6f1db6bf438fe516e213f40f0645ed954..dc248a0a91795fb67cc0e15cb0012364
      }
  
      public FishingHook(EntityType<? extends FishingHook> type, Level world) {
+@@ -397,7 +401,7 @@ public class FishingHook extends Projectile {
+             } else {
+                 // CraftBukkit start - logic to modify fishing wait time
+                 this.timeUntilLured = Mth.nextInt(this.random, this.minWaitTime, this.maxWaitTime);
+-                this.timeUntilLured -= (this.applyLure) ? this.lureSpeed * 20 * 5 : 0;
++                this.timeUntilLured -= (this.applyLure) ? (this.lureSpeed * 20 * 5 >= this.maxWaitTime ? this.timeUntilLured - 1 : this.lureSpeed * 20 * 5) : 0; // Paper - Fix Lure infinite loop
+                 // CraftBukkit end
+             }
+         }

--- a/patches/server/0150-Implement-getI18NDisplayName.patch
+++ b/patches/server/0150-Implement-getI18NDisplayName.patch
@@ -8,7 +8,7 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 73da393b26a7afd766b23716da454b0b68c26d5b..c50d3cee3dfebb62ad30f8d4efe23b5c7c9f2b57 100644
+index 73da393b26a7afd766b23716da454b0b68c26d5b..3e23fb314ec8c89643b900816075a3542b8bb890 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 @@ -362,5 +362,18 @@ public final class CraftItemFactory implements ItemFactory {
@@ -26,7 +26,7 @@ index 73da393b26a7afd766b23716da454b0b68c26d5b..c50d3cee3dfebb62ad30f8d4efe23b5c
 +            nms = CraftItemStack.asNMSCopy(item);
 +        }
 +
-+        return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId()) : null;
++        return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId(nms)) : null;
 +    }
      // Paper end
  }

--- a/patches/server/0346-Optimize-Hoppers.patch
+++ b/patches/server/0346-Optimize-Hoppers.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3e3a48a636c225ec113c1c64f6ffc8a37ad9169e..94336c6a644bf913d366baa71c2372eb67b6e2cd 100644
+index 3e3a48a636c225ec113c1c64f6ffc8a37ad9169e..98adf2fd1c2e9fe75456266ea1d7604fe64109b1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -511,5 +511,17 @@ public class PaperWorldConfig {
@@ -23,14 +23,14 @@ index 3e3a48a636c225ec113c1c64f6ffc8a37ad9169e..94336c6a644bf913d366baa71c2372eb
 +
 +    public boolean cooldownHopperWhenFull = true;
 +    public boolean disableHopperMoveEvents = false;
-+    public boolean hoppersIgnoreOccludingBlocks = true;
++    public boolean hoppersIgnoreOccludingBlocks = false;
 +    private void hopperOptimizations() {
 +        cooldownHopperWhenFull = getBoolean("hopper.cooldown-when-full", cooldownHopperWhenFull);
 +        log("Cooldown Hoppers when Full: " + (cooldownHopperWhenFull ? "enabled" : "disabled"));
 +        disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
 +        log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
 +        hoppersIgnoreOccludingBlocks = getBoolean("hopper.ignore-occluding-blocks", hoppersIgnoreOccludingBlocks);
-+        log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
++        log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
 +    }
  }
  

--- a/patches/server/0358-Increase-Light-Queue-Size.patch
+++ b/patches/server/0358-Increase-Light-Queue-Size.patch
@@ -14,12 +14,12 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 94336c6a644bf913d366baa71c2372eb67b6e2cd..723adafaf82a664b8bfff9d7d11e43e3eafafa6e 100644
+index 98adf2fd1c2e9fe75456266ea1d7604fe64109b1..d9c59ea6faa7155d415c89228c22da3311855c9d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -523,5 +523,10 @@ public class PaperWorldConfig {
          hoppersIgnoreOccludingBlocks = getBoolean("hopper.ignore-occluding-blocks", hoppersIgnoreOccludingBlocks);
-         log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
+         log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
 +
 +    public int lightQueueSize = 20;

--- a/patches/server/0372-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0372-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 88d140a03b6f28070b2f78588ee5ce4d5ac3cf0f..67dcc28e5c5f6bdcafaea4bfe317203ddee09454 100644
+index 6b0391743cd9e249c66796e7fe7a4da8c6b81b2e..5ba23152d2c7e45a824d49246706aa98c5d535ba 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -526,6 +526,11 @@ public class PaperWorldConfig {
-         log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
+         log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
  
 +    public boolean nerfNetherPortalPigmen = false;
@@ -21,7 +21,7 @@ index 88d140a03b6f28070b2f78588ee5ce4d5ac3cf0f..67dcc28e5c5f6bdcafaea4bfe317203d
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 306e23a788798dd0438a6a93cd55854c904eadbd..6fbbd591873d28dde1ff59ab0ae46f9ce4d6ae31 100644
+index e59364169c7ef5b8f9731e0f5db258b81acddae1..8d1cdf39d6512515e9f4d25d16ed347f14c1818a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -315,6 +315,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i

--- a/patches/server/0501-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/server/0501-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index c50d3cee3dfebb62ad30f8d4efe23b5c7c9f2b57..fcbd28fdeab4815c005c7dca547aee246f52fd26 100644
+index 3e23fb314ec8c89643b900816075a3542b8bb890..def8caa7e991cc5f6e8aefcf9e9e3b18149bfdfa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 @@ -375,5 +375,40 @@ public final class CraftItemFactory implements ItemFactory {
  
-         return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId()) : null;
+         return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId(nms)) : null;
      }
 +
 +    @Override

--- a/patches/server/0668-Fix-PlayerBucketEmptyEvent-result-itemstack.patch
+++ b/patches/server/0668-Fix-PlayerBucketEmptyEvent-result-itemstack.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Fix PlayerBucketEmptyEvent result itemstack
 Fixes SPIGOT-2560: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-2560
 
 diff --git a/src/main/java/net/minecraft/world/item/BucketItem.java b/src/main/java/net/minecraft/world/item/BucketItem.java
-index 5406acd65d4e1146f3bd7340ff9a1954a5c39ddb..b5a5c56fbb66c17dd2e2d1f4d69d2b1826cd4951 100644
+index 5406acd65d4e1146f3bd7340ff9a1954a5c39ddb..a3f04f66c66f40068792da3ef0e75e7df102b0e0 100644
 --- a/src/main/java/net/minecraft/world/item/BucketItem.java
 +++ b/src/main/java/net/minecraft/world/item/BucketItem.java
 @@ -39,6 +39,8 @@ import org.bukkit.event.player.PlayerBucketFillEvent;
  
  public class BucketItem extends Item implements DispensibleContainerItem {
  
-+    private static ItemStack itemLeftInHandAfterPlayerBucketEmptyEvent = null; // Paper
++    private static @Nullable ItemStack itemLeftInHandAfterPlayerBucketEmptyEvent = null; // Paper
 +
      public final Fluid content;
  
@@ -32,13 +32,11 @@ index 5406acd65d4e1146f3bd7340ff9a1954a5c39ddb..b5a5c56fbb66c17dd2e2d1f4d69d2b18
          return !player.getAbilities().instabuild ? new ItemStack(Items.BUCKET) : stack;
      }
  
-@@ -152,6 +161,9 @@ public class BucketItem extends Item implements DispensibleContainerItem {
+@@ -152,6 +161,7 @@ public class BucketItem extends Item implements DispensibleContainerItem {
                      ((ServerPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
                      return false;
                  }
-+                // Paper start
-+                itemLeftInHandAfterPlayerBucketEmptyEvent = event.getItemStack().equals(CraftItemStack.asNewCraftStack(net.minecraft.world.item.Items.BUCKET)) ? null : CraftItemStack.asNMSCopy(event.getItemStack());
-+                // Paper end
++                itemLeftInHandAfterPlayerBucketEmptyEvent = event.getItemStack() != null ? event.getItemStack().equals(CraftItemStack.asNewCraftStack(net.minecraft.world.item.Items.BUCKET)) ? null : CraftItemStack.asNMSCopy(event.getItemStack()) : ItemStack.EMPTY; // Paper - fix empty event result itemstack
              }
              // CraftBukkit end
              if (!flag1) {

--- a/patches/server/0682-Missing-Entity-Behavior-API.patch
+++ b/patches/server/0682-Missing-Entity-Behavior-API.patch
@@ -156,3 +156,85 @@ index b647a5b9fdc1da61c4035d6f2cef7814033dc608..9795341efa748c2d94567e882cd5f26a
 +    }
 +    // Paper end - Add more fox behavior API
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
+index 2d2620dbb16aec850e8afda02174508a4be5a313..ec56a520da22248cdcdfaa179489aa0db0f2273f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
+@@ -46,6 +46,77 @@ public class CraftPanda extends CraftAnimals implements Panda {
+     public void setHiddenGene(Gene gene) {
+         this.getHandle().setHiddenGene(CraftPanda.toNms(gene));
+     }
++    // Paper start - Panda API
++    @Override
++    public void setSneezeTicks(int ticks) {
++        this.getHandle().setSneezeCounter(ticks);
++    }
++
++    @Override
++    public int getSneezeTicks() {
++        return this.getHandle().getSneezeCounter();
++    }
++
++    @Override
++    public void setSneezing(boolean sneeze) {
++        this.getHandle().sneeze(sneeze);
++    }
++
++    @Override
++    public boolean isSneezing() {
++        return this.getHandle().isSneezing();
++    }
++
++    @Override
++    public void setEatingTicks(int ticks) {
++        this.getHandle().setEatCounter(ticks);
++    }
++
++    @Override
++    public int getEatingTicks() {
++        return this.getHandle().getEatCounter();
++    }
++
++    @Override
++    public void setUnhappyTicks(int ticks) {
++        this.getHandle().setUnhappyCounter(ticks);
++    }
++
++    @Override
++    public int getUnhappyTicks() {
++        return this.getHandle().getUnhappyCounter();
++    }
++
++    @Override
++    public boolean isRolling() {
++        return this.getHandle().isRolling();
++    }
++
++    @Override
++    public void setRolling(boolean rolling) {
++        this.getHandle().roll(rolling);
++    }
++
++    @Override
++    public boolean isOnBack() {
++        return this.getHandle().isOnBack();
++    }
++
++    @Override
++    public void setIsOnBack(boolean onBack) {
++        this.getHandle().setOnBack(onBack);
++    }
++
++    @Override
++    public boolean isSitting() {
++        return this.getHandle().isSitting();
++    }
++
++    @Override
++    public void setIsSitting(boolean sitting) {
++        this.getHandle().sit(sitting);
++    }
++    // Paper end - Panda API
+ 
+     public static Gene fromNms(net.minecraft.world.entity.animal.Panda.Gene gene) {
+         Preconditions.checkArgument(gene != null, "Gene may not be null");

--- a/patches/server/0689-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0689-Add-config-for-mobs-immune-to-default-effects.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Add config for mobs immune to default effects
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3a83320bae86ba1acb189b9b2cf934ad0393c353..be7b7f9345a42007d6ccea6a31c93a4c874647b6 100644
+index 047d2b47b5af22087359e76362d84dc69ae26707..36730b851203602a49d5a76b25a9e3a11c005033 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -683,6 +683,21 @@ public class PaperWorldConfig {
-         log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
+         log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
  
 +    public boolean undeadImmuneToCertainEffects = true;
@@ -31,7 +31,7 @@ index 3a83320bae86ba1acb189b9b2cf934ad0393c353..be7b7f9345a42007d6ccea6a31c93a4c
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1879271ef55e07cd93ebab2d01bfeb7e7b247883..2b0ba27fbded68270421f31037f71bb81f98d139 100644
+index 2d57ee46e66fe8962177a3a18c890f4942752b33..d10edbda254e17a555e1ad00040e1693be7c5182 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1128,7 +1128,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0841-Validate-usernames.patch
+++ b/patches/server/0841-Validate-usernames.patch
@@ -22,10 +22,18 @@ index d5aa95846e7f52108a03e3731023527281b21d73..1d3cc8836d2ccbec4a8660f86501be35
      public static int maxPlayerAutoSavePerTick = 10;
      private static void playerAutoSaveRate() {
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 33a29890435d6065a2cc4f8e8bf8209c01d5d114..462d8c36166c63a4dc8fa74ac7f82859e6f4b83a 100644
+index 33a29890435d6065a2cc4f8e8bf8209c01d5d114..bb70d2b4d284727aa5dc88dd99534d09c2e38657 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -230,10 +230,38 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+@@ -65,6 +65,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+     private ServerPlayer delayedAcceptPlayer;
+     public String hostname = ""; // CraftBukkit - add field
+     private int velocityLoginMessageId = -1; // Paper - Velocity support
++    public boolean iKnowThisMayNotBeTheBestIdeaButPleaseDisableUsernameValidation = false; // Paper - username validation overriding
+ 
+     public ServerLoginPacketListenerImpl(MinecraftServer server, Connection connection) {
+         this.state = ServerLoginPacketListenerImpl.State.HELLO;
+@@ -230,10 +231,38 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
          // Paper end
      }
  
@@ -55,7 +63,7 @@ index 33a29890435d6065a2cc4f8e8bf8209c01d5d114..462d8c36166c63a4dc8fa74ac7f82859
          this.gameProfile = packet.getGameProfile();
 +        // Paper start - validate usernames
 +        if (com.destroystokyo.paper.PaperConfig.isProxyOnlineMode() && com.destroystokyo.paper.PaperConfig.performUsernameValidation) {
-+            if (!validateUsername(this.gameProfile.getName())) {
++            if (!this.iKnowThisMayNotBeTheBestIdeaButPleaseDisableUsernameValidation && !validateUsername(this.gameProfile.getName())) {
 +                ServerLoginPacketListenerImpl.this.disconnect("Failed to verify username!");
 +                return;
 +            }

--- a/patches/server/0851-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/server/0851-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added getHostname to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 462d8c36166c63a4dc8fa74ac7f82859e6f4b83a..60ba196e17df34c3ae2a9883e5d28830a2243517 100644
+index bb70d2b4d284727aa5dc88dd99534d09c2e38657..368e32bc12a1a09bf7309f299a1a72554947f43b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -391,7 +391,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+@@ -392,7 +392,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
  
                              // Paper start
                              PlayerProfile profile = CraftPlayerProfile.asBukkitMirror(ServerLoginPacketListenerImpl.this.gameProfile);

--- a/patches/server/0852-Fix-xp-reward-for-baby-zombies.patch
+++ b/patches/server/0852-Fix-xp-reward-for-baby-zombies.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 16 Jan 2022 10:34:02 -0800
+Subject: [PATCH] Fix xp reward for baby zombies
+
+The field that tracks the xpReward was not
+getting reset if the death was cancelled
+so this resets it after each call to
+Zombie#getExperienceReward
+
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
+index e72e9b748b3f3e34baddf01366c703efba50c67c..35f0203d260c11b729c30e6241316fda4b70bfd7 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
+@@ -172,11 +172,16 @@ public class Zombie extends Monster {
+ 
+     @Override
+     protected int getExperienceReward(Player player) {
++        final int previousReward = this.xpReward; // Paper - store previous value to reset after calculating XP reward
+         if (this.isBaby()) {
+             this.xpReward = (int) ((float) this.xpReward * 2.5F);
+         }
+ 
+-        return super.getExperienceReward(player);
++        // Paper start - only change the XP reward for the calculations in the super method
++        int reward = super.getExperienceReward(player);
++        this.xpReward = previousReward;
++        return reward;
++        // Paper end
+     }
+ 
+     @Override

--- a/patches/server/0853-Kick-on-main-for-illegal-chars.patch
+++ b/patches/server/0853-Kick-on-main-for-illegal-chars.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
+Date: Mon, 17 Jan 2022 19:47:19 +0100
+Subject: [PATCH] Kick on main for illegal chars
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 926d0a80cbb55184955ac6720948d2e86683cc57..5c9310fe424943a7256f6f77c414147384bad0aa 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -2067,7 +2067,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+ 
+         for (int i = 0; i < s.length(); ++i) {
+             if (!SharedConstants.isAllowedChatCharacter(s.charAt(i))) {
++                this.server.scheduleOnMain(() -> { // Paper - push to main for event firing
+                 this.disconnect(new TranslatableComponent("multiplayer.disconnect.illegal_characters"), org.bukkit.event.player.PlayerKickEvent.Cause.ILLEGAL_CHARACTERS); // Paper - add cause
++                }); // Paper - push to main for event firing
+                 return;
+             }
+         }


### PR DESCRIPTION
Includes:
 - Further optimised collisions. I went pretty hard, there might be collision problems.
 - Reintroduction of player chunk loader patch. Helps rate limit chunk sending to clients.

 - Reversion of Mojang's internal chunk system changes to manage what chunks are ticking. They added a system on top of the existing one just to make chunks outside simulation distance not tick, obviously a complete waste. This should help bring certain aspects of chunk/entity/block ticking back under control, at least compared to 1.17. It also brings in some fixes, notably, mob spawning now _correctly_ occurs only in simulation distance.
Expected behavioral changes are that plugins adding tickets to load chunks will now cause them to tick, as they did in 1.17. Considering that's how the API was designed to work, and has been done so since 1.14, it will remain that way.
API for simulation distance is not implemented yet. This means any plugins trying to work with dynamically changing ticking distance _will not_ work. setViewDistance, unlike 1.17, will follow vanilla behavior and set a "no ticking" view distance.
As it stands, simulation distance is kept vanilla and will stay that way - this means that you do not have to change configs for this branch.

As always, dev builds are generally experimental and are expected to have issues. Keep those issues on this PR _only_.

The jar can be found here:
https://cdn.discordapp.com/attachments/876902758366736457/932942650657632266/paper-paperclip-1.18.1-R0.1-SNAPSHOT-reobf.jar
A comment will be made per update.