### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0006-Timings-v2.patch
+++ b/patches/api/0006-Timings-v2.patch
@@ -2782,10 +2782,10 @@ index 0000000000000000000000000000000000000000..5989ee21297935651b0edd44b8239e65
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 072bcbbbf167e02ce5014b672f2cf63122d29b21..de7f303bce9e2454eaec12131cd1439a54281c7e 100644
+index dff191d4b5f8866837500aca955e72d0fbe1d82c..7135cf6ac532d8f9b0958830454db92d2cec8e87 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -747,7 +747,6 @@ public final class Bukkit {
+@@ -748,7 +748,6 @@ public final class Bukkit {
       */
      public static void reload() {
          server.reload();
@@ -2794,10 +2794,10 @@ index 072bcbbbf167e02ce5014b672f2cf63122d29b21..de7f303bce9e2454eaec12131cd1439a
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 2bfccae871b92749fa5893b5a7ff327fc93695ad..31e989bdaf60d38e14c84c4a0a31ede6e1a72e86 100644
+index 07150790a26d6a6fe570c77722eef96a41a1e0c2..3281d69f23611d626b67e6c73e3b8eda3a3161f4 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1500,6 +1500,26 @@ public interface Server extends PluginMessageRecipient {
+@@ -1534,6 +1534,26 @@ public interface Server extends PluginMessageRecipient {
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -3499,7 +3499,7 @@ index a09c3f71ca563b6f40a118ce1344d0eb273bed40..cf2f517765d8f2a23cc4a17d9ee2dcd8
                  eventSet.add(new TimedRegisteredListener(listener, executor, eh.priority(), plugin, eh.ignoreCancelled()));
              } else {
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 6bdd9f1dcc4c69c1811622cddc82526d2f8d9e52..657243776c8a2abb5a57e5c407212a8387d649eb 100644
+index 930f3fe08c2acd70eaf7850d0b1b2890512defa0..24e3eaa008e53af8d77439e4f2ab9007285d7826 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -29,7 +29,8 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0007-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/api/0007-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index a238302f2a12194aa30a88867070705dc749b36b..cc42bfa74b41ef6d6374efa7b882f71677fb0824 100644
+index 7135cf6ac532d8f9b0958830454db92d2cec8e87..87b59ad1f702f5765fe84c79c566fc9789f3ea87 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -73,6 +73,20 @@ public final class Bukkit {
+@@ -74,6 +74,20 @@ public final class Bukkit {
          return server;
      }
  
@@ -32,10 +32,10 @@ index a238302f2a12194aa30a88867070705dc749b36b..cc42bfa74b41ef6d6374efa7b882f716
       * Attempts to set the {@link Server} singleton.
       * <p>
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 3e91c4000c468fd8bdcb938e942a7bbf4988cab2..1fb1d4f32af8150711ca766fcd7d0a0c177df7c4 100644
+index 3281d69f23611d626b67e6c73e3b8eda3a3161f4..bf83da28e75657be3407972c006f8ae2be6b6934 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -58,6 +58,18 @@ import org.jetbrains.annotations.Nullable;
+@@ -59,6 +59,18 @@ import org.jetbrains.annotations.Nullable;
   */
  public interface Server extends PluginMessageRecipient {
  

--- a/patches/api/0008-Adventure.patch
+++ b/patches/api/0008-Adventure.patch
@@ -488,10 +488,10 @@ index 0000000000000000000000000000000000000000..15ecb12fd2fefcac96edbaef7cdd487a
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7fa03a92eb 100644
+index 87b59ad1f702f5765fe84c79c566fc9789f3ea87..f99e16aeafaabce89f429bf6c0b3c417fac99f0c 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -369,7 +369,9 @@ public final class Bukkit {
+@@ -370,7 +370,9 @@ public final class Bukkit {
       *
       * @param message the message
       * @return the number of players
@@ -501,7 +501,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      public static int broadcastMessage(@NotNull String message) {
          return server.broadcastMessage(message);
      }
-@@ -1012,6 +1014,19 @@ public final class Bukkit {
+@@ -1013,6 +1015,19 @@ public final class Bukkit {
          server.shutdown();
      }
  
@@ -521,7 +521,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      /**
       * Broadcasts the specified message to every user with the given
       * permission name.
-@@ -1021,6 +1036,21 @@ public final class Bukkit {
+@@ -1022,6 +1037,21 @@ public final class Bukkit {
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
       */
@@ -543,7 +543,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      public static int broadcast(@NotNull String message, @NotNull String permission) {
          return server.broadcast(message, permission);
      }
-@@ -1220,6 +1250,7 @@ public final class Bukkit {
+@@ -1260,6 +1290,7 @@ public final class Bukkit {
          return server.createInventory(owner, type);
      }
  
@@ -551,7 +551,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1245,6 +1276,38 @@ public final class Bukkit {
+@@ -1285,6 +1316,38 @@ public final class Bukkit {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -590,7 +590,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      public static Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title) {
          return server.createInventory(owner, type, title);
      }
-@@ -1263,6 +1326,7 @@ public final class Bukkit {
+@@ -1303,6 +1366,7 @@ public final class Bukkit {
          return server.createInventory(owner, size);
      }
  
@@ -598,7 +598,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1275,10 +1339,30 @@ public final class Bukkit {
+@@ -1315,10 +1379,30 @@ public final class Bukkit {
       * @throws IllegalArgumentException if the size is not a multiple of 9
       */
      @NotNull
@@ -629,7 +629,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      /**
       * Creates an empty merchant.
       *
-@@ -1286,7 +1370,20 @@ public final class Bukkit {
+@@ -1326,7 +1410,20 @@ public final class Bukkit {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -650,7 +650,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      public static Merchant createMerchant(@Nullable String title) {
          return server.createMerchant(title);
      }
-@@ -1366,22 +1463,47 @@ public final class Bukkit {
+@@ -1406,22 +1503,47 @@ public final class Bukkit {
          return server.isPrimaryThread();
      }
  
@@ -802,10 +802,10 @@ index 803fa0019869127ee8c7e4fb1777a59c43e66f8a..c65f0d6569c130b4920a9e71ad24af64
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f380589dd 100644
+index bf83da28e75657be3407972c006f8ae2be6b6934..75183a26cc4f9a2c3462ed63b3963c56dc007b01 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -56,7 +56,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -57,7 +57,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a server implementation.
   */
@@ -814,7 +814,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
  
      /**
       * Returns the de facto plugins directory, generally used for storing plugin jars to be loaded,
-@@ -74,7 +74,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -75,7 +75,7 @@ public interface Server extends PluginMessageRecipient {
       * Used for all administrative messages, such as an operator using a
       * command.
       * <p>
@@ -823,7 +823,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
       */
      public static final String BROADCAST_CHANNEL_ADMINISTRATIVE = "bukkit.broadcast.admin";
  
-@@ -82,7 +82,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -83,7 +83,7 @@ public interface Server extends PluginMessageRecipient {
       * Used for all announcement messages, such as informing users that a
       * player has joined.
       * <p>
@@ -832,7 +832,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
       */
      public static final String BROADCAST_CHANNEL_USERS = "bukkit.broadcast.user";
  
-@@ -304,7 +304,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -305,7 +305,9 @@ public interface Server extends PluginMessageRecipient {
       *
       * @param message the message
       * @return the number of players
@@ -842,7 +842,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      public int broadcastMessage(@NotNull String message);
  
      /**
-@@ -856,8 +858,33 @@ public interface Server extends PluginMessageRecipient {
+@@ -857,8 +859,33 @@ public interface Server extends PluginMessageRecipient {
       * @param permission the required permission {@link Permissible
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
@@ -876,7 +876,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
  
      /**
       * Gets the player by the given name, regardless if they are offline or
-@@ -1022,6 +1049,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -1056,6 +1083,7 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type);
  
@@ -884,7 +884,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1047,6 +1075,36 @@ public interface Server extends PluginMessageRecipient {
+@@ -1081,6 +1109,36 @@ public interface Server extends PluginMessageRecipient {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -921,7 +921,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title);
  
      /**
-@@ -1061,6 +1119,22 @@ public interface Server extends PluginMessageRecipient {
+@@ -1095,6 +1153,22 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, int size) throws IllegalArgumentException;
  
@@ -944,7 +944,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1071,10 +1145,13 @@ public interface Server extends PluginMessageRecipient {
+@@ -1105,10 +1179,13 @@ public interface Server extends PluginMessageRecipient {
       *     viewed
       * @return a new inventory
       * @throws IllegalArgumentException if the size is not a multiple of 9
@@ -958,7 +958,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      /**
       * Creates an empty merchant.
       *
-@@ -1082,7 +1159,18 @@ public interface Server extends PluginMessageRecipient {
+@@ -1116,7 +1193,18 @@ public interface Server extends PluginMessageRecipient {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -977,7 +977,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      Merchant createMerchant(@Nullable String title);
  
      /**
-@@ -1146,20 +1234,41 @@ public interface Server extends PluginMessageRecipient {
+@@ -1180,20 +1268,41 @@ public interface Server extends PluginMessageRecipient {
       */
      boolean isPrimaryThread();
  
@@ -1019,7 +1019,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      String getShutdownMessage();
  
      /**
-@@ -1536,7 +1645,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1570,7 +1679,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends the component to the player
           *
           * @param component the components to send
@@ -1029,7 +1029,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
          public void broadcast(@NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1545,7 +1656,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1579,7 +1690,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends an array of components as a single message to the player
           *
           * @param components the components to send

--- a/patches/api/0010-Add-getTPS-method.patch
+++ b/patches/api/0010-Add-getTPS-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getTPS method
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 84a620bbbc24ded4075bce0209caed7fa03a92eb..bbee4e40917cca4e692c3d60c1c513b4c847160f 100644
+index f99e16aeafaabce89f429bf6c0b3c417fac99f0c..b3755d005247bd112252d91c845a74a7292b7ef4 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1728,6 +1728,17 @@ public final class Bukkit {
+@@ -1768,6 +1768,17 @@ public final class Bukkit {
          return server.getEntity(uuid);
      }
  
@@ -27,10 +27,10 @@ index 84a620bbbc24ded4075bce0209caed7fa03a92eb..bbee4e40917cca4e692c3d60c1c513b4
       * Get the advancement specified by this key.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ede5de4c310a93989608bf48b3e5116f380589dd..835041d2ab6545e52d963d96d558f9a7e52d279a 100644
+index 75183a26cc4f9a2c3462ed63b3963c56dc007b01..470efb7bf1b240f9eda47370a72c3d88b46099aa 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1461,6 +1461,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1495,6 +1495,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      Entity getEntity(@NotNull UUID uuid);
  

--- a/patches/api/0018-Expose-server-CommandMap.patch
+++ b/patches/api/0018-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index bbee4e40917cca4e692c3d60c1c513b4c847160f..259c15ada05115b9fc86f1de06649d5cec2ef137 100644
+index b3755d005247bd112252d91c845a74a7292b7ef4..655c1a856ffbbc663c4144ca8487b8aea090a3d6 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1912,6 +1912,19 @@ public final class Bukkit {
+@@ -1952,6 +1952,19 @@ public final class Bukkit {
          return server.getUnsafe();
      }
  
@@ -29,10 +29,10 @@ index bbee4e40917cca4e692c3d60c1c513b4c847160f..259c15ada05115b9fc86f1de06649d5c
      public static Server.Spigot spigot() {
          return server.spigot();
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 835041d2ab6545e52d963d96d558f9a7e52d279a..66211ef974b9e091983bfda108f6e420c01a9d78 100644
+index 470efb7bf1b240f9eda47370a72c3d88b46099aa..716fdd8ecef8387326ff9d2b029ce224ed567867 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1471,6 +1471,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1505,6 +1505,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      public double[] getTPS();
      // Paper end
  

--- a/patches/api/0019-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0019-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Graduate bungeecord chat API from spigot subclasses
 Change Javadoc to be accurate
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 259c15ada05115b9fc86f1de06649d5cec2ef137..5fc71e24f1562ff0d448b964f29fd109d4d9bb4d 100644
+index 655c1a856ffbbc663c4144ca8487b8aea090a3d6..f94c53bb2c4fa31590625bc83327d599b07b5e32 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -376,6 +376,30 @@ public final class Bukkit {
+@@ -377,6 +377,30 @@ public final class Bukkit {
          return server.broadcastMessage(message);
      }
  
@@ -41,10 +41,10 @@ index 259c15ada05115b9fc86f1de06649d5cec2ef137..5fc71e24f1562ff0d448b964f29fd109
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 66211ef974b9e091983bfda108f6e420c01a9d78..8fb6545406ab6029d82c903856bda6c6d6fa0636 100644
+index 716fdd8ecef8387326ff9d2b029ce224ed567867..4a975a633a1c6fad312fad26ca8eec8aa16d6b02 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -309,6 +309,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -310,6 +310,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Deprecated // Paper
      public int broadcastMessage(@NotNull String message);
  
@@ -76,7 +76,7 @@ index 66211ef974b9e091983bfda108f6e420c01a9d78..8fb6545406ab6029d82c903856bda6c6
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3aa34138d90b206193fee0558939d8de52cd2a85..77a3bb82f90a7779f98246ceecc150d4417043e7 100644
+index 2d93f5ad7f9c0df08bcd099a813c1d8e9b8c16eb..365b2e806d9219d9dc2d2e85cc442b03af812b8d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -733,6 +733,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0029-Add-command-to-reload-permissions.yml-and-require-co.patch
+++ b/patches/api/0029-Add-command-to-reload-permissions.yml-and-require-co.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add command to reload permissions.yml and require confirm to
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5fc71e24f1562ff0d448b964f29fd109d4d9bb4d..191e9985fc17ffbdb9b6bdadbea46da54f5f7599 100644
+index f94c53bb2c4fa31590625bc83327d599b07b5e32..12324b37ac762f4aafa8d6190ba6af992f91816a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1947,6 +1947,13 @@ public final class Bukkit {
+@@ -1987,6 +1987,13 @@ public final class Bukkit {
      public static org.bukkit.command.CommandMap getCommandMap() {
          return server.getCommandMap();
      }
@@ -24,10 +24,10 @@ index 5fc71e24f1562ff0d448b964f29fd109d4d9bb4d..191e9985fc17ffbdb9b6bdadbea46da5
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 8fb6545406ab6029d82c903856bda6c6d6fa0636..731679a0893635f5cb71a19fd9ee8562795230b8 100644
+index 4a975a633a1c6fad312fad26ca8eec8aa16d6b02..e26cf532c5b78ec4594a2ff9a8ff1c433df49180 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1717,4 +1717,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1751,4 +1751,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      Spigot spigot();
      // Spigot end

--- a/patches/api/0042-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/api/0042-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 191e9985fc17ffbdb9b6bdadbea46da54f5f7599..3f58ffb4c59a92259fc5dde3d220658b6e54896f 100644
+index 12324b37ac762f4aafa8d6190ba6af992f91816a..aa6bfe9a9b8cfca3c7bf38d6d446ebe9599472cd 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1954,6 +1954,15 @@ public final class Bukkit {
+@@ -1994,6 +1994,15 @@ public final class Bukkit {
      public static void reloadPermissions() {
          server.reloadPermissions();
      }
@@ -26,10 +26,10 @@ index 191e9985fc17ffbdb9b6bdadbea46da54f5f7599..3f58ffb4c59a92259fc5dde3d220658b
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 731679a0893635f5cb71a19fd9ee8562795230b8..01df6fc54078901a9195dd2bb45eaef1706ba036 100644
+index e26cf532c5b78ec4594a2ff9a8ff1c433df49180..a5cffbef22dae035eabf6d268667b495f6fe0c01 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1719,4 +1719,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1753,4 +1753,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      // Spigot end
  
      void reloadPermissions(); // Paper

--- a/patches/api/0053-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/api/0053-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 3f58ffb4c59a92259fc5dde3d220658b6e54896f..45c4fddb8562736eaf98810d70d002ae6e3664e7 100644
+index aa6bfe9a9b8cfca3c7bf38d6d446ebe9599472cd..431e3d4bf634ce4e69432f84ed0e88c599d3ac51 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1963,6 +1963,16 @@ public final class Bukkit {
+@@ -2003,6 +2003,16 @@ public final class Bukkit {
      public static boolean reloadCommandAliases() {
          return server.reloadCommandAliases();
      }
@@ -27,10 +27,10 @@ index 3f58ffb4c59a92259fc5dde3d220658b6e54896f..45c4fddb8562736eaf98810d70d002ae
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 01df6fc54078901a9195dd2bb45eaef1706ba036..1db8f63d9207330acc1b403adce0773149bc879f 100644
+index a5cffbef22dae035eabf6d268667b495f6fe0c01..bd30bddbffbcef1d6a78a1a06aa0e3eba1149d53 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1721,4 +1721,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1755,4 +1755,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      void reloadPermissions(); // Paper
  
      boolean reloadCommandAliases(); // Paper

--- a/patches/api/0054-Fix-upstream-javadocs.patch
+++ b/patches/api/0054-Fix-upstream-javadocs.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix upstream javadocs
 Upstream still refuses to use Java 8 with the API so they are likely unaware these are even issues.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 45c4fddb8562736eaf98810d70d002ae6e3664e7..9838557d874e498e1f7cef8f219000dcaea7a263 100644
+index 431e3d4bf634ce4e69432f84ed0e88c599d3ac51..824b22d745c2bf3a55feb166efee3e89433ae557 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1220,6 +1220,8 @@ public final class Bukkit {
+@@ -1260,6 +1260,8 @@ public final class Bukkit {
  
      /**
       * Gets every player that has ever played on this server.
@@ -19,10 +19,10 @@ index 45c4fddb8562736eaf98810d70d002ae6e3664e7..9838557d874e498e1f7cef8f219000dc
       * @return an array containing all previous players
       */
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1db8f63d9207330acc1b403adce0773149bc879f..ad11f8271d5b6f44d7d5cf0c122b51b2b8d1af3b 100644
+index bd30bddbffbcef1d6a78a1a06aa0e3eba1149d53..05e7c61022d0ba749c14c07c1824b00a7dce05e3 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1027,6 +1027,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1061,6 +1061,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
  
      /**
       * Gets every player that has ever played on this server.
@@ -45,7 +45,7 @@ index 91fc11dda99de506be83d40df8929bf7cd8e8d85..7dc631ebd009f5f5c3ac1699c3f3515c
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index db4ba67618d29f72d695c66c27d771795565a1d0..0ab94ddd3b88eee8040233a89823bd2fadc78d55 100644
+index 50ac6f0374da5697a38ef5ec7625da91d4a4276c..f607c57275958bf1cbf8e77b4d7efa936064c228 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
 @@ -21,6 +21,11 @@ import org.jetbrains.annotations.Nullable;
@@ -76,7 +76,7 @@ index be9334a8b5fba9181ad63c211697e798be63da25..0514a141cb93a650be38c63d4336d46e
       * Instructs this Mob to set the specified LivingEntity as its target.
       * <p>
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 632622b90696f0e1c8e33d897d8e14467691e760..b7a3da7a6ee0915449534f7f879eb2f40090b9dd 100644
+index a0777f9dc7cb6d4274635d794cf66de714535cde..2ba2c61dd1e8180d9dfbced8dc1642c75aaff6f7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -753,7 +753,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -267,10 +267,10 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9838557d874e498e1f7cef8f219000dcaea7a263..c7daa7c9f85c62d0effd5c3f406568d77fd8cd78 100644
+index 824b22d745c2bf3a55feb166efee3e89433ae557..a6445e19bdd829b89ccd1cc39b6ef435c7644aa8 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1975,6 +1975,40 @@ public final class Bukkit {
+@@ -2015,6 +2015,40 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
@@ -312,10 +312,10 @@ index 9838557d874e498e1f7cef8f219000dcaea7a263..c7daa7c9f85c62d0effd5c3f406568d7
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ad11f8271d5b6f44d7d5cf0c122b51b2b8d1af3b..fb5c308d82e9103a212deea2a6fa2e158cddb931 100644
+index 05e7c61022d0ba749c14c07c1824b00a7dce05e3..1002f2a49bc15cc21582babd976d1b4a13fbaadd 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1732,5 +1732,33 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1766,5 +1766,33 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();

--- a/patches/api/0083-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/patches/api/0083-Add-setPlayerProfile-API-for-Skulls.patch
@@ -7,10 +7,10 @@ This allows you to create already filled textures on Skulls to avoid texture loo
 which commonly cause rate limit issues with Mojang API
 
 diff --git a/src/main/java/org/bukkit/block/Skull.java b/src/main/java/org/bukkit/block/Skull.java
-index 943d751fb3e48212fbe258845beba03c25fa22d9..a6914f01e01e9103702185f92b0209b3c84c152a 100644
+index 83ca284e02f0c2229126d8f40cb33b18f44524d3..667f0586aa842a34a3ee33a9df09235b9ac0dc0c 100644
 --- a/src/main/java/org/bukkit/block/Skull.java
 +++ b/src/main/java/org/bukkit/block/Skull.java
-@@ -7,6 +7,7 @@ import org.bukkit.block.data.BlockData;
+@@ -8,6 +8,7 @@ import org.bukkit.profile.PlayerProfile;
  import org.jetbrains.annotations.Contract;
  import org.jetbrains.annotations.NotNull;
  import org.jetbrains.annotations.Nullable;
@@ -18,7 +18,7 @@ index 943d751fb3e48212fbe258845beba03c25fa22d9..a6914f01e01e9103702185f92b0209b3
  
  /**
   * Represents a captured state of a skull block.
-@@ -61,6 +62,20 @@ public interface Skull extends TileState {
+@@ -62,6 +63,20 @@ public interface Skull extends TileState {
       */
      public void setOwningPlayer(@NotNull OfflinePlayer player);
  
@@ -37,17 +37,18 @@ index 943d751fb3e48212fbe258845beba03c25fa22d9..a6914f01e01e9103702185f92b0209b3
 +    // Paper end
 +
      /**
-      * Gets the rotation of the skull in the world (or facing direction if this
-      * is a wall mounted skull).
+      * Gets the profile of the player who owns the skull. This player profile
+      * may appear as the texture depending on skull type.
 diff --git a/src/main/java/org/bukkit/inventory/meta/SkullMeta.java b/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
-index 496254f959345d74167a9b44d160ea1bb428c5a1..88d1c889c09adb91abb09a8e43a30c871b217da2 100644
+index dcefd0eea9461441c4209d587896d704389487d0..3924c772d005b32fa862b7a14864379b92ef3899 100644
 --- a/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
-@@ -1,9 +1,11 @@
+@@ -1,10 +1,12 @@
  package org.bukkit.inventory.meta;
  
 +import com.destroystokyo.paper.profile.PlayerProfile;
  import org.bukkit.OfflinePlayer;
+ import org.bukkit.profile.PlayerProfile;
  import org.jetbrains.annotations.NotNull;
  import org.jetbrains.annotations.Nullable;
  
@@ -55,7 +56,7 @@ index 496254f959345d74167a9b44d160ea1bb428c5a1..88d1c889c09adb91abb09a8e43a30c87
  /**
   * Represents a skull that can have an owner.
   */
-@@ -36,6 +38,20 @@ public interface SkullMeta extends ItemMeta {
+@@ -37,6 +39,20 @@ public interface SkullMeta extends ItemMeta {
      @Deprecated
      boolean setOwner(@Nullable String owner);
  

--- a/patches/api/0092-getPlayerUniqueId-API.patch
+++ b/patches/api/0092-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c7daa7c9f85c62d0effd5c3f406568d77fd8cd78..23960534cbb83cfca08ccc1e37bc7a713728b791 100644
+index a6445e19bdd829b89ccd1cc39b6ef435c7644aa8..e8e93495ad2d5f7d44b4ad41fbc4c99927664282 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -616,6 +616,20 @@ public final class Bukkit {
+@@ -617,6 +617,20 @@ public final class Bukkit {
          return server.getPlayer(id);
      }
  
@@ -34,10 +34,10 @@ index c7daa7c9f85c62d0effd5c3f406568d77fd8cd78..23960534cbb83cfca08ccc1e37bc7a71
       * Gets the plugin manager for interfacing with plugins.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index fb5c308d82e9103a212deea2a6fa2e158cddb931..f7320c0797f31cc9609a6764d886bdb6dbd082af 100644
+index 1002f2a49bc15cc21582babd976d1b4a13fbaadd..7d72994fd3072b4a1d1d730f5dc1944a6a35e168 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -524,6 +524,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -525,6 +525,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      public Player getPlayer(@NotNull UUID id);
  

--- a/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
@@ -8,10 +8,10 @@ Allows a more logical API for banning players.
 player.banPlayer("Breaking the rules");
 
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
-index 58313929f81509030216a0e5e3869da63e11108e..6cf05fed701c67a2c797a4e0839c795802a238a1 100644
+index 76e511e7f619960ab50d534c17489e2bc87ebf5a..9d774a10b9543e9293cb10ee9d7c9adebbfef34c 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
-@@ -45,6 +45,61 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -58,6 +58,61 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       * @return true if banned, otherwise false
       */
      public boolean isBanned();
@@ -74,7 +74,7 @@ index 58313929f81509030216a0e5e3869da63e11108e..6cf05fed701c67a2c797a4e0839c7958
      /**
       * Checks if this player is whitelisted or not
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5224cfe5d57ab62b52554336f325dae8829d1b30..264a35cc33f40405e9ba10de850bb3142d984ee7 100644
+index 559d45ed0af80702d86eac20f01fcfb3104cc24c..9d742cdb669ea1d2cfd99ac25a2843a637bf9307 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -5,6 +5,10 @@ import java.util.UUID;

--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 23960534cbb83cfca08ccc1e37bc7a713728b791..53a361b2f6d8d8e79f215e64d3b42fcbe54b0d81 100644
+index e8e93495ad2d5f7d44b4ad41fbc4c99927664282..db3f4c69b2488e74ec5d681939a2ffd4a474560a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1990,6 +1990,15 @@ public final class Bukkit {
+@@ -2030,6 +2030,15 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
@@ -25,10 +25,10 @@ index 23960534cbb83cfca08ccc1e37bc7a713728b791..53a361b2f6d8d8e79f215e64d3b42fcb
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f7320c0797f31cc9609a6764d886bdb6dbd082af..963edbb1e7d47410b7474b8e0ce6774a76ea9d88 100644
+index 7d72994fd3072b4a1d1d730f5dc1944a6a35e168..870508ac735808c21043a6adfaad225ac65531ed 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1745,6 +1745,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1779,6 +1779,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  

--- a/patches/api/0168-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/api/0168-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,10 +16,10 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
-index 6cf05fed701c67a2c797a4e0839c795802a238a1..3afd5f5c0208a4ee93b5dbfc2aab2b9d2e8a7544 100644
+index 9d774a10b9543e9293cb10ee9d7c9adebbfef34c..23e853bae0e051cd43deb9eb24c54e74a56d8ab0 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
-@@ -147,7 +147,9 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -160,7 +160,9 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       * UTC.
       *
       * @return Date of last log-in for this player, or 0
@@ -29,7 +29,7 @@ index 6cf05fed701c67a2c797a4e0839c795802a238a1..3afd5f5c0208a4ee93b5dbfc2aab2b9d
      public long getLastPlayed();
  
      /**
-@@ -165,6 +167,30 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -178,6 +180,30 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       */
      @Nullable
      public Location getBedSpawnLocation();

--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -9,10 +9,10 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 53a361b2f6d8d8e79f215e64d3b42fcbe54b0d81..28bc240ba5d93e4112bd95963a334215b1dc2388 100644
+index db3f4c69b2488e74ec5d681939a2ffd4a474560a..7f0af52695cb03367c978bd22c690b423d1d0519 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1576,7 +1576,7 @@ public final class Bukkit {
+@@ -1616,7 +1616,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -21,7 +21,7 @@ index 53a361b2f6d8d8e79f215e64d3b42fcbe54b0d81..28bc240ba5d93e4112bd95963a334215
      public static ScoreboardManager getScoreboardManager() {
          return server.getScoreboardManager();
      }
-@@ -1873,7 +1873,7 @@ public final class Bukkit {
+@@ -1913,7 +1913,7 @@ public final class Bukkit {
       * @param clazz the class of the tag entries
       * @return the tag or null
       */
@@ -62,10 +62,10 @@ index 88b3e0323dbc4f0fce31b147c7aaa08d65745852..23ca89dde7f6ac9082d4b97fce295942
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 963edbb1e7d47410b7474b8e0ce6774a76ea9d88..1ffdaf8a7814b44facf9648f9e1ba6525055405b 100644
+index 870508ac735808c21043a6adfaad225ac65531ed..a2fd449b4c64e0626cd9050bad99a0bb9e8b31f7 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1333,7 +1333,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1367,7 +1367,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -74,7 +74,7 @@ index 963edbb1e7d47410b7474b8e0ce6774a76ea9d88..1ffdaf8a7814b44facf9648f9e1ba652
      ScoreboardManager getScoreboardManager();
  
      /**
-@@ -1603,7 +1603,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1637,7 +1637,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param clazz the class of the tag entries
       * @return the tag or null
       */

--- a/patches/api/0183-Expose-the-internal-current-tick.patch
+++ b/patches/api/0183-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 28bc240ba5d93e4112bd95963a334215b1dc2388..f31a1f8a65a79953f6f053c785a7bdacb32291a0 100644
+index 7f0af52695cb03367c978bd22c690b423d1d0519..7e22efa4c6f86ebf4c6cc6b77257cdd4b824d746 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2032,6 +2032,10 @@ public final class Bukkit {
+@@ -2072,6 +2072,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfile(uuid, name);
      }
@@ -20,10 +20,10 @@ index 28bc240ba5d93e4112bd95963a334215b1dc2388..f31a1f8a65a79953f6f053c785a7bdac
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1ffdaf8a7814b44facf9648f9e1ba6525055405b..f78119e1fad76cd7bbb0a5b78973baf7876d3a9e 100644
+index a2fd449b4c64e0626cd9050bad99a0bb9e8b31f7..f14d11cd7ace71c4415cb73caeab53b2fc028b74 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1779,5 +1779,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1813,5 +1813,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0189-Add-tick-times-API.patch
+++ b/patches/api/0189-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f31a1f8a65a79953f6f053c785a7bdacb32291a0..c277b48d45c7aab3b727a7019b3ef253e045629d 100644
+index 7e22efa4c6f86ebf4c6cc6b77257cdd4b824d746..f3c75182bea3e8578fa7992f149e540d554cd159 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1777,6 +1777,25 @@ public final class Bukkit {
+@@ -1817,6 +1817,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index f31a1f8a65a79953f6f053c785a7bdacb32291a0..c277b48d45c7aab3b727a7019b3ef253
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f78119e1fad76cd7bbb0a5b78973baf7876d3a9e..38febebef94652a9e44475560974d6e8d6949db0 100644
+index f14d11cd7ace71c4415cb73caeab53b2fc028b74..b4a8e9ffffc2e396db6f7010943e50605ae89cbd 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1507,6 +1507,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1541,6 +1541,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0190-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0190-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c277b48d45c7aab3b727a7019b3ef253e045629d..c043e6798314e322e32a1c8e8ef6a795e022b858 100644
+index f3c75182bea3e8578fa7992f149e540d554cd159..69a62166a2de6568e877d4201daf955fedf62ca5 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2055,6 +2055,15 @@ public final class Bukkit {
+@@ -2095,6 +2095,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index c277b48d45c7aab3b727a7019b3ef253e045629d..c043e6798314e322e32a1c8e8ef6a795
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 38febebef94652a9e44475560974d6e8d6949db0..ad940c5d327c7e1e09aea7d2cee27a8abcf3fed7 100644
+index b4a8e9ffffc2e396db6f7010943e50605ae89cbd..87cd8992629f3c203d442f2fadc02f65ae7ce1d1 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1801,5 +1801,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1835,5 +1835,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0199-Expose-game-version.patch
+++ b/patches/api/0199-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c043e6798314e322e32a1c8e8ef6a795e022b858..92bebf6f46cdd2ff5bc09af32e2d6d2ef0f4f45b 100644
+index 69a62166a2de6568e877d4201daf955fedf62ca5..5132f2ba4ebe788e6937e2a2d8ce4bd22746835a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -133,6 +133,18 @@ public final class Bukkit {
+@@ -134,6 +134,18 @@ public final class Bukkit {
          return server.getBukkitVersion();
      }
  
@@ -28,10 +28,10 @@ index c043e6798314e322e32a1c8e8ef6a795e022b858..92bebf6f46cdd2ff5bc09af32e2d6d2e
       * Gets a view of all currently logged in players. This {@linkplain
       * Collections#unmodifiableCollection(Collection) view} is a reused
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ad940c5d327c7e1e09aea7d2cee27a8abcf3fed7..f9b25ecf5642c30c04f5e0483a654ff33d1c188d 100644
+index 87cd8992629f3c203d442f2fadc02f65ae7ce1d1..7f71b663f51fd4395404864d7a5ba56ae92286da 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -110,6 +110,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -111,6 +111,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public String getBukkitVersion();
  

--- a/patches/api/0200-Add-Mob-Goal-API.patch
+++ b/patches/api/0200-Add-Mob-Goal-API.patch
@@ -521,10 +521,10 @@ index 0000000000000000000000000000000000000000..2405254739a83b2fb517da7fa4ea0721
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 92bebf6f46cdd2ff5bc09af32e2d6d2ef0f4f45b..0a29ddee94051e398780b9fa07e5ce2b46c51b97 100644
+index 5132f2ba4ebe788e6937e2a2d8ce4bd22746835a..25c4bcdea9c7755e7390bea7026949b4bf3dbff6 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2076,6 +2076,16 @@ public final class Bukkit {
+@@ -2116,6 +2116,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -542,10 +542,10 @@ index 92bebf6f46cdd2ff5bc09af32e2d6d2ef0f4f45b..0a29ddee94051e398780b9fa07e5ce2b
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f9b25ecf5642c30c04f5e0483a654ff33d1c188d..a8e187a3f386210c712ab7d620d6a4aa91bf42f8 100644
+index 7f71b663f51fd4395404864d7a5ba56ae92286da..b97618007a074c57d23ba2d57f9d94e52610bc96 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1818,5 +1818,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1852,5 +1852,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0214-Add-setMaxPlayers-API.patch
+++ b/patches/api/0214-Add-setMaxPlayers-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 0a29ddee94051e398780b9fa07e5ce2b46c51b97..dee9bcd9caee7c900a38c92d5e967cdaaf875a08 100644
+index 25c4bcdea9c7755e7390bea7026949b4bf3dbff6..2ac4387640f8900dcad0895636395e3ac4577967 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -186,6 +186,17 @@ public final class Bukkit {
+@@ -187,6 +187,17 @@ public final class Bukkit {
          return server.getMaxPlayers();
      }
  
@@ -27,10 +27,10 @@ index 0a29ddee94051e398780b9fa07e5ce2b46c51b97..dee9bcd9caee7c900a38c92d5e967cda
       * Get the game port that the server runs on.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a8e187a3f386210c712ab7d620d6a4aa91bf42f8..a3f6a2bbc1d4626b657acc1e108c04ce8d0d577c 100644
+index b97618007a074c57d23ba2d57f9d94e52610bc96..b331c4730d153271010e78cc28094c5aa2fdb681 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -157,6 +157,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -158,6 +158,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      public int getMaxPlayers();
  

--- a/patches/api/0228-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0228-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index dee9bcd9caee7c900a38c92d5e967cdaaf875a08..b2699b0d82f2cf05a04ded5bc335f91362ddfa9a 100644
+index 2ac4387640f8900dcad0895636395e3ac4577967..3fa4c88fd9f4739f34cba048dbe88db92b0d1c90 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1138,6 +1138,27 @@ public final class Bukkit {
+@@ -1139,6 +1139,27 @@ public final class Bukkit {
          return server.getOfflinePlayer(name);
      }
  
@@ -37,10 +37,10 @@ index dee9bcd9caee7c900a38c92d5e967cdaaf875a08..b2699b0d82f2cf05a04ded5bc335f913
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a3f6a2bbc1d4626b657acc1e108c04ce8d0d577c..df893601ec71dcc782a7050fb10684c5980105ee 100644
+index b331c4730d153271010e78cc28094c5aa2fdb681..1337f70c25134594dd0f7b9b17a9b962a1809b10 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -961,6 +961,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -962,6 +962,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  

--- a/patches/api/0276-Implement-Keyed-on-World.patch
+++ b/patches/api/0276-Implement-Keyed-on-World.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b2699b0d82f2cf05a04ded5bc335f91362ddfa9a..ea5745e548b11e4d71737a78e10e53c23bc3eb8e 100644
+index 3fa4c88fd9f4739f34cba048dbe88db92b0d1c90..e0f7979039fd3987614c250b4cda724e54e263ef 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -751,6 +751,18 @@ public final class Bukkit {
+@@ -752,6 +752,18 @@ public final class Bukkit {
      public static World getWorld(@NotNull UUID uid) {
          return server.getWorld(uid);
      }
@@ -28,10 +28,10 @@ index b2699b0d82f2cf05a04ded5bc335f91362ddfa9a..ea5745e548b11e4d71737a78e10e53c2
      /**
       * Gets the map from the given item ID.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index df893601ec71dcc782a7050fb10684c5980105ee..e435df76a752c523b8bc0bd2d2abf35c2460f880 100644
+index 1337f70c25134594dd0f7b9b17a9b962a1809b10..908ae9a8da263a82b8840818979f2ffe1a14cb1f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -636,6 +636,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -637,6 +637,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      public World getWorld(@NotNull UUID uid);
  
@@ -50,7 +50,7 @@ index df893601ec71dcc782a7050fb10684c5980105ee..e435df76a752c523b8bc0bd2d2abf35c
       * Gets the map from the given item ID.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index f60fdb12d7dcd60179e07ea764302ebb1c91c619..82ca519c18e49fb4df1932e871a6c9d3dc7e86b2 100644
+index 255b78e5623a037774f278b3a940393ec7026ac3..7a60ad315a092baed1e4c1f05f29a8f21ebad070 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -41,7 +41,7 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0295-Add-basic-Datapack-API.patch
+++ b/patches/api/0295-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ea5745e548b11e4d71737a78e10e53c23bc3eb8e..63a4e03b0c5508d5f027c7fa3cecb8b5aa9d450b 100644
+index e0f7979039fd3987614c250b4cda724e54e263ef..4b7615de4f2243ddfcda72b47891b3a4bcf526e6 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2130,6 +2130,14 @@ public final class Bukkit {
+@@ -2170,6 +2170,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index ea5745e548b11e4d71737a78e10e53c23bc3eb8e..63a4e03b0c5508d5f027c7fa3cecb8b5
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e435df76a752c523b8bc0bd2d2abf35c2460f880..48f9b34aa6caf91174af87f0fe694562417dcc60 100644
+index 908ae9a8da263a82b8840818979f2ffe1a14cb1f..76710cb9ba7e390a42826c68e8887355d5da74ee 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1865,5 +1865,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1899,5 +1899,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0313-Add-Git-information-to-version-command-on-startup.patch
+++ b/patches/api/0313-Add-Git-information-to-version-command-on-startup.patch
@@ -48,10 +48,10 @@ index 0000000000000000000000000000000000000000..909617079db61b675cc7b60b44ef96b3
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 63a4e03b0c5508d5f027c7fa3cecb8b5aa9d450b..f7df34539f03e2d5bbb2733709dcbcda65a23b29 100644
+index 4b7615de4f2243ddfcda72b47891b3a4bcf526e6..ab0c9340dd331bbe5933f539fbb598c8f3c53c23 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -51,6 +51,7 @@ import org.bukkit.util.CachedServerIcon;
+@@ -52,6 +52,7 @@ import org.bukkit.util.CachedServerIcon;
  import org.jetbrains.annotations.Contract;
  import org.jetbrains.annotations.NotNull;
  import org.jetbrains.annotations.Nullable;
@@ -59,7 +59,7 @@ index 63a4e03b0c5508d5f027c7fa3cecb8b5aa9d450b..f7df34539f03e2d5bbb2733709dcbcda
  
  /**
   * Represents the Bukkit core, for version and Server singleton handling
-@@ -100,7 +101,25 @@ public final class Bukkit {
+@@ -101,7 +102,25 @@ public final class Bukkit {
          }
  
          Bukkit.server = server;

--- a/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f7df34539f03e2d5bbb2733709dcbcda65a23b29..53c4e5ca208ee17c7c244e416c537c7b63edf194 100644
+index ab0c9340dd331bbe5933f539fbb598c8f3c53c23..bd3f557aa57833d4eba20828fd9f6954e3f59d8d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1740,6 +1740,24 @@ public final class Bukkit {
+@@ -1780,6 +1780,24 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -34,10 +34,10 @@ index f7df34539f03e2d5bbb2733709dcbcda65a23b29..53c4e5ca208ee17c7c244e416c537c7b
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 48f9b34aa6caf91174af87f0fe694562417dcc60..e48af3822e9f118399c3a1c9358c56efae12e0da 100644
+index 76710cb9ba7e390a42826c68e8887355d5da74ee..e7b756c591e6b9571c4db0b9fc5b6b8a311becc9 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1457,6 +1457,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1491,6 +1491,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  
@@ -61,7 +61,7 @@ index 48f9b34aa6caf91174af87f0fe694562417dcc60..e48af3822e9f118399c3a1c9358c56ef
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
-index 80fcd02e9cb5f432f21b1f68fd8266f296becaa0..0667315e2bd10254aef59c2a6bcceee9d927b6d5 100644
+index d14d3851a7b0340668f44f5213f0e18072d7481b..04be4214bc1c4b476c70aea457118e786fa67eff 100644
 --- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
 +++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
 @@ -454,6 +454,22 @@ public abstract class ChunkGenerator {

--- a/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for creating command sender which forwards feedback
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 53c4e5ca208ee17c7c244e416c537c7b63edf194..3a8326735b62521f8fb95c51a0909d8b7bac83d1 100644
+index bd3f557aa57833d4eba20828fd9f6954e3f59d8d..a48c29a0a08bf28931b7650f4d29db76416d746b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1297,6 +1297,20 @@ public final class Bukkit {
+@@ -1337,6 +1337,20 @@ public final class Bukkit {
          return server.getConsoleSender();
      }
  
@@ -30,10 +30,10 @@ index 53c4e5ca208ee17c7c244e416c537c7b63edf194..3a8326735b62521f8fb95c51a0909d8b
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e48af3822e9f118399c3a1c9358c56efae12e0da..73446141e8c50b71a17ff6f0c528a62d5c75751b 100644
+index e7b756c591e6b9571c4db0b9fc5b6b8a311becc9..8d1622cb46f27dd2529dfb4f4b3482f2ec3c5fce 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1078,6 +1078,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1112,6 +1112,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 9c4382ef7373110b6e72163779316ff40234a992..bba267ecca0121df22fdfa60961017863b5e3415 100644
+index dc8f0a7ac3387323428f71139ac07ec98cd33ed8..4db0cc3f8505747e77d314320545eb71904b4eac 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -13,10 +13,9 @@ repositories {
@@ -39,7 +39,7 @@ index 9c4382ef7373110b6e72163779316ff40234a992..bba267ecca0121df22fdfa6096101786
          for (tld in setOf("net", "com", "org")) {
              attributes("$tld/bukkit", "Sealed" to true)
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 21713baa2db85a49dae0fa7675776b029f8bf4c9..ec50a122331b2ceb19822273f89f32b66a9f7db0 100644
+index 38851269bc9eff80f5593e63b61a4b25c328a3cc..0607f13dd2a568e368f96768259e8cba9c25e9c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -190,7 +190,7 @@ public class Main {
@@ -50,7 +50,7 @@ index 21713baa2db85a49dae0fa7675776b029f8bf4c9..ec50a122331b2ceb19822273f89f32b6
 +                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -14);
+                     deadline.add(Calendar.DAY_OF_YEAR, -28);
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 index 93046379d0cefd5d3236fc59e698809acdc18f80..774556a62eb240da42e84db4502e2ed43495be17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -629,7 +629,7 @@ index 82d04f803201e39b48cd514cd8d9e2b90b28c1d4..156fa293626119caf0cf414505fdf0e9
          Main.LOGGER.info("Forcing world upgrade! {}", session.getLevelId()); // CraftBukkit
          WorldUpgrader worldupgrader = new WorldUpgrader(session, dataFixer, generatorOptions, eraseCache);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ebb914e7cf3e5ba2d862e341392e904f325d720a..b3629065ebbe601802703b8671b24c7156f12d03 100644
+index d75a598576d87644a4226216dcfd685c25b29f12..b3c1373f281adfdd9fa513b597941b60b71bb06c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -602,6 +602,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -661,7 +661,7 @@ index 2599fbabd5e5c0d10d0c915016f7cc982bda0e20..4dd57007af218ba1c0e666117a49939c
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index a44b47c8ed611078764841a5b591877242c10db1..d672c467267ef4d96184e104c35d0379116880db 100644
+index 844969ea7b736508f138332a0b4b64ae34ee1a52..1231b8425c45326aaf2d59613a1176bf57c9b7f2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -337,6 +337,12 @@ public class ServerChunkCache extends ChunkSource {
@@ -714,10 +714,10 @@ index aaf71bfb582d1d86d67205618825411babd2625a..f18ae5b80c930c3a7c2da079b9926ab2
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
          this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dfd7da8bc5cdcdf1548cc5ba871fb8809ee911e8..6258eed86c1f0461a8d8c8b9f82bb8be9dc6d71e 100644
+index 926cac17514d85601707fe6e4095b39deee49d8d..ebb4ccf0a27ca254e75759fdf443d5067c146825 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -863,6 +863,7 @@ public final class CraftServer implements Server {
+@@ -866,6 +866,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
@@ -725,7 +725,7 @@ index dfd7da8bc5cdcdf1548cc5ba871fb8809ee911e8..6258eed86c1f0461a8d8c8b9f82bb8be
          for (ServerLevel world : this.console.getAllLevels()) {
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
-@@ -902,12 +903,14 @@ public final class CraftServer implements Server {
+@@ -905,12 +906,14 @@ public final class CraftServer implements Server {
                  world.ticksPerAmbientSpawns = this.getTicksPerAmbientSpawns();
              }
              world.spigotConfig.init(); // Spigot
@@ -740,7 +740,7 @@ index dfd7da8bc5cdcdf1548cc5ba871fb8809ee911e8..6258eed86c1f0461a8d8c8b9f82bb8be
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2308,4 +2311,35 @@ public final class CraftServer implements Server {
+@@ -2326,4 +2329,35 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
@@ -777,7 +777,7 @@ index dfd7da8bc5cdcdf1548cc5ba871fb8809ee911e8..6258eed86c1f0461a8d8c8b9f82bb8be
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index ec50a122331b2ceb19822273f89f32b66a9f7db0..2bd2f436d5514b5e9bbc8bbd27ead4d4cb529b4f 100644
+index 0607f13dd2a568e368f96768259e8cba9c25e9c1..399e878210606e9addb535e4efed0ddb424160e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -129,6 +129,14 @@ public class Main {
@@ -796,7 +796,7 @@ index ec50a122331b2ceb19822273f89f32b66a9f7db0..2bd2f436d5514b5e9bbc8bbd27ead4d4
          };
  
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index af8c42ed04d9a79cd426bdaa8c2ee3feac1163e3..6c5113545914842ffb310522a7549ae7dd2466b2 100644
+index 4520eda5308575aa02ef059bb2efd776f56e352b..1d802f0e81b3880e9bb7799ecd46826f4bdcee03 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -58,8 +58,14 @@ public class SpigotWorldConfig

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -1412,7 +1412,7 @@ index 8e4325abb2dda74c38b17bb27f9dcfcf97ba2de6..1be4b3ad18d314b0460ce61e01afd0d7
  
      public UserWhiteList getWhiteList() {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0736454dea12d8ffe8ef6873c5d25d17a96504b0..68ccbc193ff6682f505928dc0a29ee990349d299 100644
+index 521e525cac2109a79370321163f4f27ffefb49ad..c9ab40355f02a2abfe10d9c02595e6b761b1a779 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -125,7 +125,6 @@ import org.bukkit.craftbukkit.event.CraftPortalEvent;
@@ -1713,10 +1713,10 @@ index ed639dbb4ea94839390778654c7dd0437bac41ac..1729af83b979e35a585c8d049b14dc23
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6258eed86c1f0461a8d8c8b9f82bb8be9dc6d71e..ecc6c5aa6534fd36f7534e7fd70d9fe568ae83eb 100644
+index ebb4ccf0a27ca254e75759fdf443d5067c146825..781a6017c4a3225b8bf1df7a6f2dc6b4d1a0a11d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2280,12 +2280,31 @@ public final class CraftServer implements Server {
+@@ -2298,12 +2298,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  
@@ -1918,10 +1918,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 929d8f7bf18a618e0447f726dbbd9e6fe2a6529a..43203833aac1a95bad813ee84da3225489da4b70 100644
+index 76160b76d7d469fb75e733c24d3f1ddf4796485e..74db150aed0744d62779e00cad8bfa25cede76ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1908,6 +1908,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1915,6 +1915,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              packet.components = components;
              CraftPlayer.this.getHandle().connection.send(packet);
          }

--- a/patches/server/0011-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0011-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ecc6c5aa6534fd36f7534e7fd70d9fe568ae83eb..8b521bf3b10412b7ebe081591f0e6413e235d978 100644
+index 781a6017c4a3225b8bf1df7a6f2dc6b4d1a0a11d..059526a7b26ea574e9f7ee1624ed35efb28cdbf3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -404,10 +404,15 @@ public final class CraftServer implements Server {
+@@ -407,10 +407,15 @@ public final class CraftServer implements Server {
      public void loadPlugins() {
          this.pluginManager.registerInterface(JavaPluginLoader.class);
  
@@ -29,7 +29,7 @@ index ecc6c5aa6534fd36f7534e7fd70d9fe568ae83eb..8b521bf3b10412b7ebe081591f0e6413
              for (Plugin plugin : plugins) {
                  try {
                      String message = String.format("Loading %s", plugin.getDescription().getFullName());
-@@ -422,6 +427,35 @@ public final class CraftServer implements Server {
+@@ -425,6 +430,35 @@ public final class CraftServer implements Server {
          }
      }
  
@@ -66,7 +66,7 @@ index ecc6c5aa6534fd36f7534e7fd70d9fe568ae83eb..8b521bf3b10412b7ebe081591f0e6413
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 2bd2f436d5514b5e9bbc8bbd27ead4d4cb529b4f..dd115bd005604614e64a236ccf86a24882beb096 100644
+index 399e878210606e9addb535e4efed0ddb424160e8..707544dfd83839634dc4c1afc8e21c5c6c3d8140 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -136,6 +136,12 @@ public class Main {

--- a/patches/server/0012-Adventure.patch
+++ b/patches/server/0012-Adventure.patch
@@ -1698,10 +1698,10 @@ index 9af14095fa8dbc75fadb84c5a1d263039994e441..3b35ec1df648a3de920ea0c159623880
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f2ac30087 100644
+index 059526a7b26ea574e9f7ee1624ed35efb28cdbf3..5ee446ed53e3e42556f1c83569185ccdb52b75db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -625,8 +625,10 @@ public final class CraftServer implements Server {
+@@ -628,8 +628,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1712,7 +1712,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      }
  
      @Override
-@@ -1475,7 +1477,15 @@ public final class CraftServer implements Server {
+@@ -1478,7 +1480,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -1728,7 +1728,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1633,7 +1643,20 @@ public final class CraftServer implements Server {
+@@ -1636,7 +1646,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1749,7 +1749,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1641,14 +1664,14 @@ public final class CraftServer implements Server {
+@@ -1644,14 +1667,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -1766,7 +1766,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1884,6 +1907,14 @@ public final class CraftServer implements Server {
+@@ -1902,6 +1925,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -1781,7 +1781,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1896,13 +1927,28 @@ public final class CraftServer implements Server {
+@@ -1914,13 +1945,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -1810,7 +1810,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1951,6 +1997,12 @@ public final class CraftServer implements Server {
+@@ -1969,6 +2015,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -1823,7 +1823,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2394,5 +2446,15 @@ public final class CraftServer implements Server {
+@@ -2412,5 +2464,15 @@ public final class CraftServer implements Server {
              return null;
          }
      }
@@ -1871,7 +1871,7 @@ index d08836e06e13ba64298cc21d0e2e61f9334dddb9..83ad8c26a6152b4dd7ff9e432dabcc5f
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index dd115bd005604614e64a236ccf86a24882beb096..0c26dc0b060700323aca0a062b34d35e16a3ec9f 100644
+index 707544dfd83839634dc4c1afc8e21c5c6c3d8140..c508bfb68bb4bfd06aa0cefa5bfc0bec725a6b03 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -19,6 +19,12 @@ public class Main {
@@ -2348,10 +2348,10 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e8fd6f2f9 100644
+index 74db150aed0744d62779e00cad8bfa25cede76ab..3710423e2181533056bb87c40e129eb5d17a9afd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -255,14 +255,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -262,14 +262,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getDisplayName() {
@@ -2391,7 +2391,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      @Override
      public String getPlayerListName() {
          return this.getHandle().listName == null ? getName() : CraftChatMessage.fromComponent(this.getHandle().listName);
-@@ -281,42 +306,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -288,42 +313,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2443,7 +2443,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
          this.getHandle().connection.send(packet);
      }
  
-@@ -348,6 +373,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -355,6 +380,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.disconnect(message == null ? "" : message);
      }
  
@@ -2461,7 +2461,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      @Override
      public void setCompassTarget(Location loc) {
          if (this.getHandle().connection == null) return;
-@@ -603,6 +639,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -610,6 +646,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
@@ -2495,7 +2495,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      @Override
      public void sendSignChange(Location loc, String[] lines) {
          this.sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -630,14 +693,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -637,14 +700,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          Component[] components = CraftSign.sanitizeLines(lines);
@@ -2513,7 +2513,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      }
  
      @Override
-@@ -1332,7 +1396,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1339,7 +1403,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url) {
@@ -2522,7 +2522,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      }
  
      @Override
-@@ -1347,7 +1411,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1354,7 +1418,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url, byte[] hash, boolean force) {
@@ -2531,7 +2531,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      }
  
      @Override
-@@ -1363,6 +1427,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1370,6 +1434,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2553,7 +2553,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      public void addChannel(String channel) {
          Preconditions.checkState(this.channels.size() < 128, "Cannot register channel '%s'. Too many channels registered!", channel);
          channel = StandardMessenger.validateAndCorrectChannel(channel);
-@@ -1767,6 +1846,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1774,6 +1853,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -2566,7 +2566,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -1812,6 +1897,194 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1819,6 +1904,194 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  
@@ -2762,10 +2762,10 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index db73426f317374a070939eaef1171bb8c322041b..57c7ee1329d80fb441a4637f309d69fa120fae01 100644
+index 4b0a056a134dd5868438bdd0d46f3dab8751436d..2a3853201a6ccf14b2aab67982de7789e0cbc552 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -807,9 +807,9 @@ public class CraftEventFactory {
+@@ -817,9 +817,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -2777,7 +2777,7 @@ index db73426f317374a070939eaef1171bb8c322041b..57c7ee1329d80fb441a4637f309d69fa
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          org.bukkit.World world = entity.getWorld();
-@@ -834,7 +834,7 @@ public class CraftEventFactory {
+@@ -844,7 +844,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/patches/server/0020-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0020-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -19,7 +19,7 @@ index 2c53a400611c78236c5a1c1270d27c02e94251bf..a1d5c0f8fe2adb2ee56f3217e089211e
                      if (outputStream != null) {
                          try {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 844f24fd16aac25bf681bd3e98f0737be62bead6..f1dfb56d0158d36b583b5ee5596235540b2cb11c 100644
+index eba857195121c58d1b63c58904fd4754a8020219..6b9d947484f0b55a86c3ee27c199669153c0a5ea 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1427,7 +1427,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -32,10 +32,10 @@ index 844f24fd16aac25bf681bd3e98f0737be62bead6..f1dfb56d0158d36b583b5ee559623554
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 855740411220bc8178ea7bfd561a377f2ac30087..10f5be8b1319d371eab0c3153b5f605b033d5208 100644
+index 5ee446ed53e3e42556f1c83569185ccdb52b75db..59201653726ce656fa74bcc088fa700a2edb7b55 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -250,7 +250,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -252,7 +252,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
  public final class CraftServer implements Server {
@@ -45,11 +45,11 @@ index 855740411220bc8178ea7bfd561a377f2ac30087..10f5be8b1319d371eab0c3153b5f605b
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 0c26dc0b060700323aca0a062b34d35e16a3ec9f..e6362865d1e7beac23e520ebd2deb8a356428045 100644
+index c508bfb68bb4bfd06aa0cefa5bfc0bec725a6b03..c19bdd02db2b07a91aec2ee69ffb392ed67a818b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -216,12 +216,25 @@ public class Main {
-                     deadline.add(Calendar.DAY_OF_YEAR, -14);
+                     deadline.add(Calendar.DAY_OF_YEAR, -28);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");
 -                        System.err.println("*** Please download a new build as per instructions from https://www.spigotmc.org/go/outdated-spigot ***");

--- a/patches/server/0023-Player-affects-spawning-API.patch
+++ b/patches/server/0023-Player-affects-spawning-API.patch
@@ -117,10 +117,10 @@ index 1e420c4230a326da345b2e28442ece26b44f8259..41d20c16ea165cf166c6f3b228bc8261
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e87afc4930f5450113ffb6c4bba57e2e8fd6f2f9..3e6b0348ea7d6282725ded67ff97868e016a1e91 100644
+index 3710423e2181533056bb87c40e129eb5d17a9afd..19b0803242c7964db973473c4219db8f6e2171d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1860,8 +1860,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1867,8 +1867,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0025-Further-improve-server-tick-loop.patch
+++ b/patches/server/0025-Further-improve-server-tick-loop.patch
@@ -12,7 +12,7 @@ Previous implementation did not calculate TPS correctly.
 Switch to a realistic rolling average and factor in std deviation as an extra reporting variable
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f1dfb56d0158d36b583b5ee5596235540b2cb11c..b86ceda8f7376334987955095234bdecec5af414 100644
+index 6b9d947484f0b55a86c3ee27c199669153c0a5ea..b16c2c8e173d906097ee9ac3edace1334da11a4b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -282,7 +282,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -144,10 +144,10 @@ index f1dfb56d0158d36b583b5ee5596235540b2cb11c..b86ceda8f7376334987955095234bdec
                      this.startMetricsRecordingTick();
                      this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 10f5be8b1319d371eab0c3153b5f605b033d5208..ae2bad0ba336aa5f3c6d71a04a3ac8a15b311600 100644
+index 59201653726ce656fa74bcc088fa700a2edb7b55..a1000706632914a881c40992c3aa30fde4f65abb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2362,6 +2362,17 @@ public final class CraftServer implements Server {
+@@ -2380,6 +2380,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0026-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0026-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3e6b0348ea7d6282725ded67ff97868e016a1e91..91c27a71c5ed63ec5b75bba172e625b795793473 100644
+index 19b0803242c7964db973473c4219db8f6e2171d3..b3469e0ffd15656c8cc7a460cc4d42a6cf106982 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1529,12 +1529,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1536,12 +1536,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0039-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0039-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index 88b6be62678fc09b5a39db28c6d71cc31b16dbcd..352bfe795aea26307de9c998d67a43af
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 91c27a71c5ed63ec5b75bba172e625b795793473..a137989c06a259dbaaa0cbac52d801a6113184bb 100644
+index b3469e0ffd15656c8cc7a460cc4d42a6cf106982..9357440824bf8b125d08c6c785e71c9b1ac95ae4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1860,8 +1860,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1867,8 +1867,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0040-Per-Player-View-Distance-API-placeholders.patch
+++ b/patches/server/0040-Per-Player-View-Distance-API-placeholders.patch
@@ -56,10 +56,10 @@ index 83ad8c26a6152b4dd7ff9e432dabcc5fc17e3df0..1fa945a6431b813edbdcd7cda9bd48b5
  
      // Spigot start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a137989c06a259dbaaa0cbac52d801a6113184bb..73ab957bfafee4bbdf80b0fd34fdc7b46b55805a 100644
+index 9357440824bf8b125d08c6c785e71c9b1ac95ae4..fe27669d525c84d9f8d828dfcde1c35e3ecb7a49 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -382,6 +382,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -389,6 +389,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              connection.disconnect(message == null ? net.kyori.adventure.text.Component.empty() : message);
          }
      }

--- a/patches/server/0043-Use-UserCache-for-player-heads.patch
+++ b/patches/server/0043-Use-UserCache-for-player-heads.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use UserCache for player heads
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 6432f668f72c0543283b5a1439d01da81ff5b981..9405812b8c308d70de1e26ba55500301b24ecc3c 100644
+index f331e1b3882d10506fd89034e224e75ae2f030be..eda37a7622748feef782b54235070c04f3c714f8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -168,7 +168,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -175,7 +175,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          if (name == null) {
              this.setProfile(null);
          } else {

--- a/patches/server/0047-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0047-Ensure-commands-are-not-ran-async.patch
@@ -48,10 +48,10 @@ index 3c4e0fc879bebb55b07f6017a38311519329902e..fed5dcdc62700bd661035011a06788fd
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ae2bad0ba336aa5f3c6d71a04a3ac8a15b311600..8f49af4892390a990ea2c273b8c64e359ff15b72 100644
+index a1000706632914a881c40992c3aa30fde4f65abb..7c672d59ea8148596e6b3050a0d203ba1edd3675 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -849,6 +849,28 @@ public final class CraftServer implements Server {
+@@ -852,6 +852,28 @@ public final class CraftServer implements Server {
          Validate.notNull(commandLine, "CommandLine cannot be null");
          org.spigotmc.AsyncCatcher.catchOp("command dispatch"); // Spigot
  

--- a/patches/server/0049-Expose-server-CommandMap.patch
+++ b/patches/server/0049-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8f49af4892390a990ea2c273b8c64e359ff15b72..94804f241792bd7067edf0cdbf154ed1533241c3 100644
+index 7c672d59ea8148596e6b3050a0d203ba1edd3675..52858c999eb91f11d047364cd0cfbb04bdfd33f2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1980,6 +1980,7 @@ public final class CraftServer implements Server {
+@@ -1998,6 +1998,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0052-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/server/0052-Player-Tab-List-and-Title-APIs.patch
@@ -63,7 +63,7 @@ index bd808eb312ade7122973a47f4b96505829511da5..bf0f9cab7c66c089f35b851e799ba4a4
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 73ab957bfafee4bbdf80b0fd34fdc7b46b55805a..f2b3783373336221c0aef8bae04d350eed0e8ec2 100644
+index fe27669d525c84d9f8d828dfcde1c35e3ecb7a49..523746b698d38494f0fa76b026d50e3d9d411c54 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@
@@ -73,7 +73,7 @@ index 73ab957bfafee4bbdf80b0fd34fdc7b46b55805a..f2b3783373336221c0aef8bae04d350e
  import com.google.common.base.Preconditions;
  import com.google.common.collect.ImmutableSet;
  import com.google.common.io.BaseEncoding;
-@@ -253,6 +254,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -260,6 +261,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0053-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0053-Add-configurable-portal-search-radius.patch
@@ -23,10 +23,10 @@ index 1e3c39f0eeeb07f8d49e3651b18a152db9ccba7b..c248b66486044150c64eaddbef85fa66
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6cd4fecf8b6e49027cf8a523fb373db9a2708ed4..de15a2231057217fbbf723cf25e869998a1016f1 100644
+index 6edb88b123a8cc726cb6bd02fd83e5a11402ff00..e88c80fe1fe97e4704d5f17f97c536fdbba48447 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2914,7 +2914,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2920,7 +2920,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  double d0 = DimensionType.getTeleportationScale(this.level.dimensionType(), destination.dimensionType());
                  BlockPos blockposition = worldborder.clampToBounds(this.getX() * d0, this.getY(), this.getZ() * d0);
                  // CraftBukkit start

--- a/patches/server/0054-Add-velocity-warnings.patch
+++ b/patches/server/0054-Add-velocity-warnings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add velocity warnings
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 94804f241792bd7067edf0cdbf154ed1533241c3..607f5547d33fd2f8009837fc4a212b5f08a51027 100644
+index 52858c999eb91f11d047364cd0cfbb04bdfd33f2..f99ee2cc0dcadaf06a4edb8c3c5713a0259b9fcb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -288,6 +288,7 @@ public final class CraftServer implements Server {
+@@ -290,6 +290,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -17,7 +17,7 @@ index 94804f241792bd7067edf0cdbf154ed1533241c3..607f5547d33fd2f8009837fc4a212b5f
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 506bc08a7aadf5246f57e6935dbaa81ca482fb9a..78b3be2ea6351cb6375b77340218615aa75b87f5 100644
+index 128d635576b411c7bd6f0f4babb8d22073cc60e8..fa17458b313661d9396e2ed9398d31aacc97a6ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -436,10 +436,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0055-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0055-Configurable-inter-world-teleportation-safety.patch
@@ -30,10 +30,10 @@ index c248b66486044150c64eaddbef85fa6644494212..ada624b5f58381122e59568c2087cf38
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f2b3783373336221c0aef8bae04d350eed0e8ec2..89e22db19a42e9092bb3ee2e5fd01b2e65fd9878 100644
+index 523746b698d38494f0fa76b026d50e3d9d411c54..924260ec220f2f1abfb4383a9787ebad3a25bef1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -923,7 +923,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -930,7 +930,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (fromWorld == toWorld) {
              entity.connection.teleport(to);
          } else {

--- a/patches/server/0061-Complete-resource-pack-API.patch
+++ b/patches/server/0061-Complete-resource-pack-API.patch
@@ -23,18 +23,18 @@ index fed5dcdc62700bd661035011a06788fddec1b2a6..22d77ed6f6c63a4ba77ec582a7ba26b9
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 89e22db19a42e9092bb3ee2e5fd01b2e65fd9878..754d3c4c6aca42e569642a01ab816d5ca653d3fb 100644
+index 924260ec220f2f1abfb4383a9787ebad3a25bef1..a29c20dddb1732a46c05e9ca2386b384b782adab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -137,6 +137,7 @@ import org.bukkit.metadata.MetadataValue;
- import org.bukkit.plugin.Plugin;
+@@ -139,6 +139,7 @@ import org.bukkit.plugin.Plugin;
  import org.bukkit.plugin.messaging.StandardMessenger;
+ import org.bukkit.profile.PlayerProfile;
  import org.bukkit.scoreboard.Scoreboard;
 +import org.jetbrains.annotations.NotNull;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
-@@ -153,6 +154,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -155,6 +156,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private double health = 20;
      private boolean scaledHealth = false;
      private double healthScale = 20;
@@ -45,7 +45,7 @@ index 89e22db19a42e9092bb3ee2e5fd01b2e65fd9878..754d3c4c6aca42e569642a01ab816d5c
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -2000,6 +2005,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2007,6 +2012,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0062-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0062-Default-loading-permissions.yml-before-plugins.patch
@@ -30,10 +30,10 @@ index 701a2ffd04df48d437b2cb963dd150af99725b6e..817d4572c9991992b720b3ba163188ac
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 607f5547d33fd2f8009837fc4a212b5f08a51027..cafb0d40a7bf1a6263cb48c507f51ede0c9cd126 100644
+index f99ee2cc0dcadaf06a4edb8c3c5713a0259b9fcb..014939e87090b9bfc0f15c6c37b79c9aa82439f1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -461,6 +461,7 @@ public final class CraftServer implements Server {
+@@ -464,6 +464,7 @@ public final class CraftServer implements Server {
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
              this.helpMap.initializeGeneralTopics();
@@ -41,7 +41,7 @@ index 607f5547d33fd2f8009837fc4a212b5f08a51027..cafb0d40a7bf1a6263cb48c507f51ede
          }
  
          Plugin[] plugins = this.pluginManager.getPlugins();
-@@ -480,7 +481,7 @@ public final class CraftServer implements Server {
+@@ -483,7 +484,7 @@ public final class CraftServer implements Server {
              this.commandMap.registerServerAliases();
              DefaultPermissions.registerCorePermissions();
              CraftDefaultPermissions.registerCorePermissions();

--- a/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cafb0d40a7bf1a6263cb48c507f51ede0c9cd126..be2e3fc4f670730b6e1fc07eab8c1e612c3270dd 100644
+index 014939e87090b9bfc0f15c6c37b79c9aa82439f1..5573324f2b0e00a83c34abba8b9e9194f6649495 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2492,5 +2492,23 @@ public final class CraftServer implements Server {
+@@ -2510,5 +2510,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0064-Remove-Metadata-on-reload.patch
+++ b/patches/server/0064-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index be2e3fc4f670730b6e1fc07eab8c1e612c3270dd..13cd1fe6cae82fe73bd6df3049133db51da0084c 100644
+index 5573324f2b0e00a83c34abba8b9e9194f6649495..6d55c34fb72c9845fd08215c4b236f1e130bc546 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -966,8 +966,16 @@ public final class CraftServer implements Server {
+@@ -969,8 +969,16 @@ public final class CraftServer implements Server {
              world.paperConfig.init(); // Paper
          }
  

--- a/patches/server/0069-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0069-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -44,10 +44,10 @@ index e94344170190ae9429b744ec7878c3aa093f01b6..e13808657e0c7dc94fcd2844690a31d0
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 754d3c4c6aca42e569642a01ab816d5ca653d3fb..1bae28202288d51a67788b172b9c4e0a4eca2807 100644
+index a29c20dddb1732a46c05e9ca2386b384b782adab..816c39c3ce9ec980cda43b05d040b8da85e9c1f3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1805,6 +1805,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1812,6 +1812,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0084-Workaround-for-setting-passengers-on-players.patch
+++ b/patches/server/0084-Workaround-for-setting-passengers-on-players.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Workaround for setting passengers on players
 SPIGOT-1915 & GH-114
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1bae28202288d51a67788b172b9c4e0a4eca2807..2de322ae6c56129a5db89376e0619ffb56f73ae9 100644
+index 816c39c3ce9ec980cda43b05d040b8da85e9c1f3..e168bc5a3a3dcab404023ebe16ea90e380d6b38c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -933,6 +933,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -940,6 +940,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return true;
      }
  

--- a/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
@@ -67,10 +67,10 @@ index 876658b685ea09adb4c01d436da56daadb7eedaa..5445cb5910ec63408dc4379eec5e12d3
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 13cd1fe6cae82fe73bd6df3049133db51da0084c..a5fe53aaa10bb919888da732fe86123c8e78cd1d 100644
+index 6d55c34fb72c9845fd08215c4b236f1e130bc546..0bcaea6601d8e1adc184464cf7c35b07e947d814 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1723,7 +1723,7 @@ public final class CraftServer implements Server {
+@@ -1726,7 +1726,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0109-Add-EntityZapEvent.patch
+++ b/patches/server/0109-Add-EntityZapEvent.patch
@@ -28,10 +28,10 @@ index e2ac5290751b8c219add3823251e0131c0d2b52e..8785a112519de49e0d61eab5ab5325f9
              entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
              entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 57c7ee1329d80fb441a4637f309d69fa120fae01..cad2a30665e059ab9f0be3f94876d332ccb29178 100644
+index 2a3853201a6ccf14b2aab67982de7789e0cbc552..b94d6c79adc0858a588778b5ebf9f5e7f97f9050 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1142,6 +1142,14 @@ public class CraftEventFactory {
+@@ -1152,6 +1152,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a5fe53aaa10bb919888da732fe86123c8e78cd1d..1bfd0cb76ccd8c7e1947407a865e7be7bfa35b3a 100644
+index 0bcaea6601d8e1adc184464cf7c35b07e947d814..25dee99ced88f65d465ed1087e38abf55c8d1036 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2518,5 +2518,24 @@ public final class CraftServer implements Server {
+@@ -2536,5 +2536,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index 687904d3e1b3ee7b514c707d9b2eeccabbf56603..f7cbe6819b8c4f7eaca2389de8eaceb5
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cad2a30665e059ab9f0be3f94876d332ccb29178..16f1bac14758d5052effb3aadece9b00d8bc7752 100644
+index b94d6c79adc0858a588778b5ebf9f5e7f97f9050..20e5da655a76ce2024cbbfa00ce4dc924c6cedd0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1101,6 +1101,17 @@ public class CraftEventFactory {
+@@ -1111,6 +1111,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0115-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0115-Add-ProjectileCollideEvent.patch
@@ -87,10 +87,10 @@ index 88181c59e604ba3b132b9e695cef5eaf5b836029..94d09b05737679b133ec462815b010b1
  
          this.checkInsideBlocks();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 16f1bac14758d5052effb3aadece9b00d8bc7752..d93e79ab1a3b16bfc75209cb0b5e2e9fade35d86 100644
+index 20e5da655a76ce2024cbbfa00ce4dc924c6cedd0..23a53f0c287fea7ddf45f807ae642ba4e5acb7b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1245,6 +1245,16 @@ public class CraftEventFactory {
+@@ -1255,6 +1255,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/patches/server/0122-String-based-Action-Bar-API.patch
+++ b/patches/server/0122-String-based-Action-Bar-API.patch
@@ -26,10 +26,10 @@ index 32ef3edebe94a2014168b7e438752a80b2687e5f..ab6c58eed6707ab7b0aa3e7549a871ad
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2de322ae6c56129a5db89376e0619ffb56f73ae9..366d0ee7bc8dec667907674972785491723790f8 100644
+index e168bc5a3a3dcab404023ebe16ea90e380d6b38c..e7798e4fbfd0b9e882356e6df30ada0e1b174c56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -260,6 +260,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -267,6 +267,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      // Paper start

--- a/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -8,10 +8,10 @@ Adds lots of information about why this orb exists.
 Replaces isFromBottle() with logic that persists entity reloads too.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 15220779927ff722960401643e99971833fc5704..2869d9bb0d374c26f9569eef3ecf0480cbaa85a6 100644
+index 252613e3c4c496bd4f6fd061e36fac06c32323c9..12c9efc409e5306fb24b8338d4c60286cff1435c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -414,7 +414,7 @@ public class ServerPlayerGameMode {
+@@ -416,7 +416,7 @@ public class ServerPlayerGameMode {
  
                  // Drop event experience
                  if (flag && event != null) {

--- a/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -20,10 +20,10 @@ index 5e23ff0c5e44427a996281ae42fc12c28649e158..7a69f9d9bb9c05474d8fbab22d626529
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1bfd0cb76ccd8c7e1947407a865e7be7bfa35b3a..9bd1dac354a14735c3547215f85f1124c933f311 100644
+index 25dee99ced88f65d465ed1087e38abf55c8d1036..d1739c23b83d4c1515a45305939a46821c57cc78 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2537,5 +2537,10 @@ public final class CraftServer implements Server {
+@@ -2555,5 +2555,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -112,7 +112,7 @@ index 0000000000000000000000000000000000000000..685deaa0e5d1ddc13e3a7c0471b1cfcf
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0cf83ee46754197b2b639d07bff9a0d21566a641..123da97204af4bb40f98e09a5102227fb1359fd2 100644
+index 74792811da877dc59c25af5e46e3ab570895b6b6..c3e4aa076e2be77e5a48a4f0a12f26e67ea06476 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -9,6 +9,7 @@ import com.mojang.authlib.GameProfile;
@@ -244,7 +244,7 @@ index e47642c3164f7f7a358d2c7a9722643acf3e0089..dc891a463ec24b0b1b4c6c00b2c199e7
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9bd1dac354a14735c3547215f85f1124c933f311..0fd04a4371525d6655c5a6f24c097c55914cd225 100644
+index d1739c23b83d4c1515a45305939a46821c57cc78..183dc9fa714db22a8b37976445208b8cf1ae629b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -49,7 +49,6 @@ import java.util.logging.Level;
@@ -263,7 +263,7 @@ index 9bd1dac354a14735c3547215f85f1124c933f311..0fd04a4371525d6655c5a6f24c097c55
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.bossevents.CustomBossEvent;
  import net.minecraft.server.commands.ReloadCommand;
-@@ -1308,9 +1308,13 @@ public final class CraftServer implements Server {
+@@ -1311,9 +1311,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  
@@ -278,7 +278,7 @@ index 9bd1dac354a14735c3547215f85f1124c933f311..0fd04a4371525d6655c5a6f24c097c55
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 60ccdf33a014f3488353045e30526bc3f16e93c5..a19d5abb8188e2fd2382b9b42d65fa7a8c3d1799 100644
+index c73d785fce285d4f8eeb6f763ece21c4493071a4..77c065d74ae84f8e003141f050fe01ae582ae44c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,7 +12,7 @@ import java.util.logging.Level;

--- a/patches/server/0142-Add-UnknownCommandEvent.patch
+++ b/patches/server/0142-Add-UnknownCommandEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0fd04a4371525d6655c5a6f24c097c55914cd225..7a96dd337c41cdfa7703de4b21380a4fce0198c8 100644
+index 183dc9fa714db22a8b37976445208b8cf1ae629b..06dde9aa461f0e8da8abab829d0a760760260b19 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -879,7 +879,13 @@ public final class CraftServer implements Server {
+@@ -882,7 +882,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -491,10 +491,10 @@ index 00f783aafd81fa7e836e4eea5bfeac7434f33b0f..3789441e2df9410aa1c6efe59054aaba
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7a96dd337c41cdfa7703de4b21380a4fce0198c8..def56e6c17d6e2efddcdca22e391f11b2de58966 100644
+index 06dde9aa461f0e8da8abab829d0a760760260b19..d06cb616c95abaaab52bb01b36709138702908a9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -249,6 +249,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -251,6 +251,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
@@ -504,7 +504,7 @@ index 7a96dd337c41cdfa7703de4b21380a4fce0198c8..def56e6c17d6e2efddcdca22e391f11b
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2552,5 +2555,24 @@ public final class CraftServer implements Server {
+@@ -2570,5 +2573,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
@@ -530,10 +530,10 @@ index 7a96dd337c41cdfa7703de4b21380a4fce0198c8..def56e6c17d6e2efddcdca22e391f11b
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 9405812b8c308d70de1e26ba55500301b24ecc3c..490df0dcfd0e1e0ab05943410493522f86444ef8 100644
+index eda37a7622748feef782b54235070c04f3c714f8..b3b817893fdc840b01bbdbf95ab52d31744f3e4e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -80,6 +80,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -87,6 +87,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      }
  
      private void setProfile(GameProfile profile) {

--- a/patches/server/0152-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0152-Fix-this-stupid-bullshit.patch
@@ -31,12 +31,12 @@ index bf42e5687935022fe5bcb1ed40bab09bfe189e88..b111200a8f5d3255de29c9836f70fc7f
              Bootstrap.isBootstrapped = true;
              if (Registry.REGISTRY.keySet().isEmpty()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index a19d5abb8188e2fd2382b9b42d65fa7a8c3d1799..a87a6583a1bd31a276a79c2cfb3c3ca4e749c3dc 100644
+index 77c065d74ae84f8e003141f050fe01ae582ae44c..6f86aa59fa8bcf1b340d7207c5b2be46678c96ec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -234,10 +234,12 @@ public class Main {
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -14);
+                     deadline.add(Calendar.DAY_OF_YEAR, -28);
                      if (buildDate.before(deadline.getTime())) {
 -                        System.err.println("*** Error, this build is outdated ***");
 +                        // Paper start - This is some stupid bullshit

--- a/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
@@ -90,10 +90,10 @@ index 27d304316bec097fea4b950cb4e0ac80cb219f70..85fea9b0bf84a8b40098f35eac503070
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 366d0ee7bc8dec667907674972785491723790f8..32089b74ec209abebd7ec42ac432c10eb7cbff86 100644
+index e7798e4fbfd0b9e882356e6df30ada0e1b174c56..5cd36bb3b83cd553bc16f5f24f7ece07d5003ff9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -204,6 +204,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -211,6 +211,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -14,7 +14,7 @@ completion, such as offline players.
 Also adds isCommand and getLocation to the sync TabCompleteEvent
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ed2cbef0a1211fe5330d4d059657c7460fc2bc8d..b64bf84751e0437e26fcebdc35dd53069b9f2551 100644
+index 03cebeadf5f1e3a5e12447343c0dc048d12bc138..0240221d4415df8ac8cbcf2fd0c4118d97500620 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -703,10 +703,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -72,10 +72,10 @@ index ed2cbef0a1211fe5330d4d059657c7460fc2bc8d..b64bf84751e0437e26fcebdc35dd5306
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index def56e6c17d6e2efddcdca22e391f11b2de58966..70c12364dad4426a55e3a79c642af9be4d9212d7 100644
+index d06cb616c95abaaab52bb01b36709138702908a9..ce792b63608b76c53546bff8dcf74b1e78842732 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2072,7 +2072,7 @@ public final class CraftServer implements Server {
+@@ -2090,7 +2090,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 32089b74ec209abebd7ec42ac432c10eb7cbff86..45914c7cf1ae300c47a43b23bcf868bbb96d911b 100644
+index 5cd36bb3b83cd553bc16f5f24f7ece07d5003ff9..6eaf970663bf5de9ea30db879e135c5e06238b41 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1249,7 +1249,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1256,7 +1256,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override

--- a/patches/server/0174-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/patches/server/0174-Add-setPlayerProfile-API-for-Skulls.patch
@@ -7,7 +7,7 @@ This allows you to create already filled textures on Skulls to avoid texture loo
 which commonly cause rate limit issues with Mojang API
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
-index d6a4638271644e31fbc38f5ae9150ded63a6d62f..e89eb5d631b4226d79caf49c89ebb44155e72a0f 100644
+index 6ac03706a584e4cb07300cf6e34969a8c4595c58..5f53767c3a2448c648fa32e055acd15f1058ef56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
 @@ -1,5 +1,7 @@
@@ -18,7 +18,7 @@ index d6a4638271644e31fbc38f5ae9150ded63a6d62f..e89eb5d631b4226d79caf49c89ebb441
  import com.google.common.base.Preconditions;
  import com.mojang.authlib.GameProfile;
  import net.minecraft.server.MinecraftServer;
-@@ -100,6 +102,20 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
+@@ -102,6 +104,20 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
          }
      }
  
@@ -37,10 +37,10 @@ index d6a4638271644e31fbc38f5ae9150ded63a6d62f..e89eb5d631b4226d79caf49c89ebb441
 +    // Paper end
 +
      @Override
-     public BlockFace getRotation() {
-         BlockData blockData = getBlockData();
+     public PlayerProfile getOwnerProfile() {
+         if (!this.hasOwner()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 490df0dcfd0e1e0ab05943410493522f86444ef8..7cacc61fed0c610845c67894d1cc68e44f5e46fe 100644
+index b3b817893fdc840b01bbdbf95ab52d31744f3e4e..59b3404e566df1f57660d603f8f771e86f321f62 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 @@ -4,10 +4,8 @@ import com.google.common.collect.ImmutableMap.Builder;
@@ -56,9 +56,9 @@ index 490df0dcfd0e1e0ab05943410493522f86444ef8..7cacc61fed0c610845c67894d1cc68e4
  import org.bukkit.Bukkit;
  import org.bukkit.Material;
  import org.bukkit.OfflinePlayer;
-@@ -18,6 +16,11 @@ import org.bukkit.craftbukkit.inventory.CraftMetaItem.SerializableMeta;
- import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+@@ -20,6 +18,11 @@ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
  import org.bukkit.inventory.meta.SkullMeta;
+ import org.bukkit.profile.PlayerProfile;
  
 +import javax.annotation.Nullable;
 +import net.minecraft.nbt.CompoundTag;
@@ -68,7 +68,7 @@ index 490df0dcfd0e1e0ab05943410493522f86444ef8..7cacc61fed0c610845c67894d1cc68e4
  @DelegateDeserialization(SerializableMeta.class)
  class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
  
-@@ -151,6 +154,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -158,6 +161,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          return this.hasOwner() ? this.profile.getName() : null;
      }
  

--- a/patches/server/0178-Extend-Player-Interact-cancellation.patch
+++ b/patches/server/0178-Extend-Player-Interact-cancellation.patch
@@ -13,7 +13,7 @@ Update adjacent blocks of doors, double plants, pistons and beds
 when cancelling interaction.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 2869d9bb0d374c26f9569eef3ecf0480cbaa85a6..1d1f355a49e2324902feee10c1717fd772e359c6 100644
+index 12c9efc409e5306fb24b8338d4c60286cff1435c..3ef782b69b9f21d12b1ef214e77bc8af8a94970b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -186,6 +186,11 @@ public class ServerPlayerGameMode {
@@ -28,7 +28,7 @@ index 2869d9bb0d374c26f9569eef3ecf0480cbaa85a6..1d1f355a49e2324902feee10c1717fd7
                      this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
                      // Update any tile entity data for this block
                      BlockEntity tileentity = this.level.getBlockEntity(pos);
-@@ -501,7 +506,13 @@ public class ServerPlayerGameMode {
+@@ -503,7 +508,13 @@ public class ServerPlayerGameMode {
  
                  // send a correcting update to the client for the block above as well, this because of replaceable blocks (such as grass, sea grass etc)
                  player.connection.send(new ClientboundBlockUpdatePacket(world, blockposition.above()));

--- a/patches/server/0184-Player.setPlayerProfile-API.patch
+++ b/patches/server/0184-Player.setPlayerProfile-API.patch
@@ -26,7 +26,7 @@ index 00ef714294b6cce5fec7613eed4ba228a48e3e11..67b300574655854249c1f7440f56a6e8
                              uniqueId = gameProfile.getId();
                              // Paper end
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 45914c7cf1ae300c47a43b23bcf868bbb96d911b..096bd762a7e52230118f14bc839a87ecf437837c 100644
+index 6eaf970663bf5de9ea30db879e135c5e06238b41..aea5a7e874924a3f8c267d47cf97f89603593069 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -72,6 +72,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -37,7 +37,7 @@ index 45914c7cf1ae300c47a43b23bcf868bbb96d911b..096bd762a7e52230118f14bc839a87ec
  import net.minecraft.world.level.block.entity.SignBlockEntity;
  import net.minecraft.world.level.saveddata.maps.MapDecoration;
  import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
-@@ -1382,8 +1383,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1389,8 +1390,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.hiddenEntities.put(entity.getUniqueId(), hidingPlugins);
  
          // Remove this entity from the hidden player's EntityTrackerEntry
@@ -54,7 +54,7 @@ index 45914c7cf1ae300c47a43b23bcf868bbb96d911b..096bd762a7e52230118f14bc839a87ec
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1396,8 +1404,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1403,8 +1411,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  this.getHandle().connection.send(new ClientboundPlayerInfoPacket(ClientboundPlayerInfoPacket.Action.REMOVE_PLAYER, otherPlayer));
              }
          }
@@ -63,7 +63,7 @@ index 45914c7cf1ae300c47a43b23bcf868bbb96d911b..096bd762a7e52230118f14bc839a87ec
      }
  
      @Override
-@@ -1434,8 +1440,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1441,8 +1447,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          this.hiddenEntities.remove(entity.getUniqueId());
  
@@ -80,7 +80,7 @@ index 45914c7cf1ae300c47a43b23bcf868bbb96d911b..096bd762a7e52230118f14bc839a87ec
  
          if (other instanceof ServerPlayer) {
              ServerPlayer otherPlayer = (ServerPlayer) other;
-@@ -1446,9 +1459,51 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1453,9 +1466,51 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (entry != null && !entry.seenBy.contains(this.getHandle().connection)) {
              entry.updatePlayer(this.getHandle());
          }

--- a/patches/server/0185-getPlayerUniqueId-API.patch
+++ b/patches/server/0185-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 70c12364dad4426a55e3a79c642af9be4d9212d7..e4424e15d28c7011f2dd708f9d7bbb05b25be688 100644
+index ce792b63608b76c53546bff8dcf74b1e78842732..bdc9effc918a0f6be181cd93738af7911d749e8b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1725,6 +1725,25 @@ public final class CraftServer implements Server {
+@@ -1728,6 +1728,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0190-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0190-Flag-to-disable-the-channel-limit.patch
@@ -9,10 +9,10 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5f86cddc176b6205768653a901825e53f10dcae0..b3aa2358a5379aa1d552de9aa7fc2e0c826d05e7 100644
+index aea5a7e874924a3f8c267d47cf97f89603593069..b0da9113bc73b648e2ce275ee92e80fbde1d7a37 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -158,6 +158,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -160,6 +160,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper start
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
@@ -20,7 +20,7 @@ index 5f86cddc176b6205768653a901825e53f10dcae0..b3aa2358a5379aa1d552de9aa7fc2e0c
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1703,7 +1704,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1710,7 +1711,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0219-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0219-InventoryCloseEvent-Reason-API.patch
@@ -174,10 +174,10 @@ index c0ed3dd9ebcaf710d202ae8b38007e6a1f20b57e..adfbc156b4c4a8591609f385adaa6b04
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b3aa2358a5379aa1d552de9aa7fc2e0c826d05e7..5ae1387341c0003f1677e139a94b658c6116c18c 100644
+index b0da9113bc73b648e2ce275ee92e80fbde1d7a37..d20d98b98349d875709034a4df2c87956be4d5b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -957,7 +957,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -964,7 +964,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {
@@ -187,10 +187,10 @@ index b3aa2358a5379aa1d552de9aa7fc2e0c826d05e7..5ae1387341c0003f1677e139a94b658c
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d93e79ab1a3b16bfc75209cb0b5e2e9fade35d86..f84669c550c7571fb3df431ab850b7d624739dcd 100644
+index 23a53f0c287fea7ddf45f807ae642ba4e5acb7b9..7964fd169c393c4d3e595d6722f8f29658a27490 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1214,7 +1214,7 @@ public class CraftEventFactory {
+@@ -1224,7 +1224,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -199,7 +199,7 @@ index d93e79ab1a3b16bfc75209cb0b5e2e9fade35d86..f84669c550c7571fb3df431ab850b7d6
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1380,8 +1380,18 @@ public class CraftEventFactory {
+@@ -1390,8 +1390,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0231-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0231-Vanished-players-don-t-have-rights.patch
@@ -99,10 +99,10 @@ index b91b2c2336b40c2332e59c3f24e36ca6083ce3bd..c239a71a9d864107c3a8e9537e4160c5
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f84669c550c7571fb3df431ab850b7d624739dcd..151039f67a2233d501bbe405f470bb38cabe390f 100644
+index 7964fd169c393c4d3e595d6722f8f29658a27490..658c656c32ebab5b84837473930d4f0680fc45ba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1250,6 +1250,14 @@ public class CraftEventFactory {
+@@ -1260,6 +1260,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0237-Add-hand-to-bucket-events.patch
+++ b/patches/server/0237-Add-hand-to-bucket-events.patch
@@ -86,10 +86,10 @@ index 25f1567660682a122fcb63318f51ec45ffdf0d3b..5406acd65d4e1146f3bd7340ff9a1954
                  int i = blockposition.getX();
                  int j = blockposition.getY();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4faf98079a6a6af662e11050a0088578ba65a5eb..0d1c6f609a5198c21c895e8f6ace467355b0f166 100644
+index 658c656c32ebab5b84837473930d4f0680fc45ba..a1529301e4abcafa79d04b9819cf40a05febcac4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -421,6 +421,20 @@ public class CraftEventFactory {
+@@ -422,6 +422,20 @@ public class CraftEventFactory {
      }
  
      private static PlayerEvent getPlayerBucketEvent(boolean isFilling, ServerLevel world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, net.minecraft.world.item.Item item) {
@@ -110,7 +110,7 @@ index 4faf98079a6a6af662e11050a0088578ba65a5eb..0d1c6f609a5198c21c895e8f6ace4673
          Player player = (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);
          Material bucket = CraftMagicNumbers.getMaterial(itemstack.getItem());
-@@ -433,10 +447,10 @@ public class CraftEventFactory {
+@@ -434,10 +448,10 @@ public class CraftEventFactory {
  
          PlayerEvent event;
          if (isFilling) {

--- a/patches/server/0243-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0243-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -36,7 +36,7 @@ index 00dd9dab2b19f3e49f3b41c20eb96a84bfae1769..d9114c5fa141c37270398100db6bb2a8
      public static int tabSpamLimit = 500;
      private static void tabSpamLimiters() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f6050e8ee4b43e0405933f6f7f0c234978c0639e..d42db22e74e36a8a701a322c7bac5c73a7675508 100644
+index e89f100e950c6fa85112a67daaa157de665b17cf..37ccbfc3b5ff47fac8cd878f9de5bccec84994e5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1085,6 +1085,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -48,10 +48,10 @@ index f6050e8ee4b43e0405933f6f7f0c234978c0639e..d42db22e74e36a8a701a322c7bac5c73
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e4424e15d28c7011f2dd708f9d7bbb05b25be688..93eed255771097a396b1148e67d99a581be676c4 100644
+index bdc9effc918a0f6be181cd93738af7911d749e8b..99f058892b97431a876fc0c184a53b7a72dcc856 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -897,6 +897,7 @@ public final class CraftServer implements Server {
+@@ -900,6 +900,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -59,7 +59,7 @@ index e4424e15d28c7011f2dd708f9d7bbb05b25be688..93eed255771097a396b1148e67d99a58
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -1015,6 +1016,7 @@ public final class CraftServer implements Server {
+@@ -1018,6 +1019,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));
@@ -68,7 +68,7 @@ index e4424e15d28c7011f2dd708f9d7bbb05b25be688..93eed255771097a396b1148e67d99a58
  
      @Override
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index 682f0b57ed131d9c0c50941bf733731f63c8f861..5097623eee5c1c9412f0c4a14f70b93e21ea295e 100644
+index b53e6955f35e1308814cdb31a5fa5f4d0c49493c..6f7b34f03e0d151e4da652b9ad73e0d7930fe5d3 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -229,7 +229,7 @@ public class SpigotConfig

--- a/patches/server/0259-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0259-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5ae1387341c0003f1677e139a94b658c6116c18c..90053c916f609a4316e91e8093c12166010d7417 100644
+index d20d98b98349d875709034a4df2c87956be4d5b7..a5a9f1bc50bc93a5d9714ac48eb90cc841af5d78 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2400,6 +2400,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2407,6 +2407,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0260-Improve-death-events.patch
+++ b/patches/server/0260-Improve-death-events.patch
@@ -295,10 +295,10 @@ index 91cf7728aee475cb36f2c02bbfb7e3d2e0d00576..a3a900d10440ed5ebe24370a77ccb6ca
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 90053c916f609a4316e91e8093c12166010d7417..c270bf19cdba50d83dafe2c5ab55422cb74dd902 100644
+index a5a9f1bc50bc93a5d9714ac48eb90cc841af5d78..af972e0145e120378de1ad4e0bace6470cbb9c08 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1963,7 +1963,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1970,7 +1970,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {
@@ -315,10 +315,10 @@ index 90053c916f609a4316e91e8093c12166010d7417..c270bf19cdba50d83dafe2c5ab55422c
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 016912c8b3fe0158d144b78f71b704972950f5b6..4b26540cda951cb46ac2833a60ce6cf06f483bff 100644
+index a1529301e4abcafa79d04b9819cf40a05febcac4..5ccf7f5d0c748de6ff1f996089f4db99d39d6dfb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -807,9 +807,16 @@ public class CraftEventFactory {
+@@ -817,9 +817,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -335,7 +335,7 @@ index 016912c8b3fe0158d144b78f71b704972950f5b6..4b26540cda951cb46ac2833a60ce6cf0
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -826,8 +833,15 @@ public class CraftEventFactory {
+@@ -836,8 +843,15 @@ public class CraftEventFactory {
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
@@ -351,7 +351,7 @@ index 016912c8b3fe0158d144b78f71b704972950f5b6..4b26540cda951cb46ac2833a60ce6cf0
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -844,6 +858,31 @@ public class CraftEventFactory {
+@@ -854,6 +868,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0278-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0278-Add-Velocity-IP-Forwarding-Support.patch
@@ -225,10 +225,10 @@ index 67b300574655854249c1f7440f56a6e8f0fad351..bb767f5b626225e70a8af273384bb74d
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 93eed255771097a396b1148e67d99a581be676c4..589af624599aee8f08f786da183f5e058f2044cc 100644
+index 99f058892b97431a876fc0c184a53b7a72dcc856..0fd6e7dfc43ea1211a93dea58d09522ac2d4a617 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -765,7 +765,7 @@ public final class CraftServer implements Server {
+@@ -768,7 +768,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0290-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0290-Make-the-default-permission-message-configurable.patch
@@ -42,10 +42,10 @@ index edf0a82ba7e16b86100aa1920fa41508be2ab1e8..c48b175d5511b733bcff9a93a874f5ff
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 589af624599aee8f08f786da183f5e058f2044cc..3a82ffd3286bf84529825b9ed805d31ef521f64a 100644
+index 0fd6e7dfc43ea1211a93dea58d09522ac2d4a617..f6af9da5b4b6ae826f0861183553e6ce28e56a7c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2577,6 +2577,11 @@ public final class CraftServer implements Server {
+@@ -2595,6 +2595,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  

--- a/patches/server/0298-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0298-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -40,10 +40,10 @@ index e1603b674823067a55faa12e716b695171b31d32..73dd4776fee3429c42b279ab92050a4b
          GameProfileCache usercache = this.server.getProfileCache();
          Optional<GameProfile> optional = usercache.get(gameprofile.getId());
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
-index c7e4c6d29378675b76ebb179022ddbb02831a1dc..88bc0807e8bf66a65422f85f1112336334eb3de2 100644
+index f6665825e62a0cd912e6b06df6d68795596486f0..1f2bc88d4570c6ef00e67a772b745e0b0c98e051 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
-@@ -244,6 +244,61 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
+@@ -247,6 +247,61 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
          return this.getData() != null;
      }
  
@@ -106,10 +106,10 @@ index c7e4c6d29378675b76ebb179022ddbb02831a1dc..88bc0807e8bf66a65422f85f11123363
      public Location getBedSpawnLocation() {
          CompoundTag data = this.getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c270bf19cdba50d83dafe2c5ab55422cb74dd902..3a439a1dd3e3ad05767876ce9546fe5ec4505e00 100644
+index af972e0145e120378de1ad4e0bace6470cbb9c08..8545fe9ac633b6a5a7b92fffd7a95e435a6be68f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -159,6 +159,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -161,6 +161,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
      private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
@@ -117,7 +117,7 @@ index c270bf19cdba50d83dafe2c5ab55422cb74dd902..3a439a1dd3e3ad05767876ce9546fe5e
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1575,6 +1576,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1582,6 +1583,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index c270bf19cdba50d83dafe2c5ab55422cb74dd902..3a439a1dd3e3ad05767876ce9546fe5e
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1597,6 +1610,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1604,6 +1617,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index c270bf19cdba50d83dafe2c5ab55422cb74dd902..3a439a1dd3e3ad05767876ce9546fe5e
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1611,6 +1626,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1618,6 +1633,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0300-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0300-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3a439a1dd3e3ad05767876ce9546fe5ec4505e00..c6fa202d8353975d196b6e9cd5848fbed238a52f 100644
+index 8545fe9ac633b6a5a7b92fffd7a95e435a6be68f..8891fc9bd31d3ad6cb9217a11390d3c62863a538 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2447,6 +2447,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2454,6 +2454,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0324-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0324-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -16,7 +16,7 @@ handling that should have been handled synchronously will be handled
 synchronously when the server gets shut down.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index bc9937642a46ecd766a45ccb037de993dafa3608..bd8e654c1580a0ac7dd411b9f1dcad4a20d1d3e5 100644
+index d7048f7f05e67581ed3be28d452fbe52f4c980cf..b3c4687c6538adf851379f73cceffb114820507b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2287,7 +2287,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -29,10 +29,10 @@ index bc9937642a46ecd766a45ccb037de993dafa3608..bd8e654c1580a0ac7dd411b9f1dcad4a
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3a82ffd3286bf84529825b9ed805d31ef521f64a..9b8d39e3f323829286d06d07cc7303e6fdc1bad8 100644
+index f6af9da5b4b6ae826f0861183553e6ce28e56a7c..dbaabc0be57a4d46645d9c7e30ec8b3d6364965e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2061,7 +2061,7 @@ public final class CraftServer implements Server {
+@@ -2079,7 +2079,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0331-Expose-the-internal-current-tick.patch
+++ b/patches/server/0331-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9b8d39e3f323829286d06d07cc7303e6fdc1bad8..91ef1b0e06c30668fe4bfb18ecdf2fe499f72fee 100644
+index dbaabc0be57a4d46645d9c7e30ec8b3d6364965e..c3707e3311ef406ab3f9c6030c4d830307e9f887 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2600,5 +2600,10 @@ public final class CraftServer implements Server {
+@@ -2618,5 +2618,10 @@ public final class CraftServer implements Server {
          }
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
      }

--- a/patches/server/0360-Anti-Xray.patch
+++ b/patches/server/0360-Anti-Xray.patch
@@ -1192,7 +1192,7 @@ index 83c5b111b98e52f52b7e4cf607aac07be7043709..be75691d91b3559788365da2b813ea3c
          this.convertable = convertable_conversionsession;
          this.uuid = WorldUUID.getUUID(convertable_conversionsession.levelPath.toFile());
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index d0b54ebc05cac6535a023709c76efd802f7150f9..d87ee258db769bc072cbdae4298ebc08588b2160 100644
+index abc7b15976131dc840f40258ed5cc4ef88c27815..391e20c284b24f6c5fe446fd6a2c677214ed15c5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -48,7 +48,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
@@ -1204,7 +1204,7 @@ index d0b54ebc05cac6535a023709c76efd802f7150f9..d87ee258db769bc072cbdae4298ebc08
      protected final ServerPlayer player;
      private GameType gameModeForPlayer;
      @Nullable
-@@ -314,6 +314,8 @@ public class ServerPlayerGameMode {
+@@ -316,6 +316,8 @@ public class ServerPlayerGameMode {
              }
  
          }
@@ -1596,10 +1596,10 @@ index a1fe076d76fe5f84eca39ea68e9820096f58f5a7..155933ef7c324ea17c2349a1f73ede29
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 91ef1b0e06c30668fe4bfb18ecdf2fe499f72fee..36b7de78fa69f652079d74252286bb6df68cf0c6 100644
+index c3707e3311ef406ab3f9c6030c4d830307e9f887..cea40a607e1f981a11a5837613ed9de05eaf4e3c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2216,7 +2216,7 @@ public final class CraftServer implements Server {
+@@ -2234,7 +2234,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Validate.notNull(world, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();

--- a/patches/server/0363-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0363-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 62f19eafbb650dfbfac31c320e4883149d327e43..ae0ae298ff7ae129959ff6e4024eb7060c0786e4 100644
+index 344719bfe08bffe7012609fce64d73c467934d09..82f5f9f6f97551ac7182c68f00f5471cf7d2269f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3028,6 +3028,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3034,6 +3034,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              if (flag1) {
                  blockposition1 = ServerLevel.END_SPAWN_POINT;
              } else {

--- a/patches/server/0374-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/patches/server/0374-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b4032ce470346915251d85d1aa7375a116efe771..aaea18e64db3851f98a7a391d9f9bb265d659d99 100644
+index 5ccf7f5d0c748de6ff1f996089f4db99d39d6dfb..550e30bfbdcf1ae0adf2cc68e3ae3d3dd4faad56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -344,13 +344,18 @@ public class CraftEventFactory {
+@@ -345,13 +345,18 @@ public class CraftEventFactory {
          }
  
          org.bukkit.inventory.ItemStack item;

--- a/patches/server/0381-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0381-Add-tick-times-API-and-mspt-command.patch
@@ -87,7 +87,7 @@ index e683e5bf47abe7bd3d2f7e9811a377549308ded4..c20fe23174d8a12bfc5acb4b0e947c6f
          version = getInt("config-version", 24);
          set("config-version", 24);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b3d3e023d10fe6bb964fe7a3d1cbb96d6a406283..51b8b23892d9a57c1502a7cd9dbde033bae1ff03 100644
+index 76da16590f27702883c07200a02db823d9720c61..3c2af39f7bd62448a3075d327132ebc19af6bd77 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -245,6 +245,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -146,10 +146,10 @@ index b3d3e023d10fe6bb964fe7a3d1cbb96d6a406283..51b8b23892d9a57c1502a7cd9dbde033
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 36b7de78fa69f652079d74252286bb6df68cf0c6..fc51c094b4eb2ec6cc79a649f3a3aec8c44b915a 100644
+index cea40a607e1f981a11a5837613ed9de05eaf4e3c..17698e6b3c3fa464b1bf035ce13bee805abfee58 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2438,6 +2438,16 @@ public final class CraftServer implements Server {
+@@ -2456,6 +2456,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0382-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0382-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fc51c094b4eb2ec6cc79a649f3a3aec8c44b915a..7764e78ad23ca196bcc621bb1cb895a8e5763c82 100644
+index 17698e6b3c3fa464b1bf035ce13bee805abfee58..8ba1e6012bb9195f2c600501465b92f83cc9495c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2615,5 +2615,10 @@ public final class CraftServer implements Server {
+@@ -2633,5 +2633,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0393-Improved-Watchdog-Support.patch
+++ b/patches/server/0393-Improved-Watchdog-Support.patch
@@ -71,7 +71,7 @@ index c54530d1c66845b190a9cb6d06f985943bb4dbe1..35c9b3e6c5a2d11b4dbd491b16647df1
              cause = cause.getCause();
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 51b8b23892d9a57c1502a7cd9dbde033bae1ff03..7049126dabd8bd497b7a63f8b0980e0252638c23 100644
+index 3c2af39f7bd62448a3075d327132ebc19af6bd77..af7bc83f4a232489874f69dc2814b2c063bbb7eb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -298,7 +298,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -262,7 +262,7 @@ index 049eb5693dc98e1d0ec3bd88c73a41fdb2f59bff..0716aaf29f9d76240a0de4ca02daba44
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index ed4b4c3d3d991716078d5f008bf4665e76b30f33..4cb7e63b433b8d4a02c2d193a2596e51ddab2779 100644
+index 15792e281056b1022d457b36646d3473b7c4717c..e391894e95b00a6f9a9acdb76af05fcd3eb0a2c1 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -535,6 +535,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -323,10 +323,10 @@ index 8cfe47012b78eb582afff23ffcf758ca2e9dec95..d70bdf21dd7bdf01b34d0fd38e79f9b3
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7764e78ad23ca196bcc621bb1cb895a8e5763c82..fbdc39181ea3074c2b2e3a877a59afafd02fe3c9 100644
+index 8ba1e6012bb9195f2c600501465b92f83cc9495c..57e0a45aa2e8c14ad8849c92b6e97c1a82381c53 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2061,7 +2061,7 @@ public final class CraftServer implements Server {
+@@ -2079,7 +2079,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {
@@ -336,7 +336,7 @@ index 7764e78ad23ca196bcc621bb1cb895a8e5763c82..fbdc39181ea3074c2b2e3a877a59afaf
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index e3b2b61e5f030080e481dc00d1086f723b8b97ee..a5f8554e2cd43774b1978dce659062d9c7e7dbda 100644
+index fce5539a8eaa98f433ad65e26ef6027a15e82fb4..cbd58b1a34a8151403033322971c09c2703fe845 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,6 +12,8 @@ import java.util.logging.Level;

--- a/patches/server/0400-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0400-Implement-Player-Client-Options-API.patch
@@ -97,10 +97,10 @@ index 9cbca14b0a111e57a1d01bcbcf2164ab8b53b1a5..cdb0eb8e21299ca70ed7ed5c1195d07f
          if (getMainArm() != packet.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c6fa202d8353975d196b6e9cd5848fbed238a52f..62341d1c88d6595fa27e70985abb42f2521235cf 100644
+index 8891fc9bd31d3ad6cb9217a11390d3c62863a538..d43c2fefdf6030fdf0d8f72b413cb4d1d4871d3d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -549,6 +549,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -556,6 +556,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setSendViewDistance(int viewDistance) {
          throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }

--- a/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,7 +16,7 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c8fb6387fb3ac2849a399b2ab1f30158aa734827..a02eb37845e0609ddf14a4214395e00443534b08 100644
+index 6fa35e0acd966a9cfd3d5b3765c7d0130ea2de18..7bf62752b6604abe0bda6f5d0024f0e93efb3a9a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2162,11 +2162,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -47,7 +47,7 @@ index c8fb6387fb3ac2849a399b2ab1f30158aa734827..a02eb37845e0609ddf14a4214395e004
          if (this.level instanceof ServerLevel && !this.isRemoved()) {
              this.level.getProfiler().push("changeDimension");
              // CraftBukkit start
-@@ -2939,6 +2946,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2945,6 +2952,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  // CraftBukkit end
  
                  this.level.getProfiler().popPush("reloading");
@@ -59,7 +59,7 @@ index c8fb6387fb3ac2849a399b2ab1f30158aa734827..a02eb37845e0609ddf14a4214395e004
                  Entity entity = this.getType().create(worldserver);
  
                  if (entity != null) {
-@@ -2952,10 +2964,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2958,10 +2970,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index c8fb6387fb3ac2849a399b2ab1f30158aa734827..a02eb37845e0609ddf14a4214395e004
                      // CraftBukkit end
                  }
  
-@@ -3077,7 +3085,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3083,7 +3091,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public boolean canChangeDimensions() {
@@ -135,10 +135,10 @@ index a3a900d10440ed5ebe24370a77ccb6cad911cfc9..0d468631b9c260091e732925da43c177
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b7129aef8b08e8bd33f9f276bc2f97bbe8f5c894..624ed3d956a5614b723d32c6ad047248c5f5b038 100644
+index 550e30bfbdcf1ae0adf2cc68e3ae3d3dd4faad56..d998c0dd9e03b9c0f0a6075e5a52ba50b44ed0c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -810,6 +810,11 @@ public class CraftEventFactory {
+@@ -820,6 +820,11 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
@@ -150,7 +150,7 @@ index b7129aef8b08e8bd33f9f276bc2f97bbe8f5c894..624ed3d956a5614b723d32c6ad047248
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
          populateFields(victim, event); // Paper - make cancellable
-@@ -823,11 +828,13 @@ public class CraftEventFactory {
+@@ -833,11 +838,13 @@ public class CraftEventFactory {
          playDeathSound(victim, event);
          // Paper end
          victim.expToDrop = event.getDroppedExp();

--- a/patches/server/0413-Expose-game-version.patch
+++ b/patches/server/0413-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fbdc39181ea3074c2b2e3a877a59afafd02fe3c9..6c8b907b3c2f9e9a5cbae38620d6ebbd70eaf453 100644
+index 57e0a45aa2e8c14ad8849c92b6e97c1a82381c53..60b604e1148fbee51952faded4fc204ffa566e64 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -578,6 +578,13 @@ public final class CraftServer implements Server {
+@@ -581,6 +581,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  

--- a/patches/server/0416-misc-debugging-dumps.patch
+++ b/patches/server/0416-misc-debugging-dumps.patch
@@ -29,7 +29,7 @@ index 0000000000000000000000000000000000000000..2d5494d2813b773e60ddba6790b750a9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7049126dabd8bd497b7a63f8b0980e0252638c23..d613d9bbd2096788cd0f7e3a8aa901e44a4e25ff 100644
+index af7bc83f4a232489874f69dc2814b2c063bbb7eb..3092a50be8243a576d95e7f5ce546941f0b105fa 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -919,6 +919,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -74,10 +74,10 @@ index 301042e7a0d372a914f27ec0988dd938cf2a8262..1766a22e65af2e08611a9435c7384377
                  this.connection.send(new ClientboundDisconnectPacket(chatmessage));
                  this.connection.disconnect(chatmessage);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6c8b907b3c2f9e9a5cbae38620d6ebbd70eaf453..fc9c24e20bcdb43d79cb44bfbc2c0e82e8d1db46 100644
+index 60b604e1148fbee51952faded4fc204ffa566e64..28bccbde5fc7b59db8ea8fe72f61656f0eb7dccc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1018,6 +1018,7 @@ public final class CraftServer implements Server {
+@@ -1021,6 +1021,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getFullName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0418-Implement-Mob-Goal-API.patch
+++ b/patches/server/0418-Implement-Mob-Goal-API.patch
@@ -785,10 +785,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fc9c24e20bcdb43d79cb44bfbc2c0e82e8d1db46..a90b4d062ba602ed63ba11d42898997c4bf672f2 100644
+index 28bccbde5fc7b59db8ea8fe72f61656f0eb7dccc..00486272fc4b4c7a4ebd3d9c7df094e82097f42b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2628,5 +2628,11 @@ public final class CraftServer implements Server {
+@@ -2646,5 +2646,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0420-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0420-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -20,10 +20,10 @@ index e7cbdc75d7fd1252024c450ff0ec3b1ebdd17b93..bc880a78381b9c30e4ec92bdf17c9eca
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index de5f5856875fc4bfb051c7535344f18ded360ad3..618be6243225c82c3f7e039a00c43cf3c2ef1dbf 100644
+index d998c0dd9e03b9c0f0a6075e5a52ba50b44ed0c4..931cfbe01240e6382446aa12a545a02e44a407b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -630,16 +630,30 @@ public class CraftEventFactory {
+@@ -640,16 +640,30 @@ public class CraftEventFactory {
              net.minecraft.world.entity.ExperienceOrb xp = (net.minecraft.world.entity.ExperienceOrb) entity;
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/patches/server/0421-ExperienceOrbMergeEvent.patch
+++ b/patches/server/0421-ExperienceOrbMergeEvent.patch
@@ -9,10 +9,10 @@ Plugins can cancel this if they want to ensure experience orbs do not lose impor
 metadata such as spawn reason, or conditionally move data from source to target.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d62b1f22ee5679b0f223320db0db9c53b2120c91..f49c636a7485a7f41aae7acb584dc1c7c1d2c3a2 100644
+index 931cfbe01240e6382446aa12a545a02e44a407b9..aca2b2596a43927222f9894cc2f907cae2a331c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -640,7 +640,7 @@ public class CraftEventFactory {
+@@ -650,7 +650,7 @@ public class CraftEventFactory {
                      if (e instanceof net.minecraft.world.entity.ExperienceOrb) {
                          net.minecraft.world.entity.ExperienceOrb loopItem = (net.minecraft.world.entity.ExperienceOrb) e;
                          // Paper start

--- a/patches/server/0425-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0425-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,7 +10,7 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d613d9bbd2096788cd0f7e3a8aa901e44a4e25ff..faee8e2a29b4c9cbd62185f401ac7bbd40d8df76 100644
+index 3092a50be8243a576d95e7f5ce546941f0b105fa..9d8dd7ac4e471d658ba942e29c5028df410fa2c3 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -954,6 +954,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -22,10 +22,10 @@ index d613d9bbd2096788cd0f7e3a8aa901e44a4e25ff..faee8e2a29b4c9cbd62185f401ac7bbd
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a90b4d062ba602ed63ba11d42898997c4bf672f2..ed4e566cd18de4f58fcbb54cf2b6ed5ce4895d0a 100644
+index 00486272fc4b4c7a4ebd3d9c7df094e82097f42b..0753516dc0799abf33e16b1016bbd2a31748001f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1027,6 +1027,35 @@ public final class CraftServer implements Server {
+@@ -1030,6 +1030,35 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0448-Add-permission-for-command-blocks.patch
+++ b/patches/server/0448-Add-permission-for-command-blocks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add permission for command blocks
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index d87ee258db769bc072cbdae4298ebc08588b2160..29809127da2961858142bfb5b54c6db1ad4d4f0f 100644
+index 391e20c284b24f6c5fe446fd6a2c677214ed15c5..954aa104912cfb65b663ca49f64fd2b59da99c55 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -391,7 +391,7 @@ public class ServerPlayerGameMode {
+@@ -393,7 +393,7 @@ public class ServerPlayerGameMode {
              BlockEntity tileentity = this.level.getBlockEntity(pos);
              Block block = iblockdata.getBlock();
  
@@ -18,7 +18,7 @@ index d87ee258db769bc072cbdae4298ebc08588b2160..29809127da2961858142bfb5b54c6db1
                  return false;
              } else if (this.player.blockActionRestricted(this.level, pos, this.gameModeForPlayer)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f6007a34b56c80e96aa29def9c070f717b61c5ed..7975508532fc0e97b10eca88e43aefe3af711c0f 100644
+index 85e40e0086638b22fb69dc143803632e69dfe873..707f44c0245fdc9532a487353ebd9099151f1de5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -788,7 +788,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0449-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0449-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8e59a63e8c161e90ccff951ecb2b6530fadf3b80..df02a649ca99218745b7cd38e34edcabc2987255 100644
+index 9a4454746452f64d7a8caa52eef2dca86e9edd94..362b509c6d2df8061ba7fac51373490554843c30 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -595,8 +595,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -19,7 +19,7 @@ index 8e59a63e8c161e90ccff951ecb2b6530fadf3b80..df02a649ca99218745b7cd38e34edcab
      }
  
      protected AABB makeBoundingBox() {
-@@ -3786,6 +3786,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3792,6 +3792,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public final void setPosRaw(double x, double y, double z) {
@@ -31,7 +31,7 @@ index 8e59a63e8c161e90ccff951ecb2b6530fadf3b80..df02a649ca99218745b7cd38e34edcab
          if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
-@@ -3808,6 +3813,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3814,6 +3819,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              }
          }
  

--- a/patches/server/0450-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0450-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -107,10 +107,10 @@ index 707f44c0245fdc9532a487353ebd9099151f1de5..f33410709dbd36adf1f126d698d2b871
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ed4e566cd18de4f58fcbb54cf2b6ed5ce4895d0a..52fabc8cd1b76a825a13d39f38ca982e252cb39b 100644
+index 0753516dc0799abf33e16b1016bbd2a31748001f..8d9c999150dc688d69007566bf846a229e268f8e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -942,8 +942,8 @@ public final class CraftServer implements Server {
+@@ -945,8 +945,8 @@ public final class CraftServer implements Server {
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
          com.destroystokyo.paper.PaperConfig.init((File) console.options.valueOf("paper-settings")); // Paper
          for (ServerLevel world : this.console.getAllLevels()) {

--- a/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,10 +22,10 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 52fabc8cd1b76a825a13d39f38ca982e252cb39b..54598af96488c47b613de8eb8eb0bf31ea84743f 100644
+index 8d9c999150dc688d69007566bf846a229e268f8e..9ed6648c16e8ec5d4dcb304ff8a54a70016866e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -372,7 +372,7 @@ public final class CraftServer implements Server {
+@@ -375,7 +375,7 @@ public final class CraftServer implements Server {
          this.ambientSpawn = this.configuration.getInt("spawn-limits.ambient");
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -34,7 +34,7 @@ index 52fabc8cd1b76a825a13d39f38ca982e252cb39b..54598af96488c47b613de8eb8eb0bf31
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
      }
-@@ -922,7 +922,7 @@ public final class CraftServer implements Server {
+@@ -925,7 +925,7 @@ public final class CraftServer implements Server {
          this.waterUndergroundCreatureSpawn = this.configuration.getInt("spawn-limits.water-underground-creature");
          this.ambientSpawn = this.configuration.getInt("spawn-limits.ambient");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));

--- a/patches/server/0468-Add-PrepareResultEvent.patch
+++ b/patches/server/0468-Add-PrepareResultEvent.patch
@@ -8,7 +8,7 @@ Adds a new event for all crafting stations that generate a result slot item
 Anvil, Grindstone and Smithing now extend this event
 
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index 6b9c39b85e3a21fc0073fc15c8a76c92f75d2487..b40377e882d9cc3571f527e706862e27c59b1fd0 100644
+index b11e15d616e5584873895e076514e535289a24ed..0b60523861bbc1cd9f48207c9f5251b5659c6f24 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 @@ -316,6 +316,7 @@ public class AnvilMenu extends ItemCombinerMenu {
@@ -94,10 +94,10 @@ index cdebd0cdf6eb901464cf4c16089b10ea0147b54d..221b6ffb426edc034183dbaf37de29c6
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0d1524d6589a8055bcccd53f19bebc99553ccbe4..63f742a79e28e9e86eba01dc5a5029b5ea97158e 100644
+index aca2b2596a43927222f9894cc2f907cae2a331c1..d031eb1976cc50c0733cfef98404bc5b3fd152cb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1583,19 +1583,44 @@ public class CraftEventFactory {
+@@ -1593,19 +1593,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1151,7 +1151,7 @@ index d06e43bfaf8d22e0374bb6ed2e62c65e15699ef5..373f1c600ecdf75293dbe5ff6ef676a0
              if (updatingChunk != null) {
                  return updatingChunk.getEntityTickingChunkFuture();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index cc60127472ce47659acc35caea5a924ce54bc06b..edea3cbfe1856df0f6d32a70cac5de16abc2018a 100644
+index 0b54c4e229aab803683101d7e2b1780ae41b42e0..cd1e850c1d55d203ecba40719a0578a69c33492c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -228,7 +228,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -1210,10 +1210,10 @@ index bcb3a7e64f317732c8c758d4e743d84233bdafa6..336e65216f582a4393df07ace2eaf6ec
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 62341d1c88d6595fa27e70985abb42f2521235cf..26d784b974ee25b4d26e52822162d7998f45c640 100644
+index d43c2fefdf6030fdf0d8f72b413cb4d1d4871d3d..c277b45390bd66c93b5fb7fa768e2bf07bb6535c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -925,6 +925,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -932,6 +932,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
      }
  

--- a/patches/server/0484-Brand-support.patch
+++ b/patches/server/0484-Brand-support.patch
@@ -72,10 +72,10 @@ index 67f0a953751707f982df958e88c825ea98f4f984..bbfcadfd3316f2617288b1dd48d145b2
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 26d784b974ee25b4d26e52822162d7998f45c640..8dc8b4984b745355491760196ca4e25a944a6cae 100644
+index c277b45390bd66c93b5fb7fa768e2bf07bb6535c..b01e3c8f323b69c1e771fa1276f8f5765951ac11 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2591,6 +2591,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2598,6 +2598,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0485-Add-setMaxPlayers-API.patch
+++ b/patches/server/0485-Add-setMaxPlayers-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 98c70121c53e42e3c9bc7403eed83335f567bc74..ba46e9eafab188455d49f1a555e38b0ebe66fcf9 100644
+index 8ed4d4bc6d08c8339aba57b17f068c7bef22787c..35cf9c8235534a5c59065718ff57873f9c00bfdc 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -144,7 +144,7 @@ public abstract class PlayerList {
@@ -18,10 +18,10 @@ index 98c70121c53e42e3c9bc7403eed83335f567bc74..ba46e9eafab188455d49f1a555e38b0e
      private int simulationDistance;
      private boolean allowCheatsForAllPlayers;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 54598af96488c47b613de8eb8eb0bf31ea84743f..5e3397c8066dacdc1ebcbef57ecf4af0596cc02d 100644
+index 9ed6648c16e8ec5d4dcb304ff8a54a70016866e4..73a37734c7f7f44a5a2033b3139f681b0df69f82 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -673,6 +673,13 @@ public final class CraftServer implements Server {
+@@ -676,6 +676,13 @@ public final class CraftServer implements Server {
          return this.playerList.getMaxPlayers();
      }
  

--- a/patches/server/0506-Extend-block-drop-capture-to-capture-all-items-added.patch
+++ b/patches/server/0506-Extend-block-drop-capture-to-capture-all-items-added.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Extend block drop capture to capture all items added to the
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 230ee6dd71e55921960a81d7b3aedbc804f785e5..1a79c9767dd6e207653d59532b00742a1d85f314 100644
+index 74044db6497071debf8ad02829876e410ee4090e..0312d888c89e8d7f85cf510a653e9e08a0d08d82 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1260,6 +1260,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -24,10 +24,10 @@ index 230ee6dd71e55921960a81d7b3aedbc804f785e5..1a79c9767dd6e207653d59532b00742a
                  return false;
              }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 29809127da2961858142bfb5b54c6db1ad4d4f0f..aa065f732637b6220fd7328b4d5bc6005ee31832 100644
+index 954aa104912cfb65b663ca49f64fd2b59da99c55..84cf2f3584858a8729b26de1605a7626abe73923 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -423,10 +423,12 @@ public class ServerPlayerGameMode {
+@@ -425,10 +425,12 @@ public class ServerPlayerGameMode {
                      // return true; // CraftBukkit
                  }
                  // CraftBukkit start

--- a/patches/server/0508-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0508-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 707018a230e8f27e701c60bc7029d64c045d8bfc..2eb56ba2ecf49754e3b6229a798f837a4aa099da 100644
+index f91b4081bb2d9e86cb6f1c3ab3eb654a83bf1dbe..046f68a7736a9897789ee1a08465ffdea24c8dc0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3986,4 +3986,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3992,4 +3992,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0510-Entity-isTicking.patch
+++ b/patches/server/0510-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2eb56ba2ecf49754e3b6229a798f837a4aa099da..2c68dbfc38e9d9b7bb6cecb790d4d72fc2015a7f 100644
+index 046f68a7736a9897789ee1a08465ffdea24c8dc0..56c138d69423cd7fc99003ff4ddf124ede1c5b95 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -53,6 +53,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index 2eb56ba2ecf49754e3b6229a798f837a4aa099da..2c68dbfc38e9d9b7bb6cecb790d4d72f
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -3991,5 +3992,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3997,5 +3998,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0521-Player-elytra-boost-API.patch
+++ b/patches/server/0521-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8dc8b4984b745355491760196ca4e25a944a6cae..d606ceb051496cae03c10e1dfac5ceffa5d2d9d1 100644
+index b01e3c8f323b69c1e771fa1276f8f5765951ac11..77461ec500bdaf655051034f95cfaa53fc078f9b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -567,6 +567,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -574,6 +574,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/patches/server/0524-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0524-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5e3397c8066dacdc1ebcbef57ecf4af0596cc02d..93faeef65f846fdb472204709093ebcdba790dce 100644
+index 73a37734c7f7f44a5a2033b3139f681b0df69f82..0f757ad848436370f407a8583897e7ba39c2af52 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1820,6 +1820,28 @@ public final class CraftServer implements Server {
+@@ -1823,6 +1823,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0536-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0536-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d606ceb051496cae03c10e1dfac5ceffa5d2d9d1..daec735dd2510d2cb3089036a341efd41f8f8aaa 100644
+index 77461ec500bdaf655051034f95cfaa53fc078f9b..fee396f8b23b829f6f7e35c8ce979a9bdd9772ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2162,7 +2162,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2169,7 +2169,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0546-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0546-MC-4-Fix-item-position-desync.patch
@@ -43,10 +43,10 @@ index b30c08bfb8c55161543a4ef09f2e462e0a1fe4ae..ec93f5300cc7d423ec0d292f0f8443f9
  
      public Vec3 updateEntityPosition(Vec3 orig) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1cf13735a8c5dbfa71011012b271b3dc409a5f15..e64f17f859fc975fed07b86dfda2376018e97f6f 100644
+index 925f9b57e347bb609c159bb9d750a528ad2b87dd..6b1ea58389e32d6144e930adc72efeb4ba570d89 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3805,6 +3805,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3811,6 +3811,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
          // Paper end

--- a/patches/server/0550-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/patches/server/0550-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index dc65191f170954fbc93012bfc02401de36d8d1fd..0bfe25bd5dee6853d624af6988d2b72155aed8c0 100644
+index d031eb1976cc50c0733cfef98404bc5b3fd152cb..797e27f12a7d446442b35e0814254c4cc74b5907 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -262,6 +262,10 @@ public class CraftEventFactory {
+@@ -263,6 +263,10 @@ public class CraftEventFactory {
                          return BedEnterResult.TOO_FAR_AWAY;
                      case NOT_SAFE:
                          return BedEnterResult.NOT_SAFE;

--- a/patches/server/0569-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0569-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 4ae21aa6fc91f527d3dca508588d8257961b8d24..b3203049eade7d11602fa2a12a8104a7
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ad095e2547bc247fb38f72a3197bb45d4e048824..7b3e709898f9da4e77c83485cd35633bc6cb5ed9 100644
+index 797e27f12a7d446442b35e0814254c4cc74b5907..74aa6f2a1a55b9049f912f3e87b9032565bbc4d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1857,4 +1857,12 @@ public class CraftEventFactory {
+@@ -1867,4 +1867,12 @@ public class CraftEventFactory {
          EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
      }

--- a/patches/server/0574-Implement-API-to-expose-exact-interaction-point.patch
+++ b/patches/server/0574-Implement-API-to-expose-exact-interaction-point.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement API to expose exact interaction point
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index aa065f732637b6220fd7328b4d5bc6005ee31832..e39e16f0b3a0d168b3049c37f5a2a9dc8f15a652 100644
+index 84cf2f3584858a8729b26de1605a7626abe73923..53a0e74de9d50e0ece28f9d73a96135012b5d645 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -499,7 +499,7 @@ public class ServerPlayerGameMode {
+@@ -501,7 +501,7 @@ public class ServerPlayerGameMode {
              cancelledBlock = true;
          }
  
@@ -18,7 +18,7 @@ index aa065f732637b6220fd7328b4d5bc6005ee31832..e39e16f0b3a0d168b3049c37f5a2a9dc
          this.interactResult = event.useItemInHand() == Event.Result.DENY;
          this.interactPosition = blockposition.immutable();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d4b772c1df839ad1ec2bfb514432ee1b12099193..bfc3442e7952e1ec927f3ebdbefba153e7304e19 100644
+index 74aa6f2a1a55b9049f912f3e87b9032565bbc4d3..6d5d42a40a42b0d1e8e80d802cd629dd2854ae9b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -56,7 +56,9 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
@@ -31,7 +31,7 @@ index d4b772c1df839ad1ec2bfb514432ee1b12099193..bfc3442e7952e1ec927f3ebdbefba153
  import org.bukkit.Material;
  import org.bukkit.NamespacedKey;
  import org.bukkit.Server;
-@@ -482,7 +484,13 @@ public class CraftEventFactory {
+@@ -483,7 +485,13 @@ public class CraftEventFactory {
          return CraftEventFactory.callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand);
      }
  
@@ -45,7 +45,7 @@ index d4b772c1df839ad1ec2bfb514432ee1b12099193..bfc3442e7952e1ec927f3ebdbefba153
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
  
-@@ -508,7 +516,10 @@ public class CraftEventFactory {
+@@ -509,7 +517,10 @@ public class CraftEventFactory {
              itemInHand = null;
          }
  

--- a/patches/server/0577-Add-sendOpLevel-API.patch
+++ b/patches/server/0577-Add-sendOpLevel-API.patch
@@ -32,10 +32,10 @@ index f4e74b0bc3d192d7f7c2bc1dbfef92a28863a57c..b7f3be857d9ffb166e99f20753dbc671
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index daec735dd2510d2cb3089036a341efd41f8f8aaa..5de0093188f3dd142ef478b2654f6bf48fa90d06 100644
+index fee396f8b23b829f6f7e35c8ce979a9bdd9772ad..28dc1f225a29a60be24cc9249eab1db83728a17c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -581,6 +581,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -588,6 +588,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/patches/server/0584-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0584-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 07d357b5fcb30ed9ff074a196a19de1481fe3738..83ac86b3c1e7b9233f2db8e5488f97c5
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1a2a84c7044ab70de3fd632b0d04b33d827ce22e..5b9e76fbffa74b29f1a21374a74f46c917104fea 100644
+index 6d5d42a40a42b0d1e8e80d802cd629dd2854ae9b..97fd237a4fc31875fa66683c9ea8fed1fa794abf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1875,5 +1875,11 @@ public class CraftEventFactory {
+@@ -1885,5 +1885,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index cf932116a0cafd315e44159fbf7c5d25d43782ff..03bda898a5a263053ecd79f74799d370
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5b9e76fbffa74b29f1a21374a74f46c917104fea..7cde66a83f4abd4b25b7615139b1dd1cb2c746ce 100644
+index 97fd237a4fc31875fa66683c9ea8fed1fa794abf..66415d1e9690f1d644b73115b9873c52ef45e212 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1516,8 +1516,10 @@ public class CraftEventFactory {
+@@ -1526,8 +1526,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0595-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/patches/server/0595-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow adding items to BlockDropItemEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index afb6eb856d22845716351d5be7eff5991da72dd3..ee0e27500187d695ac6cfaf5fb5d2e844f230b32 100644
+index 66415d1e9690f1d644b73115b9873c52ef45e212..5c2beec59b0382d80bf97317cbbeab43df24ad55 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -395,13 +395,30 @@ public class CraftEventFactory {
+@@ -396,13 +396,30 @@ public class CraftEventFactory {
      }
  
      public static void handleBlockDropItemEvent(Block block, BlockState state, ServerPlayer player, List<ItemEntity> items) {

--- a/patches/server/0613-Implement-Keyed-on-World.patch
+++ b/patches/server/0613-Implement-Keyed-on-World.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 93faeef65f846fdb472204709093ebcdba790dce..28fb73ffd683a45b1d6be4b55116e861d0c2973c 100644
+index 0f757ad848436370f407a8583897e7ba39c2af52..32a88460c2f297275f950efa7f172d9448bf172a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1257,7 +1257,7 @@ public final class CraftServer implements Server {
+@@ -1260,7 +1260,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -17,7 +17,7 @@ index 93faeef65f846fdb472204709093ebcdba790dce..28fb73ffd683a45b1d6be4b55116e861
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, dimensionmanager, this.getServer().progressListenerFactory.create(11),
-@@ -1349,6 +1349,15 @@ public final class CraftServer implements Server {
+@@ -1352,6 +1352,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0653-Add-basic-Datapack-API.patch
+++ b/patches/server/0653-Add-basic-Datapack-API.patch
@@ -92,10 +92,10 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 28fb73ffd683a45b1d6be4b55116e861d0c2973c..6513cb5f236d86097f078f8c72cc3d0a0ebc9617 100644
+index 32a88460c2f297275f950efa7f172d9448bf172a..d1d92fe903617301bbe11fa0ec4ffdf5ee3ba0c8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -291,6 +291,7 @@ public final class CraftServer implements Server {
+@@ -293,6 +293,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -103,7 +103,7 @@ index 28fb73ffd683a45b1d6be4b55116e861d0c2973c..6513cb5f236d86097f078f8c72cc3d0a
      public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {
-@@ -375,6 +376,7 @@ public final class CraftServer implements Server {
+@@ -378,6 +379,7 @@ public final class CraftServer implements Server {
          TicketType.PLUGIN.timeout = Math.min(20, this.configuration.getInt("chunk-gc.period-in-ticks")); // Paper - cap plugin loads to 1 second
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
@@ -111,7 +111,7 @@ index 28fb73ffd683a45b1d6be4b55116e861d0c2973c..6513cb5f236d86097f078f8c72cc3d0a
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2701,5 +2703,11 @@ public final class CraftServer implements Server {
+@@ -2719,5 +2721,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0655-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0655-additions-to-PlayerGameModeChangeEvent.patch
@@ -93,7 +93,7 @@ index fd6eb3b3953ca0413af6a71c52503c9674917a9e..77ba7fe43ceffcb816d209da45ab0c5d
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index e39e16f0b3a0d168b3049c37f5a2a9dc8f15a652..1ca6dc1e9334bf7e03eab4c2a75f4c86c7d36a9f 100644
+index 53a0e74de9d50e0ece28f9d73a96135012b5d645..dcfb5fd1763979f081cc253716f518bc371dd546 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -72,18 +72,24 @@ public class ServerPlayerGameMode {
@@ -139,10 +139,10 @@ index b63da79cacf05edacdd755ce78a22ecbb8347dad..a76f8a64d7ec492402b29bde4c2f0a4c
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5de0093188f3dd142ef478b2654f6bf48fa90d06..09c2ac4c40b13019bcaccd3e8e34ac3d6fdd5363 100644
+index 28dc1f225a29a60be24cc9249eab1db83728a17c..5d6c142693848c46b5098af9d4b2aa73283b5cc3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1285,7 +1285,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1292,7 +1292,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0658-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0658-Fix-and-optimise-world-force-upgrading.patch
@@ -274,7 +274,7 @@ index 3835a8340792837674bdbcd5583ce74446b0460b..e2c8f716af55ebb7e4233c2a3d6515f8
          Main.LOGGER.info("Forcing world upgrade! {}", session.getLevelId()); // CraftBukkit
          WorldUpgrader worldupgrader = new WorldUpgrader(session, dataFixer, generatorOptions, eraseCache);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5de82c5d7da2ca6eeee4b804b916fa9d385cc25c..e03018882da878ddc51986733cfd6ea1c1815e9b 100644
+index d5029567bfe6f34e175e06ff7dae0e4947b2600c..860540a50c3281ab35acffd845f536dadab285d7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -557,11 +557,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -326,7 +326,7 @@ index c76b508026c5ad54879ba400a9b6f8287f3f95b8..b7f9d6682c1dc5f03ae363b782ae9346
          return this.world;
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java b/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
-index 2ee32657a49937418b352a138aca21fbb27857e6..7b4f3c30cfc4bf68cc872598726f7f7eab5f9830 100644
+index 4bc33c31d497aa7d69226ab870fd78902bedfd5b..089e8414c7bdc102ba0d914af576df1a05af7519 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
 @@ -32,6 +32,28 @@ public class RegionFileStorage implements AutoCloseable {
@@ -359,10 +359,10 @@ index 2ee32657a49937418b352a138aca21fbb27857e6..7b4f3c30cfc4bf68cc872598726f7f7e
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6513cb5f236d86097f078f8c72cc3d0a0ebc9617..dfeef8b13a86998599d17f84996e1368649c47b1 100644
+index d1d92fe903617301bbe11fa0ec4ffdf5ee3ba0c8..eda64c7e2352464bdc950958bb86cb0d6ddeb43b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1218,12 +1218,7 @@ public final class CraftServer implements Server {
+@@ -1221,12 +1221,7 @@ public final class CraftServer implements Server {
          }
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().shouldReportAsModified());
@@ -376,7 +376,7 @@ index 6513cb5f236d86097f078f8c72cc3d0a0ebc9617..dfeef8b13a86998599d17f84996e1368
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1252,6 +1247,14 @@ public final class CraftServer implements Server {
+@@ -1255,6 +1250,14 @@ public final class CraftServer implements Server {
              }
          }
  

--- a/patches/server/0666-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0666-Add-PlayerKickEvent-causes.patch
@@ -342,10 +342,10 @@ index 3900e885988bc1f2865b95f825cba34d04919731..cad8a98951795706b89ff3ea3985033f
          // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 09c2ac4c40b13019bcaccd3e8e34ac3d6fdd5363..fc5bab146ddcd4f458370e1b258049c129c72f5c 100644
+index 5d6c142693848c46b5098af9d4b2aa73283b5cc3..c6a5933438abeb09c040dbb5c57256af2ee1510a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -507,16 +507,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -514,16 +514,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          org.spigotmc.AsyncCatcher.catchOp("player kick"); // Spigot
          if (this.getHandle().connection == null) return;
  

--- a/patches/server/0696-Add-System.out-err-catcher.patch
+++ b/patches/server/0696-Add-System.out-err-catcher.patch
@@ -105,7 +105,7 @@ index 0000000000000000000000000000000000000000..76d0d00cd6742991e3f3ec827a75ee87
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dfeef8b13a86998599d17f84996e1368649c47b1..5f35c3714ac4e0e7afaa81c1ebe8d9601202bbb2 100644
+index eda64c7e2352464bdc950958bb86cb0d6ddeb43b..faf872ac11caa37d072c18f5669029c75f971e59 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -18,6 +18,7 @@ import com.mojang.serialization.Lifecycle;
@@ -116,7 +116,7 @@ index dfeef8b13a86998599d17f84996e1368649c47b1..5f35c3714ac4e0e7afaa81c1ebe8d960
  import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
  import java.awt.image.BufferedImage;
  import java.io.File;
-@@ -293,6 +294,7 @@ public final class CraftServer implements Server {
+@@ -295,6 +296,7 @@ public final class CraftServer implements Server {
      public int reloadCount;
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings

--- a/patches/server/0702-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0702-Add-PlayerSetSpawnEvent.patch
@@ -93,10 +93,10 @@ index d620f559cdd1bd0e161a99123ef6c6f64e3302df..07e893f1859abe3c2a765694c21309d6
                      return InteractionResult.SUCCESS;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fc5bab146ddcd4f458370e1b258049c129c72f5c..fb1c83d0487cac6df8768ac635d13636ec97cb53 100644
+index c6a5933438abeb09c040dbb5c57256af2ee1510a..47b55949cf70420f3e65f74425f192eb89ff7ca3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1105,9 +1105,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1112,9 +1112,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0707-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0707-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7ba5761791bdbfdc924bdf8b1ed239c9fb640cac..96fba810f9f6d105a844831de45ae1df174d1837 100644
+index c6f7c52b017d0f58ab84b3e213b5500b512bfab9..4d9e2881bfbda4efe8dc25c5efcdbda949b9c792 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3511,26 +3511,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3517,26 +3517,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      private Stream<Entity> getIndirectPassengersStream() {

--- a/patches/server/0718-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0718-Add-back-EntityPortalExitEvent.patch
@@ -5,13 +5,18 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 96fba810f9f6d105a844831de45ae1df174d1837..ddf315ab79dd42e18e73aba8b96ad33ae21073b7 100644
+index 4d9e2881bfbda4efe8dc25c5efcdbda949b9c792..98d44d3e9261cd5c6eea59574d30c395454ffae3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3022,6 +3022,25 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3022,12 +3022,25 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              } else {
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
+-                if (worldserver == this.level) {
+-                    // SPIGOT-6782: Just move the entity if a plugin changed the world to the one the entity is already in
+-                    this.moveTo(shapedetectorshape.pos.x, shapedetectorshape.pos.y, shapedetectorshape.pos.z, shapedetectorshape.yRot, shapedetectorshape.xRot);
+-                    this.setDeltaMovement(shapedetectorshape.speed);
+-                    return this;
 +
 +                // Paper start - Call EntityPortalExitEvent
 +                CraftEntity bukkitEntity = this.getBukkitEntity();
@@ -28,13 +33,13 @@ index 96fba810f9f6d105a844831de45ae1df174d1837..ddf315ab79dd42e18e73aba8b96ad33a
 +                    yaw = event.getTo().getYaw();
 +                    pitch = event.getTo().getPitch();
 +                    velocity = org.bukkit.craftbukkit.util.CraftVector.toNMS(event.getAfter());
-+                }
+                 }
 +                // Paper end
 +
                  this.unRide();
                  // CraftBukkit end
  
-@@ -3035,8 +3054,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3041,8 +3054,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
  
                  if (entity != null) {
                      entity.restoreFrom(this);

--- a/patches/server/0724-Add-critical-damage-API.patch
+++ b/patches/server/0724-Add-critical-damage-API.patch
@@ -72,10 +72,10 @@ index b436103957113bff5e553dacb869c775a3f8b059..3d3dcb47720055f550d17d1f106a2c0e
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index db4a0f26ae528680b4e2ac395a6800c6d8f4124e..519b17fac445b7118f5493508bddccd368dadcde 100644
+index 5c2beec59b0382d80bf97317cbbeab43df24ad55..a3c8a0291fa9ae6f3c96d937dd4621edd7c48535 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -970,7 +970,7 @@ public class CraftEventFactory {
+@@ -980,7 +980,7 @@ public class CraftEventFactory {
                  } else {
                      damageCause = DamageCause.ENTITY_EXPLOSION;
                  }
@@ -84,7 +84,7 @@ index db4a0f26ae528680b4e2ac395a6800c6d8f4124e..519b17fac445b7118f5493508bddccd3
              }
              event.setCancelled(cancelled);
  
-@@ -997,7 +997,7 @@ public class CraftEventFactory {
+@@ -1007,7 +1007,7 @@ public class CraftEventFactory {
                  cause = DamageCause.THORNS;
              }
  
@@ -93,7 +93,7 @@ index db4a0f26ae528680b4e2ac395a6800c6d8f4124e..519b17fac445b7118f5493508bddccd3
          } else if (source == DamageSource.OUT_OF_WORLD) {
              EntityDamageEvent event = new EntityDamageByBlockEvent(null, entity.getBukkitEntity(), DamageCause.VOID, modifiers, modifierFunctions);
              event.setCancelled(cancelled);
-@@ -1067,7 +1067,7 @@ public class CraftEventFactory {
+@@ -1077,7 +1077,7 @@ public class CraftEventFactory {
              } else {
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager.getHandle(), source.msgId));
              }
@@ -102,7 +102,7 @@ index db4a0f26ae528680b4e2ac395a6800c6d8f4124e..519b17fac445b7118f5493508bddccd3
              event.setCancelled(cancelled);
              CraftEventFactory.callEvent(event);
              if (!event.isCancelled()) {
-@@ -1112,20 +1112,28 @@ public class CraftEventFactory {
+@@ -1122,20 +1122,28 @@ public class CraftEventFactory {
          }
  
          if (cause != null) {

--- a/patches/server/0759-Lag-compensate-block-breaking.patch
+++ b/patches/server/0759-Lag-compensate-block-breaking.patch
@@ -21,7 +21,7 @@ index eeae1a043ef185f206e923a5799e173cf3cf485d..b591b47fc663289682c35f480f851b7e
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 1ca6dc1e9334bf7e03eab4c2a75f4c86c7d36a9f..3125af569ec2bb1cd613a9dd96c3a181d723006d 100644
+index dcfb5fd1763979f081cc253716f518bc371dd546..d15f6a4540557edc0f278dabcd2c3aae24cbe507 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -54,14 +54,28 @@ public class ServerPlayerGameMode {
@@ -130,16 +130,24 @@ index 1ca6dc1e9334bf7e03eab4c2a75f4c86c7d36a9f..3125af569ec2bb1cd613a9dd96c3a181
              } else if (action == ServerboundPlayerActionPacket.Action.ABORT_DESTROY_BLOCK) {
                  this.isDestroyingBlock = false;
                  if (!Objects.equals(this.destroyPos, pos) && !BlockPos.ZERO.equals(this.destroyPos)) {
-@@ -316,7 +342,7 @@ public class ServerPlayerGameMode {
+@@ -316,9 +342,14 @@ public class ServerPlayerGameMode {
                  }
  
                  this.level.destroyBlockProgress(this.player.getId(), pos, -1);
 -                this.player.connection.send(new ClientboundBlockBreakAckPacket(pos, this.level.getBlockState(pos), action, true, "aborted destroying"));
-+                if (!com.destroystokyo.paper.PaperConfig.lagCompensateBlockBreaking) this.player.connection.send(new ClientboundBlockBreakAckPacket(pos, this.level.getBlockState(pos), action, true, "aborted destroying")); // Paper - this can cause clients on a lagging server to think they stopped destroying a block they're currently destroying
+ 
+-                CraftEventFactory.callBlockDamageAbortEvent(this.player, pos, this.player.getInventory().getSelected()); // CraftBukkit
++                // Paper - start - this can cause clients on a lagging server to think they stopped destroying a block they're currently destroying
++                if (!com.destroystokyo.paper.PaperConfig.lagCompensateBlockBreaking) {
++                    this.player.connection.send(new ClientboundBlockBreakAckPacket(pos, this.level.getBlockState(pos), action, true, "aborted destroying"));
++
++                    CraftEventFactory.callBlockDamageAbortEvent(this.player, pos, this.player.getInventory().getSelected()); // CraftBukkit
++                }
++                // Paper - end - this can cause clients on a lagging server to think they stopped destroying a block they're currently destroying
              }
  
          }
-@@ -326,7 +352,13 @@ public class ServerPlayerGameMode {
+@@ -328,7 +359,13 @@ public class ServerPlayerGameMode {
  
      public void destroyAndAck(BlockPos pos, ServerboundPlayerActionPacket.Action action, String reason) {
          if (this.destroyBlock(pos)) {

--- a/patches/server/0815-Add-player-health-update-API.patch
+++ b/patches/server/0815-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fb1c83d0487cac6df8768ac635d13636ec97cb53..a18d65cd9c3e9ecf812d02997f3cae481572afd1 100644
+index 47b55949cf70420f3e65f74425f192eb89ff7ca3..d3706d374ded6e671ab56a94dcc186fdeeaf936b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2041,9 +2041,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2048,9 +2048,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index fb1c83d0487cac6df8768ac635d13636ec97cb53..a18d65cd9c3e9ecf812d02997f3cae48
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2051,7 +2053,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2058,7 +2060,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          // Paper end
      }

--- a/patches/server/0817-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0817-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5f35c3714ac4e0e7afaa81c1ebe8d9601202bbb2..ba7023e7ca5d29375ff53c2951892138d155f69f 100644
+index faf872ac11caa37d072c18f5669029c75f971e59..70cd467b5ee9d01c03a6901fe2bf3aabe00caf43 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2301,6 +2301,107 @@ public final class CraftServer implements Server {
+@@ -2319,6 +2319,107 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0844-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0844-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose vanilla BiomeProvider from WorldInfo
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 481a5dbad82f3f8dd5b1bf8ab207d82ec73d5bbd..c4e8e6af67b57406012612b617a7dcaa6e391d09 100644
+index d8ec6871cf25175a1da3db004651d4a2ae07b5eb..eab93e1e3712c0a01cac187bf5944818c813d665 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -654,7 +654,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -18,10 +18,10 @@ index 481a5dbad82f3f8dd5b1bf8ab207d82ec73d5bbd..c4e8e6af67b57406012612b617a7dcaa
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ba7023e7ca5d29375ff53c2951892138d155f69f..54e8f0f367645f3aa8af5b1cb69c39c0cec9381f 100644
+index 70cd467b5ee9d01c03a6901fe2bf3aabe00caf43..4041508e7da7b2b439ca55cbee2315de8bc5b91b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1237,7 +1237,7 @@ public final class CraftServer implements Server {
+@@ -1240,7 +1240,7 @@ public final class CraftServer implements Server {
              chunkgenerator = worlddimension.generator();
          }
  

--- a/patches/server/0854-Multi-Block-Change-API-Implementation.patch
+++ b/patches/server/0854-Multi-Block-Change-API-Implementation.patch
@@ -25,7 +25,7 @@ index 82ea4fabd5732052a286d50bcff8bbcc2c4aa7d7..652bea6868a03a5315965f79c76172fb
      public void write(FriendlyByteBuf buf) {
          buf.writeLong(this.sectionPos.asLong());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a18d65cd9c3e9ecf812d02997f3cae481572afd1..efa4afee2f3b8595bcd0c753e497d27314dfd42a 100644
+index d3706d374ded6e671ab56a94dcc186fdeeaf936b..f6cadfa342521c36881a06bada6be92d5d4cdeac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -30,6 +30,7 @@ import javax.annotation.Nullable;
@@ -36,7 +36,7 @@ index a18d65cd9c3e9ecf812d02997f3cae481572afd1..efa4afee2f3b8595bcd0c753e497d273
  import net.minecraft.nbt.CompoundTag;
  import net.minecraft.network.FriendlyByteBuf;
  import net.minecraft.network.chat.ChatType;
-@@ -838,6 +839,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -845,6 +846,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  

--- a/patches/server/0861-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0861-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -123,10 +123,10 @@ index 0000000000000000000000000000000000000000..f7c86155ce0cfd9b4bf8a2b79d77a656
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 54e8f0f367645f3aa8af5b1cb69c39c0cec9381f..1a1f5c8f9a049d65043f12374fe694068f7d08cf 100644
+index 4041508e7da7b2b439ca55cbee2315de8bc5b91b..1e1cb5a091e9f061b6f85f75074d7829c80c71da 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1988,6 +1988,13 @@ public final class CraftServer implements Server {
+@@ -2006,6 +2006,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
04c7e13c #719: Add Player Profile API
71564210 SPIGOT-6910: Add BlockDamageAbortEvent

CraftBukkit Changes:
bdac46b0 SPIGOT-6782: EntityPortalEvent should not destroy entity when setTo() uses same world as getFrom()
8f361ece #1002: Add Player Profile API
911875d4 Increase outdated build delay
e5f8a767 SPIGOT-6917: Use main scoreboard for /trigger
a672a531 Clean up callBlockDamageEvent
8e1bdeef SPIGOT-6910: Add BlockDamageAbortEvent

Spigot Changes:
7fbc6a1e Rebuild patches