### PR TITLE
Add missing InventoryHolders to inventories

### DIFF
--- a/patches/server/1036-Add-missing-InventoryHolders-to-inventories.patch
+++ b/patches/server/1036-Add-missing-InventoryHolders-to-inventories.patch
@@ -1,0 +1,302 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Mon, 24 Jan 2022 00:09:02 -0800
+Subject: [PATCH] Add missing InventoryHolders to inventories
+
+
+diff --git a/src/main/java/net/minecraft/world/Container.java b/src/main/java/net/minecraft/world/Container.java
+index 04b1531572e8fff1e46fe1c94e7fc863841e0f66..aee02acd4b2f2fdcb574c37c077fb57013ccb596 100644
+--- a/src/main/java/net/minecraft/world/Container.java
++++ b/src/main/java/net/minecraft/world/Container.java
+@@ -99,7 +99,7 @@ public interface Container extends Clearable {
+ 
+     java.util.List<org.bukkit.entity.HumanEntity> getViewers();
+ 
+-    org.bukkit.inventory.InventoryHolder getOwner();
++    org.bukkit.inventory.@org.jetbrains.annotations.Nullable InventoryHolder getOwner(); // Paper - annotation
+ 
+     void setMaxStackSize(int size);
+ 
+diff --git a/src/main/java/net/minecraft/world/SimpleContainer.java b/src/main/java/net/minecraft/world/SimpleContainer.java
+index 9d1ee40456a8d7001eee654a62e62cab2626305a..ecd6cb02ef326c8e1d7fba8138d806f3107b5ac0 100644
+--- a/src/main/java/net/minecraft/world/SimpleContainer.java
++++ b/src/main/java/net/minecraft/world/SimpleContainer.java
+@@ -30,7 +30,7 @@ public class SimpleContainer implements Container, StackedContentsCompatible {
+     // CraftBukkit start - add fields and methods
+     public List<HumanEntity> transaction = new java.util.ArrayList<HumanEntity>();
+     private int maxStack = MAX_STACK;
+-    protected org.bukkit.inventory.InventoryHolder bukkitOwner;
++    protected @Nullable org.bukkit.inventory.InventoryHolder bukkitOwner; // Paper - annotation
+ 
+     public List<ItemStack> getContents() {
+         return this.items;
+@@ -58,6 +58,11 @@ public class SimpleContainer implements Container, StackedContentsCompatible {
+     }
+ 
+     public org.bukkit.inventory.InventoryHolder getOwner() {
++        // Paper start
++        if (this.bukkitOwner == null && this.bukkitOwnerCreator != null) {
++            this.bukkitOwner = this.bukkitOwnerCreator.get();
++        }
++        // Paper end
+         return this.bukkitOwner;
+     }
+ 
+@@ -86,6 +91,13 @@ public class SimpleContainer implements Container, StackedContentsCompatible {
+     public SimpleContainer(int size) {
+         this(size, null);
+     }
++    // Paper start
++    private @Nullable java.util.function.Supplier<? extends org.bukkit.inventory.InventoryHolder> bukkitOwnerCreator;
++    public SimpleContainer(java.util.function.Supplier<? extends org.bukkit.inventory.InventoryHolder> bukkitOwnerCreator, int size) {
++        this(size);
++        this.bukkitOwnerCreator = bukkitOwnerCreator;
++    }
++    // Paper end
+ 
+     public SimpleContainer(int i, org.bukkit.inventory.InventoryHolder owner) {
+         this.bukkitOwner = owner;
+diff --git a/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java b/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java
+index 71b7a091e56dd68da280d13318a393170967b042..7bba845462813615224f48322c51c7b480adcaa7 100644
+--- a/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java
+@@ -1027,4 +1027,15 @@ public abstract class AbstractContainerMenu {
+         this.stateId = this.stateId + 1 & 32767;
+         return this.stateId;
+     }
++
++    // Paper start - add missing BlockInventoryHolder to inventories
++    // The reason this is a supplier, is that the createHolder method uses the bukkit InventoryView#getTopInventory to get the inventory in question
++    // and that can't be obtained safely until the AbstractContainerMenu has been fully constructed. Using a supplier lazily
++    // initializes the InventoryHolder safely.
++    protected final Supplier<org.bukkit.inventory.BlockInventoryHolder> createBlockHolder(final ContainerLevelAccess context) {
++        //noinspection ConstantValue
++        Preconditions.checkArgument(context != null, "context was null");
++        return () -> context.createBlockHolder(this);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/net/minecraft/world/inventory/BeaconMenu.java b/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
+index 46fd2f45923366c38b77270a45c80b31250ae37e..be507c00b9143c98820a7644f48b2944f787a9ee 100644
+--- a/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
+@@ -39,7 +39,7 @@ public class BeaconMenu extends AbstractContainerMenu {
+     public BeaconMenu(int syncId, Container inventory, ContainerData propertyDelegate, ContainerLevelAccess context) {
+         super(MenuType.BEACON, syncId);
+         this.player = (Inventory) inventory; // CraftBukkit - TODO: check this
+-        this.beacon = new SimpleContainer(1) {
++        this.beacon = new SimpleContainer(this.createBlockHolder(context), 1) { // Paper
+             @Override
+             public boolean canPlaceItem(int slot, ItemStack stack) {
+                 return stack.is(ItemTags.BEACON_PAYMENT_ITEMS);
+diff --git a/src/main/java/net/minecraft/world/inventory/CartographyTableMenu.java b/src/main/java/net/minecraft/world/inventory/CartographyTableMenu.java
+index 819187dbcf468d9278ce33bd97688476aab53f8e..09be5db3c09262e8bc56c4e20a48fe648f09237c 100644
+--- a/src/main/java/net/minecraft/world/inventory/CartographyTableMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/CartographyTableMenu.java
+@@ -52,7 +52,7 @@ public class CartographyTableMenu extends AbstractContainerMenu {
+ 
+     public CartographyTableMenu(int syncId, Inventory inventory, final ContainerLevelAccess context) {
+         super(MenuType.CARTOGRAPHY_TABLE, syncId);
+-        this.container = new SimpleContainer(2) {
++        this.container = new SimpleContainer(this.createBlockHolder(context), 2) { // Paper
+             @Override
+             public void setChanged() {
+                 CartographyTableMenu.this.slotsChanged(this);
+@@ -66,7 +66,7 @@ public class CartographyTableMenu extends AbstractContainerMenu {
+             }
+             // CraftBukkit end
+         };
+-        this.resultContainer = new ResultContainer() {
++        this.resultContainer = new ResultContainer(this.createBlockHolder(context)) { // Paper
+             @Override
+             public void setChanged() {
+                 CartographyTableMenu.this.slotsChanged(this);
+diff --git a/src/main/java/net/minecraft/world/inventory/ContainerLevelAccess.java b/src/main/java/net/minecraft/world/inventory/ContainerLevelAccess.java
+index f00a957a0f55e69f93e6d7dc80193304447c3dcb..d2f19b44ce4ab663a68ee330de4d4582ae9f3f00 100644
+--- a/src/main/java/net/minecraft/world/inventory/ContainerLevelAccess.java
++++ b/src/main/java/net/minecraft/world/inventory/ContainerLevelAccess.java
+@@ -21,6 +21,18 @@ public interface ContainerLevelAccess {
+         return new org.bukkit.Location(this.getWorld().getWorld(), this.getPosition().getX(), this.getPosition().getY(), this.getPosition().getZ());
+     }
+     // CraftBukkit end
++    // Paper start
++    default boolean isBlock() {
++        return false;
++    }
++
++    default org.bukkit.inventory.@org.jetbrains.annotations.Nullable BlockInventoryHolder createBlockHolder(AbstractContainerMenu menu) {
++        if (!this.isBlock()) {
++            return null;
++        }
++        return new org.bukkit.craftbukkit.inventory.CraftBlockInventoryHolder(this, menu.getBukkitView().getTopInventory());
++    }
++    // Paper end
+ 
+     ContainerLevelAccess NULL = new ContainerLevelAccess() {
+         @Override
+@@ -48,6 +60,12 @@ public interface ContainerLevelAccess {
+                 return pos;
+             }
+             // CraftBukkit end
++            // Paper start
++            @Override
++            public boolean isBlock() {
++                return true;
++            }
++            // Paper end
+ 
+             @Override
+             public <T> Optional<T> evaluate(BiFunction<Level, BlockPos, T> getter) {
+diff --git a/src/main/java/net/minecraft/world/inventory/EnchantmentMenu.java b/src/main/java/net/minecraft/world/inventory/EnchantmentMenu.java
+index 93e8316f9d64625dcc4df0644a2187bcc884ef65..496c3fcf49043bba4d249e1c05aac7d7b4897ea8 100644
+--- a/src/main/java/net/minecraft/world/inventory/EnchantmentMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/EnchantmentMenu.java
+@@ -58,7 +58,7 @@ public class EnchantmentMenu extends AbstractContainerMenu {
+ 
+     public EnchantmentMenu(int syncId, Inventory playerInventory, ContainerLevelAccess context) {
+         super(MenuType.ENCHANTMENT, syncId);
+-        this.enchantSlots = new SimpleContainer(2) {
++        this.enchantSlots = new SimpleContainer(this.createBlockHolder(context), 2) { // Paper
+             @Override
+             public void setChanged() {
+                 super.setChanged();
+diff --git a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
+index b56766ff0e61691294b40ea8c2370940c0e8b640..a21eadcdfbdc4be803c5793bc97996db3e706071 100644
+--- a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
+@@ -59,8 +59,8 @@ public class GrindstoneMenu extends AbstractContainerMenu {
+ 
+     public GrindstoneMenu(int syncId, Inventory playerInventory, final ContainerLevelAccess context) {
+         super(MenuType.GRINDSTONE, syncId);
+-        this.resultSlots = new ResultContainer();
+-        this.repairSlots = new SimpleContainer(2) {
++        this.resultSlots = new ResultContainer(this.createBlockHolder(context)); // Paper
++        this.repairSlots = new SimpleContainer(this.createBlockHolder(context), 2) { // Paper
+             @Override
+             public void setChanged() {
+                 super.setChanged();
+diff --git a/src/main/java/net/minecraft/world/inventory/ItemCombinerMenu.java b/src/main/java/net/minecraft/world/inventory/ItemCombinerMenu.java
+index ff770b9ce68a62418de0c7ed389650626fa1dcb2..c2cf5a8e788637c6264cf43d712a5be223ff1cc5 100644
+--- a/src/main/java/net/minecraft/world/inventory/ItemCombinerMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/ItemCombinerMenu.java
+@@ -18,7 +18,7 @@ public abstract class ItemCombinerMenu extends AbstractContainerMenu {
+     protected final Player player;
+     protected final Container inputSlots;
+     private final List<Integer> inputSlotIndexes;
+-    protected final ResultContainer resultSlots = new ResultContainer();
++    protected final ResultContainer resultSlots; // Paper - delay field init
+     private final int resultSlotIndex;
+ 
+     protected abstract boolean mayPickup(Player player, boolean present);
+@@ -30,6 +30,7 @@ public abstract class ItemCombinerMenu extends AbstractContainerMenu {
+     public ItemCombinerMenu(@Nullable MenuType<?> type, int syncId, Inventory playerInventory, ContainerLevelAccess context) {
+         super(type, syncId);
+         this.access = context;
++        this.resultSlots = new ResultContainer(this.createBlockHolder(this.access)); // Paper - delay field init
+         this.player = playerInventory.player;
+         ItemCombinerMenuSlotDefinition itemcombinermenuslotdefinition = this.createInputSlotDefinitions();
+ 
+@@ -96,7 +97,7 @@ public abstract class ItemCombinerMenu extends AbstractContainerMenu {
+     protected abstract ItemCombinerMenuSlotDefinition createInputSlotDefinitions();
+ 
+     private SimpleContainer createContainer(int size) {
+-        return new SimpleContainer(size) {
++        return new SimpleContainer(this.createBlockHolder(this.access), size) { // Paper
+             @Override
+             public void setChanged() {
+                 super.setChanged();
+diff --git a/src/main/java/net/minecraft/world/inventory/LoomMenu.java b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
+index 0a87996a6ab5b4d67c2aa10daadf6174bc647a44..95598335c29574b4a5798174f7fc56cfc27c886d 100644
+--- a/src/main/java/net/minecraft/world/inventory/LoomMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
+@@ -73,7 +73,7 @@ public class LoomMenu extends AbstractContainerMenu {
+         this.selectablePatterns = List.of();
+         this.slotUpdateListener = () -> {
+         };
+-        this.inputContainer = new SimpleContainer(3) {
++        this.inputContainer = new SimpleContainer(this.createBlockHolder(context), 3) { // Paper
+             @Override
+             public void setChanged() {
+                 super.setChanged();
+@@ -88,7 +88,7 @@ public class LoomMenu extends AbstractContainerMenu {
+             }
+             // CraftBukkit end
+         };
+-        this.outputContainer = new SimpleContainer(1) {
++        this.outputContainer = new SimpleContainer(this.createBlockHolder(context), 1) { // Paper
+             @Override
+             public void setChanged() {
+                 super.setChanged();
+diff --git a/src/main/java/net/minecraft/world/inventory/ResultContainer.java b/src/main/java/net/minecraft/world/inventory/ResultContainer.java
+index 8bed6dde4bdaae2f2cb8aa018f2d9a093191bbb3..28d1409117dd8e71195223f580db46ac02ab736c 100644
+--- a/src/main/java/net/minecraft/world/inventory/ResultContainer.java
++++ b/src/main/java/net/minecraft/world/inventory/ResultContainer.java
+@@ -28,7 +28,12 @@ public class ResultContainer implements Container, RecipeHolder {
+     }
+ 
+     public org.bukkit.inventory.InventoryHolder getOwner() {
+-        return null; // Result slots don't get an owner
++        // Paper start
++        if (this.holder == null && this.holderCreator != null) {
++            this.holder = this.holderCreator.get();
++        }
++        return this.holder; // Result slots don't get an owner
++        // Paper end - yes they do
+     }
+ 
+     // Don't need a transaction; the InventoryCrafting keeps track of it for us
+@@ -52,6 +57,14 @@ public class ResultContainer implements Container, RecipeHolder {
+         return null;
+     }
+     // CraftBukkit end
++    // Paper start
++    private @Nullable java.util.function.Supplier<? extends org.bukkit.inventory.InventoryHolder> holderCreator;
++    private @Nullable org.bukkit.inventory.InventoryHolder holder;
++    public ResultContainer(java.util.function.Supplier<? extends org.bukkit.inventory.InventoryHolder> holderCreator) {
++        this();
++        this.holderCreator = holderCreator;
++    }
++    // Paper end
+ 
+     public ResultContainer() {
+         this.itemStacks = NonNullList.withSize(1, ItemStack.EMPTY);
+diff --git a/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java b/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java
+index 1b1f814770d1a906ed880df578845be2e9a14f46..9699f97efcfecdc446ca25a6bab42cc484314cbb 100644
+--- a/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java
+@@ -67,7 +67,7 @@ public class StonecutterMenu extends AbstractContainerMenu {
+         this.input = ItemStack.EMPTY;
+         this.slotUpdateListener = () -> {
+         };
+-        this.container = new SimpleContainer(1) {
++        this.container = new SimpleContainer(this.createBlockHolder(context), 1) { // Paper
+             @Override
+             public void setChanged() {
+                 super.setChanged();
+@@ -82,7 +82,7 @@ public class StonecutterMenu extends AbstractContainerMenu {
+             }
+             // CraftBukkit end
+         };
+-        this.resultContainer = new ResultContainer();
++        this.resultContainer = new ResultContainer(this.createBlockHolder(context)); // Paper
+         this.access = context;
+         this.level = playerInventory.player.level();
+         this.inputSlot = this.addSlot(new Slot(this.container, 0, 20, 33));
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftBlockInventoryHolder.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftBlockInventoryHolder.java
+index 7ae484b0fa5bf5494c6ead15f7f1c0fa840ae270..04585d2bc27dc8a165238ee9d2612e179b66fb63 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftBlockInventoryHolder.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftBlockInventoryHolder.java
+@@ -17,6 +17,13 @@ public class CraftBlockInventoryHolder implements BlockInventoryHolder {
+         this.block = CraftBlock.at(world, pos);
+         this.inventory = new CraftInventory(inv);
+     }
++    // Paper start
++    public CraftBlockInventoryHolder(net.minecraft.world.inventory.ContainerLevelAccess levelAccess, Inventory inventory) {
++        com.google.common.base.Preconditions.checkArgument(levelAccess.isBlock());
++        this.block = CraftBlock.at(levelAccess.getWorld(), levelAccess.getPosition());
++        this.inventory = inventory;
++    }
++    // Paper end
+ 
+     @Override
+     public Block getBlock() {


### PR DESCRIPTION
All inventories that don't have block entity inventories associated with them, beacons, anvils, stonecutters, grindstone, smithing table, loom, cartography table had null inventory holders when that's not really correct. the `BlockInventoryHolder` seems to fit perfectly there.