### PR TITLE
Stop large look changes from crashing the server

### DIFF
--- a/patches/server/0863-Stop-large-look-changes-from-crashing-the-server.patch
+++ b/patches/server/0863-Stop-large-look-changes-from-crashing-the-server.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MWHunter <s0521458@student.rockvalleycollege.edu>
+Date: Tue, 8 Feb 2022 22:03:15 -0600
+Subject: [PATCH] Stop large look changes from crashing the server
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 25338fe4cfdc683ca4c01487e166a1649c6f640b..07007774ad0deb1c4e65c04e9067fcce59fd290d 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -2939,37 +2939,40 @@ public abstract class LivingEntity extends Entity {
+         this.level.getProfiler().pop();
+         this.level.getProfiler().push("rangeChecks");
+ 
+-        while (this.getYRot() - this.yRotO < -180.0F) {
++        // Paper Start - Stop large pitch and yaw changes from crashing the server
++        this.yRotO += Math.round((this.getYRot() - this.yRotO) / 360.0F) * 360.0F;
++        /*while (this.getYRot() - this.yRotO < -180.0F) {
+             this.yRotO -= 360.0F;
+         }
+ 
+         while (this.getYRot() - this.yRotO >= 180.0F) {
+             this.yRotO += 360.0F;
+-        }
+-
+-        while (this.yBodyRot - this.yBodyRotO < -180.0F) {
++        }*/
++        this.yBodyRotO += Math.round((this.yBodyRot - this.yBodyRotO) / 360.0F) * 360.0F;
++        /*while (this.yBodyRot - this.yBodyRotO < -180.0F) {
+             this.yBodyRotO -= 360.0F;
+         }
+ 
+         while (this.yBodyRot - this.yBodyRotO >= 180.0F) {
+             this.yBodyRotO += 360.0F;
+-        }
+-
+-        while (this.getXRot() - this.xRotO < -180.0F) {
++        }*/
++        this.xRotO += Math.round((this.getXRot() - this.xRotO) / 360.0F) * 360.0F;
++        /*while (this.getXRot() - this.xRotO < -180.0F) {
+             this.xRotO -= 360.0F;
+         }
+ 
+         while (this.getXRot() - this.xRotO >= 180.0F) {
+             this.xRotO += 360.0F;
+-        }
+-
+-        while (this.yHeadRot - this.yHeadRotO < -180.0F) {
++        }*/
++        this.yHeadRotO += Math.round((this.yHeadRot - this.yHeadRotO) / 360.0F) * 360.0F;
++        /*while (this.yHeadRot - this.yHeadRotO < -180.0F) {
+             this.yHeadRotO -= 360.0F;
+         }
+ 
+         while (this.yHeadRot - this.yHeadRotO >= 180.0F) {
+             this.yHeadRotO += 360.0F;
+-        }
++        }*/
++        // Paper End
+ 
+         this.level.getProfiler().pop();
+         this.animStep += f2;


### PR DESCRIPTION
If a plugin teleports a player with a large pitch or yaw, the server will crash due to some weird looping code.  I've replaced this while loop with identical code that accomplishes the same math.  I've verified this code to be identical with the following program: https://gist.github.com/MWHunter/3690afc61f290314c4e1eb8f4a2c28af

