### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0006-Timings-v2.patch
+++ b/patches/api/0006-Timings-v2.patch
@@ -2782,10 +2782,10 @@ index 0000000000000000000000000000000000000000..5989ee21297935651b0edd44b8239e65
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 072bcbbbf167e02ce5014b672f2cf63122d29b21..de7f303bce9e2454eaec12131cd1439a54281c7e 100644
+index e1cd74a2fb53e054f626641d781e4ac57ea0ea8f..f8001cafc3494675dfa31c0c5feb975c0f066c5d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -747,7 +747,6 @@ public final class Bukkit {
+@@ -787,7 +787,6 @@ public final class Bukkit {
       */
      public static void reload() {
          server.reload();
@@ -2794,10 +2794,10 @@ index 072bcbbbf167e02ce5014b672f2cf63122d29b21..de7f303bce9e2454eaec12131cd1439a
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 2bfccae871b92749fa5893b5a7ff327fc93695ad..31e989bdaf60d38e14c84c4a0a31ede6e1a72e86 100644
+index 96819d13fa837c7374c5a13bdcad864c6744f0b5..7cc8f68205f7c0ec2ebada5030f944675b776c76 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1500,6 +1500,26 @@ public interface Server extends PluginMessageRecipient {
+@@ -1593,6 +1593,26 @@ public interface Server extends PluginMessageRecipient {
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -3499,7 +3499,7 @@ index a09c3f71ca563b6f40a118ce1344d0eb273bed40..cf2f517765d8f2a23cc4a17d9ee2dcd8
                  eventSet.add(new TimedRegisteredListener(listener, executor, eh.priority(), plugin, eh.ignoreCancelled()));
              } else {
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 6bdd9f1dcc4c69c1811622cddc82526d2f8d9e52..657243776c8a2abb5a57e5c407212a8387d649eb 100644
+index 930f3fe08c2acd70eaf7850d0b1b2890512defa0..24e3eaa008e53af8d77439e4f2ab9007285d7826 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -29,7 +29,8 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0007-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/api/0007-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index a238302f2a12194aa30a88867070705dc749b36b..cc42bfa74b41ef6d6374efa7b882f71677fb0824 100644
+index f8001cafc3494675dfa31c0c5feb975c0f066c5d..4b5486bec19d330404562814a0c4cf63f2f7ef1d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -73,6 +73,20 @@ public final class Bukkit {
+@@ -75,6 +75,20 @@ public final class Bukkit {
          return server;
      }
  
@@ -32,10 +32,10 @@ index a238302f2a12194aa30a88867070705dc749b36b..cc42bfa74b41ef6d6374efa7b882f716
       * Attempts to set the {@link Server} singleton.
       * <p>
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 3e91c4000c468fd8bdcb938e942a7bbf4988cab2..1fb1d4f32af8150711ca766fcd7d0a0c177df7c4 100644
+index 7cc8f68205f7c0ec2ebada5030f944675b776c76..e38a0d7d48a57364bec0c8d1dc16e256622298a0 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -58,6 +58,18 @@ import org.jetbrains.annotations.Nullable;
+@@ -60,6 +60,18 @@ import org.jetbrains.annotations.Nullable;
   */
  public interface Server extends PluginMessageRecipient {
  

--- a/patches/api/0008-Adventure.patch
+++ b/patches/api/0008-Adventure.patch
@@ -488,10 +488,10 @@ index 0000000000000000000000000000000000000000..15ecb12fd2fefcac96edbaef7cdd487a
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7fa03a92eb 100644
+index 4b5486bec19d330404562814a0c4cf63f2f7ef1d..fc7d17fd3028f790ff9e034e8234bf0506f017c2 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -369,7 +369,9 @@ public final class Bukkit {
+@@ -371,7 +371,9 @@ public final class Bukkit {
       *
       * @param message the message
       * @return the number of players
@@ -501,7 +501,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      public static int broadcastMessage(@NotNull String message) {
          return server.broadcastMessage(message);
      }
-@@ -1012,6 +1014,19 @@ public final class Bukkit {
+@@ -1052,6 +1054,19 @@ public final class Bukkit {
          server.shutdown();
      }
  
@@ -521,7 +521,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      /**
       * Broadcasts the specified message to every user with the given
       * permission name.
-@@ -1021,6 +1036,21 @@ public final class Bukkit {
+@@ -1061,6 +1076,21 @@ public final class Bukkit {
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
       */
@@ -543,7 +543,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      public static int broadcast(@NotNull String message, @NotNull String permission) {
          return server.broadcast(message, permission);
      }
-@@ -1220,6 +1250,7 @@ public final class Bukkit {
+@@ -1299,6 +1329,7 @@ public final class Bukkit {
          return server.createInventory(owner, type);
      }
  
@@ -551,7 +551,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1245,6 +1276,38 @@ public final class Bukkit {
+@@ -1324,6 +1355,38 @@ public final class Bukkit {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -590,7 +590,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      public static Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title) {
          return server.createInventory(owner, type, title);
      }
-@@ -1263,6 +1326,7 @@ public final class Bukkit {
+@@ -1342,6 +1405,7 @@ public final class Bukkit {
          return server.createInventory(owner, size);
      }
  
@@ -598,7 +598,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1275,10 +1339,30 @@ public final class Bukkit {
+@@ -1354,10 +1418,30 @@ public final class Bukkit {
       * @throws IllegalArgumentException if the size is not a multiple of 9
       */
      @NotNull
@@ -629,7 +629,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      /**
       * Creates an empty merchant.
       *
-@@ -1286,7 +1370,20 @@ public final class Bukkit {
+@@ -1365,7 +1449,20 @@ public final class Bukkit {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -650,7 +650,7 @@ index 0d96b6bdc744a23cc7322f2bd6a7a7b38acb6830..84a620bbbc24ded4075bce0209caed7f
      public static Merchant createMerchant(@Nullable String title) {
          return server.createMerchant(title);
      }
-@@ -1366,22 +1463,47 @@ public final class Bukkit {
+@@ -1471,22 +1568,47 @@ public final class Bukkit {
          return server.isPrimaryThread();
      }
  
@@ -802,10 +802,10 @@ index 803fa0019869127ee8c7e4fb1777a59c43e66f8a..c65f0d6569c130b4920a9e71ad24af64
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f380589dd 100644
+index e38a0d7d48a57364bec0c8d1dc16e256622298a0..dd79325a8f52190c44b833870043d167641211a6 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -56,7 +56,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -58,7 +58,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a server implementation.
   */
@@ -814,7 +814,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
  
      /**
       * Returns the de facto plugins directory, generally used for storing plugin jars to be loaded,
-@@ -74,7 +74,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -76,7 +76,7 @@ public interface Server extends PluginMessageRecipient {
       * Used for all administrative messages, such as an operator using a
       * command.
       * <p>
@@ -823,7 +823,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
       */
      public static final String BROADCAST_CHANNEL_ADMINISTRATIVE = "bukkit.broadcast.admin";
  
-@@ -82,7 +82,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -84,7 +84,7 @@ public interface Server extends PluginMessageRecipient {
       * Used for all announcement messages, such as informing users that a
       * player has joined.
       * <p>
@@ -832,7 +832,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
       */
      public static final String BROADCAST_CHANNEL_USERS = "bukkit.broadcast.user";
  
-@@ -304,7 +304,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -306,7 +306,9 @@ public interface Server extends PluginMessageRecipient {
       *
       * @param message the message
       * @return the number of players
@@ -842,7 +842,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      public int broadcastMessage(@NotNull String message);
  
      /**
-@@ -856,8 +858,33 @@ public interface Server extends PluginMessageRecipient {
+@@ -893,8 +895,33 @@ public interface Server extends PluginMessageRecipient {
       * @param permission the required permission {@link Permissible
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
@@ -876,7 +876,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
  
      /**
       * Gets the player by the given name, regardless if they are offline or
-@@ -1022,6 +1049,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -1092,6 +1119,7 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type);
  
@@ -884,7 +884,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1047,6 +1075,36 @@ public interface Server extends PluginMessageRecipient {
+@@ -1117,6 +1145,36 @@ public interface Server extends PluginMessageRecipient {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -921,7 +921,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title);
  
      /**
-@@ -1061,6 +1119,22 @@ public interface Server extends PluginMessageRecipient {
+@@ -1131,6 +1189,22 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, int size) throws IllegalArgumentException;
  
@@ -944,7 +944,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1071,10 +1145,13 @@ public interface Server extends PluginMessageRecipient {
+@@ -1141,10 +1215,13 @@ public interface Server extends PluginMessageRecipient {
       *     viewed
       * @return a new inventory
       * @throws IllegalArgumentException if the size is not a multiple of 9
@@ -958,7 +958,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      /**
       * Creates an empty merchant.
       *
-@@ -1082,7 +1159,18 @@ public interface Server extends PluginMessageRecipient {
+@@ -1152,7 +1229,18 @@ public interface Server extends PluginMessageRecipient {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -977,7 +977,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      Merchant createMerchant(@Nullable String title);
  
      /**
-@@ -1146,20 +1234,41 @@ public interface Server extends PluginMessageRecipient {
+@@ -1239,20 +1327,41 @@ public interface Server extends PluginMessageRecipient {
       */
      boolean isPrimaryThread();
  
@@ -1019,7 +1019,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
      String getShutdownMessage();
  
      /**
-@@ -1536,7 +1645,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1629,7 +1738,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends the component to the player
           *
           * @param component the components to send
@@ -1029,7 +1029,7 @@ index 7f4d6d605934e47ec97b8ad7cca3c48460bc0082..ede5de4c310a93989608bf48b3e5116f
          public void broadcast(@NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1545,7 +1656,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1638,7 +1749,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends an array of components as a single message to the player
           *
           * @param components the components to send
@@ -1133,10 +1133,10 @@ index efb97712cc9dc7c1e12a59f5b94e4f2ad7c6b7d8..3024468af4c073324e536c1cb26beffb
                  return warning == null || warning.value();
              }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index f24f9391269cb80d1e7142369ca57d0e8e0606af..5d23c38758b4b9eb5802b6a22a094a3adb64e508 100644
+index a855f4c16f52f5ec478538eb182c13f8a6d60f65..33f7f4df53ba52f9afa22662427cbab1876b451c 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -38,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -39,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a world, which may contain entities, chunks and blocks
   */
@@ -1145,7 +1145,7 @@ index f24f9391269cb80d1e7142369ca57d0e8e0606af..5d23c38758b4b9eb5802b6a22a094a3a
  
      /**
       * Gets the {@link Block} at the given coordinates
-@@ -633,6 +633,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -634,6 +634,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public List<Player> getPlayers();
  
@@ -1562,7 +1562,7 @@ index 9566e4306ada5e82dede0f002aa06da12c44996b..4d5f0837bd0e02a30c943d8969fb6b13
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 25a6f9313a1953def7470e411b53016f2ca14bef..10cb6088c4618f228c757f4e592b44edab81c2dc 100644
+index 922d33ff4fa9d901d3c5c0a9f8399ad8aef62c37..cd287978c34873c7122794e4f3e762915978a1f0 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
@@ -1574,7 +1574,7 @@ index 25a6f9313a1953def7470e411b53016f2ca14bef..10cb6088c4618f228c757f4e592b44ed
  
      /**
       * Gets the entity's current position
-@@ -648,4 +648,20 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -656,4 +656,20 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      @Override
      Spigot spigot();
      // Spigot end

--- a/patches/api/0010-Add-getTPS-method.patch
+++ b/patches/api/0010-Add-getTPS-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getTPS method
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 84a620bbbc24ded4075bce0209caed7fa03a92eb..bbee4e40917cca4e692c3d60c1c513b4c847160f 100644
+index fc7d17fd3028f790ff9e034e8234bf0506f017c2..f5d697e759700b10237494f2587939eea365ab3a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1728,6 +1728,17 @@ public final class Bukkit {
+@@ -1833,6 +1833,17 @@ public final class Bukkit {
          return server.getEntity(uuid);
      }
  
@@ -27,10 +27,10 @@ index 84a620bbbc24ded4075bce0209caed7fa03a92eb..bbee4e40917cca4e692c3d60c1c513b4
       * Get the advancement specified by this key.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ede5de4c310a93989608bf48b3e5116f380589dd..835041d2ab6545e52d963d96d558f9a7e52d279a 100644
+index dd79325a8f52190c44b833870043d167641211a6..a4ec6dae0b6302b6486bb5105438ef8322b433be 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1461,6 +1461,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1554,6 +1554,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      Entity getEntity(@NotNull UUID uuid);
  

--- a/patches/api/0012-Entity-Origin-API.patch
+++ b/patches/api/0012-Entity-Origin-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Origin API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 10cb6088c4618f228c757f4e592b44edab81c2dc..65088203d29798efe211612dfadb356f457ed466 100644
+index cd287978c34873c7122794e4f3e762915978a1f0..c315d2494969190f8b53236f905ad5c5cf1bfc39 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -663,5 +663,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -671,5 +671,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.customName())));
      }

--- a/patches/api/0014-Add-view-distance-API.patch
+++ b/patches/api/0014-Add-view-distance-API.patch
@@ -8,10 +8,10 @@ Add per player no-tick, tick, and send view distances.
 Also add send/no-tick view distance to World.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 5d23c38758b4b9eb5802b6a22a094a3adb64e508..5e9f77a53bffed2e79200e9d8bb8685d3dd89901 100644
+index 33f7f4df53ba52f9afa22662427cbab1876b451c..3742bd5f1a31d45f2ac760f706f6069a88274e27 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2475,6 +2475,52 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2596,6 +2596,52 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      int getSimulationDistance();
      // Spigot end
  

--- a/patches/api/0018-Expose-server-CommandMap.patch
+++ b/patches/api/0018-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index bbee4e40917cca4e692c3d60c1c513b4c847160f..259c15ada05115b9fc86f1de06649d5cec2ef137 100644
+index f5d697e759700b10237494f2587939eea365ab3a..b9bdd75beb5888bde6f6486a785d45cb61da4b8a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1912,6 +1912,19 @@ public final class Bukkit {
+@@ -2017,6 +2017,19 @@ public final class Bukkit {
          return server.getUnsafe();
      }
  
@@ -29,10 +29,10 @@ index bbee4e40917cca4e692c3d60c1c513b4c847160f..259c15ada05115b9fc86f1de06649d5c
      public static Server.Spigot spigot() {
          return server.spigot();
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 835041d2ab6545e52d963d96d558f9a7e52d279a..66211ef974b9e091983bfda108f6e420c01a9d78 100644
+index a4ec6dae0b6302b6486bb5105438ef8322b433be..94f242adad348f8a33e7d319d1835d6eba584c2b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1471,6 +1471,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1564,6 +1564,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      public double[] getTPS();
      // Paper end
  

--- a/patches/api/0019-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0019-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Graduate bungeecord chat API from spigot subclasses
 Change Javadoc to be accurate
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 259c15ada05115b9fc86f1de06649d5cec2ef137..5fc71e24f1562ff0d448b964f29fd109d4d9bb4d 100644
+index b9bdd75beb5888bde6f6486a785d45cb61da4b8a..bd010258807bac5c495671052b143063ad784577 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -376,6 +376,30 @@ public final class Bukkit {
+@@ -378,6 +378,30 @@ public final class Bukkit {
          return server.broadcastMessage(message);
      }
  
@@ -41,10 +41,10 @@ index 259c15ada05115b9fc86f1de06649d5cec2ef137..5fc71e24f1562ff0d448b964f29fd109
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 66211ef974b9e091983bfda108f6e420c01a9d78..8fb6545406ab6029d82c903856bda6c6d6fa0636 100644
+index 94f242adad348f8a33e7d319d1835d6eba584c2b..d75b565774948cb3ae89775b0e3e42ae9358004b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -309,6 +309,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -311,6 +311,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Deprecated // Paper
      public int broadcastMessage(@NotNull String message);
  
@@ -76,7 +76,7 @@ index 66211ef974b9e091983bfda108f6e420c01a9d78..8fb6545406ab6029d82c903856bda6c6
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3aa34138d90b206193fee0558939d8de52cd2a85..77a3bb82f90a7779f98246ceecc150d4417043e7 100644
+index 2d93f5ad7f9c0df08bcd099a813c1d8e9b8c16eb..365b2e806d9219d9dc2d2e85cc442b03af812b8d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -733,6 +733,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0029-Add-command-to-reload-permissions.yml-and-require-co.patch
+++ b/patches/api/0029-Add-command-to-reload-permissions.yml-and-require-co.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add command to reload permissions.yml and require confirm to
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5fc71e24f1562ff0d448b964f29fd109d4d9bb4d..191e9985fc17ffbdb9b6bdadbea46da54f5f7599 100644
+index bd010258807bac5c495671052b143063ad784577..8f0d38bb51be1ae0eda8b59ed2edb546f646b58b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1947,6 +1947,13 @@ public final class Bukkit {
+@@ -2052,6 +2052,13 @@ public final class Bukkit {
      public static org.bukkit.command.CommandMap getCommandMap() {
          return server.getCommandMap();
      }
@@ -24,10 +24,10 @@ index 5fc71e24f1562ff0d448b964f29fd109d4d9bb4d..191e9985fc17ffbdb9b6bdadbea46da5
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 8fb6545406ab6029d82c903856bda6c6d6fa0636..731679a0893635f5cb71a19fd9ee8562795230b8 100644
+index d75b565774948cb3ae89775b0e3e42ae9358004b..51ee632dbc8efabeff9745945c2caed0f6f83f13 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1717,4 +1717,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1810,4 +1810,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      Spigot spigot();
      // Spigot end

--- a/patches/api/0042-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/api/0042-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 191e9985fc17ffbdb9b6bdadbea46da54f5f7599..3f58ffb4c59a92259fc5dde3d220658b6e54896f 100644
+index 8f0d38bb51be1ae0eda8b59ed2edb546f646b58b..33a76ef6a5e17ced24f421f4122f0565eca6274c 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1954,6 +1954,15 @@ public final class Bukkit {
+@@ -2059,6 +2059,15 @@ public final class Bukkit {
      public static void reloadPermissions() {
          server.reloadPermissions();
      }
@@ -26,10 +26,10 @@ index 191e9985fc17ffbdb9b6bdadbea46da54f5f7599..3f58ffb4c59a92259fc5dde3d220658b
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 731679a0893635f5cb71a19fd9ee8562795230b8..01df6fc54078901a9195dd2bb45eaef1706ba036 100644
+index 51ee632dbc8efabeff9745945c2caed0f6f83f13..a88574d8a0debbfc6c3999b5a7f968eb0b5da9ec 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1719,4 +1719,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1812,4 +1812,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      // Spigot end
  
      void reloadPermissions(); // Paper

--- a/patches/api/0050-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/api/0050-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -7,10 +7,10 @@ Provides counts without the ineffeciency of using .getEntities().size()
 which creates copy of the collections.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 7b1fb280a86ab44756fc233b085f878d2a27ad66..cec39714294127478b6e73452354ba7ccab78b25 100644
+index 3742bd5f1a31d45f2ac760f706f6069a88274e27..847a939b50c0a4d8bb5fecd7216a16d54e13046d 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -40,6 +40,33 @@ import org.jetbrains.annotations.Nullable;
+@@ -41,6 +41,33 @@ import org.jetbrains.annotations.Nullable;
   */
  public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, net.kyori.adventure.audience.ForwardingAudience { // Paper
  

--- a/patches/api/0053-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/api/0053-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 3f58ffb4c59a92259fc5dde3d220658b6e54896f..45c4fddb8562736eaf98810d70d002ae6e3664e7 100644
+index 33a76ef6a5e17ced24f421f4122f0565eca6274c..0da4b67ee4406995692ded99e0f0de51fd78ded2 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1963,6 +1963,16 @@ public final class Bukkit {
+@@ -2068,6 +2068,16 @@ public final class Bukkit {
      public static boolean reloadCommandAliases() {
          return server.reloadCommandAliases();
      }
@@ -27,10 +27,10 @@ index 3f58ffb4c59a92259fc5dde3d220658b6e54896f..45c4fddb8562736eaf98810d70d002ae
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 01df6fc54078901a9195dd2bb45eaef1706ba036..1db8f63d9207330acc1b403adce0773149bc879f 100644
+index a88574d8a0debbfc6c3999b5a7f968eb0b5da9ec..481548001744493fe477ef0713acbef86ccf6718 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1721,4 +1721,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1814,4 +1814,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      void reloadPermissions(); // Paper
  
      boolean reloadCommandAliases(); // Paper

--- a/patches/api/0054-Fix-upstream-javadocs.patch
+++ b/patches/api/0054-Fix-upstream-javadocs.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix upstream javadocs
 Upstream still refuses to use Java 8 with the API so they are likely unaware these are even issues.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 45c4fddb8562736eaf98810d70d002ae6e3664e7..9838557d874e498e1f7cef8f219000dcaea7a263 100644
+index 0da4b67ee4406995692ded99e0f0de51fd78ded2..b175f07b99a07ba50c4721c38f9e6330f02942f8 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1220,6 +1220,8 @@ public final class Bukkit {
+@@ -1299,6 +1299,8 @@ public final class Bukkit {
  
      /**
       * Gets every player that has ever played on this server.
@@ -19,10 +19,10 @@ index 45c4fddb8562736eaf98810d70d002ae6e3664e7..9838557d874e498e1f7cef8f219000dc
       * @return an array containing all previous players
       */
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1db8f63d9207330acc1b403adce0773149bc879f..ad11f8271d5b6f44d7d5cf0c122b51b2b8d1af3b 100644
+index 481548001744493fe477ef0713acbef86ccf6718..24e68d5cb4f713984b25ab19330cb77f1eddb5cf 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1027,6 +1027,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1097,6 +1097,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
  
      /**
       * Gets every player that has ever played on this server.
@@ -45,7 +45,7 @@ index 91fc11dda99de506be83d40df8929bf7cd8e8d85..7dc631ebd009f5f5c3ac1699c3f3515c
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index db4ba67618d29f72d695c66c27d771795565a1d0..0ab94ddd3b88eee8040233a89823bd2fadc78d55 100644
+index 50ac6f0374da5697a38ef5ec7625da91d4a4276c..f607c57275958bf1cbf8e77b4d7efa936064c228 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
 @@ -21,6 +21,11 @@ import org.jetbrains.annotations.Nullable;
@@ -76,7 +76,7 @@ index be9334a8b5fba9181ad63c211697e798be63da25..0514a141cb93a650be38c63d4336d46e
       * Instructs this Mob to set the specified LivingEntity as its target.
       * <p>
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 632622b90696f0e1c8e33d897d8e14467691e760..b7a3da7a6ee0915449534f7f879eb2f40090b9dd 100644
+index a0777f9dc7cb6d4274635d794cf66de714535cde..2ba2c61dd1e8180d9dfbced8dc1642c75aaff6f7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -753,7 +753,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -7,7 +7,7 @@ Provides basic elements of a PlayerProfile to be used by future API/events
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2ef9a7bd55e2c9cf8cb20d5f77282676ae11181f
+index 0000000000000000000000000000000000000000..8389f875bdc94ccda166824cb48b975f77b5af2d
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
 @@ -0,0 +1,177 @@
@@ -22,7 +22,7 @@ index 0000000000000000000000000000000000000000..2ef9a7bd55e2c9cf8cb20d5f77282676
 +/**
 + * Represents a players profile for the game, such as UUID, Name, and textures.
 + */
-+public interface PlayerProfile {
++public interface PlayerProfile extends org.bukkit.profile.PlayerProfile {
 +
 +    /**
 +     * @return The players name, if set
@@ -267,10 +267,10 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9838557d874e498e1f7cef8f219000dcaea7a263..c7daa7c9f85c62d0effd5c3f406568d77fd8cd78 100644
+index b175f07b99a07ba50c4721c38f9e6330f02942f8..aae3eec8d28a0047bc590ecc55d87d11ee6d08f0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1975,6 +1975,40 @@ public final class Bukkit {
+@@ -2080,6 +2080,40 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
@@ -312,10 +312,10 @@ index 9838557d874e498e1f7cef8f219000dcaea7a263..c7daa7c9f85c62d0effd5c3f406568d7
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ad11f8271d5b6f44d7d5cf0c122b51b2b8d1af3b..fb5c308d82e9103a212deea2a6fa2e158cddb931 100644
+index 24e68d5cb4f713984b25ab19330cb77f1eddb5cf..51c96a0b6645cf31f4ca051f6a8c75b5f188484c 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1732,5 +1732,33 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1825,5 +1825,33 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();

--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -7,15 +7,17 @@ Provides basic elements of a PlayerProfile to be used by future API/events
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8389f875bdc94ccda166824cb48b975f77b5af2d
+index 0000000000000000000000000000000000000000..a4d84b5dc76c6ace93ce1467f7d6b48df97fcf5f
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
-@@ -0,0 +1,177 @@
+@@ -0,0 +1,197 @@
 +package com.destroystokyo.paper.profile;
 +
 +import java.util.Collection;
 +import java.util.Set;
 +import java.util.UUID;
++
++import org.bukkit.profile.PlayerTextures;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -52,6 +54,24 @@ index 0000000000000000000000000000000000000000..8389f875bdc94ccda166824cb48b975f
 +     */
 +    @Nullable
 +    UUID setId(@Nullable UUID uuid);
++
++    /**
++     * Gets the {@link PlayerTextures} of this profile.
++     * This will build a snapshot of the current texture data once
++     * requested inside PlayerTextures.
++     *
++     * @return the textures, not <code>null</code>
++     */
++    @NotNull
++    PlayerTextures getTextures();
++
++    /**
++     * Copies the given textures.
++     *
++     * @param textures the textures to copy, or <code>null</code> to clear the
++     * textures
++     */
++    void setTextures(@Nullable PlayerTextures textures);
 +
 +    /**
 +     * @return A Mutable set of this players properties, such as textures.

--- a/patches/api/0061-Entity-fromMobSpawner.patch
+++ b/patches/api/0061-Entity-fromMobSpawner.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 65088203d29798efe211612dfadb356f457ed466..71f519b8f03d2a52f2c5a9283a18c74c1ca52328 100644
+index c315d2494969190f8b53236f905ad5c5cf1bfc39..b9a61d06d72831dc0c591e129553453a537d3785 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -673,5 +673,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -681,5 +681,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      @Nullable
      Location getOrigin();

--- a/patches/api/0083-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/patches/api/0083-Add-setPlayerProfile-API-for-Skulls.patch
@@ -7,18 +7,10 @@ This allows you to create already filled textures on Skulls to avoid texture loo
 which commonly cause rate limit issues with Mojang API
 
 diff --git a/src/main/java/org/bukkit/block/Skull.java b/src/main/java/org/bukkit/block/Skull.java
-index 943d751fb3e48212fbe258845beba03c25fa22d9..a6914f01e01e9103702185f92b0209b3c84c152a 100644
+index 83ca284e02f0c2229126d8f40cb33b18f44524d3..d89da5e370d95cfbc4dac776a64e402c5c1f5fc1 100644
 --- a/src/main/java/org/bukkit/block/Skull.java
 +++ b/src/main/java/org/bukkit/block/Skull.java
-@@ -7,6 +7,7 @@ import org.bukkit.block.data.BlockData;
- import org.jetbrains.annotations.Contract;
- import org.jetbrains.annotations.NotNull;
- import org.jetbrains.annotations.Nullable;
-+import com.destroystokyo.paper.profile.PlayerProfile; // Paper
- 
- /**
-  * Represents a captured state of a skull block.
-@@ -61,6 +62,20 @@ public interface Skull extends TileState {
+@@ -62,6 +62,20 @@ public interface Skull extends TileState {
       */
      public void setOwningPlayer(@NotNull OfflinePlayer player);
  
@@ -27,35 +19,39 @@ index 943d751fb3e48212fbe258845beba03c25fa22d9..a6914f01e01e9103702185f92b0209b3
 +     * Sets this skull to use the supplied Player Profile, which can include textures already prefilled.
 +     * @param profile The profile to set this Skull to use, may not be null
 +     */
-+    void setPlayerProfile(@NotNull PlayerProfile profile);
++    void setPlayerProfile(@NotNull com.destroystokyo.paper.profile.PlayerProfile profile);
 +
 +    /**
-+     * If the skull has an owner, per {@link #hasOwner()}, return the owners {@link PlayerProfile}
++     * If the skull has an owner, per {@link #hasOwner()}, return the owners {@link com.destroystokyo.paper.profile.PlayerProfile}
 +     * @return The profile of the owner, if set
 +     */
-+    @Nullable PlayerProfile getPlayerProfile();
++    @Nullable com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile();
 +    // Paper end
 +
      /**
-      * Gets the rotation of the skull in the world (or facing direction if this
-      * is a wall mounted skull).
+      * Gets the profile of the player who owns the skull. This player profile
+      * may appear as the texture depending on skull type.
+@@ -69,6 +83,7 @@ public interface Skull extends TileState {
+      * @return the profile of the owning player
+      */
+     @Nullable
++    @Deprecated // Paper
+     PlayerProfile getOwnerProfile();
+ 
+     /**
+@@ -83,6 +98,7 @@ public interface Skull extends TileState {
+      * @throws IllegalArgumentException if the profile does not contain the
+      * necessary information
+      */
++    @Deprecated // Paper
+     void setOwnerProfile(@Nullable PlayerProfile profile);
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/inventory/meta/SkullMeta.java b/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
-index 496254f959345d74167a9b44d160ea1bb428c5a1..88d1c889c09adb91abb09a8e43a30c871b217da2 100644
+index dcefd0eea9461441c4209d587896d704389487d0..9ad062968335ee02bff5353d8c63c330d9338cd7 100644
 --- a/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/SkullMeta.java
-@@ -1,9 +1,11 @@
- package org.bukkit.inventory.meta;
- 
-+import com.destroystokyo.paper.profile.PlayerProfile;
- import org.bukkit.OfflinePlayer;
- import org.jetbrains.annotations.NotNull;
- import org.jetbrains.annotations.Nullable;
- 
-+
- /**
-  * Represents a skull that can have an owner.
-  */
-@@ -36,6 +38,20 @@ public interface SkullMeta extends ItemMeta {
+@@ -37,6 +37,20 @@ public interface SkullMeta extends ItemMeta {
      @Deprecated
      boolean setOwner(@Nullable String owner);
  
@@ -64,15 +60,31 @@ index 496254f959345d74167a9b44d160ea1bb428c5a1..88d1c889c09adb91abb09a8e43a30c87
 +     * Sets this skull to use the supplied Player Profile, which can include textures already prefilled.
 +     * @param profile The profile to set this Skull to use, or null to clear owner
 +     */
-+    void setPlayerProfile(@Nullable PlayerProfile profile);
++    void setPlayerProfile(@Nullable com.destroystokyo.paper.profile.PlayerProfile profile);
 +
 +    /**
-+     * If the skull has an owner, per {@link #hasOwner()}, return the owners {@link PlayerProfile}
++     * If the skull has an owner, per {@link #hasOwner()}, return the owners {@link com.destroystokyo.paper.profile.PlayerProfile}
 +     * @return The profile of the owner, if set
 +     */
-+    @Nullable PlayerProfile getPlayerProfile();
++    @Nullable com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile();
 +    // Paper end
 +
      /**
       * Gets the owner of the skull.
       *
+@@ -63,6 +77,7 @@ public interface SkullMeta extends ItemMeta {
+      * @return the profile of the owning player
+      */
+     @Nullable
++    @Deprecated // Paper
+     PlayerProfile getOwnerProfile();
+ 
+     /**
+@@ -77,6 +92,7 @@ public interface SkullMeta extends ItemMeta {
+      * @throws IllegalArgumentException if the profile does not contain the
+      * necessary information
+      */
++    @Deprecated // Paper
+     void setOwnerProfile(@Nullable PlayerProfile profile);
+ 
+     @Override

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -5,6 +5,62 @@ Subject: [PATCH] Player.setPlayerProfile API
 
 This can be useful for changing name or skins after a player has logged in.
 
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index aae3eec8d28a0047bc590ecc55d87d11ee6d08f0..64cdb9d4e3007f67763f8decdd0c9645d6641597 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1166,6 +1166,7 @@ public final class Bukkit {
+      * <code>null</code> and the name is <code>null</code> or blank
+      */
+     @NotNull
++    @Deprecated // Paper
+     public static PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name) {
+         return server.createPlayerProfile(uniqueId, name);
+     }
+@@ -1178,6 +1179,7 @@ public final class Bukkit {
+      * @throws IllegalArgumentException if the unique id is <code>null</code>
+      */
+     @NotNull
++    @Deprecated // Paper
+     public static PlayerProfile createPlayerProfile(@NotNull UUID uniqueId) {
+         return server.createPlayerProfile(uniqueId);
+     }
+@@ -1191,6 +1193,7 @@ public final class Bukkit {
+      * blank
+      */
+     @NotNull
++    @Deprecated // Paper
+     public static PlayerProfile createPlayerProfile(@NotNull String name) {
+         return server.createPlayerProfile(name);
+     }
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 51c96a0b6645cf31f4ca051f6a8c75b5f188484c..80d474a979add473c99692ccde93439db3774537 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -990,6 +990,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * <code>null</code> and the name is <code>null</code> or blank
+      */
+     @NotNull
++    @Deprecated // Paper
+     PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name);
+ 
+     /**
+@@ -1000,6 +1001,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @throws IllegalArgumentException if the unique id is <code>null</code>
+      */
+     @NotNull
++    @Deprecated // Paper
+     PlayerProfile createPlayerProfile(@NotNull UUID uniqueId);
+ 
+     /**
+@@ -1011,6 +1013,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * blank
+      */
+     @NotNull
++    @Deprecated
+     PlayerProfile createPlayerProfile(@NotNull String name);
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
 index b68f2774e4f88e905cc195df6d1592d96103df7a..23df52c7ac4ec5e687e763c13a0937c3fbc5dd47 100644
 --- a/src/main/java/org/bukkit/entity/Player.java

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -6,18 +6,10 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b68f2774e4f88e905cc195df6d1592d96103df7a..e64af8a5c6cfb1bb6493261c5a057364346d8608 100644
+index b68f2774e4f88e905cc195df6d1592d96103df7a..23df52c7ac4ec5e687e763c13a0937c3fbc5dd47 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
- import java.util.UUID;
- import com.destroystokyo.paper.Title; // Paper
- import net.kyori.adventure.text.Component;
-+import com.destroystokyo.paper.profile.PlayerProfile; // Paper
- import org.bukkit.DyeColor;
- import org.bukkit.Effect;
- import org.bukkit.GameMode;
-@@ -2235,6 +2236,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2235,6 +2235,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();
@@ -27,14 +19,36 @@ index b68f2774e4f88e905cc195df6d1592d96103df7a..e64af8a5c6cfb1bb6493261c5a057364
 +     * @return The players profile object
 +     */
 +    @NotNull
-+    PlayerProfile getPlayerProfile();
++    com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile();
 +
 +    /**
 +     * Changes the PlayerProfile for this player. This will cause this player
 +     * to be reregistered to all clients that can currently see this player
 +     * @param profile The new profile to use
 +     */
-+    void setPlayerProfile(@NotNull PlayerProfile profile);
++    void setPlayerProfile(@NotNull com.destroystokyo.paper.profile.PlayerProfile profile);
      // Paper end
  
      // Spigot start
+diff --git a/src/main/java/org/bukkit/profile/PlayerProfile.java b/src/main/java/org/bukkit/profile/PlayerProfile.java
+index 16ae1282f3178e8873483a25a5d5cce16b2c21a9..c4aa20fbb0865a0b43ece475ee115ad6a7c65a48 100644
+--- a/src/main/java/org/bukkit/profile/PlayerProfile.java
++++ b/src/main/java/org/bukkit/profile/PlayerProfile.java
+@@ -16,7 +16,9 @@ import org.jetbrains.annotations.Nullable;
+  * <p>
+  * New profiles can be created via
+  * {@link Server#createPlayerProfile(UUID, String)}.
++ * @deprecated see {@link com.destroystokyo.paper.profile.PlayerProfile}
+  */
++@Deprecated // Paper
+ public interface PlayerProfile extends Cloneable, ConfigurationSerializable {
+ 
+     /**
+@@ -25,6 +27,7 @@ public interface PlayerProfile extends Cloneable, ConfigurationSerializable {
+      * @return the player's unique id, or <code>null</code> if not available
+      */
+     @Nullable
++    @Deprecated // Paper
+     UUID getUniqueId();
+ 
+     /**

--- a/patches/api/0092-getPlayerUniqueId-API.patch
+++ b/patches/api/0092-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c7daa7c9f85c62d0effd5c3f406568d77fd8cd78..23960534cbb83cfca08ccc1e37bc7a713728b791 100644
+index aae3eec8d28a0047bc590ecc55d87d11ee6d08f0..8875c963e358d1db37ecef7312e7608c89040013 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -616,6 +616,20 @@ public final class Bukkit {
+@@ -656,6 +656,20 @@ public final class Bukkit {
          return server.getPlayer(id);
      }
  
@@ -34,10 +34,10 @@ index c7daa7c9f85c62d0effd5c3f406568d77fd8cd78..23960534cbb83cfca08ccc1e37bc7a71
       * Gets the plugin manager for interfacing with plugins.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index fb5c308d82e9103a212deea2a6fa2e158cddb931..f7320c0797f31cc9609a6764d886bdb6dbd082af 100644
+index 51c96a0b6645cf31f4ca051f6a8c75b5f188484c..30d905685b336c7127445ac1d1946334ee954416 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -524,6 +524,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -561,6 +561,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      public Player getPlayer(@NotNull UUID id);
  

--- a/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
@@ -24,10 +24,10 @@ index 8a479c7dfd3825fab8bb057d8afa5ae0cb01b071..6ef0d7f3dcb779fb7dc5786e74332620
      /**
       * Make the entity drop the item in their hand.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index e64af8a5c6cfb1bb6493261c5a057364346d8608..559d45ed0af80702d86eac20f01fcfb3104cc24c 100644
+index 23df52c7ac4ec5e687e763c13a0937c3fbc5dd47..fd4613f702ebbd32ec22a81f993a1ea9d8dd896f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2091,7 +2091,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2090,7 +2090,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Open a Sign for editing by the Player.
       *

--- a/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
@@ -8,10 +8,10 @@ Allows a more logical API for banning players.
 player.banPlayer("Breaking the rules");
 
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
-index 58313929f81509030216a0e5e3869da63e11108e..6cf05fed701c67a2c797a4e0839c795802a238a1 100644
+index 76e511e7f619960ab50d534c17489e2bc87ebf5a..9d774a10b9543e9293cb10ee9d7c9adebbfef34c 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
-@@ -45,6 +45,61 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -58,6 +58,61 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       * @return true if banned, otherwise false
       */
      public boolean isBanned();
@@ -74,21 +74,10 @@ index 58313929f81509030216a0e5e3869da63e11108e..6cf05fed701c67a2c797a4e0839c7958
      /**
       * Checks if this player is whitelisted or not
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5224cfe5d57ab62b52554336f325dae8829d1b30..264a35cc33f40405e9ba10de850bb3142d984ee7 100644
+index fd4613f702ebbd32ec22a81f993a1ea9d8dd896f..61e75620b205cfeda0aee433651c45235bf21181 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -5,6 +5,10 @@ import java.util.UUID;
- import com.destroystokyo.paper.Title; // Paper
- import net.kyori.adventure.text.Component;
- import com.destroystokyo.paper.profile.PlayerProfile; // Paper
-+import java.util.Date; // Paper
-+import org.bukkit.BanEntry; // Paper
-+import org.bukkit.BanList; // Paper
-+import org.bukkit.Bukkit; // Paper
- import org.bukkit.DyeColor;
- import org.bukkit.Effect;
- import org.bukkit.GameMode;
-@@ -737,6 +741,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -736,6 +736,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start
@@ -100,7 +89,7 @@ index 5224cfe5d57ab62b52554336f325dae8829d1b30..264a35cc33f40405e9ba10de850bb314
 +     */
 +    // For reference, Bukkit defines this as nullable, while they impl isn't, we'll follow API.
 +    @Nullable
-+    public default BanEntry banPlayerFull(@Nullable String reason) {
++    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason) {
 +        return banPlayerFull(reason, null, null);
 +    }
 +
@@ -112,7 +101,7 @@ index 5224cfe5d57ab62b52554336f325dae8829d1b30..264a35cc33f40405e9ba10de850bb314
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerFull(@Nullable String reason, @Nullable String source) {
++    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason, @Nullable String source) {
 +        return banPlayerFull(reason, null, source);
 +    }
 +
@@ -124,7 +113,7 @@ index 5224cfe5d57ab62b52554336f325dae8829d1b30..264a35cc33f40405e9ba10de850bb314
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerFull(@Nullable String reason, @Nullable Date expires) {
++    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason, @Nullable java.util.Date expires) {
 +        return banPlayerFull(reason, expires, null);
 +    }
 +
@@ -137,102 +126,102 @@ index 5224cfe5d57ab62b52554336f325dae8829d1b30..264a35cc33f40405e9ba10de850bb314
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerFull(@Nullable String reason, @Nullable Date expires, @Nullable String source) {
++    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source) {
 +        banPlayer(reason, expires, source);
 +        return banPlayerIP(reason, expires, source, true);
 +    }
 +
 +    /**
 +     * Permanently Bans the IP address currently used by the player.
-+     * Does not ban the Profile, use {@link #banPlayerFull(String, Date, String)}
++     * Does not ban the Profile, use {@link #banPlayerFull(String, java.util.Date, String)}
 +     *
 +     * @param reason Reason for ban
 +     * @param kickPlayer Whether or not to kick the player afterwards
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerIP(@Nullable String reason, boolean kickPlayer) {
++    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, boolean kickPlayer) {
 +        return banPlayerIP(reason, null, null, kickPlayer);
 +    }
 +
 +    /**
 +     * Permanently Bans the IP address currently used by the player.
-+     * Does not ban the Profile, use {@link #banPlayerFull(String, Date, String)}
++     * Does not ban the Profile, use {@link #banPlayerFull(String, java.util.Date, String)}
 +     * @param reason Reason for ban
 +     * @param source Source of ban, or null for default
 +     * @param kickPlayer Whether or not to kick the player afterwards
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerIP(@Nullable String reason, @Nullable String source, boolean kickPlayer) {
++    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable String source, boolean kickPlayer) {
 +        return banPlayerIP(reason, null, source, kickPlayer);
 +    }
 +
 +    /**
 +     * Bans the IP address currently used by the player.
-+     * Does not ban the Profile, use {@link #banPlayerFull(String, Date, String)}
++     * Does not ban the Profile, use {@link #banPlayerFull(String, java.util.Date, String)}
 +     * @param reason Reason for Ban
 +     * @param expires When to expire the ban
 +     * @param kickPlayer Whether or not to kick the player afterwards
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerIP(@Nullable String reason, @Nullable Date expires, boolean kickPlayer) {
++    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires, boolean kickPlayer) {
 +        return banPlayerIP(reason, expires, null, kickPlayer);
 +    }
 +
 +    /**
 +     * Permanently Bans the IP address currently used by the player.
-+     * Does not ban the Profile, use {@link #banPlayerFull(String, Date, String)}
++     * Does not ban the Profile, use {@link #banPlayerFull(String, java.util.Date, String)}
 +     *
 +     * @param reason Reason for ban
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerIP(@Nullable String reason) {
++    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason) {
 +        return banPlayerIP(reason, null, null);
 +    }
 +
 +    /**
 +     * Permanently Bans the IP address currently used by the player.
-+     * Does not ban the Profile, use {@link #banPlayerFull(String, Date, String)}
++     * Does not ban the Profile, use {@link #banPlayerFull(String, java.util.Date, String)}
 +     * @param reason Reason for ban
 +     * @param source Source of ban, or null for default
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerIP(@Nullable String reason, @Nullable String source) {
++    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable String source) {
 +        return banPlayerIP(reason, null, source);
 +    }
 +
 +    /**
 +     * Bans the IP address currently used by the player.
-+     * Does not ban the Profile, use {@link #banPlayerFull(String, Date, String)}
++     * Does not ban the Profile, use {@link #banPlayerFull(String, java.util.Date, String)}
 +     * @param reason Reason for Ban
 +     * @param expires When to expire the ban
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerIP(@Nullable String reason, @Nullable Date expires) {
++    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires) {
 +        return banPlayerIP(reason, expires, null);
 +    }
 +
 +    /**
 +     * Bans the IP address currently used by the player.
-+     * Does not ban the Profile, use {@link #banPlayerFull(String, Date, String)}
++     * Does not ban the Profile, use {@link #banPlayerFull(String, java.util.Date, String)}
 +     * @param reason Reason for Ban
 +     * @param expires When to expire the ban
 +     * @param source Source of the banm or null for default
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerIP(@Nullable String reason, @Nullable Date expires, @Nullable String source) {
++    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source) {
 +        return banPlayerIP(reason, expires, source, true);
 +    }
 +
 +    /**
 +     * Bans the IP address currently used by the player.
-+     * Does not ban the Profile, use {@link #banPlayerFull(String, Date, String)}
++     * Does not ban the Profile, use {@link #banPlayerFull(String, java.util.Date, String)}
 +     * @param reason Reason for Ban
 +     * @param expires When to expire the ban
 +     * @param source Source of the banm or null for default
@@ -240,8 +229,8 @@ index 5224cfe5d57ab62b52554336f325dae8829d1b30..264a35cc33f40405e9ba10de850bb314
 +     * @return Ban Entry
 +     */
 +    @Nullable
-+    public default BanEntry banPlayerIP(@Nullable String reason, @Nullable Date expires, @Nullable String source, boolean kickPlayer) {
-+        BanEntry banEntry = Bukkit.getServer().getBanList(BanList.Type.IP).addBan(getAddress().getAddress().getHostAddress(), reason, expires, source);
++    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source, boolean kickPlayer) {
++        org.bukkit.BanEntry banEntry = org.bukkit.Bukkit.getServer().getBanList(org.bukkit.BanList.Type.IP).addBan(getAddress().getAddress().getHostAddress(), reason, expires, source);
 +        if (kickPlayer && isOnline()) {
 +            getPlayer().kickPlayer(reason);
 +        }

--- a/patches/api/0098-Additional-world.getNearbyEntities-API-s.patch
+++ b/patches/api/0098-Additional-world.getNearbyEntities-API-s.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Additional world.getNearbyEntities API's
 Provides more methods to get nearby entities, and filter by types and predicates
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index cec39714294127478b6e73452354ba7ccab78b25..bd1e64d03d601d55bab3f1de367792544ed802b1 100644
+index 847a939b50c0a4d8bb5fecd7216a16d54e13046d..2a1186fe30bb7df2be6825a08ed03b296f657a45 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -1,6 +1,9 @@
@@ -19,7 +19,7 @@ index cec39714294127478b6e73452354ba7ccab78b25..bd1e64d03d601d55bab3f1de36779254
  import java.util.Collection;
  import java.util.HashMap;
  import java.util.List;
-@@ -652,6 +655,256 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -653,6 +656,256 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Collection<Entity> getEntitiesByClasses(@NotNull Class<?>... classes);
  

--- a/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -522,10 +522,10 @@ index dc5142460a711ee79aed30276382b92c82cbef00..40a3a54fc82252692fc8710cabb243d0
       * Options which can be applied to redstone dust particles - a particle
       * color and size.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 7e264881bb357b382b1b444982bbb1ed77788014..e06ab626c140988431022c9209266826c4994b0f 100644
+index 2a1186fe30bb7df2be6825a08ed03b296f657a45..5ced29d9b60213ec1be70f26be837010c6758565 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2662,7 +2662,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2783,7 +2783,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
       */

--- a/patches/api/0108-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/api/0108-ItemStack-getMaxItemUseDuration.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 4b00a1833387f40a3771a254ad36f94a0c38a5eb..814854f08cce607004ad074d1f8efb44c7108f20 100644
+index 2581117ded5d91070bc9416eee53383e915a1564..9376c6a02731c71798aaf3361b2e30c521547874 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -639,5 +639,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor

--- a/patches/api/0115-Expand-Explosions-API.patch
+++ b/patches/api/0115-Expand-Explosions-API.patch
@@ -106,10 +106,10 @@ index bbc636baef2e2b0586c7d517be428438ca26ab66..a8d4f7972d07ddde171b4a1ec470a4c6
       * Returns a list of entities within a bounding box centered around a Location.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 6156fb9827400cb6c1c0a96e0b6fed180a12d610..1e29c0e69973a1f7422852a04f97a6e7c19a3e54 100644
+index 5ced29d9b60213ec1be70f26be837010c6758565..7ad40278736b959ab47b6febe748de6d91fef950 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1419,6 +1419,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1420,6 +1420,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public boolean createExplosion(@NotNull Location loc, float power, boolean setFire);
  

--- a/patches/api/0116-ItemStack-API-additions-for-quantity-flags-lore.patch
+++ b/patches/api/0116-ItemStack-API-additions-for-quantity-flags-lore.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ItemStack API additions for quantity/flags/lore
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 814854f08cce607004ad074d1f8efb44c7108f20..fbafd506f86a884a19b218e87ddc8720e83f993d 100644
+index 9376c6a02731c71798aaf3361b2e30c521547874..487e6a6391123a4792c3bdeba869aa2bcb5922cc 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -2,7 +2,9 @@ package org.bukkit.inventory;

--- a/patches/api/0119-Add-World.getEntity-UUID-API.patch
+++ b/patches/api/0119-Add-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 1e29c0e69973a1f7422852a04f97a6e7c19a3e54..91755d27b84abad516d891d4b0b7869124cb263e 100644
+index 7ad40278736b959ab47b6febe748de6d91fef950..0f096ea7516c3b14c216d74baa268db37016b27c 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -939,6 +939,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -940,6 +940,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Collection<Entity> getNearbyEntities(@NotNull Location location, double x, double y, double z);
  

--- a/patches/api/0120-InventoryCloseEvent-Reason-API.patch
+++ b/patches/api/0120-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 5cc025b69c4f405be8f7098d0dcef40fa522b39f..1d573d33304e9c15a9949af68dab0626ae04dce4 100644
+index 6ef0d7f3dcb779fb7dc5786e7433262092908eaa..b007b582d344b79ee67751fd1e21f6cef6a1a950 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
 @@ -158,6 +158,15 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder

--- a/patches/api/0122-Entity-getChunk-API.patch
+++ b/patches/api/0122-Entity-getChunk-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Entity#getChunk API
 Get the chunk the entity is currently registered to
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 71f519b8f03d2a52f2c5a9283a18c74c1ca52328..c0d6dc1b584c34c541bf9a2549016b4e29818d45 100644
+index b9a61d06d72831dc0c591e129553453a537d3785..df07eb07896790a09d1022daef5cffc6a435f739 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -3,6 +3,7 @@ package org.bukkit.entity;
@@ -17,7 +17,7 @@ index 71f519b8f03d2a52f2c5a9283a18c74c1ca52328..c0d6dc1b584c34c541bf9a2549016b4e
  import org.bukkit.EntityEffect;
  import org.bukkit.Location;
  import org.bukkit.Nameable;
-@@ -680,5 +681,16 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -688,5 +689,16 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return True if entity spawned from a mob spawner
       */
      boolean fromMobSpawner();

--- a/patches/api/0136-Provide-Chunk-Coordinates-as-a-Long-API.patch
+++ b/patches/api/0136-Provide-Chunk-Coordinates-as-a-Long-API.patch
@@ -7,7 +7,7 @@ Allows you to easily access the chunks X/z as a long, and a method
 to look up by the long key too.
 
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index 5fd6030b2693d793951ed632ad4870e1a6f909aa..40ddeb7abd49eeece531a8e90b4508f3831cc3e9 100644
+index 06737962b844275a74ee2407cc09918599cbaea4..1a4b6922c0a881b60ddf305b1e2b3af0dfde46c3 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
 @@ -28,6 +28,32 @@ public interface Chunk extends PersistentDataHolder {
@@ -44,10 +44,10 @@ index 5fd6030b2693d793951ed632ad4870e1a6f909aa..40ddeb7abd49eeece531a8e90b4508f3
       * Gets the world containing this chunk
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 91755d27b84abad516d891d4b0b7869124cb263e..d3d0e4448135f6c0440c15e0dd3fc15c2616263a 100644
+index 0f096ea7516c3b14c216d74baa268db37016b27c..13487b781317a135bedea2149e24aeac266e9358 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -207,6 +207,22 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -208,6 +208,22 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Chunk getChunkAt(@NotNull Block block);
  

--- a/patches/api/0137-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/patches/api/0137-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index 40ddeb7abd49eeece531a8e90b4508f3831cc3e9..5a4884db36d448c885e49c965ae329a0638dd628 100644
+index 1a4b6922c0a881b60ddf305b1e2b3af0dfde46c3..049c36807d2a970842442c1b7517c06f3f150041 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
 @@ -1,6 +1,8 @@

--- a/patches/api/0139-Allow-Blocks-to-be-accessed-via-a-long-key.patch
+++ b/patches/api/0139-Allow-Blocks-to-be-accessed-via-a-long-key.patch
@@ -48,10 +48,10 @@ index 36ed248f0716f2cc465c08ab851b7d83d4c7c0a7..58728a0f0722b378efa129e26f0c822b
       * @return A new location where X/Y/Z are the center of the block
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index dbfa490c997c515007fc0d86ee5e2b4b98d174e5..4789dafc716c3db63983d49d7af75e3f374f4f51 100644
+index 13487b781317a135bedea2149e24aeac266e9358..1d36788053992e06a5b48e037aa104f97f070a56 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -90,6 +90,38 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -91,6 +91,38 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Block getBlockAt(@NotNull Location location);
  
@@ -91,7 +91,7 @@ index dbfa490c997c515007fc0d86ee5e2b4b98d174e5..4789dafc716c3db63983d49d7af75e3f
       * Gets the highest non-empty (impassable) coordinate at the given
       * coordinates.
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 62ab55729e69bfac8eb4b40d877b945d95df27cd..50fb2c8cbed7a3875a81cf409238912d9b38d820 100644
+index d29bdc125dba0128d93d57e8d9393b970e6c00a9..b101f5264bdde8bd14913d5161c1047020830f8d 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -155,6 +155,82 @@ public interface Block extends Metadatable {

--- a/patches/api/0144-isChunkGenerated-API.patch
+++ b/patches/api/0144-isChunkGenerated-API.patch
@@ -34,10 +34,10 @@ index 58728a0f0722b378efa129e26f0c822b63d1af36..88b3e0323dbc4f0fce31b147c7aaa08d
      /**
       * Sets the position of this Location and returns itself
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 4789dafc716c3db63983d49d7af75e3f374f4f51..f5d21da75d5f78cc081995e3ac02464bf6a9d045 100644
+index 1d36788053992e06a5b48e037aa104f97f070a56..48e439d757a01e0487e7c3db0ab00cdf59bff277 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -253,6 +253,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -254,6 +254,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      public default Chunk getChunkAt(long chunkKey) {
          return getChunkAt((int) chunkKey, (int) (chunkKey >> 32));
      }

--- a/patches/api/0146-Async-Chunks-API.patch
+++ b/patches/api/0146-Async-Chunks-API.patch
@@ -8,10 +8,10 @@ Adds API's to load or generate chunks asynchronously.
 Also adds utility methods to Entity to teleport asynchronously.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index f5d21da75d5f78cc081995e3ac02464bf6a9d045..df90ff43657e6d5f776df95e55fa30538e5c2998 100644
+index 48e439d757a01e0487e7c3db0ab00cdf59bff277..cd228a4fd657cd60e19cf52bcf57a31cb048bb55 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -962,6 +962,482 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -963,6 +963,482 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
          }
          return nearby;
      }
@@ -495,7 +495,7 @@ index f5d21da75d5f78cc081995e3ac02464bf6a9d045..df90ff43657e6d5f776df95e55fa3053
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index c0d6dc1b584c34c541bf9a2549016b4e29818d45..23a3bf005a21cd417f9b2d8ecd64c2887d1e979e 100644
+index df07eb07896790a09d1022daef5cffc6a435f739..7a05615ec7678338801bcae2ec9a029b13d323d2 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -163,6 +163,33 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent

--- a/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9d742cdb669ea1d2cfd99ac25a2843a637bf9307..a5fa9ea0149de9bfd45617c782f0626079893d27 100644
+index 61e75620b205cfeda0aee433651c45235bf21181..11e85e664fdd875c2a6e84b158b78d4784999932 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2410,6 +2410,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2405,6 +2405,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
-     void setPlayerProfile(@NotNull PlayerProfile profile);
+     void setPlayerProfile(@NotNull com.destroystokyo.paper.profile.PlayerProfile profile);
 +
 +    /**
 +     * Returns the amount of ticks the current cooldown lasts

--- a/patches/api/0159-Add-sun-related-API.patch
+++ b/patches/api/0159-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index df90ff43657e6d5f776df95e55fa30538e5c2998..c0e7e96735c8c544b8b80908613bc97117a71703 100644
+index cd228a4fd657cd60e19cf52bcf57a31cb048bb55..b05809ecbe20d813e5cbc6be47961eb8729a8382 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1789,6 +1789,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1790,6 +1790,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public void setFullTime(long time);
  

--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 23960534cbb83cfca08ccc1e37bc7a713728b791..53a361b2f6d8d8e79f215e64d3b42fcbe54b0d81 100644
+index 8875c963e358d1db37ecef7312e7608c89040013..633d67ae1560769e5a5a0a3fe1600c2dd25ab3de 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1990,6 +1990,15 @@ public final class Bukkit {
+@@ -2095,6 +2095,15 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
@@ -25,10 +25,10 @@ index 23960534cbb83cfca08ccc1e37bc7a713728b791..53a361b2f6d8d8e79f215e64d3b42fcb
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f7320c0797f31cc9609a6764d886bdb6dbd082af..963edbb1e7d47410b7474b8e0ce6774a76ea9d88 100644
+index 30d905685b336c7127445ac1d1946334ee954416..a5c84efd6a2de3f1a3d0c11c7a9b2b98fe47b0d9 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1745,6 +1745,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1838,6 +1838,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  

--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 8875c963e358d1db37ecef7312e7608c89040013..633d67ae1560769e5a5a0a3fe1600c2dd25ab3de 100644
+index 76d379cfc00157dd76ae981ebd839ac0954b4773..686235a2347ebeaa5654a14cdd717009f2c0105f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2095,6 +2095,15 @@ public final class Bukkit {
+@@ -2098,6 +2098,15 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
@@ -25,10 +25,10 @@ index 8875c963e358d1db37ecef7312e7608c89040013..633d67ae1560769e5a5a0a3fe1600c2d
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 30d905685b336c7127445ac1d1946334ee954416..a5c84efd6a2de3f1a3d0c11c7a9b2b98fe47b0d9 100644
+index 818c37490d98c287ade9b56f3fc01001db1df773..f43720d07e80e3d2937f5b271664b5268d7af027 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1838,6 +1838,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1841,6 +1841,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  

--- a/patches/api/0168-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/api/0168-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,10 +16,10 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
-index 6cf05fed701c67a2c797a4e0839c795802a238a1..3afd5f5c0208a4ee93b5dbfc2aab2b9d2e8a7544 100644
+index 9d774a10b9543e9293cb10ee9d7c9adebbfef34c..23e853bae0e051cd43deb9eb24c54e74a56d8ab0 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
-@@ -147,7 +147,9 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -160,7 +160,9 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       * UTC.
       *
       * @return Date of last log-in for this player, or 0
@@ -29,7 +29,7 @@ index 6cf05fed701c67a2c797a4e0839c795802a238a1..3afd5f5c0208a4ee93b5dbfc2aab2b9d
      public long getLastPlayed();
  
      /**
-@@ -165,6 +167,30 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -178,6 +180,30 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       */
      @Nullable
      public Location getBedSpawnLocation();

--- a/patches/api/0174-Entity-getEntitySpawnReason.patch
+++ b/patches/api/0174-Entity-getEntitySpawnReason.patch
@@ -10,10 +10,10 @@ persistenting Living Entity, SPAWNER for spawners,
 or DEFAULT since data was not stored.
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 23a3bf005a21cd417f9b2d8ecd64c2887d1e979e..4ed3486e8ef097837cf6762b618e08fa9ff166a5 100644
+index 7a05615ec7678338801bcae2ec9a029b13d323d2..634f3b5dd22bf439aaec7c3ecfb3477b66e994e8 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -719,5 +719,11 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -727,5 +727,11 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
          // TODO remove impl here
          return getLocation().getChunk();
      }

--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -9,10 +9,10 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 53a361b2f6d8d8e79f215e64d3b42fcbe54b0d81..28bc240ba5d93e4112bd95963a334215b1dc2388 100644
+index 633d67ae1560769e5a5a0a3fe1600c2dd25ab3de..fe72d32de424c56eae9fe37fd386cd28b293abcf 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1576,7 +1576,7 @@ public final class Bukkit {
+@@ -1681,7 +1681,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -21,7 +21,7 @@ index 53a361b2f6d8d8e79f215e64d3b42fcbe54b0d81..28bc240ba5d93e4112bd95963a334215
      public static ScoreboardManager getScoreboardManager() {
          return server.getScoreboardManager();
      }
-@@ -1873,7 +1873,7 @@ public final class Bukkit {
+@@ -1978,7 +1978,7 @@ public final class Bukkit {
       * @param clazz the class of the tag entries
       * @return the tag or null
       */
@@ -62,10 +62,10 @@ index 88b3e0323dbc4f0fce31b147c7aaa08d65745852..23ca89dde7f6ac9082d4b97fce295942
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 963edbb1e7d47410b7474b8e0ce6774a76ea9d88..1ffdaf8a7814b44facf9648f9e1ba6525055405b 100644
+index a5c84efd6a2de3f1a3d0c11c7a9b2b98fe47b0d9..bb0965c9f9c735b6bc6d7d6cf495c91a459289bb 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1333,7 +1333,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1426,7 +1426,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -74,7 +74,7 @@ index 963edbb1e7d47410b7474b8e0ce6774a76ea9d88..1ffdaf8a7814b44facf9648f9e1ba652
      ScoreboardManager getScoreboardManager();
  
      /**
-@@ -1603,7 +1603,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1696,7 +1696,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param clazz the class of the tag entries
       * @return the tag or null
       */

--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -9,10 +9,10 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 633d67ae1560769e5a5a0a3fe1600c2dd25ab3de..fe72d32de424c56eae9fe37fd386cd28b293abcf 100644
+index 686235a2347ebeaa5654a14cdd717009f2c0105f..cf7f8a8f03adcbe466b59ea8b98b527fb54a0803 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1681,7 +1681,7 @@ public final class Bukkit {
+@@ -1684,7 +1684,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -21,7 +21,7 @@ index 633d67ae1560769e5a5a0a3fe1600c2dd25ab3de..fe72d32de424c56eae9fe37fd386cd28
      public static ScoreboardManager getScoreboardManager() {
          return server.getScoreboardManager();
      }
-@@ -1978,7 +1978,7 @@ public final class Bukkit {
+@@ -1981,7 +1981,7 @@ public final class Bukkit {
       * @param clazz the class of the tag entries
       * @return the tag or null
       */
@@ -62,10 +62,10 @@ index 88b3e0323dbc4f0fce31b147c7aaa08d65745852..23ca89dde7f6ac9082d4b97fce295942
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a5c84efd6a2de3f1a3d0c11c7a9b2b98fe47b0d9..bb0965c9f9c735b6bc6d7d6cf495c91a459289bb 100644
+index f43720d07e80e3d2937f5b271664b5268d7af027..49bcc2edea32ef2b31b9ed5c3a62140bcc81ffc9 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1426,7 +1426,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1429,7 +1429,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -74,7 +74,7 @@ index a5c84efd6a2de3f1a3d0c11c7a9b2b98fe47b0d9..bb0965c9f9c735b6bc6d7d6cf495c91a
      ScoreboardManager getScoreboardManager();
  
      /**
-@@ -1696,7 +1696,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1699,7 +1699,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param clazz the class of the tag entries
       * @return the tag or null
       */

--- a/patches/api/0178-Add-Heightmap-API.patch
+++ b/patches/api/0178-Add-Heightmap-API.patch
@@ -103,10 +103,10 @@ index 23ca89dde7f6ac9082d4b97fce2959425f3680cb..8321441b8f528a05e297f485672f928e
       * Creates explosion at this location with given power
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index c0e7e96735c8c544b8b80908613bc97117a71703..99729c954ae5114260ae50ad3de32ba9d9344ca8 100644
+index b05809ecbe20d813e5cbc6be47961eb8729a8382..41df2b4680a6b05d055a11f3b64d9746d1754c51 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -160,6 +160,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -161,6 +161,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Block getHighestBlockAt(@NotNull Location location);
  

--- a/patches/api/0180-Add-BlockSoundGroup-interface.patch
+++ b/patches/api/0180-Add-BlockSoundGroup-interface.patch
@@ -64,7 +64,7 @@ index 0000000000000000000000000000000000000000..8cf87d228a7006658d52ce0da16c2d74
 +    Sound getFallSound();
 +}
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 50fb2c8cbed7a3875a81cf409238912d9b38d820..747303fd89aad344af0ed0767d3555b4894701dd 100644
+index b101f5264bdde8bd14913d5161c1047020830f8d..7ea765d5d653b1b84e73fd8c4d9d923049bd06ff 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -606,4 +606,16 @@ public interface Block extends Metadatable {

--- a/patches/api/0183-Expose-the-internal-current-tick.patch
+++ b/patches/api/0183-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 28bc240ba5d93e4112bd95963a334215b1dc2388..f31a1f8a65a79953f6f053c785a7bdacb32291a0 100644
+index fe72d32de424c56eae9fe37fd386cd28b293abcf..f6af2889d7acc2e9f3f3d71d6f22cb1b0d81997b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2032,6 +2032,10 @@ public final class Bukkit {
+@@ -2137,6 +2137,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfile(uuid, name);
      }
@@ -20,10 +20,10 @@ index 28bc240ba5d93e4112bd95963a334215b1dc2388..f31a1f8a65a79953f6f053c785a7bdac
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1ffdaf8a7814b44facf9648f9e1ba6525055405b..f78119e1fad76cd7bbb0a5b78973baf7876d3a9e 100644
+index bb0965c9f9c735b6bc6d7d6cf495c91a459289bb..d4d44d29ee9c80d32399ea645fcd601d9b7eb682 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1779,5 +1779,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1872,5 +1872,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0183-Expose-the-internal-current-tick.patch
+++ b/patches/api/0183-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index fe72d32de424c56eae9fe37fd386cd28b293abcf..f6af2889d7acc2e9f3f3d71d6f22cb1b0d81997b 100644
+index cf7f8a8f03adcbe466b59ea8b98b527fb54a0803..61877d9d64840408a7aec7bcc2a54779a9e820d8 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2137,6 +2137,10 @@ public final class Bukkit {
+@@ -2140,6 +2140,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfile(uuid, name);
      }
@@ -20,10 +20,10 @@ index fe72d32de424c56eae9fe37fd386cd28b293abcf..f6af2889d7acc2e9f3f3d71d6f22cb1b
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index bb0965c9f9c735b6bc6d7d6cf495c91a459289bb..d4d44d29ee9c80d32399ea645fcd601d9b7eb682 100644
+index 49bcc2edea32ef2b31b9ed5c3a62140bcc81ffc9..73ec2a8541ae95e07e32327ad0fff3a30b091658 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1872,5 +1872,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1875,5 +1875,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0185-Add-effect-to-block-break-naturally.patch
+++ b/patches/api/0185-Add-effect-to-block-break-naturally.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add effect to block break naturally
 
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 747303fd89aad344af0ed0767d3555b4894701dd..2a862123a8b12d64a1cda39283b5fa501dd90f26 100644
+index 7ea765d5d653b1b84e73fd8c4d9d923049bd06ff..c88c4223928c2e47f1a85b73165cf433806677df 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -480,6 +480,26 @@ public interface Block extends Metadatable {

--- a/patches/api/0189-Add-tick-times-API.patch
+++ b/patches/api/0189-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f31a1f8a65a79953f6f053c785a7bdacb32291a0..c277b48d45c7aab3b727a7019b3ef253e045629d 100644
+index f6af2889d7acc2e9f3f3d71d6f22cb1b0d81997b..6e55da4cf9161178b4d71899336e94337f08d4ff 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1777,6 +1777,25 @@ public final class Bukkit {
+@@ -1882,6 +1882,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index f31a1f8a65a79953f6f053c785a7bdacb32291a0..c277b48d45c7aab3b727a7019b3ef253
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f78119e1fad76cd7bbb0a5b78973baf7876d3a9e..38febebef94652a9e44475560974d6e8d6949db0 100644
+index d4d44d29ee9c80d32399ea645fcd601d9b7eb682..ba60b84d533058b0f7f5562842e9e23158f14c39 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1507,6 +1507,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1600,6 +1600,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0189-Add-tick-times-API.patch
+++ b/patches/api/0189-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f6af2889d7acc2e9f3f3d71d6f22cb1b0d81997b..6e55da4cf9161178b4d71899336e94337f08d4ff 100644
+index 61877d9d64840408a7aec7bcc2a54779a9e820d8..6971ecc8d285f81c476f1b3442159167102a5719 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1882,6 +1882,25 @@ public final class Bukkit {
+@@ -1885,6 +1885,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index f6af2889d7acc2e9f3f3d71d6f22cb1b0d81997b..6e55da4cf9161178b4d71899336e9433
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d4d44d29ee9c80d32399ea645fcd601d9b7eb682..ba60b84d533058b0f7f5562842e9e23158f14c39 100644
+index 73ec2a8541ae95e07e32327ad0fff3a30b091658..a543d5ec7df410cad15affb22058b60ec6a5c570 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1600,6 +1600,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1603,6 +1603,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0190-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0190-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 6e55da4cf9161178b4d71899336e94337f08d4ff..13d8d2d955ada2765b6c6773f77a5407c86cc390 100644
+index 6971ecc8d285f81c476f1b3442159167102a5719..88d1b843d9c8db350f1b64da06bb1b568626d0ce 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2160,6 +2160,15 @@ public final class Bukkit {
+@@ -2163,6 +2163,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index 6e55da4cf9161178b4d71899336e94337f08d4ff..13d8d2d955ada2765b6c6773f77a5407
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ba60b84d533058b0f7f5562842e9e23158f14c39..5cd3a9a6066b01525c0d3a54e852e876535f37d3 100644
+index a543d5ec7df410cad15affb22058b60ec6a5c570..ce8e0c4e90f59d7446f761d0df9ab1c73bbbb676 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1894,5 +1894,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1897,5 +1897,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0190-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0190-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c277b48d45c7aab3b727a7019b3ef253e045629d..c043e6798314e322e32a1c8e8ef6a795e022b858 100644
+index 6e55da4cf9161178b4d71899336e94337f08d4ff..13d8d2d955ada2765b6c6773f77a5407c86cc390 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2055,6 +2055,15 @@ public final class Bukkit {
+@@ -2160,6 +2160,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index c277b48d45c7aab3b727a7019b3ef253e045629d..c043e6798314e322e32a1c8e8ef6a795
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 38febebef94652a9e44475560974d6e8d6949db0..ad940c5d327c7e1e09aea7d2cee27a8abcf3fed7 100644
+index ba60b84d533058b0f7f5562842e9e23158f14c39..5cd3a9a6066b01525c0d3a54e852e876535f37d3 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1801,5 +1801,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1894,5 +1894,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0191-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/api/0191-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -20,7 +20,7 @@ index 2b123aa748d6ba6c1367f376fedb0b9f019ef7fb..ed5835985df93e87e2eb834c501fae2f
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index aacf8ea85909299355d16cad0386072ec542a70e..b80ef2e5c23764ee68f809268185492bf5577913 100644
+index 3dd8205dd070901be82c2bef390df5df58b2a9a0..011d8cf2b2358d17e475ce88633c6843fa548834 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -629,6 +629,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor

--- a/patches/api/0194-Add-Player-Client-Options-API.patch
+++ b/patches/api/0194-Add-Player-Client-Options-API.patch
@@ -193,7 +193,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index a5fa9ea0149de9bfd45617c782f0626079893d27..4466b78315008e460bf1c4204347d174921e68de 100644
+index 11e85e664fdd875c2a6e84b158b78d4784999932..385846a2011ec07d4f37c98f38d3369199780418 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -203,8 +203,8 @@ index a5fa9ea0149de9bfd45617c782f0626079893d27..4466b78315008e460bf1c4204347d174
 +import com.destroystokyo.paper.ClientOption; // Paper
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
- import com.destroystokyo.paper.profile.PlayerProfile; // Paper
-@@ -2430,6 +2431,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+ import org.bukkit.DyeColor;
+@@ -2425,6 +2426,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0199-Expose-game-version.patch
+++ b/patches/api/0199-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c043e6798314e322e32a1c8e8ef6a795e022b858..92bebf6f46cdd2ff5bc09af32e2d6d2ef0f4f45b 100644
+index 13d8d2d955ada2765b6c6773f77a5407c86cc390..9bcde6496876bf184654c829e73b730b2e70bba6 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -133,6 +133,18 @@ public final class Bukkit {
+@@ -135,6 +135,18 @@ public final class Bukkit {
          return server.getBukkitVersion();
      }
  
@@ -28,10 +28,10 @@ index c043e6798314e322e32a1c8e8ef6a795e022b858..92bebf6f46cdd2ff5bc09af32e2d6d2e
       * Gets a view of all currently logged in players. This {@linkplain
       * Collections#unmodifiableCollection(Collection) view} is a reused
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ad940c5d327c7e1e09aea7d2cee27a8abcf3fed7..f9b25ecf5642c30c04f5e0483a654ff33d1c188d 100644
+index 5cd3a9a6066b01525c0d3a54e852e876535f37d3..5cd733705f47f9fc77d1b10065d93a9b0356f5ea 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -110,6 +110,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -112,6 +112,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public String getBukkitVersion();
  

--- a/patches/api/0200-Add-Mob-Goal-API.patch
+++ b/patches/api/0200-Add-Mob-Goal-API.patch
@@ -521,10 +521,10 @@ index 0000000000000000000000000000000000000000..2405254739a83b2fb517da7fa4ea0721
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9bcde6496876bf184654c829e73b730b2e70bba6..d9581a6270df9e3507cf60a9049ef59e7ff464af 100644
+index 111323f84fb6f34f5a61c5e24d1f1a058744416d..ed6dab65a21b9c089e69cf9fe2fda3919be4e5a3 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2181,6 +2181,16 @@ public final class Bukkit {
+@@ -2184,6 +2184,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -542,10 +542,10 @@ index 9bcde6496876bf184654c829e73b730b2e70bba6..d9581a6270df9e3507cf60a9049ef59e
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5cd733705f47f9fc77d1b10065d93a9b0356f5ea..b78ccbf832199fe84b351c7467a3d9be39f2f819 100644
+index 5b52ec962c0ebd8cf8968dcbc31a9900eb15f6c0..705d30a68d6f10e5c5dd49b70535b320895c8502 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1911,5 +1911,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1914,5 +1914,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0200-Add-Mob-Goal-API.patch
+++ b/patches/api/0200-Add-Mob-Goal-API.patch
@@ -521,10 +521,10 @@ index 0000000000000000000000000000000000000000..2405254739a83b2fb517da7fa4ea0721
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 92bebf6f46cdd2ff5bc09af32e2d6d2ef0f4f45b..0a29ddee94051e398780b9fa07e5ce2b46c51b97 100644
+index 9bcde6496876bf184654c829e73b730b2e70bba6..d9581a6270df9e3507cf60a9049ef59e7ff464af 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2076,6 +2076,16 @@ public final class Bukkit {
+@@ -2181,6 +2181,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -542,10 +542,10 @@ index 92bebf6f46cdd2ff5bc09af32e2d6d2ef0f4f45b..0a29ddee94051e398780b9fa07e5ce2b
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f9b25ecf5642c30c04f5e0483a654ff33d1c188d..a8e187a3f386210c712ab7d620d6a4aa91bf42f8 100644
+index 5cd733705f47f9fc77d1b10065d93a9b0356f5ea..b78ccbf832199fe84b351c7467a3d9be39f2f819 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1818,5 +1818,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1911,5 +1911,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0204-Prioritise-own-classes-where-possible.patch
+++ b/patches/api/0204-Prioritise-own-classes-where-possible.patch
@@ -63,7 +63,7 @@ index 4397fed2b41e5ab444aa7e3c9b5d7dccc50f4e04..d2712f45dbcf26fabe8463d99f378bf4
          for (PluginClassLoader loader : loaders) {
              try {
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 4fa5f7140ea97e1b6a63808b59115bfb1a85cb32..cd1907e8895ece9b780617635b71937596c0f982 100644
+index 684d7b1105350660fe7fc66f57a49db7f39610b4..46b705197e7520cea19da24769bce71406ec6a31 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -33,7 +33,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot

--- a/patches/api/0205-Provide-a-useful-PluginClassLoader-toString.patch
+++ b/patches/api/0205-Provide-a-useful-PluginClassLoader-toString.patch
@@ -8,7 +8,7 @@ however, this provides no indication of the owner of the classloader, making
 these messages effectively useless, this patch rectifies this
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index cd1907e8895ece9b780617635b71937596c0f982..9e14c95deaca0044a3e9284ceefbb2b5c54ede07 100644
+index 46b705197e7520cea19da24769bce71406ec6a31..c0781480ac1562bff7415f0947d733b438a4d04b 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -235,4 +235,16 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot

--- a/patches/api/0211-Add-entity-liquid-API.patch
+++ b/patches/api/0211-Add-entity-liquid-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 4ed3486e8ef097837cf6762b618e08fa9ff166a5..b7d3cd271cccbc250914c5bc17ae892ffcf14b57 100644
+index 634f3b5dd22bf439aaec7c3ecfb3477b66e994e8..1c9d0e6541d41972f9966b83cbba02f6b230a72c 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -725,5 +725,35 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -733,5 +733,35 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      @NotNull
      org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason();

--- a/patches/api/0214-Add-setMaxPlayers-API.patch
+++ b/patches/api/0214-Add-setMaxPlayers-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 0a29ddee94051e398780b9fa07e5ce2b46c51b97..dee9bcd9caee7c900a38c92d5e967cdaaf875a08 100644
+index d9581a6270df9e3507cf60a9049ef59e7ff464af..cf453476006563d8f9c165809c89d73089a84acc 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -186,6 +186,17 @@ public final class Bukkit {
+@@ -188,6 +188,17 @@ public final class Bukkit {
          return server.getMaxPlayers();
      }
  
@@ -27,10 +27,10 @@ index 0a29ddee94051e398780b9fa07e5ce2b46c51b97..dee9bcd9caee7c900a38c92d5e967cda
       * Get the game port that the server runs on.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a8e187a3f386210c712ab7d620d6a4aa91bf42f8..a3f6a2bbc1d4626b657acc1e108c04ce8d0d577c 100644
+index b78ccbf832199fe84b351c7467a3d9be39f2f819..8f6878d2b6a43ec90f5011df6530083bdf6166cb 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -157,6 +157,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -159,6 +159,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      public int getMaxPlayers();
  

--- a/patches/api/0215-Add-moon-phase-API.patch
+++ b/patches/api/0215-Add-moon-phase-API.patch
@@ -47,10 +47,10 @@ index 0000000000000000000000000000000000000000..df05153397b42930cd53d37b30824c7e
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 99729c954ae5114260ae50ad3de32ba9d9344ca8..f60fdb12d7dcd60179e07ea764302ebb1c91c619 100644
+index 41df2b4680a6b05d055a11f3b64d9746d1754c51..325c86a945b2ee365618f5c63cf4a48e47177bec 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -68,6 +68,12 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -69,6 +69,12 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The amount of Players in this world
       */
      int getPlayerCount();

--- a/patches/api/0218-Brand-support.patch
+++ b/patches/api/0218-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 4466b78315008e460bf1c4204347d174921e68de..09fc2dda0ae9b1586bf33805f6dcb4a26a02f72b 100644
+index 385846a2011ec07d4f37c98f38d3369199780418..e61d0ff51674213e4711d5bbe9e8aaed31ed00df 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2565,6 +2565,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2560,6 +2560,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0220-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0220-Add-methods-to-get-translation-keys.patch
@@ -212,7 +212,7 @@ index 13eac9ad2c1672051635d1c35cc49239252e7a61..107e36ef02a9481954bd770ce9a55a0b
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 2a862123a8b12d64a1cda39283b5fa501dd90f26..893c6cef7dd8507b165be89c5182a1500afce631 100644
+index c88c4223928c2e47f1a85b73165cf433806677df..7124f7134a0afb355c01cac9e0187164f9630bcd 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
@@ -337,7 +337,7 @@ index 511b96841f7342d0a6b38d7cff56252ea8ef9bfe..02ecc87a90bbd81e7d21279fac701ba4
  
      // Paper start - Add villager reputation API
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index afe6d4877fa4f3c5b03f8bca68f59ff0885d21d4..ea94570cb7b8673962a8c1a735cfc7c80f85db31 100644
+index 011d8cf2b2358d17e475ce88633c6843fa548834..91a228239cf2ba6d50f4489b14ee6fa9069af07f 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0221-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/api/0221-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 0f6a3efc04214fd66cc5a0e9eea9d321ca7aac58..5793a02ff5ec9310c23c471529226b300d43ec7c 100644
+index 9ba084c0aefb8d8d654880268cdb7266b4237bbb..96f9481ca2f79dca525e0720e41a716bcebe0baf 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -187,5 +187,62 @@ public interface ItemFactory {

--- a/patches/api/0222-Add-additional-open-container-api-to-HumanEntity.patch
+++ b/patches/api/0222-Add-additional-open-container-api-to-HumanEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add additional open container api to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 9cb7a9b1e1d7c20760a54bdf6aea346828ad8fc7..aae6331de24c1a65e3f708cfdc3890364bc8e681 100644
+index 43ab3d1f96179a547630be3494d85642ab2ff029..ebbe3417369201df231060dd39f1fb200eb7ad48 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
 @@ -153,6 +153,92 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder

--- a/patches/api/0224-Entity-isTicking.patch
+++ b/patches/api/0224-Entity-isTicking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index b7d3cd271cccbc250914c5bc17ae892ffcf14b57..81de9c7af05224cc866e814a7bbc7efda26947dd 100644
+index 1c9d0e6541d41972f9966b83cbba02f6b230a72c..718af7c49ab8cc232bf72cecdef8a90e2595e835 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -755,5 +755,10 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -763,5 +763,10 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * Check if entity is in lava
       */
      public boolean isInLava();

--- a/patches/api/0225-Clarify-the-Javadocs-for-Entity.getEntitySpawnReason.patch
+++ b/patches/api/0225-Clarify-the-Javadocs-for-Entity.getEntitySpawnReason.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Clarify the Javadocs for Entity.getEntitySpawnReason()
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 81de9c7af05224cc866e814a7bbc7efda26947dd..2c892de67ecca09e490246186c8d2eccf91f3536 100644
+index 718af7c49ab8cc232bf72cecdef8a90e2595e835..e3de56ffa7b3a554755a7401988945eca655d816 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -721,7 +721,7 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -729,7 +729,7 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      }
  
      /**

--- a/patches/api/0227-Player-elytra-boost-API.patch
+++ b/patches/api/0227-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 09fc2dda0ae9b1586bf33805f6dcb4a26a02f72b..df9b6031649b751ae737c6fb76761b1b42d54a93 100644
+index e61d0ff51674213e4711d5bbe9e8aaed31ed00df..45284317f195f08e88a4977a32a1757afb6c4b17 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2437,6 +2437,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2432,6 +2432,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull ClientOption<T> option);

--- a/patches/api/0228-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0228-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index dee9bcd9caee7c900a38c92d5e967cdaaf875a08..b2699b0d82f2cf05a04ded5bc335f91362ddfa9a 100644
+index cf453476006563d8f9c165809c89d73089a84acc..9549cfeadac8a45d27917ecdf05644cfff23eb0a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1138,6 +1138,27 @@ public final class Bukkit {
+@@ -1178,6 +1178,27 @@ public final class Bukkit {
          return server.getOfflinePlayer(name);
      }
  
@@ -37,10 +37,10 @@ index dee9bcd9caee7c900a38c92d5e967cdaaf875a08..b2699b0d82f2cf05a04ded5bc335f913
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a3f6a2bbc1d4626b657acc1e108c04ce8d0d577c..df893601ec71dcc782a7050fb10684c5980105ee 100644
+index 8f6878d2b6a43ec90f5011df6530083bdf6166cb..50fbcb8867b0a7680ff491f7cf9af3069ba064c3 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -961,6 +961,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -998,6 +998,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  

--- a/patches/api/0233-Add-Destroy-Speed-API.patch
+++ b/patches/api/0233-Add-Destroy-Speed-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 893c6cef7dd8507b165be89c5182a1500afce631..a403ee3eeadd8138b252d188773428037fde1fe7 100644
+index 7124f7134a0afb355c01cac9e0187164f9630bcd..839867cd0a92fc0ea2b9ea009b67a841f8c7edd6 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -647,5 +647,29 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran

--- a/patches/api/0238-Enable-multi-release-plugin-jars.patch
+++ b/patches/api/0238-Enable-multi-release-plugin-jars.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Enable multi-release plugin jars
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 9e14c95deaca0044a3e9284ceefbb2b5c54ede07..c4ffe80bc7b4903eb8b8b2dbb18b5ff2d9877508 100644
+index c0781480ac1562bff7415f0947d733b438a4d04b..d30aae64e85c48141d0e3ec55e3d3f42d5f17eb8 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -58,7 +58,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot

--- a/patches/api/0244-Additional-Block-Material-API-s.patch
+++ b/patches/api/0244-Additional-Block-Material-API-s.patch
@@ -9,7 +9,7 @@ process to do this in the Bukkit API
 Adds API for buildable, replaceable, burnable too.
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index a403ee3eeadd8138b252d188773428037fde1fe7..cd807331e55e3caded2a812eeda438c1a781a04f 100644
+index 839867cd0a92fc0ea2b9ea009b67a841f8c7edd6..bcf3dc1bc640dc270446db0e1da081272d3933f1 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -438,6 +438,42 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran

--- a/patches/api/0255-Add-sendOpLevel-API.patch
+++ b/patches/api/0255-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index df9b6031649b751ae737c6fb76761b1b42d54a93..302f9fc837918dfa85660e00ae70e00fe0ba1780 100644
+index 45284317f195f08e88a4977a32a1757afb6c4b17..71de9f4c7f07c4c0b1155df14794de3ba8e28d69 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2450,6 +2450,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2445,6 +2445,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0267-Add-getMainThreadExecutor-to-BukkitScheduler.patch
+++ b/patches/api/0267-Add-getMainThreadExecutor-to-BukkitScheduler.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add getMainThreadExecutor to BukkitScheduler
 
 
 diff --git a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
-index c239c4de617933d20f75c33f943ba4a88954144e..1ea49965bf72edd862dc0d43e42c61df80966e45 100644
+index 5aefb7f2de890673aea275e85dbae9a2422b59b1..d2ab2ee1e1e8fbaac4edef5b3ee313ee4ceb6991 100644
 --- a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
 +++ b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
 @@ -457,4 +457,15 @@ public interface BukkitScheduler {

--- a/patches/api/0270-Expose-Tracked-Players.patch
+++ b/patches/api/0270-Expose-Tracked-Players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 2c892de67ecca09e490246186c8d2eccf91f3536..18795003815d5bb6e04a15256430f69a31b2ace5 100644
+index e3de56ffa7b3a554755a7401988945eca655d816..898c005cb715235df8d7ed6a98faa8191af2fd91 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -760,5 +760,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -768,5 +768,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * Check if entity is inside a ticking chunk
       */
      public boolean isTicking();

--- a/patches/api/0275-Add-Block-isValidTool.patch
+++ b/patches/api/0275-Add-Block-isValidTool.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add Block#isValidTool
 
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index cd807331e55e3caded2a812eeda438c1a781a04f..d789f14d7af2fbe1a653040f3014748acfc3b240 100644
+index bcf3dc1bc640dc270446db0e1da081272d3933f1..cff83028e9a08466551db4698cf4860553dd750d 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -229,6 +229,15 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran

--- a/patches/api/0276-Implement-Keyed-on-World.patch
+++ b/patches/api/0276-Implement-Keyed-on-World.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b2699b0d82f2cf05a04ded5bc335f91362ddfa9a..ea5745e548b11e4d71737a78e10e53c23bc3eb8e 100644
+index 9549cfeadac8a45d27917ecdf05644cfff23eb0a..2f6ebed7ae9305f1cb4502b9727b8eac97f4209c 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -751,6 +751,18 @@ public final class Bukkit {
+@@ -791,6 +791,18 @@ public final class Bukkit {
      public static World getWorld(@NotNull UUID uid) {
          return server.getWorld(uid);
      }
@@ -28,10 +28,10 @@ index b2699b0d82f2cf05a04ded5bc335f91362ddfa9a..ea5745e548b11e4d71737a78e10e53c2
      /**
       * Gets the map from the given item ID.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index df893601ec71dcc782a7050fb10684c5980105ee..e435df76a752c523b8bc0bd2d2abf35c2460f880 100644
+index 50fbcb8867b0a7680ff491f7cf9af3069ba064c3..f19aa510dfc4c5716d80235acfa593eea03c2110 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -636,6 +636,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -673,6 +673,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      public World getWorld(@NotNull UUID uid);
  
@@ -50,10 +50,10 @@ index df893601ec71dcc782a7050fb10684c5980105ee..e435df76a752c523b8bc0bd2d2abf35c
       * Gets the map from the given item ID.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index f60fdb12d7dcd60179e07ea764302ebb1c91c619..82ca519c18e49fb4df1932e871a6c9d3dc7e86b2 100644
+index 325c86a945b2ee365618f5c63cf4a48e47177bec..6ae40c6480e0db948504cd15d7047dd676478e30 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -41,7 +41,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -42,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a world, which may contain entities, chunks and blocks
   */
@@ -62,7 +62,7 @@ index f60fdb12d7dcd60179e07ea764302ebb1c91c619..82ca519c18e49fb4df1932e871a6c9d3
  
      // Paper start
      /**
-@@ -1525,6 +1525,15 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1526,6 +1526,15 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
  
      @NotNull
      java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent);

--- a/patches/api/0277-Item-Rarity-API.patch
+++ b/patches/api/0277-Item-Rarity-API.patch
@@ -88,7 +88,7 @@ index a7a5eada1302dac046619d8a01c887965f22dd09..2392efea1b514671014c39d75407f59f
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index ea94570cb7b8673962a8c1a735cfc7c80f85db31..45e656643f07e25ee4432786dea750b83abc95ae 100644
+index 91a228239cf2ba6d50f4489b14ee6fa9069af07f..ebc44aae46d67ae565eeafb5bb3af74bbc88dbc1 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -880,5 +880,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor

--- a/patches/api/0284-More-World-API.patch
+++ b/patches/api/0284-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 7a60ad315a092baed1e4c1f05f29a8f21ebad070..c19efb8beb3d13681ef1771849d74b96c9c28705 100644
+index 6ae40c6480e0db948504cd15d7047dd676478e30..33ddc4cd57d1ce2d1abb1daa78d9e934ae0bc93f 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3523,6 +3523,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3644,6 +3644,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public Location locateNearestStructure(@NotNull Location origin, @NotNull StructureType structureType, int radius, boolean findUnexplored);
  

--- a/patches/api/0295-Add-basic-Datapack-API.patch
+++ b/patches/api/0295-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 2f6ebed7ae9305f1cb4502b9727b8eac97f4209c..0ecff0322c3ff4e6e3c6fcaf72d0ab786ba423fa 100644
+index c8ea04b06d7178c6cc992a9a1b0355a70a035152..7732d26277ca8b845898cb01c7623a2f175f0aaa 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2235,6 +2235,14 @@ public final class Bukkit {
+@@ -2238,6 +2238,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index 2f6ebed7ae9305f1cb4502b9727b8eac97f4209c..0ecff0322c3ff4e6e3c6fcaf72d0ab78
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f19aa510dfc4c5716d80235acfa593eea03c2110..de7b958e3833f10ef25451fd27a3dcdd0356cd5e 100644
+index 67c6443c5639beafade19bc39932f30bf1001a8d..ca4a9428e89b084436ef43099974ae7684648776 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1958,5 +1958,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1961,5 +1961,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0295-Add-basic-Datapack-API.patch
+++ b/patches/api/0295-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ea5745e548b11e4d71737a78e10e53c23bc3eb8e..63a4e03b0c5508d5f027c7fa3cecb8b5aa9d450b 100644
+index 2f6ebed7ae9305f1cb4502b9727b8eac97f4209c..0ecff0322c3ff4e6e3c6fcaf72d0ab786ba423fa 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2130,6 +2130,14 @@ public final class Bukkit {
+@@ -2235,6 +2235,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index ea5745e548b11e4d71737a78e10e53c23bc3eb8e..63a4e03b0c5508d5f027c7fa3cecb8b5
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e435df76a752c523b8bc0bd2d2abf35c2460f880..48f9b34aa6caf91174af87f0fe694562417dcc60 100644
+index f19aa510dfc4c5716d80235acfa593eea03c2110..de7b958e3833f10ef25451fd27a3dcdd0356cd5e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1865,5 +1865,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1958,5 +1958,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0297-ItemStack-repair-check-API.patch
+++ b/patches/api/0297-ItemStack-repair-check-API.patch
@@ -26,7 +26,7 @@ index 8f85c41be166ea720a0bf5b6b58bc51a6d2c71cc..c1bda4dba319999261613d4aa45a280e
       * Returns the server's protocol version.
       *
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 45e656643f07e25ee4432786dea750b83abc95ae..a1d332a5eafb88c2f5d95bea6dc7e528ea2047be 100644
+index ebc44aae46d67ae565eeafb5bb3af74bbc88dbc1..e126c45a4184cd637c94b55c5eb14fe4b5afe32e 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -890,5 +890,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor

--- a/patches/api/0301-ItemStack-editMeta.patch
+++ b/patches/api/0301-ItemStack-editMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ItemStack#editMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 86bd9f14de5c1ff3d797955be1af56e5efcac884..56072cb4d32ca8a09023be08a5a832c2c108379a 100644
+index e126c45a4184cd637c94b55c5eb14fe4b5afe32e..7dfc84c77d8e185bb0513d9f9c603ce1b501a5e0 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -543,6 +543,50 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor

--- a/patches/api/0306-Add-PlayerKickEvent-causes.patch
+++ b/patches/api/0306-Add-PlayerKickEvent-causes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3b24457a1d25515132613b7e4fdaa7901d00ab78..ecd1a8c13137adc880067f9e911e8b1a08c5cd14 100644
+index 71de9f4c7f07c4c0b1155df14794de3ba8e28d69..c7d02e196d57f41c35d37e9a16d8e079a5c176ae 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -241,6 +241,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -236,6 +236,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param message kick message
       */
      void kick(final @Nullable net.kyori.adventure.text.Component message);

--- a/patches/api/0310-Add-more-line-of-sight-methods.patch
+++ b/patches/api/0310-Add-more-line-of-sight-methods.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add more line of sight methods
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index facbf08b5427cf3841d58cfb946129bf7d7f8ea3..a0e4264b5dc8df806b5bec52a8cb831005833161 100644
+index 33ddc4cd57d1ce2d1abb1daa78d9e934ae0bc93f..fa2720db5fdb67da1fe6c47c4875037d929d9aec 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -74,6 +74,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -75,6 +75,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      @NotNull
      io.papermc.paper.world.MoonPhase getMoonPhase();

--- a/patches/api/0313-Add-Git-information-to-version-command-on-startup.patch
+++ b/patches/api/0313-Add-Git-information-to-version-command-on-startup.patch
@@ -48,10 +48,10 @@ index 0000000000000000000000000000000000000000..909617079db61b675cc7b60b44ef96b3
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 63a4e03b0c5508d5f027c7fa3cecb8b5aa9d450b..f7df34539f03e2d5bbb2733709dcbcda65a23b29 100644
+index 0ecff0322c3ff4e6e3c6fcaf72d0ab786ba423fa..c88eb8946d5ce145fc1cd27795826daeb7f27bff 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -51,6 +51,7 @@ import org.bukkit.util.CachedServerIcon;
+@@ -53,6 +53,7 @@ import org.bukkit.util.CachedServerIcon;
  import org.jetbrains.annotations.Contract;
  import org.jetbrains.annotations.NotNull;
  import org.jetbrains.annotations.Nullable;
@@ -59,7 +59,7 @@ index 63a4e03b0c5508d5f027c7fa3cecb8b5aa9d450b..f7df34539f03e2d5bbb2733709dcbcda
  
  /**
   * Represents the Bukkit core, for version and Server singleton handling
-@@ -100,7 +101,25 @@ public final class Bukkit {
+@@ -102,7 +103,25 @@ public final class Bukkit {
          }
  
          Bukkit.server = server;

--- a/patches/api/0318-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
+++ b/patches/api/0318-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Rewrite LogEvents to contain the source jars in stack traces
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index c4ffe80bc7b4903eb8b8b2dbb18b5ff2d9877508..8a39c48fce819d72a94d5309db8dfc42930989af 100644
+index d30aae64e85c48141d0e3ec55e3d3f42d5f17eb8..9938ebb38353f4aa2adf1bb08cd1c347ddd9fc88 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -51,7 +51,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot

--- a/patches/api/0330-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/api/0330-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index a0e4264b5dc8df806b5bec52a8cb831005833161..96235d5e77563496bcf3e2152b6aad9956f492c9 100644
+index fa2720db5fdb67da1fe6c47c4875037d929d9aec..6e150341dbb4439a186f55d6bb537b46bee74e89 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -757,6 +757,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -758,6 +758,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public LightningStrike strikeLightningEffect(@NotNull Location loc);
  

--- a/patches/api/0334-Add-ItemFactory-getMonsterEgg-API.patch
+++ b/patches/api/0334-Add-ItemFactory-getMonsterEgg-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add ItemFactory#getMonsterEgg API
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 5793a02ff5ec9310c23c471529226b300d43ec7c..bd2500068e984bd06b1121c34adbaaefda9c746a 100644
+index 96f9481ca2f79dca525e0720e41a716bcebe0baf..6a4c4161adabb8e131761c2af4bdf1f26b52434d 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -244,5 +244,14 @@ public interface ItemFactory {

--- a/patches/api/0337-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/api/0337-Add-isCollidable-methods-to-various-places.patch
@@ -45,7 +45,7 @@ index ae55b9e3560ba63bc95f90ceadccc6492be9de56..7406c413f2988f2aadac95a85801df30
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index d789f14d7af2fbe1a653040f3014748acfc3b240..5f35ba35f8517ec28c1b21b3007c9a20dea097a7 100644
+index cff83028e9a08466551db4698cf4860553dd750d..3e980c630452c8ea72227bc4cd92c605253cd41b 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -481,6 +481,13 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran

--- a/patches/api/0340-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/api/0340-Add-Raw-Byte-Entity-Serialization.patch
@@ -24,10 +24,10 @@ index 7406c413f2988f2aadac95a85801df30deb6ae43..f59030893eba2bf653207b040a5f54fd
       * Return the translation key for the Material, so the client can translate it into the active
       * locale when using a {@link net.kyori.adventure.text.TranslatableComponent}.
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 18795003815d5bb6e04a15256430f69a31b2ace5..bafad5764cc3933fcd9602d37bd2e68424cbd575 100644
+index 898c005cb715235df8d7ed6a98faa8191af2fd91..9b46e42fcd803c2f0fb46b220ed79d69b1d16fc4 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -767,5 +767,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -775,5 +775,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return players in tracking range
       */
      @NotNull Set<Player> getTrackedPlayers();

--- a/patches/api/0342-Add-player-health-update-API.patch
+++ b/patches/api/0342-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9ccdb05d2be4547a3ed1d10479f10b58775336ef..c8fc528b5f9e7c898106bc5b30c245700ed17095 100644
+index c7d02e196d57f41c35d37e9a16d8e079a5c176ae..5a1b733934bfe4388dad59125caa9c2d45df5dd1 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1854,6 +1854,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1849,6 +1849,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public double getHealthScale();
  

--- a/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c88eb8946d5ce145fc1cd27795826daeb7f27bff..b3cf1956e8e21679ef814bfdf888b2d243e5e2a4 100644
+index 2af2a948dc9c0d4ad28fccb1c9a2b28d5db99203..416d402b7e885ccc9b187a8e8111da2378197b45 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1845,6 +1845,24 @@ public final class Bukkit {
+@@ -1848,6 +1848,24 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -34,10 +34,10 @@ index c88eb8946d5ce145fc1cd27795826daeb7f27bff..b3cf1956e8e21679ef814bfdf888b2d2
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index de7b958e3833f10ef25451fd27a3dcdd0356cd5e..eba296692f4678205a17a08c8271977c0e90a24a 100644
+index ca4a9428e89b084436ef43099974ae7684648776..32f84a04add01a244e4abba4c7e1c1183aa62db1 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1550,6 +1550,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1553,6 +1553,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  

--- a/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f7df34539f03e2d5bbb2733709dcbcda65a23b29..53c4e5ca208ee17c7c244e416c537c7b63edf194 100644
+index c88eb8946d5ce145fc1cd27795826daeb7f27bff..b3cf1956e8e21679ef814bfdf888b2d243e5e2a4 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1740,6 +1740,24 @@ public final class Bukkit {
+@@ -1845,6 +1845,24 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -34,10 +34,10 @@ index f7df34539f03e2d5bbb2733709dcbcda65a23b29..53c4e5ca208ee17c7c244e416c537c7b
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 48f9b34aa6caf91174af87f0fe694562417dcc60..e48af3822e9f118399c3a1c9358c56efae12e0da 100644
+index de7b958e3833f10ef25451fd27a3dcdd0356cd5e..eba296692f4678205a17a08c8271977c0e90a24a 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1457,6 +1457,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1550,6 +1550,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  
@@ -61,7 +61,7 @@ index 48f9b34aa6caf91174af87f0fe694562417dcc60..e48af3822e9f118399c3a1c9358c56ef
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
-index 80fcd02e9cb5f432f21b1f68fd8266f296becaa0..0667315e2bd10254aef59c2a6bcceee9d927b6d5 100644
+index d14d3851a7b0340668f44f5213f0e18072d7481b..04be4214bc1c4b476c70aea457118e786fa67eff 100644
 --- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
 +++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
 @@ -454,6 +454,22 @@ public abstract class ChunkGenerator {

--- a/patches/api/0347-Entity-powdered-snow-API.patch
+++ b/patches/api/0347-Entity-powdered-snow-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity powdered snow API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index bafad5764cc3933fcd9602d37bd2e68424cbd575..51ec2e4ec4239659272bba3d6ba2ad73926ebb88 100644
+index 9b46e42fcd803c2f0fb46b220ed79d69b1d16fc4..9c31424a297b9b727ac4ad13040eb9e5674b716b 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -794,5 +794,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -802,5 +802,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return Whether the entity was successfully spawned.
       */
      public boolean spawnAt(@NotNull Location location, @NotNull org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason);

--- a/patches/api/0353-Remove-upstream-snakeyaml-fix.patch
+++ b/patches/api/0353-Remove-upstream-snakeyaml-fix.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Remove upstream snakeyaml fix
 See Server Patch: Fix saving configs with more long comments
 
 diff --git a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
-index df250bf41463c57b3ec7c288e134460a2295eed5..2159e7a49ed1bc01533e67ac9f6917801ec963e3 100644
+index f9abe6991dadc7c652dcf6682bdb1b43240af438..9ba2e956be80952c146bac9a03bdb837f92b2726 100644
 --- a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
 +++ b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
 @@ -65,7 +65,7 @@ public class YamlConfiguration extends FileConfiguration {
@@ -19,7 +19,7 @@ index df250bf41463c57b3ec7c288e134460a2295eed5..2159e7a49ed1bc01533e67ac9f691780
  
      @NotNull
 diff --git a/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java b/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
-index a0ff42abd3ced3513ee3343e14d5068cc5dd4532..9dd844fde37fe47b51cd30092e86b5b41a2344ef 100644
+index 3522baa0a234999114db69dea5743de2c8f059a0..cbdf7aa91e8399d3b936690b34a29bd6d0f2d518 100644
 --- a/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
 +++ b/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
 @@ -146,6 +146,7 @@ public class YamlConfigurationTest extends FileConfigurationTest {

--- a/patches/api/0358-Multi-Block-Change-API.patch
+++ b/patches/api/0358-Multi-Block-Change-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Multi Block Change API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7eda2ba17e39b8183e572c1cefa8afffbf17afcb..fb8bd05a0204740ec323e9b657916de6ccbf6f90 100644
+index 5a1b733934bfe4388dad59125caa9c2d45df5dd1..131daee2b29f7016463a00ce7927dff7b0a1b1b4 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -584,6 +584,27 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -579,6 +579,27 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendBlockDamage(@NotNull Location loc, float progress);
  

--- a/patches/api/0360-Freeze-Tick-Lock-API.patch
+++ b/patches/api/0360-Freeze-Tick-Lock-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 51ec2e4ec4239659272bba3d6ba2ad73926ebb88..c2c45a93887f99466a8ac4275355ac75c7f901c4 100644
+index 9c31424a297b9b727ac4ad13040eb9e5674b716b..8bc6876c82935988436597161fa0ec94c032174b 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -278,6 +278,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent

--- a/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for creating command sender which forwards feedback
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b3cf1956e8e21679ef814bfdf888b2d243e5e2a4..59e4adc6cba06e29f8826e4cc69db192d42b2716 100644
+index 416d402b7e885ccc9b187a8e8111da2378197b45..795f8c0aa3929f6de4b4ea4b139bef8b672ab97a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1376,6 +1376,20 @@ public final class Bukkit {
+@@ -1379,6 +1379,20 @@ public final class Bukkit {
          return server.getConsoleSender();
      }
  
@@ -30,10 +30,10 @@ index b3cf1956e8e21679ef814bfdf888b2d243e5e2a4..59e4adc6cba06e29f8826e4cc69db192
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index eba296692f4678205a17a08c8271977c0e90a24a..225297e0dc98636b529100dc13530fff03515660 100644
+index 32f84a04add01a244e4abba4c7e1c1183aa62db1..a62c27777672eff1c488517b37876e3a44a2d57d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1148,6 +1148,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1151,6 +1151,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for creating command sender which forwards feedback
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 53c4e5ca208ee17c7c244e416c537c7b63edf194..3a8326735b62521f8fb95c51a0909d8b7bac83d1 100644
+index b3cf1956e8e21679ef814bfdf888b2d243e5e2a4..59e4adc6cba06e29f8826e4cc69db192d42b2716 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1297,6 +1297,20 @@ public final class Bukkit {
+@@ -1376,6 +1376,20 @@ public final class Bukkit {
          return server.getConsoleSender();
      }
  
@@ -30,10 +30,10 @@ index 53c4e5ca208ee17c7c244e416c537c7b63edf194..3a8326735b62521f8fb95c51a0909d8b
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e48af3822e9f118399c3a1c9358c56efae12e0da..73446141e8c50b71a17ff6f0c528a62d5c75751b 100644
+index eba296692f4678205a17a08c8271977c0e90a24a..225297e0dc98636b529100dc13530fff03515660 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1078,6 +1078,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1148,6 +1148,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/api/0365-Implement-regenerateChunk.patch
+++ b/patches/api/0365-Implement-regenerateChunk.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement regenerateChunk
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index c808cc8dc96e325c543391048414880ed18a3ed3..7d2873a924ee81411a2a00bace0f58403fec43ea 100644
+index 6e150341dbb4439a186f55d6bb537b46bee74e89..959ee46cd440af5a4e5db3f6ee8b163db8e40d86 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -505,8 +505,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -506,8 +506,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return Whether the chunk was actually regenerated
       *
       * @deprecated regenerating a single chunk is not likely to produce the same

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 9c4382ef7373110b6e72163779316ff40234a992..bba267ecca0121df22fdfa60961017863b5e3415 100644
+index dc8f0a7ac3387323428f71139ac07ec98cd33ed8..4db0cc3f8505747e77d314320545eb71904b4eac 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -13,10 +13,9 @@ repositories {
@@ -39,7 +39,7 @@ index 9c4382ef7373110b6e72163779316ff40234a992..bba267ecca0121df22fdfa6096101786
          for (tld in setOf("net", "com", "org")) {
              attributes("$tld/bukkit", "Sealed" to true)
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 21713baa2db85a49dae0fa7675776b029f8bf4c9..ec50a122331b2ceb19822273f89f32b66a9f7db0 100644
+index 38851269bc9eff80f5593e63b61a4b25c328a3cc..0607f13dd2a568e368f96768259e8cba9c25e9c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -190,7 +190,7 @@ public class Main {
@@ -50,7 +50,7 @@ index 21713baa2db85a49dae0fa7675776b029f8bf4c9..ec50a122331b2ceb19822273f89f32b6
 +                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -14);
+                     deadline.add(Calendar.DAY_OF_YEAR, -28);
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 index 93046379d0cefd5d3236fc59e698809acdc18f80..774556a62eb240da42e84db4502e2ed43495be17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -629,7 +629,7 @@ index 82d04f803201e39b48cd514cd8d9e2b90b28c1d4..156fa293626119caf0cf414505fdf0e9
          Main.LOGGER.info("Forcing world upgrade! {}", session.getLevelId()); // CraftBukkit
          WorldUpgrader worldupgrader = new WorldUpgrader(session, dataFixer, generatorOptions, eraseCache);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ebb914e7cf3e5ba2d862e341392e904f325d720a..b3629065ebbe601802703b8671b24c7156f12d03 100644
+index d75a598576d87644a4226216dcfd685c25b29f12..b3c1373f281adfdd9fa513b597941b60b71bb06c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -602,6 +602,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -661,7 +661,7 @@ index 2599fbabd5e5c0d10d0c915016f7cc982bda0e20..4dd57007af218ba1c0e666117a49939c
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index a44b47c8ed611078764841a5b591877242c10db1..d672c467267ef4d96184e104c35d0379116880db 100644
+index 183cb57fa8d31bd5d96b0ccef6e79b3d7b9e6c73..0d23c92af7aa381976c45d36e07d965819f19707 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -337,6 +337,12 @@ public class ServerChunkCache extends ChunkSource {
@@ -693,10 +693,10 @@ index 1bee6fc5b9fa70adf2f7cac792778f5ed203d291..e688949fc2f3031dc9c9817bc59554e9
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index aaf71bfb582d1d86d67205618825411babd2625a..f18ae5b80c930c3a7c2da079b9926ab2657c36a3 100644
+index c3afe1e60535241bf5f643034d1858de53e3a422..8de437c79e105331165efaf1b154287e16e1b8ef 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -149,6 +149,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -146,6 +146,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean populating;
      public final org.spigotmc.SpigotWorldConfig spigotConfig; // Spigot
  
@@ -705,19 +705,19 @@ index aaf71bfb582d1d86d67205618825411babd2625a..f18ae5b80c930c3a7c2da079b9926ab2
      public final SpigotTimings.WorldTimingsHandler timings; // Spigot
      public static BlockPos lastPhysicsProblem; // Spigot
      private org.spigotmc.TickLimiter entityLimiter;
-@@ -167,6 +169,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -164,6 +166,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, final DimensionType dimensionmanager, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env) {
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
 +        this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName(), this.spigotConfig); // Paper
          this.generator = gen;
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
-         this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
+ 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dfd7da8bc5cdcdf1548cc5ba871fb8809ee911e8..6258eed86c1f0461a8d8c8b9f82bb8be9dc6d71e 100644
+index 269f5dd75cc51549af1b50e6ec2dd066ca0dbdf6..355a6af98163079bc60c77d6fb88cd7023264a1b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -863,6 +863,7 @@ public final class CraftServer implements Server {
+@@ -869,6 +869,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
@@ -725,8 +725,8 @@ index dfd7da8bc5cdcdf1548cc5ba871fb8809ee911e8..6258eed86c1f0461a8d8c8b9f82bb8be
          for (ServerLevel world : this.console.getAllLevels()) {
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
-@@ -902,12 +903,14 @@ public final class CraftServer implements Server {
-                 world.ticksPerAmbientSpawns = this.getTicksPerAmbientSpawns();
+@@ -884,12 +885,14 @@ public final class CraftServer implements Server {
+                 }
              }
              world.spigotConfig.init(); // Spigot
 +            world.paperConfig.init(); // Paper
@@ -740,7 +740,7 @@ index dfd7da8bc5cdcdf1548cc5ba871fb8809ee911e8..6258eed86c1f0461a8d8c8b9f82bb8be
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2308,4 +2311,35 @@ public final class CraftServer implements Server {
+@@ -2316,4 +2319,35 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
@@ -777,7 +777,7 @@ index dfd7da8bc5cdcdf1548cc5ba871fb8809ee911e8..6258eed86c1f0461a8d8c8b9f82bb8be
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index ec50a122331b2ceb19822273f89f32b66a9f7db0..2bd2f436d5514b5e9bbc8bbd27ead4d4cb529b4f 100644
+index 0607f13dd2a568e368f96768259e8cba9c25e9c1..399e878210606e9addb535e4efed0ddb424160e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -129,6 +129,14 @@ public class Main {
@@ -796,7 +796,7 @@ index ec50a122331b2ceb19822273f89f32b66a9f7db0..2bd2f436d5514b5e9bbc8bbd27ead4d4
          };
  
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index af8c42ed04d9a79cd426bdaa8c2ee3feac1163e3..6c5113545914842ffb310522a7549ae7dd2466b2 100644
+index 4520eda5308575aa02ef059bb2efd776f56e352b..1d802f0e81b3880e9bb7799ecd46826f4bdcee03 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -58,8 +58,14 @@ public class SpigotWorldConfig

--- a/patches/server/0006-MC-Utils.patch
+++ b/patches/server/0006-MC-Utils.patch
@@ -5001,7 +5001,7 @@ index 0000000000000000000000000000000000000000..9f292deee1b793d52b5774304318e940
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 4d13345f3caa0c8ec55de465fc486d50b43d1e24..02ef6a24565f776986a745a1fa0f58f537e4e8f8 100644
+index 2b76a87213ea8880ede32a6f3bb91f59ed54e681..8c2b1d1a1e7f2716ee27aa10165b94550dccd19a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -295,6 +295,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -5291,7 +5291,7 @@ index 40dd2077f26a2c1fa15f21861204faa53748140e..45de5e508540b4ba622985d530f1aada
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 2fc246ca7ade62c0c2aff3f13f07bd376f032816..ae93a5bd184e084720400a44a3d9b14910343333 100644
+index 09f5ce03f842e357bbe0dd6b0fffde8ec5851f1d..504492c3889fab7b95eec3bcd9b0d1bcd619e8cf 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -59,6 +59,7 @@ import net.minecraft.network.protocol.game.ClientboundSetChunkCacheCenterPacket;
@@ -5483,7 +5483,7 @@ index ef87c37633cee4ab438f1991144188ade1c4e65f..19d3802becd353e130b785f8286e595e
  
      protected void purgeStaleTickets() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index d672c467267ef4d96184e104c35d0379116880db..be11caf7c0dcdb11e24cfb053cda45ac1867da63 100644
+index 0d23c92af7aa381976c45d36e07d965819f19707..9dd0eb49048ceccd82e139dac5d658d168694dda 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -48,6 +48,8 @@ import net.minecraft.world.level.storage.LevelData;
@@ -6055,10 +6055,10 @@ index d679be6c3ce0d57fa2063a45baec1b108a0a2707..de5e18a331178da8f7e82aa2419a0ee6
      public BlockState getBlockState(BlockPos pos) {
          return this.getChunk(SectionPos.blockToSectionCoord(pos.getX()), SectionPos.blockToSectionCoord(pos.getZ())).getBlockState(pos);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 02dd09abc24479f5f78a99ab8c3a7f42d62150fc..c3e9391a0a50449fa163c2265efb80dd6e56380d 100644
+index 8b406bc884a974cf46378a9fc38645e38e00f0ab..ee55db9770eb84792200b407defc04f0fd7b7e98 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -218,9 +218,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -217,9 +217,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      private final MinecraftServer server;
      public ServerPlayer player;
      private int tickCount;
@@ -6090,7 +6090,7 @@ index a4c5edee297af6d68d518b77f706732b5ccbe4de..7bf4bf5cb2c1b54a7e2733091f48f3a8
      @Override
      public void tell(R runnable) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a54b10896825ef61bd005bcd5a1232bd5f2ec132..52eb344feee9c3bc34a6d22a32de174c52736fb5 100644
+index 595a821e3dbbb0ecac8592356149d839624bcd50..78ea2df454919707a938ff75aa655f5bfa12fc99 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -308,6 +308,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -6294,7 +6294,7 @@ index 3c707d6674b2594b09503b959a31c1f4ad3981e6..db61b6b0158a9bcc0e1d735e34fe3671
      public BlockState getBlockState(BlockPos pos) {
          return Blocks.AIR.defaultBlockState();
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index f18ae5b80c930c3a7c2da079b9926ab2657c36a3..84b462d5f3c9727f8da6d254e67a7a752c4508d3 100644
+index 8de437c79e105331165efaf1b154287e16e1b8ef..ff001049d71127a0b9e7a9d73996be02ec0ad044 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -85,6 +85,7 @@ import org.bukkit.craftbukkit.CraftServer;
@@ -6303,9 +6303,9 @@ index f18ae5b80c930c3a7c2da079b9926ab2657c36a3..84b462d5f3c9727f8da6d254e67a7a75
  import org.bukkit.craftbukkit.block.CapturedBlockState;
 +import org.bukkit.craftbukkit.block.CraftBlockState;
  import org.bukkit.craftbukkit.block.data.CraftBlockData;
+ import org.bukkit.craftbukkit.util.CraftSpawnCategory;
  import org.bukkit.craftbukkit.util.CraftNamespacedKey;
- import org.bukkit.event.block.BlockPhysicsEvent;
-@@ -271,18 +272,51 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -270,18 +271,51 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return y < -20000000 || y >= 20000000;
      }
  
@@ -6361,7 +6361,7 @@ index f18ae5b80c930c3a7c2da079b9926ab2657c36a3..84b462d5f3c9727f8da6d254e67a7a75
          ChunkAccess ichunkaccess = this.getChunkSource().getChunk(chunkX, chunkZ, leastStatus, create);
  
          if (ichunkaccess == null && create) {
-@@ -293,7 +327,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -292,7 +326,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      }
  
      @Override
@@ -6370,7 +6370,7 @@ index f18ae5b80c930c3a7c2da079b9926ab2657c36a3..84b462d5f3c9727f8da6d254e67a7a75
          return this.setBlock(pos, state, flags, 512);
      }
  
-@@ -598,7 +632,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -597,7 +631,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          if (this.isOutsideBuildHeight(pos)) {
              return Blocks.VOID_AIR.defaultBlockState();
          } else {
@@ -6718,7 +6718,7 @@ index 28555314738ba891e0e36d3c85b1623116f743dd..f263022e1d15e78b51cfd148cf024b9a
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java b/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
-index 1ea0048e1ee5321a1fd1584ac5371a371de9d45f..41530d0b759604716f739d10f41627871f2ba319 100644
+index 37a75bb9b15356b6fb9c76c1bc1fff8e0a28b1dd..7c2e3331fac1de2e20974c8eed8aeeb9f2c92789 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
 @@ -73,6 +73,18 @@ public class ProtoChunk extends ChunkAccess {

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -1125,7 +1125,7 @@ index 504492c3889fab7b95eec3bcd9b0d1bcd619e8cf..5d1ac4e7afa0f1d9c9face049f768a20
  
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 7113446e1176145b0ba0df410f58a396a39d1b43..bc6cfd8ceb313328a9f4eb0b8a13c5f01704595f 100644
+index 9dd0eb49048ceccd82e139dac5d658d168694dda..a1740dd320967aa6d1ce84e081a1f2b9a1ee7d08 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -528,13 +528,15 @@ public class ServerChunkCache extends ChunkSource {
@@ -1167,7 +1167,7 @@ index 7113446e1176145b0ba0df410f58a396a39d1b43..bc6cfd8ceb313328a9f4eb0b8a13c5f0
          this.level.getProfiler().popPush("unload");
          this.chunkMap.tick(shouldKeepTicking);
 @@ -797,13 +803,16 @@ public class ServerChunkCache extends ChunkSource {
-             boolean flag1 = level.ticksPerAnimalSpawns != 0L && worlddata.getGameTime() % level.ticksPerAnimalSpawns == 0L; // CraftBukkit
+             boolean flag1 = level.ticksPerSpawnCategory.getLong(org.bukkit.entity.SpawnCategory.ANIMAL) != 0L && worlddata.getGameTime() % level.ticksPerSpawnCategory.getLong(org.bukkit.entity.SpawnCategory.ANIMAL) == 0L; // CraftBukkit
  
              gameprofilerfiller.push("naturalSpawnCount");
 +            this.level.timings.countNaturalMobs.startTiming(); // Paper - timings
@@ -1333,18 +1333,18 @@ index 073cea951644f25c276ba05ff1fc48fda08593da..c7fe4b6aa8d68bd5dc394752a5ae635e
                  this.entityManager.saveAll();
              } else {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 017723d4c067572755c828b4c3b00fe744e6f4ba..3f3e5686b91c117ee49ebfa284ecc4649c109261 100644
+index ee55db9770eb84792200b407defc04f0fd7b7e98..ea652f6394c7e575ce06a6b691d8b2c442eafb03 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -208,6 +208,7 @@ import org.bukkit.inventory.EquipmentSlot;
+@@ -207,6 +207,7 @@ import org.bukkit.inventory.CraftingInventory;
+ import org.bukkit.inventory.EquipmentSlot;
  import org.bukkit.inventory.InventoryView;
  import org.bukkit.inventory.SmithingInventory;
- import org.bukkit.util.NumberConversions;
 +import co.aikar.timings.MinecraftTimings; // Paper
  // CraftBukkit end
  
  public class ServerGamePacketListenerImpl implements ServerPlayerConnection, ServerGamePacketListener {
-@@ -288,7 +289,6 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -285,7 +286,6 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      // CraftBukkit end
  
      public void tick() {
@@ -1352,7 +1352,7 @@ index 017723d4c067572755c828b4c3b00fe744e6f4ba..3f3e5686b91c117ee49ebfa284ecc464
          this.resetPosition();
          this.player.xo = this.player.getX();
          this.player.yo = this.player.getY();
-@@ -364,7 +364,6 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -361,7 +361,6 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              this.player.resetLastActionTime(); // CraftBukkit - SPIGOT-854
              this.disconnect(new TranslatableComponent("multiplayer.disconnect.idling"));
          }
@@ -1360,7 +1360,7 @@ index 017723d4c067572755c828b4c3b00fe744e6f4ba..3f3e5686b91c117ee49ebfa284ecc464
  
      }
  
-@@ -1923,7 +1922,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1919,7 +1918,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      // CraftBukkit end
  
      private void handleCommand(String input) {
@@ -1369,7 +1369,7 @@ index 017723d4c067572755c828b4c3b00fe744e6f4ba..3f3e5686b91c117ee49ebfa284ecc464
          // CraftBukkit start - whole method
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + input);
-@@ -1934,7 +1933,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1930,7 +1929,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          this.cserver.getPluginManager().callEvent(event);
  
          if (event.isCancelled()) {
@@ -1378,7 +1378,7 @@ index 017723d4c067572755c828b4c3b00fe744e6f4ba..3f3e5686b91c117ee49ebfa284ecc464
              return;
          }
  
-@@ -1947,7 +1946,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1943,7 +1942,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              java.util.logging.Logger.getLogger(ServerGamePacketListenerImpl.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
              return;
          } finally {
@@ -1412,7 +1412,7 @@ index 8e4325abb2dda74c38b17bb27f9dcfcf97ba2de6..1be4b3ad18d314b0460ce61e01afd0d7
  
      public UserWhiteList getWhiteList() {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0736454dea12d8ffe8ef6873c5d25d17a96504b0..68ccbc193ff6682f505928dc0a29ee990349d299 100644
+index 521e525cac2109a79370321163f4f27ffefb49ad..c9ab40355f02a2abfe10d9c02595e6b761b1a779 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -125,7 +125,6 @@ import org.bukkit.craftbukkit.event.CraftPortalEvent;
@@ -1582,7 +1582,7 @@ index a3b6883d7fc856ed8550ffb7aa8dd929922853e2..59bb2aafcbc1a4a5c963ef0391b4e9b4
          if (!this.level.isClientSide && this.isSensitiveToWater() && this.isInWaterRainOrBubble()) {
              this.hurt(DamageSource.DROWN, 1.0F);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 84b462d5f3c9727f8da6d254e67a7a752c4508d3..a75171ecfd23df3f626ca651febb75da28079c2d 100644
+index ff001049d71127a0b9e7a9d73996be02ec0ad044..72fd18a307a7e1f769195c7ef44a12bb47f2f49c 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -83,7 +83,6 @@ import org.bukkit.Bukkit;
@@ -1593,7 +1593,7 @@ index 84b462d5f3c9727f8da6d254e67a7a752c4508d3..a75171ecfd23df3f626ca651febb75da
  import org.bukkit.craftbukkit.block.CapturedBlockState;
  import org.bukkit.craftbukkit.block.CraftBlockState;
  import org.bukkit.craftbukkit.block.data.CraftBlockData;
-@@ -152,7 +151,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -149,7 +148,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      public final com.destroystokyo.paper.PaperWorldConfig paperConfig; // Paper
  
@@ -1602,7 +1602,7 @@ index 84b462d5f3c9727f8da6d254e67a7a752c4508d3..a75171ecfd23df3f626ca651febb75da
      public static BlockPos lastPhysicsProblem; // Spigot
      private org.spigotmc.TickLimiter entityLimiter;
      private org.spigotmc.TickLimiter tileLimiter;
-@@ -240,7 +239,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -239,7 +238,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              public void onBorderSetDamageSafeZOne(WorldBorder border, double safeZoneRadius) {}
          });
          // CraftBukkit end
@@ -1611,7 +1611,7 @@ index 84b462d5f3c9727f8da6d254e67a7a752c4508d3..a75171ecfd23df3f626ca651febb75da
          this.entityLimiter = new org.spigotmc.TickLimiter(spigotConfig.entityMaxTickTime);
          this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
      }
-@@ -729,15 +728,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -728,15 +727,14 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
          timings.tileEntityTick.stopTiming(); // Spigot
          this.tickingBlockEntities = false;
@@ -1713,10 +1713,10 @@ index ed639dbb4ea94839390778654c7dd0437bac41ac..1729af83b979e35a585c8d049b14dc23
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6258eed86c1f0461a8d8c8b9f82bb8be9dc6d71e..ecc6c5aa6534fd36f7534e7fd70d9fe568ae83eb 100644
+index 355a6af98163079bc60c77d6fb88cd7023264a1b..20d80a7320c6ab9f9e9bd245c4a6e0542b670758 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2280,12 +2280,31 @@ public final class CraftServer implements Server {
+@@ -2288,12 +2288,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  
@@ -1918,10 +1918,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 929d8f7bf18a618e0447f726dbbd9e6fe2a6529a..43203833aac1a95bad813ee84da3225489da4b70 100644
+index 76160b76d7d469fb75e733c24d3f1ddf4796485e..74db150aed0744d62779e00cad8bfa25cede76ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1908,6 +1908,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1915,6 +1915,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              packet.components = components;
              CraftPlayer.this.getHandle().connection.send(packet);
          }

--- a/patches/server/0011-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0011-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ecc6c5aa6534fd36f7534e7fd70d9fe568ae83eb..8b521bf3b10412b7ebe081591f0e6413e235d978 100644
+index 20d80a7320c6ab9f9e9bd245c4a6e0542b670758..c9521d383c77eab823072c0d7569b76b75678d28 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -404,10 +404,15 @@ public final class CraftServer implements Server {
+@@ -402,10 +402,15 @@ public final class CraftServer implements Server {
      public void loadPlugins() {
          this.pluginManager.registerInterface(JavaPluginLoader.class);
  
@@ -29,7 +29,7 @@ index ecc6c5aa6534fd36f7534e7fd70d9fe568ae83eb..8b521bf3b10412b7ebe081591f0e6413
              for (Plugin plugin : plugins) {
                  try {
                      String message = String.format("Loading %s", plugin.getDescription().getFullName());
-@@ -422,6 +427,35 @@ public final class CraftServer implements Server {
+@@ -420,6 +425,35 @@ public final class CraftServer implements Server {
          }
      }
  
@@ -45,15 +45,15 @@ index ecc6c5aa6534fd36f7534e7fd70d9fe568ae83eb..8b521bf3b10412b7ebe081591f0e6413
 +        final List<File> list = new ArrayList<>();
 +        for (final File file : jars) {
 +            if (!file.exists()) {
-+                MinecraftServer.LOGGER.warn("File '{}' specified through 'add-plugin' argument does not exist, cannot load a plugin from it!", file.getAbsolutePath());
++                net.minecraft.server.MinecraftServer.LOGGER.warn("File '{}' specified through 'add-plugin' argument does not exist, cannot load a plugin from it!", file.getAbsolutePath());
 +                continue;
 +            }
 +            if (!file.isFile()) {
-+                MinecraftServer.LOGGER.warn("File '{}' specified through 'add-plugin' argument is not a file, cannot load a plugin from it!", file.getAbsolutePath());
++                net.minecraft.server.MinecraftServer.LOGGER.warn("File '{}' specified through 'add-plugin' argument is not a file, cannot load a plugin from it!", file.getAbsolutePath());
 +                continue;
 +            }
 +            if (!file.getName().endsWith(".jar")) {
-+                MinecraftServer.LOGGER.warn("File '{}' specified through 'add-plugin' argument is not a jar file, cannot load a plugin from it!", file.getAbsolutePath());
++                net.minecraft.server.MinecraftServer.LOGGER.warn("File '{}' specified through 'add-plugin' argument is not a jar file, cannot load a plugin from it!", file.getAbsolutePath());
 +                continue;
 +            }
 +            list.add(file);
@@ -66,7 +66,7 @@ index ecc6c5aa6534fd36f7534e7fd70d9fe568ae83eb..8b521bf3b10412b7ebe081591f0e6413
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 2bd2f436d5514b5e9bbc8bbd27ead4d4cb529b4f..dd115bd005604614e64a236ccf86a24882beb096 100644
+index 399e878210606e9addb535e4efed0ddb424160e8..707544dfd83839634dc4c1afc8e21c5c6c3d8140 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -136,6 +136,12 @@ public class Main {

--- a/patches/server/0012-Adventure.patch
+++ b/patches/server/0012-Adventure.patch
@@ -1292,7 +1292,7 @@ index 925ffbddd5475be7fe00570d861b615f707434b4..a3436596d05547a60c9906c92f709bb5
          // CraftBukkit end
          this.chatVisibility = packet.chatVisibility();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3f3e5686b91c117ee49ebfa284ecc4649c109261..3c4e0fc879bebb55b07f6017a38311519329902e 100644
+index ea652f6394c7e575ce06a6b691d8b2c442eafb03..306af349e96967d21ee0dda9cac04d4507bf5b00 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -154,6 +154,8 @@ import org.apache.logging.log4j.LogManager;
@@ -1304,7 +1304,7 @@ index 3f3e5686b91c117ee49ebfa284ecc4649c109261..3c4e0fc879bebb55b07f6017a3831151
  import java.util.concurrent.ExecutionException;
  import java.util.concurrent.atomic.AtomicInteger;
  import net.minecraft.world.entity.animal.Bucketable;
-@@ -385,21 +387,24 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -382,21 +384,24 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          return this.server.isSingleplayerOwner(this.player.getGameProfile());
      }
  
@@ -1337,7 +1337,7 @@ index 3f3e5686b91c117ee49ebfa284ecc4649c109261..3c4e0fc879bebb55b07f6017a3831151
  
          if (this.cserver.getServer().isRunning()) {
              this.cserver.getPluginManager().callEvent(event);
-@@ -410,8 +415,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -407,8 +412,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              return;
          }
          // Send the possibly modified leave message
@@ -1347,7 +1347,7 @@ index 3f3e5686b91c117ee49ebfa284ecc4649c109261..3c4e0fc879bebb55b07f6017a3831151
          // CraftBukkit end
  
          this.connection.send(new ClientboundDisconnectPacket(ichatbasecomponent), (future) -> {
-@@ -1673,9 +1677,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1669,9 +1673,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          */
  
          this.player.disconnect();
@@ -1362,7 +1362,7 @@ index 3f3e5686b91c117ee49ebfa284ecc4649c109261..3c4e0fc879bebb55b07f6017a3831151
          }
          // CraftBukkit end
          this.player.getTextFilter().leave();
-@@ -1857,7 +1863,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1853,7 +1859,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              this.handleCommand(s);
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
@@ -1376,7 +1376,7 @@ index 3f3e5686b91c117ee49ebfa284ecc4649c109261..3c4e0fc879bebb55b07f6017a3831151
              Player player = this.getCraftPlayer();
              AsyncPlayerChatEvent event = new AsyncPlayerChatEvent(async, player, s, new LazyPlayerSet(this.server));
              this.cserver.getPluginManager().callEvent(event);
-@@ -2647,30 +2658,30 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2643,30 +2654,30 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  return;
              }
  
@@ -1698,10 +1698,10 @@ index 9af14095fa8dbc75fadb84c5a1d263039994e441..3b35ec1df648a3de920ea0c159623880
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f2ac30087 100644
+index 11610250c91fb1dd5921f617f4232b5462cb74da..fd87b6b719794f65a83d53e6fd06ea9a8b06002f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -625,8 +625,10 @@ public final class CraftServer implements Server {
+@@ -623,8 +623,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1712,7 +1712,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      }
  
      @Override
-@@ -1475,7 +1477,15 @@ public final class CraftServer implements Server {
+@@ -1457,7 +1459,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -1728,7 +1728,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1633,7 +1643,20 @@ public final class CraftServer implements Server {
+@@ -1615,7 +1625,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1749,7 +1749,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1641,14 +1664,14 @@ public final class CraftServer implements Server {
+@@ -1623,14 +1646,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -1766,7 +1766,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1884,6 +1907,14 @@ public final class CraftServer implements Server {
+@@ -1881,6 +1904,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -1781,7 +1781,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1896,13 +1927,28 @@ public final class CraftServer implements Server {
+@@ -1893,13 +1924,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -1810,7 +1810,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1951,6 +1997,12 @@ public final class CraftServer implements Server {
+@@ -1959,6 +2005,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -1823,7 +1823,7 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2394,5 +2446,15 @@ public final class CraftServer implements Server {
+@@ -2402,5 +2454,15 @@ public final class CraftServer implements Server {
              return null;
          }
      }
@@ -1840,18 +1840,18 @@ index 8b521bf3b10412b7ebe081591f0e6413e235d978..855740411220bc8178ea7bfd561a377f
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d08836e06e13ba64298cc21d0e2e61f9334dddb9..83ad8c26a6152b4dd7ff9e432dabcc5fc17e3df0 100644
+index 6a321fb7b861b4209e988204ebb165e56c3a3c4a..219db550296680306bacf59b60e8e3608d3392c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -135,6 +135,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-     private int waterAmbientSpawn = -1;
-     private int waterUndergroundCreatureSpawn = -1;
-     private int ambientSpawn = -1;
+@@ -132,6 +132,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+     private final List<BlockPopulator> populators = new ArrayList<BlockPopulator>();
+     private final BlockMetadataStore blockMetadata = new BlockMetadataStore(this);
+     private final Object2IntOpenHashMap<SpawnCategory> spawnCategoryLimit = new Object2IntOpenHashMap<>();
 +    private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  
      private static final Random rand = new Random();
  
-@@ -1802,4 +1803,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1835,4 +1836,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.spigot;
      }
      // Spigot end
@@ -1871,7 +1871,7 @@ index d08836e06e13ba64298cc21d0e2e61f9334dddb9..83ad8c26a6152b4dd7ff9e432dabcc5f
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index dd115bd005604614e64a236ccf86a24882beb096..0c26dc0b060700323aca0a062b34d35e16a3ec9f 100644
+index 707544dfd83839634dc4c1afc8e21c5c6c3d8140..c508bfb68bb4bfd06aa0cefa5bfc0bec725a6b03 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -19,6 +19,12 @@ public class Main {
@@ -2233,10 +2233,10 @@ index cf69a45f038c2b8336010f5fe277313fd0513b5b..eb99e0c2462a2d1ab4508a5c3f1580b6
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
          return this.target;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 4e823d5e8e78db502f979182f1ce276ba0096007..2980a92e548efea7104e909e1cdf9887ef617a9d 100644
+index a4907dee676e9e9cc2725a3312831198a0db7b10..4b7ed15279bbdd116d993f190094f80c888aed69 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -189,6 +189,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -191,6 +191,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      protected Entity entity;
      private EntityDamageEvent lastDamageEvent;
      private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftEntity.DATA_TYPE_REGISTRY);
@@ -2244,7 +2244,7 @@ index 4e823d5e8e78db502f979182f1ce276ba0096007..2980a92e548efea7104e909e1cdf9887
  
      public CraftEntity(final CraftServer server, final Entity entity) {
          this.server = server;
-@@ -816,6 +817,32 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -818,6 +819,32 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.getHandle().getVehicle().getBukkitEntity();
      }
  
@@ -2277,7 +2277,7 @@ index 4e823d5e8e78db502f979182f1ce276ba0096007..2980a92e548efea7104e909e1cdf9887
      @Override
      public void setCustomName(String name) {
          // sane limit for name length
-@@ -871,6 +898,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -873,6 +900,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public String getName() {
          return CraftChatMessage.fromComponent(this.getHandle().getName());
      }
@@ -2348,10 +2348,10 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e8fd6f2f9 100644
+index 74db150aed0744d62779e00cad8bfa25cede76ab..3710423e2181533056bb87c40e129eb5d17a9afd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -255,14 +255,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -262,14 +262,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getDisplayName() {
@@ -2391,7 +2391,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      @Override
      public String getPlayerListName() {
          return this.getHandle().listName == null ? getName() : CraftChatMessage.fromComponent(this.getHandle().listName);
-@@ -281,42 +306,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -288,42 +313,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2443,7 +2443,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
          this.getHandle().connection.send(packet);
      }
  
-@@ -348,6 +373,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -355,6 +380,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.disconnect(message == null ? "" : message);
      }
  
@@ -2461,7 +2461,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      @Override
      public void setCompassTarget(Location loc) {
          if (this.getHandle().connection == null) return;
-@@ -603,6 +639,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -610,6 +646,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
@@ -2495,7 +2495,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      @Override
      public void sendSignChange(Location loc, String[] lines) {
          this.sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -630,14 +693,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -637,14 +700,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          Component[] components = CraftSign.sanitizeLines(lines);
@@ -2513,7 +2513,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      }
  
      @Override
-@@ -1332,7 +1396,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1339,7 +1403,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url) {
@@ -2522,7 +2522,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      }
  
      @Override
-@@ -1347,7 +1411,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1354,7 +1418,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url, byte[] hash, boolean force) {
@@ -2531,7 +2531,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      }
  
      @Override
-@@ -1363,6 +1427,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1370,6 +1434,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2553,7 +2553,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      public void addChannel(String channel) {
          Preconditions.checkState(this.channels.size() < 128, "Cannot register channel '%s'. Too many channels registered!", channel);
          channel = StandardMessenger.validateAndCorrectChannel(channel);
-@@ -1767,6 +1846,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1774,6 +1853,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -2566,7 +2566,7 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -1812,6 +1897,194 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1819,6 +1904,194 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  
@@ -2762,10 +2762,10 @@ index 43203833aac1a95bad813ee84da3225489da4b70..e87afc4930f5450113ffb6c4bba57e2e
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index db73426f317374a070939eaef1171bb8c322041b..57c7ee1329d80fb441a4637f309d69fa120fae01 100644
+index 4b0a056a134dd5868438bdd0d46f3dab8751436d..2a3853201a6ccf14b2aab67982de7789e0cbc552 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -807,9 +807,9 @@ public class CraftEventFactory {
+@@ -817,9 +817,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -2777,7 +2777,7 @@ index db73426f317374a070939eaef1171bb8c322041b..57c7ee1329d80fb441a4637f309d69fa
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          org.bukkit.World world = entity.getWorld();
-@@ -834,7 +834,7 @@ public class CraftEventFactory {
+@@ -844,7 +844,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/patches/server/0018-Allow-for-toggling-of-spawn-chunks.patch
+++ b/patches/server/0018-Allow-for-toggling-of-spawn-chunks.patch
@@ -20,10 +20,10 @@ index 6ee62d06cc2b59c06d0f7acfb59384075aa6521c..9b908c5c66dc454faa479430a908dda0
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 99685c3ad91ca0e3bf20fb6ca100466ec14b7a0f..e112598c854a2c93a8e6b6bda3cfdd4ee4091980 100644
+index 72fd18a307a7e1f769195c7ef44a12bb47f2f49c..3914d0e21b36a480c68c091478ab282826d2b1ae 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -240,6 +240,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -239,6 +239,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          });
          // CraftBukkit end
          timings = new co.aikar.timings.WorldTimingsHandler(this); // Paper - code below can generate new world and access timings

--- a/patches/server/0020-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0020-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -19,7 +19,7 @@ index 2c53a400611c78236c5a1c1270d27c02e94251bf..a1d5c0f8fe2adb2ee56f3217e089211e
                      if (outputStream != null) {
                          try {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 844f24fd16aac25bf681bd3e98f0737be62bead6..f1dfb56d0158d36b583b5ee5596235540b2cb11c 100644
+index eba857195121c58d1b63c58904fd4754a8020219..6b9d947484f0b55a86c3ee27c199669153c0a5ea 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1427,7 +1427,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -32,10 +32,10 @@ index 844f24fd16aac25bf681bd3e98f0737be62bead6..f1dfb56d0158d36b583b5ee559623554
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 855740411220bc8178ea7bfd561a377f2ac30087..10f5be8b1319d371eab0c3153b5f605b033d5208 100644
+index fd87b6b719794f65a83d53e6fd06ea9a8b06002f..d1734e5b210507d7ad999ef37ea463f7c5e99e17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -250,7 +250,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -249,7 +249,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
  public final class CraftServer implements Server {
@@ -45,11 +45,11 @@ index 855740411220bc8178ea7bfd561a377f2ac30087..10f5be8b1319d371eab0c3153b5f605b
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 0c26dc0b060700323aca0a062b34d35e16a3ec9f..e6362865d1e7beac23e520ebd2deb8a356428045 100644
+index c508bfb68bb4bfd06aa0cefa5bfc0bec725a6b03..c19bdd02db2b07a91aec2ee69ffb392ed67a818b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -216,12 +216,25 @@ public class Main {
-                     deadline.add(Calendar.DAY_OF_YEAR, -14);
+                     deadline.add(Calendar.DAY_OF_YEAR, -28);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");
 -                        System.err.println("*** Please download a new build as per instructions from https://www.spigotmc.org/go/outdated-spigot ***");

--- a/patches/server/0023-Player-affects-spawning-API.patch
+++ b/patches/server/0023-Player-affects-spawning-API.patch
@@ -117,10 +117,10 @@ index 1e420c4230a326da345b2e28442ece26b44f8259..41d20c16ea165cf166c6f3b228bc8261
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e87afc4930f5450113ffb6c4bba57e2e8fd6f2f9..3e6b0348ea7d6282725ded67ff97868e016a1e91 100644
+index 3710423e2181533056bb87c40e129eb5d17a9afd..19b0803242c7964db973473c4219db8f6e2171d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1860,8 +1860,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1867,8 +1867,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0025-Further-improve-server-tick-loop.patch
+++ b/patches/server/0025-Further-improve-server-tick-loop.patch
@@ -12,7 +12,7 @@ Previous implementation did not calculate TPS correctly.
 Switch to a realistic rolling average and factor in std deviation as an extra reporting variable
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f1dfb56d0158d36b583b5ee5596235540b2cb11c..b86ceda8f7376334987955095234bdecec5af414 100644
+index 6b9d947484f0b55a86c3ee27c199669153c0a5ea..b16c2c8e173d906097ee9ac3edace1334da11a4b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -282,7 +282,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -144,10 +144,10 @@ index f1dfb56d0158d36b583b5ee5596235540b2cb11c..b86ceda8f7376334987955095234bdec
                      this.startMetricsRecordingTick();
                      this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 10f5be8b1319d371eab0c3153b5f605b033d5208..ae2bad0ba336aa5f3c6d71a04a3ac8a15b311600 100644
+index d1734e5b210507d7ad999ef37ea463f7c5e99e17..17112a3c7f4ab32ad7d0dc4da083459f0109cf52 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2362,6 +2362,17 @@ public final class CraftServer implements Server {
+@@ -2370,6 +2370,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0026-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0026-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3e6b0348ea7d6282725ded67ff97868e016a1e91..91c27a71c5ed63ec5b75bba172e625b795793473 100644
+index 19b0803242c7964db973473c4219db8f6e2171d3..b3469e0ffd15656c8cc7a460cc4d42a6cf106982 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1529,12 +1529,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1536,12 +1536,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0027-Entity-Origin-API.patch
+++ b/patches/server/0027-Entity-Origin-API.patch
@@ -25,7 +25,7 @@ index c7fe4b6aa8d68bd5dc394752a5ae635eb46c5f31..a38fe84e9f8060640eb0c485957e8cea
  
          public void onTrackingEnd(Entity entity) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3321df3bcc0b92277dc18b7f6efa42393e657a52..4e835004679b3f5ae0fc7103566b613a6766aefe 100644
+index b883558c101ad1e5d051cc8d14e1905aa3af6aad..a0c9493c7067dabbc5c9f118d01eb9c8bdd6a8a1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -297,7 +297,27 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -132,10 +132,10 @@ index 1f61dcc3d6f33f69fbebaaaee0554403c3e13adf..7135e22a2ee274eaef52804d60f15002
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 2980a92e548efea7104e909e1cdf9887ef617a9d..128d635576b411c7bd6f0f4babb8d22073cc60e8 100644
+index 4b7ed15279bbdd116d993f190094f80c888aed69..fdbcf4989f72e1604a2841f565adfeebf8d45622 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1147,4 +1147,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1154,4 +1154,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0028-Prevent-tile-entity-and-entity-crashes.patch
+++ b/patches/server/0028-Prevent-tile-entity-and-entity-crashes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent tile entity and entity crashes
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 03c667b08db332f33b6da4e386c22d1a69c4f9a7..8a2d18524e089cdc07125e424b37f1b629e591a6 100644
+index 3914d0e21b36a480c68c091478ab282826d2b1ae..7b6ad4acee4a78dbea61c490dc53bd3d10346b56 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -738,11 +738,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -737,11 +737,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          try {
              tickConsumer.accept(entity);
          } catch (Throwable throwable) {
@@ -44,7 +44,7 @@ index 65aedffad9bef4ab80eb835e9c05b6d411f6bb15..14ac3c7b47525b7fd0345d817c9020b5
          }
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index ba10a0128852d1052db1b0527352019e308d81b2..9638e28077b5720745f6125805fbda702a804f74 100644
+index d942dbfdffba68507908317be8eef02037b7a7a6..949d8cc16c91390ea573dd566bec566dc95efc18 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -1031,11 +1031,11 @@ public class LevelChunk extends ChunkAccess {

--- a/patches/server/0034-Optimize-explosions.patch
+++ b/patches/server/0034-Optimize-explosions.patch
@@ -25,7 +25,7 @@ index bc35bdd9cbd544ae2ab27ad042d7d1b3166db9a6..2b0a75dc2e292e655ca3300f64bc1211
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b86ceda8f7376334987955095234bdecec5af414..9d6daeba112e68c64c2b5d7d0c7717766913fd56 100644
+index b16c2c8e173d906097ee9ac3edace1334da11a4b..4db15f60a5da9594cfc313f6fa97032ffc9259e0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1406,6 +1406,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -135,10 +135,10 @@ index 047864651dfbf009b66706e5cb0dd3d1749424bc..a901ce351c484820a8ca95889125e561
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index cb115128ac988dc4b58f452532644dd8fcf37d4c..16f212b4005469dc99fdd83ed6e5810a5b6f8abf 100644
+index 7b6ad4acee4a78dbea61c490dc53bd3d10346b56..c3f19d36fb200e9cdc20cf2993fd72ad8810f254 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -156,6 +156,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -153,6 +153,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      private org.spigotmc.TickLimiter entityLimiter;
      private org.spigotmc.TickLimiter tileLimiter;
      private int tileTickPosition;

--- a/patches/server/0039-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0039-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index 88b6be62678fc09b5a39db28c6d71cc31b16dbcd..352bfe795aea26307de9c998d67a43af
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 91c27a71c5ed63ec5b75bba172e625b795793473..a137989c06a259dbaaa0cbac52d801a6113184bb 100644
+index b3469e0ffd15656c8cc7a460cc4d42a6cf106982..9357440824bf8b125d08c6c785e71c9b1ac95ae4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1860,8 +1860,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1867,8 +1867,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0040-Per-Player-View-Distance-API-placeholders.patch
+++ b/patches/server/0040-Per-Player-View-Distance-API-placeholders.patch
@@ -20,10 +20,10 @@ index 352bfe795aea26307de9c998d67a43af3e4845f0..4689d52cd314a607d17be3657099157e
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_XZ = 32;
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 83ad8c26a6152b4dd7ff9e432dabcc5fc17e3df0..1fa945a6431b813edbdcd7cda9bd48b5c47598d1 100644
+index 219db550296680306bacf59b60e8e3608d3392c5..58fd165fcb6ebb9b2c9dee44d78c5a3cb55794ac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1771,6 +1771,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1804,6 +1804,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getSimulationDistance() {
          return world.spigotConfig.simulationDistance;
      }
@@ -56,10 +56,10 @@ index 83ad8c26a6152b4dd7ff9e432dabcc5fc17e3df0..1fa945a6431b813edbdcd7cda9bd48b5
  
      // Spigot start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a137989c06a259dbaaa0cbac52d801a6113184bb..73ab957bfafee4bbdf80b0fd34fdc7b46b55805a 100644
+index 9357440824bf8b125d08c6c785e71c9b1ac95ae4..fe27669d525c84d9f8d828dfcde1c35e3ecb7a49 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -382,6 +382,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -389,6 +389,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              connection.disconnect(message == null ? net.kyori.adventure.text.Component.empty() : message);
          }
      }

--- a/patches/server/0043-Use-UserCache-for-player-heads.patch
+++ b/patches/server/0043-Use-UserCache-for-player-heads.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use UserCache for player heads
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 6432f668f72c0543283b5a1439d01da81ff5b981..9405812b8c308d70de1e26ba55500301b24ecc3c 100644
+index f331e1b3882d10506fd89034e224e75ae2f030be..eda37a7622748feef782b54235070c04f3c714f8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -168,7 +168,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -175,7 +175,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          if (name == null) {
              this.setProfile(null);
          } else {

--- a/patches/server/0044-Disable-spigot-tick-limiters.patch
+++ b/patches/server/0044-Disable-spigot-tick-limiters.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable spigot tick limiters
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 809f1ac0aca97d484e2f92ebf38a0303499f08ae..db226fe9515e904b8520a063b6dcde62b315a9b1 100644
+index c3f19d36fb200e9cdc20cf2993fd72ad8810f254..0e5142f6479787ab26a22b9ec935c3d09a8dfd2c 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -704,9 +704,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -703,9 +703,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          // Spigot start
          // Iterator iterator = this.blockEntityTickers.iterator();
          int tilesThisCycle = 0;

--- a/patches/server/0047-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0047-Ensure-commands-are-not-ran-async.patch
@@ -14,10 +14,10 @@ big slowdown in execution but throwing an exception at same time to raise awaren
 that it is happening so that plugin authors can fix their code to stop executing commands async.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3c4e0fc879bebb55b07f6017a38311519329902e..fed5dcdc62700bd661035011a06788fddec1b2a6 100644
+index 306af349e96967d21ee0dda9cac04d4507bf5b00..979ece36de5c160a188b4c14b2bf991924f6fd98 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1860,6 +1860,29 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1856,6 +1856,29 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
  
          if (!async && s.startsWith("/")) {
@@ -48,10 +48,10 @@ index 3c4e0fc879bebb55b07f6017a38311519329902e..fed5dcdc62700bd661035011a06788fd
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ae2bad0ba336aa5f3c6d71a04a3ac8a15b311600..8f49af4892390a990ea2c273b8c64e359ff15b72 100644
+index 17112a3c7f4ab32ad7d0dc4da083459f0109cf52..5b7e2f92315a8963b38303ed72de7f144e6c2773 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -849,6 +849,28 @@ public final class CraftServer implements Server {
+@@ -860,6 +860,28 @@ public final class CraftServer implements Server {
          Validate.notNull(commandLine, "CommandLine cannot be null");
          org.spigotmc.AsyncCatcher.catchOp("command dispatch"); // Spigot
  

--- a/patches/server/0049-Expose-server-CommandMap.patch
+++ b/patches/server/0049-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8f49af4892390a990ea2c273b8c64e359ff15b72..94804f241792bd7067edf0cdbf154ed1533241c3 100644
+index 5b7e2f92315a8963b38303ed72de7f144e6c2773..f421e55cc6c629f3718d0c7f4cb7ff287c2b643f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1980,6 +1980,7 @@ public final class CraftServer implements Server {
+@@ -1977,6 +1977,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0052-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/server/0052-Player-Tab-List-and-Title-APIs.patch
@@ -63,7 +63,7 @@ index bd808eb312ade7122973a47f4b96505829511da5..bf0f9cab7c66c089f35b851e799ba4a4
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 73ab957bfafee4bbdf80b0fd34fdc7b46b55805a..f2b3783373336221c0aef8bae04d350eed0e8ec2 100644
+index fe27669d525c84d9f8d828dfcde1c35e3ecb7a49..523746b698d38494f0fa76b026d50e3d9d411c54 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@
@@ -73,7 +73,7 @@ index 73ab957bfafee4bbdf80b0fd34fdc7b46b55805a..f2b3783373336221c0aef8bae04d350e
  import com.google.common.base.Preconditions;
  import com.google.common.collect.ImmutableSet;
  import com.google.common.io.BaseEncoding;
-@@ -253,6 +254,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -260,6 +261,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0053-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0053-Add-configurable-portal-search-radius.patch
@@ -23,10 +23,10 @@ index 1e3c39f0eeeb07f8d49e3651b18a152db9ccba7b..c248b66486044150c64eaddbef85fa66
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6cd4fecf8b6e49027cf8a523fb373db9a2708ed4..de15a2231057217fbbf723cf25e869998a1016f1 100644
+index 6edb88b123a8cc726cb6bd02fd83e5a11402ff00..e88c80fe1fe97e4704d5f17f97c536fdbba48447 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2914,7 +2914,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2920,7 +2920,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  double d0 = DimensionType.getTeleportationScale(this.level.dimensionType(), destination.dimensionType());
                  BlockPos blockposition = worldborder.clampToBounds(this.getX() * d0, this.getY(), this.getZ() * d0);
                  // CraftBukkit start

--- a/patches/server/0054-Add-velocity-warnings.patch
+++ b/patches/server/0054-Add-velocity-warnings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add velocity warnings
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 94804f241792bd7067edf0cdbf154ed1533241c3..607f5547d33fd2f8009837fc4a212b5f08a51027 100644
+index f421e55cc6c629f3718d0c7f4cb7ff287c2b643f..b6e9c6fc7f31b06f77cf108ee0f5548cd530ba5a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -288,6 +288,7 @@ public final class CraftServer implements Server {
+@@ -282,6 +282,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -17,10 +17,10 @@ index 94804f241792bd7067edf0cdbf154ed1533241c3..607f5547d33fd2f8009837fc4a212b5f
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 506bc08a7aadf5246f57e6935dbaa81ca482fb9a..78b3be2ea6351cb6375b77340218615aa75b87f5 100644
+index fdbcf4989f72e1604a2841f565adfeebf8d45622..4ebd7609ec2bf62586feef4da7605dbb89569567 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -436,10 +436,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -438,10 +438,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public void setVelocity(Vector velocity) {
          Preconditions.checkArgument(velocity != null, "velocity");
          velocity.checkFinite();

--- a/patches/server/0055-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0055-Configurable-inter-world-teleportation-safety.patch
@@ -30,10 +30,10 @@ index c248b66486044150c64eaddbef85fa6644494212..ada624b5f58381122e59568c2087cf38
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f2b3783373336221c0aef8bae04d350eed0e8ec2..89e22db19a42e9092bb3ee2e5fd01b2e65fd9878 100644
+index 523746b698d38494f0fa76b026d50e3d9d411c54..924260ec220f2f1abfb4383a9787ebad3a25bef1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -923,7 +923,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -930,7 +930,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (fromWorld == toWorld) {
              entity.connection.teleport(to);
          } else {

--- a/patches/server/0056-Add-exception-reporting-event.patch
+++ b/patches/server/0056-Add-exception-reporting-event.patch
@@ -49,7 +49,7 @@ index 0000000000000000000000000000000000000000..f699ce18ca044f813e194ef2786b7ea8
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 67113f1bb622acde89c05d1ee0af88644f67e776..c72d19a903a5cbb48d38f493e00e8c54a8e23b9c 100644
+index 5d1ac4e7afa0f1d9c9face049f768a2030eb411f..85af59ffb6b11ae1980fef5ef449031c78626b9a 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -919,6 +919,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -108,7 +108,7 @@ index 4cde8d630a0951f297622af4ef781f5b3fabf9af..7044d8c71e85551e11bf2d96b767e088
              }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ad4b29c96113d15b284aed78e5768588802e468c..731e1cefd2a9c829bfe82ec87038d9333ef21fb3 100644
+index 0e5142f6479787ab26a22b9ec935c3d09a8dfd2c..389cb85aa369dff606b21c10fcbf4825c17bbd4f 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -1,5 +1,10 @@
@@ -122,7 +122,7 @@ index ad4b29c96113d15b284aed78e5768588802e468c..731e1cefd2a9c829bfe82ec87038d933
  import com.google.common.collect.Lists;
  import com.mojang.serialization.Codec;
  import java.io.IOException;
-@@ -740,6 +745,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -739,6 +744,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // Paper start - Prevent tile entity and entity crashes
              final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level.getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
              MinecraftServer.LOGGER.error(msg, throwable);
@@ -131,10 +131,10 @@ index ad4b29c96113d15b284aed78e5768588802e468c..731e1cefd2a9c829bfe82ec87038d933
              // Paper end
          }
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 81b61b6cc1e99328d4d339ca32895d1268c88ca7..28a7c53d98450cc79bee953411a18f50cfed26c2 100644
+index 5e2a3baf46175dd92958f47c4503bb8d6f6a0941..373fbdf56dddbae5f793585e31c7e4ff6d31823b 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-@@ -316,6 +316,7 @@ public final class NaturalSpawner {
+@@ -289,6 +289,7 @@ public final class NaturalSpawner {
              }
          } catch (Exception exception) {
              NaturalSpawner.LOGGER.warn("Failed to create mob", exception);
@@ -142,7 +142,7 @@ index 81b61b6cc1e99328d4d339ca32895d1268c88ca7..28a7c53d98450cc79bee953411a18f50
              return null;
          }
      }
-@@ -422,6 +423,7 @@ public final class NaturalSpawner {
+@@ -395,6 +396,7 @@ public final class NaturalSpawner {
                                      entity = biomesettingsmobs_c.type.create(world.getLevel());
                                  } catch (Exception exception) {
                                      NaturalSpawner.LOGGER.warn("Failed to create mob", exception);

--- a/patches/server/0061-Complete-resource-pack-API.patch
+++ b/patches/server/0061-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index fed5dcdc62700bd661035011a06788fddec1b2a6..22d77ed6f6c63a4ba77ec582a7ba26b9f7cd8a44 100644
+index 979ece36de5c160a188b4c14b2bf991924f6fd98..18854aaa1359dd5c944d7e3a6177152bff9614a2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1642,8 +1642,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1638,8 +1638,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              ServerGamePacketListenerImpl.LOGGER.info("Disconnecting {} due to resource pack rejection", this.player.getName());
              this.disconnect(new TranslatableComponent("multiplayer.requiredTexturePrompt.disconnect"));
          }
@@ -23,18 +23,18 @@ index fed5dcdc62700bd661035011a06788fddec1b2a6..22d77ed6f6c63a4ba77ec582a7ba26b9
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 89e22db19a42e9092bb3ee2e5fd01b2e65fd9878..754d3c4c6aca42e569642a01ab816d5ca653d3fb 100644
+index 924260ec220f2f1abfb4383a9787ebad3a25bef1..a29c20dddb1732a46c05e9ca2386b384b782adab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -137,6 +137,7 @@ import org.bukkit.metadata.MetadataValue;
- import org.bukkit.plugin.Plugin;
+@@ -139,6 +139,7 @@ import org.bukkit.plugin.Plugin;
  import org.bukkit.plugin.messaging.StandardMessenger;
+ import org.bukkit.profile.PlayerProfile;
  import org.bukkit.scoreboard.Scoreboard;
 +import org.jetbrains.annotations.NotNull;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
-@@ -153,6 +154,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -155,6 +156,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private double health = 20;
      private boolean scaledHealth = false;
      private double healthScale = 20;
@@ -45,7 +45,7 @@ index 89e22db19a42e9092bb3ee2e5fd01b2e65fd9878..754d3c4c6aca42e569642a01ab816d5c
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -2000,6 +2005,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2007,6 +2012,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0062-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0062-Default-loading-permissions.yml-before-plugins.patch
@@ -30,10 +30,10 @@ index 701a2ffd04df48d437b2cb963dd150af99725b6e..817d4572c9991992b720b3ba163188ac
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 607f5547d33fd2f8009837fc4a212b5f08a51027..cafb0d40a7bf1a6263cb48c507f51ede0c9cd126 100644
+index b6e9c6fc7f31b06f77cf108ee0f5548cd530ba5a..b06542f4b79bffda579ab91cb3b463063a34d472 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -461,6 +461,7 @@ public final class CraftServer implements Server {
+@@ -459,6 +459,7 @@ public final class CraftServer implements Server {
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
              this.helpMap.initializeGeneralTopics();
@@ -41,7 +41,7 @@ index 607f5547d33fd2f8009837fc4a212b5f08a51027..cafb0d40a7bf1a6263cb48c507f51ede
          }
  
          Plugin[] plugins = this.pluginManager.getPlugins();
-@@ -480,7 +481,7 @@ public final class CraftServer implements Server {
+@@ -478,7 +479,7 @@ public final class CraftServer implements Server {
              this.commandMap.registerServerAliases();
              DefaultPermissions.registerCorePermissions();
              CraftDefaultPermissions.registerCorePermissions();

--- a/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cafb0d40a7bf1a6263cb48c507f51ede0c9cd126..be2e3fc4f670730b6e1fc07eab8c1e612c3270dd 100644
+index b06542f4b79bffda579ab91cb3b463063a34d472..01d99c5f916d93375f701a5fe9e250102ff57e8a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2492,5 +2492,23 @@ public final class CraftServer implements Server {
+@@ -2500,5 +2500,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0064-Remove-Metadata-on-reload.patch
+++ b/patches/server/0064-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index be2e3fc4f670730b6e1fc07eab8c1e612c3270dd..13cd1fe6cae82fe73bd6df3049133db51da0084c 100644
+index 01d99c5f916d93375f701a5fe9e250102ff57e8a..1065f69322bb9d068f4ec63e40cc4db6f5425c40 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -966,8 +966,16 @@ public final class CraftServer implements Server {
+@@ -948,8 +948,16 @@ public final class CraftServer implements Server {
              world.paperConfig.init(); // Paper
          }
  

--- a/patches/server/0067-Add-World-Util-Methods.patch
+++ b/patches/server/0067-Add-World-Util-Methods.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add World Util Methods
 Methods that can be used for other patches to help improve logic.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c8ba29065b2e195bdb2570806763e299108725af..b106dfc16820d89b9c9792ad85d09fd66b7204b6 100644
+index 7a536f30a1ff7f93bad14f734aeb5d5ff69a5c9a..767a48000e41c43ccaf71be521348fcd1c71ee11 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -208,7 +208,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -19,10 +19,10 @@ index c8ba29065b2e195bdb2570806763e299108725af..b106dfc16820d89b9c9792ad85d09fd6
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 731e1cefd2a9c829bfe82ec87038d9333ef21fb3..648642a30b499532f55f80a103f759740d815691 100644
+index 389cb85aa369dff606b21c10fcbf4825c17bbd4f..c2fe955b23383effca7a8d712a08e346d648d2a8 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -320,6 +320,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -319,6 +319,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return chunk == null ? null : chunk.getFluidState(blockposition);
      }
  

--- a/patches/server/0069-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0069-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -44,10 +44,10 @@ index e94344170190ae9429b744ec7878c3aa093f01b6..e13808657e0c7dc94fcd2844690a31d0
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 754d3c4c6aca42e569642a01ab816d5ca653d3fb..1bae28202288d51a67788b172b9c4e0a4eca2807 100644
+index a29c20dddb1732a46c05e9ca2386b384b782adab..816c39c3ce9ec980cda43b05d040b8da85e9c1f3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1805,6 +1805,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1812,6 +1812,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0072-Optimize-isInWorldBounds-and-getBlockState-for-inlin.patch
+++ b/patches/server/0072-Optimize-isInWorldBounds-and-getBlockState-for-inlin.patch
@@ -12,7 +12,7 @@ Replace all calls to the new place to the unnecessary forward.
 Optimize getType and getBlockData to manually inline and optimize the calls
 
 diff --git a/src/main/java/net/minecraft/core/Vec3i.java b/src/main/java/net/minecraft/core/Vec3i.java
-index 543d5a67e76a3114f6eac29a053ff04ceecb6256..cf7cbab325865c8e0d114187a5a15f7345ec7f89 100644
+index dba7872cf337a5c3dc5a6fe508dd50b93462fae5..75aa5df03c162fa10046fbad806b81051fb5765b 100644
 --- a/src/main/java/net/minecraft/core/Vec3i.java
 +++ b/src/main/java/net/minecraft/core/Vec3i.java
 @@ -33,6 +33,12 @@ public class Vec3i implements Comparable<Vec3i> {
@@ -29,10 +29,10 @@ index 543d5a67e76a3114f6eac29a053ff04ceecb6256..cf7cbab325865c8e0d114187a5a15f73
          this.x = x;
          this.y = y;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index de1bb9ecb8891b66b2c469f2ee52b9eee9d7ddea..c28285ab7e698a214aea6ff4a5ff6d4f8b8b52bd 100644
+index c2fe955b23383effca7a8d712a08e346d648d2a8..85d3ece733d78897f85a7a02d323fdb025193622 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -263,7 +263,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -262,7 +262,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      }
  
      public boolean isInWorldBounds(BlockPos pos) {
@@ -88,7 +88,7 @@ index ef74f37cae96e61d5648fce7bbd793fb67ba9e4a..e15263a152c88371ebc65b47f0be938f
      @Override
      public FluidState getFluidState(BlockPos pos) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index f9fbe225cc11b2bafa733e92d9537aaa7c1e007b..78cb2d16654cd679531bba9d7d9d0cb810e689e2 100644
+index 3ba9f8d7dc12709670dcd94df5d82b8d44f983fa..cbffb4eb93ba1888666d4b0de98b2fb05c1400a0 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -288,12 +288,29 @@ public class LevelChunk extends ChunkAccess {
@@ -138,7 +138,7 @@ index 6abd3cf0a388b158252628d8031b92bb8a6d65fb..50b6ecfea7a342be0d21e37ae87777a4
      private short tickingFluidCount;
      public final PalettedContainer<BlockState> states;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java b/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
-index b7dbdcb0ce7948c6f98ec67d0cf2033a8e348085..150dd90598bbe4057b4e9ad17c87a4c07af3d56d 100644
+index 7c2e3331fac1de2e20974c8eed8aeeb9f2c92789..acfd46c7035b4009d61bda8a7c8dd6953e4836e6 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
 @@ -87,14 +87,18 @@ public class ProtoChunk extends ChunkAccess {

--- a/patches/server/0073-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/patches/server/0073-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Only process BlockPhysicsEvent if a plugin has a listener
 Saves on some object allocation and processing when no plugin listens to this
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9d6daeba112e68c64c2b5d7d0c7717766913fd56..b8938c4118b61758874624229b6986956f30cc8e 100644
+index 4db15f60a5da9594cfc313f6fa97032ffc9259e0..b807bd1e53f39a1d635800f02f6772f0fc878f7a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1367,6 +1367,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -18,7 +18,7 @@ index 9d6daeba112e68c64c2b5d7d0c7717766913fd56..b8938c4118b61758874624229b698695
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4e896cdc395cfb2b976e13ee3f0228d9f475069f..419f539109ca0b8103475e52d0fdda40a7b99cc7 100644
+index ddf2468fe4adb5115f21c7eb0d695c999f1c3efe..db3f50d7bdfff919cfaee3b035f6ae4e79beb000 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -207,6 +207,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -30,10 +30,10 @@ index 4e896cdc395cfb2b976e13ee3f0228d9f475069f..419f539109ca0b8103475e52d0fdda40
      @Override public LevelChunk getChunkIfLoaded(int x, int z) { // Paper - this was added in world too but keeping here for NMS ABI
          return this.chunkSource.getChunk(x, z, false);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 987962d1142c0ec0e28a9f2c7a62c8440bb10bd7..a0529181ab587c6675a6b6252efa12354c29316e 100644
+index 85d3ece733d78897f85a7a02d323fdb025193622..c91652cf949c099145587e758b259e2b3dfbe8c5 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -475,7 +475,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -474,7 +474,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  // CraftBukkit start
                  iblockdata1.updateIndirectNeighbourShapes(this, blockposition, k, j - 1); // Don't call an event for the old block to limit event spam
                  CraftWorld world = ((ServerLevel) this).getWorld();
@@ -42,7 +42,7 @@ index 987962d1142c0ec0e28a9f2c7a62c8440bb10bd7..a0529181ab587c6675a6b6252efa1235
                      BlockPhysicsEvent event = new BlockPhysicsEvent(world.getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), CraftBlockData.fromData(iblockdata));
                      this.getCraftServer().getPluginManager().callEvent(event);
  
-@@ -588,7 +588,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -587,7 +587,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              try {
                  // CraftBukkit start
                  CraftWorld world = ((ServerLevel) this).getWorld();

--- a/patches/server/0079-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0079-Add-PlayerUseUnknownEntityEvent.patch
@@ -20,10 +20,10 @@ index 8834ed411a7db86b4d2b88183a1315317107d719..c45b5ab6776f3ac79f856c3a6467c510
      static final ServerboundInteractPacket.Action ATTACK_ACTION = new ServerboundInteractPacket.Action() {
          @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 22d77ed6f6c63a4ba77ec582a7ba26b9f7cd8a44..fbfedf1f8e4be9391c6959e527037132585ab19a 100644
+index 18854aaa1359dd5c944d7e3a6177152bff9614a2..bacb8ff97a6745847b5e3eb82dd08bde934e8d1f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2208,8 +2208,37 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2204,8 +2204,37 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  });
              }
          }

--- a/patches/server/0081-Fix-Cancelling-BlockPlaceEvent-triggering-physics.patch
+++ b/patches/server/0081-Fix-Cancelling-BlockPlaceEvent-triggering-physics.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Cancelling BlockPlaceEvent triggering physics
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 2cc265cb984160047a44261ebbf5ff718bdf6b0c..2cec48979dafd3edf8c6744e2f5f65a922537b0f 100644
+index c91652cf949c099145587e758b259e2b3dfbe8c5..46f8fff21c0d91b9326b9270def43bd99c54b3ac 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -546,6 +546,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -545,6 +545,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public void setBlocksDirty(BlockPos pos, BlockState old, BlockState updated) {}
  
      public void updateNeighborsAt(BlockPos pos, Block block) {

--- a/patches/server/0084-Workaround-for-setting-passengers-on-players.patch
+++ b/patches/server/0084-Workaround-for-setting-passengers-on-players.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Workaround for setting passengers on players
 SPIGOT-1915 & GH-114
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1bae28202288d51a67788b172b9c4e0a4eca2807..2de322ae6c56129a5db89376e0619ffb56f73ae9 100644
+index 816c39c3ce9ec980cda43b05d040b8da85e9c1f3..e168bc5a3a3dcab404023ebe16ea90e380d6b38c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -933,6 +933,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -940,6 +940,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return true;
      }
  

--- a/patches/server/0097-Faster-redstone-torch-rapid-clock-removal.patch
+++ b/patches/server/0097-Faster-redstone-torch-rapid-clock-removal.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Faster redstone torch rapid clock removal
 Only resize the the redstone torch list once, since resizing arrays / lists is costly
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 7c0437929964d95797c13b690a6167f2bce95736..8142f6c2d3bd17aec313d46141910f0743c6345e 100644
+index 46f8fff21c0d91b9326b9270def43bd99c54b3ac..e33c9116ebd8ad751774fd0fa736c42214aed654 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -162,6 +162,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -159,6 +159,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      private org.spigotmc.TickLimiter tileLimiter;
      private int tileTickPosition;
      public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions

--- a/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
@@ -67,10 +67,10 @@ index 876658b685ea09adb4c01d436da56daadb7eedaa..5445cb5910ec63408dc4379eec5e12d3
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 13cd1fe6cae82fe73bd6df3049133db51da0084c..a5fe53aaa10bb919888da732fe86123c8e78cd1d 100644
+index 1065f69322bb9d068f4ec63e40cc4db6f5425c40..88315ebb3b5e698ecc8332951ad72ef538bc44fd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1723,7 +1723,7 @@ public final class CraftServer implements Server {
+@@ -1705,7 +1705,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0105-Configurable-packet-in-spam-threshold.patch
+++ b/patches/server/0105-Configurable-packet-in-spam-threshold.patch
@@ -23,10 +23,10 @@ index 728835cddd413d778e9628360989724f65335b46..6c13fe725ca2b2a6f0f375b80f6c2cb6
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index fbfedf1f8e4be9391c6959e527037132585ab19a..7801b0c694c06db034ad6e7601f70881c15892bf 100644
+index bacb8ff97a6745847b5e3eb82dd08bde934e8d1f..035920097271ce50b21eddbed7c874b9628ac28a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1497,13 +1497,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1494,13 +1494,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      // Spigot start - limit place/interactions
      private int limitedPackets;
      private long lastLimitedPacket = -1;

--- a/patches/server/0106-Configurable-flying-kick-messages.patch
+++ b/patches/server/0106-Configurable-flying-kick-messages.patch
@@ -21,10 +21,10 @@ index 6c13fe725ca2b2a6f0f375b80f6c2cb643b9913d..5e23ff0c5e44427a996281ae42fc12c2
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index faeb99b93ead7c444fc23d542c7e2b11055ebfba..6de1ea5c10f335a39f73033998629068cf93a539 100644
+index 035920097271ce50b21eddbed7c874b9628ac28a..16bb1d2d5f168d45bef86fad6e9ebc68f2e822f4 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -302,7 +302,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -299,7 +299,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          if (this.clientIsFloating && !this.player.isSleeping()) {
              if (++this.aboveGroundTickCount > 80) {
                  ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked for floating too long!", this.player.getName().getString());
@@ -33,7 +33,7 @@ index faeb99b93ead7c444fc23d542c7e2b11055ebfba..6de1ea5c10f335a39f73033998629068
                  return;
              }
          } else {
-@@ -321,7 +321,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -318,7 +318,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              if (this.clientVehicleIsFloating && this.player.getRootVehicle().getControllingPassenger() == this.player) {
                  if (++this.aboveGroundVehicleTickCount > 80) {
                      ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked for floating a vehicle too long!", this.player.getName().getString());

--- a/patches/server/0109-Add-EntityZapEvent.patch
+++ b/patches/server/0109-Add-EntityZapEvent.patch
@@ -28,10 +28,10 @@ index e2ac5290751b8c219add3823251e0131c0d2b52e..8785a112519de49e0d61eab5ab5325f9
              entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
              entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 57c7ee1329d80fb441a4637f309d69fa120fae01..cad2a30665e059ab9f0be3f94876d332ccb29178 100644
+index 2a3853201a6ccf14b2aab67982de7789e0cbc552..b94d6c79adc0858a588778b5ebf9f5e7f97f9050 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1142,6 +1142,14 @@ public class CraftEventFactory {
+@@ -1152,6 +1152,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a5fe53aaa10bb919888da732fe86123c8e78cd1d..1bfd0cb76ccd8c7e1947407a865e7be7bfa35b3a 100644
+index 88315ebb3b5e698ecc8332951ad72ef538bc44fd..903e4d866ffd2711c540c8982fe189d6992361f3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2518,5 +2518,24 @@ public final class CraftServer implements Server {
+@@ -2526,5 +2526,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index 687904d3e1b3ee7b514c707d9b2eeccabbf56603..f7cbe6819b8c4f7eaca2389de8eaceb5
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cad2a30665e059ab9f0be3f94876d332ccb29178..16f1bac14758d5052effb3aadece9b00d8bc7752 100644
+index b94d6c79adc0858a588778b5ebf9f5e7f97f9050..20e5da655a76ce2024cbbfa00ce4dc924c6cedd0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1101,6 +1101,17 @@ public class CraftEventFactory {
+@@ -1111,6 +1111,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0115-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0115-Add-ProjectileCollideEvent.patch
@@ -87,10 +87,10 @@ index 88181c59e604ba3b132b9e695cef5eaf5b836029..94d09b05737679b133ec462815b010b1
  
          this.checkInsideBlocks();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 16f1bac14758d5052effb3aadece9b00d8bc7752..d93e79ab1a3b16bfc75209cb0b5e2e9fade35d86 100644
+index 20e5da655a76ce2024cbbfa00ce4dc924c6cedd0..23a53f0c287fea7ddf45f807ae642ba4e5acb7b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1245,6 +1245,16 @@ public class CraftEventFactory {
+@@ -1255,6 +1255,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/patches/server/0117-Optimize-World.isLoaded-BlockPosition-Z.patch
+++ b/patches/server/0117-Optimize-World.isLoaded-BlockPosition-Z.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimize World.isLoaded(BlockPosition)Z
 Reduce method invocations for World.isLoaded(BlockPosition)Z
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 11cd3fc535717f074c20a39b4248d623176f7445..7a392ab56a95bba28aca33be6a738136a6803e0c 100644
+index e33c9116ebd8ad751774fd0fa736c42214aed654..d65fcf365a2c24c099e70597c843562ec341df3a 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -321,6 +321,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -320,6 +320,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return chunk == null ? null : chunk.getFluidState(blockposition);
      }
  

--- a/patches/server/0122-String-based-Action-Bar-API.patch
+++ b/patches/server/0122-String-based-Action-Bar-API.patch
@@ -26,10 +26,10 @@ index 32ef3edebe94a2014168b7e438752a80b2687e5f..ab6c58eed6707ab7b0aa3e7549a871ad
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2de322ae6c56129a5db89376e0619ffb56f73ae9..366d0ee7bc8dec667907674972785491723790f8 100644
+index e168bc5a3a3dcab404023ebe16ea90e380d6b38c..e7798e4fbfd0b9e882356e6df30ada0e1b174c56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -260,6 +260,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -267,6 +267,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      // Paper start

--- a/patches/server/0123-Properly-fix-item-duplication-bug.patch
+++ b/patches/server/0123-Properly-fix-item-duplication-bug.patch
@@ -19,10 +19,10 @@ index 3a97690a1e65db9a1c184fa4df5899cfda3d44bc..ab73818893b00551f8137704a727e330
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0f100b31655e8c6c411b199ee43f15796f811337..2ab340cd71daf87bd2bb9e7194986dc1ba52715b 100644
+index 16bb1d2d5f168d45bef86fad6e9ebc68f2e822f4..1a29ea597de65689b5e374e98da988e86afb4d11 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2825,7 +2825,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2821,7 +2821,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      }
  
      public final boolean isDisconnected() {

--- a/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -7,10 +7,10 @@ Provides counts without the ineffeciency of using .getEntities().size()
 which creates copy of the collections.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index b40cdc7a49d005af6e142f6bc59e25dd29c96d5d..88b2681b15d2dca66b22d12b7dc7f854883793c8 100644
+index d65fcf365a2c24c099e70597c843562ec341df3a..41e7474588d8e5ba4cd4af0fed1e62e452389a3e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -111,7 +111,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -113,7 +113,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public static final int TICKS_PER_DAY = 24000;
      public static final int MAX_ENTITY_SPAWN_Y = 20000000;
      public static final int MIN_ENTITY_SPAWN_Y = -20000000;
@@ -20,11 +20,11 @@ index b40cdc7a49d005af6e142f6bc59e25dd29c96d5d..88b2681b15d2dca66b22d12b7dc7f854
      private boolean tickingBlockEntities;
      public final Thread thread;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1fa945a6431b813edbdcd7cda9bd48b5c47598d1..cf051e821ec5969cafd815b95569e88d209e42e0 100644
+index 58fd165fcb6ebb9b2c9dee44d78c5a3cb55794ac..b9d0a2f8d1ed290d2fa12d6c2307903412727fc1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -137,6 +137,57 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-     private int ambientSpawn = -1;
+@@ -134,6 +134,57 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+     private final Object2IntOpenHashMap<SpawnCategory> spawnCategoryLimit = new Object2IntOpenHashMap<>();
      private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  
 +    // Paper start - Provide fast information methods

--- a/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -8,10 +8,10 @@ Adds lots of information about why this orb exists.
 Replaces isFromBottle() with logic that persists entity reloads too.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 15220779927ff722960401643e99971833fc5704..2869d9bb0d374c26f9569eef3ecf0480cbaa85a6 100644
+index 252613e3c4c496bd4f6fd061e36fac06c32323c9..12c9efc409e5306fb24b8338d4c60286cff1435c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -414,7 +414,7 @@ public class ServerPlayerGameMode {
+@@ -416,7 +416,7 @@ public class ServerPlayerGameMode {
  
                  // Drop event experience
                  if (flag && event != null) {

--- a/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -26,10 +26,10 @@ index 47b717e8741bb2b8f3aa776dcdc73a3e7dbb5960..9dad1efab44b8a23f274aa89c85944d9
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2ab340cd71daf87bd2bb9e7194986dc1ba52715b..f7649a153191732a33ba9cdd02c573f04b62ce53 100644
+index 1a29ea597de65689b5e374e98da988e86afb4d11..92c9254335854067683d98e1576c7d06f28415b1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2058,6 +2058,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2054,6 +2054,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          switch (packet.getAction()) {
              case PRESS_SHIFT_KEY:
                  this.player.setShiftKeyDown(true);

--- a/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -20,10 +20,10 @@ index 5e23ff0c5e44427a996281ae42fc12c28649e158..7a69f9d9bb9c05474d8fbab22d626529
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1bfd0cb76ccd8c7e1947407a865e7be7bfa35b3a..9bd1dac354a14735c3547215f85f1124c933f311 100644
+index 903e4d866ffd2711c540c8982fe189d6992361f3..2d782eb547136e1dae123044b114bd77ca23383a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2537,5 +2537,10 @@ public final class CraftServer implements Server {
+@@ -2545,5 +2545,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -112,7 +112,7 @@ index 0000000000000000000000000000000000000000..685deaa0e5d1ddc13e3a7c0471b1cfcf
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0cf83ee46754197b2b639d07bff9a0d21566a641..123da97204af4bb40f98e09a5102227fb1359fd2 100644
+index 74792811da877dc59c25af5e46e3ab570895b6b6..c3e4aa076e2be77e5a48a4f0a12f26e67ea06476 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -9,6 +9,7 @@ import com.mojang.authlib.GameProfile;
@@ -244,10 +244,10 @@ index e47642c3164f7f7a358d2c7a9722643acf3e0089..dc891a463ec24b0b1b4c6c00b2c199e7
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9bd1dac354a14735c3547215f85f1124c933f311..0fd04a4371525d6655c5a6f24c097c55914cd225 100644
+index 6efe539d3a19d5b4b673ec24f36111320daf772f..e5f4c6091e38a298c08dea09f77b9c5a8e61a2ba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -49,7 +49,6 @@ import java.util.logging.Level;
+@@ -46,7 +46,6 @@ import java.util.logging.Level;
  import java.util.logging.Logger;
  import java.util.stream.Collectors;
  import javax.imageio.ImageIO;
@@ -255,15 +255,7 @@ index 9bd1dac354a14735c3547215f85f1124c933f311..0fd04a4371525d6655c5a6f24c097c55
  import net.minecraft.advancements.Advancement;
  import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
-@@ -61,6 +60,7 @@ import net.minecraft.resources.RegistryReadOps;
- import net.minecraft.resources.ResourceKey;
- import net.minecraft.resources.ResourceLocation;
- import net.minecraft.server.ConsoleInput;
-+//import jline.console.ConsoleReader; // Paper
- import net.minecraft.server.MinecraftServer;
- import net.minecraft.server.bossevents.CustomBossEvent;
- import net.minecraft.server.commands.ReloadCommand;
-@@ -1308,9 +1308,13 @@ public final class CraftServer implements Server {
+@@ -1290,9 +1289,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  
@@ -278,7 +270,7 @@ index 9bd1dac354a14735c3547215f85f1124c933f311..0fd04a4371525d6655c5a6f24c097c55
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 60ccdf33a014f3488353045e30526bc3f16e93c5..a19d5abb8188e2fd2382b9b42d65fa7a8c3d1799 100644
+index c73d785fce285d4f8eeb6f763ece21c4493071a4..77c065d74ae84f8e003141f050fe01ae582ae44c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,7 +12,7 @@ import java.util.logging.Level;

--- a/patches/server/0142-Add-UnknownCommandEvent.patch
+++ b/patches/server/0142-Add-UnknownCommandEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0fd04a4371525d6655c5a6f24c097c55914cd225..7a96dd337c41cdfa7703de4b21380a4fce0198c8 100644
+index e5f4c6091e38a298c08dea09f77b9c5a8e61a2ba..909724efb99f88f3de0967b85d539e0ab1bec8e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -879,7 +879,13 @@ public final class CraftServer implements Server {
+@@ -889,7 +889,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -7,36 +7,38 @@ Establishes base extension of profile systems for future edits too
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..84551164b76bc8f064a3a0c030c3a1b47f567b6f
+index 0000000000000000000000000000000000000000..a4b580be7f3c52f27915256e00b354d4455a718e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
-@@ -0,0 +1,302 @@
+@@ -0,0 +1,372 @@
 +package com.destroystokyo.paper.profile;
 +
 +import com.destroystokyo.paper.PaperConfig;
 +import com.google.common.base.Charsets;
++import com.google.common.collect.Iterables;
 +import com.mojang.authlib.GameProfile;
 +import com.mojang.authlib.properties.Property;
 +import com.mojang.authlib.properties.PropertyMap;
++import net.minecraft.Util;
 +import net.minecraft.server.MinecraftServer;
 +import net.minecraft.server.players.GameProfileCache;
 +import org.apache.commons.lang3.Validate;
 +import org.bukkit.craftbukkit.entity.CraftPlayer;
++import org.bukkit.craftbukkit.profile.CraftPlayerTextures;
++import org.bukkit.craftbukkit.profile.CraftProfileProperty;
++import org.bukkit.profile.PlayerTextures;
++import org.jetbrains.annotations.NotNull;
 +
 +import javax.annotation.Nonnull;
 +import javax.annotation.Nullable;
-+import java.util.AbstractSet;
-+import java.util.Collection;
-+import java.util.Iterator;
-+import java.util.Objects;
-+import java.util.Optional;
-+import java.util.Set;
-+import java.util.UUID;
++import java.util.*;
++import java.util.concurrent.CompletableFuture;
 +
-+public class CraftPlayerProfile implements PlayerProfile {
++public class CraftPlayerProfile implements PlayerProfile, SharedPlayerProfile {
 +
 +    private GameProfile profile;
 +    private final PropertySet properties = new PropertySet();
++    private final CraftPlayerTextures textures = new CraftPlayerTextures(this);
 +
 +    public CraftPlayerProfile(CraftPlayer player) {
 +        this.profile = player.getHandle().getGameProfile();
@@ -64,6 +66,21 @@ index 0000000000000000000000000000000000000000..84551164b76bc8f064a3a0c030c3a1b4
 +        properties.put(name, new Property(name, property.getValue(), property.getSignature()));
 +    }
 +
++    @Override
++    public CraftPlayerTextures getTextures() {
++        return this.textures;
++    }
++
++    @Override
++    public void setTextures(@Nullable PlayerTextures textures) {
++        if (textures == null) {
++            this.textures.clear();
++        } else {
++            this.textures.copyFrom(textures);
++        }
++        this.textures.rebuildPropertyIfDirty();
++    }
++
 +    public GameProfile getGameProfile() {
 +        return profile;
 +    }
@@ -80,6 +97,11 @@ index 0000000000000000000000000000000000000000..84551164b76bc8f064a3a0c030c3a1b4
 +        this.profile = new GameProfile(uuid, prev.getName());
 +        copyProfileProperties(prev, this.profile);
 +        return prev.getId();
++    }
++
++    @Override
++    public UUID getUniqueId() {
++        return getId();
 +    }
 +
 +    @Nullable
@@ -117,6 +139,29 @@ index 0000000000000000000000000000000000000000..84551164b76bc8f064a3a0c030c3a1b4
 +        return !profile.getProperties().removeAll(property).isEmpty();
 +    }
 +
++    @Nullable
++    @Override
++    public Property getProperty(String property) {
++        return Iterables.getFirst(this.profile.getProperties().get(property), null);
++    }
++
++    @Nullable
++    @Override
++    public void setProperty(@NotNull String propertyName, @Nullable Property property) {
++        PropertyMap properties = profile.getProperties();
++        properties.removeAll(propertyName);
++        if (property != null) {
++            properties.put(propertyName, property);
++        }
++    }
++
++    @Override
++    public @NotNull GameProfile buildGameProfile() {
++        GameProfile profile = new GameProfile(this.profile.getId(), this.profile.getName());
++        profile.getProperties().putAll(this.profile.getProperties());
++        return profile;
++    }
++
 +    @Override
 +    public boolean equals(Object o) {
 +        if (this == o) return true;
@@ -148,8 +193,16 @@ index 0000000000000000000000000000000000000000..84551164b76bc8f064a3a0c030c3a1b4
 +    }
 +
 +    @Override
++    public @NotNull CompletableFuture<org.bukkit.profile.PlayerProfile> update() {
++        return CompletableFuture.supplyAsync(() -> {
++            final CraftPlayerProfile clone = clone();
++            clone.complete(true);
++            return clone;
++        }, Util.backgroundExecutor());
++    }
++
++    @Override
 +    public boolean completeFromCache() {
-+        MinecraftServer server = MinecraftServer.getServer();
 +        return completeFromCache(false, PaperConfig.isProxyOnlineMode());
 +    }
 +
@@ -193,12 +246,10 @@ index 0000000000000000000000000000000000000000..84551164b76bc8f064a3a0c030c3a1b4
 +    }
 +
 +    public boolean complete(boolean textures) {
-+        MinecraftServer server = MinecraftServer.getServer();
 +        return complete(textures, PaperConfig.isProxyOnlineMode());
 +    }
 +    public boolean complete(boolean textures, boolean onlineMode) {
 +        MinecraftServer server = MinecraftServer.getServer();
-+
 +        boolean isCompleteFromCache = this.completeFromCache(true, onlineMode);
 +        if (onlineMode && (!isCompleteFromCache || textures && !hasTextures())) {
 +            GameProfile result = server.getSessionService().fillProfileProperties(profile, true);
@@ -256,6 +307,25 @@ index 0000000000000000000000000000000000000000..84551164b76bc8f064a3a0c030c3a1b4
 +    public static GameProfile asAuthlib(PlayerProfile profile) {
 +        CraftPlayerProfile craft = ((CraftPlayerProfile) profile);
 +        return craft.getGameProfile();
++    }
++
++    @Override
++    public @NotNull Map<String, Object> serialize() {
++        Map<String, Object> map = new LinkedHashMap<>();
++        if (this.getId() != null) {
++            map.put("uniqueId", this.getId().toString());
++        }
++        if (this.getName() != null) {
++            map.put("name", getName());
++        }
++        if (!this.properties.isEmpty()) {
++            List<Object> propertiesData = new ArrayList<>();
++            for (ProfileProperty property : properties) {
++                propertiesData.add(CraftProfileProperty.serialize(new Property(property.getName(), property.getValue(), property.getSignature())));
++            }
++            map.put("properties", propertiesData);
++        }
++        return map;
 +    }
 +
 +    private class PropertySet extends AbstractSet<ProfileProperty> {
@@ -428,6 +498,35 @@ index 0000000000000000000000000000000000000000..3cdd06d3af7ff94f1fe1a11b9a9275e1
 +        super(authenticationService, UUID.randomUUID().toString(), agent);
 +    }
 +}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/SharedPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/SharedPlayerProfile.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..7ac27392a8647ef7d0dc78efe78703e993885017
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/SharedPlayerProfile.java
+@@ -0,0 +1,23 @@
++package com.destroystokyo.paper.profile;
++
++import com.mojang.authlib.GameProfile;
++import com.mojang.authlib.properties.Property;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++import java.util.UUID;
++
++public interface SharedPlayerProfile {
++
++    @Nullable UUID getUniqueId();
++
++    @Nullable String getName();
++
++    boolean removeProperty(@NotNull String property);
++
++    @Nullable Property getProperty(@NotNull String propertyName);
++
++    @Nullable void setProperty(@NotNull String propertyName, @Nullable Property property);
++
++    @NotNull GameProfile buildGameProfile();
++}
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
 index 9f292deee1b793d52b5774304318e940128d1e26..0cf818fceddd76e7704fdc6625456787856b2815 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
@@ -491,10 +590,10 @@ index 00f783aafd81fa7e836e4eea5bfeac7434f33b0f..3789441e2df9410aa1c6efe59054aaba
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7a96dd337c41cdfa7703de4b21380a4fce0198c8..def56e6c17d6e2efddcdca22e391f11b2de58966 100644
+index 909724efb99f88f3de0967b85d539e0ab1bec8e8..7653c23690b927f93ca4692c6e077abfb9e1c5ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -249,6 +249,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -247,6 +247,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
@@ -504,7 +603,7 @@ index 7a96dd337c41cdfa7703de4b21380a4fce0198c8..def56e6c17d6e2efddcdca22e391f11b
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2552,5 +2555,24 @@ public final class CraftServer implements Server {
+@@ -2559,5 +2562,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
@@ -529,21 +628,101 @@ index 7a96dd337c41cdfa7703de4b21380a4fce0198c8..def56e6c17d6e2efddcdca22e391f11b
 +    }
      // Paper end
  }
-diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 9405812b8c308d70de1e26ba55500301b24ecc3c..490df0dcfd0e1e0ab05943410493522f86444ef8 100644
---- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-+++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -80,6 +80,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+diff --git a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
+index 3cd37402c1f98d47ea009fa4ea71c85044bbe59f..992d4cd38246d67ab1220dac611d6540b3c3791f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
++++ b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
+@@ -27,7 +27,7 @@ import org.bukkit.profile.PlayerProfile;
+ import org.bukkit.profile.PlayerTextures;
+ 
+ @SerializableAs("PlayerProfile")
+-public final class CraftPlayerProfile implements PlayerProfile {
++public final class CraftPlayerProfile implements PlayerProfile, com.destroystokyo.paper.profile.SharedPlayerProfile { // Paper
+ 
+     @Nonnull
+     public static GameProfile validateSkullProfile(@Nonnull GameProfile gameProfile) {
+@@ -80,11 +80,11 @@ public final class CraftPlayerProfile implements PlayerProfile {
      }
  
-     private void setProfile(GameProfile profile) {
-+        // Paper start
-+        if (profile != null) {
-+            com.destroystokyo.paper.profile.CraftPlayerProfile paperProfile = new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
-+            paperProfile.completeFromCache(false, true);
-+            profile = paperProfile.getGameProfile();
-+        }
-+        // Paper end
-         this.profile = profile;
-         this.serializedProfile = (profile == null) ? null : NbtUtils.writeGameProfile(new CompoundTag(), profile);
+     @Nullable
+-    Property getProperty(String propertyName) {
++    public Property getProperty(String propertyName) { // Paper - public
+         return Iterables.getFirst(this.properties.get(propertyName), null);
      }
+ 
+-    void setProperty(String propertyName, @Nullable Property property) {
++    public void setProperty(String propertyName, @Nullable Property property) { // Paper - public
+         // Assert: (property == null) || property.getName().equals(propertyName)
+         this.removeProperty(propertyName);
+         if (property != null) {
+@@ -92,8 +92,10 @@ public final class CraftPlayerProfile implements PlayerProfile {
+         }
+     }
+ 
+-    void removeProperty(String propertyName) {
+-        this.properties.removeAll(propertyName);
++    // Paper start - change return value for shared interface
++    public boolean removeProperty(String propertyName) {
++        return !this.properties.removeAll(propertyName).isEmpty();
++        // Paper end
+     }
+ 
+     void rebuildDirtyProperties() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java
+index c930b7557b141650d63d6802c26139b14ddab6b9..bf56d4fbd34586190e2d680cc33d125578a0953e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java
++++ b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java
+@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
+ import org.bukkit.craftbukkit.util.JsonHelper;
+ import org.bukkit.profile.PlayerTextures;
+ 
+-final class CraftPlayerTextures implements PlayerTextures {
++public final class CraftPlayerTextures implements PlayerTextures { // Paper - public
+ 
+     static final String PROPERTY_NAME = "textures";
+     private static final String MINECRAFT_HOST = "textures.minecraft.net";
+@@ -48,7 +48,7 @@ final class CraftPlayerTextures implements PlayerTextures {
+         }
+     }
+ 
+-    private final CraftPlayerProfile profile;
++    private final com.destroystokyo.paper.profile.SharedPlayerProfile profile; // Paper
+ 
+     // The textures data is loaded lazily:
+     private boolean loaded = false;
+@@ -67,11 +67,11 @@ final class CraftPlayerTextures implements PlayerTextures {
+     // GameProfiles (even if these modifications are later reverted).
+     private boolean dirty = false;
+ 
+-    CraftPlayerTextures(@Nonnull CraftPlayerProfile profile) {
++    public CraftPlayerTextures(@Nonnull com.destroystokyo.paper.profile.SharedPlayerProfile profile) { // Paper
+         this.profile = profile;
+     }
+ 
+-    void copyFrom(@Nonnull PlayerTextures other) {
++    public void copyFrom(@Nonnull PlayerTextures other) { // Paper - public
+         if (other == this) return;
+         Preconditions.checkArgument(other instanceof CraftPlayerTextures, "Expecting CraftPlayerTextures, got %s", other.getClass().getName());
+         CraftPlayerTextures otherTextures = (CraftPlayerTextures) other;
+@@ -238,7 +238,7 @@ final class CraftPlayerTextures implements PlayerTextures {
+         return this.profile.getProperty(PROPERTY_NAME);
+     }
+ 
+-    void rebuildPropertyIfDirty() {
++    public void rebuildPropertyIfDirty() { // Paper - public
+         if (!this.dirty) return;
+         // Assert: loaded
+         this.dirty = false;
+diff --git a/src/main/java/org/bukkit/craftbukkit/profile/CraftProfileProperty.java b/src/main/java/org/bukkit/craftbukkit/profile/CraftProfileProperty.java
+index 0617ad166dd4cb5e26c0c22b264116c23b50195b..07348f0d2c61a78610c5f7bdb280b5a39633a831 100644
+--- a/src/main/java/org/bukkit/craftbukkit/profile/CraftProfileProperty.java
++++ b/src/main/java/org/bukkit/craftbukkit/profile/CraftProfileProperty.java
+@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
+ import org.apache.commons.io.IOUtils;
+ import org.bukkit.craftbukkit.configuration.ConfigSerializationUtil;
+ 
+-final class CraftProfileProperty {
++public final class CraftProfileProperty { // Paper - public
+ 
+     /**
+      * Different JSON formatting styles to use for encoded property values.

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -7,7 +7,7 @@ Establishes base extension of profile systems for future edits too
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a4b580be7f3c52f27915256e00b354d4455a718e
+index 0000000000000000000000000000000000000000..d64a05742ba78aefc64b2e5d824b4caa2c7bc479
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 @@ -0,0 +1,372 @@
@@ -38,7 +38,6 @@ index 0000000000000000000000000000000000000000..a4b580be7f3c52f27915256e00b354d4
 +
 +    private GameProfile profile;
 +    private final PropertySet properties = new PropertySet();
-+    private final CraftPlayerTextures textures = new CraftPlayerTextures(this);
 +
 +    public CraftPlayerProfile(CraftPlayer player) {
 +        this.profile = player.getHandle().getGameProfile();
@@ -68,17 +67,18 @@ index 0000000000000000000000000000000000000000..a4b580be7f3c52f27915256e00b354d4
 +
 +    @Override
 +    public CraftPlayerTextures getTextures() {
-+        return this.textures;
++        return new CraftPlayerTextures(this);
 +    }
 +
 +    @Override
 +    public void setTextures(@Nullable PlayerTextures textures) {
 +        if (textures == null) {
-+            this.textures.clear();
++            this.removeProperty("textures");
 +        } else {
-+            this.textures.copyFrom(textures);
++            CraftPlayerTextures craftPlayerTextures = new CraftPlayerTextures(this);
++            craftPlayerTextures.copyFrom(textures);
++            craftPlayerTextures.rebuildPropertyIfDirty();
 +        }
-+        this.textures.rebuildPropertyIfDirty();
 +    }
 +
 +    public GameProfile getGameProfile() {

--- a/patches/server/0147-Entity-fromMobSpawner.patch
+++ b/patches/server/0147-Entity-fromMobSpawner.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fb7487b52af00ae44e669242a4182a49e9b00428..c2b24ad7ca280972f287cbb876dcc7011fb49db9 100644
+index e80cfab4b8c384067cf76667fb8ba1f0305f03cf..3e9e5736a6c357fbece9bebfeefbbc88b06e6adc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -315,6 +315,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -49,10 +49,10 @@ index 002144601e8f75766b9e462579123559e4d651fe..1c5865ee2a9f3b142d92d63c19ffd785
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
                              Entity vehicle = entity.getVehicle();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index fa17458b313661d9396e2ed9398d31aacc97a6ab..0b4548eada28b11a69d29427cdefd328a81eda9d 100644
+index 4ebd7609ec2bf62586feef4da7605dbb89569567..2fe32de341258c31682ed7f55adf0c6be1328713 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1193,5 +1193,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1200,5 +1200,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          //noinspection ConstantConditions
          return originVector.toLocation(world);
      }

--- a/patches/server/0152-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0152-Fix-this-stupid-bullshit.patch
@@ -31,12 +31,12 @@ index bf42e5687935022fe5bcb1ed40bab09bfe189e88..b111200a8f5d3255de29c9836f70fc7f
              Bootstrap.isBootstrapped = true;
              if (Registry.REGISTRY.keySet().isEmpty()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index a19d5abb8188e2fd2382b9b42d65fa7a8c3d1799..a87a6583a1bd31a276a79c2cfb3c3ca4e749c3dc 100644
+index 77c065d74ae84f8e003141f050fe01ae582ae44c..6f86aa59fa8bcf1b340d7207c5b2be46678c96ec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -234,10 +234,12 @@ public class Main {
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -14);
+                     deadline.add(Calendar.DAY_OF_YEAR, -28);
                      if (buildDate.before(deadline.getTime())) {
 -                        System.err.println("*** Error, this build is outdated ***");
 +                        // Paper start - This is some stupid bullshit

--- a/patches/server/0159-Add-PlayerJumpEvent.patch
+++ b/patches/server/0159-Add-PlayerJumpEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerJumpEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f7649a153191732a33ba9cdd02c573f04b62ce53..ef21b549cf69dbba3ac3b735fe9e8470d91c37ae 100644
+index 92c9254335854067683d98e1576c7d06f28415b1..6c1f2be778b830bf01eb7a1ed01431dd5a568e51 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1181,7 +1181,34 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1178,7 +1178,34 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              boolean flag = d8 > 0.0D;
  
                              if (this.player.isOnGround() && !packet.isOnGround() && flag) {

--- a/patches/server/0160-handle-PacketPlayInKeepAlive-async.patch
+++ b/patches/server/0160-handle-PacketPlayInKeepAlive-async.patch
@@ -15,10 +15,10 @@ also adding some additional logging in order to help work out what is causing
 random disconnections for clients.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ef21b549cf69dbba3ac3b735fe9e8470d91c37ae..d50ab6df4df502220cc09bb6ad8aab65fbfe52c5 100644
+index 6c1f2be778b830bf01eb7a1ed01431dd5a568e51..849b94665e20aca54bd1df0cd8f4e3d5be30e31c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2784,14 +2784,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2780,14 +2780,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleKeepAlive(ServerboundKeepAlivePacket packet) {

--- a/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
@@ -90,10 +90,10 @@ index 27d304316bec097fea4b950cb4e0ac80cb219f70..85fea9b0bf84a8b40098f35eac503070
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 366d0ee7bc8dec667907674972785491723790f8..32089b74ec209abebd7ec42ac432c10eb7cbff86 100644
+index e7798e4fbfd0b9e882356e6df30ada0e1b174c56..5cd36bb3b83cd553bc16f5f24f7ece07d5003ff9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -204,6 +204,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -211,6 +211,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0162-revert-serverside-behavior-of-keepalives.patch
+++ b/patches/server/0162-revert-serverside-behavior-of-keepalives.patch
@@ -17,10 +17,10 @@ from networking or during connections flood of chunk packets on slower clients,
  at the cost of dead connections being kept open for longer.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6fe3749376dabf6c6d003fee7ccdd6f882e1cf02..ed2cbef0a1211fe5330d4d059657c7460fc2bc8d 100644
+index 849b94665e20aca54bd1df0cd8f4e3d5be30e31c..5b8ecb96f0a6dbc9e396644b074b50ccb7b38e78 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -221,9 +221,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -220,9 +220,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      private final MinecraftServer server;
      public ServerPlayer player;
      private int tickCount;
@@ -33,7 +33,7 @@ index 6fe3749376dabf6c6d003fee7ccdd6f882e1cf02..ed2cbef0a1211fe5330d4d059657c746
      // CraftBukkit start - multithreaded fields
      private final AtomicInteger chatSpamTickCount = new AtomicInteger();
      // CraftBukkit end
-@@ -252,6 +252,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -251,6 +251,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      private int aboveGroundVehicleTickCount;
      private int receivedMovePacketCount;
      private int knownMovePacketCount;
@@ -41,7 +41,7 @@ index 6fe3749376dabf6c6d003fee7ccdd6f882e1cf02..ed2cbef0a1211fe5330d4d059657c746
  
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
          this.server = server;
-@@ -335,18 +336,25 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -332,18 +333,25 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
  
          this.server.getProfiler().push("keepAlive");

--- a/patches/server/0166-Fix-MC-117075-TE-Unload-Lag-Spike.patch
+++ b/patches/server/0166-Fix-MC-117075-TE-Unload-Lag-Spike.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix MC-117075: TE Unload Lag Spike
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ea1e85fa125f2dd1a251e1589fff32d7083e2c13..73ff83f2c3a6b9796305abd5a98e8a77f7a44240 100644
+index 41e7474588d8e5ba4cd4af0fed1e62e452389a3e..20f73254881e0ed2957329245acef58c99e93fcb 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -732,6 +732,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -731,6 +731,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          // Spigot start
          // Iterator iterator = this.blockEntityTickers.iterator();
          int tilesThisCycle = 0;
@@ -17,7 +17,7 @@ index ea1e85fa125f2dd1a251e1589fff32d7083e2c13..73ff83f2c3a6b9796305abd5a98e8a77
          for (tileTickPosition = 0; tileTickPosition < this.blockEntityTickers.size(); tileTickPosition++) { // Paper - Disable tick limiters
              this.tileTickPosition = (this.tileTickPosition < this.blockEntityTickers.size()) ? this.tileTickPosition : 0;
              TickingBlockEntity tickingblockentity = (TickingBlockEntity) this.blockEntityTickers.get(tileTickPosition);
-@@ -739,7 +741,6 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -738,7 +740,6 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              if (tickingblockentity == null) {
                  this.getCraftServer().getLogger().severe("Spigot has detected a null entity and has removed it, preventing a crash");
                  tilesThisCycle--;
@@ -25,7 +25,7 @@ index ea1e85fa125f2dd1a251e1589fff32d7083e2c13..73ff83f2c3a6b9796305abd5a98e8a77
                  continue;
              }
              // Spigot end
-@@ -747,12 +748,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -746,12 +747,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              if (tickingblockentity.isRemoved()) {
                  // Spigot start
                  tilesThisCycle--;

--- a/patches/server/0167-use-CB-BlockState-implementations-for-captured-block.patch
+++ b/patches/server/0167-use-CB-BlockState-implementations-for-captured-block.patch
@@ -18,10 +18,10 @@ the blockstate that will be valid for restoration, as opposed to dropping
 information on restoration when the event is cancelled.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 73ff83f2c3a6b9796305abd5a98e8a77f7a44240..cd2278765439f4dc1652d997c8e0174af9b180cb 100644
+index 20f73254881e0ed2957329245acef58c99e93fcb..cd4c3be34647e772753dc68fbe50060365d8cd29 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -142,7 +142,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -144,7 +144,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean preventPoiUpdated = false; // CraftBukkit - SPIGOT-5710
      public boolean captureBlockStates = false;
      public boolean captureTreeGeneration = false;
@@ -29,8 +29,8 @@ index 73ff83f2c3a6b9796305abd5a98e8a77f7a44240..cd2278765439f4dc1652d997c8e0174a
 +    public Map<BlockPos, org.bukkit.craftbukkit.block.CraftBlockState> capturedBlockStates = new java.util.LinkedHashMap<>(); // Paper
      public Map<BlockPos, BlockEntity> capturedTileEntities = new HashMap<>();
      public List<ItemEntity> captureDrops;
-     public long ticksPerAnimalSpawns;
-@@ -363,7 +363,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+     public final it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<SpawnCategory> ticksPerSpawnCategory = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
+@@ -362,7 +362,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean setBlock(BlockPos pos, BlockState state, int flags, int maxUpdateDepth) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {
@@ -39,7 +39,7 @@ index 73ff83f2c3a6b9796305abd5a98e8a77f7a44240..cd2278765439f4dc1652d997c8e0174a
              if (blockstate == null) {
                  blockstate = CapturedBlockState.getTreeBlockState(this, pos, flags);
                  this.capturedBlockStates.put(pos.immutable(), blockstate);
-@@ -383,7 +383,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -382,7 +382,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // CraftBukkit start - capture blockstates
              boolean captured = false;
              if (this.captureBlockStates && !this.capturedBlockStates.containsKey(pos)) {
@@ -49,7 +49,7 @@ index 73ff83f2c3a6b9796305abd5a98e8a77f7a44240..cd2278765439f4dc1652d997c8e0174a
                  this.capturedBlockStates.put(pos.immutable(), blockstate);
                  captured = true;
              }
-@@ -652,7 +653,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -651,7 +652,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public BlockState getBlockState(BlockPos pos) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -14,10 +14,10 @@ completion, such as offline players.
 Also adds isCommand and getLocation to the sync TabCompleteEvent
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ed2cbef0a1211fe5330d4d059657c7460fc2bc8d..b64bf84751e0437e26fcebdc35dd53069b9f2551 100644
+index 5b8ecb96f0a6dbc9e396644b074b50ccb7b38e78..815901f857d283e2529c01ea81640c6b6d5716ea 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -703,10 +703,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -700,10 +700,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleCustomCommandSuggestions(ServerboundCommandSuggestionPacket packet) {
@@ -30,7 +30,7 @@ index ed2cbef0a1211fe5330d4d059657c7460fc2bc8d..b64bf84751e0437e26fcebdc35dd5306
              return;
          }
          // CraftBukkit end
-@@ -716,12 +716,35 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -713,12 +713,35 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              stringreader.skip();
          }
  
@@ -72,10 +72,10 @@ index ed2cbef0a1211fe5330d4d059657c7460fc2bc8d..b64bf84751e0437e26fcebdc35dd5306
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index def56e6c17d6e2efddcdca22e391f11b2de58966..70c12364dad4426a55e3a79c642af9be4d9212d7 100644
+index 7653c23690b927f93ca4692c6e077abfb9e1c5ca..198fdedf1b7164df006188e11d5e361a26cd9f90 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2072,7 +2072,7 @@ public final class CraftServer implements Server {
+@@ -2079,7 +2079,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 32089b74ec209abebd7ec42ac432c10eb7cbff86..45914c7cf1ae300c47a43b23bcf868bbb96d911b 100644
+index 5cd36bb3b83cd553bc16f5f24f7ece07d5003ff9..6eaf970663bf5de9ea30db879e135c5e06238b41 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1249,7 +1249,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1256,7 +1256,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override

--- a/patches/server/0173-PreCreatureSpawnEvent.patch
+++ b/patches/server/0173-PreCreatureSpawnEvent.patch
@@ -98,10 +98,10 @@ index 9c27f69f5b8e95ee56428a597e67dc4e8beb6d29..33e7a9eb613a4984ebcb5f3cde5a1fa5
                          Entity entity = EntityType.loadEntityRecursive(nbttagcompound, world, (entity1) -> {
                              entity1.moveTo(d0, d1, d2, entity1.getYRot(), entity1.getXRot());
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 28a7c53d98450cc79bee953411a18f50cfed26c2..831799937d4e1f31dbf7caaf0c6b38762ccec127 100644
+index 373fbdf56dddbae5f793585e31c7e4ff6d31823b..18166f773301bb4eeef9e6892fac85dd58dfd28c 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-@@ -239,7 +239,13 @@ public final class NaturalSpawner {
+@@ -212,7 +212,13 @@ public final class NaturalSpawner {
                                          j1 = biomesettingsmobs_c.minCount + world.random.nextInt(1 + biomesettingsmobs_c.maxCount - biomesettingsmobs_c.minCount);
                                      }
  
@@ -116,7 +116,7 @@ index 28a7c53d98450cc79bee953411a18f50cfed26c2..831799937d4e1f31dbf7caaf0c6b3876
                                          Mob entityinsentient = NaturalSpawner.getMobForSpawn(world, biomesettingsmobs_c.type);
  
                                          if (entityinsentient == null) {
-@@ -286,9 +292,25 @@ public final class NaturalSpawner {
+@@ -259,9 +265,25 @@ public final class NaturalSpawner {
          return squaredDistance <= 576.0D ? false : (world.getSharedSpawnPos().closerThan((Position) (new Vec3((double) pos.getX() + 0.5D, (double) pos.getY(), (double) pos.getZ() + 0.5D)), 24.0D) ? false : Objects.equals(new ChunkPos(pos), chunk.getPos()) || world.isPositionEntityTicking((BlockPos) pos));
      }
  

--- a/patches/server/0174-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/patches/server/0174-Add-setPlayerProfile-API-for-Skulls.patch
@@ -7,43 +7,51 @@ This allows you to create already filled textures on Skulls to avoid texture loo
 which commonly cause rate limit issues with Mojang API
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
-index d6a4638271644e31fbc38f5ae9150ded63a6d62f..e89eb5d631b4226d79caf49c89ebb44155e72a0f 100644
+index 6ac03706a584e4cb07300cf6e34969a8c4595c58..0be71d9d06f34e9ac58da3bbef954b2786cee53b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
-@@ -1,5 +1,7 @@
- package org.bukkit.craftbukkit.block;
- 
-+import com.destroystokyo.paper.profile.CraftPlayerProfile;
-+import com.destroystokyo.paper.profile.PlayerProfile;
- import com.google.common.base.Preconditions;
- import com.mojang.authlib.GameProfile;
- import net.minecraft.server.MinecraftServer;
-@@ -100,6 +102,20 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
+@@ -102,7 +102,22 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
          }
      }
  
 +    // Paper start
-+    @Override
-+    public void setPlayerProfile(PlayerProfile profile) {
+     @Override
++    public void setPlayerProfile(com.destroystokyo.paper.profile.PlayerProfile profile) {
 +        Preconditions.checkNotNull(profile, "profile");
-+        this.profile = CraftPlayerProfile.asAuthlibCopy(profile);
++        this.profile = com.destroystokyo.paper.profile.CraftPlayerProfile.asAuthlibCopy(profile);
 +    }
 +
 +    @javax.annotation.Nullable
 +    @Override
-+    public PlayerProfile getPlayerProfile() {
-+        return profile != null ? CraftPlayerProfile.asBukkitCopy(profile) : null;
++    public com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile() {
++        return profile != null ? com.destroystokyo.paper.profile.CraftPlayerProfile.asBukkitCopy(profile) : null;
 +    }
 +    // Paper end
 +
++    @Override
++    @Deprecated // Paper
+     public PlayerProfile getOwnerProfile() {
+         if (!this.hasOwner()) {
+             return null;
+@@ -112,11 +127,12 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
+     }
+ 
      @Override
-     public BlockFace getRotation() {
-         BlockData blockData = getBlockData();
++    @Deprecated // Paper
+     public void setOwnerProfile(PlayerProfile profile) {
+         if (profile == null) {
+             this.profile = null;
+         } else {
+-            this.profile = CraftPlayerProfile.validateSkullProfile(((CraftPlayerProfile) profile).buildGameProfile());
++            this.profile = CraftPlayerProfile.validateSkullProfile(((com.destroystokyo.paper.profile.SharedPlayerProfile) profile).buildGameProfile()); // Paper
+         }
+     }
+ 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 490df0dcfd0e1e0ab05943410493522f86444ef8..7cacc61fed0c610845c67894d1cc68e44f5e46fe 100644
+index eda37a7622748feef782b54235070c04f3c714f8..9f72e1623fc85301c4ca8751a7e03877a7745948 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -4,10 +4,8 @@ import com.google.common.collect.ImmutableMap.Builder;
+@@ -4,10 +4,6 @@ import com.google.common.collect.ImmutableMap.Builder;
  import com.mojang.authlib.GameProfile;
  import java.util.Map;
  import java.util.UUID;
@@ -51,14 +59,12 @@ index 490df0dcfd0e1e0ab05943410493522f86444ef8..7cacc61fed0c610845c67894d1cc68e4
 -import net.minecraft.nbt.NbtUtils;
 -import net.minecraft.nbt.Tag;
 -import net.minecraft.world.level.block.entity.SkullBlockEntity;
-+import com.destroystokyo.paper.profile.CraftPlayerProfile;
-+import com.destroystokyo.paper.profile.PlayerProfile;
  import org.bukkit.Bukkit;
  import org.bukkit.Material;
  import org.bukkit.OfflinePlayer;
-@@ -18,6 +16,11 @@ import org.bukkit.craftbukkit.inventory.CraftMetaItem.SerializableMeta;
- import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+@@ -20,6 +16,11 @@ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
  import org.bukkit.inventory.meta.SkullMeta;
+ import org.bukkit.profile.PlayerProfile;
  
 +import javax.annotation.Nullable;
 +import net.minecraft.nbt.CompoundTag;
@@ -68,23 +74,54 @@ index 490df0dcfd0e1e0ab05943410493522f86444ef8..7cacc61fed0c610845c67894d1cc68e4
  @DelegateDeserialization(SerializableMeta.class)
  class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
  
-@@ -151,6 +154,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -151,6 +152,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          return this.hasOwner() ? this.profile.getName() : null;
      }
  
 +    // Paper start
 +    @Override
-+    public void setPlayerProfile(@Nullable PlayerProfile profile) {
-+        setProfile((profile == null) ? null : CraftPlayerProfile.asAuthlibCopy(profile));
++    public void setPlayerProfile(@Nullable com.destroystokyo.paper.profile.PlayerProfile profile) {
++        setProfile((profile == null) ? null : com.destroystokyo.paper.profile.CraftPlayerProfile.asAuthlibCopy(profile));
 +    }
 +
 +    @Nullable
 +    @Override
-+    public PlayerProfile getPlayerProfile() {
-+        return profile != null ? CraftPlayerProfile.asBukkitCopy(profile) : null;
++    public com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile() {
++        return profile != null ? com.destroystokyo.paper.profile.CraftPlayerProfile.asBukkitCopy(profile) : null;
 +    }
 +    // Paper end
 +
      @Override
      public OfflinePlayer getOwningPlayer() {
          if (this.hasOwner()) {
+@@ -201,6 +215,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+     }
+ 
+     @Override
++    @Deprecated // Paper
+     public PlayerProfile getOwnerProfile() {
+         if (!this.hasOwner()) {
+             return null;
+@@ -210,11 +225,12 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+     }
+ 
+     @Override
++    @Deprecated // Paper
+     public void setOwnerProfile(PlayerProfile profile) {
+         if (profile == null) {
+             this.setProfile(null);
+         } else {
+-            this.setProfile(CraftPlayerProfile.validateSkullProfile(((CraftPlayerProfile) profile).buildGameProfile()));
++            this.setProfile(CraftPlayerProfile.validateSkullProfile(((com.destroystokyo.paper.profile.SharedPlayerProfile) profile).buildGameProfile())); // Paper
+         }
+     }
+ 
+@@ -251,7 +267,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+     Builder<String, Object> serialize(Builder<String, Object> builder) {
+         super.serialize(builder);
+         if (this.hasOwner()) {
+-            return builder.put(SKULL_OWNER.BUKKIT, new CraftPlayerProfile(this.profile));
++            return builder.put(SKULL_OWNER.BUKKIT, new com.destroystokyo.paper.profile.CraftPlayerProfile(this.profile)); // Paper
+         }
+         return builder;
+     }

--- a/patches/server/0178-Extend-Player-Interact-cancellation.patch
+++ b/patches/server/0178-Extend-Player-Interact-cancellation.patch
@@ -13,7 +13,7 @@ Update adjacent blocks of doors, double plants, pistons and beds
 when cancelling interaction.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 2869d9bb0d374c26f9569eef3ecf0480cbaa85a6..1d1f355a49e2324902feee10c1717fd772e359c6 100644
+index 12c9efc409e5306fb24b8338d4c60286cff1435c..3ef782b69b9f21d12b1ef214e77bc8af8a94970b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -186,6 +186,11 @@ public class ServerPlayerGameMode {
@@ -28,7 +28,7 @@ index 2869d9bb0d374c26f9569eef3ecf0480cbaa85a6..1d1f355a49e2324902feee10c1717fd7
                      this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
                      // Update any tile entity data for this block
                      BlockEntity tileentity = this.level.getBlockEntity(pos);
-@@ -501,7 +506,13 @@ public class ServerPlayerGameMode {
+@@ -503,7 +508,13 @@ public class ServerPlayerGameMode {
  
                  // send a correcting update to the client for the block above as well, this because of replaceable blocks (such as grass, sea grass etc)
                  player.connection.send(new ClientboundBlockUpdatePacket(world, blockposition.above()));

--- a/patches/server/0184-Player.setPlayerProfile-API.patch
+++ b/patches/server/0184-Player.setPlayerProfile-API.patch
@@ -26,7 +26,7 @@ index 00ef714294b6cce5fec7613eed4ba228a48e3e11..67b300574655854249c1f7440f56a6e8
                              uniqueId = gameProfile.getId();
                              // Paper end
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 45914c7cf1ae300c47a43b23bcf868bbb96d911b..096bd762a7e52230118f14bc839a87ecf437837c 100644
+index 6eaf970663bf5de9ea30db879e135c5e06238b41..e1d81be0a7ad66fc77c89563fd4e814ce80e24a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -72,6 +72,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -37,7 +37,19 @@ index 45914c7cf1ae300c47a43b23bcf868bbb96d911b..096bd762a7e52230118f14bc839a87ec
  import net.minecraft.world.level.block.entity.SignBlockEntity;
  import net.minecraft.world.level.saveddata.maps.MapDecoration;
  import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
-@@ -1382,8 +1383,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -194,11 +195,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         return server.getPlayer(getUniqueId()) != null;
+     }
+ 
+-    @Override
+-    public PlayerProfile getPlayerProfile() {
+-        return new CraftPlayerProfile(this.getProfile());
+-    }
+-
+     @Override
+     public InetSocketAddress getAddress() {
+         if (this.getHandle().connection == null) return null;
+@@ -1389,8 +1385,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.hiddenEntities.put(entity.getUniqueId(), hidingPlugins);
  
          // Remove this entity from the hidden player's EntityTrackerEntry
@@ -54,7 +66,7 @@ index 45914c7cf1ae300c47a43b23bcf868bbb96d911b..096bd762a7e52230118f14bc839a87ec
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1396,8 +1404,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1403,8 +1406,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  this.getHandle().connection.send(new ClientboundPlayerInfoPacket(ClientboundPlayerInfoPacket.Action.REMOVE_PLAYER, otherPlayer));
              }
          }
@@ -63,7 +75,7 @@ index 45914c7cf1ae300c47a43b23bcf868bbb96d911b..096bd762a7e52230118f14bc839a87ec
      }
  
      @Override
-@@ -1434,8 +1440,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1441,8 +1442,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          this.hiddenEntities.remove(entity.getUniqueId());
  
@@ -80,7 +92,7 @@ index 45914c7cf1ae300c47a43b23bcf868bbb96d911b..096bd762a7e52230118f14bc839a87ec
  
          if (other instanceof ServerPlayer) {
              ServerPlayer otherPlayer = (ServerPlayer) other;
-@@ -1446,9 +1459,51 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1453,9 +1461,51 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (entry != null && !entry.seenBy.contains(this.getHandle().connection)) {
              entry.updatePlayer(this.getHandle());
          }

--- a/patches/server/0185-getPlayerUniqueId-API.patch
+++ b/patches/server/0185-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 70c12364dad4426a55e3a79c642af9be4d9212d7..e4424e15d28c7011f2dd708f9d7bbb05b25be688 100644
+index 198fdedf1b7164df006188e11d5e361a26cd9f90..7e8c50c3fd27e5f5a931f2d7263c55ede441aacc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1725,6 +1725,25 @@ public final class CraftServer implements Server {
+@@ -1706,6 +1706,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0190-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0190-Flag-to-disable-the-channel-limit.patch
@@ -9,10 +9,10 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5f86cddc176b6205768653a901825e53f10dcae0..b3aa2358a5379aa1d552de9aa7fc2e0c826d05e7 100644
+index e1d81be0a7ad66fc77c89563fd4e814ce80e24a7..09c9d6bf9000bbdbded2cfa4a949ffca34672481 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -158,6 +158,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -160,6 +160,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper start
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
@@ -20,7 +20,7 @@ index 5f86cddc176b6205768653a901825e53f10dcae0..b3aa2358a5379aa1d552de9aa7fc2e0c
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1703,7 +1704,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1705,7 +1706,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0193-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
+++ b/patches/server/0193-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix exploit that allowed colored signs to be created
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0240221d4415df8ac8cbcf2fd0c4118d97500620..8980f0187d0e236ae115317199619fc9f4e69745 100644
+index 815901f857d283e2529c01ea81640c6b6d5716ea..ed477b6a229ed9e53067a8bb50f76b96945cab71 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2790,9 +2790,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2786,9 +2786,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  TextFilter.FilteredText currentLine = signText.get(i);
  
                  if (this.player.isTextFilteringEnabled()) {

--- a/patches/server/0197-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0197-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -34,10 +34,10 @@ index 32253b7d4eec3cb0b7d047bb5ce05c46e9d3649d..11b0f1ef4aa02cf719e4d937c98d41b8
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index cf051e821ec5969cafd815b95569e88d209e42e0..d10ed2b2b547298580a8ae5fbe14526172cb5b7c 100644
+index b9d0a2f8d1ed290d2fa12d6c2307903412727fc1..05d684d5be41df09180cd8426d4b9848634cd935 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1769,11 +1769,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1802,11 +1802,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0207-Fix-CraftEntity-hashCode.patch
+++ b/patches/server/0207-Fix-CraftEntity-hashCode.patch
@@ -21,10 +21,10 @@ check is essentially the same as this.getHandle() == other.getHandle()
 However, replaced it too to make it clearer of intent.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 0b4548eada28b11a69d29427cdefd328a81eda9d..e5dea302a7548b648ed0b0a5297cc35397cabe50 100644
+index 2fe32de341258c31682ed7f55adf0c6be1328713..e496a346b12497e5e0834e0bc523c2221b45cab7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -793,14 +793,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -795,14 +795,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return false;
          }
          final CraftEntity other = (CraftEntity) obj;

--- a/patches/server/0214-Expand-Explosions-API.patch
+++ b/patches/server/0214-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d10ed2b2b547298580a8ae5fbe14526172cb5b7c..e611dba302344df257ecb0bcdff404444cfa5b72 100644
+index 05d684d5be41df09180cd8426d4b9848634cd935..483f215ffc3a9318266d878e055ff1479a631b95 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -693,6 +693,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -690,6 +690,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
          return !this.world.explode(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, breakBlocks ? Explosion.BlockInteraction.BREAK : Explosion.BlockInteraction.NONE).wasCanceled;
      }

--- a/patches/server/0218-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0218-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e611dba302344df257ecb0bcdff404444cfa5b72..bf3a5bfe15b630970553a67366bf6be24c57bcf0 100644
+index 483f215ffc3a9318266d878e055ff1479a631b95..7e283d29d0eeb03073e97a848cd34cc8d9532558 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1027,6 +1027,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1024,6 +1024,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return list;
      }
  

--- a/patches/server/0219-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0219-InventoryCloseEvent-Reason-API.patch
@@ -75,7 +75,7 @@ index 90bff0dd400a67bcb84f8576bd8326793420919a..fd1937f49312204d38510996a5be43b7
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8980f0187d0e236ae115317199619fc9f4e69745..9591d1493fdc47e1b75b28cdcc54b812ac105718 100644
+index ed477b6a229ed9e53067a8bb50f76b96945cab71..011b0a6c4fbcf9b5ffa7435c4fb325ce6b3fb262 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -187,6 +187,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -86,7 +86,7 @@ index 8980f0187d0e236ae115317199619fc9f4e69745..9591d1493fdc47e1b75b28cdcc54b812
  import org.bukkit.event.inventory.InventoryCreativeEvent;
  import org.bukkit.event.inventory.InventoryType.SlotType;
  import org.bukkit.event.inventory.SmithItemEvent;
-@@ -2338,10 +2339,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2334,10 +2335,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleContainerClose(ServerboundContainerClosePacket packet) {
@@ -174,10 +174,10 @@ index c0ed3dd9ebcaf710d202ae8b38007e6a1f20b57e..adfbc156b4c4a8591609f385adaa6b04
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b3aa2358a5379aa1d552de9aa7fc2e0c826d05e7..5ae1387341c0003f1677e139a94b658c6116c18c 100644
+index 09c9d6bf9000bbdbded2cfa4a949ffca34672481..dd33f7fe76686855d52eaf5ba9b9f1ef9d7d1d15 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -957,7 +957,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -959,7 +959,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {
@@ -187,10 +187,10 @@ index b3aa2358a5379aa1d552de9aa7fc2e0c826d05e7..5ae1387341c0003f1677e139a94b658c
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d93e79ab1a3b16bfc75209cb0b5e2e9fade35d86..f84669c550c7571fb3df431ab850b7d624739dcd 100644
+index 23a53f0c287fea7ddf45f807ae642ba4e5acb7b9..7964fd169c393c4d3e595d6722f8f29658a27490 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1214,7 +1214,7 @@ public class CraftEventFactory {
+@@ -1224,7 +1224,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -199,7 +199,7 @@ index d93e79ab1a3b16bfc75209cb0b5e2e9fade35d86..f84669c550c7571fb3df431ab850b7d6
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1380,8 +1380,18 @@ public class CraftEventFactory {
+@@ -1390,8 +1390,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0221-Refresh-player-inventory-when-cancelling-PlayerInter.patch
+++ b/patches/server/0221-Refresh-player-inventory-when-cancelling-PlayerInter.patch
@@ -16,10 +16,10 @@ Refresh the player inventory when PlayerInteractEntityEvent is
 cancelled to avoid this problem.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9591d1493fdc47e1b75b28cdcc54b812ac105718..406f2e65d353cfbb7ea6bd698c5a1bd0b9b6235e 100644
+index 011b0a6c4fbcf9b5ffa7435c4fb325ce6b3fb262..cca7ce86c619527c5ec920e68e308af46878fd8e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2223,6 +2223,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2219,6 +2219,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          }
  
                          if (event.isCancelled()) {

--- a/patches/server/0230-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/patches/server/0230-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 825f8de6f5a6f6221724ba35dde265aadb15e4e8..391a4cd47438cf8fd72b43f6cb0b4e278fa844ad 100644
+index e203647884c20a8512a0aebdbad3488939226a8c..5993ea31ebdf1b37f85cee27f11234b7981f77fe 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -414,4 +414,9 @@ public class PaperWorldConfig {
@@ -31,10 +31,10 @@ index 138422903dcb3056cd011a72e0625a1a225b4280..b92c2d5f9ad3936f619b51c79379983e
  
          for (int i = 0; i < list.size(); ++i) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index cd2278765439f4dc1652d997c8e0174af9b180cb..aba12f5a941fb07a2f4dd54af8f0a4310488ac78 100644
+index cd4c3be34647e772753dc68fbe50060365d8cd29..d61e598478d297857f5e76d7c42a9e5c157514d5 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -776,6 +776,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -775,6 +775,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // Paper end
          }
      }

--- a/patches/server/0231-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0231-Vanished-players-don-t-have-rights.patch
@@ -38,7 +38,7 @@ index c3fb7d41688855010c643b91c8d9496486dae089..8175bb6331727440da2232998bdad068
  
          BlockCanBuildEvent event = new BlockCanBuildEvent(CraftBlock.at(context.getLevel(), context.getClickedPos()), player, CraftBlockData.fromData(state), defaultReturn);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index b91b2c2336b40c2332e59c3f24e36ca6083ce3bd..c239a71a9d864107c3a8e9537e4160c50b3a76c9 100644
+index d61e598478d297857f5e76d7c42a9e5c157514d5..fe666bb392ca16a9a6210dcb08bd0ddae22ead85 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -72,6 +72,10 @@ import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
@@ -52,7 +52,7 @@ index b91b2c2336b40c2332e59c3f24e36ca6083ce3bd..c239a71a9d864107c3a8e9537e4160c5
  import net.minecraft.world.scores.Scoreboard;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -252,6 +256,45 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -251,6 +255,45 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
      }
  
@@ -99,10 +99,10 @@ index b91b2c2336b40c2332e59c3f24e36ca6083ce3bd..c239a71a9d864107c3a8e9537e4160c5
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f84669c550c7571fb3df431ab850b7d624739dcd..151039f67a2233d501bbe405f470bb38cabe390f 100644
+index 7964fd169c393c4d3e595d6722f8f29658a27490..658c656c32ebab5b84837473930d4f0680fc45ba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1250,6 +1250,14 @@ public class CraftEventFactory {
+@@ -1260,6 +1260,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0237-Add-hand-to-bucket-events.patch
+++ b/patches/server/0237-Add-hand-to-bucket-events.patch
@@ -86,10 +86,10 @@ index 25f1567660682a122fcb63318f51ec45ffdf0d3b..5406acd65d4e1146f3bd7340ff9a1954
                  int i = blockposition.getX();
                  int j = blockposition.getY();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4faf98079a6a6af662e11050a0088578ba65a5eb..0d1c6f609a5198c21c895e8f6ace467355b0f166 100644
+index 658c656c32ebab5b84837473930d4f0680fc45ba..a1529301e4abcafa79d04b9819cf40a05febcac4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -421,6 +421,20 @@ public class CraftEventFactory {
+@@ -422,6 +422,20 @@ public class CraftEventFactory {
      }
  
      private static PlayerEvent getPlayerBucketEvent(boolean isFilling, ServerLevel world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, net.minecraft.world.item.Item item) {
@@ -110,7 +110,7 @@ index 4faf98079a6a6af662e11050a0088578ba65a5eb..0d1c6f609a5198c21c895e8f6ace4673
          Player player = (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);
          Material bucket = CraftMagicNumbers.getMaterial(itemstack.getItem());
-@@ -433,10 +447,10 @@ public class CraftEventFactory {
+@@ -434,10 +448,10 @@ public class CraftEventFactory {
  
          PlayerEvent event;
          if (isFilling) {

--- a/patches/server/0239-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/patches/server/0239-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -45,10 +45,10 @@ index 915e2c5b0ffbd0d459a203e1bfb131be4c5476d4..00dd9dab2b19f3e49f3b41c20eb96a84
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 86ff600e471effc97b214f6b6fb5b2e0a0d0df1c..d9ee15ba1aeae66e7da1c40a565e594f9e636dbb 100644
+index cca7ce86c619527c5ec920e68e308af46878fd8e..c0f558d3c6f3b4b01e56d453ab136cf2357f2463 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -227,6 +227,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -226,6 +226,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      private long keepAliveChallenge;
      // CraftBukkit start - multithreaded fields
      private final AtomicInteger chatSpamTickCount = new AtomicInteger();
@@ -56,7 +56,7 @@ index 86ff600e471effc97b214f6b6fb5b2e0a0d0df1c..d9ee15ba1aeae66e7da1c40a565e594f
      // CraftBukkit end
      private int dropSpamTickCount;
      private double firstGoodX;
-@@ -360,6 +361,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -357,6 +358,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          this.server.getProfiler().pop();
          // CraftBukkit start
          for (int spam; (spam = this.chatSpamTickCount.get()) > 0 && !this.chatSpamTickCount.compareAndSet(spam, spam - 1); ) ;
@@ -64,7 +64,7 @@ index 86ff600e471effc97b214f6b6fb5b2e0a0d0df1c..d9ee15ba1aeae66e7da1c40a565e594f
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -706,7 +708,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -703,7 +705,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleCustomCommandSuggestions(ServerboundCommandSuggestionPacket packet) {
          // PlayerConnectionUtils.ensureMainThread(packetplayintabcomplete, this, this.player.getWorldServer()); // Paper - run this async
          // CraftBukkit start

--- a/patches/server/0242-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/patches/server/0242-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -8,7 +8,7 @@ Add -Ddebug.entities=true to your JVM flags to gain more information
 1.17: Needs to be reworked for new entity storage system
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 871c5839ec7ea39282380a42e1a45ea18897a507..a8c47535ec8c0cf992c40ec74a7a3a1f78da4865 100644
+index 71e0206e31eafca2859fe972214bea0ad74f203e..8593f68b0d2c1043009d02ada5396333c8da4d50 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1312,6 +1312,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -29,7 +29,7 @@ index 871c5839ec7ea39282380a42e1a45ea18897a507..a8c47535ec8c0cf992c40ec74a7a3a1f
  
      protected void tick() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 17eb43f6bb0a9bbc4e0abb991255b322a56f6160..2d0e04cd2ab6403b3f5324cad130ec768a39d608 100644
+index 9f3b3c34e625e27c9c56ccbfd244dd053c2e703f..cd11361cd2dc12c7b94f3e8505937b484ec19dff 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -208,6 +208,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -72,7 +72,7 @@ index 17eb43f6bb0a9bbc4e0abb991255b322a56f6160..2d0e04cd2ab6403b3f5324cad130ec76
              return false;
          } else {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2a11514554b6aea819046282cfcaeeb43d1ed920..2981a29b011cb1a08a776abc5ec6a94228061f98 100644
+index 6defa5579f3c7dba3dc9d82937a14edd1bb16cfe..37f337efb7ac164749c73974e4acfde93d649290 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -170,6 +170,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -85,10 +85,10 @@ index 2a11514554b6aea819046282cfcaeeb43d1ed920..2981a29b011cb1a08a776abc5ec6a942
          if (this.bukkitEntity == null) {
              this.bukkitEntity = CraftEntity.getEntity(this.level.getCraftServer(), this);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index c239a71a9d864107c3a8e9537e4160c50b3a76c9..ee5415574dea0712f08e2467ecf93aa1ce39a2e5 100644
+index fe666bb392ca16a9a6210dcb08bd0ddae22ead85..5e3d1a36b0eb350536e29730540ee17b68fe315b 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -142,6 +142,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -144,6 +144,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean pvpMode;
      public boolean keepSpawnInMemory = true;
      public org.bukkit.generator.ChunkGenerator generator;

--- a/patches/server/0243-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0243-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -36,7 +36,7 @@ index 00dd9dab2b19f3e49f3b41c20eb96a84bfae1769..d9114c5fa141c37270398100db6bb2a8
      public static int tabSpamLimit = 500;
      private static void tabSpamLimiters() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f6050e8ee4b43e0405933f6f7f0c234978c0639e..d42db22e74e36a8a701a322c7bac5c73a7675508 100644
+index e89f100e950c6fa85112a67daaa157de665b17cf..37ccbfc3b5ff47fac8cd878f9de5bccec84994e5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1085,6 +1085,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -48,10 +48,10 @@ index f6050e8ee4b43e0405933f6f7f0c234978c0639e..d42db22e74e36a8a701a322c7bac5c73
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e4424e15d28c7011f2dd708f9d7bbb05b25be688..93eed255771097a396b1148e67d99a581be676c4 100644
+index 7e8c50c3fd27e5f5a931f2d7263c55ede441aacc..17ec1302e06792835f57d97b7d406065522cba54 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -897,6 +897,7 @@ public final class CraftServer implements Server {
+@@ -907,6 +907,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -59,7 +59,7 @@ index e4424e15d28c7011f2dd708f9d7bbb05b25be688..93eed255771097a396b1148e67d99a58
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -1015,6 +1016,7 @@ public final class CraftServer implements Server {
+@@ -996,6 +997,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));
@@ -68,7 +68,7 @@ index e4424e15d28c7011f2dd708f9d7bbb05b25be688..93eed255771097a396b1148e67d99a58
  
      @Override
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index 682f0b57ed131d9c0c50941bf733731f63c8f861..5097623eee5c1c9412f0c4a14f70b93e21ea295e 100644
+index b53e6955f35e1308814cdb31a5fa5f4d0c49493c..6f7b34f03e0d151e4da652b9ad73e0d7930fe5d3 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -229,7 +229,7 @@ public class SpigotConfig

--- a/patches/server/0256-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0256-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index bf3a5bfe15b630970553a67366bf6be24c57bcf0..63cbcd8d62d52ed485cbd923b405e0234173d2f0 100644
+index 7e283d29d0eeb03073e97a848cd34cc8d9532558..d299d4c5c0af841a1569229ccf1977c6a57e7e92 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -374,7 +374,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -371,7 +371,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0257-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0257-Asynchronous-chunk-IO-and-loading.patch
@@ -2318,7 +2318,7 @@ index e98492adfb83c24e1baa6cab24cca55f3ec151bf..afc7606e0df5dc87767444b42bb4e4b1
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, datapackconfiguration1, thread, iregistrycustom_dimension, convertable_conversionsession, resourcepackrepository, datapackresources, null, dedicatedserversettings, DataFixers.getDataFixer(), minecraftsessionservice, gameprofilerepository, usercache, LoggerChunkProgressListener::new);
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d42db22e74e36a8a701a322c7bac5c73a7675508..534c02bc7f4fe925d2e12257e88001801a63444c 100644
+index 37ccbfc3b5ff47fac8cd878f9de5bccec84994e5..d8023ef3237fd415a0dd04e01a78c84298a330d1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -985,7 +985,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -2344,7 +2344,7 @@ index 45de5e508540b4ba622985d530f1aadaa7eb4535..5b8b9dabc6673b6f0a335a42d2ec71a5
          ChunkHolder.FullChunkStatus playerchunk_state1 = ChunkHolder.getFullChunkStatus(this.ticketLevel);
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index bf80f2e299108d3de70354bf45fcd0efeff42ec7..8ccdaddcef1e5e83660e58075b039b124f36fce3 100644
+index 8593f68b0d2c1043009d02ada5396333c8da4d50..244f6a2934e807fa4f67c617dcd08a9ae2065bbf 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -466,6 +466,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -2609,7 +2609,7 @@ index bf80f2e299108d3de70354bf45fcd0efeff42ec7..8ccdaddcef1e5e83660e58075b039b12
      public CompoundTag readChunk(ChunkPos pos) throws IOException {
          CompoundTag nbttagcompound = this.read(pos);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 87c9a7ffc69206554cf37c7d2c9939eb3cbea3a9..7b391d6ab84eeaed7bdd27ea70d5e3f9690a0abf 100644
+index dc618a0dde6c15cb2ee812ed21c10b343f75f280..343d54addd67998175db152d38702adda37b7d21 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -502,10 +502,111 @@ public class ServerChunkCache extends ChunkSource {
@@ -2875,10 +2875,10 @@ index 0d536d72ac918fbd403397ff369d10143ee9c204..be677d437d17b74c6188ce1bd5fc6fdc
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d9ee15ba1aeae66e7da1c40a565e594f9e636dbb..995895dc1a97564e7f5565f9c26d18d1d8b4b4c0 100644
+index c0f558d3c6f3b4b01e56d453ab136cf2357f2463..607be2544cc163065dcbb7fedd5709cca2453ea2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -712,6 +712,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -709,6 +709,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              server.scheduleOnMain(() -> this.disconnect(new TranslatableComponent("disconnect.spam", new Object[0]))); // Paper
              return;
          }
@@ -3571,10 +3571,10 @@ index 415ec2cb81e956526e7f4965b899c9aa04f62f2e..ff6cadec530dedf9efc5d6226e48a096
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 63cbcd8d62d52ed485cbd923b405e0234173d2f0..024fb684644bcebd42714abcfbba379bc6f68249 100644
+index d299d4c5c0af841a1569229ccf1977c6a57e7e92..ef2673b744fe1ad0fca722271e167176d499593a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1832,6 +1832,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1865,6 +1865,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public DragonBattle getEnderDragonBattle() {
          return (this.getHandle().dragonFight() == null) ? null : new CraftDragonBattle(this.getHandle().dragonFight());
      }
@@ -3610,7 +3610,7 @@ index 63cbcd8d62d52ed485cbd923b405e0234173d2f0..024fb684644bcebd42714abcfbba379b
      // Spigot start
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index e5dea302a7548b648ed0b0a5297cc35397cabe50..a1812c570215b14e89ce61ebbd78871fa57c9323 100644
+index e496a346b12497e5e0834e0bc523c2221b45cab7..16f2479de2c330b17c9ef6f3bee8e4ade5b66d15 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -15,6 +15,7 @@ import net.minecraft.network.chat.Component;
@@ -3621,7 +3621,7 @@ index e5dea302a7548b648ed0b0a5297cc35397cabe50..a1812c570215b14e89ce61ebbd78871f
  import net.minecraft.world.damagesource.DamageSource;
  import net.minecraft.world.entity.AreaEffectCloud;
  import net.minecraft.world.entity.Entity;
-@@ -519,6 +520,37 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -521,6 +522,37 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          this.entity.setYHeadRot(yaw);
      }
  

--- a/patches/server/0259-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0259-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5ae1387341c0003f1677e139a94b658c6116c18c..90053c916f609a4316e91e8093c12166010d7417 100644
+index dd33f7fe76686855d52eaf5ba9b9f1ef9d7d1d15..83123b1609d7643b818da8adf11edb4f17b30de3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2400,6 +2400,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2402,6 +2402,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0260-Improve-death-events.patch
+++ b/patches/server/0260-Improve-death-events.patch
@@ -295,10 +295,10 @@ index 91cf7728aee475cb36f2c02bbfb7e3d2e0d00576..a3a900d10440ed5ebe24370a77ccb6ca
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 90053c916f609a4316e91e8093c12166010d7417..c270bf19cdba50d83dafe2c5ab55422cb74dd902 100644
+index 83123b1609d7643b818da8adf11edb4f17b30de3..3fc1c400100a87e576052c6d977c8ce1659f7582 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1963,7 +1963,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1965,7 +1965,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {
@@ -315,10 +315,10 @@ index 90053c916f609a4316e91e8093c12166010d7417..c270bf19cdba50d83dafe2c5ab55422c
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 016912c8b3fe0158d144b78f71b704972950f5b6..4b26540cda951cb46ac2833a60ce6cf06f483bff 100644
+index a1529301e4abcafa79d04b9819cf40a05febcac4..5ccf7f5d0c748de6ff1f996089f4db99d39d6dfb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -807,9 +807,16 @@ public class CraftEventFactory {
+@@ -817,9 +817,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -335,7 +335,7 @@ index 016912c8b3fe0158d144b78f71b704972950f5b6..4b26540cda951cb46ac2833a60ce6cf0
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -826,8 +833,15 @@ public class CraftEventFactory {
+@@ -836,8 +843,15 @@ public class CraftEventFactory {
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
@@ -351,7 +351,7 @@ index 016912c8b3fe0158d144b78f71b704972950f5b6..4b26540cda951cb46ac2833a60ce6cf0
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -844,6 +858,31 @@ public class CraftEventFactory {
+@@ -854,6 +868,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0266-Prevent-mob-spawning-from-loading-generating-chunks.patch
+++ b/patches/server/0266-Prevent-mob-spawning-from-loading-generating-chunks.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent mob spawning from loading/generating chunks
 also prevents if out of world border bounds
 
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 831799937d4e1f31dbf7caaf0c6b38762ccec127..94d2d83da52ce20f12a4e3f235f75d5c537ae9d1 100644
+index 18166f773301bb4eeef9e6892fac85dd58dfd28c..cc3312af20b74a3cbec667ecb50d3cac30b455fa 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-@@ -196,9 +196,9 @@ public final class NaturalSpawner {
+@@ -169,9 +169,9 @@ public final class NaturalSpawner {
          StructureFeatureManager structuremanager = world.structureFeatureManager();
          ChunkGenerator chunkgenerator = world.getChunkSource().getGenerator();
          int i = pos.getY();
@@ -21,7 +21,7 @@ index 831799937d4e1f31dbf7caaf0c6b38762ccec127..94d2d83da52ce20f12a4e3f235f75d5c
              BlockPos.MutableBlockPos blockposition_mutableblockposition = new BlockPos.MutableBlockPos();
              int j = 0;
              int k = 0;
-@@ -227,7 +227,7 @@ public final class NaturalSpawner {
+@@ -200,7 +200,7 @@ public final class NaturalSpawner {
                              if (entityhuman != null) {
                                  double d2 = entityhuman.distanceToSqr(d0, (double) i, d1);
  

--- a/patches/server/0274-Add-sun-related-API.patch
+++ b/patches/server/0274-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 024fb684644bcebd42714abcfbba379bc6f68249..1b3412c1cb9a90defcd3db7ef86a21d2bbe07bf4 100644
+index ef2673b744fe1ad0fca722271e167176d499593a..cfb3c5a00b64022ed616d59fe8b99eae5e4ccc48 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -669,6 +669,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -666,6 +666,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
      }
  

--- a/patches/server/0278-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0278-Add-Velocity-IP-Forwarding-Support.patch
@@ -225,10 +225,10 @@ index 67b300574655854249c1f7440f56a6e8f0fad351..bb767f5b626225e70a8af273384bb74d
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 93eed255771097a396b1148e67d99a581be676c4..589af624599aee8f08f786da183f5e058f2044cc 100644
+index 17ec1302e06792835f57d97b7d406065522cba54..092f6e2a76d8252de0a40425e271abd11763ee62 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -765,7 +765,7 @@ public final class CraftServer implements Server {
+@@ -762,7 +762,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0281-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/patches/server/0281-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -20,10 +20,10 @@ index e57ab8a3e6efd78e12385042b7d91dcd27fef11d..eb44aef0aecf65f5c1b19f42bf85a3a2
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e0eb7ace7cc3d153efcfbab1e0492749c0713610..59ecb7eb693e9e101ae8cb7bf58777bf180f340d 100644
+index 607be2544cc163065dcbb7fedd5709cca2453ea2..99f8c661908d6540b8f0bb08a9fd0f5511c885d1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -532,6 +532,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -529,6 +529,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
                  speed *= 2f; // TODO: Get the speed of the vehicle instead of the player
  
@@ -37,7 +37,7 @@ index e0eb7ace7cc3d153efcfbab1e0492749c0713610..59ecb7eb693e9e101ae8cb7bf58777bf
                  if (d10 - d9 > Math.max(100.0D, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
                  // CraftBukkit end
                      ServerGamePacketListenerImpl.LOGGER.warn("{} (vehicle of {}) moved too quickly! {},{},{}", entity.getName().getString(), this.player.getName().getString(), d6, d7, d8);
-@@ -1162,9 +1169,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1159,9 +1166,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          float prevYaw = this.player.getYRot();
                          float prevPitch = this.player.getXRot();
                          // CraftBukkit end
@@ -49,7 +49,7 @@ index e0eb7ace7cc3d153efcfbab1e0492749c0713610..59ecb7eb693e9e101ae8cb7bf58777bf
                          double d6 = this.player.getY();
                          double d7 = d0 - this.firstGoodX;
                          double d8 = d1 - this.firstGoodY;
-@@ -1202,6 +1209,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1199,6 +1206,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              } else {
                                  speed = this.player.getAbilities().walkingSpeed * 10f;
                              }

--- a/patches/server/0289-Don-t-allow-digging-into-unloaded-chunks.patch
+++ b/patches/server/0289-Don-t-allow-digging-into-unloaded-chunks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Don't allow digging into unloaded chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 1d1f355a49e2324902feee10c1717fd772e359c6..d0b54ebc05cac6535a023709c76efd802f7150f9 100644
+index 3ef782b69b9f21d12b1ef214e77bc8af8a94970b..abc7b15976131dc840f40258ed5cc4ef88c27815 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -118,8 +118,8 @@ public class ServerPlayerGameMode {
@@ -59,10 +59,10 @@ index 1d1f355a49e2324902feee10c1717fd772e359c6..d0b54ebc05cac6535a023709c76efd80
  
                  this.level.destroyBlockProgress(this.player.getId(), pos, -1);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 59ecb7eb693e9e101ae8cb7bf58777bf180f340d..4b09d2ff24a1dca2a45c18a99af3ba6efc7acd85 100644
+index 99f8c661908d6540b8f0bb08a9fd0f5511c885d1..c5800f0e502815bf0e71a389e30e9b604ac6b107 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1558,7 +1558,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1555,7 +1555,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              case START_DESTROY_BLOCK:
              case ABORT_DESTROY_BLOCK:
              case STOP_DESTROY_BLOCK:

--- a/patches/server/0290-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0290-Make-the-default-permission-message-configurable.patch
@@ -42,10 +42,10 @@ index edf0a82ba7e16b86100aa1920fa41508be2ab1e8..c48b175d5511b733bcff9a93a874f5ff
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 589af624599aee8f08f786da183f5e058f2044cc..3a82ffd3286bf84529825b9ed805d31ef521f64a 100644
+index 092f6e2a76d8252de0a40425e271abd11763ee62..17aa8e654b5676e4401131e1b8196625618d2ee6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2577,6 +2577,11 @@ public final class CraftServer implements Server {
+@@ -2584,6 +2584,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  

--- a/patches/server/0295-Book-Size-Limits.patch
+++ b/patches/server/0295-Book-Size-Limits.patch
@@ -24,10 +24,10 @@ index c48b175d5511b733bcff9a93a874f5ffc0174691..e683e5bf47abe7bd3d2f7e9811a37754
      private static void asyncChunks() {
          ConfigurationSection section;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4b09d2ff24a1dca2a45c18a99af3ba6efc7acd85..2b4295f969ad63d5b23ca197fcdb96980c880684 100644
+index c5800f0e502815bf0e71a389e30e9b604ac6b107..b1ea73320b7927b23d48ee6e80b63b37d1806c97 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1008,6 +1008,45 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1005,6 +1005,45 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleEditBook(ServerboundEditBookPacket packet) {

--- a/patches/server/0298-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0298-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -40,10 +40,10 @@ index e1603b674823067a55faa12e716b695171b31d32..73dd4776fee3429c42b279ab92050a4b
          GameProfileCache usercache = this.server.getProfileCache();
          Optional<GameProfile> optional = usercache.get(gameprofile.getId());
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
-index c7e4c6d29378675b76ebb179022ddbb02831a1dc..88bc0807e8bf66a65422f85f1112336334eb3de2 100644
+index f6665825e62a0cd912e6b06df6d68795596486f0..1f2bc88d4570c6ef00e67a772b745e0b0c98e051 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
-@@ -244,6 +244,61 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
+@@ -247,6 +247,61 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
          return this.getData() != null;
      }
  
@@ -106,10 +106,10 @@ index c7e4c6d29378675b76ebb179022ddbb02831a1dc..88bc0807e8bf66a65422f85f11123363
      public Location getBedSpawnLocation() {
          CompoundTag data = this.getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c270bf19cdba50d83dafe2c5ab55422cb74dd902..3a439a1dd3e3ad05767876ce9546fe5ec4505e00 100644
+index 3fc1c400100a87e576052c6d977c8ce1659f7582..a270e5a65d599c3200a4e6d8ca74db991068081e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -159,6 +159,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -161,6 +161,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
      private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
@@ -117,7 +117,7 @@ index c270bf19cdba50d83dafe2c5ab55422cb74dd902..3a439a1dd3e3ad05767876ce9546fe5e
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1575,6 +1576,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1577,6 +1578,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index c270bf19cdba50d83dafe2c5ab55422cb74dd902..3a439a1dd3e3ad05767876ce9546fe5e
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1597,6 +1610,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1599,6 +1612,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index c270bf19cdba50d83dafe2c5ab55422cb74dd902..3a439a1dd3e3ad05767876ce9546fe5e
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1611,6 +1626,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1613,6 +1628,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0300-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0300-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3a439a1dd3e3ad05767876ce9546fe5ec4505e00..c6fa202d8353975d196b6e9cd5848fbed238a52f 100644
+index a270e5a65d599c3200a4e6d8ca74db991068081e..42062d64b7ea55f5360c435ef1953452d439029b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2447,6 +2447,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2449,6 +2449,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0301-BlockDestroyEvent.patch
+++ b/patches/server/0301-BlockDestroyEvent.patch
@@ -11,7 +11,7 @@ floating in the air.
 This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ee5415574dea0712f08e2467ecf93aa1ce39a2e5..40a445f6aa0440307368aba8433e5e7c70753566 100644
+index 5e3d1a36b0eb350536e29730540ee17b68fe315b..9d963766cce68f5cb837988c73c8b271404c8376 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -28,6 +28,7 @@ import net.minecraft.nbt.CompoundTag;
@@ -22,7 +22,7 @@ index ee5415574dea0712f08e2467ecf93aa1ce39a2e5..40a445f6aa0440307368aba8433e5e7c
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ChunkHolder;
  import net.minecraft.server.level.ServerLevel;
-@@ -565,8 +566,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -564,8 +565,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              return false;
          } else {
              FluidState fluid = this.getFluidState(pos);

--- a/patches/server/0303-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0303-Implement-Brigadier-Mojang-API.patch
@@ -81,10 +81,10 @@ index ee31455158afbed8f3bbac57d2f41a59d01a0670..4049576478efed97092b7e1b3d40afda
          event.getPlayer().getServer().getPluginManager().callEvent(event);
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 5c7f1b6b6e5fbd4c064ef39ab910655e90ace788..39913117f5ba2d455af6781e35abc3088640185e 100644
+index b1ea73320b7927b23d48ee6e80b63b37d1806c97..e2044745f490f99deb993e42385d71fa8d927ab1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -749,8 +749,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -746,8 +746,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                      ParseResults<CommandSourceStack> parseresults = this.server.getCommands().getDispatcher().parse(stringreader, this.player.createCommandSourceStack());
  
                      this.server.getCommands().getDispatcher().getCompletionSuggestions(parseresults).thenAccept((suggestions) -> {
@@ -99,7 +99,7 @@ index 5c7f1b6b6e5fbd4c064ef39ab910655e90ace788..39913117f5ba2d455af6781e35abc308
                      });
                  });
              }
-@@ -759,7 +763,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -756,7 +760,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              builder = builder.createOffset(builder.getInput().lastIndexOf(' ') + 1);
              completions.forEach(builder::suggest);

--- a/patches/server/0305-Limit-Client-Sign-length-more.patch
+++ b/patches/server/0305-Limit-Client-Sign-length-more.patch
@@ -22,10 +22,10 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 57a14ed626824171adb45c4af1fc861549ffbdd6..aae26c430fea5a86c8730dbdd3bbf7af34cf2be0 100644
+index e2044745f490f99deb993e42385d71fa8d927ab1..7b639081b1bd5ac0cca7c6be1692c179bc9692fb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -254,6 +254,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -253,6 +253,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      private int aboveGroundVehicleTickCount;
      private int receivedMovePacketCount;
      private int knownMovePacketCount;
@@ -33,7 +33,7 @@ index 57a14ed626824171adb45c4af1fc861549ffbdd6..aae26c430fea5a86c8730dbdd3bbf7af
      private static final long KEEPALIVE_LIMIT = Long.getLong("paper.playerconnection.keepalive", 30) * 1000; // Paper - provide property to set keepalive limit
  
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
-@@ -2869,6 +2870,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2865,6 +2866,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              for (int i = 0; i < signText.size(); ++i) {
                  TextFilter.FilteredText currentLine = signText.get(i);

--- a/patches/server/0312-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0312-Entity-getEntitySpawnReason.patch
@@ -35,7 +35,7 @@ index 25da9e3252154415303db662286e89e3aa7cfcd8..eea7a625fb00af13944b21e1af4bf180
              });
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8018c9dae36335c2fb654269684445b6411450ee..0f6ed83a866153864cb52e978645a7278473718d 100644
+index 3a013ffe5feec6dab478684964f581c354f2a7ae..e42da944f70520b7b8f0a67928614b85f7385f9f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -67,6 +67,8 @@ import net.minecraft.world.InteractionHand;
@@ -105,10 +105,10 @@ index f08c5ae9d41ec9efb627665f5de4dd6165fd0092..30930a24c197c45f2ed86eaf7a150252
                          // Spigot Start
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index a1812c570215b14e89ce61ebbd78871fa57c9323..d7dabaa5087f87b97a2e66b871fb618918eb568b 100644
+index 16f2479de2c330b17c9ef6f3bee8e4ade5b66d15..c066be9b92d73de66ee3f1ef6aa8910de4589210 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1231,5 +1231,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1238,5 +1238,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean fromMobSpawner() {
          return getHandle().spawnedViaMobSpawner;
      }

--- a/patches/server/0313-Update-entity-Metadata-for-all-tracked-players.patch
+++ b/patches/server/0313-Update-entity-Metadata-for-all-tracked-players.patch
@@ -22,10 +22,10 @@ index 3d27cbf5e9105def2f38525a85da5acf8ebf8fe9..ceba19ea3bb9664899b83f82f28af064
          this.broadcast.accept(packet);
          if (this.entity instanceof ServerPlayer) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index aae26c430fea5a86c8730dbdd3bbf7af34cf2be0..21a4c1f9d89a8ec0d76fbf2fbe445eb724e36b6d 100644
+index 7b639081b1bd5ac0cca7c6be1692c179bc9692fb..d61a841653c26c210ba583141517ff421319ee1a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2294,7 +2294,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2290,7 +2290,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                          if (event.isCancelled() || ServerGamePacketListenerImpl.this.player.getInventory().getSelected() == null || ServerGamePacketListenerImpl.this.player.getInventory().getSelected().getItem() != origItem) {
                              // Refresh the current entity metadata

--- a/patches/server/0319-Optimize-Captured-TileEntity-Lookup.patch
+++ b/patches/server/0319-Optimize-Captured-TileEntity-Lookup.patch
@@ -10,10 +10,10 @@ Optimize to check if the captured list even has values in it, and also to
 just do a get call since the value can never be null.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 40a445f6aa0440307368aba8433e5e7c70753566..dac62bad9def39aba8fe7bebf1631eccde9cbf00 100644
+index 9d963766cce68f5cb837988c73c8b271404c8376..46c340685327173e6719c040e46886f0f49a19b6 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -876,9 +876,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -875,9 +875,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Nullable
      public BlockEntity getBlockEntity(BlockPos blockposition, boolean validate) {

--- a/patches/server/0320-Add-Heightmap-API.patch
+++ b/patches/server/0320-Add-Heightmap-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1b3412c1cb9a90defcd3db7ef86a21d2bbe07bf4..94e0284098f71613f37be8d65047a20420d2ddd1 100644
+index cfb3c5a00b64022ed616d59fe8b99eae5e4ccc48..19b5d23a39181c9a87bed37ea20cc75ee03e9545 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -208,6 +208,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -205,6 +205,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.getHighestBlockYAt(x, z, org.bukkit.HeightMap.MOTION_BLOCKING);
      }
  

--- a/patches/server/0322-Fix-CB-call-to-changed-postToMainThread-method.patch
+++ b/patches/server/0322-Fix-CB-call-to-changed-postToMainThread-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CB call to changed postToMainThread method
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 29e5265a99c8156ad83e5e2cc75910273d84458e..0b6739fcda89df0f91cddc493f45b0bf9e433b53 100644
+index d61a841653c26c210ba583141517ff421319ee1a..8e6bf6f5026e2d19ed5983eaee81f2aae4b8cca2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -440,7 +440,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -437,7 +437,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          Objects.requireNonNull(this.connection);
          // CraftBukkit - Don't wait

--- a/patches/server/0324-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0324-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -16,7 +16,7 @@ handling that should have been handled synchronously will be handled
 synchronously when the server gets shut down.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index bc9937642a46ecd766a45ccb037de993dafa3608..bd8e654c1580a0ac7dd411b9f1dcad4a20d1d3e5 100644
+index d7048f7f05e67581ed3be28d452fbe52f4c980cf..b3c4687c6538adf851379f73cceffb114820507b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2287,7 +2287,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -29,10 +29,10 @@ index bc9937642a46ecd766a45ccb037de993dafa3608..bd8e654c1580a0ac7dd411b9f1dcad4a
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3a82ffd3286bf84529825b9ed805d31ef521f64a..9b8d39e3f323829286d06d07cc7303e6fdc1bad8 100644
+index 17aa8e654b5676e4401131e1b8196625618d2ee6..e707208d4cfd39e6f984c62b78521799b1e35173 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2061,7 +2061,7 @@ public final class CraftServer implements Server {
+@@ -2068,7 +2068,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0325-improve-CraftWorld-isChunkLoaded.patch
+++ b/patches/server/0325-improve-CraftWorld-isChunkLoaded.patch
@@ -9,10 +9,10 @@ waiting for the execution queue to get to our request; We can just query
 the chunk status and get a response now, vs having to wait
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 94e0284098f71613f37be8d65047a20420d2ddd1..3ba558e36cbb87e67736654bcd1d46474b6d4e2f 100644
+index 19b5d23a39181c9a87bed37ea20cc75ee03e9545..675169c842fc9d333a08ad6012dbfa16a0d0ce75 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -279,13 +279,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -276,13 +276,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkLoaded(int x, int z) {

--- a/patches/server/0327-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0327-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -23,7 +23,7 @@ index eb44aef0aecf65f5c1b19f42bf85a3a263965a7c..5589ee42959e3665dd5df9049fe108b6
          config.addDefault("world-settings.default." + path, def);
          return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index bd8e654c1580a0ac7dd411b9f1dcad4a20d1d3e5..7576047ea9695434ca06ca8fefde0dce68980be8 100644
+index b3c4687c6538adf851379f73cceffb114820507b..a243592ff0f70eabcc2e895a96859dd8a13e5e32 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -760,35 +760,36 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -221,10 +221,10 @@ index 4185e6bcf9b2bb65b2a0fa5fcbeb5684615169a7..dbc29442f2b2ad3ea451910f4944e901
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3ba558e36cbb87e67736654bcd1d46474b6d4e2f..0816aa64d50b3144057024b998bc8dc4cd43b7a0 100644
+index 675169c842fc9d333a08ad6012dbfa16a0d0ce75..f34b67f6ed65422fe372cecf130401133f0211bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1342,15 +1342,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1339,15 +1339,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/patches/server/0331-Expose-the-internal-current-tick.patch
+++ b/patches/server/0331-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9b8d39e3f323829286d06d07cc7303e6fdc1bad8..91ef1b0e06c30668fe4bfb18ecdf2fe499f72fee 100644
+index e707208d4cfd39e6f984c62b78521799b1e35173..f1dd55972b0a0f389527c1fef739a78f1d85b579 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2600,5 +2600,10 @@ public final class CraftServer implements Server {
+@@ -2607,5 +2607,10 @@ public final class CraftServer implements Server {
          }
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
      }

--- a/patches/server/0332-Fix-World-isChunkGenerated-calls.patch
+++ b/patches/server/0332-Fix-World-isChunkGenerated-calls.patch
@@ -8,7 +8,7 @@ This patch also adds a chunk status cache on region files (note that
 its only purpose is to cache the status on DISK)
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 8ccdaddcef1e5e83660e58075b039b124f36fce3..e78ad9330ae1b89aca9aef197f593156546138f0 100644
+index 244f6a2934e807fa4f67c617dcd08a9ae2065bbf..e47dc348a98de67146d45d5f57cc72dbc2c0f975 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -87,6 +87,7 @@ import net.minecraft.world.level.chunk.ProtoChunk;
@@ -196,10 +196,10 @@ index a1bfcdd713c47d8613eb4af7625a64d51161690b..4bc33c31d497aa7d69226ab870fd7890
              } catch (Throwable throwable) {
                  if (dataoutputstream != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0816aa64d50b3144057024b998bc8dc4cd43b7a0..0ef9fc9cecdefcec3369c45643e474c16a588cea 100644
+index f34b67f6ed65422fe372cecf130401133f0211bf..fe35d72dd2e13bce16c7b02d726144ff6cb2ecbe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -19,6 +19,7 @@ import java.util.Objects;
+@@ -20,6 +20,7 @@ import java.util.Objects;
  import java.util.Random;
  import java.util.Set;
  import java.util.UUID;
@@ -207,7 +207,7 @@ index 0816aa64d50b3144057024b998bc8dc4cd43b7a0..0ef9fc9cecdefcec3369c45643e474c1
  import java.util.function.Predicate;
  import java.util.stream.Collectors;
  import net.minecraft.core.BlockPos;
-@@ -284,8 +285,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -281,8 +282,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -231,7 +231,7 @@ index 0816aa64d50b3144057024b998bc8dc4cd43b7a0..0ef9fc9cecdefcec3369c45643e474c1
          } catch (IOException ex) {
              throw new RuntimeException(ex);
          }
-@@ -397,20 +412,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -394,20 +409,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0334-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/patches/server/0334-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -37,10 +37,10 @@ index 5589ee42959e3665dd5df9049fe108b6f6629608..e5365453655c0f394dea3d3b388afc24
  }
 +
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 94d2d83da52ce20f12a4e3f235f75d5c537ae9d1..6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5 100644
+index cc3312af20b74a3cbec667ecb50d3cac30b455fa..be1068c305ef0c968caa2ee9412ed7ad1b1946f1 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-@@ -85,6 +85,13 @@ public final class NaturalSpawner {
+@@ -87,6 +87,13 @@ public final class NaturalSpawner {
              MobCategory enumcreaturetype = entity.getType().getCategory();
  
              if (enumcreaturetype != MobCategory.MISC) {

--- a/patches/server/0339-Dont-send-unnecessary-sign-update.patch
+++ b/patches/server/0339-Dont-send-unnecessary-sign-update.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Dont send unnecessary sign update
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3ef13c8a688540b2fdbe194cb4d9224d2c1b5095..dd874b3194f0f95122c066e22207e98212193d94 100644
+index 8e6bf6f5026e2d19ed5983eaee81f2aae4b8cca2..10a392b381e681eead9c55a6e261ae1849cacc47 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2864,6 +2864,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2860,6 +2860,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              if (!tileentitysign.isEditable() || !this.player.getUUID().equals(tileentitysign.getPlayerWhoMayEdit())) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Player {} just tried to change non-editable sign", this.player.getName().getString());

--- a/patches/server/0341-Fix-AssertionError-when-player-hand-set-to-empty-typ.patch
+++ b/patches/server/0341-Fix-AssertionError-when-player-hand-set-to-empty-typ.patch
@@ -7,10 +7,10 @@ Fixes an AssertionError when setting the player's item in hand to null or a new 
 Fixes GH-2718
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index dd874b3194f0f95122c066e22207e98212193d94..ddb60a2d9fa1d2faefedc9d8e538a5188901f940 100644
+index 10a392b381e681eead9c55a6e261ae1849cacc47..d51637e88119b17d6c1727405853d923fe15b2fa 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1742,6 +1742,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1738,6 +1738,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  this.player.getBukkitEntity().updateInventory(); // SPIGOT-2524
                  return;
              }

--- a/patches/server/0357-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0357-Entity-Activation-Range-2.0.patch
@@ -108,7 +108,7 @@ index 367e074dd5f85f824b7c4f5506d0ccac60580c1b..83c5b111b98e52f52b7e4cf607aac07b
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0f6ed83a866153864cb52e978645a7278473718d..62f19eafbb650dfbfac31c320e4883149d327e43 100644
+index e42da944f70520b7b8f0a67928614b85f7385f9f..344719bfe08bffe7012609fce64d73c467934d09 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -319,6 +319,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -303,13 +303,13 @@ index 6600272bfd5e5ae1699485b143a49a2471c561d9..8bcb6df10e99e47dee35f441261847aa
          super.customServerAiStep();
      }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index dac62bad9def39aba8fe7bebf1631eccde9cbf00..615204f7e3095fcd65099a1b752635fa08d44d25 100644
+index 46c340685327173e6719c040e46886f0f49a19b6..f28ae6eb853f9abbae295ab2753b4f0c91aa5fe4 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -157,6 +157,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
-     public long ticksPerWaterAmbientSpawns;
-     public long ticksPerWaterUndergroundCreatureSpawns;
-     public long ticksPerAmbientSpawns;
+@@ -154,6 +154,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+     public Map<BlockPos, BlockEntity> capturedTileEntities = new HashMap<>();
+     public List<ItemEntity> captureDrops;
+     public final it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<SpawnCategory> ticksPerSpawnCategory = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
 +    // Paper start
 +    public int wakeupInactiveRemainingAnimals;
 +    public int wakeupInactiveRemainingFlying;

--- a/patches/server/0360-Anti-Xray.patch
+++ b/patches/server/0360-Anti-Xray.patch
@@ -1192,7 +1192,7 @@ index 83c5b111b98e52f52b7e4cf607aac07be7043709..be75691d91b3559788365da2b813ea3c
          this.convertable = convertable_conversionsession;
          this.uuid = WorldUUID.getUUID(convertable_conversionsession.levelPath.toFile());
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index d0b54ebc05cac6535a023709c76efd802f7150f9..d87ee258db769bc072cbdae4298ebc08588b2160 100644
+index abc7b15976131dc840f40258ed5cc4ef88c27815..391e20c284b24f6c5fe446fd6a2c677214ed15c5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -48,7 +48,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
@@ -1204,7 +1204,7 @@ index d0b54ebc05cac6535a023709c76efd802f7150f9..d87ee258db769bc072cbdae4298ebc08
      protected final ServerPlayer player;
      private GameType gameModeForPlayer;
      @Nullable
-@@ -314,6 +314,8 @@ public class ServerPlayerGameMode {
+@@ -316,6 +316,8 @@ public class ServerPlayerGameMode {
              }
  
          }
@@ -1214,10 +1214,10 @@ index d0b54ebc05cac6535a023709c76efd802f7150f9..d87ee258db769bc072cbdae4298ebc08
  
      public void destroyAndAck(BlockPos pos, ServerboundPlayerActionPacket.Action action, String reason) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 615204f7e3095fcd65099a1b752635fa08d44d25..65bfcc218e50c05d5d1b90081b888f596bfef780 100644
+index f28ae6eb853f9abbae295ab2753b4f0c91aa5fe4..95d4785222d732488971e640567668353d6cf96d 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -167,6 +167,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -164,6 +164,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public final org.spigotmc.SpigotWorldConfig spigotConfig; // Spigot
  
      public final com.destroystokyo.paper.PaperWorldConfig paperConfig; // Paper
@@ -1225,7 +1225,7 @@ index 615204f7e3095fcd65099a1b752635fa08d44d25..65bfcc218e50c05d5d1b90081b888f59
  
      public final co.aikar.timings.WorldTimingsHandler timings; // Paper
      public static BlockPos lastPhysicsProblem; // Spigot
-@@ -186,7 +187,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -183,7 +184,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      public abstract ResourceKey<LevelStem> getTypeKey();
  
@@ -1234,7 +1234,7 @@ index 615204f7e3095fcd65099a1b752635fa08d44d25..65bfcc218e50c05d5d1b90081b888f59
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
          this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName(), this.spigotConfig); // Paper
          this.generator = gen;
-@@ -262,6 +263,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -261,6 +262,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.keepSpawnInMemory = this.paperConfig.keepSpawnInMemory; // Paper
          this.entityLimiter = new org.spigotmc.TickLimiter(spigotConfig.entityMaxTickTime);
          this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
@@ -1242,7 +1242,7 @@ index 615204f7e3095fcd65099a1b752635fa08d44d25..65bfcc218e50c05d5d1b90081b888f59
      }
  
      // Paper start
-@@ -442,6 +444,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -441,6 +443,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // CraftBukkit end
  
              BlockState iblockdata1 = chunk.setBlockState(pos, state, (flags & 64) != 0, (flags & 1024) == 0); // CraftBukkit custom NO_PLACE flag
@@ -1596,10 +1596,10 @@ index a1fe076d76fe5f84eca39ea68e9820096f58f5a7..155933ef7c324ea17c2349a1f73ede29
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 91ef1b0e06c30668fe4bfb18ecdf2fe499f72fee..36b7de78fa69f652079d74252286bb6df68cf0c6 100644
+index f1dd55972b0a0f389527c1fef739a78f1d85b579..dce382bb853dff010dc2c8ef86f8bf1cce7438c6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2216,7 +2216,7 @@ public final class CraftServer implements Server {
+@@ -2223,7 +2223,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Validate.notNull(world, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();

--- a/patches/server/0363-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0363-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 62f19eafbb650dfbfac31c320e4883149d327e43..ae0ae298ff7ae129959ff6e4024eb7060c0786e4 100644
+index 344719bfe08bffe7012609fce64d73c467934d09..82f5f9f6f97551ac7182c68f00f5471cf7d2269f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3028,6 +3028,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3034,6 +3034,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              if (flag1) {
                  blockposition1 = ServerLevel.END_SPAWN_POINT;
              } else {

--- a/patches/server/0364-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0364-implement-optional-per-player-mob-spawns.patch
@@ -370,7 +370,7 @@ index f0dac1f596911eb2109192ef16a619f8ae71d1f7..07b616d9d7cde77c001f5c627daef073
          this.naturalSpawnChunkCounter.runAllUpdates();
          return this.naturalSpawnChunkCounter.chunks.size();
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index cb57ac51f4acb35710f58ffce2fcc76cc88dd79b..06ddca6290b89ed96b8f9075f5c8b0b5244b9c3f 100644
+index 343d54addd67998175db152d38702adda37b7d21..6830d1d9929b472e530b6676c7d0f8b316aea899 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -916,7 +916,18 @@ public class ServerChunkCache extends ChunkSource {
@@ -418,10 +418,10 @@ index b193f8dfbe7b61c919ad5eb452d29885982e25e4..01b9edc8aaf472650f171f1b88229807
  
      // Yes, this doesn't match Vanilla, but it's the best we can do for now.
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5..a9d9c54c7bae0ad681a67106689897a31de49288 100644
+index be1068c305ef0c968caa2ee9412ed7ad1b1946f1..8e63d93a574f2c37094770099ea8e1f45cde3db5 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-@@ -65,7 +65,13 @@ public final class NaturalSpawner {
+@@ -67,7 +67,13 @@ public final class NaturalSpawner {
  
      private NaturalSpawner() {}
  
@@ -435,7 +435,7 @@ index 6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5..a9d9c54c7bae0ad681a67106689897a3
          PotentialCalculator spawnercreatureprobabilities = new PotentialCalculator();
          Object2IntOpenHashMap<MobCategory> object2intopenhashmap = new Object2IntOpenHashMap();
          Iterator iterator = entities.iterator();
-@@ -101,11 +107,16 @@ public final class NaturalSpawner {
+@@ -103,11 +109,16 @@ public final class NaturalSpawner {
                          spawnercreatureprobabilities.addCharge(entity.blockPosition(), biomesettingsmobs_b.getCharge());
                      }
  
@@ -453,7 +453,7 @@ index 6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5..a9d9c54c7bae0ad681a67106689897a3
                  });
              }
          }
-@@ -169,13 +180,37 @@ public final class NaturalSpawner {
+@@ -142,13 +153,37 @@ public final class NaturalSpawner {
                  continue;
              }
  
@@ -493,7 +493,7 @@ index 6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5..a9d9c54c7bae0ad681a67106689897a3
              }
          }
  
-@@ -183,12 +218,18 @@ public final class NaturalSpawner {
+@@ -156,12 +191,18 @@ public final class NaturalSpawner {
          world.getProfiler().pop();
      }
  
@@ -513,7 +513,7 @@ index 6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5..a9d9c54c7bae0ad681a67106689897a3
      }
  
      @VisibleForDebug
-@@ -199,15 +240,21 @@ public final class NaturalSpawner {
+@@ -172,15 +213,21 @@ public final class NaturalSpawner {
          });
      }
  
@@ -536,7 +536,7 @@ index 6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5..a9d9c54c7bae0ad681a67106689897a3
              int k = 0;
  
              while (k < 3) {
-@@ -249,14 +296,14 @@ public final class NaturalSpawner {
+@@ -222,14 +269,14 @@ public final class NaturalSpawner {
                                      // Paper start
                                      Boolean doSpawning = isValidSpawnPostitionForType(world, group, structuremanager, chunkgenerator, biomesettingsmobs_c, blockposition_mutableblockposition, d2);
                                      if (doSpawning == null) {
@@ -553,7 +553,7 @@ index 6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5..a9d9c54c7bae0ad681a67106689897a3
                                          }
  
                                          entityinsentient.moveTo(d0, (double) i, d1, world.random.nextFloat() * 360.0F, 0.0F);
-@@ -268,10 +315,15 @@ public final class NaturalSpawner {
+@@ -241,10 +288,15 @@ public final class NaturalSpawner {
                                                  ++j;
                                                  ++k1;
                                                  runner.run(entityinsentient, chunk);
@@ -571,7 +571,7 @@ index 6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5..a9d9c54c7bae0ad681a67106689897a3
                                              }
  
                                              if (entityinsentient.isMaxGroupSizeReached(k1)) {
-@@ -293,6 +345,7 @@ public final class NaturalSpawner {
+@@ -266,6 +318,7 @@ public final class NaturalSpawner {
              }
  
          }
@@ -579,7 +579,7 @@ index 6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5..a9d9c54c7bae0ad681a67106689897a3
      }
  
      private static boolean isRightDistanceToPlayerAndSpawnPoint(ServerLevel world, ChunkAccess chunk, BlockPos.MutableBlockPos pos, double squaredDistance) {
-@@ -572,7 +625,7 @@ public final class NaturalSpawner {
+@@ -545,7 +598,7 @@ public final class NaturalSpawner {
              MobCategory enumcreaturetype = entitytypes.getCategory();
  
              this.mobCategoryCounts.addTo(enumcreaturetype, 1);
@@ -588,7 +588,7 @@ index 6f63f471c2c9a3b85c6fc92bdee31a5ff9714ff5..a9d9c54c7bae0ad681a67106689897a3
          }
  
          public int getSpawnableChunkCount() {
-@@ -588,6 +641,7 @@ public final class NaturalSpawner {
+@@ -561,6 +614,7 @@ public final class NaturalSpawner {
              int i = limit * this.spawnableChunkCount / NaturalSpawner.MAGIC_NUMBER;
              // CraftBukkit end
  

--- a/patches/server/0365-Avoid-hopper-searches-if-there-are-no-items.patch
+++ b/patches/server/0365-Avoid-hopper-searches-if-there-are-no-items.patch
@@ -14,10 +14,10 @@ And since minecart hoppers are used _very_ rarely near we can avoid alot of sear
 Combined, this adds up a lot.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 65bfcc218e50c05d5d1b90081b888f596bfef780..dbccf3c687cf52ca95934c274ae6949f600c7ca8 100644
+index 95d4785222d732488971e640567668353d6cf96d..bb990265990769eacc99a0ce8b1384888976ec31 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -988,7 +988,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -987,7 +987,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  }
              }
  

--- a/patches/server/0374-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/patches/server/0374-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b4032ce470346915251d85d1aa7375a116efe771..aaea18e64db3851f98a7a391d9f9bb265d659d99 100644
+index 5ccf7f5d0c748de6ff1f996089f4db99d39d6dfb..550e30bfbdcf1ae0adf2cc68e3ae3d3dd4faad56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -344,13 +344,18 @@ public class CraftEventFactory {
+@@ -345,13 +345,18 @@ public class CraftEventFactory {
          }
  
          org.bukkit.inventory.ItemStack item;

--- a/patches/server/0375-Prevent-teleporting-dead-entities.patch
+++ b/patches/server/0375-Prevent-teleporting-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent teleporting dead entities
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ddb60a2d9fa1d2faefedc9d8e538a5188901f940..d7a7bd1de587026f8b290012ffafde1ad6fd57ed 100644
+index d51637e88119b17d6c1727405853d923fe15b2fa..78804497375740189d01c594c26786254288ef19 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1502,6 +1502,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1499,6 +1499,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      }
  
      private void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<ClientboundPlayerPositionPacket.RelativeArgument> set, boolean flag) {

--- a/patches/server/0381-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0381-Add-tick-times-API-and-mspt-command.patch
@@ -87,7 +87,7 @@ index e683e5bf47abe7bd3d2f7e9811a377549308ded4..c20fe23174d8a12bfc5acb4b0e947c6f
          version = getInt("config-version", 24);
          set("config-version", 24);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b3d3e023d10fe6bb964fe7a3d1cbb96d6a406283..51b8b23892d9a57c1502a7cd9dbde033bae1ff03 100644
+index 76da16590f27702883c07200a02db823d9720c61..3c2af39f7bd62448a3075d327132ebc19af6bd77 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -245,6 +245,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -146,10 +146,10 @@ index b3d3e023d10fe6bb964fe7a3d1cbb96d6a406283..51b8b23892d9a57c1502a7cd9dbde033
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 36b7de78fa69f652079d74252286bb6df68cf0c6..fc51c094b4eb2ec6cc79a649f3a3aec8c44b915a 100644
+index dce382bb853dff010dc2c8ef86f8bf1cce7438c6..2b315621eaf3b889f417339c22c6afe6a23959fd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2438,6 +2438,16 @@ public final class CraftServer implements Server {
+@@ -2445,6 +2445,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0382-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0382-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fc51c094b4eb2ec6cc79a649f3a3aec8c44b915a..7764e78ad23ca196bcc621bb1cb895a8e5763c82 100644
+index 2b315621eaf3b889f417339c22c6afe6a23959fd..989dc2ebbe10d8f2619661f20eddcdd0071b8bb4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2615,5 +2615,10 @@ public final class CraftServer implements Server {
+@@ -2622,5 +2622,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0393-Improved-Watchdog-Support.patch
+++ b/patches/server/0393-Improved-Watchdog-Support.patch
@@ -71,7 +71,7 @@ index c54530d1c66845b190a9cb6d06f985943bb4dbe1..35c9b3e6c5a2d11b4dbd491b16647df1
              cause = cause.getCause();
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 51b8b23892d9a57c1502a7cd9dbde033bae1ff03..7049126dabd8bd497b7a63f8b0980e0252638c23 100644
+index 3c2af39f7bd62448a3075d327132ebc19af6bd77..af7bc83f4a232489874f69dc2814b2c063bbb7eb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -298,7 +298,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -262,7 +262,7 @@ index 049eb5693dc98e1d0ec3bd88c73a41fdb2f59bff..0716aaf29f9d76240a0de4ca02daba44
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index ed4b4c3d3d991716078d5f008bf4665e76b30f33..4cb7e63b433b8d4a02c2d193a2596e51ddab2779 100644
+index 15792e281056b1022d457b36646d3473b7c4717c..e391894e95b00a6f9a9acdb76af05fcd3eb0a2c1 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -535,6 +535,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -299,10 +299,10 @@ index 7bf4bf5cb2c1b54a7e2733091f48f3a824336d36..dcce05d2f4ab16424db4ab103a12188e
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index dbccf3c687cf52ca95934c274ae6949f600c7ca8..634a858e4e03968ada7c13e26e151d8f05ad611c 100644
+index bb990265990769eacc99a0ce8b1384888976ec31..33cc7cb32f2d8ac780ca4b4058db6da87b28e1e5 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -834,6 +834,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -833,6 +833,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          try {
              tickConsumer.accept(entity);
          } catch (Throwable throwable) {
@@ -323,10 +323,10 @@ index 8cfe47012b78eb582afff23ffcf758ca2e9dec95..d70bdf21dd7bdf01b34d0fd38e79f9b3
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7764e78ad23ca196bcc621bb1cb895a8e5763c82..fbdc39181ea3074c2b2e3a877a59afafd02fe3c9 100644
+index 989dc2ebbe10d8f2619661f20eddcdd0071b8bb4..34249d98a4db6c6d9e06a30faf6333ddf996e4a5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2061,7 +2061,7 @@ public final class CraftServer implements Server {
+@@ -2068,7 +2068,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {
@@ -336,7 +336,7 @@ index 7764e78ad23ca196bcc621bb1cb895a8e5763c82..fbdc39181ea3074c2b2e3a877a59afaf
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index e3b2b61e5f030080e481dc00d1086f723b8b97ee..a5f8554e2cd43774b1978dce659062d9c7e7dbda 100644
+index fce5539a8eaa98f433ad65e26ef6027a15e82fb4..cbd58b1a34a8151403033322971c09c2703fe845 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,6 +12,8 @@ import java.util.logging.Level;

--- a/patches/server/0400-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0400-Implement-Player-Client-Options-API.patch
@@ -97,10 +97,10 @@ index 9cbca14b0a111e57a1d01bcbcf2164ab8b53b1a5..cdb0eb8e21299ca70ed7ed5c1195d07f
          if (getMainArm() != packet.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c6fa202d8353975d196b6e9cd5848fbed238a52f..62341d1c88d6595fa27e70985abb42f2521235cf 100644
+index 42062d64b7ea55f5360c435ef1953452d439029b..0a9d519596b074fd88fc3594d673189ef2c5e3d9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -549,6 +549,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -551,6 +551,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setSendViewDistance(int viewDistance) {
          throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }

--- a/patches/server/0405-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0405-Load-Chunks-for-Login-Asynchronously.patch
@@ -37,10 +37,10 @@ index be677d437d17b74c6188ce1bd5fc6fdc228fd92f..78fbb4c3e52e900956ae0811aaf934c8
      public static final TicketType<ChunkPos> UNKNOWN = TicketType.create("unknown", Comparator.comparingLong(ChunkPos::toLong), 1);
      public static final TicketType<Unit> PLUGIN = TicketType.create("plugin", (a, b) -> 0); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0e91a6b4d07b14cff98c97262329a46c4238317c..ea6e6dd473be39722271dd2a2928356ded6e14fd 100644
+index 78804497375740189d01c594c26786254288ef19..f0630bf6502d0b7be1c63e9c610ca2c8e1edc9d5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -220,6 +220,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -219,6 +219,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      private static final int LATENCY_CHECK_INTERVAL = 15000;
      public final Connection connection;
      private final MinecraftServer server;
@@ -48,7 +48,7 @@ index 0e91a6b4d07b14cff98c97262329a46c4238317c..ea6e6dd473be39722271dd2a2928356d
      public ServerPlayer player;
      private int tickCount;
      private long keepAliveTime = Util.getMillis();
-@@ -295,6 +296,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -292,6 +293,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      // CraftBukkit end
  
      public void tick() {
@@ -64,7 +64,7 @@ index 0e91a6b4d07b14cff98c97262329a46c4238317c..ea6e6dd473be39722271dd2a2928356d
          this.resetPosition();
          this.player.xo = this.player.getX();
          this.player.yo = this.player.getY();
-@@ -336,7 +346,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -333,7 +343,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              this.lastVehicle = null;
              this.clientVehicleIsFloating = false;
              this.aboveGroundVehicleTickCount = 0;

--- a/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,7 +16,7 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c8fb6387fb3ac2849a399b2ab1f30158aa734827..a02eb37845e0609ddf14a4214395e00443534b08 100644
+index 6fa35e0acd966a9cfd3d5b3765c7d0130ea2de18..7bf62752b6604abe0bda6f5d0024f0e93efb3a9a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2162,11 +2162,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -47,7 +47,7 @@ index c8fb6387fb3ac2849a399b2ab1f30158aa734827..a02eb37845e0609ddf14a4214395e004
          if (this.level instanceof ServerLevel && !this.isRemoved()) {
              this.level.getProfiler().push("changeDimension");
              // CraftBukkit start
-@@ -2939,6 +2946,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2945,6 +2952,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  // CraftBukkit end
  
                  this.level.getProfiler().popPush("reloading");
@@ -59,7 +59,7 @@ index c8fb6387fb3ac2849a399b2ab1f30158aa734827..a02eb37845e0609ddf14a4214395e004
                  Entity entity = this.getType().create(worldserver);
  
                  if (entity != null) {
-@@ -2952,10 +2964,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2958,10 +2970,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index c8fb6387fb3ac2849a399b2ab1f30158aa734827..a02eb37845e0609ddf14a4214395e004
                      // CraftBukkit end
                  }
  
-@@ -3077,7 +3085,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3083,7 +3091,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public boolean canChangeDimensions() {
@@ -135,10 +135,10 @@ index a3a900d10440ed5ebe24370a77ccb6cad911cfc9..0d468631b9c260091e732925da43c177
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b7129aef8b08e8bd33f9f276bc2f97bbe8f5c894..624ed3d956a5614b723d32c6ad047248c5f5b038 100644
+index 550e30bfbdcf1ae0adf2cc68e3ae3d3dd4faad56..d998c0dd9e03b9c0f0a6075e5a52ba50b44ed0c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -810,6 +810,11 @@ public class CraftEventFactory {
+@@ -820,6 +820,11 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
@@ -150,7 +150,7 @@ index b7129aef8b08e8bd33f9f276bc2f97bbe8f5c894..624ed3d956a5614b723d32c6ad047248
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
          populateFields(victim, event); // Paper - make cancellable
-@@ -823,11 +828,13 @@ public class CraftEventFactory {
+@@ -833,11 +838,13 @@ public class CraftEventFactory {
          playDeathSound(victim, event);
          // Paper end
          victim.expToDrop = event.getDroppedExp();

--- a/patches/server/0412-Validate-PickItem-Packet-and-kick-for-invalid.patch
+++ b/patches/server/0412-Validate-PickItem-Packet-and-kick-for-invalid.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Validate PickItem Packet and kick for invalid
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ea6e6dd473be39722271dd2a2928356ded6e14fd..9bbffaa02b68f4c99ae3008e25a81a15fc09aa49 100644
+index f0630bf6502d0b7be1c63e9c610ca2c8e1edc9d5..f7542d053be38298229719bd63e950fc6d167fb9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -877,7 +877,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -874,7 +874,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      @Override
      public void handlePickItem(ServerboundPickItemPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());

--- a/patches/server/0413-Expose-game-version.patch
+++ b/patches/server/0413-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fbdc39181ea3074c2b2e3a877a59afafd02fe3c9..6c8b907b3c2f9e9a5cbae38620d6ebbd70eaf453 100644
+index 34249d98a4db6c6d9e06a30faf6333ddf996e4a5..81fae30cde0bf377ad98abb8d4c3ce0383bb0e85 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -578,6 +578,13 @@ public final class CraftServer implements Server {
+@@ -575,6 +575,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  

--- a/patches/server/0416-misc-debugging-dumps.patch
+++ b/patches/server/0416-misc-debugging-dumps.patch
@@ -29,7 +29,7 @@ index 0000000000000000000000000000000000000000..2d5494d2813b773e60ddba6790b750a9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7049126dabd8bd497b7a63f8b0980e0252638c23..d613d9bbd2096788cd0f7e3a8aa901e44a4e25ff 100644
+index af7bc83f4a232489874f69dc2814b2c063bbb7eb..3092a50be8243a576d95e7f5ce546941f0b105fa 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -919,6 +919,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -74,10 +74,10 @@ index 301042e7a0d372a914f27ec0988dd938cf2a8262..1766a22e65af2e08611a9435c7384377
                  this.connection.send(new ClientboundDisconnectPacket(chatmessage));
                  this.connection.disconnect(chatmessage);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6c8b907b3c2f9e9a5cbae38620d6ebbd70eaf453..fc9c24e20bcdb43d79cb44bfbc2c0e82e8d1db46 100644
+index 81fae30cde0bf377ad98abb8d4c3ce0383bb0e85..db8c8a2846faa5b07015a67d43e0a16b76f19849 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1018,6 +1018,7 @@ public final class CraftServer implements Server {
+@@ -999,6 +999,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getFullName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0418-Implement-Mob-Goal-API.patch
+++ b/patches/server/0418-Implement-Mob-Goal-API.patch
@@ -785,10 +785,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fc9c24e20bcdb43d79cb44bfbc2c0e82e8d1db46..a90b4d062ba602ed63ba11d42898997c4bf672f2 100644
+index db8c8a2846faa5b07015a67d43e0a16b76f19849..2dd7a67630cc69ae7754baaae411594237572631 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2628,5 +2628,11 @@ public final class CraftServer implements Server {
+@@ -2635,5 +2635,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0420-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0420-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -20,10 +20,10 @@ index e7cbdc75d7fd1252024c450ff0ec3b1ebdd17b93..bc880a78381b9c30e4ec92bdf17c9eca
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index de5f5856875fc4bfb051c7535344f18ded360ad3..618be6243225c82c3f7e039a00c43cf3c2ef1dbf 100644
+index d998c0dd9e03b9c0f0a6075e5a52ba50b44ed0c4..931cfbe01240e6382446aa12a545a02e44a407b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -630,16 +630,30 @@ public class CraftEventFactory {
+@@ -640,16 +640,30 @@ public class CraftEventFactory {
              net.minecraft.world.entity.ExperienceOrb xp = (net.minecraft.world.entity.ExperienceOrb) entity;
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/patches/server/0421-ExperienceOrbMergeEvent.patch
+++ b/patches/server/0421-ExperienceOrbMergeEvent.patch
@@ -9,10 +9,10 @@ Plugins can cancel this if they want to ensure experience orbs do not lose impor
 metadata such as spawn reason, or conditionally move data from source to target.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d62b1f22ee5679b0f223320db0db9c53b2120c91..f49c636a7485a7f41aae7acb584dc1c7c1d2c3a2 100644
+index 931cfbe01240e6382446aa12a545a02e44a407b9..aca2b2596a43927222f9894cc2f907cae2a331c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -640,7 +640,7 @@ public class CraftEventFactory {
+@@ -650,7 +650,7 @@ public class CraftEventFactory {
                      if (e instanceof net.minecraft.world.entity.ExperienceOrb) {
                          net.minecraft.world.entity.ExperienceOrb loopItem = (net.minecraft.world.entity.ExperienceOrb) e;
                          // Paper start

--- a/patches/server/0425-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0425-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,7 +10,7 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d613d9bbd2096788cd0f7e3a8aa901e44a4e25ff..faee8e2a29b4c9cbd62185f401ac7bbd40d8df76 100644
+index 3092a50be8243a576d95e7f5ce546941f0b105fa..9d8dd7ac4e471d658ba942e29c5028df410fa2c3 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -954,6 +954,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -22,10 +22,10 @@ index d613d9bbd2096788cd0f7e3a8aa901e44a4e25ff..faee8e2a29b4c9cbd62185f401ac7bbd
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a90b4d062ba602ed63ba11d42898997c4bf672f2..ed4e566cd18de4f58fcbb54cf2b6ed5ce4895d0a 100644
+index 2dd7a67630cc69ae7754baaae411594237572631..ac582976fb2cc3edd258d004a8e9a7325b975fee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1027,6 +1027,35 @@ public final class CraftServer implements Server {
+@@ -1008,6 +1008,35 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0427-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0427-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -54,10 +54,10 @@ index e2bc9e91f03997884af381b3261b102a6e0bc5cb..8325ccbcae2a5ed55f436163bb8136cc
  
                      this.level.getProfiler().push("explosion_blocks");
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 634a858e4e03968ada7c13e26e151d8f05ad611c..ad9b48a0c89689a602c85f65e6cc68977af5ea29 100644
+index 33cc7cb32f2d8ac780ca4b4058db6da87b28e1e5..eec0e1b28f90083ac2422d0c61ceed2b26a9a25d 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -416,6 +416,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -415,6 +415,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean setBlock(BlockPos pos, BlockState state, int flags, int maxUpdateDepth) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {

--- a/patches/server/0443-Prevent-position-desync-in-playerconnection-causing-.patch
+++ b/patches/server/0443-Prevent-position-desync-in-playerconnection-causing-.patch
@@ -14,10 +14,10 @@ behaviour, we need to move all of this dangerous logic outside
 of the move call and into an appropriate place in the tick method.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a935f61273527c32277f511ab35ce6615adfc97d..28131052a9e6e2646e37f930199c7e8e47e8f071 100644
+index f7542d053be38298229719bd63e950fc6d167fb9..1030a835086591bcc166ef1e52db8b7a62da5292 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1332,6 +1332,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1329,6 +1329,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                              this.player.move(MoverType.PLAYER, new Vec3(d7, d8, d9));
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move

--- a/patches/server/0446-Add-and-implement-PlayerRecipeBookClickEvent.patch
+++ b/patches/server/0446-Add-and-implement-PlayerRecipeBookClickEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add and implement PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 28131052a9e6e2646e37f930199c7e8e47e8f071..85e40e0086638b22fb69dc143803632e69dfe873 100644
+index 1030a835086591bcc166ef1e52db8b7a62da5292..25d392d89a461c6b5dea1d14134666927bee5d46 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2784,9 +2784,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2780,9 +2780,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          this.player.resetLastActionTime();
          if (!this.player.isSpectator() && this.player.containerMenu.containerId == packet.getContainerId() && this.player.containerMenu instanceof RecipeBookMenu) {

--- a/patches/server/0448-Add-permission-for-command-blocks.patch
+++ b/patches/server/0448-Add-permission-for-command-blocks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add permission for command blocks
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index d87ee258db769bc072cbdae4298ebc08588b2160..29809127da2961858142bfb5b54c6db1ad4d4f0f 100644
+index 391e20c284b24f6c5fe446fd6a2c677214ed15c5..954aa104912cfb65b663ca49f64fd2b59da99c55 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -391,7 +391,7 @@ public class ServerPlayerGameMode {
+@@ -393,7 +393,7 @@ public class ServerPlayerGameMode {
              BlockEntity tileentity = this.level.getBlockEntity(pos);
              Block block = iblockdata.getBlock();
  
@@ -18,10 +18,10 @@ index d87ee258db769bc072cbdae4298ebc08588b2160..29809127da2961858142bfb5b54c6db1
                  return false;
              } else if (this.player.blockActionRestricted(this.level, pos, this.gameModeForPlayer)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f6007a34b56c80e96aa29def9c070f717b61c5ed..7975508532fc0e97b10eca88e43aefe3af711c0f 100644
+index 25d392d89a461c6b5dea1d14134666927bee5d46..ec784bb54f7e4b4cb90a64e636392a752302cf86 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -788,7 +788,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -785,7 +785,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (!this.server.isCommandBlockEnabled()) {
              this.player.sendMessage(new TranslatableComponent("advMode.notEnabled"), Util.NIL_UUID);
@@ -30,7 +30,7 @@ index f6007a34b56c80e96aa29def9c070f717b61c5ed..7975508532fc0e97b10eca88e43aefe3
              this.player.sendMessage(new TranslatableComponent("advMode.notAllowed"), Util.NIL_UUID);
          } else {
              BaseCommandBlock commandblocklistenerabstract = null;
-@@ -855,7 +855,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -852,7 +852,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (!this.server.isCommandBlockEnabled()) {
              this.player.sendMessage(new TranslatableComponent("advMode.notEnabled"), Util.NIL_UUID);

--- a/patches/server/0449-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0449-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8e59a63e8c161e90ccff951ecb2b6530fadf3b80..df02a649ca99218745b7cd38e34edcabc2987255 100644
+index 9a4454746452f64d7a8caa52eef2dca86e9edd94..362b509c6d2df8061ba7fac51373490554843c30 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -595,8 +595,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -19,7 +19,7 @@ index 8e59a63e8c161e90ccff951ecb2b6530fadf3b80..df02a649ca99218745b7cd38e34edcab
      }
  
      protected AABB makeBoundingBox() {
-@@ -3786,6 +3786,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3792,6 +3792,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public final void setPosRaw(double x, double y, double z) {
@@ -31,7 +31,7 @@ index 8e59a63e8c161e90ccff951ecb2b6530fadf3b80..df02a649ca99218745b7cd38e34edcab
          if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
-@@ -3808,6 +3813,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3814,6 +3819,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              }
          }
  

--- a/patches/server/0450-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0450-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -94,10 +94,10 @@ index 2f13055a39c26fe12d2c1094103186635e536166..6b0cb662d9163c360035e19c5faad59f
  
                  playerlist.sendPlayerPermissionLevel(this);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 707f44c0245fdc9532a487353ebd9099151f1de5..f33410709dbd36adf1f126d698d2b87145c5d404 100644
+index ec784bb54f7e4b4cb90a64e636392a752302cf86..1486ac77bf4621a3a2a5da6d53461bada44c27c1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3039,7 +3039,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3035,7 +3035,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleChangeDifficulty(ServerboundChangeDifficultyPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (this.player.hasPermissions(2) || this.isSingleplayerOwner()) {
@@ -107,10 +107,10 @@ index 707f44c0245fdc9532a487353ebd9099151f1de5..f33410709dbd36adf1f126d698d2b871
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ed4e566cd18de4f58fcbb54cf2b6ed5ce4895d0a..52fabc8cd1b76a825a13d39f38ca982e252cb39b 100644
+index ac582976fb2cc3edd258d004a8e9a7325b975fee..f796194c1c7cc8a656eef0f50b83ce7b7898e895 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -942,8 +942,8 @@ public final class CraftServer implements Server {
+@@ -947,8 +947,8 @@ public final class CraftServer implements Server {
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
          com.destroystokyo.paper.PaperConfig.init((File) console.options.valueOf("paper-settings")); // Paper
          for (ServerLevel world : this.console.getAllLevels()) {
@@ -118,6 +118,6 @@ index ed4e566cd18de4f58fcbb54cf2b6ed5ce4895d0a..52fabc8cd1b76a825a13d39f38ca982e
 -            world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 +            // world.serverLevelData.setDifficulty(config.difficulty); // Paper - per level difficulty
 +            world.setSpawnSettings(world.serverLevelData.getDifficulty() != Difficulty.PEACEFUL && config.spawnMonsters, config.spawnAnimals); // Paper - per level difficulty (from MinecraftServer#setDifficulty(ServerLevel, Difficulty, boolean))
-             if (this.getTicksPerAnimalSpawns() < 0) {
-                 world.ticksPerAnimalSpawns = 400;
-             } else {
+ 
+             for (SpawnCategory spawnCategory : SpawnCategory.values()) {
+                 if (CraftSpawnCategory.isValidForLimits(spawnCategory)) {

--- a/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,11 +22,11 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 52fabc8cd1b76a825a13d39f38ca982e252cb39b..54598af96488c47b613de8eb8eb0bf31ea84743f 100644
+index f796194c1c7cc8a656eef0f50b83ce7b7898e895..e41cbccb533327f8ab159f30be81a1cbeb5d37c3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -372,7 +372,7 @@ public final class CraftServer implements Server {
-         this.ambientSpawn = this.configuration.getInt("spawn-limits.ambient");
+@@ -361,7 +361,7 @@ public final class CraftServer implements Server {
+         this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
 -        TicketType.PLUGIN.timeout = this.configuration.getInt("chunk-gc.period-in-ticks");
@@ -34,9 +34,9 @@ index 52fabc8cd1b76a825a13d39f38ca982e252cb39b..54598af96488c47b613de8eb8eb0bf31
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
      }
-@@ -922,7 +922,7 @@ public final class CraftServer implements Server {
-         this.waterUndergroundCreatureSpawn = this.configuration.getInt("spawn-limits.water-underground-creature");
-         this.ambientSpawn = this.configuration.getInt("spawn-limits.ambient");
+@@ -927,7 +927,7 @@ public final class CraftServer implements Server {
+         this.console.setMotd(config.motd);
+         this.overrideSpawnLimits();
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
 -        TicketType.PLUGIN.timeout = this.configuration.getInt("chunk-gc.period-in-ticks");
 +        TicketType.PLUGIN.timeout = Math.min(20, configuration.getInt("chunk-gc.period-in-ticks")); // Paper - cap plugin loads to 1 second
@@ -44,10 +44,10 @@ index 52fabc8cd1b76a825a13d39f38ca982e252cb39b..54598af96488c47b613de8eb8eb0bf31
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0ef9fc9cecdefcec3369c45643e474c16a588cea..bcb3a7e64f317732c8c758d4e743d84233bdafa6 100644
+index fe35d72dd2e13bce16c7b02d726144ff6cb2ecbe..fd82082326e9f4c572803ba1f525c7125a89222a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -268,8 +268,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -265,8 +265,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -70,7 +70,7 @@ index 0ef9fc9cecdefcec3369c45643e474c16a588cea..bcb3a7e64f317732c8c758d4e743d842
  
      @Override
      public Chunk getChunkAt(Block block) {
-@@ -336,7 +349,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -333,7 +346,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (this.isChunkLoaded(x, z)) {
@@ -79,7 +79,7 @@ index 0ef9fc9cecdefcec3369c45643e474c16a588cea..bcb3a7e64f317732c8c758d4e743d842
          }
  
          return true;
-@@ -414,9 +427,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -411,9 +424,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -93,7 +93,7 @@ index 0ef9fc9cecdefcec3369c45643e474c16a588cea..bcb3a7e64f317732c8c758d4e743d842
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -424,7 +440,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -421,7 +437,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -102,7 +102,7 @@ index 0ef9fc9cecdefcec3369c45643e474c16a588cea..bcb3a7e64f317732c8c758d4e743d842
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -450,7 +466,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -447,7 +463,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -111,7 +111,7 @@ index 0ef9fc9cecdefcec3369c45643e474c16a588cea..bcb3a7e64f317732c8c758d4e743d842
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -1935,6 +1951,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1968,6 +1984,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);

--- a/patches/server/0465-Add-entity-liquid-API.patch
+++ b/patches/server/0465-Add-entity-liquid-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index df02a649ca99218745b7cd38e34edcabc2987255..cc60127472ce47659acc35caea5a924ce54bc06b 100644
+index 362b509c6d2df8061ba7fac51373490554843c30..0b54c4e229aab803683101d7e2b1780ae41b42e0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1359,7 +1359,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -17,10 +17,10 @@ index df02a649ca99218745b7cd38e34edcabc2987255..cc60127472ce47659acc35caea5a924c
          return this.isInWater() || this.isInRain() || this.isInBubbleColumn();
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index d7dabaa5087f87b97a2e66b871fb618918eb568b..7f9409bf8c3cc39376d9da04440f124958df401a 100644
+index c066be9b92d73de66ee3f1ef6aa8910de4589210..1fb0d345b0b22d40d9313f35c792c646533da008 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1236,5 +1236,29 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1243,5 +1243,29 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason() {
          return getHandle().spawnReason;
      }

--- a/patches/server/0468-Add-PrepareResultEvent.patch
+++ b/patches/server/0468-Add-PrepareResultEvent.patch
@@ -8,7 +8,7 @@ Adds a new event for all crafting stations that generate a result slot item
 Anvil, Grindstone and Smithing now extend this event
 
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index 6b9c39b85e3a21fc0073fc15c8a76c92f75d2487..b40377e882d9cc3571f527e706862e27c59b1fd0 100644
+index b11e15d616e5584873895e076514e535289a24ed..0b60523861bbc1cd9f48207c9f5251b5659c6f24 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 @@ -316,6 +316,7 @@ public class AnvilMenu extends ItemCombinerMenu {
@@ -94,10 +94,10 @@ index cdebd0cdf6eb901464cf4c16089b10ea0147b54d..221b6ffb426edc034183dbaf37de29c6
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0d1524d6589a8055bcccd53f19bebc99553ccbe4..63f742a79e28e9e86eba01dc5a5029b5ea97158e 100644
+index aca2b2596a43927222f9894cc2f907cae2a331c1..d031eb1976cc50c0733cfef98404bc5b3fd152cb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1583,19 +1583,44 @@ public class CraftEventFactory {
+@@ -1593,19 +1593,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -711,7 +711,7 @@ index cd81e7844c985d7d0f0930faa96478af6a7f6cd4..1744f4983b24a87f3861ebd5d68120cf
          Ticket<ChunkPos> ticket = new Ticket<>(TicketType.FORCED, 31, pos);
          long i = pos.toLong();
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 43136d3a679f1e00ce21ee185cc50e1338ee7a74..16a16668db466ade3b162197600acdb1492fc822 100644
+index fdc027bc5a7e9d691ac90c5fee0cdfebd959bc5f..0eca545278568f5521bd721ff5bdcd7090c75e6e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -601,6 +601,26 @@ public class ServerChunkCache extends ChunkSource {
@@ -1151,7 +1151,7 @@ index d06e43bfaf8d22e0374bb6ed2e62c65e15699ef5..373f1c600ecdf75293dbe5ff6ef676a0
              if (updatingChunk != null) {
                  return updatingChunk.getEntityTickingChunkFuture();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index cc60127472ce47659acc35caea5a924ce54bc06b..edea3cbfe1856df0f6d32a70cac5de16abc2018a 100644
+index 0b54c4e229aab803683101d7e2b1780ae41b42e0..cd1e850c1d55d203ecba40719a0578a69c33492c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -228,7 +228,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -1193,10 +1193,10 @@ index 6eaba33b7730d66bf631b6d5c6a7080f9f019f8b..8e03e63a00dd242791ba0d5a8a179222
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index bcb3a7e64f317732c8c758d4e743d84233bdafa6..336e65216f582a4393df07ace2eaf6ecc0c57e2e 100644
+index fd82082326e9f4c572803ba1f525c7125a89222a..fe200e3694bd80da4e8715ee72247a5e04a47e41 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1949,6 +1949,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1982,6 +1982,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return future;
          }
  
@@ -1210,10 +1210,10 @@ index bcb3a7e64f317732c8c758d4e743d84233bdafa6..336e65216f582a4393df07ace2eaf6ec
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 62341d1c88d6595fa27e70985abb42f2521235cf..26d784b974ee25b4d26e52822162d7998f45c640 100644
+index 0a9d519596b074fd88fc3594d673189ef2c5e3d9..6ae1b3e95783a0692a72a3754edb1850cd2dc83a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -925,6 +925,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -927,6 +927,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
      }
  

--- a/patches/server/0475-Move-range-check-for-block-placing-up.patch
+++ b/patches/server/0475-Move-range-check-for-block-placing-up.patch
@@ -5,17 +5,19 @@ Subject: [PATCH] Move range check for block placing up
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f33410709dbd36adf1f126d698d2b87145c5d404..67f0a953751707f982df958e88c825ea98f4f984 100644
+index 1486ac77bf4621a3a2a5da6d53461bada44c27c1..93f190cb2ccf59230a453356100e8e15fc174cc0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1677,6 +1677,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1674,6 +1674,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      }
      // Spigot end
  
 +    // Paper start
++    private static final int SURVIVAL_PLACE_DISTANCE_SQUARED = 6 * 6;
++    private static final int CREATIVE_PLACE_DISTANCE_SQUARED = 7 * 7;
 +    private boolean isOutsideOfReach(double x, double y, double z) {
 +        Location eyeLoc = this.getCraftPlayer().getEyeLocation();
-+        double reachDistance = NumberConversions.square(eyeLoc.getX() - x) + NumberConversions.square(eyeLoc.getY() - y) + NumberConversions.square(eyeLoc.getZ() - z);
++        double reachDistance = org.bukkit.util.NumberConversions.square(eyeLoc.getX() - x) + org.bukkit.util.NumberConversions.square(eyeLoc.getY() - y) + org.bukkit.util.NumberConversions.square(eyeLoc.getZ() - z);
 +        return reachDistance > (this.getCraftPlayer().getGameMode() == org.bukkit.GameMode.CREATIVE ? CREATIVE_PLACE_DISTANCE_SQUARED : SURVIVAL_PLACE_DISTANCE_SQUARED);
 +    }
 +    // Paper end
@@ -23,31 +25,27 @@ index f33410709dbd36adf1f126d698d2b87145c5d404..67f0a953751707f982df958e88c825ea
      @Override
      public void handleUseItemOn(ServerboundUseItemOnPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
-@@ -1689,17 +1697,22 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
-         BlockPos blockposition = movingobjectpositionblock.getBlockPos();
-         Direction enumdirection = movingobjectpositionblock.getDirection();
+@@ -1688,15 +1698,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
-+        // Paper start - move check up and check actual location as well
+         this.player.resetLastActionTime();
+         int i = this.player.level.getMaxBuildHeight();
+-        // CraftBukkit start
+-        double distanceSqr = this.player.distanceToSqr((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D);
+-        if (distanceSqr > 100.0D) {
++
++        // Paper start - improve distance check
 +        final Vec3 clickedLocation = movingobjectpositionblock.getLocation();
 +        if (isOutsideOfReach(blockposition.getX() + 0.5D, blockposition.getY() + 0.5D, blockposition.getZ() + 0.5D)
 +            || !Double.isFinite(clickedLocation.x) || !Double.isFinite(clickedLocation.y) || !Double.isFinite(clickedLocation.z)
 +            || isOutsideOfReach(clickedLocation.x, clickedLocation.y, clickedLocation.z)) {
-+            return;
-+        }
-+        // Paper end - move check up
-+
-         this.player.resetLastActionTime();
-         int i = this.player.level.getMaxBuildHeight();
+             return;
+         }
+-        // CraftBukkit end
++        // Paper end
  
          if (blockposition.getY() < i) {
-             if (this.awaitingPositionFromClient == null && this.player.distanceToSqr((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D) < 64.0D && worldserver.mayInteract(this.player, blockposition)) {
-                 // CraftBukkit start - Check if we can actually do something over this large a distance
--                Location eyeLoc = this.getCraftPlayer().getEyeLocation();
--                double reachDistance = NumberConversions.square(eyeLoc.getX() - blockposition.getX()) + NumberConversions.square(eyeLoc.getY() - blockposition.getY()) + NumberConversions.square(eyeLoc.getZ() - blockposition.getZ());
--                if (reachDistance > (this.getCraftPlayer().getGameMode() == org.bukkit.GameMode.CREATIVE ? ServerGamePacketListenerImpl.CREATIVE_PLACE_DISTANCE_SQUARED : ServerGamePacketListenerImpl.SURVIVAL_PLACE_DISTANCE_SQUARED)) {
--                    return;
--                }
-+                // Paper - move check up
-                 this.player.stopUsingItem(); // SPIGOT-4706
-                 // CraftBukkit end
+-            if (this.awaitingPositionFromClient == null && distanceSqr < 64.0D && worldserver.mayInteract(this.player, blockposition)) { // CraftBukkit - reuse value
++            if (this.awaitingPositionFromClient == null && this.player.distanceToSqr((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D) < 64.0D && worldserver.mayInteract(this.player, blockposition)) { // CraftBukkit - reuse value // Paper - revert CB change
+                 this.player.stopUsingItem(); // CraftBukkit - SPIGOT-4706
                  InteractionResult enuminteractionresult = this.player.gameMode.useItemOn(this.player, worldserver, itemstack, enumhand, movingobjectpositionblock);
+ 

--- a/patches/server/0480-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/patches/server/0480-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 336e65216f582a4393df07ace2eaf6ecc0c57e2e..2cd0185f607e39d445da3f5952d7f6f3b2cd7520 100644
+index fe200e3694bd80da4e8715ee72247a5e04a47e41..9e7a85441890d71a3ac6037a5444d62d112acd28 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2021,6 +2021,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2054,6 +2054,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
              lightning.visualOnly = true;
              lightning.isSilent = isSilent;

--- a/patches/server/0484-Brand-support.patch
+++ b/patches/server/0484-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 67f0a953751707f982df958e88c825ea98f4f984..bbfcadfd3316f2617288b1dd48d145b266b29cfe 100644
+index 93f190cb2ccf59230a453356100e8e15fc174cc0..d43b3433879bcfad7ceca6bc67c5d101438c4dfb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
@@ -24,7 +24,7 @@ index 67f0a953751707f982df958e88c825ea98f4f984..bbfcadfd3316f2617288b1dd48d145b2
  import net.minecraft.network.chat.ChatType;
  import net.minecraft.network.chat.Component;
  import net.minecraft.network.chat.MutableComponent;
-@@ -258,6 +260,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -257,6 +259,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      private static final int MAX_SIGN_LINE_LENGTH = Integer.getInteger("Paper.maxSignLength", 80);
      private static final long KEEPALIVE_LIMIT = Long.getLong("paper.playerconnection.keepalive", 30) * 1000; // Paper - provide property to set keepalive limit
  
@@ -33,7 +33,7 @@ index 67f0a953751707f982df958e88c825ea98f4f984..bbfcadfd3316f2617288b1dd48d145b2
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
          this.server = server;
          this.connection = connection;
-@@ -3007,6 +3011,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3003,6 +3007,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      private static final ResourceLocation CUSTOM_REGISTER = new ResourceLocation("register");
      private static final ResourceLocation CUSTOM_UNREGISTER = new ResourceLocation("unregister");
  
@@ -42,7 +42,7 @@ index 67f0a953751707f982df958e88c825ea98f4f984..bbfcadfd3316f2617288b1dd48d145b2
      @Override
      public void handleCustomPayload(ServerboundCustomPayloadPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
-@@ -3034,6 +3040,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3030,6 +3036,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              try {
                  byte[] data = new byte[packet.data.readableBytes()];
                  packet.data.readBytes(data);
@@ -58,7 +58,7 @@ index 67f0a953751707f982df958e88c825ea98f4f984..bbfcadfd3316f2617288b1dd48d145b2
                  this.cserver.getMessenger().dispatchIncomingMessage(this.player.getBukkitEntity(), packet.identifier.toString(), data);
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
-@@ -3043,6 +3058,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3039,6 +3054,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      }
  
@@ -72,10 +72,10 @@ index 67f0a953751707f982df958e88c825ea98f4f984..bbfcadfd3316f2617288b1dd48d145b2
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 26d784b974ee25b4d26e52822162d7998f45c640..8dc8b4984b745355491760196ca4e25a944a6cae 100644
+index 6ae1b3e95783a0692a72a3754edb1850cd2dc83a..faa942e08d7614755824329b2c8eba7ba7cbcbc5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2591,6 +2591,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2593,6 +2593,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0485-Add-setMaxPlayers-API.patch
+++ b/patches/server/0485-Add-setMaxPlayers-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 98c70121c53e42e3c9bc7403eed83335f567bc74..ba46e9eafab188455d49f1a555e38b0ebe66fcf9 100644
+index 8ed4d4bc6d08c8339aba57b17f068c7bef22787c..35cf9c8235534a5c59065718ff57873f9c00bfdc 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -144,7 +144,7 @@ public abstract class PlayerList {
@@ -18,10 +18,10 @@ index 98c70121c53e42e3c9bc7403eed83335f567bc74..ba46e9eafab188455d49f1a555e38b0e
      private int simulationDistance;
      private boolean allowCheatsForAllPlayers;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 54598af96488c47b613de8eb8eb0bf31ea84743f..5e3397c8066dacdc1ebcbef57ecf4af0596cc02d 100644
+index e41cbccb533327f8ab159f30be81a1cbeb5d37c3..c9c569a917132ea82edf905f8f76a33576554780 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -673,6 +673,13 @@ public final class CraftServer implements Server {
+@@ -670,6 +670,13 @@ public final class CraftServer implements Server {
          return this.playerList.getMaxPlayers();
      }
  

--- a/patches/server/0488-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0488-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -17,10 +17,10 @@ index b27fb07aacb66259f640de5c5aa6849eb7e8cc9c..74044db6497071debf8ad02829876e41
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig.keepLoadedRange, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2cd0185f607e39d445da3f5952d7f6f3b2cd7520..31e5ee79c92aa50182ccf4af5489ffa1407923af 100644
+index 9e7a85441890d71a3ac6037a5444d62d112acd28..60b494370908819b9e22df17c81b8b14c490695d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -249,11 +249,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -246,11 +246,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {
              Location previousLocation = this.getSpawnLocation();

--- a/patches/server/0489-Add-moon-phase-API.patch
+++ b/patches/server/0489-Add-moon-phase-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add moon phase API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 31e5ee79c92aa50182ccf4af5489ffa1407923af..11f0c423c240b447af72b2a413164c15a36b52c4 100644
+index 60b494370908819b9e22df17c81b8b14c490695d..cd3ddf4405e7f061758e6ef24fff522cdf96a513 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -187,6 +187,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -184,6 +184,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getPlayerCount() {
          return world.players().size();
      }

--- a/patches/server/0503-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0503-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -9,10 +9,10 @@ as this is how Vanilla teleports entities.
 Cancel any pending motion when teleported.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index bbfcadfd3316f2617288b1dd48d145b266b29cfe..eed7b0107f8910f8982d83a7081cf3c2cfe055fd 100644
+index d43b3433879bcfad7ceca6bc67c5d101438c4dfb..b87208de4204c789c9e1e9eaa588997bab7bb8d8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -682,7 +682,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -679,7 +679,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleAcceptTeleportPacket(ServerboundAcceptTeleportationPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (packet.getId() == this.awaitingTeleport && this.awaitingPositionFromClient != null) { // CraftBukkit
@@ -21,7 +21,7 @@ index bbfcadfd3316f2617288b1dd48d145b266b29cfe..eed7b0107f8910f8982d83a7081cf3c2
              this.lastGoodX = this.awaitingPositionFromClient.x;
              this.lastGoodY = this.awaitingPositionFromClient.y;
              this.lastGoodZ = this.awaitingPositionFromClient.z;
-@@ -1565,7 +1565,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1562,7 +1562,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // CraftBukkit end
  
          this.awaitingTeleportTime = this.tickCount;
@@ -31,7 +31,7 @@ index bbfcadfd3316f2617288b1dd48d145b266b29cfe..eed7b0107f8910f8982d83a7081cf3c2
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index edea3cbfe1856df0f6d32a70cac5de16abc2018a..707018a230e8f27e701c60bc7029d64c045d8bfc 100644
+index cd1e850c1d55d203ecba40719a0578a69c33492c..f91b4081bb2d9e86cb6f1c3ab3eb654a83bf1dbe 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -151,6 +151,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -69,10 +69,10 @@ index c0f33a6cb4812e13204552c125df06210adc7196..03726227fdd60e9cf77213d50184abff
                          if (entity instanceof Mob) {
                              Mob entityinsentient = (Mob) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 7f9409bf8c3cc39376d9da04440f124958df401a..d0ad0e6bbb944a33fd67a7d3e36958407a774ede 100644
+index 1fb0d345b0b22d40d9313f35c792c646533da008..27c48e853ee93ab8eeb27560666fafc1057585be 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -577,7 +577,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -579,7 +579,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          }
  
          // entity.setLocation() throws no event, and so cannot be cancelled

--- a/patches/server/0506-Extend-block-drop-capture-to-capture-all-items-added.patch
+++ b/patches/server/0506-Extend-block-drop-capture-to-capture-all-items-added.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Extend block drop capture to capture all items added to the
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 230ee6dd71e55921960a81d7b3aedbc804f785e5..1a79c9767dd6e207653d59532b00742a1d85f314 100644
+index 74044db6497071debf8ad02829876e410ee4090e..0312d888c89e8d7f85cf510a653e9e08a0d08d82 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1260,6 +1260,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -24,10 +24,10 @@ index 230ee6dd71e55921960a81d7b3aedbc804f785e5..1a79c9767dd6e207653d59532b00742a
                  return false;
              }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 29809127da2961858142bfb5b54c6db1ad4d4f0f..aa065f732637b6220fd7328b4d5bc6005ee31832 100644
+index 954aa104912cfb65b663ca49f64fd2b59da99c55..84cf2f3584858a8729b26de1605a7626abe73923 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -423,10 +423,12 @@ public class ServerPlayerGameMode {
+@@ -425,10 +425,12 @@ public class ServerPlayerGameMode {
                      // return true; // CraftBukkit
                  }
                  // CraftBukkit start

--- a/patches/server/0508-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0508-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 707018a230e8f27e701c60bc7029d64c045d8bfc..2eb56ba2ecf49754e3b6229a798f837a4aa099da 100644
+index f91b4081bb2d9e86cb6f1c3ab3eb654a83bf1dbe..046f68a7736a9897789ee1a08465ffdea24c8dc0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3986,4 +3986,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3992,4 +3992,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0510-Entity-isTicking.patch
+++ b/patches/server/0510-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2eb56ba2ecf49754e3b6229a798f837a4aa099da..2c68dbfc38e9d9b7bb6cecb790d4d72fc2015a7f 100644
+index 046f68a7736a9897789ee1a08465ffdea24c8dc0..56c138d69423cd7fc99003ff4ddf124ede1c5b95 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -53,6 +53,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index 2eb56ba2ecf49754e3b6229a798f837a4aa099da..2c68dbfc38e9d9b7bb6cecb790d4d72f
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -3991,5 +3992,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3997,5 +3998,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }
@@ -27,10 +27,10 @@ index 2eb56ba2ecf49754e3b6229a798f837a4aa099da..2c68dbfc38e9d9b7bb6cecb790d4d72f
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index d0ad0e6bbb944a33fd67a7d3e36958407a774ede..c2d92e0eb65b2a70fcae12b09e5a105cc820894f 100644
+index 27c48e853ee93ab8eeb27560666fafc1057585be..ff890a42f1d67e197f4aac5d76a18527bae5b79d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1260,5 +1260,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1267,5 +1267,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean isInLava() {
          return getHandle().isInLava();
      }

--- a/patches/server/0514-Fix-for-large-move-vectors-crashing-server.patch
+++ b/patches/server/0514-Fix-for-large-move-vectors-crashing-server.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix for large move vectors crashing server
 Check movement distance also based on current position.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index eed7b0107f8910f8982d83a7081cf3c2cfe055fd..4e34ec168463f41f374c02ff09a7718a001f8670 100644
+index b87208de4204c789c9e1e9eaa588997bab7bb8d8..3ab42e5c83d96f05f60c53a200b579193b4b57fa 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -507,20 +507,31 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -504,20 +504,31 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              if (entity != this.player && entity.getControllingPassenger() == this.player && entity == this.lastVehicle) {
                  ServerLevel worldserver = this.player.getLevel();
@@ -49,7 +49,7 @@ index eed7b0107f8910f8982d83a7081cf3c2cfe055fd..4e34ec168463f41f374c02ff09a7718a
  
                  // CraftBukkit start - handle custom speeds and skipped ticks
                  this.allowedPlayerTicks += (System.currentTimeMillis() / 50) - this.lastTick;
-@@ -563,9 +574,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -560,9 +571,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                  boolean flag = worldserver.noCollision(entity, entity.getBoundingBox().deflate(0.0625D));
  
@@ -62,7 +62,7 @@ index eed7b0107f8910f8982d83a7081cf3c2cfe055fd..4e34ec168463f41f374c02ff09a7718a
                  entity.move(MoverType.PLAYER, new Vec3(d6, d7, d8));
                  double d11 = d7;
  
-@@ -1239,14 +1250,25 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1236,14 +1247,25 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          float prevPitch = this.player.getXRot();
                          // CraftBukkit end
                          double d3 = this.player.getX(); final double toX = d3; // Paper - OBFHELPER
@@ -90,7 +90,7 @@ index eed7b0107f8910f8982d83a7081cf3c2cfe055fd..4e34ec168463f41f374c02ff09a7718a
  
                          if (this.player.isSleeping()) {
                              if (d11 > 1.0D) {
-@@ -1298,9 +1320,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1295,9 +1317,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                              AABB axisalignedbb = this.player.getBoundingBox();
  

--- a/patches/server/0518-Retain-block-place-order-when-capturing-blockstates.patch
+++ b/patches/server/0518-Retain-block-place-order-when-capturing-blockstates.patch
@@ -10,15 +10,15 @@ In general, look at making this logic more robust (i.e properly handling
 cases where a captured entry is overriden) - but for now this will do.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ad9b48a0c89689a602c85f65e6cc68977af5ea29..c76b508026c5ad54879ba400a9b6f8287f3f95b8 100644
+index eec0e1b28f90083ac2422d0c61ceed2b26a9a25d..043b43dbb21c7086031353d146a596e126e35162 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -149,7 +149,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -151,7 +151,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean captureBlockStates = false;
      public boolean captureTreeGeneration = false;
      public Map<BlockPos, org.bukkit.craftbukkit.block.CraftBlockState> capturedBlockStates = new java.util.LinkedHashMap<>(); // Paper
 -    public Map<BlockPos, BlockEntity> capturedTileEntities = new HashMap<>();
 +    public Map<BlockPos, BlockEntity> capturedTileEntities = new java.util.LinkedHashMap<>(); // Paper
      public List<ItemEntity> captureDrops;
-     public long ticksPerAnimalSpawns;
-     public long ticksPerMonsterSpawns;
+     public final it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<SpawnCategory> ticksPerSpawnCategory = new it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap<>();
+     // Paper start

--- a/patches/server/0521-Player-elytra-boost-API.patch
+++ b/patches/server/0521-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8dc8b4984b745355491760196ca4e25a944a6cae..d606ceb051496cae03c10e1dfac5ceffa5d2d9d1 100644
+index faa942e08d7614755824329b2c8eba7ba7cbcbc5..6a5813e56ba06be7b8dbebd6d23c373bd4b5dfe6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -567,6 +567,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -569,6 +569,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/patches/server/0524-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0524-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5e3397c8066dacdc1ebcbef57ecf4af0596cc02d..93faeef65f846fdb472204709093ebcdba790dce 100644
+index c9c569a917132ea82edf905f8f76a33576554780..d3c98840ca493259417ab435f8cc70c7e181648d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1820,6 +1820,28 @@ public final class CraftServer implements Server {
+@@ -1801,6 +1801,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0531-Add-API-for-quit-reason.patch
+++ b/patches/server/0531-Add-API-for-quit-reason.patch
@@ -37,10 +37,10 @@ index c68b95ef0d4c3e0d942e61bfccf23a00d0d8afd9..57ca53876941faf6a1cbefd6e0382ee0
      public ServerPlayer(MinecraftServer server, ServerLevel world, GameProfile profile) {
          super(world, world.getSharedSpawnPos(), world.getSharedSpawnAngle(), profile);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index da130b7f0da73eb9868539911ba3157b88fc7199..c321f22af679cafd00be09a9212346b5ccbc8dfc 100644
+index 3ab42e5c83d96f05f60c53a200b579193b4b57fa..64bd37e70997d1cbafa6a5f9b800352a7c105f28 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -444,6 +444,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -441,6 +441,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          final Component ichatbasecomponent = PaperAdventure.asVanilla(event.reason()); // Paper - Adventure
          // CraftBukkit end
  

--- a/patches/server/0534-Expose-world-spawn-angle.patch
+++ b/patches/server/0534-Expose-world-spawn-angle.patch
@@ -18,10 +18,10 @@ index e5ed9784b0e7d208604b41f51f1adf9c8f50fe08..8ce5f463f16857b5862b6e0a77c63d81
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 11f0c423c240b447af72b2a413164c15a36b52c4..147276e051be53276d788b0b3d68f1df48ddf7d5 100644
+index cd3ddf4405e7f061758e6ef24fff522cdf96a513..f192df45b1522d98f68c7c19301d783938c582e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -240,7 +240,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -237,7 +237,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public Location getSpawnLocation() {
          BlockPos spawn = this.world.getSharedSpawnPos();

--- a/patches/server/0536-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0536-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d606ceb051496cae03c10e1dfac5ceffa5d2d9d1..daec735dd2510d2cb3089036a341efd41f8f8aaa 100644
+index 6a5813e56ba06be7b8dbebd6d23c373bd4b5dfe6..f3665156fcd4058f630ae814de658f5e9d5b4e14 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2162,7 +2162,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2164,7 +2164,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0544-Limit-recipe-packets.patch
+++ b/patches/server/0544-Limit-recipe-packets.patch
@@ -23,10 +23,10 @@ index ec42fb00b6f4a691fa710c68131f80b242e3e6e8..d5ae781d65016e0382cb3497cb8cac20
      public static boolean velocityOnlineMode;
      public static byte[] velocitySecretKey;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 09f4354700a5c69159e6714063875a6bb06b8e5e..4a6305583250a4fb25888719e1ffb436bbf0314b 100644
+index 64bd37e70997d1cbafa6a5f9b800352a7c105f28..f93b6822f5180720849db4bd47c53366060bbe89 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -231,6 +231,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -230,6 +230,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      // CraftBukkit start - multithreaded fields
      private final AtomicInteger chatSpamTickCount = new AtomicInteger();
      private final java.util.concurrent.atomic.AtomicInteger tabSpamLimiter = new java.util.concurrent.atomic.AtomicInteger(); // Paper - configurable tab spam limits
@@ -34,7 +34,7 @@ index 09f4354700a5c69159e6714063875a6bb06b8e5e..4a6305583250a4fb25888719e1ffb436
      // CraftBukkit end
      private int dropSpamTickCount;
      private double firstGoodX;
-@@ -377,6 +378,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -374,6 +375,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // CraftBukkit start
          for (int spam; (spam = this.chatSpamTickCount.get()) > 0 && !this.chatSpamTickCount.compareAndSet(spam, spam - 1); ) ;
          if (tabSpamLimiter.get() > 0) tabSpamLimiter.getAndDecrement(); // Paper - split to seperate variable
@@ -42,7 +42,7 @@ index 09f4354700a5c69159e6714063875a6bb06b8e5e..4a6305583250a4fb25888719e1ffb436
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -2821,6 +2823,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2817,6 +2819,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handlePlaceRecipe(ServerboundPlaceRecipePacket packet) {

--- a/patches/server/0546-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0546-MC-4-Fix-item-position-desync.patch
@@ -43,10 +43,10 @@ index b30c08bfb8c55161543a4ef09f2e462e0a1fe4ae..ec93f5300cc7d423ec0d292f0f8443f9
  
      public Vec3 updateEntityPosition(Vec3 orig) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1cf13735a8c5dbfa71011012b271b3dc409a5f15..e64f17f859fc975fed07b86dfda2376018e97f6f 100644
+index 925f9b57e347bb609c159bb9d750a528ad2b87dd..6b1ea58389e32d6144e930adc72efeb4ba570d89 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3805,6 +3805,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3811,6 +3811,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
          // Paper end

--- a/patches/server/0550-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/patches/server/0550-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index dc65191f170954fbc93012bfc02401de36d8d1fd..0bfe25bd5dee6853d624af6988d2b72155aed8c0 100644
+index d031eb1976cc50c0733cfef98404bc5b3fd152cb..797e27f12a7d446442b35e0814254c4cc74b5907 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -262,6 +262,10 @@ public class CraftEventFactory {
+@@ -263,6 +263,10 @@ public class CraftEventFactory {
                          return BedEnterResult.TOO_FAR_AWAY;
                      case NOT_SAFE:
                          return BedEnterResult.NOT_SAFE;

--- a/patches/server/0561-Fix-interact-event-not-being-called-in-adventure.patch
+++ b/patches/server/0561-Fix-interact-event-not-being-called-in-adventure.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix interact event not being called in adventure
 Call PlayerInteractEvent when left-clicking on a block in adventure mode
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4a6305583250a4fb25888719e1ffb436bbf0314b..90eb1c56439bb1a87d03fcc92b0d0e6f8db6a317 100644
+index f93b6822f5180720849db4bd47c53366060bbe89..5d749940aad4634df2066f7e9228543adc2d61b2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1750,7 +1750,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1746,7 +1746,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                      MutableComponent ichatmutablecomponent = (new TranslatableComponent("build.tooHigh", new Object[]{i - 1})).withStyle(ChatFormatting.RED);
  
                      this.player.sendMessage(ichatmutablecomponent, ChatType.GAME_INFO, Util.NIL_UUID);
@@ -18,7 +18,7 @@ index 4a6305583250a4fb25888719e1ffb436bbf0314b..90eb1c56439bb1a87d03fcc92b0d0e6f
                      this.player.swing(enumhand, true);
                  }
              }
-@@ -2222,7 +2222,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2218,7 +2218,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          Vec3 vec3d1 = vec3d.add((double) f7 * d3, (double) f6 * d3, (double) f8 * d3);
          HitResult movingobjectposition = this.player.level.clip(new ClipContext(vec3d, vec3d1, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, this.player));
  

--- a/patches/server/0566-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0566-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 888d812118c15c212284687ae5842a94f5715d52..e7ca5d6fb8922e7e8065864f736b0605
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 147276e051be53276d788b0b3d68f1df48ddf7d5..7417b983b1c230e9a7f131bea978f0e0eaeb9e50 100644
+index f192df45b1522d98f68c7c19301d783938c582e7..706a1c37c81828ab570a7012f96a421d6c9977c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1754,8 +1754,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1787,8 +1787,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index 147276e051be53276d788b0b3d68f1df48ddf7d5..7417b983b1c230e9a7f131bea978f0e0
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1790,8 +1795,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1823,8 +1828,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0569-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0569-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 4ae21aa6fc91f527d3dca508588d8257961b8d24..b3203049eade7d11602fa2a12a8104a7
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ad095e2547bc247fb38f72a3197bb45d4e048824..7b3e709898f9da4e77c83485cd35633bc6cb5ed9 100644
+index 797e27f12a7d446442b35e0814254c4cc74b5907..74aa6f2a1a55b9049f912f3e87b9032565bbc4d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1857,4 +1857,12 @@ public class CraftEventFactory {
+@@ -1867,4 +1867,12 @@ public class CraftEventFactory {
          EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
      }

--- a/patches/server/0574-Implement-API-to-expose-exact-interaction-point.patch
+++ b/patches/server/0574-Implement-API-to-expose-exact-interaction-point.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement API to expose exact interaction point
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index aa065f732637b6220fd7328b4d5bc6005ee31832..e39e16f0b3a0d168b3049c37f5a2a9dc8f15a652 100644
+index 84cf2f3584858a8729b26de1605a7626abe73923..53a0e74de9d50e0ece28f9d73a96135012b5d645 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -499,7 +499,7 @@ public class ServerPlayerGameMode {
+@@ -501,7 +501,7 @@ public class ServerPlayerGameMode {
              cancelledBlock = true;
          }
  
@@ -18,7 +18,7 @@ index aa065f732637b6220fd7328b4d5bc6005ee31832..e39e16f0b3a0d168b3049c37f5a2a9dc
          this.interactResult = event.useItemInHand() == Event.Result.DENY;
          this.interactPosition = blockposition.immutable();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d4b772c1df839ad1ec2bfb514432ee1b12099193..bfc3442e7952e1ec927f3ebdbefba153e7304e19 100644
+index 74aa6f2a1a55b9049f912f3e87b9032565bbc4d3..6d5d42a40a42b0d1e8e80d802cd629dd2854ae9b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -56,7 +56,9 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
@@ -31,7 +31,7 @@ index d4b772c1df839ad1ec2bfb514432ee1b12099193..bfc3442e7952e1ec927f3ebdbefba153
  import org.bukkit.Material;
  import org.bukkit.NamespacedKey;
  import org.bukkit.Server;
-@@ -482,7 +484,13 @@ public class CraftEventFactory {
+@@ -483,7 +485,13 @@ public class CraftEventFactory {
          return CraftEventFactory.callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand);
      }
  
@@ -45,7 +45,7 @@ index d4b772c1df839ad1ec2bfb514432ee1b12099193..bfc3442e7952e1ec927f3ebdbefba153
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
  
-@@ -508,7 +516,10 @@ public class CraftEventFactory {
+@@ -509,7 +517,10 @@ public class CraftEventFactory {
              itemInHand = null;
          }
  

--- a/patches/server/0577-Add-sendOpLevel-API.patch
+++ b/patches/server/0577-Add-sendOpLevel-API.patch
@@ -32,10 +32,10 @@ index f4e74b0bc3d192d7f7c2bc1dbfef92a28863a57c..b7f3be857d9ffb166e99f20753dbc671
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index daec735dd2510d2cb3089036a341efd41f8f8aaa..5de0093188f3dd142ef478b2654f6bf48fa90d06 100644
+index f3665156fcd4058f630ae814de658f5e9d5b4e14..502af6311d8ca28f0c1af30ebf65d159eb13b505 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -581,6 +581,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -583,6 +583,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/patches/server/0584-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0584-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 07d357b5fcb30ed9ff074a196a19de1481fe3738..83ac86b3c1e7b9233f2db8e5488f97c5
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1a2a84c7044ab70de3fd632b0d04b33d827ce22e..5b9e76fbffa74b29f1a21374a74f46c917104fea 100644
+index 6d5d42a40a42b0d1e8e80d802cd629dd2854ae9b..97fd237a4fc31875fa66683c9ea8fed1fa794abf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1875,5 +1875,11 @@ public class CraftEventFactory {
+@@ -1885,5 +1885,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index cf932116a0cafd315e44159fbf7c5d25d43782ff..03bda898a5a263053ecd79f74799d370
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5b9e76fbffa74b29f1a21374a74f46c917104fea..7cde66a83f4abd4b25b7615139b1dd1cb2c746ce 100644
+index 97fd237a4fc31875fa66683c9ea8fed1fa794abf..66415d1e9690f1d644b73115b9873c52ef45e212 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1516,8 +1516,10 @@ public class CraftEventFactory {
+@@ -1526,8 +1526,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0595-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/patches/server/0595-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow adding items to BlockDropItemEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index afb6eb856d22845716351d5be7eff5991da72dd3..ee0e27500187d695ac6cfaf5fb5d2e844f230b32 100644
+index 66415d1e9690f1d644b73115b9873c52ef45e212..5c2beec59b0382d80bf97317cbbeab43df24ad55 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -395,13 +395,30 @@ public class CraftEventFactory {
+@@ -396,13 +396,30 @@ public class CraftEventFactory {
      }
  
      public static void handleBlockDropItemEvent(Block block, BlockState state, ServerPlayer player, List<ItemEntity> items) {

--- a/patches/server/0601-Expose-Tracked-Players.patch
+++ b/patches/server/0601-Expose-Tracked-Players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index c2d92e0eb65b2a70fcae12b09e5a105cc820894f..dd1a86ddbe54aa6c26fd81cfe42a7f89eca5899d 100644
+index ff890a42f1d67e197f4aac5d76a18527bae5b79d..49738cdb2f712d9ce76d3fff92b79e829bfa2370 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1264,5 +1264,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1271,5 +1271,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean isTicking() {
          return getHandle().isTicking();
      }

--- a/patches/server/0612-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0612-Allow-using-signs-inside-spawn-protection.patch
@@ -19,15 +19,15 @@ index 59675e523625b95169236bd0ead063cf0d87847e..bdd531806a4f006085be113c34b5780c
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 90eb1c56439bb1a87d03fcc92b0d0e6f8db6a317..e1b5b714d06a537ad7983d7647f2ce0f51545da7 100644
+index 5d749940aad4634df2066f7e9228543adc2d61b2..506d26fb19a94f08c88d148d555b9781217c699a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1739,7 +1739,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
-         int i = this.player.level.getMaxBuildHeight();
+@@ -1738,7 +1738,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+         // Paper end
  
          if (blockposition.getY() < i) {
--            if (this.awaitingPositionFromClient == null && this.player.distanceToSqr((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D) < 64.0D && worldserver.mayInteract(this.player, blockposition)) {
-+            if (this.awaitingPositionFromClient == null && this.player.distanceToSqr((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D) < 64.0D && (worldserver.mayInteract(this.player, blockposition) || (worldserver.paperConfig.allowUsingSignsInsideSpawnProtection && worldserver.getBlockState(blockposition).getBlock() instanceof net.minecraft.world.level.block.SignBlock))) { // Paper
-                 // CraftBukkit start - Check if we can actually do something over this large a distance
-                 // Paper - move check up
-                 this.player.stopUsingItem(); // SPIGOT-4706
+-            if (this.awaitingPositionFromClient == null && this.player.distanceToSqr((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D) < 64.0D && worldserver.mayInteract(this.player, blockposition)) { // CraftBukkit - reuse value // Paper - revert CB change
++            if (this.awaitingPositionFromClient == null && this.player.distanceToSqr((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D) < 64.0D && (worldserver.mayInteract(this.player, blockposition) || (worldserver.paperConfig.allowUsingSignsInsideSpawnProtection && worldserver.getBlockState(blockposition).getBlock() instanceof net.minecraft.world.level.block.SignBlock))) { // CraftBukkit - reuse value // Paper - revert CB change // Paper - sign check
+                 this.player.stopUsingItem(); // CraftBukkit - SPIGOT-4706
+                 InteractionResult enuminteractionresult = this.player.gameMode.useItemOn(this.player, worldserver, itemstack, enumhand, movingobjectpositionblock);
+ 

--- a/patches/server/0613-Implement-Keyed-on-World.patch
+++ b/patches/server/0613-Implement-Keyed-on-World.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 93faeef65f846fdb472204709093ebcdba790dce..28fb73ffd683a45b1d6be4b55116e861d0c2973c 100644
+index d3c98840ca493259417ab435f8cc70c7e181648d..b404fb1642fa4480f87ad675418c57c84944b3a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1257,7 +1257,7 @@ public final class CraftServer implements Server {
+@@ -1238,7 +1238,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -17,7 +17,7 @@ index 93faeef65f846fdb472204709093ebcdba790dce..28fb73ffd683a45b1d6be4b55116e861
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, dimensionmanager, this.getServer().progressListenerFactory.create(11),
-@@ -1349,6 +1349,15 @@ public final class CraftServer implements Server {
+@@ -1330,6 +1330,15 @@ public final class CraftServer implements Server {
          return null;
      }
  
@@ -34,10 +34,10 @@ index 93faeef65f846fdb472204709093ebcdba790dce..28fb73ffd683a45b1d6be4b55116e861
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7417b983b1c230e9a7f131bea978f0e0eaeb9e50..ecf67066669b7942f9373f760b75cfc36aab34e2 100644
+index 706a1c37c81828ab570a7012f96a421d6c9977c1..f6c531d416b4e85df88d0fbed5773cb0b9644c1d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1977,6 +1977,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2010,6 +2010,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return java.util.concurrent.CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
          }, net.minecraft.server.MinecraftServer.getServer());
      }

--- a/patches/server/0620-Don-t-ignore-result-of-PlayerEditBookEvent.patch
+++ b/patches/server/0620-Don-t-ignore-result-of-PlayerEditBookEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't ignore result of PlayerEditBookEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e1b5b714d06a537ad7983d7647f2ce0f51545da7..a58f7ed3e31bb4a4718ed2c1937cf12316939a08 100644
+index 506d26fb19a94f08c88d148d555b9781217c699a..5a7c0f201a4c84c8c8bf138b21e92b59946abff2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1184,7 +1184,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1181,7 +1181,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
  
          itemstack.addTagElement("pages", nbttaglist);

--- a/patches/server/0624-Allow-for-Component-suggestion-tooltips-in-AsyncTabC.patch
+++ b/patches/server/0624-Allow-for-Component-suggestion-tooltips-in-AsyncTabC.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow for Component suggestion tooltips in
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e3d0c7f357a579811de1b55d8fde018aa55fea47..acbaba8750c373b90f6af0fb592f7226ba1acf0e 100644
+index 5a7c0f201a4c84c8c8bf138b21e92b59946abff2..6c0c45ec3fd376a2863b54e49120db662d176491 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -764,12 +764,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -761,12 +761,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          // Paper start - async tab completion
          com.destroystokyo.paper.event.server.AsyncTabCompleteEvent event;
@@ -24,7 +24,7 @@ index e3d0c7f357a579811de1b55d8fde018aa55fea47..acbaba8750c373b90f6af0fb592f7226
          // If the event isn't handled, we can assume that we have no completions, and so we'll ask the server
          if (!event.isHandled()) {
              if (!event.isCancelled()) {
-@@ -788,10 +787,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -785,10 +784,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  });
              }
          } else if (!completions.isEmpty()) {

--- a/patches/server/0635-fix-PlayerItemHeldEvent-firing-twice.patch
+++ b/patches/server/0635-fix-PlayerItemHeldEvent-firing-twice.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] fix PlayerItemHeldEvent firing twice
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index de7728566223dcf60b5dcd4229e0550b95f568c0..6d9f224d28321e03a2e6d54ee3a50c1f9226a7c7 100644
+index 6c0c45ec3fd376a2863b54e49120db662d176491..1044534df2d8355d6485d08fa1f9b325bd165cda 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1943,6 +1943,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1939,6 +1939,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (this.player.isImmobile()) return; // CraftBukkit
          if (packet.getSlot() >= 0 && packet.getSlot() < Inventory.getSelectionSize()) {

--- a/patches/server/0637-More-World-API.patch
+++ b/patches/server/0637-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ecf67066669b7942f9373f760b75cfc36aab34e2..7119e59c228e6f3fa1cdb81a92a54a9e3dd1bc8e 100644
+index f6c531d416b4e85df88d0fbed5773cb0b9644c1d..364eb4abe7f51c716018b65389abed4ec5227ed6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1923,6 +1923,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1956,6 +1956,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0642-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/server/0642-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add RespawnFlags to PlayerRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6d9f224d28321e03a2e6d54ee3a50c1f9226a7c7..b63da79cacf05edacdd755ce78a22ecbb8347dad 100644
+index 1044534df2d8355d6485d08fa1f9b325bd165cda..7a76e5a83f98295bbac29b89e8b8900b38ed5bad 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2481,7 +2481,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2477,7 +2477,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              case PERFORM_RESPAWN:
                  if (this.player.wonGame) {
                      this.player.wonGame = false;

--- a/patches/server/0653-Add-basic-Datapack-API.patch
+++ b/patches/server/0653-Add-basic-Datapack-API.patch
@@ -92,10 +92,10 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 28fb73ffd683a45b1d6be4b55116e861d0c2973c..6513cb5f236d86097f078f8c72cc3d0a0ebc9617 100644
+index b404fb1642fa4480f87ad675418c57c84944b3a2..79f785b907e009de21b5299e6cc5c4cddc1b95d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -291,6 +291,7 @@ public final class CraftServer implements Server {
+@@ -284,6 +284,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -103,7 +103,7 @@ index 28fb73ffd683a45b1d6be4b55116e861d0c2973c..6513cb5f236d86097f078f8c72cc3d0a
      public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {
-@@ -375,6 +376,7 @@ public final class CraftServer implements Server {
+@@ -364,6 +365,7 @@ public final class CraftServer implements Server {
          TicketType.PLUGIN.timeout = Math.min(20, this.configuration.getInt("chunk-gc.period-in-ticks")); // Paper - cap plugin loads to 1 second
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
@@ -111,7 +111,7 @@ index 28fb73ffd683a45b1d6be4b55116e861d0c2973c..6513cb5f236d86097f078f8c72cc3d0a
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2701,5 +2703,11 @@ public final class CraftServer implements Server {
+@@ -2708,5 +2710,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0655-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0655-additions-to-PlayerGameModeChangeEvent.patch
@@ -93,7 +93,7 @@ index fd6eb3b3953ca0413af6a71c52503c9674917a9e..77ba7fe43ceffcb816d209da45ab0c5d
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index e39e16f0b3a0d168b3049c37f5a2a9dc8f15a652..1ca6dc1e9334bf7e03eab4c2a75f4c86c7d36a9f 100644
+index 53a0e74de9d50e0ece28f9d73a96135012b5d645..dcfb5fd1763979f081cc253716f518bc371dd546 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -72,18 +72,24 @@ public class ServerPlayerGameMode {
@@ -126,10 +126,10 @@ index e39e16f0b3a0d168b3049c37f5a2a9dc8f15a652..1ca6dc1e9334bf7e03eab4c2a75f4c86
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b63da79cacf05edacdd755ce78a22ecbb8347dad..a76f8a64d7ec492402b29bde4c2f0a4c556a35cf 100644
+index 7a76e5a83f98295bbac29b89e8b8900b38ed5bad..8a1041d8ef225131428cebf9e293563e540944bf 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2490,7 +2490,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2486,7 +2486,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                      this.player = this.server.getPlayerList().respawn(this.player, false);
                      if (this.server.isHardcore()) {
@@ -139,10 +139,10 @@ index b63da79cacf05edacdd755ce78a22ecbb8347dad..a76f8a64d7ec492402b29bde4c2f0a4c
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5de0093188f3dd142ef478b2654f6bf48fa90d06..09c2ac4c40b13019bcaccd3e8e34ac3d6fdd5363 100644
+index 502af6311d8ca28f0c1af30ebf65d159eb13b505..b542df24792f3fecb7b017db46555d38cacce15d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1285,7 +1285,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1287,7 +1287,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0658-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0658-Fix-and-optimise-world-force-upgrading.patch
@@ -274,7 +274,7 @@ index 3835a8340792837674bdbcd5583ce74446b0460b..e2c8f716af55ebb7e4233c2a3d6515f8
          Main.LOGGER.info("Forcing world upgrade! {}", session.getLevelId()); // CraftBukkit
          WorldUpgrader worldupgrader = new WorldUpgrader(session, dataFixer, generatorOptions, eraseCache);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5de82c5d7da2ca6eeee4b804b916fa9d385cc25c..e03018882da878ddc51986733cfd6ea1c1815e9b 100644
+index d5029567bfe6f34e175e06ff7dae0e4947b2600c..860540a50c3281ab35acffd845f536dadab285d7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -557,11 +557,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -306,10 +306,10 @@ index 5de82c5d7da2ca6eeee4b804b916fa9d385cc25c..e03018882da878ddc51986733cfd6ea1
  
              if (dimensionKey == LevelStem.OVERWORLD) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index c76b508026c5ad54879ba400a9b6f8287f3f95b8..b7f9d6682c1dc5f03ae363b782ae9346f5bbe841 100644
+index 043b43dbb21c7086031353d146a596e126e35162..980c0c391d4090da062650634276a418cf38c45e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -177,6 +177,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -174,6 +174,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions
      public java.util.ArrayDeque<net.minecraft.world.level.block.RedstoneTorchBlock.Toggle> redstoneUpdateInfos; // Paper - Move from Map in BlockRedstoneTorch to here
  
@@ -326,7 +326,7 @@ index c76b508026c5ad54879ba400a9b6f8287f3f95b8..b7f9d6682c1dc5f03ae363b782ae9346
          return this.world;
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java b/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
-index 2ee32657a49937418b352a138aca21fbb27857e6..7b4f3c30cfc4bf68cc872598726f7f7eab5f9830 100644
+index 4bc33c31d497aa7d69226ab870fd78902bedfd5b..089e8414c7bdc102ba0d914af576df1a05af7519 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
 @@ -32,6 +32,28 @@ public class RegionFileStorage implements AutoCloseable {
@@ -359,10 +359,10 @@ index 2ee32657a49937418b352a138aca21fbb27857e6..7b4f3c30cfc4bf68cc872598726f7f7e
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6513cb5f236d86097f078f8c72cc3d0a0ebc9617..dfeef8b13a86998599d17f84996e1368649c47b1 100644
+index 79f785b907e009de21b5299e6cc5c4cddc1b95d2..bf2718441e46c47f227862c4f79fae08db1ad123 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1218,12 +1218,7 @@ public final class CraftServer implements Server {
+@@ -1199,12 +1199,7 @@ public final class CraftServer implements Server {
          }
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().shouldReportAsModified());
@@ -376,7 +376,7 @@ index 6513cb5f236d86097f078f8c72cc3d0a0ebc9617..dfeef8b13a86998599d17f84996e1368
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1252,6 +1247,14 @@ public final class CraftServer implements Server {
+@@ -1233,6 +1228,14 @@ public final class CraftServer implements Server {
              }
          }
  

--- a/patches/server/0663-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0663-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -95,10 +95,10 @@ index d88003a29d382d8952964257601f93c5fe95fa8b..30cd6dc004ef1d1518c9a10304ea2a20
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7119e59c228e6f3fa1cdb81a92a54a9e3dd1bc8e..9b7c49753a997ed04a6f588a99d896ece25578da 100644
+index 364eb4abe7f51c716018b65389abed4ec5227ed6..3d343914c95ac08a704f56292ad6e2ab430a258e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1175,7 +1175,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1172,7 +1172,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index 7119e59c228e6f3fa1cdb81a92a54a9e3dd1bc8e..9b7c49753a997ed04a6f588a99d896ec
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1197,7 +1197,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1194,7 +1194,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0666-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0666-Add-PlayerKickEvent-causes.patch
@@ -57,10 +57,10 @@ index 708ac03d5a849bf09c49547306e4a8c5a5ef8d91..5a8df368a4a25839cd4ac9be6972da2e
          }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52667a14ba 100644
+index 8a1041d8ef225131428cebf9e293563e540944bf..9862fc84a2b988983663bc2621a20b76c0132d28 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -321,7 +321,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -318,7 +318,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          if (this.clientIsFloating && !this.player.isSleeping()) {
              if (++this.aboveGroundTickCount > 80) {
                  ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked for floating too long!", this.player.getName().getString());
@@ -69,7 +69,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
                  return;
              }
          } else {
-@@ -340,7 +340,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -337,7 +337,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              if (this.clientVehicleIsFloating && this.player.getRootVehicle().getControllingPassenger() == this.player) {
                  if (++this.aboveGroundVehicleTickCount > 80) {
                      ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked for floating a vehicle too long!", this.player.getName().getString());
@@ -78,7 +78,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
                      return;
                  }
              } else {
-@@ -362,7 +362,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -359,7 +359,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          if (this.keepAlivePending) {
              if (!this.processedDisconnect && elapsedTime >= KEEPALIVE_LIMIT) { // check keepalive limit, don't fire if already disconnected
                  ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked due to keepalive timeout!", this.player.getScoreboardName()); // more info
@@ -87,7 +87,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
              }
          } else {
              if (elapsedTime >= 15000L) { // 15 seconds
-@@ -392,7 +392,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -389,7 +389,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) (this.server.getPlayerIdleTimeout() * 1000 * 60)) {
              this.player.resetLastActionTime(); // CraftBukkit - SPIGOT-854
@@ -96,7 +96,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
          }
  
      }
-@@ -417,14 +417,22 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -414,14 +414,22 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      public void disconnect(String s) {
          // Paper start
@@ -122,7 +122,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
          // Paper end
          // CraftBukkit start - fire PlayerKickEvent
          if (this.processedDisconnect) {
-@@ -432,7 +440,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -429,7 +437,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
          net.kyori.adventure.text.Component leaveMessage = net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, this.player.getBukkitEntity().displayName()); // Paper - Adventure
  
@@ -131,7 +131,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
  
          if (this.cserver.getServer().isRunning()) {
              this.cserver.getPluginManager().callEvent(event);
-@@ -504,7 +512,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -501,7 +509,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleMoveVehicle(ServerboundMoveVehiclePacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (ServerGamePacketListenerImpl.containsInvalidValues(packet.getX(), packet.getY(), packet.getZ(), packet.getYRot(), packet.getXRot())) {
@@ -140,7 +140,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
          } else {
              Entity entity = this.player.getRootVehicle();
  
-@@ -745,13 +753,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -742,13 +750,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // PlayerConnectionUtils.ensureMainThread(packetplayintabcomplete, this, this.player.getWorldServer()); // Paper - run this async
          // CraftBukkit start
          if (this.chatSpamTickCount.addAndGet(com.destroystokyo.paper.PaperConfig.tabSpamIncrement) > com.destroystokyo.paper.PaperConfig.tabSpamLimit && !this.server.getPlayerList().isOp(this.player.getGameProfile())) { // Paper start - split and make configurable
@@ -156,7 +156,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
              return;
          }
          // Paper end
-@@ -903,7 +911,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -900,7 +908,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Paper start - validate pick item position
          if (!(packet.getSlot() >= 0 && packet.getSlot() < this.player.getInventory().items.size())) {
              ServerGamePacketListenerImpl.LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
@@ -165,7 +165,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
              return;
          }
          this.player.getInventory().pickSlot(packet.getSlot()); // Paper - Diff above if changed
-@@ -1068,7 +1076,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1065,7 +1073,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  int byteLength = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
                  if (byteLength > 256 * 4) {
                      ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send a book with with a page too large!");
@@ -174,7 +174,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
                      return;
                  }
                  byteTotal += byteLength;
-@@ -1091,14 +1099,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1088,14 +1096,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              if (byteTotal > byteAllowed) {
                  ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send too large of a book. Book Size: " + byteTotal + " - Allowed:  "+ byteAllowed + " - Pages: " + pageList.size());
@@ -191,7 +191,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
              return;
          }
          this.lastBookTick = MinecraftServer.currentTick;
-@@ -1222,7 +1230,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1219,7 +1227,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleMovePlayer(ServerboundMovePlayerPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (ServerGamePacketListenerImpl.containsInvalidValues(packet.getX(0.0D), packet.getY(0.0D), packet.getZ(0.0D), packet.getYRot(0.0F), packet.getXRot(0.0F))) {
@@ -200,7 +200,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
          } else {
              ServerLevel worldserver = this.player.getLevel();
  
-@@ -1648,7 +1656,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1645,7 +1653,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          this.dropCount++;
                          if (this.dropCount >= 20) {
                              ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " dropped their items too quickly!");
@@ -209,7 +209,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
                              return;
                          }
                      }
-@@ -1855,7 +1863,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1851,7 +1859,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (packet.getAction() == ServerboundResourcePackPacket.Action.DECLINED && this.server.isResourcePackRequired()) {
              ServerGamePacketListenerImpl.LOGGER.info("Disconnecting {} due to resource pack rejection", this.player.getName());
@@ -218,7 +218,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
          }
          // Paper start
          PlayerResourcePackStatusEvent.Status packStatus = PlayerResourcePackStatusEvent.Status.values()[packet.action.ordinal()];
-@@ -1960,7 +1968,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1956,7 +1964,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              this.player.resetLastActionTime();
          } else {
              ServerGamePacketListenerImpl.LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
@@ -227,7 +227,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
          }
      }
  
-@@ -1976,7 +1984,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1972,7 +1980,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          for (int i = 0; i < s.length(); ++i) {
              if (!SharedConstants.isAllowedChatCharacter(s.charAt(i))) {
@@ -236,7 +236,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
                  return;
              }
          }
-@@ -2049,7 +2057,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2045,7 +2053,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                      Waitable waitable = new Waitable() {
                          @Override
                          protected Object evaluate() {
@@ -245,7 +245,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
                              return null;
                          }
                      };
-@@ -2064,7 +2072,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2060,7 +2068,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          throw new RuntimeException(e);
                      }
                  } else {
@@ -254,7 +254,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
                  }
                  // CraftBukkit end
              }
-@@ -2337,7 +2345,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2333,7 +2341,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Spigot Start
          if ( entity == this.player && !this.player.isSpectator() )
          {
@@ -263,7 +263,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
              return;
          }
          // Spigot End
-@@ -2432,7 +2440,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2428,7 +2436,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              }
                              // CraftBukkit end
                          } else {
@@ -272,7 +272,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
                              ServerGamePacketListenerImpl.LOGGER.warn("Player {} tried to attack an invalid entity", ServerGamePacketListenerImpl.this.player.getName().getString());
                          }
                      }
-@@ -2832,7 +2840,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2828,7 +2836,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Paper start
          if (!org.bukkit.Bukkit.isPrimaryThread()) {
              if (recipeSpamPackets.addAndGet(com.destroystokyo.paper.PaperConfig.autoRecipeIncrement) > com.destroystokyo.paper.PaperConfig.autoRecipeLimit) {
@@ -281,7 +281,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
                  return;
              }
          }
-@@ -3017,7 +3025,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3013,7 +3021,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          } else if (!this.isSingleplayerOwner()) {
              // Paper start - This needs to be handled on the main thread for plugins
              server.submit(() -> {
@@ -290,7 +290,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
              });
              // Paper end
          }
-@@ -3063,7 +3071,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3059,7 +3067,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t register custom payload", ex);
@@ -299,7 +299,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
              }
          } else if (packet.identifier.equals(CUSTOM_UNREGISTER)) {
              try {
-@@ -3073,7 +3081,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3069,7 +3077,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t unregister custom payload", ex);
@@ -308,7 +308,7 @@ index a76f8a64d7ec492402b29bde4c2f0a4c556a35cf..7dcae22ac58e44b2fa410fe606f28e52
              }
          } else {
              try {
-@@ -3091,7 +3099,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3087,7 +3095,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  this.cserver.getMessenger().dispatchIncomingMessage(this.player.getBukkitEntity(), packet.identifier.toString(), data);
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
@@ -342,10 +342,10 @@ index 3900e885988bc1f2865b95f825cba34d04919731..cad8a98951795706b89ff3ea3985033f
          // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 09c2ac4c40b13019bcaccd3e8e34ac3d6fdd5363..fc5bab146ddcd4f458370e1b258049c129c72f5c 100644
+index b542df24792f3fecb7b017db46555d38cacce15d..9dbcd27b5e4a53fdbd73b1558b6e984ffe43bb63 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -507,16 +507,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -509,16 +509,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          org.spigotmc.AsyncCatcher.catchOp("player kick"); // Spigot
          if (this.getHandle().connection == null) return;
  

--- a/patches/server/0677-Line-Of-Sight-Changes.patch
+++ b/patches/server/0677-Line-Of-Sight-Changes.patch
@@ -19,10 +19,10 @@ index 510c2f0d47b593ac2bd60608c43cef8c069a5373..3d197ddb412e7df6723be0e86db86d93
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9b7c49753a997ed04a6f588a99d896ece25578da..761f3f671ba23ab46b3c72ff488d0d43642cb2da 100644
+index 3d343914c95ac08a704f56292ad6e2ab430a258e..a42d293733e6f67e5ea1f7626b245f87b6ed438f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -192,6 +192,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -189,6 +189,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public io.papermc.paper.world.MoonPhase getMoonPhase() {
          return io.papermc.paper.world.MoonPhase.getPhase(getFullTime() / 24000L);
      }

--- a/patches/server/0678-add-per-world-spawn-limits.patch
+++ b/patches/server/0678-add-per-world-spawn-limits.patch
@@ -44,20 +44,19 @@ index d980e31884ea70493628e4934e19fa68314ba8e2..54a1fb5b6d1dee73761851c55c6bdc1c
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a42d293733e6f67e5ea1f7626b245f87b6ed438f..03ae648489482e2120c58033e2dab972eccec57c 100644
+index 4191d44a0bbb59fee6934e1718e2ac8cfaba9cfa..518c711264b0d7112c09472764fda4cb6dc32180 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -211,6 +211,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -211,6 +211,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          this.biomeProvider = biomeProvider;
  
          this.environment = env;
 +        // Paper start - per world spawn limits
-+        setSpawnLimit(SpawnCategory.MONSTER, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.MONSTER));
-+        setSpawnLimit(SpawnCategory.ANIMAL, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.CREATURE));
-+        setSpawnLimit(SpawnCategory.WATER_ANIMAL, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.WATER_CREATURE));
-+        setSpawnLimit(SpawnCategory.WATER_AMBIENT, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.WATER_AMBIENT));
-+        setSpawnLimit(SpawnCategory.AMBIENT, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.AMBIENT));
-+        setSpawnLimit(SpawnCategory.WATER_UNDERGROUND_CREATURE, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.UNDERGROUND_WATER_CREATURE));
++        for (SpawnCategory spawnCategory : SpawnCategory.values()) {
++            if (CraftSpawnCategory.isValidForLimits(spawnCategory)) {
++                setSpawnLimit(spawnCategory, this.world.paperConfig.perWorldSpawnLimits.getInt(CraftSpawnCategory.toNMS(spawnCategory)));
++            }
++        }
 +        // Paper end
      }
  

--- a/patches/server/0678-add-per-world-spawn-limits.patch
+++ b/patches/server/0678-add-per-world-spawn-limits.patch
@@ -44,20 +44,20 @@ index d980e31884ea70493628e4934e19fa68314ba8e2..54a1fb5b6d1dee73761851c55c6bdc1c
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 761f3f671ba23ab46b3c72ff488d0d43642cb2da..7821ebcbae8c63c3607d2ac8f92cb5a55a62bd97 100644
+index a42d293733e6f67e5ea1f7626b245f87b6ed438f..03ae648489482e2120c58033e2dab972eccec57c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -214,6 +214,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -211,6 +211,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          this.biomeProvider = biomeProvider;
  
          this.environment = env;
 +        // Paper start - per world spawn limits
-+        this.monsterSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.MONSTER);
-+        this.animalSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.CREATURE);
-+        this.waterAnimalSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.WATER_CREATURE);
-+        this.waterAmbientSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.WATER_AMBIENT);
-+        this.ambientSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.AMBIENT);
-+        this.waterUndergroundCreatureSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.UNDERGROUND_WATER_CREATURE);
++        setSpawnLimit(SpawnCategory.MONSTER, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.MONSTER));
++        setSpawnLimit(SpawnCategory.ANIMAL, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.CREATURE));
++        setSpawnLimit(SpawnCategory.WATER_ANIMAL, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.WATER_CREATURE));
++        setSpawnLimit(SpawnCategory.WATER_AMBIENT, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.WATER_AMBIENT));
++        setSpawnLimit(SpawnCategory.AMBIENT, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.AMBIENT));
++        setSpawnLimit(SpawnCategory.WATER_UNDERGROUND_CREATURE, this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.UNDERGROUND_WATER_CREATURE));
 +        // Paper end
      }
  

--- a/patches/server/0683-Ensure-disconnect-for-book-edit-is-called-on-main.patch
+++ b/patches/server/0683-Ensure-disconnect-for-book-edit-is-called-on-main.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure disconnect for book edit is called on main
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 7dcae22ac58e44b2fa410fe606f28e52667a14ba..e34b980296e447fe52e435737b4cca2de7267369 100644
+index 9862fc84a2b988983663bc2621a20b76c0132d28..81c752a903060904ce595a5b5b14229d26dfa4fe 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1106,7 +1106,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1103,7 +1103,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Paper end
          // CraftBukkit start
          if (this.lastBookTick + 20 > MinecraftServer.currentTick) {

--- a/patches/server/0685-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0685-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -21,10 +21,10 @@ index 49640474611c4e1781a93c6eaa627a2865f5f72e..d4129cb5ffa6bea474020c47b82d8905
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e34b980296e447fe52e435737b4cca2de7267369..1ab0b0a813af70e4df6580fc377e496d151e2a56 100644
+index 81c752a903060904ce595a5b5b14229d26dfa4fe..85a0883b50a9f858e9acbcff6363ccf44cf373a4 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1317,7 +1317,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1314,7 +1314,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                                  speed = this.player.getAbilities().walkingSpeed * 10f;
                              }
                              // Paper start - Prevent moving into unloaded chunks
@@ -34,10 +34,10 @@ index e34b980296e447fe52e435737b4cca2de7267369..1ab0b0a813af70e4df6580fc377e496d
                                  return;
                              }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index b7f9d6682c1dc5f03ae363b782ae9346f5bbe841..d63f4108012b4d3ed566298c7cda27bbbf018c6a 100644
+index 980c0c391d4090da062650634276a418cf38c45e..48fdf3aebb252a2670899011f112b1c802ccc0e6 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -194,6 +194,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -191,6 +191,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return (CraftServer) Bukkit.getServer();
      }
  
@@ -51,7 +51,7 @@ index b7f9d6682c1dc5f03ae363b782ae9346f5bbe841..d63f4108012b4d3ed566298c7cda27bb
      public abstract ResourceKey<LevelStem> getTypeKey();
  
      protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, final DimensionType dimensionmanager, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.concurrent.Executor executor) { // Paper - Async-Anti-Xray - Pass executor
-@@ -1366,7 +1373,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1365,7 +1372,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
          for (int l1 = j; l1 <= l; ++l1) {
              for (int i2 = k; i2 <= i1; ++i2) {

--- a/patches/server/0687-Adds-PlayerArmSwingEvent.patch
+++ b/patches/server/0687-Adds-PlayerArmSwingEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Adds PlayerArmSwingEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1ab0b0a813af70e4df6580fc377e496d151e2a56..e6fa9f7b4f128e8e7cacc6cee7b42a31bfcd6f03 100644
+index 85a0883b50a9f858e9acbcff6363ccf44cf373a4..0525fea70de86e639fa6b686b69bd0abb3190216 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2241,7 +2241,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2237,7 +2237,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
  
          // Arm swing animation

--- a/patches/server/0688-Fixes-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0688-Fixes-kick-event-leave-message-not-being-sent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fixes kick event leave message not being sent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e6fa9f7b4f128e8e7cacc6cee7b42a31bfcd6f03..21e46f073cb88b993ec46644e10eb8bfe70a178b 100644
+index 0525fea70de86e639fa6b686b69bd0abb3190216..44a8fba1461b455b085bd66d6562190f13097c2c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -458,7 +458,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -455,7 +455,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          this.connection.send(new ClientboundDisconnectPacket(ichatbasecomponent), (future) -> {
              this.connection.disconnect(ichatbasecomponent);
          });
@@ -17,7 +17,7 @@ index e6fa9f7b4f128e8e7cacc6cee7b42a31bfcd6f03..21e46f073cb88b993ec46644e10eb8bf
          this.connection.setReadOnly();
          MinecraftServer minecraftserver = this.server;
          Connection networkmanager = this.connection;
-@@ -1888,6 +1888,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1884,6 +1884,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void onDisconnect(Component reason) {
@@ -29,7 +29,7 @@ index e6fa9f7b4f128e8e7cacc6cee7b42a31bfcd6f03..21e46f073cb88b993ec46644e10eb8bf
          // CraftBukkit start - Rarely it would send a disconnect line twice
          if (this.processedDisconnect) {
              return;
-@@ -1904,7 +1909,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1900,7 +1905,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          this.player.disconnect();
          // Paper start - Adventure

--- a/patches/server/0696-Add-System.out-err-catcher.patch
+++ b/patches/server/0696-Add-System.out-err-catcher.patch
@@ -105,22 +105,14 @@ index 0000000000000000000000000000000000000000..76d0d00cd6742991e3f3ec827a75ee87
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dfeef8b13a86998599d17f84996e1368649c47b1..5f35c3714ac4e0e7afaa81c1ebe8d9601202bbb2 100644
+index bf2718441e46c47f227862c4f79fae08db1ad123..7075ee9ea0f2ac12cee7644a5f84410bb317ab70 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -18,6 +18,7 @@ import com.mojang.serialization.Lifecycle;
- import io.netty.buffer.ByteBuf;
- import io.netty.buffer.ByteBufOutputStream;
- import io.netty.buffer.Unpooled;
-+import io.papermc.paper.logging.SysoutCatcher;
- import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
- import java.awt.image.BufferedImage;
- import java.io.File;
-@@ -293,6 +294,7 @@ public final class CraftServer implements Server {
+@@ -286,6 +286,7 @@ public final class CraftServer implements Server {
      public int reloadCount;
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings
-+    private final SysoutCatcher sysoutCatcher = new SysoutCatcher(); // Paper
++    private final io.papermc.paper.logging.SysoutCatcher sysoutCatcher = new io.papermc.paper.logging.SysoutCatcher(); // Paper
  
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);

--- a/patches/server/0700-Prevent-AFK-kick-while-watching-end-credits.patch
+++ b/patches/server/0700-Prevent-AFK-kick-while-watching-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent AFK kick while watching end credits.
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index afed4675ebedb13bb313815580fe14c06445ba0a..3d92d901007a406ddf5e85be5391fc451b2ea2ec 100644
+index 44a8fba1461b455b085bd66d6562190f13097c2c..be57a11febb169051af99711b7b1704dddc77898 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -390,7 +390,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -387,7 +387,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              --this.dropSpamTickCount;
          }
  

--- a/patches/server/0702-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0702-Add-PlayerSetSpawnEvent.patch
@@ -93,10 +93,10 @@ index d620f559cdd1bd0e161a99123ef6c6f64e3302df..07e893f1859abe3c2a765694c21309d6
                      return InteractionResult.SUCCESS;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fc5bab146ddcd4f458370e1b258049c129c72f5c..fb1c83d0487cac6df8768ac635d13636ec97cb53 100644
+index 9dbcd27b5e4a53fdbd73b1558b6e984ffe43bb63..897459cb9c4bbf17378a181450199a90174ac4a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1105,9 +1105,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1107,9 +1107,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0707-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0707-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7ba5761791bdbfdc924bdf8b1ed239c9fb640cac..96fba810f9f6d105a844831de45ae1df174d1837 100644
+index c6f7c52b017d0f58ab84b3e213b5500b512bfab9..4d9e2881bfbda4efe8dc25c5efcdbda949b9c792 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3511,26 +3511,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3517,26 +3517,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      private Stream<Entity> getIndirectPassengersStream() {

--- a/patches/server/0718-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0718-Add-back-EntityPortalExitEvent.patch
@@ -5,14 +5,13 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 96fba810f9f6d105a844831de45ae1df174d1837..ddf315ab79dd42e18e73aba8b96ad33ae21073b7 100644
+index 4d9e2881bfbda4efe8dc25c5efcdbda949b9c792..296efe4970b1f0b6673e8e09ff0f6ac46e624c5f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3022,6 +3022,25 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3022,6 +3022,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              } else {
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
-+
 +                // Paper start - Call EntityPortalExitEvent
 +                CraftEntity bukkitEntity = this.getBukkitEntity();
 +                Vec3 position = shapedetectorshape.pos;
@@ -30,11 +29,10 @@ index 96fba810f9f6d105a844831de45ae1df174d1837..ddf315ab79dd42e18e73aba8b96ad33a
 +                    velocity = org.bukkit.craftbukkit.util.CraftVector.toNMS(event.getAfter());
 +                }
 +                // Paper end
-+
-                 this.unRide();
-                 // CraftBukkit end
- 
-@@ -3035,8 +3054,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+                 if (worldserver == this.level) {
+                     // SPIGOT-6782: Just move the entity if a plugin changed the world to the one the entity is already in
+                     this.moveTo(shapedetectorshape.pos.x, shapedetectorshape.pos.y, shapedetectorshape.pos.z, shapedetectorshape.yRot, shapedetectorshape.xRot);
+@@ -3041,8 +3058,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
  
                  if (entity != null) {
                      entity.restoreFrom(this);

--- a/patches/server/0719-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0719-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -29,10 +29,10 @@ index d4129cb5ffa6bea474020c47b82d8905d1f4d9f5..df37739055bc705d9aebf8db4ee2007e
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7821ebcbae8c63c3607d2ac8f92cb5a55a62bd97..246a25d76c26302833f86a2c329a9a0d738af707 100644
+index 03ae648489482e2120c58033e2dab972eccec57c..494185f729ff3f7afc04a77442bdfe8d556eb198 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -695,6 +695,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -692,6 +692,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0719-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0719-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -29,10 +29,10 @@ index d4129cb5ffa6bea474020c47b82d8905d1f4d9f5..df37739055bc705d9aebf8db4ee2007e
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 03ae648489482e2120c58033e2dab972eccec57c..494185f729ff3f7afc04a77442bdfe8d556eb198 100644
+index 518c711264b0d7112c09472764fda4cb6dc32180..004af6a256e76389234723e0f79634f5a8e26c23 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -692,6 +692,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -691,6 +691,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0724-Add-critical-damage-API.patch
+++ b/patches/server/0724-Add-critical-damage-API.patch
@@ -72,10 +72,10 @@ index b436103957113bff5e553dacb869c775a3f8b059..3d3dcb47720055f550d17d1f106a2c0e
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index db4a0f26ae528680b4e2ac395a6800c6d8f4124e..519b17fac445b7118f5493508bddccd368dadcde 100644
+index 5c2beec59b0382d80bf97317cbbeab43df24ad55..a3c8a0291fa9ae6f3c96d937dd4621edd7c48535 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -970,7 +970,7 @@ public class CraftEventFactory {
+@@ -980,7 +980,7 @@ public class CraftEventFactory {
                  } else {
                      damageCause = DamageCause.ENTITY_EXPLOSION;
                  }
@@ -84,7 +84,7 @@ index db4a0f26ae528680b4e2ac395a6800c6d8f4124e..519b17fac445b7118f5493508bddccd3
              }
              event.setCancelled(cancelled);
  
-@@ -997,7 +997,7 @@ public class CraftEventFactory {
+@@ -1007,7 +1007,7 @@ public class CraftEventFactory {
                  cause = DamageCause.THORNS;
              }
  
@@ -93,7 +93,7 @@ index db4a0f26ae528680b4e2ac395a6800c6d8f4124e..519b17fac445b7118f5493508bddccd3
          } else if (source == DamageSource.OUT_OF_WORLD) {
              EntityDamageEvent event = new EntityDamageByBlockEvent(null, entity.getBukkitEntity(), DamageCause.VOID, modifiers, modifierFunctions);
              event.setCancelled(cancelled);
-@@ -1067,7 +1067,7 @@ public class CraftEventFactory {
+@@ -1077,7 +1077,7 @@ public class CraftEventFactory {
              } else {
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager.getHandle(), source.msgId));
              }
@@ -102,7 +102,7 @@ index db4a0f26ae528680b4e2ac395a6800c6d8f4124e..519b17fac445b7118f5493508bddccd3
              event.setCancelled(cancelled);
              CraftEventFactory.callEvent(event);
              if (!event.isCancelled()) {
-@@ -1112,20 +1112,28 @@ public class CraftEventFactory {
+@@ -1122,20 +1122,28 @@ public class CraftEventFactory {
          }
  
          if (cause != null) {

--- a/patches/server/0729-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0729-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ddf315ab79dd42e18e73aba8b96ad33ae21073b7..1d4a01b52f026d0610b49f1c2f048a6c68c54c4e 100644
+index 296efe4970b1f0b6673e8e09ff0f6ac46e624c5f..445c292cbfd151148945f57ad8dd2f0a2481936f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1832,6 +1832,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -25,10 +25,10 @@ index ddf315ab79dd42e18e73aba8b96ad33ae21073b7..1d4a01b52f026d0610b49f1c2f048a6c
          return this.isPassenger() ? false : this.saveAsPassenger(nbt);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index dd1a86ddbe54aa6c26fd81cfe42a7f89eca5899d..135e2992e394095814e47126b28ab5c2426c38ef 100644
+index 49738cdb2f712d9ce76d3fff92b79e829bfa2370..788148145eddc90eac35881bc847e958b6a47ebe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1277,5 +1277,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1284,5 +1284,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          }
          return set;
      }

--- a/patches/server/0741-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0741-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -10,7 +10,7 @@ Also has a hover text on each mob category listing what entity types are
 in said category
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index f436ab35798c9b6e6cb2eb60d2c02cbf9b742e69..4d7575087947f3b199dd895cd9aa02a7d61768b1 100644
+index f436ab35798c9b6e6cb2eb60d2c02cbf9b742e69..8934c9f2d578932aae43ea3da7894f2f2b7dd452 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -3,6 +3,7 @@ package com.destroystokyo.paper;
@@ -213,7 +213,7 @@ index f436ab35798c9b6e6cb2eb60d2c02cbf9b742e69..4d7575087947f3b199dd895cd9aa02a7
 +        sender.sendMessage(Component.join(JoinConfiguration.noSeparators(), Component.text("Mobcaps for player: "), Component.text(player.getName(), NamedTextColor.GREEN)));
 +        sender.sendMessage(this.buildMobcapsComponent(
 +            category -> level.chunkSource.chunkMap.getMobCountNear(serverPlayer, category),
-+            category -> NaturalSpawner.limitForCategory(level, category)
++            category -> level.getWorld().getSpawnLimit(org.bukkit.craftbukkit.util.CraftSpawnCategory.toBukkit(category))
 +        ));
 +    }
 +
@@ -272,70 +272,16 @@ index f436ab35798c9b6e6cb2eb60d2c02cbf9b742e69..4d7575087947f3b199dd895cd9aa02a7
          List<org.bukkit.World> worlds;
          if (args.length < 2 || args[1].equals("*")) {
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index a9d9c54c7bae0ad681a67106689897a31de49288..f0e67e007057c460f4f217fdaa60d3198d18684e 100644
+index 8e63d93a574f2c37094770099ea8e1f45cde3db5..6a62214b2763538e20fd218c445990d7f2cbc737 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-@@ -148,32 +148,16 @@ public final class NaturalSpawner {
-             MobCategory enumcreaturetype = aenumcreaturetype[j];
-             // CraftBukkit start - Use per-world spawn limits
-             boolean spawnThisTick = true;
--            int limit = enumcreaturetype.getMaxInstancesPerChunk();
-+            final int limit = limitForCategory(world, enumcreaturetype); // Paper
-             switch (enumcreaturetype) {
--                case MONSTER:
--                    spawnThisTick = spawnMonsterThisTick;
--                    limit = world.getWorld().getMonsterSpawnLimit();
--                    break;
--                case CREATURE:
--                    spawnThisTick = spawnAnimalThisTick;
--                    limit = world.getWorld().getAnimalSpawnLimit();
--                    break;
--                case WATER_CREATURE:
--                    spawnThisTick = spawnWaterThisTick;
--                    limit = world.getWorld().getWaterAnimalSpawnLimit();
--                    break;
--                case UNDERGROUND_WATER_CREATURE:
--                    spawnThisTick = spawnWaterUndergroundCreatureThisTick;
--                    limit = world.getWorld().getWaterUndergroundCreatureSpawnLimit();
--                    break;
--                case AMBIENT:
--                    spawnThisTick = spawnAmbientThisTick;
--                    limit = world.getWorld().getAmbientSpawnLimit();
--                    break;
--                case WATER_AMBIENT:
--                    spawnThisTick = spawnWaterAmbientThisTick;
--                    limit = world.getWorld().getWaterAmbientSpawnLimit();
--                    break;
-+                // Paper start - not mindiff so we get conflict on change
-+                case MONSTER -> spawnThisTick = spawnMonsterThisTick;
-+                case CREATURE -> spawnThisTick = spawnAnimalThisTick;
-+                case WATER_CREATURE -> spawnThisTick = spawnWaterThisTick;
-+                case UNDERGROUND_WATER_CREATURE -> spawnThisTick = spawnWaterUndergroundCreatureThisTick;
-+                case AMBIENT -> spawnThisTick = spawnAmbientThisTick;
-+                case WATER_AMBIENT -> spawnThisTick = spawnWaterAmbientThisTick;
-+                // Paper end
-             }
- 
-             if (!spawnThisTick || limit == 0) {
-@@ -218,6 +202,28 @@ public final class NaturalSpawner {
+@@ -191,6 +191,16 @@ public final class NaturalSpawner {
          world.getProfiler().pop();
      }
  
 +    // Paper start
-+    public static int limitForCategory(final ServerLevel world, final MobCategory enumcreaturetype) {
-+        return switch (enumcreaturetype) {
-+            case MONSTER -> world.getWorld().getMonsterSpawnLimit();
-+            case CREATURE -> world.getWorld().getAnimalSpawnLimit();
-+            case WATER_CREATURE -> world.getWorld().getWaterAnimalSpawnLimit();
-+            case UNDERGROUND_WATER_CREATURE -> world.getWorld().getWaterUndergroundCreatureSpawnLimit();
-+            case AMBIENT -> world.getWorld().getAmbientSpawnLimit();
-+            case WATER_AMBIENT -> world.getWorld().getWaterAmbientSpawnLimit();
-+            default -> enumcreaturetype.getMaxInstancesPerChunk();
-+        };
-+    }
-+
 +    public static int globalLimitForCategory(final ServerLevel level, final MobCategory category, final int spawnableChunkCount) {
-+        final int categoryLimit = limitForCategory(level, category);
++        final int categoryLimit = level.getWorld().getSpawnLimit(CraftSpawnCategory.toBukkit(category));
 +        if (categoryLimit < 1) {
 +            return categoryLimit;
 +        }

--- a/patches/server/0747-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0747-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -953,7 +953,7 @@ index de5e18a331178da8f7e82aa2419a0ee606e801ee..9b25d36fe5230e287d81b99be31b9edd
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1d4a01b52f026d0610b49f1c2f048a6c68c54c4e..688c606d8b01e24863849b5a7fede8dfa5cb6571 100644
+index 445c292cbfd151148945f57ad8dd2f0a2481936f..9d16faa522cf627bc59df56b04d28b4d4896cb7c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -425,6 +425,56 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -1028,7 +1028,7 @@ index 1d4a01b52f026d0610b49f1c2f048a6c68c54c4e..688c606d8b01e24863849b5a7fede8df
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/EntityGetter.java b/src/main/java/net/minecraft/world/level/EntityGetter.java
-index bc3bfe8d3c2f87e2e9f167b9ff34d9ca8a696391..30276959c0119813c27ee3f98e237c93236e5b39 100644
+index 99f69f11e86fdee801504303fe025797f7959db8..f9527d1d867f93b4e0e2758485cfa1f6efa0bf8b 100644
 --- a/src/main/java/net/minecraft/world/level/EntityGetter.java
 +++ b/src/main/java/net/minecraft/world/level/EntityGetter.java
 @@ -19,6 +19,18 @@ import net.minecraft.world.phys.shapes.Shapes;
@@ -1051,10 +1051,10 @@ index bc3bfe8d3c2f87e2e9f167b9ff34d9ca8a696391..30276959c0119813c27ee3f98e237c93
  
      <T extends Entity> List<T> getEntities(EntityTypeTest<Entity, T> filter, AABB box, Predicate<? super T> predicate);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index d63f4108012b4d3ed566298c7cda27bbbf018c6a..3831895e2219d846022500553d9b714c7d654b3a 100644
+index 48fdf3aebb252a2670899011f112b1c802ccc0e6..c603dcbe89a49e9e7de7fbc5c863e4b3a9869f95 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -203,6 +203,48 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -200,6 +200,48 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      public abstract ResourceKey<LevelStem> getTypeKey();
  
@@ -1103,7 +1103,7 @@ index d63f4108012b4d3ed566298c7cda27bbbf018c6a..3831895e2219d846022500553d9b714c
      protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, final DimensionType dimensionmanager, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.concurrent.Executor executor) { // Paper - Async-Anti-Xray - Pass executor
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
          this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName(), this.spigotConfig); // Paper
-@@ -280,6 +322,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -279,6 +321,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.entityLimiter = new org.spigotmc.TickLimiter(spigotConfig.entityMaxTickTime);
          this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
          this.chunkPacketBlockController = this.paperConfig.antiXray ? new com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray(this, executor) : com.destroystokyo.paper.antixray.ChunkPacketBlockController.NO_OPERATION_INSTANCE; // Paper - Anti-Xray
@@ -1111,7 +1111,7 @@ index d63f4108012b4d3ed566298c7cda27bbbf018c6a..3831895e2219d846022500553d9b714c
      }
  
      // Paper start
-@@ -990,26 +1033,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -989,26 +1032,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public List<Entity> getEntities(@Nullable Entity except, AABB box, Predicate<? super Entity> predicate) {
          this.getProfiler().incrementCounter("getEntities");
          List<Entity> list = Lists.newArrayList();
@@ -1139,7 +1139,7 @@ index d63f4108012b4d3ed566298c7cda27bbbf018c6a..3831895e2219d846022500553d9b714c
          return list;
      }
  
-@@ -1018,27 +1042,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1017,27 +1041,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.getProfiler().incrementCounter("getEntities");
          List<T> list = Lists.newArrayList();
  

--- a/patches/server/0749-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0749-Execute-chunk-tasks-mid-tick.patch
@@ -19,7 +19,7 @@ index b27021a42cbed3f0648a8d0903d00d03922ae221..eada966d7f108a6081be7a848f5c1dfc
  
      private MinecraftTimings() {}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 088334869cb62797a1e1d1bbb6187f03189d852d..c245c1f4611f7273c8da629f774e0c64e9f98fc2 100644
+index 79e5b8a05828bbc07468d2deeb0f4dad51ca12a5..7be369cf60e45a551fb2d274b9514856dca7b2e5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -332,6 +332,76 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -108,7 +108,7 @@ index 088334869cb62797a1e1d1bbb6187f03189d852d..c245c1f4611f7273c8da629f774e0c64
          } else {
              if (this.haveTime()) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index f7b2fa30eac4da6847d77fd3b2bdd73349b41822..05f2fad85da8192d097c2349e630349f6c61754c 100644
+index 579b2ac31034082456de5ee91e3c6906c7199e32..4e7027d739f7d3c8586804fc053931b2dca1de59 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -1019,6 +1019,7 @@ public class ServerChunkCache extends ChunkSource {
@@ -128,7 +128,7 @@ index f7b2fa30eac4da6847d77fd3b2bdd73349b41822..05f2fad85da8192d097c2349e630349f
                  }
                  // Paper start - optimise chunk tick iteration
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 5e65df1a9a8282c4ffa06801379b79ab0ed1b45c..7e837b2896cac64a982d9025c4e190dfa7ebc451 100644
+index 9362b39f4cc321bf0d4fc272bc3fb0463c47d4ce..cb327920cfa8d4eec626af1fe42ec1cc5e8953c7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -201,7 +201,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -143,10 +143,10 @@ index 5e65df1a9a8282c4ffa06801379b79ab0ed1b45c..7e837b2896cac64a982d9025c4e190df
      // CraftBukkit start
      private int tickPosition;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 3831895e2219d846022500553d9b714c7d654b3a..86bcedec97f1bc95621380da6ad074bdcc4bfeab 100644
+index c603dcbe89a49e9e7de7fbc5c863e4b3a9869f95..1a76c8a52926bf15f55640d5c053a7235c58d3ed 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -896,6 +896,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -895,6 +895,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public <T extends Entity> void guardEntityTick(Consumer<T> tickConsumer, T entity) {
          try {
              tickConsumer.accept(entity);

--- a/patches/server/0750-Do-not-copy-visible-chunks.patch
+++ b/patches/server/0750-Do-not-copy-visible-chunks.patch
@@ -166,7 +166,7 @@ index f9f1afb49c8dba14d8d9134e84c73fa2e1d13f02..2e11bedafe383242996aeb545d6612f2
          while (objectbidirectionaliterator.hasNext()) {
              Entry<ChunkHolder> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 494185f729ff3f7afc04a77442bdfe8d556eb198..a76d8f39556561523e407b159891fbf853bb1129 100644
+index 004af6a256e76389234723e0f79634f5a8e26c23..19c72e0072afbb4a47a62fde74112e192f91803f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -150,7 +150,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -187,7 +187,7 @@ index 494185f729ff3f7afc04a77442bdfe8d556eb198..a76d8f39556561523e407b159891fbf8
              if (chunkHolder.getTickingChunk() != null) {
                  ++ret;
              }
-@@ -345,7 +345,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -344,7 +344,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {
@@ -207,7 +207,7 @@ index 494185f729ff3f7afc04a77442bdfe8d556eb198..a76d8f39556561523e407b159891fbf8
          return chunks.values().stream().map(ChunkHolder::getFullChunk).filter(Objects::nonNull).map(net.minecraft.world.level.chunk.LevelChunk::getBukkitChunk).toArray(Chunk[]::new);
      }
  
-@@ -421,7 +432,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -420,7 +431,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean refreshChunk(int x, int z) {

--- a/patches/server/0750-Do-not-copy-visible-chunks.patch
+++ b/patches/server/0750-Do-not-copy-visible-chunks.patch
@@ -9,7 +9,7 @@ the function. I saw approximately 1/3rd of the function
 on the copy.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 4d7575087947f3b199dd895cd9aa02a7d61768b1..315bd2408e4a45993c9b2572e0ab5260a70522ec 100644
+index 8934c9f2d578932aae43ea3da7894f2f2b7dd452..54e91401c173a03a11d09d201ffc6ad3238a79b3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -476,7 +476,7 @@ public class PaperCommand extends Command {
@@ -35,7 +35,7 @@ index b3516862d796c2d9fcc1c67a6073445403d73088..b61abf227a04b4565c2525e5f469db30
              List<ChunkHolder> allChunks = new ArrayList<>(visibleChunks.values());
              List<ServerPlayer> players = world.players;
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index fa458b35977b49fd5a7dabd826d6bf33a86319fe..26349902ea206d93cde94f0ed2741ba106e186e5 100644
+index f9f1afb49c8dba14d8d9134e84c73fa2e1d13f02..2e11bedafe383242996aeb545d6612f245070e72 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -120,9 +120,11 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -166,10 +166,10 @@ index fa458b35977b49fd5a7dabd826d6bf33a86319fe..26349902ea206d93cde94f0ed2741ba1
          while (objectbidirectionaliterator.hasNext()) {
              Entry<ChunkHolder> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 246a25d76c26302833f86a2c329a9a0d738af707..a31da19c22d9fca4f5ed2bedf4210f661089da3f 100644
+index 494185f729ff3f7afc04a77442bdfe8d556eb198..a76d8f39556561523e407b159891fbf853bb1129 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -153,7 +153,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -150,7 +150,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public int getTileEntityCount() {
          // We don't use the full world tile entity list, so we must iterate chunks
@@ -178,7 +178,7 @@ index 246a25d76c26302833f86a2c329a9a0d738af707..a31da19c22d9fca4f5ed2bedf4210f66
          int size = 0;
          for (ChunkHolder playerchunk : chunks.values()) {
              net.minecraft.world.level.chunk.LevelChunk chunk = playerchunk.getTickingChunk();
-@@ -174,7 +174,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -171,7 +171,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getChunkCount() {
          int ret = 0;
  
@@ -187,7 +187,7 @@ index 246a25d76c26302833f86a2c329a9a0d738af707..a31da19c22d9fca4f5ed2bedf4210f66
              if (chunkHolder.getTickingChunk() != null) {
                  ++ret;
              }
-@@ -348,7 +348,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -345,7 +345,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {
@@ -207,7 +207,7 @@ index 246a25d76c26302833f86a2c329a9a0d738af707..a31da19c22d9fca4f5ed2bedf4210f66
          return chunks.values().stream().map(ChunkHolder::getFullChunk).filter(Objects::nonNull).map(net.minecraft.world.level.chunk.LevelChunk::getBukkitChunk).toArray(Chunk[]::new);
      }
  
-@@ -424,7 +435,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -421,7 +432,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean refreshChunk(int x, int z) {

--- a/patches/server/0753-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0753-Detail-more-information-in-watchdog-dumps.patch
@@ -123,7 +123,7 @@ index cb327920cfa8d4eec626af1fe42ec1cc5e8953c7..3735b80c6f827500a9c474d4139d6e74
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 688c606d8b01e24863849b5a7fede8dfa5cb6571..a0ba2eb443c8ba63a813b97b69a80d77e7320867 100644
+index 9d16faa522cf627bc59df56b04d28b4d4896cb7c..e4d6133253fc982858a7b33c2d1104347b149a83 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -904,7 +904,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -183,7 +183,7 @@ index 688c606d8b01e24863849b5a7fede8dfa5cb6571..a0ba2eb443c8ba63a813b97b69a80d77
      }
  
      protected boolean isHorizontalCollisionMinor(Vec3 adjustedMovement) {
-@@ -3865,7 +3907,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3869,7 +3911,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -193,7 +193,7 @@ index 688c606d8b01e24863849b5a7fede8dfa5cb6571..a0ba2eb443c8ba63a813b97b69a80d77
      }
  
      public void setDeltaMovement(double x, double y, double z) {
-@@ -3941,7 +3985,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3945,7 +3989,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          }
          // Paper end - fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {

--- a/patches/server/0757-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
+++ b/patches/server/0757-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
@@ -13,10 +13,10 @@ Paper recently reverted this optimisation, so it's been reintroduced
 here.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 86bcedec97f1bc95621380da6ad074bdcc4bfeab..a8e0d2609978652cf07e865c1af555d47bdaaea6 100644
+index 1a76c8a52926bf15f55640d5c053a7235c58d3ed..f0eb297e0a894864de4e4198396edcbef9ae191e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -397,6 +397,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -396,6 +396,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Override
      public final LevelChunk getChunk(int chunkX, int chunkZ) { // Paper - final to help inline

--- a/patches/server/0759-Lag-compensate-block-breaking.patch
+++ b/patches/server/0759-Lag-compensate-block-breaking.patch
@@ -21,7 +21,7 @@ index eeae1a043ef185f206e923a5799e173cf3cf485d..b591b47fc663289682c35f480f851b7e
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 1ca6dc1e9334bf7e03eab4c2a75f4c86c7d36a9f..3125af569ec2bb1cd613a9dd96c3a181d723006d 100644
+index dcfb5fd1763979f081cc253716f518bc371dd546..cc5dbc86c8265540948e6b1445d84ecf0b7762aa 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -54,14 +54,28 @@ public class ServerPlayerGameMode {
@@ -136,10 +136,10 @@ index 1ca6dc1e9334bf7e03eab4c2a75f4c86c7d36a9f..3125af569ec2bb1cd613a9dd96c3a181
                  this.level.destroyBlockProgress(this.player.getId(), pos, -1);
 -                this.player.connection.send(new ClientboundBlockBreakAckPacket(pos, this.level.getBlockState(pos), action, true, "aborted destroying"));
 +                if (!com.destroystokyo.paper.PaperConfig.lagCompensateBlockBreaking) this.player.connection.send(new ClientboundBlockBreakAckPacket(pos, this.level.getBlockState(pos), action, true, "aborted destroying")); // Paper - this can cause clients on a lagging server to think they stopped destroying a block they're currently destroying
-             }
  
-         }
-@@ -326,7 +352,13 @@ public class ServerPlayerGameMode {
+                 CraftEventFactory.callBlockDamageAbortEvent(this.player, pos, this.player.getInventory().getSelected()); // CraftBukkit
+             }
+@@ -328,7 +354,13 @@ public class ServerPlayerGameMode {
  
      public void destroyAndAck(BlockPos pos, ServerboundPlayerActionPacket.Action action, String reason) {
          if (this.destroyBlock(pos)) {

--- a/patches/server/0770-Optimise-random-block-ticking.patch
+++ b/patches/server/0770-Optimise-random-block-ticking.patch
@@ -71,7 +71,7 @@ index 0000000000000000000000000000000000000000..e8b4053babe46999980b926431254050
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c353e41fa733b42350285861a5ddbdf304ec0e02..83517c4eaf419770178f0520210218e0a70c4642 100644
+index 3735b80c6f827500a9c474d4139d6e748b14863b..fe2e5eb72307f8f07987b12a1af9100348b86a82 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -642,6 +642,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -297,10 +297,10 @@ index 60e1111f3c2c43398f21c541248f38524f41f4fb..56e9c0d15249562ebea8eb451d4bcc9f
  
      public BlockPos getHomePos() {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index a8e0d2609978652cf07e865c1af555d47bdaaea6..103428df78d1efe805ab425f1b4085077239bdf6 100644
+index f0eb297e0a894864de4e4198396edcbef9ae191e..742d4645a6d22d10bc2833e3b742a6bc653d473d 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1355,10 +1355,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1354,10 +1354,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public abstract TagContainer getTagManager();
  
      public BlockPos getBlockRandomPos(int x, int y, int z, int l) {

--- a/patches/server/0772-Optimise-nearby-player-lookups.patch
+++ b/patches/server/0772-Optimise-nearby-player-lookups.patch
@@ -26,7 +26,7 @@ index 1f602d50f3212078490c0092ceefd3b17e0b1532..825fdb0336b0388dbbc54c8da9978190
      // Paper end - optimise anyPlayerCloseEnoughForSpawning
      long lastAutoSaveTime; // Paper - incremental autosave
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 075c09e241ca71d21049b71e0b520ba71caebd24..1ceb4f282fdcbe3bc7b75db95a93e547bee227ae 100644
+index dd23e7110259574859a074c423312c452d533668..c56ccb8a6faba0be36b53038e723da5a4461ded1 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -159,6 +159,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -92,7 +92,7 @@ index 075c09e241ca71d21049b71e0b520ba71caebd24..1ceb4f282fdcbe3bc7b75db95a93e547
  
      protected ChunkGenerator generator() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 83517c4eaf419770178f0520210218e0a70c4642..0918bb28fd058e6b79f45993a46738a50b05b60a 100644
+index fe2e5eb72307f8f07987b12a1af9100348b86a82..94798e2715a16b43f11493b08fe342aeecf11cef 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -399,6 +399,83 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -213,10 +213,10 @@ index 736b51e411b009db0482d9a72f179cc7b6241265..031660f7d0ea270f87e5174a4fe65cca
              if (entityhuman != null) {
                  double d0 = entityhuman.distanceToSqr((Entity) this);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 103428df78d1efe805ab425f1b4085077239bdf6..4247dcb003626535dbb997f48ad9f61380bd17e9 100644
+index 742d4645a6d22d10bc2833e3b742a6bc653d473d..7dda99a5464816f1488fb110da587f12d751b3fb 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -244,6 +244,69 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -241,6 +241,69 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return ret;
      }
      // Paper end
@@ -287,10 +287,10 @@ index 103428df78d1efe805ab425f1b4085077239bdf6..4247dcb003626535dbb997f48ad9f613
      protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, final DimensionType dimensionmanager, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.concurrent.Executor executor) { // Paper - Async-Anti-Xray - Pass executor
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index abb57345a97f36d05eab9bc96ffd6396926c219f..c6bddf5e08376f1f254a27fc38647587eefcb00a 100644
+index 6a62214b2763538e20fd218c445990d7f2cbc737..11524461954d7243da1058e7c9b7ce2ea455706d 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-@@ -282,7 +282,7 @@ public final class NaturalSpawner {
+@@ -259,7 +259,7 @@ public final class NaturalSpawner {
                              blockposition_mutableblockposition.set(l, i, i1);
                              double d0 = (double) l + 0.5D;
                              double d1 = (double) i1 + 0.5D;
@@ -299,7 +299,7 @@ index abb57345a97f36d05eab9bc96ffd6396926c219f..c6bddf5e08376f1f254a27fc38647587
  
                              if (entityhuman != null) {
                                  double d2 = entityhuman.distanceToSqr(d0, (double) i, d1);
-@@ -355,7 +355,7 @@ public final class NaturalSpawner {
+@@ -332,7 +332,7 @@ public final class NaturalSpawner {
      }
  
      private static boolean isRightDistanceToPlayerAndSpawnPoint(ServerLevel world, ChunkAccess chunk, BlockPos.MutableBlockPos pos, double squaredDistance) {

--- a/patches/server/0783-Don-t-respond-to-ServerboundCommandSuggestionPacket-.patch
+++ b/patches/server/0783-Don-t-respond-to-ServerboundCommandSuggestionPacket-.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Don't respond to ServerboundCommandSuggestionPacket when
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3d92d901007a406ddf5e85be5391fc451b2ea2ec..f1a1ae33d41a08a0614c3e50e854e5a26f8a94f7 100644
+index be57a11febb169051af99711b7b1704dddc77898..ea3db5e9168e6195b0680b9600d0bb12f04f0532 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -764,6 +764,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -761,6 +761,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
          // Paper end
          // CraftBukkit end

--- a/patches/server/0815-Add-player-health-update-API.patch
+++ b/patches/server/0815-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fb1c83d0487cac6df8768ac635d13636ec97cb53..a18d65cd9c3e9ecf812d02997f3cae481572afd1 100644
+index 897459cb9c4bbf17378a181450199a90174ac4a2..7474e607680be7203c87e15550515110d526df68 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2041,9 +2041,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2043,9 +2043,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index fb1c83d0487cac6df8768ac635d13636ec97cb53..a18d65cd9c3e9ecf812d02997f3cae48
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2051,7 +2053,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2053,7 +2055,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          // Paper end
      }

--- a/patches/server/0817-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0817-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5f35c3714ac4e0e7afaa81c1ebe8d9601202bbb2..ba7023e7ca5d29375ff53c2951892138d155f69f 100644
+index 7075ee9ea0f2ac12cee7644a5f84410bb317ab70..5215ae06260f930a8e313af35a20e916e60aa6c0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2301,6 +2301,107 @@ public final class CraftServer implements Server {
+@@ -2307,6 +2307,107 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0819-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/patches/server/0819-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimise collision checking in player move packet handling
 Move collision logic to just the hasNewCollision call instead of getCubes + hasNewCollision
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f3d5ac0fbd87e606565bc1c4669d8609416c099d..dbb6a03f3ef93ec50b860fb171062d31ec5bf33b 100644
+index ea3db5e9168e6195b0680b9600d0bb12f04f0532..f73a94ac7009d41cd99b229e28d969586d6df419 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -583,12 +583,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -580,12 +580,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                      return;
                  }
  
@@ -24,7 +24,7 @@ index f3d5ac0fbd87e606565bc1c4669d8609416c099d..dbb6a03f3ef93ec50b860fb171062d31
                  double d11 = d7;
  
                  d6 = d3 - entity.getX();
-@@ -602,16 +603,23 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -599,16 +600,23 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  boolean flag1 = false;
  
                  if (d10 > org.spigotmc.SpigotConfig.movedWronglyThreshold) { // Spigot
@@ -52,7 +52,7 @@ index f3d5ac0fbd87e606565bc1c4669d8609416c099d..dbb6a03f3ef93ec50b860fb171062d31
                      entity.absMoveTo(d0, d1, d2, f, f1);
                      this.player.absMoveTo(d0, d1, d2, this.player.getYRot(), this.player.getXRot()); // CraftBukkit
                      this.connection.send(new ClientboundMoveVehiclePacket(entity));
-@@ -697,7 +705,32 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -694,7 +702,32 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      }
  
      private boolean noBlocksAround(Entity entity) {
@@ -86,7 +86,7 @@ index f3d5ac0fbd87e606565bc1c4669d8609416c099d..dbb6a03f3ef93ec50b860fb171062d31
      }
  
      @Override
-@@ -1245,7 +1278,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1242,7 +1275,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
  
                  if (this.awaitingPositionFromClient != null) {
@@ -95,7 +95,7 @@ index f3d5ac0fbd87e606565bc1c4669d8609416c099d..dbb6a03f3ef93ec50b860fb171062d31
                          this.awaitingTeleportTime = this.tickCount;
                          this.teleport(this.awaitingPositionFromClient.x, this.awaitingPositionFromClient.y, this.awaitingPositionFromClient.z, this.player.getYRot(), this.player.getXRot());
                      }
-@@ -1339,7 +1372,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1336,7 +1369,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                                  }
                              }
  
@@ -104,7 +104,7 @@ index f3d5ac0fbd87e606565bc1c4669d8609416c099d..dbb6a03f3ef93ec50b860fb171062d31
  
                              d7 = d0 - this.lastGoodX; // Paper - diff on change, used for checking large move vectors above
                              d8 = d1 - this.lastGoodY; // Paper - diff on change, used for checking large move vectors above
-@@ -1378,6 +1411,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1375,6 +1408,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              }
  
                              this.player.move(MoverType.PLAYER, new Vec3(d7, d8, d9));
@@ -112,7 +112,7 @@ index f3d5ac0fbd87e606565bc1c4669d8609416c099d..dbb6a03f3ef93ec50b860fb171062d31
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move
                              // Paper start - prevent position desync
                              if (this.awaitingPositionFromClient != null) {
-@@ -1397,12 +1431,23 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1394,12 +1428,23 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              boolean flag1 = false;
  
                              if (!this.player.isChangingDimension() && d11 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
@@ -138,7 +138,7 @@ index f3d5ac0fbd87e606565bc1c4669d8609416c099d..dbb6a03f3ef93ec50b860fb171062d31
                                  this.teleport(d3, d4, d5, f, f1);
                              } else {
                                  // CraftBukkit start - fire PlayerMoveEvent
-@@ -1489,6 +1534,27 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1486,6 +1531,27 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
      }
  

--- a/patches/server/0828-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0828-Forward-CraftEntity-in-teleport-command.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2e61243b86ea1f21ec799a63badeae329e1ac3fa..eac13465c8c1827953a8b1bb2feb4d7f92c773fb 100644
+index fe6f2ec41c521c8f1ac17aa3af8bb7f7375e5a02..9b5bd68f328306e26eced7d3112b2c01301b543b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3168,6 +3168,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -22,7 +22,7 @@ index 2e61243b86ea1f21ec799a63badeae329e1ac3fa..eac13465c8c1827953a8b1bb2feb4d7f
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3245,10 +3252,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3249,10 +3256,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                      if (worldserver.getTypeKey() == LevelStem.END) { // CraftBukkit
                          ServerLevel.makeObsidianPlatform(worldserver, this); // CraftBukkit
                      }

--- a/patches/server/0830-Entity-powdered-snow-API.patch
+++ b/patches/server/0830-Entity-powdered-snow-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity powdered snow API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 135e2992e394095814e47126b28ab5c2426c38ef..69223b13e894d86d9529f2ef8b60a08a1f7a9267 100644
+index 788148145eddc90eac35881bc847e958b6a47ebe..7490f4127cb9dddf9332a0db7fd4d124e150cd9c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1287,5 +1287,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1294,5 +1294,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          entity.setRot(location.getYaw(), location.getPitch());
          return !entity.valid && entity.level.addFreshEntity(entity, reason);
      }

--- a/patches/server/0840-Fix-riding-distance-statistics.patch
+++ b/patches/server/0840-Fix-riding-distance-statistics.patch
@@ -7,10 +7,10 @@ Fixes entity ride distance stats not being awarded correctly.
 Based upon https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/pull-requests/900
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d85f5817f1aaebff3d93ee472d4580af72f7eae2..926d0a80cbb55184955ac6720948d2e86683cc57 100644
+index f73a94ac7009d41cd99b229e28d969586d6df419..0c87166beb89dd220e2f7aed1c47a331297eef0d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -609,7 +609,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -606,7 +606,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  Location curPos = this.getCraftPlayer().getLocation(); // Spigot
  
                  entity.absMoveTo(d3, d4, d5, f, f1);
@@ -26,7 +26,7 @@ index d85f5817f1aaebff3d93ee472d4580af72f7eae2..926d0a80cbb55184955ac6720948d2e8
                  // Paper start - optimise out extra getCubes
                  boolean teleportBack = flag1; // violating this is always a fail
                  if (!teleportBack) {
-@@ -621,10 +628,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -618,10 +625,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
                  if (teleportBack) { // Paper end - optimise out extra getCubes
                      entity.absMoveTo(d0, d1, d2, f, f1);

--- a/patches/server/0844-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0844-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose vanilla BiomeProvider from WorldInfo
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 481a5dbad82f3f8dd5b1bf8ab207d82ec73d5bbd..c4e8e6af67b57406012612b617a7dcaa6e391d09 100644
+index d8ec6871cf25175a1da3db004651d4a2ae07b5eb..eab93e1e3712c0a01cac187bf5944818c813d665 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -654,7 +654,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -18,10 +18,10 @@ index 481a5dbad82f3f8dd5b1bf8ab207d82ec73d5bbd..c4e8e6af67b57406012612b617a7dcaa
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ba7023e7ca5d29375ff53c2951892138d155f69f..54e8f0f367645f3aa8af5b1cb69c39c0cec9381f 100644
+index 5215ae06260f930a8e313af35a20e916e60aa6c0..50f3cce22d97d28b00878ba54f9b299da3a5fc2d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1237,7 +1237,7 @@ public final class CraftServer implements Server {
+@@ -1217,7 +1217,7 @@ public final class CraftServer implements Server {
              chunkgenerator = worlddimension.generator();
          }
  
@@ -31,10 +31,10 @@ index ba7023e7ca5d29375ff53c2951892138d155f69f..54e8f0f367645f3aa8af5b1cb69c39c0
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a31da19c22d9fca4f5ed2bedf4210f661089da3f..5fb475b3ccaa98861e2c817b37cd1740e5bfed8d 100644
+index ebc8b0cfd743c3c643cd0f55c9d72cc478665593..a69ea06b81d84a282d43939b461775fa263b6750 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -204,6 +204,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -201,6 +201,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.getHandle().clip(new ClipContext(vec3d, vec3d1, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, null)).getType() == HitResult.Type.MISS;
      }

--- a/patches/server/0853-Kick-on-main-for-illegal-chars.patch
+++ b/patches/server/0853-Kick-on-main-for-illegal-chars.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Kick on main for illegal chars
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0352a3923cb5dc1cd99f939fc7cb513841762a74..23eddc502816e84ab25366c7d5710ce2e660c7a0 100644
+index 0c87166beb89dd220e2f7aed1c47a331297eef0d..d945a22e2bb992f3cbba3c9ed0f660b6a385a1b0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2073,7 +2073,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2069,7 +2069,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          for (int i = 0; i < s.length(); ++i) {
              if (!SharedConstants.isAllowedChatCharacter(s.charAt(i))) {

--- a/patches/server/0854-Multi-Block-Change-API-Implementation.patch
+++ b/patches/server/0854-Multi-Block-Change-API-Implementation.patch
@@ -25,7 +25,7 @@ index 82ea4fabd5732052a286d50bcff8bbcc2c4aa7d7..652bea6868a03a5315965f79c76172fb
      public void write(FriendlyByteBuf buf) {
          buf.writeLong(this.sectionPos.asLong());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a18d65cd9c3e9ecf812d02997f3cae481572afd1..efa4afee2f3b8595bcd0c753e497d27314dfd42a 100644
+index 7474e607680be7203c87e15550515110d526df68..d309d9f0b54e2a966ccfbb780359bb8e68d15ee3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -30,6 +30,7 @@ import javax.annotation.Nullable;
@@ -36,7 +36,7 @@ index a18d65cd9c3e9ecf812d02997f3cae481572afd1..efa4afee2f3b8595bcd0c753e497d273
  import net.minecraft.nbt.CompoundTag;
  import net.minecraft.network.FriendlyByteBuf;
  import net.minecraft.network.chat.ChatType;
-@@ -838,6 +839,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -840,6 +841,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  

--- a/patches/server/0856-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0856-Freeze-Tick-Lock-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index eac13465c8c1827953a8b1bb2feb4d7f92c773fb..4584dcec835f97e94dcf12788b66703075dafe45 100644
+index 9b5bd68f328306e26eced7d3112b2c01301b543b..9ca080e2745686fc2e39485965ec54c5de0bae6e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -332,6 +332,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -59,10 +59,10 @@ index 44a32fd2c08a09af0bba01547847b8594a7cd077..25338fe4cfdc683ca4c01487e166a164
              if (this.isInPowderSnow && this.canFreeze()) {
                  this.setTicksFrozen(Math.min(this.getTicksRequiredToFreeze(), i + 1));
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 69223b13e894d86d9529f2ef8b60a08a1f7a9267..a3673e2943f251e056ecf84a9bff2de12efdb52a 100644
+index 7490f4127cb9dddf9332a0db7fd4d124e150cd9c..989aaca1d56423729d4f5a491cd4c501342dac7c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -660,6 +660,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -662,6 +662,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.getHandle().isFullyFrozen();
      }
  

--- a/patches/server/0861-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0861-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -123,10 +123,10 @@ index 0000000000000000000000000000000000000000..f7c86155ce0cfd9b4bf8a2b79d77a656
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 54e8f0f367645f3aa8af5b1cb69c39c0cec9381f..1a1f5c8f9a049d65043f12374fe694068f7d08cf 100644
+index 50f3cce22d97d28b00878ba54f9b299da3a5fc2d..250ac849d01f6e8c281e3a8d62438359153f3992 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1988,6 +1988,13 @@ public final class CraftServer implements Server {
+@@ -1983,6 +1983,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  

--- a/patches/server/0862-Implement-regenerateChunk.patch
+++ b/patches/server/0862-Implement-regenerateChunk.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement regenerateChunk
 Co-authored-by: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 116ddf87c573865125f26844ec0ff83d82710594..38764d0833bbfcb9ef4ae55efd06dd5ff4ae4552 100644
+index bb87c4969fe4574196d0e45f8c9f918296c78c9c..c60e16bdbc4707084377de640db8247b12e042ba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -123,6 +123,7 @@ import org.bukkit.util.Vector;
@@ -17,7 +17,7 @@ index 116ddf87c573865125f26844ec0ff83d82710594..38764d0833bbfcb9ef4ae55efd06dd5f
  
      private final ServerLevel world;
      private WorldBorder worldBorder;
-@@ -432,27 +433,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -431,27 +432,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean regenerateChunk(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk regenerate"); // Spigot

--- a/patches/server/0862-Implement-regenerateChunk.patch
+++ b/patches/server/0862-Implement-regenerateChunk.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement regenerateChunk
 Co-authored-by: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5fb475b3ccaa98861e2c817b37cd1740e5bfed8d..f2deb875992ad2d5c9dbcfe9ee7071a773fed684 100644
+index 116ddf87c573865125f26844ec0ff83d82710594..38764d0833bbfcb9ef4ae55efd06dd5ff4ae4552 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -121,6 +121,7 @@ import org.bukkit.util.Vector;
+@@ -123,6 +123,7 @@ import org.bukkit.util.Vector;
  
  public class CraftWorld extends CraftRegionAccessor implements World {
      public static final int CUSTOM_DIMENSION_OFFSET = 10;
@@ -17,7 +17,7 @@ index 5fb475b3ccaa98861e2c817b37cd1740e5bfed8d..f2deb875992ad2d5c9dbcfe9ee7071a7
  
      private final ServerLevel world;
      private WorldBorder worldBorder;
-@@ -435,27 +436,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -432,27 +433,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean regenerateChunk(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk regenerate"); // Spigot
@@ -25,10 +25,6 @@ index 5fb475b3ccaa98861e2c817b37cd1740e5bfed8d..f2deb875992ad2d5c9dbcfe9ee7071a7
 -        /*
 -        if (!unloadChunk0(x, z, false)) {
 -            return false;
--        }
--
--        final long chunkKey = ChunkCoordIntPair.pair(x, z);
--        world.getChunkProvider().unloadQueue.remove(chunkKey);
 +        // Paper start - implement regenerateChunk method
 +        final ServerLevel serverLevel = this.world;
 +        final net.minecraft.server.level.ServerChunkCache serverChunkCache = serverLevel.getChunkSource();
@@ -36,9 +32,11 @@ index 5fb475b3ccaa98861e2c817b37cd1740e5bfed8d..f2deb875992ad2d5c9dbcfe9ee7071a7
 +        final net.minecraft.world.level.chunk.LevelChunk levelChunk = serverChunkCache.getChunk(chunkPos.x, chunkPos.z, true);
 +        for (final BlockPos blockPos : BlockPos.betweenClosed(chunkPos.getMinBlockX(), serverLevel.getMinBuildHeight(), chunkPos.getMinBlockZ(), chunkPos.getMaxBlockX(), serverLevel.getMaxBuildHeight() - 1, chunkPos.getMaxBlockZ())) {
 +            levelChunk.removeBlockEntity(blockPos);
-+            serverLevel.setBlock(blockPos, Blocks.AIR.defaultBlockState(), 16);
-+        }
-+
++            serverLevel.setBlock(blockPos, net.minecraft.world.level.block.Blocks.AIR.defaultBlockState(), 16);
+         }
+ 
+-        final long chunkKey = ChunkCoordIntPair.pair(x, z);
+-        world.getChunkProvider().unloadQueue.remove(chunkKey);
 +        for (final ChunkStatus chunkStatus : REGEN_CHUNK_STATUSES) {
 +            final List<ChunkAccess> list = new ArrayList<>();
 +            final int range = Math.max(1, chunkStatus.getRange());


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
8085edde SPIGOT-6918: Add SpawnCategory API and configurations for Axolotls
04c7e13c PR-719: Add Player Profile API
71564210 SPIGOT-6910: Add BlockDamageAbortEvent

CraftBukkit Changes:
de951355 SPIGOT-6927: Fix default value of spawn-limits in Worlds
febaa1c6 SPIGOT-6918: Add SpawnCategory API and configurations for Axolotls
9dafd109 Don't send updates over large distances
bdac46b0 SPIGOT-6782: EntityPortalEvent should not destroy entity when setTo() uses same world as getFrom()
8f361ece PR-1002: Add Player Profile API
911875d4 Increase outdated build delay
e5f8a767 SPIGOT-6917: Use main scoreboard for /trigger
a672a531 Clean up callBlockDamageEvent
8e1bdeef SPIGOT-6910: Add BlockDamageAbortEvent

Spigot Changes:
6edb62f3 Rebuild patches
7fbc6a1e Rebuild patches