### PR TITLE
Fix items vanishing through end portal

### DIFF
--- a/patches/server/0363-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0363-Fix-items-vanishing-through-end-portal.patch
@@ -13,16 +13,16 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 62f19eafbb650dfbfac31c320e4883149d327e43..a9705e54b88339e2746348aee9ab1acdae5182b2 100644
+index 62f19eafbb650dfbfac31c320e4883149d327e43..ae0ae298ff7ae129959ff6e4024eb7060c0786e4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3026,6 +3026,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
-             BlockPos blockposition1;
- 
+@@ -3028,6 +3028,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              if (flag1) {
-+                // Paper start - Ensure spawn chunk is always loaded before calculating Y coordinate
-+                this.level.getChunkAt(((ServerLevel) this.level).getSharedSpawnPos());
-+                // Paper end
                  blockposition1 = ServerLevel.END_SPAWN_POINT;
              } else {
++                // Paper start - Ensure spawn chunk is always loaded before calculating Y coordinate
++                destination.getChunkAt(destination.getSharedSpawnPos());
++                // Paper end
                  blockposition1 = destination.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, destination.getSharedSpawnPos());
+             }
+             // CraftBukkit start


### PR DESCRIPTION
From my understanding, this patch is meant to load the spawn chunk before trying to get height map information about the overworld spawn location. If a chunk is not loaded, the heightmap returns a Y value of -64 by default, so this existing patch ensures the chunk is loaded so that the true heightmap value can be retrieved. However, there appears to be two issues:

1. The chunk was being loaded when an item was going to the end (not when it was going to the overworld)
2. The chunk in the entity's current world was being loaded (not the destination world)

I have fixed this by:

1. Moving the code into the else statement of the `flag1` if statement. `flag1` is true when the destiantion world is the end.
2. Using the destination world instead of the entity's current world.