### PR TITLE
Don't load plugins prefixed with a dot

### DIFF
--- a/patches/api/0366-Don-t-load-plugins-prefixed-with-a-dot.patch
+++ b/patches/api/0366-Don-t-load-plugins-prefixed-with-a-dot.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sat, 22 Jan 2022 16:35:44 +0100
+Subject: [PATCH] Don't load plugins prefixed with a dot
+
+
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index 1366496271c4c7f72d1e5f990e51775b1c371f99..42da20011544075a9bea63a12ae86f2f21720667 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -142,6 +142,7 @@ public final class SimplePluginManager implements PluginManager {
+         final List<File> pluginJars = new ArrayList<>(java.util.Arrays.asList(directory.listFiles()));
+         pluginJars.addAll(extraPluginJars);
+         for (File file : pluginJars) {
++            if (file.getName().startsWith(".") && !extraPluginJars.contains(file)) continue; // Don't load plugin if the file name starts with a dot, except if it's a extra plugin jar.
+             // Paper end
+             PluginLoader loader = null;
+             for (Pattern filter : filters) {


### PR DESCRIPTION
Fixes #7301. Not sure if there should be some sort of toggle for this, since there probably aren't a lot of (non-malicous) use-cases for loading plugin files starting with a dot.