### PR TITLE
Add missing javadoc stuff from paperweight migration

### DIFF
--- a/patches/api/0001-Convert-project-to-Gradle.patch
+++ b/patches/api/0001-Convert-project-to-Gradle.patch
@@ -27,10 +27,10 @@ index e431e3435737e28394d81b56568a08b3c3148b9b..b23bde3b5e881f146539a307d0a59f21
 +/.factorypath
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..c76bfbcfbe034700bdbd9396643cfca625273a14
+index 0000000000000000000000000000000000000000..778939f2947fe5ae9b2f079cd83f51db6c3307e0
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,66 @@
+@@ -0,0 +1,76 @@
 +plugins {
 +    `java-library`
 +    `maven-publish`
@@ -90,12 +90,22 @@ index 0000000000000000000000000000000000000000..c76bfbcfbe034700bdbd9396643cfca6
 +}
 +
 +tasks.withType<Javadoc> {
-+    (options as StandardJavadocDocletOptions).links(
++    val javadocOptions = options as StandardJavadocDocletOptions
++    javadocOptions.overview = "src/main/javadoc/overview.html"
++    javadocOptions.links(
 +        "https://guava.dev/releases/31.0.1-jre/api/docs/",
 +        "https://javadoc.io/doc/org.yaml/snakeyaml/1.30/",
 +        "https://javadoc.io/doc/org.jetbrains/annotations-java5/23.0.0/",
 +        "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
 +    )
++    doLast {
++        copy {
++            from("src/main/javadoc") {
++                exclude("overview.html")
++            }
++            into("$buildDir/docs/javadoc")
++        }
++    }
 +}
 diff --git a/pom.xml b/pom.xml
 deleted file mode 100644

--- a/patches/api/0002-Build-system-changes.patch
+++ b/patches/api/0002-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index c76bfbcfbe034700bdbd9396643cfca625273a14..1f680baffba17265e8ce38b3516624bffd034075 100644
+index 778939f2947fe5ae9b2f079cd83f51db6c3307e0..5e3cb0819de37396cd4c9614342f1150b5adb4e4 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -15,15 +15,27 @@ dependencies {
@@ -37,12 +37,12 @@ index c76bfbcfbe034700bdbd9396643cfca625273a14..1f680baffba17265e8ce38b3516624bf
      testImplementation("junit:junit:4.13.2")
      testImplementation("org.hamcrest:hamcrest-library:1.3")
      testImplementation("org.ow2.asm:asm-tree:9.2")
-@@ -60,7 +72,7 @@ tasks.withType<Javadoc> {
-     (options as StandardJavadocDocletOptions).links(
+@@ -62,7 +74,7 @@ tasks.withType<Javadoc> {
+     javadocOptions.links(
          "https://guava.dev/releases/31.0.1-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/1.30/",
 -        "https://javadoc.io/doc/org.jetbrains/annotations-java5/23.0.0/",
 +        "https://javadoc.io/doc/org.jetbrains/annotations/23.0.0/", // Paper - we don't want Java 5 annotations
          "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
      )
- }
+     doLast {

--- a/patches/api/0008-Adventure.patch
+++ b/patches/api/0008-Adventure.patch
@@ -7,7 +7,7 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 55ee0c6330e4dbba22b4044346d1e1dd39c745ce..80fdd05dd593455ca89b66636ed30f1d9facf4ed 100644
+index 51cdeea169bd6b1db0f7445683e9ce8727ab7ca7..95d231adbb61a4f2e6b7ce91cf5e9de42a3aea1e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -8,6 +8,19 @@ java {
@@ -42,7 +42,7 @@ index 55ee0c6330e4dbba22b4044346d1e1dd39c745ce..80fdd05dd593455ca89b66636ed30f1d
      // Paper end
  
      compileOnly("org.apache.maven:maven-resolver-provider:3.8.4")
-@@ -70,10 +88,25 @@ tasks.jar {
+@@ -70,6 +88,15 @@ tasks.jar {
  }
  
  tasks.withType<Javadoc> {
@@ -55,8 +55,10 @@ index 55ee0c6330e4dbba22b4044346d1e1dd39c745ce..80fdd05dd593455ca89b66636ed30f1d
 +            apiAndDocs.resolvedConfiguration.files.joinToString(separator = File.pathSeparator, transform = File::getPath)
 +        )
 +    }
-     (options as StandardJavadocDocletOptions).links(
-         "https://guava.dev/releases/31.0.1-jre/api/docs/",
+     val javadocOptions = options as StandardJavadocDocletOptions
+     javadocOptions.overview = "src/main/javadoc/overview.html"
+     javadocOptions.links(
+@@ -77,6 +104,12 @@ tasks.withType<Javadoc> {
          "https://javadoc.io/doc/org.yaml/snakeyaml/1.30/",
          "https://javadoc.io/doc/org.jetbrains/annotations/23.0.0/", // Paper - we don't want Java 5 annotations
          "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
@@ -67,7 +69,8 @@ index 55ee0c6330e4dbba22b4044346d1e1dd39c745ce..80fdd05dd593455ca89b66636ed30f1d
 +        "https://jd.adventure.kyori.net/text-serializer-plain/$adventureVersion/",
 +        // Paper end
      )
- }
+     doLast {
+         copy {
 diff --git a/src/main/java/co/aikar/timings/TimingsReportListener.java b/src/main/java/co/aikar/timings/TimingsReportListener.java
 index ef58a6c00f444bd498a2d8fc4e457236f393954f..ecd149157d4fb80444f34bf5633d74bcdb63dec5 100644
 --- a/src/main/java/co/aikar/timings/TimingsReportListener.java

--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -83,6 +83,18 @@ index 963edbb1e7d47410b7474b8e0ce6774a76ea9d88..1ffdaf8a7814b44facf9648f9e1ba652
      <T extends Keyed> Tag<T> getTag(@NotNull String registry, @NotNull NamespacedKey tag, @NotNull Class<T> clazz);
  
      /**
+diff --git a/src/main/java/org/bukkit/UndefinedNullability.java b/src/main/java/org/bukkit/UndefinedNullability.java
+index f465ea001c190e10eb99db818559d302e5512e99..8570ae15314898c07434f152209021ceabd29a8e 100644
+--- a/src/main/java/org/bukkit/UndefinedNullability.java
++++ b/src/main/java/org/bukkit/UndefinedNullability.java
+@@ -13,6 +13,7 @@ import java.lang.annotation.RetentionPolicy;
+  * suggests a bad API design.
+  */
+ @Retention(RetentionPolicy.CLASS)
++@java.lang.annotation.Documented
+ @Deprecated
+ public @interface UndefinedNullability {
+ 
 diff --git a/src/main/java/org/bukkit/entity/LingeringPotion.java b/src/main/java/org/bukkit/entity/LingeringPotion.java
 index f124b35ec76e6cb6a1a0dc464005087043c3efd0..94a2fef0dc9e13c754cd31d5eabc1bde2dbbe6a5 100644
 --- a/src/main/java/org/bukkit/entity/LingeringPotion.java
@@ -192,7 +204,7 @@ index 9750c52309b32b4b12ecd277300aa4f9998b8072..9ba084c0aefb8d8d654880268cdb7266
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 487e6a6391123a4792c3bdeba869aa2bcb5922cc..3dd8205dd070901be82c2bef390df5df58b2a9a0 100644
+index 487e6a6391123a4792c3bdeba869aa2bcb5922cc..847e5e0823397e106e5e881dd2fb53605c3becc7 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -8,6 +8,7 @@ import java.util.Set; // Paper
@@ -216,7 +228,7 @@ index 487e6a6391123a4792c3bdeba869aa2bcb5922cc..3dd8205dd070901be82c2bef390df5df
       * @return a copy of the current ItemStack's ItemData
       */
 -    @Nullable
-+    @UndefinedNullability // Paper
++    @UndefinedNullability("Only null when the stack type is AIR") // Paper
      public ItemMeta getItemMeta() {
          return this.meta == null ? Bukkit.getItemFactory().getItemMeta(this.type) : this.meta.clone();
      }


### PR DESCRIPTION
When paper migrated to gradle, the overview.html and external files
were never included in the javadocs