### PR TITLE
Allow blocks above y 255 to be randomticked

### DIFF
--- a/patches/server/0770-Optimise-random-block-ticking.patch
+++ b/patches/server/0770-Optimise-random-block-ticking.patch
@@ -71,7 +71,7 @@ index 0000000000000000000000000000000000000000..e8b4053babe46999980b926431254050
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c353e41fa733b42350285861a5ddbdf304ec0e02..83517c4eaf419770178f0520210218e0a70c4642 100644
+index 3735b80c6f827500a9c474d4139d6e748b14863b..0fcd2883637df145b3793ea6f16844d496d00abc 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -642,6 +642,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -98,7 +98,7 @@ index c353e41fa733b42350285861a5ddbdf304ec0e02..83517c4eaf419770178f0520210218e0
              if (this.isRainingAt(blockposition)) {
                  DifficultyInstance difficultydamagescaler = this.getCurrentDifficultyAt(blockposition);
                  boolean flag1 = this.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING) && this.random.nextDouble() < (double) difficultydamagescaler.getEffectiveDifficulty() * paperConfig.skeleHorseSpawnChance && !this.getBlockState(blockposition.below()).is(Blocks.LIGHTNING_ROD); // Paper
-@@ -677,65 +681,78 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -677,65 +681,79 @@ public class ServerLevel extends Level implements WorldGenLevel {
          }
  
          gameprofilerfiller.popPush("iceandsnow");
@@ -167,6 +167,7 @@ index c353e41fa733b42350285861a5ddbdf304ec0e02..83517c4eaf419770178f0520210218e0
 -                        BlockState iblockdata1 = chunksection.getBlockState(blockposition2.getX() - j, blockposition2.getY() - j1, blockposition2.getZ() - k);
 +            LevelChunkSection[] sections = chunk.getSections();
 +            int minSection = io.papermc.paper.util.WorldUtil.getMinSection(this);
++            int maxYPos = this.getMaxBuildHeight();
 +            for (int sectionIndex = 0; sectionIndex < sections.length; ++sectionIndex) {
 +                LevelChunkSection section = sections[sectionIndex];
 +                if (section == null || section.tickingList.size() == 0) {
@@ -188,7 +189,7 @@ index c353e41fa733b42350285861a5ddbdf304ec0e02..83517c4eaf419770178f0520210218e0
 +                    long raw = section.tickingList.getRaw(index);
 +                    int location = com.destroystokyo.paper.util.maplist.IBlockDataList.getLocationFromRaw(raw);
 +                    int randomX = location & 15;
-+                    int randomY = ((location >>> (4 + 4)) & 255) | yPos;
++                    int randomY = ((location >>> (4 + 4)) & maxYPos) | yPos;
 +                    int randomZ = (location >>> 4) & 15;
  
 -                        if (fluid.isRandomlyTicking()) {

--- a/patches/server/0773-Optimise-WorldServer-notify.patch
+++ b/patches/server/0773-Optimise-WorldServer-notify.patch
@@ -8,7 +8,7 @@ Instead, only iterate over navigators in the current region that are
 eligible for repathing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 60ae567fe76a643f6a363644bfc99eac2ef64835..634f8690ccce7cdcc524258a6f2844c60b9563b5 100644
+index 7ae757faa28a3344e306e930eae1b88acb630fb5..2a25a55bfee58321dc20619257221c0c752f40cd 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -296,15 +296,81 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -110,10 +110,10 @@ index 60ae567fe76a643f6a363644bfc99eac2ef64835..634f8690ccce7cdcc524258a6f2844c6
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 0918bb28fd058e6b79f45993a46738a50b05b60a..f17c0f501c89c07651a40673ad5ecfe6c7168fce 100644
+index f3b610a0117541b78b51b9a988aa9c8b26da86aa..34744109e9b03988b3ea2ed86d1e9c7f0bcdc8ad 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1093,6 +1093,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1094,6 +1094,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      public void tickNonPassenger(Entity entity) {
          // Paper start - log detailed entity tick information
          io.papermc.paper.util.TickThread.ensureTickThread("Cannot tick an entity off-main");
@@ -121,7 +121,7 @@ index 0918bb28fd058e6b79f45993a46738a50b05b60a..f17c0f501c89c07651a40673ad5ecfe6
          try {
              if (currentlyTickingEntity.get() == null) {
                  currentlyTickingEntity.lazySet(entity);
-@@ -1545,9 +1546,18 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1546,9 +1547,18 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          if (Shapes.joinIsNotEmpty(voxelshape, voxelshape1, BooleanOp.NOT_SAME)) {
              List<PathNavigation> list = new ObjectArrayList();
@@ -142,7 +142,7 @@ index 0918bb28fd058e6b79f45993a46738a50b05b60a..f17c0f501c89c07651a40673ad5ecfe6
                  // CraftBukkit start - fix SPIGOT-6362
                  Mob entityinsentient;
                  try {
-@@ -1569,16 +1579,23 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1570,16 +1580,23 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
              try {
                  this.isUpdatingNavigations = true;
@@ -169,7 +169,7 @@ index 0918bb28fd058e6b79f45993a46738a50b05b60a..f17c0f501c89c07651a40673ad5ecfe6
  
          }
          } // Paper
-@@ -2374,10 +2391,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2375,10 +2392,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          public void onTickingStart(Entity entity) {
              ServerLevel.this.entityTickList.add(entity);

--- a/patches/server/0781-Fix-merchant-inventory-not-closing-on-entity-removal.patch
+++ b/patches/server/0781-Fix-merchant-inventory-not-closing-on-entity-removal.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix merchant inventory not closing on entity removal
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d14948b581f0a659511ba482015a03388f4aa3c0..a2abb8aa1a257ccd2b5dbddc037fffc6eb600758 100644
+index 34744109e9b03988b3ea2ed86d1e9c7f0bcdc8ad..ee7e44516c9b0ba50ad218806e41212ecb7bf049 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2475,6 +2475,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2476,6 +2476,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // Spigot end
              // Spigot Start
              if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder && (!(entity instanceof ServerPlayer) || entity.getRemovalReason() != Entity.RemovalReason.KILLED)) { // SPIGOT-6876: closeInventory clears death message


### PR DESCRIPTION
It seems that the 1.18 worldheight changes weren't taken into account when porting a patch that optimizes random block ticking. This PR corrects that and now allows blocks above 255 to be random ticked.