### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0060-Shoulder-Entities-Release-API.patch
+++ b/patches/api/0060-Shoulder-Entities-Release-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Shoulder Entities Release API
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 0ab94ddd3b88eee8040233a89823bd2fadc78d55..396092fd249928ca01133eeeeb61f0ad90b2e332 100644
+index f607c57275958bf1cbf8e77b4d7efa936064c228..8a479c7dfd3825fab8bb057d8afa5ae0cb01b071 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
-@@ -315,6 +315,26 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -318,6 +318,26 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       */
      public int getExpToLevel();
  

--- a/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add openSign method to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 396092fd249928ca01133eeeeb61f0ad90b2e332..5cc025b69c4f405be8f7098d0dcef40fa522b39f 100644
+index 8a479c7dfd3825fab8bb057d8afa5ae0cb01b071..6ef0d7f3dcb779fb7dc5786e7433262092908eaa 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
-@@ -476,6 +476,14 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -479,6 +479,14 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       */
      @Deprecated
      public void setShoulderEntityRight(@Nullable Entity entity);

--- a/patches/api/0197-Add-item-slot-convenience-methods.patch
+++ b/patches/api/0197-Add-item-slot-convenience-methods.patch
@@ -1,14 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Sat, 25 Apr 2020 23:31:28 +0200
 Subject: [PATCH] Add item slot convenience methods
 
 
 diff --git a/src/main/java/org/bukkit/inventory/AnvilInventory.java b/src/main/java/org/bukkit/inventory/AnvilInventory.java
-index 4af562426aa38faeb6822abb0c878a3ac346b383..b95e563b5454306a9188ae3295309ee86a756477 100644
+index 52519cd877017704b53d36088d4d4c28f8f27397..c60be4fd24c7fdf65251dd6169e5e1ac3b588d95 100644
 --- a/src/main/java/org/bukkit/inventory/AnvilInventory.java
 +++ b/src/main/java/org/bukkit/inventory/AnvilInventory.java
-@@ -49,4 +49,64 @@ public interface AnvilInventory extends Inventory {
+@@ -63,4 +63,64 @@ public interface AnvilInventory extends Inventory {
       * @param levels the maximum experience cost
       */
      void setMaximumRepairCost(int levels);

--- a/patches/api/0203-Potential-bed-API.patch
+++ b/patches/api/0203-Potential-bed-API.patch
@@ -8,10 +8,10 @@ Adds a new method to fetch the location of a player's bed without generating any
 getPotentialBedLocation - Gets the last known location of a player's bed. This does not preform any check if the bed is still valid and does not load any chunks.
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 1d573d33304e9c15a9949af68dab0626ae04dce4..9cb7a9b1e1d7c20760a54bdf6aea346828ad8fc7 100644
+index b007b582d344b79ee67751fd1e21f6cef6a1a950..43ab3d1f96179a547630be3494d85642ab2ff029 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
-@@ -245,6 +245,19 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -248,6 +248,19 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       */
      public int getSleepTicks();
  

--- a/patches/api/0235-Add-PlayerItemCooldownEvent.patch
+++ b/patches/api/0235-Add-PlayerItemCooldownEvent.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Tue, 25 Aug 2020 13:45:15 +0200
 Subject: [PATCH] Add PlayerItemCooldownEvent
 

--- a/patches/api/0236-More-lightning-API.patch
+++ b/patches/api/0236-More-lightning-API.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Sun, 26 Jul 2020 14:44:16 +0200
 Subject: [PATCH] More lightning API
 

--- a/patches/api/0263-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/api/0263-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Fri, 29 Jan 2021 15:13:04 +0100
 Subject: [PATCH] Add dropLeash variable to EntityUnleashEvent
 

--- a/patches/api/0278-Expose-protocol-version.patch
+++ b/patches/api/0278-Expose-protocol-version.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Fri, 26 Mar 2021 11:23:27 +0100
 Subject: [PATCH] Expose protocol version
 

--- a/patches/api/0280-add-isDeeplySleeping-to-HumanEntity.patch
+++ b/patches/api/0280-add-isDeeplySleeping-to-HumanEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add isDeeplySleeping to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index aae6331de24c1a65e3f708cfdc3890364bc8e681..28d1ff809e44bda0324ffac957c1d455be02e783 100644
+index ebbe3417369201df231060dd39f1fb200eb7ad48..e8b6cfe7e454c666b4d60b702a3b211dab238830 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
-@@ -324,6 +324,15 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -327,6 +327,15 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       */
      public void setCooldown(@NotNull Material material, int ticks);
  

--- a/patches/server/0144-Shoulder-Entities-Release-API.patch
+++ b/patches/server/0144-Shoulder-Entities-Release-API.patch
@@ -58,10 +58,10 @@ index 51666c237abda8cce63997a655f4f621dd50ccca..3e007cb4cfef94af14800c47b3f19496
      @Override
      public abstract boolean isSpectator();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index afb71ae8bd5f417f6cd99e26c3b45e5b544beb21..cc1caa32ea430f69d0dcfb76e1a08fb78650877d 100644
+index ebd5372fdd7aa3e5e67a8b3b916176eeb6ff54bf..8b6452f21e7bbd90ce8311513f1dae0f936b6c3d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -500,6 +500,32 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -503,6 +503,32 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          this.getHandle().getCooldowns().addCooldown(CraftMagicNumbers.getItem(material), ticks);
      }
  

--- a/patches/server/0191-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/server/0191-Add-openSign-method-to-HumanEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add openSign method to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-index 71cde0f5b27105c3ece994471017999b00794fa3..de3a0a272e9cb0182e08d5401e7e8a6be4434219 100644
+index 9d513b3a1a50e67284ee7ebdc5607e4f44bd0a4b..bfa2345642142ea45460552fce97d5b411a5e48e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 @@ -118,15 +118,15 @@ public class CraftSign extends CraftBlockEntityState<SignBlockEntity> implements
@@ -28,10 +28,10 @@ index 71cde0f5b27105c3ece994471017999b00794fa3..de3a0a272e9cb0182e08d5401e7e8a6b
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index cc1caa32ea430f69d0dcfb76e1a08fb78650877d..278f1f403c43a5c55a53ef8639bf2ea87a676498 100644
+index 8b6452f21e7bbd90ce8311513f1dae0f936b6c3d..c0ed3dd9ebcaf710d202ae8b38007e6a1f20b57e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -610,6 +610,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -613,6 +613,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          }
      }
  

--- a/patches/server/0538-Add-PlayerItemCooldownEvent.patch
+++ b/patches/server/0538-Add-PlayerItemCooldownEvent.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Tue, 25 Aug 2020 13:48:33 +0200
 Subject: [PATCH] Add PlayerItemCooldownEvent
 

--- a/patches/server/0539-More-lightning-API.patch
+++ b/patches/server/0539-More-lightning-API.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Sun, 26 Jul 2020 14:44:09 +0200
 Subject: [PATCH] More lightning API
 

--- a/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Fri, 29 Jan 2021 15:13:11 +0100
 Subject: [PATCH] Add dropLeash variable to EntityUnleashEvent
 

--- a/patches/server/0623-Expose-protocol-version.patch
+++ b/patches/server/0623-Expose-protocol-version.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Fri, 26 Mar 2021 11:23:17 +0100
 Subject: [PATCH] Expose protocol version
 

--- a/patches/server/0643-Add-Channel-initialization-listeners.patch
+++ b/patches/server/0643-Add-Channel-initialization-listeners.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Thu, 29 Apr 2021 21:19:33 +0200
 Subject: [PATCH] Add Channel initialization listeners
 

--- a/patches/server/0743-Sanitize-ResourceLocation-error-logging.patch
+++ b/patches/server/0743-Sanitize-ResourceLocation-error-logging.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: kennytv <jahnke.nassim@gmail.com>
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Thu, 26 Aug 2021 12:09:47 +0200
 Subject: [PATCH] Sanitize ResourceLocation error logging
 

--- a/patches/server/0799-Configurable-feature-seeds.patch
+++ b/patches/server/0799-Configurable-feature-seeds.patch
@@ -79,7 +79,7 @@ index e5eeab49d167a9a151301ca910e1421550e14245..0a70dfd7880f5fcf1292dd2fdae2964b
          return getIntOrDefault(behaviorTickRates, typeName, entityType, def);
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
-index e2b7da265e9616ac47e6be72cc6e6d2c75cfec44..e4591c0b3c8547cc6f4e2a0891fc378ee4334d9e 100644
+index 3461e62af6de8e4c5c72ff27937948d314bebf6a..3f0d83a90e1319baa0622b708b3ba940d3cee64a 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 @@ -277,7 +277,7 @@ public abstract class ChunkGenerator implements BiomeManager.NoiseBiomeSource {

--- a/patches/server/0850-Fix-int-overflow-in-chunk-range-check.patch
+++ b/patches/server/0850-Fix-int-overflow-in-chunk-range-check.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix int overflow in chunk range check
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 16fd37a5048ee4b2fa6760c66af6f14e8fd71f89..0a04980a8015fe08907a040f0f3ff537267bd462 100644
+index 387b0e9b862621e7d0c1179f348e07c25f1ee9c0..2e6e86439173ebdb13b9cebd1e266e91335c1e2d 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -621,9 +621,11 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
af88996a SPIGOT-6890: Add repair cost amount in AnvilInventory
bc7bd363 PR-716: Fix scheduler javadocs (previously, the &lt;b&gt; tag broke the rendering)
6db1ab70 Improve item cooldown JavaDocs

CraftBukkit Changes:
13670b44 SPIGOT-6890: Add repair cost amount in AnvilInventory
0d109e86 PR-999: Prevent non-item cooldowns