### PR TITLE
Expand PlayerItemMendEvent

### DIFF
--- a/patches/api/0416-Expand-PlayerItemMendEvent.patch
+++ b/patches/api/0416-Expand-PlayerItemMendEvent.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 20 Jan 2022 18:11:44 -0800
+Subject: [PATCH] Expand PlayerItemMendEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerItemMendEvent.java b/src/main/java/org/bukkit/event/player/PlayerItemMendEvent.java
+index 5b2415c2c92127947a21dfe8d672d2b88ea457df..533531f69a8d549e184161eefe6e5bf8a9e85c05 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerItemMendEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerItemMendEvent.java
+@@ -23,14 +23,60 @@ public class PlayerItemMendEvent extends PlayerEvent implements Cancellable {
+     private final ExperienceOrb experienceOrb;
+     private int repairAmount;
+     private boolean cancelled;
++    private java.util.function.IntUnaryOperator durabilityToXpOp; // Paper
+ 
++    @Deprecated // Paper
+     public PlayerItemMendEvent(@NotNull Player who, @NotNull ItemStack item, @NotNull EquipmentSlot slot, @NotNull ExperienceOrb experienceOrb, int repairAmount) {
++        // Paper start
++        this(who, item, slot, experienceOrb, repairAmount, amount -> amount / 2);
++    }
++
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public PlayerItemMendEvent(@NotNull Player who, @NotNull ItemStack item, @NotNull EquipmentSlot slot, @NotNull ExperienceOrb experienceOrb, int repairAmount, @NotNull java.util.function.IntUnaryOperator durabilityToXpOp) {
++        // Paper end
+         super(who);
+         this.item = item;
+         this.slot = slot;
+         this.experienceOrb = experienceOrb;
+         this.repairAmount = repairAmount;
++        // Paper start
++        this.durabilityToXpOp = durabilityToXpOp;
++    }
++
++    /**
++     * Get the operation used to calculate xp used based on
++     * the set repair amount. Used to calculate how much of
++     * an XP orb will be consumed by this mend operation.
++     *
++     * @return the durability-to-xp operation
++     */
++    public @NotNull java.util.function.IntUnaryOperator getDurabilityToXpOperation() {
++        return this.durabilityToXpOp;
++    }
++
++    /**
++     * Sets the operation used to calculate xp used based on
++     * the set repair amount. Used to calculate how much of
++     * an XP orb will be consumed by this mend operation.
++     *
++     * @param durabilityToXpOp the durability-to-xp operation
++     */
++    public void setDurabilityToXpOperation(@NotNull java.util.function.IntUnaryOperator durabilityToXpOp) {
++        com.google.common.base.Preconditions.checkNotNull(durabilityToXpOp);
++        this.durabilityToXpOp = durabilityToXpOp;
++    }
++
++    /**
++     * Helper method to get the amount of experience that will be consumed.
++     * This method just returns the result of inputting {@link #getRepairAmount()}
++     * into the function {@link #getDurabilityToXpOperation()}.
++     *
++     * @return the amount of xp that will be consumed
++     */
++    public int getConsumedExperience() {
++        return this.durabilityToXpOp.applyAsInt(this.getRepairAmount());
+     }
++    // Paper end
+ 
+     @Deprecated
+     public PlayerItemMendEvent(@NotNull Player who, @NotNull ItemStack item, @NotNull ExperienceOrb experienceOrb, int repairAmount) {

--- a/patches/server/0984-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0984-Expand-PlayerItemMendEvent.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 20 Jan 2022 18:11:20 -0800
+Subject: [PATCH] Expand PlayerItemMendEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
+index a9f20e6a73e2e1875abd1e122a5d08c4ef44f9d8..89699aaccd45a5a928a97d1b3ad06f5de5b9fad1 100644
+--- a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
++++ b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
+@@ -330,7 +330,7 @@ public class ExperienceOrb extends Entity {
+             ItemStack itemstack = (ItemStack) entry.getValue();
+             int j = Math.min(this.xpToDurability(this.value), itemstack.getDamageValue());
+             // CraftBukkit start
+-            org.bukkit.event.player.PlayerItemMendEvent event = CraftEventFactory.callPlayerItemMendEvent(player, this, itemstack, entry.getKey(), j);
++            org.bukkit.event.player.PlayerItemMendEvent event = CraftEventFactory.callPlayerItemMendEvent(player, this, itemstack, entry.getKey(), j, this::durabilityToXp); // Paper
+             j = event.getRepairAmount();
+             if (event.isCancelled()) {
+                 return amount;
+@@ -338,8 +338,13 @@ public class ExperienceOrb extends Entity {
+             // CraftBukkit end
+ 
+             itemstack.setDamageValue(itemstack.getDamageValue() - j);
+-            int k = amount - this.durabilityToXp(j);
++            int k = amount - event.getDurabilityToXpOperation().applyAsInt(j); // Paper
+             this.value = k; // CraftBukkit - update exp value of orb for PlayerItemMendEvent calls
++            // Paper start
++            if (j == 0 && amount == k) { // if repair amount is 0 and no xp was removed, don't do recursion; treat as cancelled
++                return k;
++            }
++            // Paper end
+ 
+             return k > 0 ? this.repairPlayerItems(player, k) : 0;
+         } else {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 5f0146255b050dfc873789e7dd4bc1dc4a929f02..be64633c8bcee96f2ad5247525cac965b7b031b1 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1700,11 +1700,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+             orb.setPosRaw(handle.getX(), handle.getY(), handle.getZ());
+ 
+             int i = Math.min(orb.xpToDurability(amount), itemstack.getDamageValue());
+-            org.bukkit.event.player.PlayerItemMendEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerItemMendEvent(handle, orb, itemstack, stackEntry.getKey(), i);
++            org.bukkit.event.player.PlayerItemMendEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerItemMendEvent(handle, orb, itemstack, stackEntry.getKey(), i, orb::durabilityToXp); // Paper
+             i = event.getRepairAmount();
+             orb.discard();
+             if (!event.isCancelled()) {
+-                amount -= orb.durabilityToXp(i);
++                amount -= event.getDurabilityToXpOperation().applyAsInt(i); // Paper
+                 itemstack.setDamageValue(itemstack.getDamageValue() - i);
+             }
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 221f5088953b3452966d07eabd4ea8b38c465fd9..a153c134cf26e86d49ef419eca35994539af0db3 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1262,10 +1262,10 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
+-    public static PlayerItemMendEvent callPlayerItemMendEvent(net.minecraft.world.entity.player.Player entity, net.minecraft.world.entity.ExperienceOrb orb, net.minecraft.world.item.ItemStack nmsMendedItem, net.minecraft.world.entity.EquipmentSlot slot, int repairAmount) {
++    public static PlayerItemMendEvent callPlayerItemMendEvent(net.minecraft.world.entity.player.Player entity, net.minecraft.world.entity.ExperienceOrb orb, net.minecraft.world.item.ItemStack nmsMendedItem, net.minecraft.world.entity.EquipmentSlot slot, int repairAmount, java.util.function.IntUnaryOperator durabilityToXpOp) { // Paper
+         Player player = (Player) entity.getBukkitEntity();
+         org.bukkit.inventory.ItemStack bukkitStack = CraftItemStack.asCraftMirror(nmsMendedItem);
+-        PlayerItemMendEvent event = new PlayerItemMendEvent(player, bukkitStack, CraftEquipmentSlot.getSlot(slot), (ExperienceOrb) orb.getBukkitEntity(), repairAmount);
++        PlayerItemMendEvent event = new PlayerItemMendEvent(player, bukkitStack, CraftEquipmentSlot.getSlot(slot), (ExperienceOrb) orb.getBukkitEntity(), repairAmount, durabilityToXpOp); // Paper
+         Bukkit.getPluginManager().callEvent(event);
+         return event;
+     }


### PR DESCRIPTION
Resolves https://github.com/PaperMC/Paper/issues/7313
Resolves https://github.com/PaperMC/Paper/issues/7449
Closes https://github.com/PaperMC/Paper/issues/7815

Adds a getter/setter for the operation used to turn the amount of durability repaired, into an XP value to be subtracted away from the total value of the experience orb.