### PR TITLE
Add CPU name and JVM vendor info in timings

### DIFF
--- a/patches/server/0012-Timings-v2.patch
+++ b/patches/server/0012-Timings-v2.patch
@@ -163,10 +163,10 @@ index 0000000000000000000000000000000000000000..b47b7dce26805badd422c1867733ff4b
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ee53453440177537fc653ea156785d7591498614
+index 0000000000000000000000000000000000000000..ee72086b2dee2bd6415803e77825b2b1cb83cd3d
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -0,0 +1,376 @@
+@@ -0,0 +1,383 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -204,6 +204,8 @@ index 0000000000000000000000000000000000000000..ee53453440177537fc653ea156785d75
 +import org.bukkit.entity.EntityType;
 +import org.json.simple.JSONObject;
 +import org.json.simple.JSONValue;
++import oshi.SystemInfo;
++import oshi.hardware.HardwareAbstractionLayer;
 +
 +import java.io.ByteArrayOutputStream;
 +import java.io.IOException;
@@ -295,12 +297,16 @@ index 0000000000000000000000000000000000000000..ee53453440177537fc653ea156785d75
 +
 +        OperatingSystemMXBean osInfo = ManagementFactory.getOperatingSystemMXBean();
 +
++        HardwareAbstractionLayer hardwareInfo = new SystemInfo().getHardware();
++
 +        parent.put("system", createObject(
 +                pair("timingcost", getCost()),
 +                pair("loadavg", osInfo.getSystemLoadAverage()),
 +                pair("name", System.getProperty("os.name")),
 +                pair("version", System.getProperty("os.version")),
 +                pair("jvmversion", System.getProperty("java.version")),
++                pair("jvmvendor", System.getProperty("java.vendor")),
++                pair("jvmvendorversion", System.getProperty("java.vendor.version")),
 +                pair("arch", System.getProperty("os.arch")),
 +                pair("maxmem", runtime.maxMemory()),
 +                pair("memory", createObject(
@@ -309,6 +315,7 @@ index 0000000000000000000000000000000000000000..ee53453440177537fc653ea156785d75
 +                    pair("finalizing", ManagementFactory.getMemoryMXBean().getObjectPendingFinalizationCount())
 +                )),
 +                pair("cpu", runtime.availableProcessors()),
++                pair("cpuname", hardwareInfo.getProcessor().getProcessorIdentifier().getName().trim()),
 +                pair("runtime", runtimeBean.getUptime()),
 +                pair("flags", StringUtils.join(runtimeBean.getInputArguments(), " ")),
 +                pair("gc", toObjectMapper(ManagementFactory.getGarbageCollectorMXBeans(), input -> pair(input.getName(), toArray(input.getCollectionCount(), input.getCollectionTime()))))

--- a/patches/server/0800-Configurable-feature-seeds.patch
+++ b/patches/server/0800-Configurable-feature-seeds.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable feature seeds
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index ee53453440177537fc653ea156785d7591498614..5e3b7fb2e0b7608610555cd23e7ad25a05883181 100644
+index ee72086b2dee2bd6415803e77825b2b1cb83cd3d..309dbf5fce3ce940d5e1b57d267b9d6b2c5ff5b6 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -273,7 +273,7 @@ public class TimingsExport extends Thread {
+@@ -280,7 +280,7 @@ public class TimingsExport extends Thread {
          JSONObject object = new JSONObject();
          for (String key : config.getKeys(false)) {
              String fullKey = (parentKey != null ? parentKey + "." + key : key);

--- a/patches/server/0865-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0865-Replace-player-chunk-loader-system.patch
@@ -67,10 +67,10 @@ determined by the number of players on the server multiplied by the
 whatever `global-max-concurrent-loads` is configured to.
 
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index 5e3b7fb2e0b7608610555cd23e7ad25a05883181..1cb0aae3e0c619a715766e0fa604dfd9a8caefcc 100644
+index 309dbf5fce3ce940d5e1b57d267b9d6b2c5ff5b6..5ba64e1083b7cb1eec64d1925095c6ca5865ff07 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -152,7 +152,11 @@ public class TimingsExport extends Thread {
+@@ -159,7 +159,11 @@ public class TimingsExport extends Thread {
                  pair("gamerules", toObjectMapper(world.getWorld().getGameRules(), rule -> {
                      return pair(rule, world.getWorld().getGameRuleValue(rule));
                  })),


### PR DESCRIPTION
This tries to get the CPU name (as requested here: aikar/timings#80, should be working on the most common Linux distributions as well as on Windows) as well as vendor info of the JVM to add to the exported timings data. (Requires changes in the timings website repo to display: https://github.com/aikar/timings/pull/137)

Imo. adding a full blown extra library like [OSHI](https://github.com/oshi/oshi) just to get the CPU info is a bit overkill if most servers will run on linux or windows anyways and the methods used here should produce proper results on the majority of systems.