### PR TITLE
Fix IllegalArgumentException for /paper mobcaps command

### DIFF
--- a/patches/server/0741-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0741-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -272,15 +272,18 @@ index f436ab35798c9b6e6cb2eb60d2c02cbf9b742e69..8934c9f2d578932aae43ea3da7894f2f
          List<org.bukkit.World> worlds;
          if (args.length < 2 || args[1].equals("*")) {
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 8e63d93a574f2c37094770099ea8e1f45cde3db5..6a62214b2763538e20fd218c445990d7f2cbc737 100644
+index 8e63d93a574f2c37094770099ea8e1f45cde3db5..ded0c79bcf1f78c6858270c6787aa5baced856b6 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-@@ -191,6 +191,16 @@ public final class NaturalSpawner {
+@@ -191,6 +191,19 @@ public final class NaturalSpawner {
          world.getProfiler().pop();
      }
  
 +    // Paper start
 +    public static int globalLimitForCategory(final ServerLevel level, final MobCategory category, final int spawnableChunkCount) {
++        if (category == MobCategory.MISC) {
++            return -1;
++        }
 +        final int categoryLimit = level.getWorld().getSpawnLimit(CraftSpawnCategory.toBukkit(category));
 +        if (categoryLimit < 1) {
 +            return categoryLimit;

--- a/patches/server/0772-Optimise-nearby-player-lookups.patch
+++ b/patches/server/0772-Optimise-nearby-player-lookups.patch
@@ -287,10 +287,10 @@ index 742d4645a6d22d10bc2833e3b742a6bc653d473d..7dda99a5464816f1488fb110da587f12
      protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, final DimensionType dimensionmanager, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.concurrent.Executor executor) { // Paper - Async-Anti-Xray - Pass executor
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 6a62214b2763538e20fd218c445990d7f2cbc737..11524461954d7243da1058e7c9b7ce2ea455706d 100644
+index ded0c79bcf1f78c6858270c6787aa5baced856b6..96fe666d55ec98724ae67704026013ab1288fa99 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-@@ -259,7 +259,7 @@ public final class NaturalSpawner {
+@@ -262,7 +262,7 @@ public final class NaturalSpawner {
                              blockposition_mutableblockposition.set(l, i, i1);
                              double d0 = (double) l + 0.5D;
                              double d1 = (double) i1 + 0.5D;
@@ -299,7 +299,7 @@ index 6a62214b2763538e20fd218c445990d7f2cbc737..11524461954d7243da1058e7c9b7ce2e
  
                              if (entityhuman != null) {
                                  double d2 = entityhuman.distanceToSqr(d0, (double) i, d1);
-@@ -332,7 +332,7 @@ public final class NaturalSpawner {
+@@ -335,7 +335,7 @@ public final class NaturalSpawner {
      }
  
      private static boolean isRightDistanceToPlayerAndSpawnPoint(ServerLevel world, ChunkAccess chunk, BlockPos.MutableBlockPos pos, double squaredDistance) {


### PR DESCRIPTION
Bukkit throws an error when you try to get the spawn limit for the MISC category, because it doesn't have limits (or as bukkit calls it, not validForLimits). This exception was missed in todays upstream update (#7454). This PR makes `NaturalSpawner#globalLimitForCategory` (only used in the mobcap command) always return `-1` early if the category is MISC, before `World#getSpawnLimit` throws an exception.

