### PR TITLE
Fix PlayerProfile BukkitObject serialization, deprecate setName and setId for removal

### DIFF
--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -7,10 +7,10 @@ Provides basic elements of a PlayerProfile to be used by future API/events
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a4d84b5dc76c6ace93ce1467f7d6b48df97fcf5f
+index 0000000000000000000000000000000000000000..d4766e2116c2202d84080637a2832bef0ab3f718
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
-@@ -0,0 +1,197 @@
+@@ -0,0 +1,199 @@
 +package com.destroystokyo.paper.profile;
 +
 +import java.util.Collection;
@@ -39,6 +39,7 @@ index 0000000000000000000000000000000000000000..a4d84b5dc76c6ace93ce1467f7d6b48d
 +     * @return The previous Name
 +     */
 +    @NotNull
++    @Deprecated(forRemoval = true)
 +    String setName(@Nullable String name);
 +
 +    /**
@@ -53,6 +54,7 @@ index 0000000000000000000000000000000000000000..a4d84b5dc76c6ace93ce1467f7d6b48d
 +     * @return The previous UUID
 +     */
 +    @Nullable
++    @Deprecated(forRemoval = true)
 +    UUID setId(@Nullable UUID uuid);
 +
 +    /**

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -7,10 +7,10 @@ Establishes base extension of profile systems for future edits too
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d64a05742ba78aefc64b2e5d824b4caa2c7bc479
+index 0000000000000000000000000000000000000000..2041376dfd5520776f7e32c1828973f2b719d82a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
-@@ -0,0 +1,372 @@
+@@ -0,0 +1,399 @@
 +package com.destroystokyo.paper.profile;
 +
 +import com.destroystokyo.paper.PaperConfig;
@@ -23,6 +23,8 @@ index 0000000000000000000000000000000000000000..d64a05742ba78aefc64b2e5d824b4caa
 +import net.minecraft.server.MinecraftServer;
 +import net.minecraft.server.players.GameProfileCache;
 +import org.apache.commons.lang3.Validate;
++import org.bukkit.configuration.serialization.SerializableAs;
++import org.bukkit.craftbukkit.configuration.ConfigSerializationUtil;
 +import org.bukkit.craftbukkit.entity.CraftPlayer;
 +import org.bukkit.craftbukkit.profile.CraftPlayerTextures;
 +import org.bukkit.craftbukkit.profile.CraftProfileProperty;
@@ -34,6 +36,7 @@ index 0000000000000000000000000000000000000000..d64a05742ba78aefc64b2e5d824b4caa
 +import java.util.*;
 +import java.util.concurrent.CompletableFuture;
 +
++@SerializableAs("PlayerProfile")
 +public class CraftPlayerProfile implements PlayerProfile, SharedPlayerProfile {
 +
 +    private GameProfile profile;
@@ -92,6 +95,7 @@ index 0000000000000000000000000000000000000000..d64a05742ba78aefc64b2e5d824b4caa
 +    }
 +
 +    @Override
++    @Deprecated(forRemoval = true)
 +    public UUID setId(@Nullable UUID uuid) {
 +        GameProfile prev = this.profile;
 +        this.profile = new GameProfile(uuid, prev.getName());
@@ -111,6 +115,7 @@ index 0000000000000000000000000000000000000000..d64a05742ba78aefc64b2e5d824b4caa
 +    }
 +
 +    @Override
++    @Deprecated(forRemoval = true)
 +    public String setName(@Nullable String name) {
 +        GameProfile prev = this.profile;
 +        this.profile = new GameProfile(prev.getId(), name);
@@ -160,24 +165,6 @@ index 0000000000000000000000000000000000000000..d64a05742ba78aefc64b2e5d824b4caa
 +        GameProfile profile = new GameProfile(this.profile.getId(), this.profile.getName());
 +        profile.getProperties().putAll(this.profile.getProperties());
 +        return profile;
-+    }
-+
-+    @Override
-+    public boolean equals(Object o) {
-+        if (this == o) return true;
-+        if (o == null || getClass() != o.getClass()) return false;
-+        CraftPlayerProfile that = (CraftPlayerProfile) o;
-+        return Objects.equals(profile, that.profile);
-+    }
-+
-+    @Override
-+    public int hashCode() {
-+        return profile.hashCode();
-+    }
-+
-+    @Override
-+    public String toString() {
-+        return profile.toString();
 +    }
 +
 +    @Override
@@ -326,6 +313,46 @@ index 0000000000000000000000000000000000000000..d64a05742ba78aefc64b2e5d824b4caa
 +            map.put("properties", propertiesData);
 +        }
 +        return map;
++    }
++
++    public static CraftPlayerProfile deserialize(Map<String, Object> map) {
++        UUID uniqueId = ConfigSerializationUtil.getUuid(map, "uniqueId", true);
++        String name = ConfigSerializationUtil.getString(map, "name", true);
++
++        // This also validates the deserialized unique id and name (ensures that not both are null):
++        CraftPlayerProfile profile = new CraftPlayerProfile(uniqueId, name);
++
++        if (map.containsKey("properties")) {
++            for (Object propertyData : (List<?>) map.get("properties")) {
++                if (!(propertyData instanceof Map)) {
++                    throw new IllegalArgumentException("Property data (" + propertyData + ") is not a valid Map");
++                }
++                Property property = CraftProfileProperty.deserialize((Map<?, ?>) propertyData);
++                profile.profile.getProperties().put(property.getName(), property);
++            }
++        }
++
++        return profile;
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        if (this == obj) return true;
++        if (!(obj instanceof CraftPlayerProfile otherProfile)) return false;
++        return Objects.equals(this.profile, otherProfile.profile);
++    }
++
++    @Override
++    public String toString() {
++        return "CraftPlayerProfile [uniqueId=" + getId() +
++            ", name=" + getName() +
++            ", properties=" + org.bukkit.craftbukkit.profile.CraftPlayerProfile.toString(this.profile.getProperties()) +
++            "]";
++    }
++
++    @Override
++    public int hashCode() {
++        return this.profile.hashCode();
 +    }
 +
 +    private class PropertySet extends AbstractSet<ProfileProperty> {
@@ -590,7 +617,7 @@ index 00f783aafd81fa7e836e4eea5bfeac7434f33b0f..3789441e2df9410aa1c6efe59054aaba
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 909724efb99f88f3de0967b85d539e0ab1bec8e8..7653c23690b927f93ca4692c6e077abfb9e1c5ca 100644
+index 909724efb99f88f3de0967b85d539e0ab1bec8e8..e93c743500e3c439cd32757b16025804e0552181 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -247,6 +247,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -603,7 +630,15 @@ index 909724efb99f88f3de0967b85d539e0ab1bec8e8..7653c23690b927f93ca4692c6e077abf
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2559,5 +2562,24 @@ public final class CraftServer implements Server {
+@@ -286,6 +289,7 @@ public final class CraftServer implements Server {
+     static {
+         ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
+         ConfigurationSerialization.registerClass(CraftPlayerProfile.class);
++        ConfigurationSerialization.registerClass(com.destroystokyo.paper.profile.CraftPlayerProfile.class); // Paper
+         CraftItemFactory.instance();
+     }
+ 
+@@ -2559,5 +2563,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
@@ -629,7 +664,7 @@ index 909724efb99f88f3de0967b85d539e0ab1bec8e8..7653c23690b927f93ca4692c6e077abf
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
-index 3cd37402c1f98d47ea009fa4ea71c85044bbe59f..992d4cd38246d67ab1220dac611d6540b3c3791f 100644
+index 3cd37402c1f98d47ea009fa4ea71c85044bbe59f..8e4a1598d31e362bd7b10033460c11cb49f6275e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
 +++ b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
 @@ -27,7 +27,7 @@ import org.bukkit.profile.PlayerProfile;
@@ -668,6 +703,63 @@ index 3cd37402c1f98d47ea009fa4ea71c85044bbe59f..992d4cd38246d67ab1220dac611d6540
      }
  
      void rebuildDirtyProperties() {
+@@ -168,7 +170,7 @@ public final class CraftPlayerProfile implements PlayerProfile {
+         return builder.toString();
+     }
+ 
+-    private static String toString(@Nonnull PropertyMap propertyMap) {
++    public static String toString(@Nonnull PropertyMap propertyMap) { // Paper - public
+         StringBuilder builder = new StringBuilder();
+         builder.append("{");
+         propertyMap.asMap().forEach((propertyName, properties) -> {
+@@ -194,7 +196,7 @@ public final class CraftPlayerProfile implements PlayerProfile {
+         return true;
+     }
+ 
+-    private static boolean equals(@Nonnull PropertyMap propertyMap, @Nonnull PropertyMap other) {
++    public static boolean equals(@Nonnull PropertyMap propertyMap, @Nonnull PropertyMap other) { // Paper - public
+         if (propertyMap.size() != other.size()) return false;
+         // We take the order of properties into account here, because it is
+         // also relevant in the serialized and NBT forms of GameProfiles.
+@@ -221,7 +223,7 @@ public final class CraftPlayerProfile implements PlayerProfile {
+         return result;
+     }
+ 
+-    private static int hashCode(PropertyMap propertyMap) {
++    public static int hashCode(PropertyMap propertyMap) { // Paper - public
+         int result = 1;
+         for (Property property : propertyMap.values()) {
+             result = 31 * result + CraftProfileProperty.hashCode(property);
+@@ -236,6 +238,7 @@ public final class CraftPlayerProfile implements PlayerProfile {
+ 
+     @Override
+     public Map<String, Object> serialize() {
++        // Paper - diff on change
+         Map<String, Object> map = new LinkedHashMap<>();
+         if (this.uniqueId != null) {
+             map.put("uniqueId", this.uniqueId.toString());
+@@ -251,10 +254,12 @@ public final class CraftPlayerProfile implements PlayerProfile {
+             });
+             map.put("properties", propertiesData);
+         }
++        // Paper - diff on change
+         return map;
+     }
+ 
+     public static CraftPlayerProfile deserialize(Map<String, Object> map) {
++        // Paper - diff on change
+         UUID uniqueId = ConfigSerializationUtil.getUuid(map, "uniqueId", true);
+         String name = ConfigSerializationUtil.getString(map, "name", true);
+ 
+@@ -270,7 +275,7 @@ public final class CraftPlayerProfile implements PlayerProfile {
+                 profile.properties.put(property.getName(), property);
+             }
+         }
+-
++        // Paper - diff on change
+         return profile;
+     }
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java
 index c930b7557b141650d63d6802c26139b14ddab6b9..bf56d4fbd34586190e2d680cc33d125578a0953e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerTextures.java

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -72,10 +72,10 @@ index 5b8ecb96f0a6dbc9e396644b074b50ccb7b38e78..815901f857d283e2529c01ea81640c6b
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7653c23690b927f93ca4692c6e077abfb9e1c5ca..198fdedf1b7164df006188e11d5e361a26cd9f90 100644
+index e93c743500e3c439cd32757b16025804e0552181..d8ae9ab815936712cde9d185d98728a77c0657d9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2079,7 +2079,7 @@ public final class CraftServer implements Server {
+@@ -2080,7 +2080,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0185-getPlayerUniqueId-API.patch
+++ b/patches/server/0185-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 198fdedf1b7164df006188e11d5e361a26cd9f90..7e8c50c3fd27e5f5a931f2d7263c55ede441aacc 100644
+index d8ae9ab815936712cde9d185d98728a77c0657d9..602b55cc7f224a1a67ac7c3b45d206f12d505dc3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1706,6 +1706,25 @@ public final class CraftServer implements Server {
+@@ -1707,6 +1707,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0243-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0243-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -48,10 +48,10 @@ index e89f100e950c6fa85112a67daaa157de665b17cf..37ccbfc3b5ff47fac8cd878f9de5bcce
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7e8c50c3fd27e5f5a931f2d7263c55ede441aacc..17ec1302e06792835f57d97b7d406065522cba54 100644
+index 602b55cc7f224a1a67ac7c3b45d206f12d505dc3..9fc876f3de20b0ad043a9dc6772d4bc6639c943d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -907,6 +907,7 @@ public final class CraftServer implements Server {
+@@ -908,6 +908,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -59,7 +59,7 @@ index 7e8c50c3fd27e5f5a931f2d7263c55ede441aacc..17ec1302e06792835f57d97b7d406065
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -996,6 +997,7 @@ public final class CraftServer implements Server {
+@@ -997,6 +998,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/patches/server/0278-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0278-Add-Velocity-IP-Forwarding-Support.patch
@@ -225,10 +225,10 @@ index 67b300574655854249c1f7440f56a6e8f0fad351..bb767f5b626225e70a8af273384bb74d
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 17ec1302e06792835f57d97b7d406065522cba54..092f6e2a76d8252de0a40425e271abd11763ee62 100644
+index 9fc876f3de20b0ad043a9dc6772d4bc6639c943d..8ef4679af2e7ad090f6cbdca9d69a5d88b3c6e93 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -762,7 +762,7 @@ public final class CraftServer implements Server {
+@@ -763,7 +763,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0290-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0290-Make-the-default-permission-message-configurable.patch
@@ -42,10 +42,10 @@ index edf0a82ba7e16b86100aa1920fa41508be2ab1e8..c48b175d5511b733bcff9a93a874f5ff
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 092f6e2a76d8252de0a40425e271abd11763ee62..17aa8e654b5676e4401131e1b8196625618d2ee6 100644
+index 8ef4679af2e7ad090f6cbdca9d69a5d88b3c6e93..23d450f150d2f2acbb6add825add5f9c777d30b3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2584,6 +2584,11 @@ public final class CraftServer implements Server {
+@@ -2585,6 +2585,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  

--- a/patches/server/0324-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0324-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -29,10 +29,10 @@ index d7048f7f05e67581ed3be28d452fbe52f4c980cf..b3c4687c6538adf851379f73cceffb11
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 17aa8e654b5676e4401131e1b8196625618d2ee6..e707208d4cfd39e6f984c62b78521799b1e35173 100644
+index 23d450f150d2f2acbb6add825add5f9c777d30b3..4d0ff2866580a7ce7e83e8ed223ebb16d328ecbf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2068,7 +2068,7 @@ public final class CraftServer implements Server {
+@@ -2069,7 +2069,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0331-Expose-the-internal-current-tick.patch
+++ b/patches/server/0331-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e707208d4cfd39e6f984c62b78521799b1e35173..f1dd55972b0a0f389527c1fef739a78f1d85b579 100644
+index 4d0ff2866580a7ce7e83e8ed223ebb16d328ecbf..3573856d032605236c5b73196a7287a1e4ed41ac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2607,5 +2607,10 @@ public final class CraftServer implements Server {
+@@ -2608,5 +2608,10 @@ public final class CraftServer implements Server {
          }
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
      }

--- a/patches/server/0360-Anti-Xray.patch
+++ b/patches/server/0360-Anti-Xray.patch
@@ -1596,10 +1596,10 @@ index a1fe076d76fe5f84eca39ea68e9820096f58f5a7..155933ef7c324ea17c2349a1f73ede29
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f1dd55972b0a0f389527c1fef739a78f1d85b579..dce382bb853dff010dc2c8ef86f8bf1cce7438c6 100644
+index 3573856d032605236c5b73196a7287a1e4ed41ac..2b79cc8538b583c991bda78656cfb0fca888d406 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2223,7 +2223,7 @@ public final class CraftServer implements Server {
+@@ -2224,7 +2224,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Validate.notNull(world, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();

--- a/patches/server/0381-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0381-Add-tick-times-API-and-mspt-command.patch
@@ -146,10 +146,10 @@ index 76da16590f27702883c07200a02db823d9720c61..3c2af39f7bd62448a3075d327132ebc1
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dce382bb853dff010dc2c8ef86f8bf1cce7438c6..2b315621eaf3b889f417339c22c6afe6a23959fd 100644
+index 2b79cc8538b583c991bda78656cfb0fca888d406..745789b9ebffc446ebef1834b1e91606249b75de 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2445,6 +2445,16 @@ public final class CraftServer implements Server {
+@@ -2446,6 +2446,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0382-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0382-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2b315621eaf3b889f417339c22c6afe6a23959fd..989dc2ebbe10d8f2619661f20eddcdd0071b8bb4 100644
+index 745789b9ebffc446ebef1834b1e91606249b75de..42b615b4acb109f29d90430013db00b011c169ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2622,5 +2622,10 @@ public final class CraftServer implements Server {
+@@ -2623,5 +2623,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0393-Improved-Watchdog-Support.patch
+++ b/patches/server/0393-Improved-Watchdog-Support.patch
@@ -323,10 +323,10 @@ index 8cfe47012b78eb582afff23ffcf758ca2e9dec95..d70bdf21dd7bdf01b34d0fd38e79f9b3
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 989dc2ebbe10d8f2619661f20eddcdd0071b8bb4..34249d98a4db6c6d9e06a30faf6333ddf996e4a5 100644
+index 42b615b4acb109f29d90430013db00b011c169ad..f3acca2144011e57fe49acf1ba09d7041b7aaba4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2068,7 +2068,7 @@ public final class CraftServer implements Server {
+@@ -2069,7 +2069,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0413-Expose-game-version.patch
+++ b/patches/server/0413-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 34249d98a4db6c6d9e06a30faf6333ddf996e4a5..81fae30cde0bf377ad98abb8d4c3ce0383bb0e85 100644
+index f3acca2144011e57fe49acf1ba09d7041b7aaba4..a200cdfcab72980ed5df3810a0c7b3e9f30f4e04 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -575,6 +575,13 @@ public final class CraftServer implements Server {
+@@ -576,6 +576,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  

--- a/patches/server/0416-misc-debugging-dumps.patch
+++ b/patches/server/0416-misc-debugging-dumps.patch
@@ -74,10 +74,10 @@ index 301042e7a0d372a914f27ec0988dd938cf2a8262..1766a22e65af2e08611a9435c7384377
                  this.connection.send(new ClientboundDisconnectPacket(chatmessage));
                  this.connection.disconnect(chatmessage);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 81fae30cde0bf377ad98abb8d4c3ce0383bb0e85..db8c8a2846faa5b07015a67d43e0a16b76f19849 100644
+index a200cdfcab72980ed5df3810a0c7b3e9f30f4e04..2a2f4e4d05ebeef44153171a09bf9ef79bd9c65e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -999,6 +999,7 @@ public final class CraftServer implements Server {
+@@ -1000,6 +1000,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getFullName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0418-Implement-Mob-Goal-API.patch
+++ b/patches/server/0418-Implement-Mob-Goal-API.patch
@@ -785,10 +785,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index db8c8a2846faa5b07015a67d43e0a16b76f19849..2dd7a67630cc69ae7754baaae411594237572631 100644
+index 2a2f4e4d05ebeef44153171a09bf9ef79bd9c65e..ed5418dac2fc781437f840792581b61e73e46bc4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2635,5 +2635,11 @@ public final class CraftServer implements Server {
+@@ -2636,5 +2636,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0425-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0425-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,10 +22,10 @@ index 3092a50be8243a576d95e7f5ce546941f0b105fa..9d8dd7ac4e471d658ba942e29c5028df
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2dd7a67630cc69ae7754baaae411594237572631..ac582976fb2cc3edd258d004a8e9a7325b975fee 100644
+index ed5418dac2fc781437f840792581b61e73e46bc4..c5da0ee99ce3dfea836378e31bf5b6f43b2c33ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1008,6 +1008,35 @@ public final class CraftServer implements Server {
+@@ -1009,6 +1009,35 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0450-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0450-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -107,10 +107,10 @@ index ec784bb54f7e4b4cb90a64e636392a752302cf86..1486ac77bf4621a3a2a5da6d53461bad
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ac582976fb2cc3edd258d004a8e9a7325b975fee..f796194c1c7cc8a656eef0f50b83ce7b7898e895 100644
+index c5da0ee99ce3dfea836378e31bf5b6f43b2c33ad..dd1a8b58c2ffffa9955b782d6cf15da8b9c54204 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -947,8 +947,8 @@ public final class CraftServer implements Server {
+@@ -948,8 +948,8 @@ public final class CraftServer implements Server {
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
          com.destroystokyo.paper.PaperConfig.init((File) console.options.valueOf("paper-settings")); // Paper
          for (ServerLevel world : this.console.getAllLevels()) {

--- a/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,10 +22,10 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f796194c1c7cc8a656eef0f50b83ce7b7898e895..e41cbccb533327f8ab159f30be81a1cbeb5d37c3 100644
+index dd1a8b58c2ffffa9955b782d6cf15da8b9c54204..dd49caa38c2934eab581ad5c3393693bc03716d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -361,7 +361,7 @@ public final class CraftServer implements Server {
+@@ -362,7 +362,7 @@ public final class CraftServer implements Server {
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -34,7 +34,7 @@ index f796194c1c7cc8a656eef0f50b83ce7b7898e895..e41cbccb533327f8ab159f30be81a1cb
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
      }
-@@ -927,7 +927,7 @@ public final class CraftServer implements Server {
+@@ -928,7 +928,7 @@ public final class CraftServer implements Server {
          this.console.setMotd(config.motd);
          this.overrideSpawnLimits();
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -44,7 +44,7 @@ index f796194c1c7cc8a656eef0f50b83ce7b7898e895..e41cbccb533327f8ab159f30be81a1cb
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fe35d72dd2e13bce16c7b02d726144ff6cb2ecbe..fd82082326e9f4c572803ba1f525c7125a89222a 100644
+index 2bd734ee97afd0febf157508f867853f3a5abbf9..90830956fca6d862f3b382996f6d785c07ea3bfb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -265,8 +265,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0485-Add-setMaxPlayers-API.patch
+++ b/patches/server/0485-Add-setMaxPlayers-API.patch
@@ -18,10 +18,10 @@ index 8ed4d4bc6d08c8339aba57b17f068c7bef22787c..35cf9c8235534a5c59065718ff57873f
      private int simulationDistance;
      private boolean allowCheatsForAllPlayers;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e41cbccb533327f8ab159f30be81a1cbeb5d37c3..c9c569a917132ea82edf905f8f76a33576554780 100644
+index dd49caa38c2934eab581ad5c3393693bc03716d2..01fc3f252f6a05aa97df29b88acf0ff3ef8dfcb7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -670,6 +670,13 @@ public final class CraftServer implements Server {
+@@ -671,6 +671,13 @@ public final class CraftServer implements Server {
          return this.playerList.getMaxPlayers();
      }
  

--- a/patches/server/0524-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0524-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c9c569a917132ea82edf905f8f76a33576554780..d3c98840ca493259417ab435f8cc70c7e181648d 100644
+index 01fc3f252f6a05aa97df29b88acf0ff3ef8dfcb7..e116d734d482ac918cc88cf038c3aeae13c1a531 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1801,6 +1801,28 @@ public final class CraftServer implements Server {
+@@ -1802,6 +1802,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0613-Implement-Keyed-on-World.patch
+++ b/patches/server/0613-Implement-Keyed-on-World.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d3c98840ca493259417ab435f8cc70c7e181648d..b404fb1642fa4480f87ad675418c57c84944b3a2 100644
+index e116d734d482ac918cc88cf038c3aeae13c1a531..bd92d9671d99b81af401a0f7509ef65ca221024e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1238,7 +1238,7 @@ public final class CraftServer implements Server {
+@@ -1239,7 +1239,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -17,7 +17,7 @@ index d3c98840ca493259417ab435f8cc70c7e181648d..b404fb1642fa4480f87ad675418c57c8
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, dimensionmanager, this.getServer().progressListenerFactory.create(11),
-@@ -1330,6 +1330,15 @@ public final class CraftServer implements Server {
+@@ -1331,6 +1331,15 @@ public final class CraftServer implements Server {
          return null;
      }
  
@@ -34,7 +34,7 @@ index d3c98840ca493259417ab435f8cc70c7e181648d..b404fb1642fa4480f87ad675418c57c8
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 706a1c37c81828ab570a7012f96a421d6c9977c1..f6c531d416b4e85df88d0fbed5773cb0b9644c1d 100644
+index afe0bb86903c76285804fcb466e043a62ad88b89..d228e085322fb22c3559058edaabb818c4c60111 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -2010,6 +2010,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0653-Add-basic-Datapack-API.patch
+++ b/patches/server/0653-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b404fb1642fa4480f87ad675418c57c84944b3a2..79f785b907e009de21b5299e6cc5c4cddc1b95d2 100644
+index bd92d9671d99b81af401a0f7509ef65ca221024e..f551ff9565dec612c007b4569362061a96135d59 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -284,6 +284,7 @@ public final class CraftServer implements Server {
@@ -103,7 +103,7 @@ index b404fb1642fa4480f87ad675418c57c84944b3a2..79f785b907e009de21b5299e6cc5c4cd
      public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {
-@@ -364,6 +365,7 @@ public final class CraftServer implements Server {
+@@ -365,6 +366,7 @@ public final class CraftServer implements Server {
          TicketType.PLUGIN.timeout = Math.min(20, this.configuration.getInt("chunk-gc.period-in-ticks")); // Paper - cap plugin loads to 1 second
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
@@ -111,7 +111,7 @@ index b404fb1642fa4480f87ad675418c57c84944b3a2..79f785b907e009de21b5299e6cc5c4cd
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2708,5 +2710,11 @@ public final class CraftServer implements Server {
+@@ -2709,5 +2711,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0658-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0658-Fix-and-optimise-world-force-upgrading.patch
@@ -359,10 +359,10 @@ index 4bc33c31d497aa7d69226ab870fd78902bedfd5b..089e8414c7bdc102ba0d914af576df1a
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 79f785b907e009de21b5299e6cc5c4cddc1b95d2..bf2718441e46c47f227862c4f79fae08db1ad123 100644
+index f551ff9565dec612c007b4569362061a96135d59..dfc1f5a9203acd85f481658d76193f9ed943f01c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1199,12 +1199,7 @@ public final class CraftServer implements Server {
+@@ -1200,12 +1200,7 @@ public final class CraftServer implements Server {
          }
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().shouldReportAsModified());
@@ -376,7 +376,7 @@ index 79f785b907e009de21b5299e6cc5c4cddc1b95d2..bf2718441e46c47f227862c4f79fae08
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1233,6 +1228,14 @@ public final class CraftServer implements Server {
+@@ -1234,6 +1229,14 @@ public final class CraftServer implements Server {
              }
          }
  

--- a/patches/server/0817-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0817-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7075ee9ea0f2ac12cee7644a5f84410bb317ab70..5215ae06260f930a8e313af35a20e916e60aa6c0 100644
+index e0e7fb4cc5516d8712f384fb5cb4d22c5bdceff5..077998f9a40b43d881d4fbfb8f21fb579855dc53 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2307,6 +2307,107 @@ public final class CraftServer implements Server {
+@@ -2308,6 +2308,107 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0844-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0844-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,10 +18,10 @@ index d8ec6871cf25175a1da3db004651d4a2ae07b5eb..eab93e1e3712c0a01cac187bf5944818
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5215ae06260f930a8e313af35a20e916e60aa6c0..50f3cce22d97d28b00878ba54f9b299da3a5fc2d 100644
+index 077998f9a40b43d881d4fbfb8f21fb579855dc53..51c325be202ed141eea3e24b44dd7ff38b206d20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1217,7 +1217,7 @@ public final class CraftServer implements Server {
+@@ -1218,7 +1218,7 @@ public final class CraftServer implements Server {
              chunkgenerator = worlddimension.generator();
          }
  
@@ -31,7 +31,7 @@ index 5215ae06260f930a8e313af35a20e916e60aa6c0..50f3cce22d97d28b00878ba54f9b299d
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ebc8b0cfd743c3c643cd0f55c9d72cc478665593..a69ea06b81d84a282d43939b461775fa263b6750 100644
+index 19c72e0072afbb4a47a62fde74112e192f91803f..bb87c4969fe4574196d0e45f8c9f918296c78c9c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -201,6 +201,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0861-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0861-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -123,10 +123,10 @@ index 0000000000000000000000000000000000000000..f7c86155ce0cfd9b4bf8a2b79d77a656
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 50f3cce22d97d28b00878ba54f9b299da3a5fc2d..250ac849d01f6e8c281e3a8d62438359153f3992 100644
+index 51c325be202ed141eea3e24b44dd7ff38b206d20..b3db64bbb4e06e5a04a632a5b8f2939de227527c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1983,6 +1983,13 @@ public final class CraftServer implements Server {
+@@ -1984,6 +1984,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  


### PR DESCRIPTION
Fixes #7470
Having a modifiable hash here is a bit flawed and most developers should never need these methods