### PR TITLE
Fix player flight being disabled on world change

### DIFF
--- a/patches/server/0860-Fix-player-flight-disabling-on-world-change.patch
+++ b/patches/server/0860-Fix-player-flight-disabling-on-world-change.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mxson <m@son.xxx>
+Date: Mon, 24 Jan 2022 18:54:45 -0800
+Subject: [PATCH] Fix player flight disabling on world change
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 7b23535a680d2a8534dcb8dd87770f66fb982c13..30cc6c77856a93d5642832ba91dc0bb7e5e4eb6b 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -1721,7 +1721,13 @@ public class ServerPlayer extends Player {
+ 
+     public void restoreFrom(ServerPlayer oldPlayer, boolean alive) {
+         this.textFilteringEnabled = oldPlayer.textFilteringEnabled;
+-        this.gameMode.setGameModeForPlayer(oldPlayer.gameMode.getGameModeForPlayer(), oldPlayer.gameMode.getPreviousGameModeForPlayer());
++
++        // Paper start - only change the player's gamemode if it's different from their current one
++        if (this.gameMode.getGameModeForPlayer() != oldPlayer.gameMode.getGameModeForPlayer()) {
++            this.gameMode.setGameModeForPlayer(oldPlayer.gameMode.getGameModeForPlayer(), oldPlayer.gameMode.getPreviousGameModeForPlayer());
++        }
++        // Paper end
++
+         if (alive) {
+             this.getInventory().replaceWith(oldPlayer.getInventory());
+             this.setHealth(oldPlayer.getHealth());


### PR DESCRIPTION
Currently, when a player is flying while in survival mode and teleports to a different world, their flight will be disabled. This is due to being set to survival mode while already in survival mode, which resets the player's "mayfly" and "flying" abilities to the default "false" state. This behavior began in 1.17, 1.16 did not have this issue.

This patch resolves this issue, allowing players to teleport between worlds without their flight status being changed.

I've been running this patch in a production environment without any side effects.