### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0008-Adventure.patch
+++ b/patches/api/0008-Adventure.patch
@@ -1133,19 +1133,19 @@ index efb97712cc9dc7c1e12a59f5b94e4f2ad7c6b7d8..3024468af4c073324e536c1cb26beffb
                  return warning == null || warning.value();
              }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index a855f4c16f52f5ec478538eb182c13f8a6d60f65..33f7f4df53ba52f9afa22662427cbab1876b451c 100644
+index 81adea0efd380b7452f5f573e7a6ea378b071eab..cf6fe1b5a1531e8d30c0386e36c023d003458b7e 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -39,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -40,7 +40,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a world, which may contain entities, chunks and blocks
   */
--public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable {
-+public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, net.kyori.adventure.audience.ForwardingAudience { // Paper
+-public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, PersistentDataHolder {
++public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, PersistentDataHolder, net.kyori.adventure.audience.ForwardingAudience { // Paper
  
      /**
       * Gets the {@link Block} at the given coordinates
-@@ -634,6 +634,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -635,6 +635,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public List<Player> getPlayers();
  

--- a/patches/api/0014-Add-view-distance-API.patch
+++ b/patches/api/0014-Add-view-distance-API.patch
@@ -8,10 +8,10 @@ Add per player no-tick, tick, and send view distances.
 Also add send/no-tick view distance to World.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 33f7f4df53ba52f9afa22662427cbab1876b451c..3742bd5f1a31d45f2ac760f706f6069a88274e27 100644
+index cf6fe1b5a1531e8d30c0386e36c023d003458b7e..bf23ef001fb5177b7aab0b3ed8752f58641bb840 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2596,6 +2596,52 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2597,6 +2597,52 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      int getSimulationDistance();
      // Spigot end
  

--- a/patches/api/0050-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/api/0050-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -7,12 +7,12 @@ Provides counts without the ineffeciency of using .getEntities().size()
 which creates copy of the collections.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 3742bd5f1a31d45f2ac760f706f6069a88274e27..847a939b50c0a4d8bb5fecd7216a16d54e13046d 100644
+index bf23ef001fb5177b7aab0b3ed8752f58641bb840..8a2ca11be9ebde91268b20d25a35e1d6842f49de 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -41,6 +41,33 @@ import org.jetbrains.annotations.Nullable;
+@@ -42,6 +42,33 @@ import org.jetbrains.annotations.Nullable;
   */
- public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, net.kyori.adventure.audience.ForwardingAudience { // Paper
+ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, PersistentDataHolder, net.kyori.adventure.audience.ForwardingAudience { // Paper
  
 +    // Paper start
 +    /**

--- a/patches/api/0098-Additional-world.getNearbyEntities-API-s.patch
+++ b/patches/api/0098-Additional-world.getNearbyEntities-API-s.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Additional world.getNearbyEntities API's
 Provides more methods to get nearby entities, and filter by types and predicates
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 847a939b50c0a4d8bb5fecd7216a16d54e13046d..2a1186fe30bb7df2be6825a08ed03b296f657a45 100644
+index 8a2ca11be9ebde91268b20d25a35e1d6842f49de..e6d6283f3dd76b6c5af34374a05a5ab966419d06 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -1,6 +1,9 @@
@@ -19,7 +19,7 @@ index 847a939b50c0a4d8bb5fecd7216a16d54e13046d..2a1186fe30bb7df2be6825a08ed03b29
  import java.util.Collection;
  import java.util.HashMap;
  import java.util.List;
-@@ -653,6 +656,256 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -654,6 +657,256 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Collection<Entity> getEntitiesByClasses(@NotNull Class<?>... classes);
  

--- a/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -500,10 +500,10 @@ index 0000000000000000000000000000000000000000..f45b8cfd1611345e8d81ecb8297a586f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Particle.java b/src/main/java/org/bukkit/Particle.java
-index dc5142460a711ee79aed30276382b92c82cbef00..40a3a54fc82252692fc8710cabb243d0984ccf4f 100644
+index 8d048a8f1446f862dcc61952971b54bab9bb2ac3..60a70b9e7a613e64a31a127264f17485ed2aa76f 100644
 --- a/src/main/java/org/bukkit/Particle.java
 +++ b/src/main/java/org/bukkit/Particle.java
-@@ -122,6 +122,17 @@ public enum Particle {
+@@ -155,6 +155,17 @@ public enum Particle {
          return dataType;
      }
  
@@ -522,10 +522,10 @@ index dc5142460a711ee79aed30276382b92c82cbef00..40a3a54fc82252692fc8710cabb243d0
       * Options which can be applied to redstone dust particles - a particle
       * color and size.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 2a1186fe30bb7df2be6825a08ed03b296f657a45..5ced29d9b60213ec1be70f26be837010c6758565 100644
+index e6d6283f3dd76b6c5af34374a05a5ab966419d06..d4c55682f6b2433808a2f0542189a5672d4991ea 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2783,7 +2783,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2784,7 +2784,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
       */

--- a/patches/api/0115-Expand-Explosions-API.patch
+++ b/patches/api/0115-Expand-Explosions-API.patch
@@ -106,10 +106,10 @@ index bbc636baef2e2b0586c7d517be428438ca26ab66..a8d4f7972d07ddde171b4a1ec470a4c6
       * Returns a list of entities within a bounding box centered around a Location.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 5ced29d9b60213ec1be70f26be837010c6758565..7ad40278736b959ab47b6febe748de6d91fef950 100644
+index d4c55682f6b2433808a2f0542189a5672d4991ea..68b10c8643e9c2c873e627b2185f983a9c1023aa 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1420,6 +1420,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1421,6 +1421,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public boolean createExplosion(@NotNull Location loc, float power, boolean setFire);
  

--- a/patches/api/0119-Add-World.getEntity-UUID-API.patch
+++ b/patches/api/0119-Add-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 7ad40278736b959ab47b6febe748de6d91fef950..0f096ea7516c3b14c216d74baa268db37016b27c 100644
+index 68b10c8643e9c2c873e627b2185f983a9c1023aa..057b7ace5428d2799d33d91097f6cec786c7bd58 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -940,6 +940,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -941,6 +941,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Collection<Entity> getNearbyEntities(@NotNull Location location, double x, double y, double z);
  

--- a/patches/api/0136-Provide-Chunk-Coordinates-as-a-Long-API.patch
+++ b/patches/api/0136-Provide-Chunk-Coordinates-as-a-Long-API.patch
@@ -44,10 +44,10 @@ index 06737962b844275a74ee2407cc09918599cbaea4..1a4b6922c0a881b60ddf305b1e2b3af0
       * Gets the world containing this chunk
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 0f096ea7516c3b14c216d74baa268db37016b27c..13487b781317a135bedea2149e24aeac266e9358 100644
+index 057b7ace5428d2799d33d91097f6cec786c7bd58..ee277a464b1ecaaa7948c333a04e347e6255c904 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -208,6 +208,22 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -209,6 +209,22 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Chunk getChunkAt(@NotNull Block block);
  

--- a/patches/api/0139-Allow-Blocks-to-be-accessed-via-a-long-key.patch
+++ b/patches/api/0139-Allow-Blocks-to-be-accessed-via-a-long-key.patch
@@ -48,10 +48,10 @@ index 36ed248f0716f2cc465c08ab851b7d83d4c7c0a7..58728a0f0722b378efa129e26f0c822b
       * @return A new location where X/Y/Z are the center of the block
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 13487b781317a135bedea2149e24aeac266e9358..1d36788053992e06a5b48e037aa104f97f070a56 100644
+index ee277a464b1ecaaa7948c333a04e347e6255c904..7d77647dfe085cde87a9d2adb4c02b1f441940d7 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -91,6 +91,38 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -92,6 +92,38 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Block getBlockAt(@NotNull Location location);
  

--- a/patches/api/0144-isChunkGenerated-API.patch
+++ b/patches/api/0144-isChunkGenerated-API.patch
@@ -34,10 +34,10 @@ index 58728a0f0722b378efa129e26f0c822b63d1af36..88b3e0323dbc4f0fce31b147c7aaa08d
      /**
       * Sets the position of this Location and returns itself
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 1d36788053992e06a5b48e037aa104f97f070a56..48e439d757a01e0487e7c3db0ab00cdf59bff277 100644
+index 7d77647dfe085cde87a9d2adb4c02b1f441940d7..39f7817838c73c78f138c98546a1b797e7529550 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -254,6 +254,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -255,6 +255,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      public default Chunk getChunkAt(long chunkKey) {
          return getChunkAt((int) chunkKey, (int) (chunkKey >> 32));
      }

--- a/patches/api/0146-Async-Chunks-API.patch
+++ b/patches/api/0146-Async-Chunks-API.patch
@@ -8,10 +8,10 @@ Adds API's to load or generate chunks asynchronously.
 Also adds utility methods to Entity to teleport asynchronously.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 48e439d757a01e0487e7c3db0ab00cdf59bff277..cd228a4fd657cd60e19cf52bcf57a31cb048bb55 100644
+index 39f7817838c73c78f138c98546a1b797e7529550..fc8631f45abaaabe2cdb7653c43b98b36a80ec78 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -963,6 +963,482 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -964,6 +964,482 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
          }
          return nearby;
      }

--- a/patches/api/0154-Implement-furnace-cook-speed-multiplier-API.patch
+++ b/patches/api/0154-Implement-furnace-cook-speed-multiplier-API.patch
@@ -6,12 +6,12 @@ Subject: [PATCH] Implement furnace cook speed multiplier API
 Signed-off-by: Tassu <git@tassu.me>
 
 diff --git a/src/main/java/org/bukkit/block/Furnace.java b/src/main/java/org/bukkit/block/Furnace.java
-index c5a8c96fa2204d6b4d2409b1bfc97697d39d964e..9063cf370a0fe66c2a27086e125f9111b77366ae 100644
+index ac3b24c5c99eeb1435d785efade728dd40947da5..dbdf3dbe9517b09a7965cf9d65cae1edd87af67d 100644
 --- a/src/main/java/org/bukkit/block/Furnace.java
 +++ b/src/main/java/org/bukkit/block/Furnace.java
-@@ -61,6 +61,26 @@ public interface Furnace extends Container {
-      */
-     public void setCookTimeTotal(int cookTimeTotal);
+@@ -74,6 +74,26 @@ public interface Furnace extends Container {
+     @NotNull
+     public Map<CookingRecipe<?>, Integer> getRecipesUsed();
  
 +    // Paper start
 +    /**

--- a/patches/api/0159-Add-sun-related-API.patch
+++ b/patches/api/0159-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index cd228a4fd657cd60e19cf52bcf57a31cb048bb55..b05809ecbe20d813e5cbc6be47961eb8729a8382 100644
+index fc8631f45abaaabe2cdb7653c43b98b36a80ec78..656b39a3ca70afb2cb00c3c827e850912ebc4d0e 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1790,6 +1790,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1791,6 +1791,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public void setFullTime(long time);
  

--- a/patches/api/0178-Add-Heightmap-API.patch
+++ b/patches/api/0178-Add-Heightmap-API.patch
@@ -103,10 +103,10 @@ index 23ca89dde7f6ac9082d4b97fce2959425f3680cb..8321441b8f528a05e297f485672f928e
       * Creates explosion at this location with given power
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index b05809ecbe20d813e5cbc6be47961eb8729a8382..41df2b4680a6b05d055a11f3b64d9746d1754c51 100644
+index 656b39a3ca70afb2cb00c3c827e850912ebc4d0e..fe2b9b88ad854f29e9162a316ca952b9f0b38121 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -161,6 +161,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -162,6 +162,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Block getHighestBlockAt(@NotNull Location location);
  

--- a/patches/api/0215-Add-moon-phase-API.patch
+++ b/patches/api/0215-Add-moon-phase-API.patch
@@ -47,10 +47,10 @@ index 0000000000000000000000000000000000000000..df05153397b42930cd53d37b30824c7e
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 41df2b4680a6b05d055a11f3b64d9746d1754c51..325c86a945b2ee365618f5c63cf4a48e47177bec 100644
+index fe2b9b88ad854f29e9162a316ca952b9f0b38121..85c1f5b33e933b23946cad3c5ad37cc350ee5d3c 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -69,6 +69,12 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -70,6 +70,12 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The amount of Players in this world
       */
      int getPlayerCount();

--- a/patches/api/0276-Implement-Keyed-on-World.patch
+++ b/patches/api/0276-Implement-Keyed-on-World.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9549cfeadac8a45d27917ecdf05644cfff23eb0a..2f6ebed7ae9305f1cb4502b9727b8eac97f4209c 100644
+index 0aa141c590cf61a1fc99bec4cf8d5590a3ab6519..c8ea04b06d7178c6cc992a9a1b0355a70a035152 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -791,6 +791,18 @@ public final class Bukkit {
@@ -28,7 +28,7 @@ index 9549cfeadac8a45d27917ecdf05644cfff23eb0a..2f6ebed7ae9305f1cb4502b9727b8eac
      /**
       * Gets the map from the given item ID.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 50fbcb8867b0a7680ff491f7cf9af3069ba064c3..f19aa510dfc4c5716d80235acfa593eea03c2110 100644
+index b1cfea011efa985f644328486196edf5c73e72cd..67c6443c5639beafade19bc39932f30bf1001a8d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -673,6 +673,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -50,19 +50,19 @@ index 50fbcb8867b0a7680ff491f7cf9af3069ba064c3..f19aa510dfc4c5716d80235acfa593ee
       * Gets the map from the given item ID.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 325c86a945b2ee365618f5c63cf4a48e47177bec..6ae40c6480e0db948504cd15d7047dd676478e30 100644
+index 85c1f5b33e933b23946cad3c5ad37cc350ee5d3c..a17b0f540f1b0a85d16ca3e07da2fc495349a699 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -42,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -43,7 +43,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a world, which may contain entities, chunks and blocks
   */
--public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, net.kyori.adventure.audience.ForwardingAudience { // Paper
-+public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, net.kyori.adventure.audience.ForwardingAudience, Keyed { // Paper
+-public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, PersistentDataHolder, net.kyori.adventure.audience.ForwardingAudience { // Paper
++public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, PersistentDataHolder, net.kyori.adventure.audience.ForwardingAudience, Keyed { // Paper
  
      // Paper start
      /**
-@@ -1526,6 +1526,15 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1527,6 +1527,15 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
  
      @NotNull
      java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent);

--- a/patches/api/0284-More-World-API.patch
+++ b/patches/api/0284-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 6ae40c6480e0db948504cd15d7047dd676478e30..33ddc4cd57d1ce2d1abb1daa78d9e934ae0bc93f 100644
+index a17b0f540f1b0a85d16ca3e07da2fc495349a699..b29b313dfe6342460d5f1ff085a0a61b4604d5ea 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3644,6 +3644,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3645,6 +3645,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public Location locateNearestStructure(@NotNull Location origin, @NotNull StructureType structureType, int radius, boolean findUnexplored);
  

--- a/patches/api/0310-Add-more-line-of-sight-methods.patch
+++ b/patches/api/0310-Add-more-line-of-sight-methods.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add more line of sight methods
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 33ddc4cd57d1ce2d1abb1daa78d9e934ae0bc93f..fa2720db5fdb67da1fe6c47c4875037d929d9aec 100644
+index b29b313dfe6342460d5f1ff085a0a61b4604d5ea..abce27d50ef62f14948220272a2452874ae69836 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -75,6 +75,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -76,6 +76,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      @NotNull
      io.papermc.paper.world.MoonPhase getMoonPhase();

--- a/patches/api/0330-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/api/0330-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index fa2720db5fdb67da1fe6c47c4875037d929d9aec..6e150341dbb4439a186f55d6bb537b46bee74e89 100644
+index abce27d50ef62f14948220272a2452874ae69836..268d77210e47d5247ac9b82c344fac323b16a0c4 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -758,6 +758,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -759,6 +759,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public LightningStrike strikeLightningEffect(@NotNull Location loc);
  

--- a/patches/api/0365-Implement-regenerateChunk.patch
+++ b/patches/api/0365-Implement-regenerateChunk.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement regenerateChunk
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 6e150341dbb4439a186f55d6bb537b46bee74e89..959ee46cd440af5a4e5db3f6ee8b163db8e40d86 100644
+index 268d77210e47d5247ac9b82c344fac323b16a0c4..d63570d60481e864a15d5594ac54c372151093d4 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -506,8 +506,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -507,8 +507,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return Whether the chunk was actually regenerated
       *
       * @deprecated regenerating a single chunk is not likely to produce the same

--- a/patches/server/0012-Adventure.patch
+++ b/patches/server/0012-Adventure.patch
@@ -1698,7 +1698,7 @@ index 9af14095fa8dbc75fadb84c5a1d263039994e441..3b35ec1df648a3de920ea0c159623880
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 11610250c91fb1dd5921f617f4232b5462cb74da..fd87b6b719794f65a83d53e6fd06ea9a8b06002f 100644
+index c9521d383c77eab823072c0d7569b76b75678d28..66bceb7bd8aa4aa1d398d4d011d59f8441276c7b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -623,8 +623,10 @@ public final class CraftServer implements Server {
@@ -1840,18 +1840,18 @@ index 11610250c91fb1dd5921f617f4232b5462cb74da..fd87b6b719794f65a83d53e6fd06ea9a
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6a321fb7b861b4209e988204ebb165e56c3a3c4a..219db550296680306bacf59b60e8e3608d3392c5 100644
+index 962ee738a4cce4d3bd87bfb9b481c6f158ee9756..1d0c745673bfb14966c6d644825604260f2bc69f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -132,6 +132,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-     private final List<BlockPopulator> populators = new ArrayList<BlockPopulator>();
+@@ -139,6 +139,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      private final BlockMetadataStore blockMetadata = new BlockMetadataStore(this);
      private final Object2IntOpenHashMap<SpawnCategory> spawnCategoryLimit = new Object2IntOpenHashMap<>();
+     private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftWorld.DATA_TYPE_REGISTRY);
 +    private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  
      private static final Random rand = new Random();
  
-@@ -1835,4 +1836,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1859,4 +1860,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0040-Per-Player-View-Distance-API-placeholders.patch
+++ b/patches/server/0040-Per-Player-View-Distance-API-placeholders.patch
@@ -20,10 +20,10 @@ index 352bfe795aea26307de9c998d67a43af3e4845f0..4689d52cd314a607d17be3657099157e
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_XZ = 32;
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 219db550296680306bacf59b60e8e3608d3392c5..58fd165fcb6ebb9b2c9dee44d78c5a3cb55794ac 100644
+index 1d0c745673bfb14966c6d644825604260f2bc69f..deeb4afbbe6d4b6f44dfe20265a1a2d7d7e66e2e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1804,6 +1804,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1828,6 +1828,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getSimulationDistance() {
          return world.spigotConfig.simulationDistance;
      }

--- a/patches/server/0043-Use-UserCache-for-player-heads.patch
+++ b/patches/server/0043-Use-UserCache-for-player-heads.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use UserCache for player heads
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index f331e1b3882d10506fd89034e224e75ae2f030be..eda37a7622748feef782b54235070c04f3c714f8 100644
+index 0281a825f5a00f1416405dfe8b1edd9c61fccd93..545074f5f7b109daf17af05fa36a9dc5816f22d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -175,7 +175,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -167,7 +167,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          if (name == null) {
              this.setProfile(null);
          } else {

--- a/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -20,11 +20,11 @@ index d65fcf365a2c24c099e70597c843562ec341df3a..41e7474588d8e5ba4cd4af0fed1e62e4
      private boolean tickingBlockEntities;
      public final Thread thread;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 58fd165fcb6ebb9b2c9dee44d78c5a3cb55794ac..b9d0a2f8d1ed290d2fa12d6c2307903412727fc1 100644
+index deeb4afbbe6d4b6f44dfe20265a1a2d7d7e66e2e..e2289fbfbb59b0b1d2a09d6bb0e17664de209ebb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -134,6 +134,57 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-     private final Object2IntOpenHashMap<SpawnCategory> spawnCategoryLimit = new Object2IntOpenHashMap<>();
+@@ -141,6 +141,57 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+     private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftWorld.DATA_TYPE_REGISTRY);
      private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  
 +    // Paper start - Provide fast information methods

--- a/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -288,10 +288,10 @@ index 5147f67c87ba3b8912a8ae24f876a9e996504600..b77eda6af8b430311e502465a2590d83
  
      }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index ba9f209c2674107fd5751cb28c4f80fcbbc0aaa2..6c33b524d81ccd8ed060c3a9067cb1b669c7660d 100644
+index 16c272856bf9d8f8f2bf18f408cea2de94177f37..d39546b3f8d0c97fefdcc90f638eee60a5db409e 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-@@ -623,7 +623,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -627,7 +627,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
          j = event.getExpToDrop();
          // CraftBukkit end
  

--- a/patches/server/0174-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/patches/server/0174-Add-setPlayerProfile-API-for-Skulls.patch
@@ -48,43 +48,20 @@ index 6ac03706a584e4cb07300cf6e34969a8c4595c58..0be71d9d06f34e9ac58da3bbef954b27
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index eda37a7622748feef782b54235070c04f3c714f8..9f72e1623fc85301c4ca8751a7e03877a7745948 100644
+index 545074f5f7b109daf17af05fa36a9dc5816f22d4..292ae4a68093b7d939a755e1062cee57da186ab1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -4,10 +4,6 @@ import com.google.common.collect.ImmutableMap.Builder;
- import com.mojang.authlib.GameProfile;
- import java.util.Map;
- import java.util.UUID;
--import net.minecraft.nbt.CompoundTag;
--import net.minecraft.nbt.NbtUtils;
--import net.minecraft.nbt.Tag;
--import net.minecraft.world.level.block.entity.SkullBlockEntity;
- import org.bukkit.Bukkit;
- import org.bukkit.Material;
- import org.bukkit.OfflinePlayer;
-@@ -20,6 +16,11 @@ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
- import org.bukkit.inventory.meta.SkullMeta;
- import org.bukkit.profile.PlayerProfile;
- 
-+import javax.annotation.Nullable;
-+import net.minecraft.nbt.CompoundTag;
-+import net.minecraft.nbt.NbtUtils;
-+import net.minecraft.nbt.Tag;
-+import net.minecraft.world.level.block.entity.SkullBlockEntity;
- @DelegateDeserialization(SerializableMeta.class)
- class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
- 
-@@ -151,6 +152,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -143,6 +143,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          return this.hasOwner() ? this.profile.getName() : null;
      }
  
 +    // Paper start
 +    @Override
-+    public void setPlayerProfile(@Nullable com.destroystokyo.paper.profile.PlayerProfile profile) {
++    public void setPlayerProfile(@org.jetbrains.annotations.Nullable com.destroystokyo.paper.profile.PlayerProfile profile) {
 +        setProfile((profile == null) ? null : com.destroystokyo.paper.profile.CraftPlayerProfile.asAuthlibCopy(profile));
 +    }
 +
-+    @Nullable
++    @org.jetbrains.annotations.Nullable
 +    @Override
 +    public com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile() {
 +        return profile != null ? com.destroystokyo.paper.profile.CraftPlayerProfile.asBukkitCopy(profile) : null;
@@ -94,7 +71,7 @@ index eda37a7622748feef782b54235070c04f3c714f8..9f72e1623fc85301c4ca8751a7e03877
      @Override
      public OfflinePlayer getOwningPlayer() {
          if (this.hasOwner()) {
-@@ -201,6 +215,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -193,6 +206,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      }
  
      @Override
@@ -102,7 +79,7 @@ index eda37a7622748feef782b54235070c04f3c714f8..9f72e1623fc85301c4ca8751a7e03877
      public PlayerProfile getOwnerProfile() {
          if (!this.hasOwner()) {
              return null;
-@@ -210,11 +225,12 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -202,11 +216,12 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      }
  
      @Override
@@ -116,10 +93,10 @@ index eda37a7622748feef782b54235070c04f3c714f8..9f72e1623fc85301c4ca8751a7e03877
          }
      }
  
-@@ -251,7 +267,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -243,7 +258,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      Builder<String, Object> serialize(Builder<String, Object> builder) {
          super.serialize(builder);
-         if (this.hasOwner()) {
+         if (this.profile != null) {
 -            return builder.put(SKULL_OWNER.BUKKIT, new CraftPlayerProfile(this.profile));
 +            return builder.put(SKULL_OWNER.BUKKIT, new com.destroystokyo.paper.profile.CraftPlayerProfile(this.profile)); // Paper
          }

--- a/patches/server/0197-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0197-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,7 +10,7 @@ Adds an option to control the force mode of the particle.
 This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 32253b7d4eec3cb0b7d047bb5ce05c46e9d3649d..11b0f1ef4aa02cf719e4d937c98d41b82ffca23a 100644
+index c90a3df46ce2d478d7e279a05cd1a876a54a791e..a8d80e2409a98f9e928454b56104295dbc86de7c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1383,12 +1383,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -34,10 +34,10 @@ index 32253b7d4eec3cb0b7d047bb5ce05c46e9d3649d..11b0f1ef4aa02cf719e4d937c98d41b8
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b9d0a2f8d1ed290d2fa12d6c2307903412727fc1..05d684d5be41df09180cd8426d4b9848634cd935 100644
+index e2289fbfbb59b0b1d2a09d6bb0e17664de209ebb..9d9915f2984f87c8cc9d6dd1d445dfcf127bc010 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1802,11 +1802,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1809,11 +1809,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0214-Expand-Explosions-API.patch
+++ b/patches/server/0214-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 05d684d5be41df09180cd8426d4b9848634cd935..483f215ffc3a9318266d878e055ff1479a631b95 100644
+index 9d9915f2984f87c8cc9d6dd1d445dfcf127bc010..b084ac797e6512295c1adbf9226270b4607a4359 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -690,6 +690,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -697,6 +697,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
          return !this.world.explode(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, breakBlocks ? Explosion.BlockInteraction.BREAK : Explosion.BlockInteraction.NONE).wasCanceled;
      }

--- a/patches/server/0218-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0218-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 483f215ffc3a9318266d878e055ff1479a631b95..7e283d29d0eeb03073e97a848cd34cc8d9532558 100644
+index b084ac797e6512295c1adbf9226270b4607a4359..7b98b8639b48504096f8ab1a2cadf98d492b6789 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1024,6 +1024,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1031,6 +1031,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return list;
      }
  

--- a/patches/server/0256-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0256-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7e283d29d0eeb03073e97a848cd34cc8d9532558..d299d4c5c0af841a1569229ccf1977c6a57e7e92 100644
+index 7b98b8639b48504096f8ab1a2cadf98d492b6789..20d0e19851a4e8b62a8f781eb7f5795b2d156eb8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -371,7 +371,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -378,7 +378,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0257-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0257-Asynchronous-chunk-IO-and-loading.patch
@@ -2771,7 +2771,7 @@ index dc618a0dde6c15cb2ee812ed21c10b343f75f280..343d54addd67998175db152d38702add
          } finally {
              chunkMap.callbackExecutor.run();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index cd11361cd2dc12c7b94f3e8505937b484ec19dff..8da73bd016b7da297e64383e2e6dc65a1dd3be87 100644
+index 2e791dc863e6f41b1d9d4f99e5054caa93f6ca52..fb0d99ca76896a710a16d70aaf7ee714a428430d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -309,6 +309,78 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -3571,10 +3571,10 @@ index 415ec2cb81e956526e7f4965b899c9aa04f62f2e..ff6cadec530dedf9efc5d6226e48a096
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d299d4c5c0af841a1569229ccf1977c6a57e7e92..ef2673b744fe1ad0fca722271e167176d499593a 100644
+index 20d0e19851a4e8b62a8f781eb7f5795b2d156eb8..e76a98b8144ab0de92263fb00bf521b2683a6b7d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1865,6 +1865,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1872,6 +1872,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public DragonBattle getEnderDragonBattle() {
          return (this.getHandle().dragonFight() == null) ? null : new CraftDragonBattle(this.getHandle().dragonFight());
      }
@@ -3607,8 +3607,8 @@ index d299d4c5c0af841a1569229ccf1977c6a57e7e92..ef2673b744fe1ad0fca722271e167176
 +    }
 +    // Paper end
  
-     // Spigot start
      @Override
+     public PersistentDataContainer getPersistentDataContainer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 index e496a346b12497e5e0834e0bc523c2221b45cab7..16f2479de2c330b17c9ef6f3bee8e4ade5b66d15 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java

--- a/patches/server/0267-Implement-furnace-cook-speed-multiplier-API.patch
+++ b/patches/server/0267-Implement-furnace-cook-speed-multiplier-API.patch
@@ -11,7 +11,7 @@ to the nearest Integer when updating its current cook time.
 Modified by: Eric Su <ericsu@alumni.usc.edu>
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..0584c37824bb37ff546df956b82ffaaaafd30bfe 100644
+index d39546b3f8d0c97fefdcc90f638eee60a5db409e..8c69b817eeb5d5555e8eb2093ff2c5377c884946 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 @@ -73,6 +73,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
@@ -22,7 +22,7 @@ index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..0584c37824bb37ff546df956b82ffaaa
      public int cookingProgress;
      public int cookingTotalTime;
      protected final ContainerData dataAccess;
-@@ -275,6 +276,11 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -279,6 +280,11 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
              this.recipesUsed.put(new ResourceLocation(s), nbttagcompound1.getInt(s));
          }
  
@@ -34,7 +34,7 @@ index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..0584c37824bb37ff546df956b82ffaaa
      }
  
      @Override
-@@ -283,6 +289,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -287,6 +293,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
          nbt.putShort("BurnTime", (short) this.litTime);
          nbt.putShort("CookTime", (short) this.cookingProgress);
          nbt.putShort("CookTimeTotal", (short) this.cookingTotalTime);
@@ -42,7 +42,7 @@ index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..0584c37824bb37ff546df956b82ffaaa
          ContainerHelper.saveAllItems(nbt, this.items);
          CompoundTag nbttagcompound1 = new CompoundTag();
  
-@@ -345,7 +352,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -349,7 +356,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
                      CraftItemStack source = CraftItemStack.asCraftMirror(blockEntity.items.get(0));
                      CookingRecipe<?> recipe = (CookingRecipe<?>) irecipe.toBukkitRecipe();
  
@@ -51,7 +51,7 @@ index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..0584c37824bb37ff546df956b82ffaaa
                      world.getCraftServer().getPluginManager().callEvent(event);
  
                      blockEntity.cookingTotalTime = event.getTotalCookTime();
-@@ -353,9 +360,9 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -357,9 +364,9 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
                  // CraftBukkit end
  
                  ++blockEntity.cookingProgress;
@@ -63,7 +63,7 @@ index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..0584c37824bb37ff546df956b82ffaaa
                      if (AbstractFurnaceBlockEntity.burn(blockEntity.level, blockEntity.worldPosition, irecipe, blockEntity.items, i)) { // CraftBukkit
                          blockEntity.setRecipeUsed(irecipe);
                      }
-@@ -455,9 +462,13 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -459,9 +466,13 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
          }
      }
  
@@ -79,7 +79,7 @@ index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..0584c37824bb37ff546df956b82ffaaa
  
      public static boolean isFuel(ItemStack stack) {
          return AbstractFurnaceBlockEntity.getFuel().containsKey(stack.getItem());
-@@ -526,7 +537,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -530,7 +541,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
          }
  
          if (slot == 0 && !flag) {
@@ -89,12 +89,12 @@ index 6c33b524d81ccd8ed060c3a9067cb1b669c7660d..0584c37824bb37ff546df956b82ffaaa
              this.setChanged();
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java b/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
-index a5022dc1e2376e655bfa00f7c3ffb63788fa54d6..b6ee228d256e8dec0bcbd816a6dbaf53b47e5c8d 100644
+index facf95a44b5d3a63fda156c6afc8cabe50b21d32..3da4616c904d47bbecae0d4cb6970496fbec9a8b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
-@@ -58,4 +58,20 @@ public abstract class CraftFurnace<T extends AbstractFurnaceBlockEntity> extends
-     public void setCookTimeTotal(int cookTimeTotal) {
-         this.getSnapshot().cookingTotalTime = cookTimeTotal;
+@@ -78,4 +78,20 @@ public abstract class CraftFurnace<T extends AbstractFurnaceBlockEntity> extends
+ 
+         return recipesUsed.build();
      }
 +
 +    // Paper start - cook speed multiplier API

--- a/patches/server/0274-Add-sun-related-API.patch
+++ b/patches/server/0274-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ef2673b744fe1ad0fca722271e167176d499593a..cfb3c5a00b64022ed616d59fe8b99eae5e4ccc48 100644
+index e76a98b8144ab0de92263fb00bf521b2683a6b7d..fd034c619b0615f480d1686d76e0f155cd9f9949 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -666,6 +666,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -673,6 +673,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
      }
  

--- a/patches/server/0320-Add-Heightmap-API.patch
+++ b/patches/server/0320-Add-Heightmap-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index cfb3c5a00b64022ed616d59fe8b99eae5e4ccc48..19b5d23a39181c9a87bed37ea20cc75ee03e9545 100644
+index fd034c619b0615f480d1686d76e0f155cd9f9949..fa7864c498fc2aaf483b54c37b4a396ac0f4b051 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -205,6 +205,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -212,6 +212,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.getHighestBlockYAt(x, z, org.bukkit.HeightMap.MOTION_BLOCKING);
      }
  

--- a/patches/server/0325-improve-CraftWorld-isChunkLoaded.patch
+++ b/patches/server/0325-improve-CraftWorld-isChunkLoaded.patch
@@ -9,10 +9,10 @@ waiting for the execution queue to get to our request; We can just query
 the chunk status and get a response now, vs having to wait
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 19b5d23a39181c9a87bed37ea20cc75ee03e9545..675169c842fc9d333a08ad6012dbfa16a0d0ce75 100644
+index fa7864c498fc2aaf483b54c37b4a396ac0f4b051..3d1bd00124d88cb5c278c78467c60e067af9bb47 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -276,13 +276,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -283,13 +283,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkLoaded(int x, int z) {

--- a/patches/server/0327-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0327-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -85,7 +85,7 @@ index b3c4687c6538adf851379f73cceffb114820507b..a243592ff0f70eabcc2e895a96859dd8
          // CraftBukkit start
          // this.updateMobSpawningFlags();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d01f3207d4a7516d2eba9df44c44a7c41c354c84..bb6b8d123967850f5b305a94968648ca65ae6c75 100644
+index 39d459b86b32f249bf3a62394b43ec4d5883d9d0..86246f90ed674295b57c0d171e41f3db6e09d4ef 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -60,6 +60,7 @@ import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
@@ -221,10 +221,10 @@ index 4185e6bcf9b2bb65b2a0fa5fcbeb5684615169a7..dbc29442f2b2ad3ea451910f4944e901
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 675169c842fc9d333a08ad6012dbfa16a0d0ce75..f34b67f6ed65422fe372cecf130401133f0211bf 100644
+index 3d1bd00124d88cb5c278c78467c60e067af9bb47..a8f759c6a122411a78ea93c075c2b5eb3f9b06d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1339,15 +1339,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1346,15 +1346,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/patches/server/0332-Fix-World-isChunkGenerated-calls.patch
+++ b/patches/server/0332-Fix-World-isChunkGenerated-calls.patch
@@ -196,7 +196,7 @@ index a1bfcdd713c47d8613eb4af7625a64d51161690b..4bc33c31d497aa7d69226ab870fd7890
              } catch (Throwable throwable) {
                  if (dataoutputstream != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f34b67f6ed65422fe372cecf130401133f0211bf..fe35d72dd2e13bce16c7b02d726144ff6cb2ecbe 100644
+index a8f759c6a122411a78ea93c075c2b5eb3f9b06d2..62fb9636364e2f45465a4bd5fc62d47d81e1fd2f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -20,6 +20,7 @@ import java.util.Objects;
@@ -207,7 +207,7 @@ index f34b67f6ed65422fe372cecf130401133f0211bf..fe35d72dd2e13bce16c7b02d726144ff
  import java.util.function.Predicate;
  import java.util.stream.Collectors;
  import net.minecraft.core.BlockPos;
-@@ -281,8 +282,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -288,8 +289,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -231,7 +231,7 @@ index f34b67f6ed65422fe372cecf130401133f0211bf..fe35d72dd2e13bce16c7b02d726144ff
          } catch (IOException ex) {
              throw new RuntimeException(ex);
          }
-@@ -394,20 +409,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -401,20 +416,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -44,10 +44,10 @@ index dd1a8b58c2ffffa9955b782d6cf15da8b9c54204..dd49caa38c2934eab581ad5c3393693b
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2bd734ee97afd0febf157508f867853f3a5abbf9..90830956fca6d862f3b382996f6d785c07ea3bfb 100644
+index 62fb9636364e2f45465a4bd5fc62d47d81e1fd2f..d4df7a712738d53aa7b9876a2fea9a09b9e3caf1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -265,8 +265,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -272,8 +272,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -70,7 +70,7 @@ index 2bd734ee97afd0febf157508f867853f3a5abbf9..90830956fca6d862f3b382996f6d785c
  
      @Override
      public Chunk getChunkAt(Block block) {
-@@ -333,7 +346,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -340,7 +353,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (this.isChunkLoaded(x, z)) {
@@ -79,7 +79,7 @@ index 2bd734ee97afd0febf157508f867853f3a5abbf9..90830956fca6d862f3b382996f6d785c
          }
  
          return true;
-@@ -411,9 +424,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -418,9 +431,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -93,7 +93,7 @@ index 2bd734ee97afd0febf157508f867853f3a5abbf9..90830956fca6d862f3b382996f6d785c
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -421,7 +437,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -428,7 +444,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -102,7 +102,7 @@ index 2bd734ee97afd0febf157508f867853f3a5abbf9..90830956fca6d862f3b382996f6d785c
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -447,7 +463,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -454,7 +470,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -111,7 +111,7 @@ index 2bd734ee97afd0febf157508f867853f3a5abbf9..90830956fca6d862f3b382996f6d785c
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -1968,6 +1984,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1975,6 +1991,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);

--- a/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1193,10 +1193,10 @@ index 6eaba33b7730d66bf631b6d5c6a7080f9f019f8b..8e03e63a00dd242791ba0d5a8a179222
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fd82082326e9f4c572803ba1f525c7125a89222a..fe200e3694bd80da4e8715ee72247a5e04a47e41 100644
+index d4df7a712738d53aa7b9876a2fea9a09b9e3caf1..bbba0658990cf6f10d09b78204788c8b5ad08787 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1982,6 +1982,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1989,6 +1989,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return future;
          }
  

--- a/patches/server/0480-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/patches/server/0480-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fe200e3694bd80da4e8715ee72247a5e04a47e41..9e7a85441890d71a3ac6037a5444d62d112acd28 100644
+index bbba0658990cf6f10d09b78204788c8b5ad08787..1f22f4d22959f210f7a374d0194d853d88f4dc1c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2054,6 +2054,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2078,6 +2078,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
              lightning.visualOnly = true;
              lightning.isSilent = isSilent;

--- a/patches/server/0488-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0488-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix SpawnChangeEvent not firing for all use-cases
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index b27fb07aacb66259f640de5c5aa6849eb7e8cc9c..74044db6497071debf8ad02829876e410ee4090e 100644
+index 3b99a6dda3638f3a7212d7c9fab5470409de4e6f..a57f9b332a9d3341e994a4c8d7dc80473c521493 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1743,6 +1743,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -17,10 +17,10 @@ index b27fb07aacb66259f640de5c5aa6849eb7e8cc9c..74044db6497071debf8ad02829876e41
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig.keepLoadedRange, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9e7a85441890d71a3ac6037a5444d62d112acd28..60b494370908819b9e22df17c81b8b14c490695d 100644
+index 1f22f4d22959f210f7a374d0194d853d88f4dc1c..c68f03e876e7d8d1ba694dccc3b208527d004240 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -246,11 +246,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -253,11 +253,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {
              Location previousLocation = this.getSpawnLocation();

--- a/patches/server/0489-Add-moon-phase-API.patch
+++ b/patches/server/0489-Add-moon-phase-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add moon phase API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 60b494370908819b9e22df17c81b8b14c490695d..cd3ddf4405e7f061758e6ef24fff522cdf96a513 100644
+index c68f03e876e7d8d1ba694dccc3b208527d004240..5012fc9626e522b34e79f265f794365e8f359b96 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -184,6 +184,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -191,6 +191,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getPlayerCount() {
          return world.players().size();
      }

--- a/patches/server/0534-Expose-world-spawn-angle.patch
+++ b/patches/server/0534-Expose-world-spawn-angle.patch
@@ -18,10 +18,10 @@ index e5ed9784b0e7d208604b41f51f1adf9c8f50fe08..8ce5f463f16857b5862b6e0a77c63d81
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index cd3ddf4405e7f061758e6ef24fff522cdf96a513..f192df45b1522d98f68c7c19301d783938c582e7 100644
+index 5012fc9626e522b34e79f265f794365e8f359b96..997a21a8344adf8d5298fbe54a50631ae3f40693 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -237,7 +237,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -244,7 +244,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public Location getSpawnLocation() {
          BlockPos spawn = this.world.getSharedSpawnPos();

--- a/patches/server/0566-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0566-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 888d812118c15c212284687ae5842a94f5715d52..e7ca5d6fb8922e7e8065864f736b0605
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f192df45b1522d98f68c7c19301d783938c582e7..706a1c37c81828ab570a7012f96a421d6c9977c1 100644
+index 997a21a8344adf8d5298fbe54a50631ae3f40693..b6c4d0f4fbe0dc8a4148939e231426cac42dbc18 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1787,8 +1787,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1794,8 +1794,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index f192df45b1522d98f68c7c19301d783938c582e7..706a1c37c81828ab570a7012f96a421d
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1823,8 +1828,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1830,8 +1835,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0610-Add-recipe-to-cook-events.patch
+++ b/patches/server/0610-Add-recipe-to-cook-events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add recipe to cook events
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index b05019614a172ef071aaefc5fcc1d18627cc0402..4e40eb50effb5508cdbfdc5d55a4b75c832a1ff3 100644
+index 83daa40a79c841d03a9a831c46e9ee2876b89da0..c0803a17b3cd25aea02047287effa0cc76456bbc 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-@@ -421,7 +421,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -425,7 +425,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
              CraftItemStack source = CraftItemStack.asCraftMirror(itemstack);
              org.bukkit.inventory.ItemStack result = CraftItemStack.asBukkitCopy(itemstack1);
  

--- a/patches/server/0613-Implement-Keyed-on-World.patch
+++ b/patches/server/0613-Implement-Keyed-on-World.patch
@@ -34,10 +34,10 @@ index e116d734d482ac918cc88cf038c3aeae13c1a531..bd92d9671d99b81af401a0f7509ef65c
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index afe0bb86903c76285804fcb466e043a62ad88b89..d228e085322fb22c3559058edaabb818c4c60111 100644
+index b6c4d0f4fbe0dc8a4148939e231426cac42dbc18..80c1bc9581ba227144b97e5bd2d6fbae0cd37edd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2010,6 +2010,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2017,6 +2017,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return java.util.concurrent.CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
          }, net.minecraft.server.MinecraftServer.getServer());
      }
@@ -48,4 +48,4 @@ index afe0bb86903c76285804fcb466e043a62ad88b89..d228e085322fb22c3559058edaabb818
 +    }
      // Paper end
  
-     // Spigot start
+     @Override

--- a/patches/server/0631-add-consumeFuel-to-FurnaceBurnEvent.patch
+++ b/patches/server/0631-add-consumeFuel-to-FurnaceBurnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add consumeFuel to FurnaceBurnEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index 4e40eb50effb5508cdbfdc5d55a4b75c832a1ff3..fb15ece736dde16066818216749fb2efba0b3b21 100644
+index c0803a17b3cd25aea02047287effa0cc76456bbc..11b2fcb783422216b45c8fcf5df37842b2b4e7b2 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-@@ -342,7 +342,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -346,7 +346,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
                  if (blockEntity.isLit() && furnaceBurnEvent.isBurning()) {
                      // CraftBukkit end
                      flag1 = true;

--- a/patches/server/0637-More-World-API.patch
+++ b/patches/server/0637-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f6c531d416b4e85df88d0fbed5773cb0b9644c1d..364eb4abe7f51c716018b65389abed4ec5227ed6 100644
+index 80c1bc9581ba227144b97e5bd2d6fbae0cd37edd..e053a6be61f1e9a98d108b8eb7cd4fc053f6c75e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1956,6 +1956,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1963,6 +1963,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0663-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0663-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add cause to Weather/ThunderChangeEvents
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d76668ab79d6afa0972fd54408a8475781b1c928..49640474611c4e1781a93c6eaa627a2865f5f72e 100644
+index 777584bf6858df530812c378e9651339155e4cd7..a8befb2fabd24b6129887fc4ebab39caf1f5d803 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -471,8 +471,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -48,10 +48,10 @@ index d76668ab79d6afa0972fd54408a8475781b1c928..49640474611c4e1781a93c6eaa627a28
          // If we stop due to everyone sleeping we should reset the weather duration to some other random value.
          // Not that everyone ever manages to get the whole server to sleep at the same time....
 diff --git a/src/main/java/net/minecraft/world/level/storage/PrimaryLevelData.java b/src/main/java/net/minecraft/world/level/storage/PrimaryLevelData.java
-index d88003a29d382d8952964257601f93c5fe95fa8b..30cd6dc004ef1d1518c9a10304ea2a20c0616831 100644
+index 2dfff38f9720159939ee9b288366218131d4c35e..2ae71dd7fbbd2017c9faaa69c3fa2d4c0a0db069 100644
 --- a/src/main/java/net/minecraft/world/level/storage/PrimaryLevelData.java
 +++ b/src/main/java/net/minecraft/world/level/storage/PrimaryLevelData.java
-@@ -331,6 +331,11 @@ public class PrimaryLevelData implements ServerLevelData, WorldData {
+@@ -344,6 +344,11 @@ public class PrimaryLevelData implements ServerLevelData, WorldData {
  
      @Override
      public void setThundering(boolean thundering) {
@@ -63,7 +63,7 @@ index d88003a29d382d8952964257601f93c5fe95fa8b..30cd6dc004ef1d1518c9a10304ea2a20
          // CraftBukkit start
          if (this.thundering == thundering) {
              return;
-@@ -338,7 +343,7 @@ public class PrimaryLevelData implements ServerLevelData, WorldData {
+@@ -351,7 +356,7 @@ public class PrimaryLevelData implements ServerLevelData, WorldData {
  
          org.bukkit.World world = Bukkit.getWorld(this.getLevelName());
          if (world != null) {
@@ -72,7 +72,7 @@ index d88003a29d382d8952964257601f93c5fe95fa8b..30cd6dc004ef1d1518c9a10304ea2a20
              Bukkit.getServer().getPluginManager().callEvent(thunder);
              if (thunder.isCancelled()) {
                  return;
-@@ -365,6 +370,12 @@ public class PrimaryLevelData implements ServerLevelData, WorldData {
+@@ -378,6 +383,12 @@ public class PrimaryLevelData implements ServerLevelData, WorldData {
  
      @Override
      public void setRaining(boolean raining) {
@@ -85,7 +85,7 @@ index d88003a29d382d8952964257601f93c5fe95fa8b..30cd6dc004ef1d1518c9a10304ea2a20
          // CraftBukkit start
          if (this.raining == raining) {
              return;
-@@ -372,7 +383,7 @@ public class PrimaryLevelData implements ServerLevelData, WorldData {
+@@ -385,7 +396,7 @@ public class PrimaryLevelData implements ServerLevelData, WorldData {
  
          org.bukkit.World world = Bukkit.getWorld(this.getLevelName());
          if (world != null) {
@@ -95,10 +95,10 @@ index d88003a29d382d8952964257601f93c5fe95fa8b..30cd6dc004ef1d1518c9a10304ea2a20
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 364eb4abe7f51c716018b65389abed4ec5227ed6..3d343914c95ac08a704f56292ad6e2ab430a258e 100644
+index e053a6be61f1e9a98d108b8eb7cd4fc053f6c75e..fb37aa387918e2970c5a5d9a94d86935cb854a72 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1172,7 +1172,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1179,7 +1179,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index 364eb4abe7f51c716018b65389abed4ec5227ed6..3d343914c95ac08a704f56292ad6e2ab
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1194,7 +1194,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1201,7 +1201,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0677-Line-Of-Sight-Changes.patch
+++ b/patches/server/0677-Line-Of-Sight-Changes.patch
@@ -19,10 +19,10 @@ index 510c2f0d47b593ac2bd60608c43cef8c069a5373..3d197ddb412e7df6723be0e86db86d93
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3d343914c95ac08a704f56292ad6e2ab430a258e..a42d293733e6f67e5ea1f7626b245f87b6ed438f 100644
+index fb37aa387918e2970c5a5d9a94d86935cb854a72..081e900534d4447471dcace27ca4a209f6fda96b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -189,6 +189,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -196,6 +196,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public io.papermc.paper.world.MoonPhase getMoonPhase() {
          return io.papermc.paper.world.MoonPhase.getPhase(getFullTime() / 24000L);
      }

--- a/patches/server/0678-add-per-world-spawn-limits.patch
+++ b/patches/server/0678-add-per-world-spawn-limits.patch
@@ -44,10 +44,10 @@ index d980e31884ea70493628e4934e19fa68314ba8e2..54a1fb5b6d1dee73761851c55c6bdc1c
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4191d44a0bbb59fee6934e1718e2ac8cfaba9cfa..518c711264b0d7112c09472764fda4cb6dc32180 100644
+index 081e900534d4447471dcace27ca4a209f6fda96b..1e46c61205a479419b3c2d641568c7f4bb6d7466 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -211,6 +211,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -218,6 +218,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          this.biomeProvider = biomeProvider;
  
          this.environment = env;

--- a/patches/server/0719-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0719-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d4129cb5ffa6bea474020c47b82d8905d1f4d9f5..df37739055bc705d9aebf8db4ee2007e366af7dd 100644
+index 47f9fec531b7e83ba8f5305df05ae89eb7aa84b5..111b02348059f8c730b8027a6bfa5d71b62bc332 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -751,6 +751,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -29,10 +29,10 @@ index d4129cb5ffa6bea474020c47b82d8905d1f4d9f5..df37739055bc705d9aebf8db4ee2007e
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 518c711264b0d7112c09472764fda4cb6dc32180..004af6a256e76389234723e0f79634f5a8e26c23 100644
+index 1e46c61205a479419b3c2d641568c7f4bb6d7466..d82795b119a7d6d8bde42f052d1915621f65bace 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -691,6 +691,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -698,6 +698,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0741-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0741-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -309,10 +309,10 @@ index e0e7fb4cc5516d8712f384fb5cb4d22c5bdceff5..51f537069c195edf1b7a60f233997d3c
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 004af6a256e76389234723e0f79634f5a8e26c23..9dd77d989fa6e33ce55525b88fb21a863e156810 100644
+index d82795b119a7d6d8bde42f052d1915621f65bace..f1301ffcfc03298f65186b043ed3ba173f2a923b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1707,9 +1707,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1714,9 +1714,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(spawnCategory, "SpawnCategory cannot be null");
          Validate.isTrue(CraftSpawnCategory.isValidForLimits(spawnCategory), "SpawnCategory." + spawnCategory + " are not supported.");
  

--- a/patches/server/0750-Do-not-copy-visible-chunks.patch
+++ b/patches/server/0750-Do-not-copy-visible-chunks.patch
@@ -9,7 +9,7 @@ the function. I saw approximately 1/3rd of the function
 on the copy.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 8934c9f2d578932aae43ea3da7894f2f2b7dd452..54e91401c173a03a11d09d201ffc6ad3238a79b3 100644
+index be1da6ebf8c1468182cbb92a16e4866bfb2ecfc3..c57999061a7a9adb7b5207a13af3d693529a43cd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -476,7 +476,7 @@ public class PaperCommand extends Command {
@@ -166,10 +166,10 @@ index f9f1afb49c8dba14d8d9134e84c73fa2e1d13f02..2e11bedafe383242996aeb545d6612f2
          while (objectbidirectionaliterator.hasNext()) {
              Entry<ChunkHolder> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 004af6a256e76389234723e0f79634f5a8e26c23..19c72e0072afbb4a47a62fde74112e192f91803f 100644
+index f1301ffcfc03298f65186b043ed3ba173f2a923b..99784a6531eb17d2758ff374f30b7b38656de2e2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -150,7 +150,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -157,7 +157,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public int getTileEntityCount() {
          // We don't use the full world tile entity list, so we must iterate chunks
@@ -178,7 +178,7 @@ index 004af6a256e76389234723e0f79634f5a8e26c23..19c72e0072afbb4a47a62fde74112e19
          int size = 0;
          for (ChunkHolder playerchunk : chunks.values()) {
              net.minecraft.world.level.chunk.LevelChunk chunk = playerchunk.getTickingChunk();
-@@ -171,7 +171,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -178,7 +178,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getChunkCount() {
          int ret = 0;
  
@@ -187,7 +187,7 @@ index 004af6a256e76389234723e0f79634f5a8e26c23..19c72e0072afbb4a47a62fde74112e19
              if (chunkHolder.getTickingChunk() != null) {
                  ++ret;
              }
-@@ -344,7 +344,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -351,7 +351,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {
@@ -207,7 +207,7 @@ index 004af6a256e76389234723e0f79634f5a8e26c23..19c72e0072afbb4a47a62fde74112e19
          return chunks.values().stream().map(ChunkHolder::getFullChunk).filter(Objects::nonNull).map(net.minecraft.world.level.chunk.LevelChunk::getBukkitChunk).toArray(Chunk[]::new);
      }
  
-@@ -420,7 +431,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -427,7 +438,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean refreshChunk(int x, int z) {

--- a/patches/server/0844-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0844-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,7 +18,7 @@ index d8ec6871cf25175a1da3db004651d4a2ae07b5eb..eab93e1e3712c0a01cac187bf5944818
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 077998f9a40b43d881d4fbfb8f21fb579855dc53..51c325be202ed141eea3e24b44dd7ff38b206d20 100644
+index f81638de69a0f6935291062484244bf62e3e8a9e..480604c11db1490f5a7a39ade08d8db23c929f21 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1218,7 +1218,7 @@ public final class CraftServer implements Server {
@@ -31,10 +31,10 @@ index 077998f9a40b43d881d4fbfb8f21fb579855dc53..51c325be202ed141eea3e24b44dd7ff3
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 19c72e0072afbb4a47a62fde74112e192f91803f..bb87c4969fe4574196d0e45f8c9f918296c78c9c 100644
+index 99784a6531eb17d2758ff374f30b7b38656de2e2..d113ec9b4d371f6468f59b1d85ebdf5adb8e3971 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -201,6 +201,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -208,6 +208,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.getHandle().clip(new ClipContext(vec3d, vec3d1, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, null)).getType() == HitResult.Type.MISS;
      }

--- a/patches/server/0862-Implement-regenerateChunk.patch
+++ b/patches/server/0862-Implement-regenerateChunk.patch
@@ -6,18 +6,18 @@ Subject: [PATCH] Implement regenerateChunk
 Co-authored-by: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index bb87c4969fe4574196d0e45f8c9f918296c78c9c..c60e16bdbc4707084377de640db8247b12e042ba 100644
+index d113ec9b4d371f6468f59b1d85ebdf5adb8e3971..23bd74836e8396720747540829c7b8e27cfb00bd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -123,6 +123,7 @@ import org.bukkit.util.Vector;
- 
+@@ -129,6 +129,7 @@ import org.bukkit.util.Vector;
  public class CraftWorld extends CraftRegionAccessor implements World {
      public static final int CUSTOM_DIMENSION_OFFSET = 10;
+     private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
 +    private static final ChunkStatus[] REGEN_CHUNK_STATUSES = {ChunkStatus.BIOMES, ChunkStatus.NOISE, ChunkStatus.SURFACE, ChunkStatus.CARVERS, ChunkStatus.LIQUID_CARVERS, ChunkStatus.FEATURES}; // Paper - implement regenerate chunk method
  
      private final ServerLevel world;
      private WorldBorder worldBorder;
-@@ -431,27 +432,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -438,27 +439,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean regenerateChunk(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk regenerate"); // Spigot
@@ -25,6 +25,10 @@ index bb87c4969fe4574196d0e45f8c9f918296c78c9c..c60e16bdbc4707084377de640db8247b
 -        /*
 -        if (!unloadChunk0(x, z, false)) {
 -            return false;
+-        }
+-
+-        final long chunkKey = ChunkCoordIntPair.pair(x, z);
+-        world.getChunkProvider().unloadQueue.remove(chunkKey);
 +        // Paper start - implement regenerateChunk method
 +        final ServerLevel serverLevel = this.world;
 +        final net.minecraft.server.level.ServerChunkCache serverChunkCache = serverLevel.getChunkSource();
@@ -33,10 +37,8 @@ index bb87c4969fe4574196d0e45f8c9f918296c78c9c..c60e16bdbc4707084377de640db8247b
 +        for (final BlockPos blockPos : BlockPos.betweenClosed(chunkPos.getMinBlockX(), serverLevel.getMinBuildHeight(), chunkPos.getMinBlockZ(), chunkPos.getMaxBlockX(), serverLevel.getMaxBuildHeight() - 1, chunkPos.getMaxBlockZ())) {
 +            levelChunk.removeBlockEntity(blockPos);
 +            serverLevel.setBlock(blockPos, net.minecraft.world.level.block.Blocks.AIR.defaultBlockState(), 16);
-         }
- 
--        final long chunkKey = ChunkCoordIntPair.pair(x, z);
--        world.getChunkProvider().unloadQueue.remove(chunkKey);
++        }
++
 +        for (final ChunkStatus chunkStatus : REGEN_CHUNK_STATUSES) {
 +            final List<ChunkAccess> list = new ArrayList<>();
 +            final int range = Math.max(1, chunkStatus.getRange());


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
8d818032 PR-723: Add Furnace#getRecipesUsed
d7b5a313 PR-726: Add Particle dataTypes to javadocs
72fe8b71 PR-724: Add PDC to World

CraftBukkit Changes:
c0326c28 PR-1009: Add Furnace#getRecipesUsed
cc5ddd79 PR-1010: Add PDC to World
6a54e5d3 PR-1012: Always save as skull owner and not as internal data

Spigot Changes:
699290cd Rebuild patches