### PR TITLE
Log exceptions thrown during chat processing

### DIFF
--- a/patches/server/0863-Log-exceptions-thrown-during-chat-processing.patch
+++ b/patches/server/0863-Log-exceptions-thrown-during-chat-processing.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <lynxplay101@gmail.com>
+Date: Sat, 12 Feb 2022 03:20:36 +0100
+Subject: [PATCH] Log exceptions thrown during chat processing
+
+Previously the async chat executor service would take chat handling
+using the #submit method, which wraps the logic in a future task.
+The future takes full ownership of the task, including any potential
+exception, meaning that the uncaught exception handler never gets
+notified about potential exceptions thrown during async chat logic.
+
+As the chat task does neither need to be cancelled nor returns something
+required later on, this commit moves from #submit to #execute, skipping
+any future task creation. This properly propagates any exception upwards
+to the worker thread in the executor service, allowing the server to
+catch and properly log the exception to the console.
+
+diff --git a/src/main/java/net/minecraft/network/protocol/game/ServerboundChatPacket.java b/src/main/java/net/minecraft/network/protocol/game/ServerboundChatPacket.java
+index 8a0ced3f9b9099913ade4b71181aff6cafbc4ee6..21588ce5a408fed3454c317b56c05439ad3af27d 100644
+--- a/src/main/java/net/minecraft/network/protocol/game/ServerboundChatPacket.java
++++ b/src/main/java/net/minecraft/network/protocol/game/ServerboundChatPacket.java
+@@ -31,7 +31,7 @@ public class ServerboundChatPacket implements Packet<ServerGamePacketListener> {
+     public void handle(final ServerGamePacketListener listener) {
+         if ( !this.message.startsWith("/") )
+         {
+-            ServerboundChatPacket.executors.submit( new Runnable()
++            ServerboundChatPacket.executors.execute( new Runnable() // Paper - Use #execute to propagate exceptions up instead of swallowing them
+             {
+ 
+                 @Override


### PR DESCRIPTION
Previously the async chat executor service would take chat handling
using the #submit method, which wraps the logic in a future task.
The future takes full ownership of the task, including any potential
exception, meaning that the uncaught exception handler never gets
notified about potential exceptions thrown during async chat logic.

As the chat task does neither need to be cancelled nor returns something
required later on, this commit moves from #submit to #execute, skipping
any future task creation. This properly propagates any exception upwards
to the worker thread in the executor service, allowing the server to
catch and deobfuscate the exception before properly logging it into the
servers console.

Resolves: #7466 