### PR TITLE
Use access transformers for player profile API

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -267,8 +267,17 @@ public net.minecraft.world.level.NaturalSpawner SPAWNING_CATEGORIES
 # Optimize isValidLocation
 public net.minecraft.world.level.chunk.LevelChunkSection states
 
-# Player.setPlayerProfile API
+# Player Profile API
 public-f net.minecraft.world.entity.player.Player gameProfile
+public org.bukkit.craftbukkit.profile.CraftProfileProperty
+public org.bukkit.craftbukkit.profile.CraftPlayerTextures
+public org.bukkit.craftbukkit.profile.CraftPlayerTextures copyFrom(Lorg/bukkit/profile/PlayerTextures;)V
+public org.bukkit.craftbukkit.profile.CraftPlayerTextures rebuildPropertyIfDirty()V
+public org.bukkit.craftbukkit.profile.CraftPlayerProfile getProperty(Ljava/lang/String;)Lcom/mojang/authlib/properties/Property;
+public org.bukkit.craftbukkit.profile.CraftPlayerProfile setProperty(Ljava/lang/String;Lcom/mojang/authlib/properties/Property;)V
+public org.bukkit.craftbukkit.profile.CraftPlayerProfile toString(Lcom/mojang/authlib/properties/PropertyMap;)Ljava/lang/String;
+public org.bukkit.craftbukkit.profile.CraftPlayerProfile equals(Lcom/mojang/authlib/properties/PropertyMap;Lcom/mojang/authlib/properties/PropertyMap;)Z
+public org.bukkit.craftbukkit.profile.CraftPlayerProfile hashCode(Lcom/mojang/authlib/properties/PropertyMap;)I
 
 # Generator Settings
 public net.minecraft.world.level.levelgen.SurfaceRules$Condition

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -664,7 +664,7 @@ index 909724efb99f88f3de0967b85d539e0ab1bec8e8..e93c743500e3c439cd32757b16025804
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
-index 3cd37402c1f98d47ea009fa4ea71c85044bbe59f..8e4a1598d31e362bd7b10033460c11cb49f6275e 100644
+index 2d49bd6f3f017d43dfaa23cedf35040b64bcdcf8..661d8e9882509700faa9bc10a2e3074c5553af44 100644
 --- a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
 +++ b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
 @@ -27,7 +27,7 @@ import org.bukkit.profile.PlayerProfile;
@@ -676,20 +676,6 @@ index 3cd37402c1f98d47ea009fa4ea71c85044bbe59f..8e4a1598d31e362bd7b10033460c11cb
  
      @Nonnull
      public static GameProfile validateSkullProfile(@Nonnull GameProfile gameProfile) {
-@@ -80,11 +80,11 @@ public final class CraftPlayerProfile implements PlayerProfile {
-     }
- 
-     @Nullable
--    Property getProperty(String propertyName) {
-+    public Property getProperty(String propertyName) { // Paper - public
-         return Iterables.getFirst(this.properties.get(propertyName), null);
-     }
- 
--    void setProperty(String propertyName, @Nullable Property property) {
-+    public void setProperty(String propertyName, @Nullable Property property) { // Paper - public
-         // Assert: (property == null) || property.getName().equals(propertyName)
-         this.removeProperty(propertyName);
-         if (property != null) {
 @@ -92,8 +92,10 @@ public final class CraftPlayerProfile implements PlayerProfile {
          }
      }
@@ -703,33 +689,6 @@ index 3cd37402c1f98d47ea009fa4ea71c85044bbe59f..8e4a1598d31e362bd7b10033460c11cb
      }
  
      void rebuildDirtyProperties() {
-@@ -168,7 +170,7 @@ public final class CraftPlayerProfile implements PlayerProfile {
-         return builder.toString();
-     }
- 
--    private static String toString(@Nonnull PropertyMap propertyMap) {
-+    public static String toString(@Nonnull PropertyMap propertyMap) { // Paper - public
-         StringBuilder builder = new StringBuilder();
-         builder.append("{");
-         propertyMap.asMap().forEach((propertyName, properties) -> {
-@@ -194,7 +196,7 @@ public final class CraftPlayerProfile implements PlayerProfile {
-         return true;
-     }
- 
--    private static boolean equals(@Nonnull PropertyMap propertyMap, @Nonnull PropertyMap other) {
-+    public static boolean equals(@Nonnull PropertyMap propertyMap, @Nonnull PropertyMap other) { // Paper - public
-         if (propertyMap.size() != other.size()) return false;
-         // We take the order of properties into account here, because it is
-         // also relevant in the serialized and NBT forms of GameProfiles.
-@@ -221,7 +223,7 @@ public final class CraftPlayerProfile implements PlayerProfile {
-         return result;
-     }
- 
--    private static int hashCode(PropertyMap propertyMap) {
-+    public static int hashCode(PropertyMap propertyMap) { // Paper - public
-         int result = 1;
-         for (Property property : propertyMap.values()) {
-             result = 31 * result + CraftProfileProperty.hashCode(property);
 @@ -236,6 +238,7 @@ public final class CraftPlayerProfile implements PlayerProfile {
  
      @Override
@@ -761,19 +720,10 @@ index 3cd37402c1f98d47ea009fa4ea71c85044bbe59f..8e4a1598d31e362bd7b10033460c11cb
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java
-index c930b7557b141650d63d6802c26139b14ddab6b9..bf56d4fbd34586190e2d680cc33d125578a0953e 100644
+index e5b61bc1f3a4bfccca386360c4920ffb8b768308..ab1fd3fb39bd40fb867432861462db5f866bce6f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java
 +++ b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java
-@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
- import org.bukkit.craftbukkit.util.JsonHelper;
- import org.bukkit.profile.PlayerTextures;
- 
--final class CraftPlayerTextures implements PlayerTextures {
-+public final class CraftPlayerTextures implements PlayerTextures { // Paper - public
- 
-     static final String PROPERTY_NAME = "textures";
-     private static final String MINECRAFT_HOST = "textures.minecraft.net";
-@@ -48,7 +48,7 @@ final class CraftPlayerTextures implements PlayerTextures {
+@@ -48,7 +48,7 @@ public final class CraftPlayerTextures implements PlayerTextures {
          }
      }
  
@@ -782,7 +732,7 @@ index c930b7557b141650d63d6802c26139b14ddab6b9..bf56d4fbd34586190e2d680cc33d1255
  
      // The textures data is loaded lazily:
      private boolean loaded = false;
-@@ -67,11 +67,11 @@ final class CraftPlayerTextures implements PlayerTextures {
+@@ -67,7 +67,7 @@ public final class CraftPlayerTextures implements PlayerTextures {
      // GameProfiles (even if these modifications are later reverted).
      private boolean dirty = false;
  
@@ -791,30 +741,3 @@ index c930b7557b141650d63d6802c26139b14ddab6b9..bf56d4fbd34586190e2d680cc33d1255
          this.profile = profile;
      }
  
--    void copyFrom(@Nonnull PlayerTextures other) {
-+    public void copyFrom(@Nonnull PlayerTextures other) { // Paper - public
-         if (other == this) return;
-         Preconditions.checkArgument(other instanceof CraftPlayerTextures, "Expecting CraftPlayerTextures, got %s", other.getClass().getName());
-         CraftPlayerTextures otherTextures = (CraftPlayerTextures) other;
-@@ -238,7 +238,7 @@ final class CraftPlayerTextures implements PlayerTextures {
-         return this.profile.getProperty(PROPERTY_NAME);
-     }
- 
--    void rebuildPropertyIfDirty() {
-+    public void rebuildPropertyIfDirty() { // Paper - public
-         if (!this.dirty) return;
-         // Assert: loaded
-         this.dirty = false;
-diff --git a/src/main/java/org/bukkit/craftbukkit/profile/CraftProfileProperty.java b/src/main/java/org/bukkit/craftbukkit/profile/CraftProfileProperty.java
-index 0617ad166dd4cb5e26c0c22b264116c23b50195b..07348f0d2c61a78610c5f7bdb280b5a39633a831 100644
---- a/src/main/java/org/bukkit/craftbukkit/profile/CraftProfileProperty.java
-+++ b/src/main/java/org/bukkit/craftbukkit/profile/CraftProfileProperty.java
-@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
- import org.apache.commons.io.IOUtils;
- import org.bukkit.craftbukkit.configuration.ConfigSerializationUtil;
- 
--final class CraftProfileProperty {
-+public final class CraftProfileProperty { // Paper - public
- 
-     /**
-      * Different JSON formatting styles to use for encoded property values.


### PR DESCRIPTION
During the previous upstream update, craftbukkit classes and methods had
their modifiers changed through in-patch modifications, which is an
outdated way of modifying access modifiers in server internals.

This commit moves all of the in-patch access transformers into the
paper.at file and unites them with the single existing access
transformer used for the player profile api.