### PR TITLE
automatically disable online mode when using either bungee or velocity

### DIFF
--- a/patches/server/0867-automatically-disable-online-mode-when-using-either-.patch
+++ b/patches/server/0867-automatically-disable-online-mode-when-using-either-.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yannick Lamprecht <yannicklamprecht@live.de>
+Date: Sun, 13 Feb 2022 13:13:54 +0100
+Subject: [PATCH] automatically disable online mode when using either bungee or
+ velocity
+
+
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index 38a0fb9a7c4ade9cacfd30dffabfea7e6b773981..f52e2f3a76c0a39d0e322e556b7c09386a24f1e6 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -226,6 +226,10 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+             DedicatedServer.LOGGER.error("Unable to load server configuration", e);
+             return false;
+         }
++        // Paper - deactivate authentication when in bungee mode or velocity online mode
++        if(org.spigotmc.SpigotConfig.bungee || com.destroystokyo.paper.PaperConfig.velocityOnlineMode){
++            this.setUsesAuthentication(false);
++        }
+         thread.start(); // Paper - start console thread after MinecraftServer.console & PaperConfig are initialized
+         com.destroystokyo.paper.PaperConfig.registerCommands();
+         com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now


### PR DESCRIPTION
I don't know if that is a wanted change.

Use case:
Many Velocity or Bungee/Waterfall user fail to disable online-mode.

Feel free to share some insides why this PR doesn't work out. Side-effects or something else.