### PR TITLE
Trigger bee_nest_destroyed trigger in the correct place

### DIFF
--- a/patches/server/0898-Trigger-bee_nest_destroyed-trigger-in-the-correct-pl.patch
+++ b/patches/server/0898-Trigger-bee_nest_destroyed-trigger-in-the-correct-pl.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 2 Feb 2022 13:50:06 -0800
+Subject: [PATCH] Trigger bee_nest_destroyed trigger in the correct place
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
+index 891199d02539fa46454cd0aa7c133637e5dc8235..415b6c2bbf11c5a2ac75d18f52b93f80b9e14fe4 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
+@@ -458,12 +458,16 @@ public class ServerPlayerGameMode {
+                     block.destroy(this.level, pos, iblockdata);
+                 }
+ 
++                ItemStack mainHandStack = null; // Paper
++                boolean isCorrectTool = false; // Paper
+                 if (this.isCreative()) {
+                     // return true; // CraftBukkit
+                 } else {
+                     ItemStack itemstack = this.player.getMainHandItem();
+                     ItemStack itemstack1 = itemstack.copy();
+                     boolean flag1 = this.player.hasCorrectToolForDrops(iblockdata);
++                    mainHandStack = itemstack1; // Paper
++                    isCorrectTool = flag1; // Paper
+ 
+                     itemstack.mineBlock(this.level, iblockdata, pos, this.player);
+                     if (flag && flag1 && event.isDropItems()) { // CraftBukkit - Check if block should drop items
+@@ -484,6 +488,13 @@ public class ServerPlayerGameMode {
+                 if (flag && event != null) {
+                     iblockdata.getBlock().popExperience(this.level, pos, event.getExpToDrop(), this.player); // Paper
+                 }
++                // Paper start - trigger after items are dropped (check impls of block#playerDestroy)
++                if (mainHandStack != null) {
++                    if (flag && isCorrectTool && event.isDropItems() && block instanceof net.minecraft.world.level.block.BeehiveBlock && tileentity instanceof net.minecraft.world.level.block.entity.BeehiveBlockEntity beehiveBlockEntity) { // simulates the guard on block#playerDestroy above
++                        CriteriaTriggers.BEE_NEST_DESTROYED.trigger(player, iblockdata, mainHandStack, beehiveBlockEntity.getOccupantCount());
++                    }
++                }
++                // Paper end
+ 
+                 return true;
+                 // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java b/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java
+index e9974415e8f016f50a93a5eea117afe25a6b735d..a510ec076ff91bb5e06ebfca0b00e6f82a92e8cd 100644
+--- a/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/BeehiveBlock.java
+@@ -88,7 +88,7 @@ public class BeehiveBlock extends BaseEntityBlock {
+                 this.angerNearbyBees(world, pos);
+             }
+ 
+-            CriteriaTriggers.BEE_NEST_DESTROYED.trigger((ServerPlayer) player, state, stack, tileentitybeehive.getOccupantCount());
++            // CriteriaTriggers.BEE_NEST_DESTROYED.trigger((ServerPlayer) player, state, stack, tileentitybeehive.getOccupantCount()); // Paper - moved until after items are dropped
+         }
+ 
+     }


### PR DESCRIPTION
Reported here: https://forums.papermc.io/threads/datapack-using-advancements-to-run-functions-on-newly-spawned-item-not-working.119

Issue here, is that drops were being captured for the BlockDropItemEvent and not actually in the world. The `bee_nest_destroyed` trigger is expecting to be run after those drops are in the world.