### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -772,7 +772,7 @@ index b3a6aeba2363d283f03982cf749f25cfa11a5052..449f1b2f5dca350dc0912e14c8c2bf3e
                      PacketUtils.LOGGER.debug("Ignoring packet due to disconnection: {}", packet);
                  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 02ef6a24565f776986a745a1fa0f58f537e4e8f8..844f24fd16aac25bf681bd3e98f0737be62bead6 100644
+index 8c2b1d1a1e7f2716ee27aa10165b94550dccd19a..eba857195121c58d1b63c58904fd4754a8020219 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -179,7 +179,7 @@ import org.bukkit.craftbukkit.generator.CustomWorldChunkManager;
@@ -1333,7 +1333,7 @@ index 073cea951644f25c276ba05ff1fc48fda08593da..c7fe4b6aa8d68bd5dc394752a5ae635e
                  this.entityManager.saveAll();
              } else {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c3e9391a0a50449fa163c2265efb80dd6e56380d..267a2dea86f8d9b3dc4ff588a49466fe2ffb3d63 100644
+index 017723d4c067572755c828b4c3b00fe744e6f4ba..3f3e5686b91c117ee49ebfa284ecc4649c109261 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -208,6 +208,7 @@ import org.bukkit.inventory.EquipmentSlot;
@@ -1360,7 +1360,7 @@ index c3e9391a0a50449fa163c2265efb80dd6e56380d..267a2dea86f8d9b3dc4ff588a49466fe
  
      }
  
-@@ -1917,7 +1916,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1923,7 +1922,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      // CraftBukkit end
  
      private void handleCommand(String input) {
@@ -1369,7 +1369,7 @@ index c3e9391a0a50449fa163c2265efb80dd6e56380d..267a2dea86f8d9b3dc4ff588a49466fe
          // CraftBukkit start - whole method
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + input);
-@@ -1928,7 +1927,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1934,7 +1933,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          this.cserver.getPluginManager().callEvent(event);
  
          if (event.isCancelled()) {
@@ -1378,7 +1378,7 @@ index c3e9391a0a50449fa163c2265efb80dd6e56380d..267a2dea86f8d9b3dc4ff588a49466fe
              return;
          }
  
-@@ -1941,7 +1940,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1947,7 +1946,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              java.util.logging.Logger.getLogger(ServerGamePacketListenerImpl.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
              return;
          } finally {

--- a/patches/server/0012-Adventure.patch
+++ b/patches/server/0012-Adventure.patch
@@ -1292,7 +1292,7 @@ index 925ffbddd5475be7fe00570d861b615f707434b4..a3436596d05547a60c9906c92f709bb5
          // CraftBukkit end
          this.chatVisibility = packet.chatVisibility();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 267a2dea86f8d9b3dc4ff588a49466fe2ffb3d63..687e638d21b868396b77cf0148f4d9ea00f80066 100644
+index 3f3e5686b91c117ee49ebfa284ecc4649c109261..3c4e0fc879bebb55b07f6017a38311519329902e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -154,6 +154,8 @@ import org.apache.logging.log4j.LogManager;
@@ -1347,7 +1347,7 @@ index 267a2dea86f8d9b3dc4ff588a49466fe2ffb3d63..687e638d21b868396b77cf0148f4d9ea
          // CraftBukkit end
  
          this.connection.send(new ClientboundDisconnectPacket(ichatbasecomponent), (future) -> {
-@@ -1667,9 +1671,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1673,9 +1677,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          */
  
          this.player.disconnect();
@@ -1362,7 +1362,7 @@ index 267a2dea86f8d9b3dc4ff588a49466fe2ffb3d63..687e638d21b868396b77cf0148f4d9ea
          }
          // CraftBukkit end
          this.player.getTextFilter().leave();
-@@ -1851,7 +1857,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1857,7 +1863,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              this.handleCommand(s);
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
@@ -1376,7 +1376,7 @@ index 267a2dea86f8d9b3dc4ff588a49466fe2ffb3d63..687e638d21b868396b77cf0148f4d9ea
              Player player = this.getCraftPlayer();
              AsyncPlayerChatEvent event = new AsyncPlayerChatEvent(async, player, s, new LazyPlayerSet(this.server));
              this.cserver.getPluginManager().callEvent(event);
-@@ -2641,30 +2652,30 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2647,30 +2658,30 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  return;
              }
  
@@ -2296,7 +2296,7 @@ index 4e823d5e8e78db502f979182f1ce276ba0096007..2980a92e548efea7104e909e1cdf9887
      @Override
      public boolean isPermissionSet(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index bc6a95e48fff620b052a4433f24ff1dadbf8a1b6..afb71ae8bd5f417f6cd99e26c3b45e5b544beb21 100644
+index b4d3f6358b8a762d44586fbded8844ba5485f2d0..ebd5372fdd7aa3e5e67a8b3b916176eeb6ff54bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -317,9 +317,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
@@ -2762,7 +2762,7 @@ index 42df05eb0f7fe1910433e4bfe53c17dc5f5cbdfe..3869717bb9246cabf900840aac93eaa3
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e5e2179e47cd0497b4a30e1bf99228953ec8d319..1e8c5b0194e1ba2f9a0f85dcaf6a3bcb632f6cbf 100644
+index db73426f317374a070939eaef1171bb8c322041b..57c7ee1329d80fb441a4637f309d69fa120fae01 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -807,9 +807,9 @@ public class CraftEventFactory {

--- a/patches/server/0047-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0047-Ensure-commands-are-not-ran-async.patch
@@ -14,10 +14,10 @@ big slowdown in execution but throwing an exception at same time to raise awaren
 that it is happening so that plugin authors can fix their code to stop executing commands async.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 687e638d21b868396b77cf0148f4d9ea00f80066..a1fe02097f369a350de79d7eb94f4a6eb3d3530e 100644
+index 3c4e0fc879bebb55b07f6017a38311519329902e..fed5dcdc62700bd661035011a06788fddec1b2a6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1854,6 +1854,29 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1860,6 +1860,29 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
  
          if (!async && s.startsWith("/")) {

--- a/patches/server/0061-Complete-resource-pack-API.patch
+++ b/patches/server/0061-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a1fe02097f369a350de79d7eb94f4a6eb3d3530e..d64e7bbfda0ad2fd086fd918bf5fa31ebbdbd67e 100644
+index fed5dcdc62700bd661035011a06788fddec1b2a6..22d77ed6f6c63a4ba77ec582a7ba26b9f7cd8a44 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1636,8 +1636,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1642,8 +1642,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              ServerGamePacketListenerImpl.LOGGER.info("Disconnecting {} due to resource pack rejection", this.player.getName());
              this.disconnect(new TranslatableComponent("multiplayer.requiredTexturePrompt.disconnect"));
          }

--- a/patches/server/0079-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0079-Add-PlayerUseUnknownEntityEvent.patch
@@ -20,10 +20,10 @@ index 8834ed411a7db86b4d2b88183a1315317107d719..c45b5ab6776f3ac79f856c3a6467c510
      static final ServerboundInteractPacket.Action ATTACK_ACTION = new ServerboundInteractPacket.Action() {
          @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d64e7bbfda0ad2fd086fd918bf5fa31ebbdbd67e..4ee11bd08c4b9f0ec3f1620e63cbe98d52b70db5 100644
+index 22d77ed6f6c63a4ba77ec582a7ba26b9f7cd8a44..fbfedf1f8e4be9391c6959e527037132585ab19a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2202,8 +2202,37 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2208,8 +2208,37 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  });
              }
          }

--- a/patches/server/0105-Configurable-packet-in-spam-threshold.patch
+++ b/patches/server/0105-Configurable-packet-in-spam-threshold.patch
@@ -23,10 +23,10 @@ index 728835cddd413d778e9628360989724f65335b46..6c13fe725ca2b2a6f0f375b80f6c2cb6
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4ee11bd08c4b9f0ec3f1620e63cbe98d52b70db5..faeb99b93ead7c444fc23d542c7e2b11055ebfba 100644
+index fbfedf1f8e4be9391c6959e527037132585ab19a..7801b0c694c06db034ad6e7601f70881c15892bf 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1491,13 +1491,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1497,13 +1497,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      // Spigot start - limit place/interactions
      private int limitedPackets;
      private long lastLimitedPacket = -1;

--- a/patches/server/0123-Properly-fix-item-duplication-bug.patch
+++ b/patches/server/0123-Properly-fix-item-duplication-bug.patch
@@ -19,10 +19,10 @@ index 3a97690a1e65db9a1c184fa4df5899cfda3d44bc..ab73818893b00551f8137704a727e330
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6de1ea5c10f335a39f73033998629068cf93a539..84f62311f50b6ed58fa37588d8fc6f7782758d19 100644
+index 0f100b31655e8c6c411b199ee43f15796f811337..2ab340cd71daf87bd2bb9e7194986dc1ba52715b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2819,7 +2819,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2825,7 +2825,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      }
  
      public final boolean isDisconnected() {

--- a/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -26,10 +26,10 @@ index 47b717e8741bb2b8f3aa776dcdc73a3e7dbb5960..9dad1efab44b8a23f274aa89c85944d9
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 84f62311f50b6ed58fa37588d8fc6f7782758d19..e9bccb569f6161dff3dd232355d8692123f846fe 100644
+index 2ab340cd71daf87bd2bb9e7194986dc1ba52715b..f7649a153191732a33ba9cdd02c573f04b62ce53 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2052,6 +2052,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2058,6 +2058,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          switch (packet.getAction()) {
              case PRESS_SHIFT_KEY:
                  this.player.setShiftKeyDown(true);
@@ -44,7 +44,7 @@ index 84f62311f50b6ed58fa37588d8fc6f7782758d19..e9bccb569f6161dff3dd232355d86921
              case RELEASE_SHIFT_KEY:
                  this.player.setShiftKeyDown(false);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 2862e75108b3304ab186ed89eb36801500e58b85..84252d88469d045a776d1e51b05991463971f64d 100644
+index 2533ac009bb3778b26f168ca21c04e0c8a19366a..51666c237abda8cce63997a655f4f621dd50ccca 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -577,7 +577,7 @@ public abstract class Player extends LivingEntity {

--- a/patches/server/0159-Add-PlayerJumpEvent.patch
+++ b/patches/server/0159-Add-PlayerJumpEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerJumpEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e9bccb569f6161dff3dd232355d8692123f846fe..b57b7d2337b363b711a2347a3e6a71b6500fefe2 100644
+index f7649a153191732a33ba9cdd02c573f04b62ce53..ef21b549cf69dbba3ac3b735fe9e8470d91c37ae 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1175,7 +1175,34 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1181,7 +1181,34 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              boolean flag = d8 > 0.0D;
  
                              if (this.player.isOnGround() && !packet.isOnGround() && flag) {

--- a/patches/server/0160-handle-PacketPlayInKeepAlive-async.patch
+++ b/patches/server/0160-handle-PacketPlayInKeepAlive-async.patch
@@ -15,10 +15,10 @@ also adding some additional logging in order to help work out what is causing
 random disconnections for clients.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b57b7d2337b363b711a2347a3e6a71b6500fefe2..6fe3749376dabf6c6d003fee7ccdd6f882e1cf02 100644
+index ef21b549cf69dbba3ac3b735fe9e8470d91c37ae..d50ab6df4df502220cc09bb6ad8aab65fbfe52c5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2778,14 +2778,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2784,14 +2784,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleKeepAlive(ServerboundKeepAlivePacket packet) {

--- a/patches/server/0193-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
+++ b/patches/server/0193-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix exploit that allowed colored signs to be created
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b64bf84751e0437e26fcebdc35dd53069b9f2551..d3ec46ea2e6dddcd760ac8daf32869b7f6ddf64d 100644
+index 0240221d4415df8ac8cbcf2fd0c4118d97500620..8980f0187d0e236ae115317199619fc9f4e69745 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2784,9 +2784,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2790,9 +2790,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  TextFilter.FilteredText currentLine = signText.get(i);
  
                  if (this.player.isTextFilteringEnabled()) {

--- a/patches/server/0219-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0219-InventoryCloseEvent-Reason-API.patch
@@ -75,7 +75,7 @@ index 90bff0dd400a67bcb84f8576bd8326793420919a..fd1937f49312204d38510996a5be43b7
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d3ec46ea2e6dddcd760ac8daf32869b7f6ddf64d..99dc424cd8e740baf12032d1bdc7d28ce84b2ca8 100644
+index 8980f0187d0e236ae115317199619fc9f4e69745..9591d1493fdc47e1b75b28cdcc54b812ac105718 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -187,6 +187,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -86,7 +86,7 @@ index d3ec46ea2e6dddcd760ac8daf32869b7f6ddf64d..99dc424cd8e740baf12032d1bdc7d28c
  import org.bukkit.event.inventory.InventoryCreativeEvent;
  import org.bukkit.event.inventory.InventoryType.SlotType;
  import org.bukkit.event.inventory.SmithItemEvent;
-@@ -2332,10 +2333,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2338,10 +2339,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleContainerClose(ServerboundContainerClosePacket packet) {
@@ -145,7 +145,7 @@ index e72657009686461a28d27883573ecff09a77ccee..fcd66b668008a0c3be8d20f7f169b213
          this.containerMenu = this.inventoryMenu;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 278f1f403c43a5c55a53ef8639bf2ea87a676498..c787bb69baa1b30fc513965fe4a9578c1be551d8 100644
+index c0ed3dd9ebcaf710d202ae8b38007e6a1f20b57e..adfbc156b4c4a8591609f385adaa6b04f984a64f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -373,7 +373,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {

--- a/patches/server/0221-Refresh-player-inventory-when-cancelling-PlayerInter.patch
+++ b/patches/server/0221-Refresh-player-inventory-when-cancelling-PlayerInter.patch
@@ -16,10 +16,10 @@ Refresh the player inventory when PlayerInteractEntityEvent is
 cancelled to avoid this problem.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 99dc424cd8e740baf12032d1bdc7d28ce84b2ca8..86ff600e471effc97b214f6b6fb5b2e0a0d0df1c 100644
+index 9591d1493fdc47e1b75b28cdcc54b812ac105718..406f2e65d353cfbb7ea6bd698c5a1bd0b9b6235e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2217,6 +2217,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2223,6 +2223,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          }
  
                          if (event.isCancelled()) {

--- a/patches/server/0281-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/patches/server/0281-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -20,7 +20,7 @@ index e57ab8a3e6efd78e12385042b7d91dcd27fef11d..eb44aef0aecf65f5c1b19f42bf85a3a2
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 995895dc1a97564e7f5565f9c26d18d1d8b4b4c0..6976987320f168b422d9d430ab00d4b49dbd0d43 100644
+index e0eb7ace7cc3d153efcfbab1e0492749c0713610..59ecb7eb693e9e101ae8cb7bf58777bf180f340d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -532,6 +532,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -37,7 +37,7 @@ index 995895dc1a97564e7f5565f9c26d18d1d8b4b4c0..6976987320f168b422d9d430ab00d4b4
                  if (d10 - d9 > Math.max(100.0D, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
                  // CraftBukkit end
                      ServerGamePacketListenerImpl.LOGGER.warn("{} (vehicle of {}) moved too quickly! {},{},{}", entity.getName().getString(), this.player.getName().getString(), d6, d7, d8);
-@@ -1156,9 +1163,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1162,9 +1169,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          float prevYaw = this.player.getYRot();
                          float prevPitch = this.player.getXRot();
                          // CraftBukkit end
@@ -49,7 +49,7 @@ index 995895dc1a97564e7f5565f9c26d18d1d8b4b4c0..6976987320f168b422d9d430ab00d4b4
                          double d6 = this.player.getY();
                          double d7 = d0 - this.firstGoodX;
                          double d8 = d1 - this.firstGoodY;
-@@ -1196,6 +1203,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1202,6 +1209,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              } else {
                                  speed = this.player.getAbilities().walkingSpeed * 10f;
                              }

--- a/patches/server/0289-Don-t-allow-digging-into-unloaded-chunks.patch
+++ b/patches/server/0289-Don-t-allow-digging-into-unloaded-chunks.patch
@@ -59,10 +59,10 @@ index 1d1f355a49e2324902feee10c1717fd772e359c6..d0b54ebc05cac6535a023709c76efd80
  
                  this.level.destroyBlockProgress(this.player.getId(), pos, -1);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6976987320f168b422d9d430ab00d4b49dbd0d43..3dbd73a83942a693746d1565f92d163f912c9bde 100644
+index 59ecb7eb693e9e101ae8cb7bf58777bf180f340d..4b09d2ff24a1dca2a45c18a99af3ba6efc7acd85 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1552,7 +1552,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1558,7 +1558,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              case START_DESTROY_BLOCK:
              case ABORT_DESTROY_BLOCK:
              case STOP_DESTROY_BLOCK:

--- a/patches/server/0295-Book-Size-Limits.patch
+++ b/patches/server/0295-Book-Size-Limits.patch
@@ -24,10 +24,10 @@ index c48b175d5511b733bcff9a93a874f5ffc0174691..e683e5bf47abe7bd3d2f7e9811a37754
      private static void asyncChunks() {
          ConfigurationSection section;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3dbd73a83942a693746d1565f92d163f912c9bde..5c7f1b6b6e5fbd4c064ef39ab910655e90ace788 100644
+index 4b09d2ff24a1dca2a45c18a99af3ba6efc7acd85..2b4295f969ad63d5b23ca197fcdb96980c880684 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1002,6 +1002,45 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1008,6 +1008,45 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleEditBook(ServerboundEditBookPacket packet) {

--- a/patches/server/0305-Limit-Client-Sign-length-more.patch
+++ b/patches/server/0305-Limit-Client-Sign-length-more.patch
@@ -22,7 +22,7 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 39913117f5ba2d455af6781e35abc3088640185e..8250b82056d63a2bd48d2bc8d830c53f1867152e 100644
+index 57a14ed626824171adb45c4af1fc861549ffbdd6..aae26c430fea5a86c8730dbdd3bbf7af34cf2be0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -254,6 +254,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -33,7 +33,7 @@ index 39913117f5ba2d455af6781e35abc3088640185e..8250b82056d63a2bd48d2bc8d830c53f
      private static final long KEEPALIVE_LIMIT = Long.getLong("paper.playerconnection.keepalive", 30) * 1000; // Paper - provide property to set keepalive limit
  
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
-@@ -2863,6 +2864,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2869,6 +2870,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              for (int i = 0; i < signText.size(); ++i) {
                  TextFilter.FilteredText currentLine = signText.get(i);

--- a/patches/server/0313-Update-entity-Metadata-for-all-tracked-players.patch
+++ b/patches/server/0313-Update-entity-Metadata-for-all-tracked-players.patch
@@ -22,10 +22,10 @@ index 3d27cbf5e9105def2f38525a85da5acf8ebf8fe9..ceba19ea3bb9664899b83f82f28af064
          this.broadcast.accept(packet);
          if (this.entity instanceof ServerPlayer) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8250b82056d63a2bd48d2bc8d830c53f1867152e..29e5265a99c8156ad83e5e2cc75910273d84458e 100644
+index aae26c430fea5a86c8730dbdd3bbf7af34cf2be0..21a4c1f9d89a8ec0d76fbf2fbe445eb724e36b6d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2288,7 +2288,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2294,7 +2294,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                          if (event.isCancelled() || ServerGamePacketListenerImpl.this.player.getInventory().getSelected() == null || ServerGamePacketListenerImpl.this.player.getInventory().getSelected().getItem() != origItem) {
                              // Refresh the current entity metadata

--- a/patches/server/0339-Dont-send-unnecessary-sign-update.patch
+++ b/patches/server/0339-Dont-send-unnecessary-sign-update.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Dont send unnecessary sign update
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0b6739fcda89df0f91cddc493f45b0bf9e433b53..66f0b20964f2cd3a46d7f34680d2abd3da887c46 100644
+index 3ef13c8a688540b2fdbe194cb4d9224d2c1b5095..dd874b3194f0f95122c066e22207e98212193d94 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2858,6 +2858,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2864,6 +2864,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              if (!tileentitysign.isEditable() || !this.player.getUUID().equals(tileentitysign.getPlayerWhoMayEdit())) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Player {} just tried to change non-editable sign", this.player.getName().getString());

--- a/patches/server/0341-Fix-AssertionError-when-player-hand-set-to-empty-typ.patch
+++ b/patches/server/0341-Fix-AssertionError-when-player-hand-set-to-empty-typ.patch
@@ -7,10 +7,10 @@ Fixes an AssertionError when setting the player's item in hand to null or a new 
 Fixes GH-2718
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 66f0b20964f2cd3a46d7f34680d2abd3da887c46..8fb4aa97b07bd9fadd1751f41155b83077d25991 100644
+index dd874b3194f0f95122c066e22207e98212193d94..ddb60a2d9fa1d2faefedc9d8e538a5188901f940 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1736,6 +1736,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1742,6 +1742,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  this.player.getBukkitEntity().updateInventory(); // SPIGOT-2524
                  return;
              }

--- a/patches/server/0375-Prevent-teleporting-dead-entities.patch
+++ b/patches/server/0375-Prevent-teleporting-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent teleporting dead entities
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8fb4aa97b07bd9fadd1751f41155b83077d25991..0e91a6b4d07b14cff98c97262329a46c4238317c 100644
+index ddb60a2d9fa1d2faefedc9d8e538a5188901f940..d7a7bd1de587026f8b290012ffafde1ad6fd57ed 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1496,6 +1496,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1502,6 +1502,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      }
  
      private void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<ClientboundPlayerPositionPacket.RelativeArgument> set, boolean flag) {

--- a/patches/server/0443-Prevent-position-desync-in-playerconnection-causing-.patch
+++ b/patches/server/0443-Prevent-position-desync-in-playerconnection-causing-.patch
@@ -14,10 +14,10 @@ behaviour, we need to move all of this dangerous logic outside
 of the move call and into an appropriate place in the tick method.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9bbffaa02b68f4c99ae3008e25a81a15fc09aa49..9008b4ae19baee69bc8b510e2680caaa58300423 100644
+index a935f61273527c32277f511ab35ce6615adfc97d..28131052a9e6e2646e37f930199c7e8e47e8f071 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1326,6 +1326,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1332,6 +1332,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                              this.player.move(MoverType.PLAYER, new Vec3(d7, d8, d9));
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move

--- a/patches/server/0446-Add-and-implement-PlayerRecipeBookClickEvent.patch
+++ b/patches/server/0446-Add-and-implement-PlayerRecipeBookClickEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add and implement PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9008b4ae19baee69bc8b510e2680caaa58300423..f6007a34b56c80e96aa29def9c070f717b61c5ed 100644
+index 28131052a9e6e2646e37f930199c7e8e47e8f071..85e40e0086638b22fb69dc143803632e69dfe873 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2778,9 +2778,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2784,9 +2784,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          this.player.resetLastActionTime();
          if (!this.player.isSpectator() && this.player.containerMenu.containerId == packet.getContainerId() && this.player.containerMenu instanceof RecipeBookMenu) {

--- a/patches/server/0450-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0450-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -8,7 +8,7 @@ makes it so that the server keeps the last difficulty used instead
 of restoring the server.properties every single load.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index faee8e2a29b4c9cbd62185f401ac7bbd40d8df76..918fdf14080338983b8725bf2619088fd23c332a 100644
+index 9d8dd7ac4e471d658ba942e29c5028df410fa2c3..9a926114aa550ca5a6329e3ce993bf1f686cd10e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -824,7 +824,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -94,10 +94,10 @@ index 2f13055a39c26fe12d2c1094103186635e536166..6b0cb662d9163c360035e19c5faad59f
  
                  playerlist.sendPlayerPermissionLevel(this);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 7975508532fc0e97b10eca88e43aefe3af711c0f..2d8405652f4bae5a9ad0815c17325ac238e737fd 100644
+index 707f44c0245fdc9532a487353ebd9099151f1de5..f33410709dbd36adf1f126d698d2b87145c5d404 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3033,7 +3033,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3039,7 +3039,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleChangeDifficulty(ServerboundChangeDifficultyPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (this.player.hasPermissions(2) || this.isSingleplayerOwner()) {

--- a/patches/server/0475-Move-range-check-for-block-placing-up.patch
+++ b/patches/server/0475-Move-range-check-for-block-placing-up.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Move range check for block placing up
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2d8405652f4bae5a9ad0815c17325ac238e737fd..4a17f98d06f061a2253dc75e313c618e550ed100 100644
+index f33410709dbd36adf1f126d698d2b87145c5d404..67f0a953751707f982df958e88c825ea98f4f984 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1671,6 +1671,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1677,6 +1677,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      }
      // Spigot end
  
@@ -23,7 +23,7 @@ index 2d8405652f4bae5a9ad0815c17325ac238e737fd..4a17f98d06f061a2253dc75e313c618e
      @Override
      public void handleUseItemOn(ServerboundUseItemOnPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
-@@ -1683,17 +1691,22 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1689,17 +1697,22 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          BlockPos blockposition = movingobjectpositionblock.getBlockPos();
          Direction enumdirection = movingobjectpositionblock.getDirection();
  

--- a/patches/server/0484-Brand-support.patch
+++ b/patches/server/0484-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4a17f98d06f061a2253dc75e313c618e550ed100..f9073eaa82c79f0b8ad738213b53f991d1b855a3 100644
+index 67f0a953751707f982df958e88c825ea98f4f984..bbfcadfd3316f2617288b1dd48d145b266b29cfe 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
@@ -33,7 +33,7 @@ index 4a17f98d06f061a2253dc75e313c618e550ed100..f9073eaa82c79f0b8ad738213b53f991
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
          this.server = server;
          this.connection = connection;
-@@ -3001,6 +3005,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3007,6 +3011,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      private static final ResourceLocation CUSTOM_REGISTER = new ResourceLocation("register");
      private static final ResourceLocation CUSTOM_UNREGISTER = new ResourceLocation("unregister");
  
@@ -42,7 +42,7 @@ index 4a17f98d06f061a2253dc75e313c618e550ed100..f9073eaa82c79f0b8ad738213b53f991
      @Override
      public void handleCustomPayload(ServerboundCustomPayloadPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
-@@ -3028,6 +3034,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3034,6 +3040,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              try {
                  byte[] data = new byte[packet.data.readableBytes()];
                  packet.data.readBytes(data);
@@ -58,7 +58,7 @@ index 4a17f98d06f061a2253dc75e313c618e550ed100..f9073eaa82c79f0b8ad738213b53f991
                  this.cserver.getMessenger().dispatchIncomingMessage(this.player.getBukkitEntity(), packet.identifier.toString(), data);
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
-@@ -3037,6 +3052,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3043,6 +3058,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      }
  

--- a/patches/server/0503-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0503-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -9,7 +9,7 @@ as this is how Vanilla teleports entities.
 Cancel any pending motion when teleported.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f9073eaa82c79f0b8ad738213b53f991d1b855a3..ff313dad1215762e2dc25d751f20aa71b91bd6fc 100644
+index bbfcadfd3316f2617288b1dd48d145b266b29cfe..eed7b0107f8910f8982d83a7081cf3c2cfe055fd 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -682,7 +682,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -21,7 +21,7 @@ index f9073eaa82c79f0b8ad738213b53f991d1b855a3..ff313dad1215762e2dc25d751f20aa71
              this.lastGoodX = this.awaitingPositionFromClient.x;
              this.lastGoodY = this.awaitingPositionFromClient.y;
              this.lastGoodZ = this.awaitingPositionFromClient.z;
-@@ -1559,7 +1559,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1565,7 +1565,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // CraftBukkit end
  
          this.awaitingTeleportTime = this.tickCount;

--- a/patches/server/0514-Fix-for-large-move-vectors-crashing-server.patch
+++ b/patches/server/0514-Fix-for-large-move-vectors-crashing-server.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix for large move vectors crashing server
 Check movement distance also based on current position.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ff313dad1215762e2dc25d751f20aa71b91bd6fc..da130b7f0da73eb9868539911ba3157b88fc7199 100644
+index eed7b0107f8910f8982d83a7081cf3c2cfe055fd..4e34ec168463f41f374c02ff09a7718a001f8670 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -507,20 +507,31 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -62,7 +62,7 @@ index ff313dad1215762e2dc25d751f20aa71b91bd6fc..da130b7f0da73eb9868539911ba3157b
                  entity.move(MoverType.PLAYER, new Vec3(d6, d7, d8));
                  double d11 = d7;
  
-@@ -1233,14 +1244,25 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1239,14 +1250,25 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          float prevPitch = this.player.getXRot();
                          // CraftBukkit end
                          double d3 = this.player.getX(); final double toX = d3; // Paper - OBFHELPER
@@ -90,7 +90,7 @@ index ff313dad1215762e2dc25d751f20aa71b91bd6fc..da130b7f0da73eb9868539911ba3157b
  
                          if (this.player.isSleeping()) {
                              if (d11 > 1.0D) {
-@@ -1292,9 +1314,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1298,9 +1320,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                              AABB axisalignedbb = this.player.getBoundingBox();
  

--- a/patches/server/0544-Limit-recipe-packets.patch
+++ b/patches/server/0544-Limit-recipe-packets.patch
@@ -23,7 +23,7 @@ index ec42fb00b6f4a691fa710c68131f80b242e3e6e8..d5ae781d65016e0382cb3497cb8cac20
      public static boolean velocityOnlineMode;
      public static byte[] velocitySecretKey;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c321f22af679cafd00be09a9212346b5ccbc8dfc..b2768522a94944bd70ffdcf45119565a55f2c5ce 100644
+index 09f4354700a5c69159e6714063875a6bb06b8e5e..4a6305583250a4fb25888719e1ffb436bbf0314b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -231,6 +231,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -42,7 +42,7 @@ index c321f22af679cafd00be09a9212346b5ccbc8dfc..b2768522a94944bd70ffdcf45119565a
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -2815,6 +2817,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2821,6 +2823,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handlePlaceRecipe(ServerboundPlaceRecipePacket packet) {

--- a/patches/server/0561-Fix-interact-event-not-being-called-in-adventure.patch
+++ b/patches/server/0561-Fix-interact-event-not-being-called-in-adventure.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix interact event not being called in adventure
 Call PlayerInteractEvent when left-clicking on a block in adventure mode
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b2768522a94944bd70ffdcf45119565a55f2c5ce..b6b22a3fdb73fc2b3e2eed12216ae199d2f14022 100644
+index 4a6305583250a4fb25888719e1ffb436bbf0314b..90eb1c56439bb1a87d03fcc92b0d0e6f8db6a317 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1744,7 +1744,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1750,7 +1750,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                      MutableComponent ichatmutablecomponent = (new TranslatableComponent("build.tooHigh", new Object[]{i - 1})).withStyle(ChatFormatting.RED);
  
                      this.player.sendMessage(ichatmutablecomponent, ChatType.GAME_INFO, Util.NIL_UUID);
@@ -18,7 +18,7 @@ index b2768522a94944bd70ffdcf45119565a55f2c5ce..b6b22a3fdb73fc2b3e2eed12216ae199
                      this.player.swing(enumhand, true);
                  }
              }
-@@ -2216,7 +2216,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2222,7 +2222,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          Vec3 vec3d1 = vec3d.add((double) f7 * d3, (double) f6 * d3, (double) f8 * d3);
          HitResult movingobjectposition = this.player.level.clip(new ClipContext(vec3d, vec3d1, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, this.player));
  

--- a/patches/server/0612-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0612-Allow-using-signs-inside-spawn-protection.patch
@@ -19,10 +19,10 @@ index 59675e523625b95169236bd0ead063cf0d87847e..bdd531806a4f006085be113c34b5780c
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b6b22a3fdb73fc2b3e2eed12216ae199d2f14022..1bb4ef2daea3bc919059ffdfeb17f7db157e0619 100644
+index 90eb1c56439bb1a87d03fcc92b0d0e6f8db6a317..e1b5b714d06a537ad7983d7647f2ce0f51545da7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1733,7 +1733,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1739,7 +1739,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          int i = this.player.level.getMaxBuildHeight();
  
          if (blockposition.getY() < i) {

--- a/patches/server/0620-Don-t-ignore-result-of-PlayerEditBookEvent.patch
+++ b/patches/server/0620-Don-t-ignore-result-of-PlayerEditBookEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't ignore result of PlayerEditBookEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1bb4ef2daea3bc919059ffdfeb17f7db157e0619..e3d0c7f357a579811de1b55d8fde018aa55fea47 100644
+index e1b5b714d06a537ad7983d7647f2ce0f51545da7..a58f7ed3e31bb4a4718ed2c1937cf12316939a08 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1178,7 +1178,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1184,7 +1184,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
  
          itemstack.addTagElement("pages", nbttaglist);

--- a/patches/server/0635-fix-PlayerItemHeldEvent-firing-twice.patch
+++ b/patches/server/0635-fix-PlayerItemHeldEvent-firing-twice.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] fix PlayerItemHeldEvent firing twice
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index acbaba8750c373b90f6af0fb592f7226ba1acf0e..e3d62889d7a985289d20ada6b42cc008aee7f353 100644
+index de7728566223dcf60b5dcd4229e0550b95f568c0..6d9f224d28321e03a2e6d54ee3a50c1f9226a7c7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1937,6 +1937,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1943,6 +1943,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (this.player.isImmobile()) return; // CraftBukkit
          if (packet.getSlot() >= 0 && packet.getSlot() < Inventory.getSelectionSize()) {

--- a/patches/server/0642-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/server/0642-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add RespawnFlags to PlayerRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e3d62889d7a985289d20ada6b42cc008aee7f353..9f93ce18a0406321462fb5e4c4dbfab720b87da8 100644
+index 6d9f224d28321e03a2e6d54ee3a50c1f9226a7c7..b63da79cacf05edacdd755ce78a22ecbb8347dad 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2475,7 +2475,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2481,7 +2481,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              case PERFORM_RESPAWN:
                  if (this.player.wonGame) {
                      this.player.wonGame = false;

--- a/patches/server/0655-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0655-additions-to-PlayerGameModeChangeEvent.patch
@@ -126,10 +126,10 @@ index e39e16f0b3a0d168b3049c37f5a2a9dc8f15a652..1ca6dc1e9334bf7e03eab4c2a75f4c86
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9f93ce18a0406321462fb5e4c4dbfab720b87da8..b12d7f8ac2ac446eb0cdfa1e73de6690255752e5 100644
+index b63da79cacf05edacdd755ce78a22ecbb8347dad..a76f8a64d7ec492402b29bde4c2f0a4c556a35cf 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2484,7 +2484,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2490,7 +2490,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                      this.player = this.server.getPlayerList().respawn(this.player, false);
                      if (this.server.isHardcore()) {
@@ -139,7 +139,7 @@ index 9f93ce18a0406321462fb5e4c4dbfab720b87da8..b12d7f8ac2ac446eb0cdfa1e73de6690
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bed138215387343c25d481ae3643499d5551d1e3..32c700ae33f66844577dd2aaf4c38c6a264570e0 100644
+index 708678cea022d7a430244173d5bcfa8a50cd3f18..db970a33f4f4ba76084fbdaa404c88115280245e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1283,7 +1283,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0666-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0666-Add-PlayerKickEvent-causes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e03018882da878ddc51986733cfd6ea1c1815e9b..088334869cb62797a1e1d1bbb6187f03189d852d 100644
+index 860540a50c3281ab35acffd845f536dadab285d7..79e5b8a05828bbc07468d2deeb0f4dad51ca12a5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2064,7 +2064,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -57,7 +57,7 @@ index 708ac03d5a849bf09c49547306e4a8c5a5ef8d91..5a8df368a4a25839cd4ac9be6972da2e
          }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d0472b9a2 100644
+index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52667a14ba 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -321,7 +321,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -165,7 +165,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
              return;
          }
          this.player.getInventory().pickSlot(packet.getSlot()); // Paper - Diff above if changed
-@@ -1062,7 +1070,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1068,7 +1076,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  int byteLength = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
                  if (byteLength > 256 * 4) {
                      ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send a book with with a page too large!");
@@ -174,7 +174,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
                      return;
                  }
                  byteTotal += byteLength;
-@@ -1085,14 +1093,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1091,14 +1099,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              if (byteTotal > byteAllowed) {
                  ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send too large of a book. Book Size: " + byteTotal + " - Allowed:  "+ byteAllowed + " - Pages: " + pageList.size());
@@ -191,7 +191,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
              return;
          }
          this.lastBookTick = MinecraftServer.currentTick;
-@@ -1216,7 +1224,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1222,7 +1230,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleMovePlayer(ServerboundMovePlayerPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (ServerGamePacketListenerImpl.containsInvalidValues(packet.getX(0.0D), packet.getY(0.0D), packet.getZ(0.0D), packet.getYRot(0.0F), packet.getXRot(0.0F))) {
@@ -200,7 +200,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
          } else {
              ServerLevel worldserver = this.player.getLevel();
  
-@@ -1642,7 +1650,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1648,7 +1656,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          this.dropCount++;
                          if (this.dropCount >= 20) {
                              ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " dropped their items too quickly!");
@@ -209,7 +209,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
                              return;
                          }
                      }
-@@ -1849,7 +1857,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1855,7 +1863,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (packet.getAction() == ServerboundResourcePackPacket.Action.DECLINED && this.server.isResourcePackRequired()) {
              ServerGamePacketListenerImpl.LOGGER.info("Disconnecting {} due to resource pack rejection", this.player.getName());
@@ -218,7 +218,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
          }
          // Paper start
          PlayerResourcePackStatusEvent.Status packStatus = PlayerResourcePackStatusEvent.Status.values()[packet.action.ordinal()];
-@@ -1954,7 +1962,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1960,7 +1968,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              this.player.resetLastActionTime();
          } else {
              ServerGamePacketListenerImpl.LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
@@ -227,7 +227,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
          }
      }
  
-@@ -1970,7 +1978,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1976,7 +1984,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          for (int i = 0; i < s.length(); ++i) {
              if (!SharedConstants.isAllowedChatCharacter(s.charAt(i))) {
@@ -236,7 +236,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
                  return;
              }
          }
-@@ -2043,7 +2051,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2049,7 +2057,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                      Waitable waitable = new Waitable() {
                          @Override
                          protected Object evaluate() {
@@ -245,7 +245,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
                              return null;
                          }
                      };
-@@ -2058,7 +2066,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2064,7 +2072,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          throw new RuntimeException(e);
                      }
                  } else {
@@ -254,7 +254,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
                  }
                  // CraftBukkit end
              }
-@@ -2331,7 +2339,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2337,7 +2345,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Spigot Start
          if ( entity == this.player && !this.player.isSpectator() )
          {
@@ -263,7 +263,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
              return;
          }
          // Spigot End
-@@ -2426,7 +2434,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2432,7 +2440,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              }
                              // CraftBukkit end
                          } else {
@@ -272,7 +272,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
                              ServerGamePacketListenerImpl.LOGGER.warn("Player {} tried to attack an invalid entity", ServerGamePacketListenerImpl.this.player.getName().getString());
                          }
                      }
-@@ -2826,7 +2834,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2832,7 +2840,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Paper start
          if (!org.bukkit.Bukkit.isPrimaryThread()) {
              if (recipeSpamPackets.addAndGet(com.destroystokyo.paper.PaperConfig.autoRecipeIncrement) > com.destroystokyo.paper.PaperConfig.autoRecipeLimit) {
@@ -281,7 +281,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
                  return;
              }
          }
-@@ -3011,7 +3019,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3017,7 +3025,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          } else if (!this.isSingleplayerOwner()) {
              // Paper start - This needs to be handled on the main thread for plugins
              server.submit(() -> {
@@ -290,7 +290,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
              });
              // Paper end
          }
-@@ -3057,7 +3065,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3063,7 +3071,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t register custom payload", ex);
@@ -299,7 +299,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
              }
          } else if (packet.identifier.equals(CUSTOM_UNREGISTER)) {
              try {
-@@ -3067,7 +3075,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3073,7 +3081,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t unregister custom payload", ex);
@@ -308,7 +308,7 @@ index b12d7f8ac2ac446eb0cdfa1e73de6690255752e5..a12685a383ffd8431e172e46fcc9b95d
              }
          } else {
              try {
-@@ -3085,7 +3093,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3091,7 +3099,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  this.cserver.getMessenger().dispatchIncomingMessage(this.player.getBukkitEntity(), packet.identifier.toString(), data);
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
@@ -342,7 +342,7 @@ index 3900e885988bc1f2865b95f825cba34d04919731..cad8a98951795706b89ff3ea3985033f
          // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 32c700ae33f66844577dd2aaf4c38c6a264570e0..9cc5531b7ed08f56b296e0fce92cf56d5ceb2730 100644
+index db970a33f4f4ba76084fbdaa404c88115280245e..60383ae5225303f77f0ade70a8355a3ff0915426 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -505,16 +505,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0680-Add-more-LimitedRegion-API.patch
+++ b/patches/server/0680-Add-more-LimitedRegion-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add more LimitedRegion API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java
-index 94fee76f0b2145e3cf99460c407815bb32bd19d0..671ec060981790043f5685a5b647324ddfee6af2 100644
+index a98b39271123e3e7a595d74882f9c453645ee44b..bee7bded2aa5d91bc13ecdf3ad89680257b38701 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java
-@@ -151,7 +151,10 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
+@@ -175,7 +175,10 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
      @Override
      public BlockState getBlockState(int x, int y, int z) {
          Preconditions.checkArgument(this.isInRegion(x, y, z), "Coordinates %s, %s, %s are not in the region", x, y, z);
@@ -20,7 +20,7 @@ index 94fee76f0b2145e3cf99460c407815bb32bd19d0..671ec060981790043f5685a5b647324d
      }
  
      @Override
-@@ -169,7 +172,7 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
+@@ -193,7 +196,7 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
      @Override
      public void setBlockData(int x, int y, int z, BlockData blockData) {
          Preconditions.checkArgument(this.isInRegion(x, y, z), "Coordinates %s, %s, %s are not in the region", x, y, z);
@@ -29,7 +29,7 @@ index 94fee76f0b2145e3cf99460c407815bb32bd19d0..671ec060981790043f5685a5b647324d
      }
  
      @Override
-@@ -199,4 +202,45 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
+@@ -225,4 +228,45 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
      public void addEntityToWorld(net.minecraft.world.entity.Entity entity, CreatureSpawnEvent.SpawnReason reason) {
          this.entities.add(entity);
      }

--- a/patches/server/0683-Ensure-disconnect-for-book-edit-is-called-on-main.patch
+++ b/patches/server/0683-Ensure-disconnect-for-book-edit-is-called-on-main.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure disconnect for book edit is called on main
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a12685a383ffd8431e172e46fcc9b95d0472b9a2..87fd9e456bdef1becbadb0f368ccb39160986e37 100644
+index 7dcae22ac58e44b2fa410fe606f28e52667a14ba..e34b980296e447fe52e435737b4cca2de7267369 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1100,7 +1100,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1106,7 +1106,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Paper end
          // CraftBukkit start
          if (this.lastBookTick + 20 > MinecraftServer.currentTick) {

--- a/patches/server/0685-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0685-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -8,7 +8,7 @@ ticket level 33 (yes getChunkIfLoaded will actually perform a chunk
 load in that case).
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2c8acd5610e873d64470b0e4b0373566357d885d..4f3719e77e008cbd3d2bd9262a03a526000bc837 100644
+index 49640474611c4e1781a93c6eaa627a2865f5f72e..d4129cb5ffa6bea474020c47b82d8905d1f4d9f5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -214,7 +214,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -21,10 +21,10 @@ index 2c8acd5610e873d64470b0e4b0373566357d885d..4f3719e77e008cbd3d2bd9262a03a526
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 87fd9e456bdef1becbadb0f368ccb39160986e37..b4d0b792f5476d567e317927c312f4db637c122a 100644
+index e34b980296e447fe52e435737b4cca2de7267369..1ab0b0a813af70e4df6580fc377e496d151e2a56 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1311,7 +1311,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1317,7 +1317,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                                  speed = this.player.getAbilities().walkingSpeed * 10f;
                              }
                              // Paper start - Prevent moving into unloaded chunks

--- a/patches/server/0687-Adds-PlayerArmSwingEvent.patch
+++ b/patches/server/0687-Adds-PlayerArmSwingEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Adds PlayerArmSwingEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b4d0b792f5476d567e317927c312f4db637c122a..a9f56903e7ef18dfa3c640510334dbf50110cf26 100644
+index 1ab0b0a813af70e4df6580fc377e496d151e2a56..e6fa9f7b4f128e8e7cacc6cee7b42a31bfcd6f03 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2235,7 +2235,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2241,7 +2241,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
  
          // Arm swing animation

--- a/patches/server/0688-Fixes-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0688-Fixes-kick-event-leave-message-not-being-sent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fixes kick event leave message not being sent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a9f56903e7ef18dfa3c640510334dbf50110cf26..afed4675ebedb13bb313815580fe14c06445ba0a 100644
+index e6fa9f7b4f128e8e7cacc6cee7b42a31bfcd6f03..21e46f073cb88b993ec46644e10eb8bfe70a178b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -458,7 +458,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -17,7 +17,7 @@ index a9f56903e7ef18dfa3c640510334dbf50110cf26..afed4675ebedb13bb313815580fe14c0
          this.connection.setReadOnly();
          MinecraftServer minecraftserver = this.server;
          Connection networkmanager = this.connection;
-@@ -1882,6 +1882,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1888,6 +1888,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void onDisconnect(Component reason) {
@@ -29,7 +29,7 @@ index a9f56903e7ef18dfa3c640510334dbf50110cf26..afed4675ebedb13bb313815580fe14c0
          // CraftBukkit start - Rarely it would send a disconnect line twice
          if (this.processedDisconnect) {
              return;
-@@ -1898,7 +1903,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1904,7 +1909,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          this.player.disconnect();
          // Paper start - Adventure

--- a/patches/server/0819-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/patches/server/0819-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimise collision checking in player move packet handling
 Move collision logic to just the hasNewCollision call instead of getCubes + hasNewCollision
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f1a1ae33d41a08a0614c3e50e854e5a26f8a94f7..d85f5817f1aaebff3d93ee472d4580af72f7eae2 100644
+index f3d5ac0fbd87e606565bc1c4669d8609416c099d..dbb6a03f3ef93ec50b860fb171062d31ec5bf33b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -583,12 +583,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -86,7 +86,7 @@ index f1a1ae33d41a08a0614c3e50e854e5a26f8a94f7..d85f5817f1aaebff3d93ee472d4580af
      }
  
      @Override
-@@ -1239,7 +1272,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1245,7 +1278,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
  
                  if (this.awaitingPositionFromClient != null) {
@@ -95,7 +95,7 @@ index f1a1ae33d41a08a0614c3e50e854e5a26f8a94f7..d85f5817f1aaebff3d93ee472d4580af
                          this.awaitingTeleportTime = this.tickCount;
                          this.teleport(this.awaitingPositionFromClient.x, this.awaitingPositionFromClient.y, this.awaitingPositionFromClient.z, this.player.getYRot(), this.player.getXRot());
                      }
-@@ -1333,7 +1366,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1339,7 +1372,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                                  }
                              }
  
@@ -104,7 +104,7 @@ index f1a1ae33d41a08a0614c3e50e854e5a26f8a94f7..d85f5817f1aaebff3d93ee472d4580af
  
                              d7 = d0 - this.lastGoodX; // Paper - diff on change, used for checking large move vectors above
                              d8 = d1 - this.lastGoodY; // Paper - diff on change, used for checking large move vectors above
-@@ -1372,6 +1405,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1378,6 +1411,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              }
  
                              this.player.move(MoverType.PLAYER, new Vec3(d7, d8, d9));
@@ -112,7 +112,7 @@ index f1a1ae33d41a08a0614c3e50e854e5a26f8a94f7..d85f5817f1aaebff3d93ee472d4580af
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move
                              // Paper start - prevent position desync
                              if (this.awaitingPositionFromClient != null) {
-@@ -1391,12 +1425,23 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1397,12 +1431,23 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              boolean flag1 = false;
  
                              if (!this.player.isChangingDimension() && d11 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
@@ -138,7 +138,7 @@ index f1a1ae33d41a08a0614c3e50e854e5a26f8a94f7..d85f5817f1aaebff3d93ee472d4580af
                                  this.teleport(d3, d4, d5, f, f1);
                              } else {
                                  // CraftBukkit start - fire PlayerMoveEvent
-@@ -1483,6 +1528,27 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1489,6 +1534,27 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
      }
  

--- a/patches/server/0853-Kick-on-main-for-illegal-chars.patch
+++ b/patches/server/0853-Kick-on-main-for-illegal-chars.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Kick on main for illegal chars
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 926d0a80cbb55184955ac6720948d2e86683cc57..5c9310fe424943a7256f6f77c414147384bad0aa 100644
+index 0352a3923cb5dc1cd99f939fc7cb513841762a74..23eddc502816e84ab25366c7d5710ce2e660c7a0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2067,7 +2067,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2073,7 +2073,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          for (int i = 0; i < s.length(); ++i) {
              if (!SharedConstants.isAllowedChatCharacter(s.charAt(i))) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
d356515a SPIGOT-6914: Remove confusing loadbefore message for dependency issues
958bbd72 PR-720: Fix bounds in documentation about power in FireworkMeta

CraftBukkit Changes:
507e2f65 PR-1004: Call WorldInitEvent before any chunks are generated
1eeba6a0 SPIGOT-6891: Crash when importing 1.16 chunks with entities above the world, when a BlockPopulator is active
eb7a2dcc PR-1003: Fix cancellation of TradeSelectEvent

-----
Closes https://github.com/PaperMC/Paper/issues/7409