### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/server/0006-MC-Utils.patch
+++ b/patches/server/0006-MC-Utils.patch
@@ -5460,7 +5460,7 @@ index 09f5ce03f842e357bbe0dd6b0fffde8ec5851f1d..504492c3889fab7b95eec3bcd9b0d1bc
  
          @Override
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index ef87c37633cee4ab438f1991144188ade1c4e65f..19d3802becd353e130b785f8286e595e08dc5c5f 100644
+index 43f4f2dad621e4eb39b0b32fa70bb84bfffd27f5..c9f79ded29c0e4136117eef16e3acd86ba57bf9b 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
 @@ -59,8 +59,9 @@ public abstract class DistanceManager {
@@ -5483,7 +5483,7 @@ index ef87c37633cee4ab438f1991144188ade1c4e65f..19d3802becd353e130b785f8286e595e
  
      protected void purgeStaleTickets() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 0d23c92af7aa381976c45d36e07d965819f19707..9dd0eb49048ceccd82e139dac5d658d168694dda 100644
+index 0d23c92af7aa381976c45d36e07d965819f19707..7dffd704444e1d5f6646c61f3747ea0c83a0bdac 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -48,6 +48,8 @@ import net.minecraft.world.level.storage.LevelData;
@@ -5608,7 +5608,7 @@ index 0d23c92af7aa381976c45d36e07d965819f19707..9dd0eb49048ceccd82e139dac5d658d1
 +        }
 +        ChunkPos chunkPos = new ChunkPos(x, z);
 +        Long identifier = this.chunkFutureAwaitCounter++;
-+        this.distanceManager.addTicketAtLevel(TicketType.FUTURE_AWAIT, chunkPos, ticketLevel, identifier);
++        this.distanceManager.addTicket(TicketType.FUTURE_AWAIT, chunkPos, ticketLevel, identifier);
 +        this.runDistanceManagerUpdates();
 +
 +        ChunkHolder chunk = this.chunkMap.getUpdatingChunkIfPresent(chunkPos.toLong());
@@ -5643,8 +5643,8 @@ index 0d23c92af7aa381976c45d36e07d965819f19707..9dd0eb49048ceccd82e139dac5d658d1
 +                }
 +            } finally {
 +                // due to odd behaviour with CB unload implementation we need to have these AFTER the load callback.
-+                ServerChunkCache.this.distanceManager.addTicketAtLevel(TicketType.UNKNOWN, chunkPos, ticketLevel, chunkPos);
-+                ServerChunkCache.this.distanceManager.removeTicketAtLevel(TicketType.FUTURE_AWAIT, chunkPos, ticketLevel, identifier);
++                ServerChunkCache.this.distanceManager.addTicket(TicketType.UNKNOWN, chunkPos, ticketLevel, chunkPos);
++                ServerChunkCache.this.distanceManager.removeTicket(TicketType.FUTURE_AWAIT, chunkPos, ticketLevel, identifier);
 +            }
 +        }, this.mainThreadProcessor);
 +    }
@@ -5751,11 +5751,11 @@ index 0d23c92af7aa381976c45d36e07d965819f19707..9dd0eb49048ceccd82e139dac5d658d1
 +    }
 +
 +    public <T> void addTicketAtLevel(TicketType<T> ticketType, ChunkPos chunkPos, int ticketLevel, T identifier) {
-+        this.distanceManager.addTicketAtLevel(ticketType, chunkPos, ticketLevel, identifier);
++        this.distanceManager.addTicket(ticketType, chunkPos, ticketLevel, identifier);
 +    }
 +
 +    public <T> void removeTicketAtLevel(TicketType<T> ticketType, ChunkPos chunkPos, int ticketLevel, T identifier) {
-+        this.distanceManager.removeTicketAtLevel(ticketType, chunkPos, ticketLevel, identifier);
++        this.distanceManager.removeTicket(ticketType, chunkPos, ticketLevel, identifier);
 +    }
 +
 +    void chunkLoadAccept(int chunkX, int chunkZ, ChunkAccess chunk, java.util.function.Consumer<ChunkAccess> consumer) {
@@ -5881,7 +5881,7 @@ index 0d23c92af7aa381976c45d36e07d965819f19707..9dd0eb49048ceccd82e139dac5d658d1
      @Override
      public ChunkAccess getChunk(int x, int z, ChunkStatus leastStatus, boolean create) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index b9ef6e33e584099b77b966774e1ae6aa497dfca1..073cea951644f25c276ba05ff1fc48fda08593da 100644
+index 297dc259852dbc17ad7a90de38a930dced64e82f..8181a7422b453fcef7a1146b81eef0a9e82904d9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -159,6 +159,7 @@ import org.bukkit.event.server.MapInitializeEvent;
@@ -6090,7 +6090,7 @@ index a4c5edee297af6d68d518b77f706732b5ccbe4de..7bf4bf5cb2c1b54a7e2733091f48f3a8
      @Override
      public void tell(R runnable) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 595a821e3dbbb0ecac8592356149d839624bcd50..78ea2df454919707a938ff75aa655f5bfa12fc99 100644
+index c06b8048a766f3e2e1e73c969319f485c43865b1..4be6f154358bfb2bdaa3f09af398d82d551196a4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -308,6 +308,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -6118,7 +6118,7 @@ index 1c5f30b199904c74aa3e473b7696c416d93f0efe..a3b6883d7fc856ed8550ffb7aa8dd929
      @Override
      public float getBukkitYaw() {
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 59a54e99baf8219c3878b25a214508e09e819778..31f98763da600c34246d722cb92dda4442a3f046 100644
+index fb0433b01045508fe4853d7af4cdf281cb82553f..4acf6c54778563e315c0a16ed6381b33a2219342 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -238,6 +238,7 @@ public abstract class Mob extends LivingEntity {

--- a/patches/server/0053-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0053-Add-configurable-portal-search-radius.patch
@@ -23,10 +23,10 @@ index 1e3c39f0eeeb07f8d49e3651b18a152db9ccba7b..c248b66486044150c64eaddbef85fa66
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6edb88b123a8cc726cb6bd02fd83e5a11402ff00..e88c80fe1fe97e4704d5f17f97c536fdbba48447 100644
+index 8e08780db174b5e0154650d731bbdec50728e363..b71746bd4ee170df27f666397c77d82b1837f5b6 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2920,7 +2920,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2921,7 +2921,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  double d0 = DimensionType.getTeleportationScale(this.level.dimensionType(), destination.dimensionType());
                  BlockPos blockposition = worldborder.clampToBounds(this.getX() * d0, this.getY(), this.getZ() * d0);
                  // CraftBukkit start

--- a/patches/server/0224-add-more-information-to-Entity.toString.patch
+++ b/patches/server/0224-add-more-information-to-Entity.toString.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add more information to Entity.toString()
 UUID, ticks lived, valid, dead
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c2b24ad7ca280972f287cbb876dcc7011fb49db9..612478675192471ffcf937842d522bd179c43c51 100644
+index 418b5f29f7793f0b67af97848c8e792a581d5268..037ea299071652cb205892e79a2afb26cee228f0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2827,7 +2827,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2828,7 +2828,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public String toString() {
          String s = this.level == null ? "~NULL~" : this.level.toString();
  

--- a/patches/server/0328-ChunkMapDistance-CME.patch
+++ b/patches/server/0328-ChunkMapDistance-CME.patch
@@ -17,7 +17,7 @@ index 5b8b9dabc6673b6f0a335a42d2ec71a583c410fb..74d674b2684b0db4aa6c183edc6091d5
  
      public ChunkHolder(ChunkPos pos, int level, LevelHeightAccessor world, LevelLightEngine lightingProvider, ChunkHolder.LevelChangeListener levelUpdateListener, ChunkHolder.PlayerProvider playersWatchingChunkProvider) {
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index 19d3802becd353e130b785f8286e595e08dc5c5f..f0dac1f596911eb2109192ef16a619f8ae71d1f7 100644
+index c9f79ded29c0e4136117eef16e3acd86ba57bf9b..1027ff9d4ea7540df3678d98ca4cb857344eeccf 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
 @@ -51,7 +51,16 @@ public abstract class DistanceManager {
@@ -73,7 +73,7 @@ index 19d3802becd353e130b785f8286e595e08dc5c5f..f0dac1f596911eb2109192ef16a619f8
              return true;
          } else {
              if (!this.ticketsToRelease.isEmpty()) {
-@@ -434,7 +431,7 @@ public abstract class DistanceManager {
+@@ -436,7 +433,7 @@ public abstract class DistanceManager {
              if (k != level) {
                  playerchunk = DistanceManager.this.updateChunkScheduling(id, level, playerchunk, k);
                  if (playerchunk != null) {

--- a/patches/server/0363-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0363-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 344719bfe08bffe7012609fce64d73c467934d09..82f5f9f6f97551ac7182c68f00f5471cf7d2269f 100644
+index f5ce12cac45f9287f1243e9ba3716ba27819ce3c..ebf4e9356990561dd83149a156c985827e972bc4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3034,6 +3034,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3035,6 +3035,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              if (flag1) {
                  blockposition1 = ServerLevel.END_SPAWN_POINT;
              } else {

--- a/patches/server/0364-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0364-implement-optional-per-player-mob-spawns.patch
@@ -353,10 +353,10 @@ index d2755c00a28fa584d506259f33f8da44c2cf4842..6a8d929721f61b5235614496f60473b8
          double d0 = (double) SectionPos.sectionToBlockCoord(pos.x, 8);
          double d1 = (double) SectionPos.sectionToBlockCoord(pos.z, 8);
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index f0dac1f596911eb2109192ef16a619f8ae71d1f7..07b616d9d7cde77c001f5c627daef0731d883e61 100644
+index 1027ff9d4ea7540df3678d98ca4cb857344eeccf..05e8e2f07ad6bac6fa57fa4a322456fd06fe0f6b 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
-@@ -323,6 +323,12 @@ public abstract class DistanceManager {
+@@ -325,6 +325,12 @@ public abstract class DistanceManager {
  
      }
  

--- a/patches/server/0401-Don-t-crash-if-player-is-attempted-to-be-removed-fro.patch
+++ b/patches/server/0401-Don-t-crash-if-player-is-attempted-to-be-removed-fro.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Don't crash if player is attempted to be removed from
 I suspect it deals with teleporting as it uses players current x/y/z
 
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index e8b4de332cc655a55621e40360fa46d893d903f4..75f11490737018096e7645ce0b991fd210c8f596 100644
+index 2e67b2604cc51776bbe7026cb24fe09d82eb1268..a289a0e5e737824e91aefa03edc38c10d1d6be1b 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
-@@ -297,8 +297,8 @@ public abstract class DistanceManager {
+@@ -299,8 +299,8 @@ public abstract class DistanceManager {
          ObjectSet<ServerPlayer> objectset = (ObjectSet) this.playersPerChunk.get(i);
          if (objectset == null) return; // CraftBukkit - SPIGOT-6208
  

--- a/patches/server/0405-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0405-Load-Chunks-for-Login-Asynchronously.patch
@@ -96,7 +96,7 @@ index bb767f5b626225e70a8af273384bb74dbd21430d..301042e7a0d372a914f27ec0988dd938
              try {
                  ServerPlayer entityplayer1 = this.server.getPlayerList().getPlayerForLogin(this.gameProfile, s); // CraftBukkit - add player reference
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f096fbe48d8cc70e3749f48bc9972def42b0068d..b84124abaca401406fbffc8bc6bd21245c303156 100644
+index f096fbe48d8cc70e3749f48bc9972def42b0068d..10a22b7022dd755b06b984faae3c85879813e782 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -39,6 +39,7 @@ import net.minecraft.network.protocol.Packet;
@@ -164,7 +164,7 @@ index f096fbe48d8cc70e3749f48bc9972def42b0068d..b84124abaca401406fbffc8bc6bd2124
 +        final net.minecraft.world.level.ChunkPos pos = new net.minecraft.world.level.ChunkPos(chunkX, chunkZ);
 +        net.minecraft.server.level.ChunkMap playerChunkMap = worldserver1.getChunkSource().chunkMap;
 +        net.minecraft.server.level.DistanceManager distanceManager = playerChunkMap.distanceManager;
-+        distanceManager.addTicketAtLevel(net.minecraft.server.level.TicketType.LOGIN, pos, 31, pos.toLong());
++        distanceManager.addTicket(net.minecraft.server.level.TicketType.LOGIN, pos, 31, pos.toLong());
 +        worldserver1.getChunkSource().runDistanceManagerUpdates();
 +        worldserver1.getChunkSource().getChunkAtAsynchronously(chunkX, chunkZ, true, true).thenApply(chunk -> {
 +            net.minecraft.server.level.ChunkHolder updatingChunk = playerChunkMap.getUpdatingChunkIfPresent(pos.toLong());

--- a/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,7 +16,7 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6fa35e0acd966a9cfd3d5b3765c7d0130ea2de18..7bf62752b6604abe0bda6f5d0024f0e93efb3a9a 100644
+index ffd26ee3d7599702d4856194029005332fddd506..c3920ef9e728023362fc54d48fec358575f059b3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2162,11 +2162,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -34,7 +34,7 @@ index 6fa35e0acd966a9cfd3d5b3765c7d0130ea2de18..7bf62752b6604abe0bda6f5d0024f0e9
  
              entityitem.setDefaultPickUpDelay();
              // CraftBukkit start
-@@ -2919,6 +2920,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2920,6 +2921,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      @Nullable
      public Entity teleportTo(ServerLevel worldserver, BlockPos location) {
          // CraftBukkit end
@@ -47,7 +47,7 @@ index 6fa35e0acd966a9cfd3d5b3765c7d0130ea2de18..7bf62752b6604abe0bda6f5d0024f0e9
          if (this.level instanceof ServerLevel && !this.isRemoved()) {
              this.level.getProfiler().push("changeDimension");
              // CraftBukkit start
-@@ -2945,6 +2952,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2946,6 +2953,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                  // CraftBukkit end
  
                  this.level.getProfiler().popPush("reloading");
@@ -59,7 +59,7 @@ index 6fa35e0acd966a9cfd3d5b3765c7d0130ea2de18..7bf62752b6604abe0bda6f5d0024f0e9
                  Entity entity = this.getType().create(worldserver);
  
                  if (entity != null) {
-@@ -2958,10 +2970,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -2959,10 +2971,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index 6fa35e0acd966a9cfd3d5b3765c7d0130ea2de18..7bf62752b6604abe0bda6f5d0024f0e9
                      // CraftBukkit end
                  }
  
-@@ -3083,7 +3091,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3084,7 +3092,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public boolean canChangeDimensions() {

--- a/patches/server/0432-Optimize-anyPlayerCloseEnoughForSpawning-to-use-dist.patch
+++ b/patches/server/0432-Optimize-anyPlayerCloseEnoughForSpawning-to-use-dist.patch
@@ -224,7 +224,7 @@ index 00eeaa04c98a658bac63f72da6b6d157131e9120..cd58121bfa059366919e098005299dde
  
      public List<ServerPlayer> getPlayersCloseForSpawning(ChunkPos pos) {
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index 75f11490737018096e7645ce0b991fd210c8f596..14774d51dd35a98471d29230a64fadee74651d19 100644
+index a289a0e5e737824e91aefa03edc38c10d1d6be1b..2718381dc37c835e08db23c5eca4733e9dd4845f 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
 @@ -48,7 +48,7 @@ public abstract class DistanceManager {
@@ -245,7 +245,7 @@ index 75f11490737018096e7645ce0b991fd210c8f596..14774d51dd35a98471d29230a64fadee
          this.tickingTicketsTracker.runAllUpdates();
          this.playerTicketManager.runAllUpdates();
          int i = Integer.MAX_VALUE - this.ticketTracker.runDistanceUpdates(Integer.MAX_VALUE);
-@@ -286,7 +286,7 @@ public abstract class DistanceManager {
+@@ -288,7 +288,7 @@ public abstract class DistanceManager {
          ((ObjectSet) this.playersPerChunk.computeIfAbsent(i, (j) -> {
              return new ObjectOpenHashSet();
          })).add(player);
@@ -254,7 +254,7 @@ index 75f11490737018096e7645ce0b991fd210c8f596..14774d51dd35a98471d29230a64fadee
          this.playerTicketManager.update(i, 0, true);
          this.tickingTicketsTracker.addTicket(TicketType.PLAYER, chunkcoordintpair, this.getPlayerTicketLevel(), chunkcoordintpair);
      }
-@@ -300,7 +300,7 @@ public abstract class DistanceManager {
+@@ -302,7 +302,7 @@ public abstract class DistanceManager {
          if (objectset != null) objectset.remove(player); // Paper - some state corruption happens here, don't crash, clean up gracefully.
          if (objectset == null || objectset.isEmpty()) { // Paper
              this.playersPerChunk.remove(i);
@@ -263,7 +263,7 @@ index 75f11490737018096e7645ce0b991fd210c8f596..14774d51dd35a98471d29230a64fadee
              this.playerTicketManager.update(i, Integer.MAX_VALUE, false);
              this.tickingTicketsTracker.removeTicket(TicketType.PLAYER, chunkcoordintpair, this.getPlayerTicketLevel(), chunkcoordintpair);
          }
-@@ -344,13 +344,17 @@ public abstract class DistanceManager {
+@@ -346,13 +346,17 @@ public abstract class DistanceManager {
      // Paper end
  
      public int getNaturalSpawnChunkCount() {

--- a/patches/server/0449-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0449-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9a4454746452f64d7a8caa52eef2dca86e9edd94..362b509c6d2df8061ba7fac51373490554843c30 100644
+index 7487cb6f2abb8bea95950a258c2ff38c080e39bf..e63e5a10807e6bd4f6ff28ec290400f9b746c487 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -595,8 +595,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -19,7 +19,7 @@ index 9a4454746452f64d7a8caa52eef2dca86e9edd94..362b509c6d2df8061ba7fac513734905
      }
  
      protected AABB makeBoundingBox() {
-@@ -3792,6 +3792,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3793,6 +3793,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public final void setPosRaw(double x, double y, double z) {
@@ -31,7 +31,7 @@ index 9a4454746452f64d7a8caa52eef2dca86e9edd94..362b509c6d2df8061ba7fac513734905
          if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
-@@ -3814,6 +3819,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3815,6 +3820,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              }
          }
  

--- a/patches/server/0450-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0450-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -8,7 +8,7 @@ makes it so that the server keeps the last difficulty used instead
 of restoring the server.properties every single load.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9d8dd7ac4e471d658ba942e29c5028df410fa2c3..9a926114aa550ca5a6329e3ce993bf1f686cd10e 100644
+index 9d8dd7ac4e471d658ba942e29c5028df410fa2c3..bfcd33e7de5b222f762fa2867ea34f183c9f2a8e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -824,7 +824,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -34,41 +34,44 @@ index 9d8dd7ac4e471d658ba942e29c5028df410fa2c3..9a926114aa550ca5a6329e3ce993bf1f
 +        PrimaryLevelData worldData = level.serverLevelData;
 +        if (forceUpdate || !worldData.isDifficultyLocked()) {
 +            worldData.setDifficulty(worldData.isHardcore() ? Difficulty.HARD : difficulty);
-+            level.setSpawnSettings(worldData.getDifficulty() != Difficulty.PEACEFUL && ((DedicatedServer) this).settings.getProperties().spawnMonsters, this.isSpawningAnimals());
-+            // this.getPlayerList().getPlayers().forEach(this::sendDifficultyUpdate);
++            this.updateMobSpawningFlags(level);
++            // this.getPlayerList().getPlayers().forEach(this::sendDifficultyUpdate); // don't send update because CB adds the update packet sending in worldData#setDifficulty
 +            // Paper end
          }
      }
  
-@@ -1718,7 +1721,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1717,8 +1720,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+ 
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
++            // Paper start
++            this.updateMobSpawningFlags(worldserver);
++        }
++    }
++    private void updateMobSpawningFlags(ServerLevel worldserver) {
++        {
++            // Paper end
  
 -            worldserver.setSpawnSettings(this.isSpawningMonsters(), this.isSpawningAnimals());
-+            worldserver.setSpawnSettings(worldserver.serverLevelData.getDifficulty() != Difficulty.PEACEFUL && ((DedicatedServer) this).settings.getProperties().spawnMonsters, this.isSpawningAnimals()); // Paper - per level difficulty (from setDifficulty(ServerLevel, Difficulty, boolean))
++            worldserver.setSpawnSettings(worldserver.serverLevelData.getDifficulty() != Difficulty.PEACEFUL && ((DedicatedServer) this).settings.getProperties().spawnMonsters, this.isSpawningAnimals()); // Paper - per level difficulty (spawnMonsters from DedicatedServerProperties and world setting)
          }
  
      }
 diff --git a/src/main/java/net/minecraft/server/commands/DifficultyCommand.java b/src/main/java/net/minecraft/server/commands/DifficultyCommand.java
-index 33c859df0b669d0c3e97ccba29f17c1ba2166a27..9f03b738aea623fe409ca176397f48be055466da 100644
+index e23dca1a711955417ef3f590960d4e7a388b9147..36dd28498eb75152a79dae4353ef657a0485403d 100644
 --- a/src/main/java/net/minecraft/server/commands/DifficultyCommand.java
 +++ b/src/main/java/net/minecraft/server/commands/DifficultyCommand.java
-@@ -35,10 +35,11 @@ public class DifficultyCommand {
- 
-     public static int setDifficulty(CommandSourceStack source, Difficulty difficulty) throws CommandSyntaxException {
-         MinecraftServer minecraftServer = source.getServer();
--        if (minecraftServer.getWorldData().getDifficulty() == difficulty) {
-+        net.minecraft.server.level.ServerLevel level = source.getLevel(); // Paper
-+        if (level.serverLevelData.getDifficulty() == difficulty) { // Paper
-             throw ERROR_ALREADY_DIFFICULT.create(difficulty.getKey());
+@@ -47,7 +47,7 @@ public class DifficultyCommand {
+         if (worldServer.getDifficulty() == difficulty) { // CraftBukkit
+             throw DifficultyCommand.ERROR_ALREADY_DIFFICULT.create(difficulty.getKey());
          } else {
--            minecraftServer.setDifficulty(difficulty, true);
-+            minecraftServer.setDifficulty(level, difficulty, true); // Paper - use world
-             source.sendSuccess(new TranslatableComponent("commands.difficulty.success", difficulty.getDisplayName()), true);
+-            worldServer.serverLevelData.setDifficulty(difficulty); // CraftBukkit
++            minecraftserver.setDifficulty(worldServer, difficulty, true); // Paper - don't skip other difficulty-changing logic (fix upstream's fix)
+             source.sendSuccess(new TranslatableComponent("commands.difficulty.success", new Object[]{difficulty.getDisplayName()}), true);
              return 0;
          }
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 2b7ba5d8dda0297c8b35a0cea68c3ae10188e3f2..e968b880e435b8753314d85b919a0abc4f35be25 100644
+index 2b7ba5d8dda0297c8b35a0cea68c3ae10188e3f2..a9fdb1aa6d676c2084312d111719909ffd7e23f4 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -366,7 +366,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -76,7 +79,7 @@ index 2b7ba5d8dda0297c8b35a0cea68c3ae10188e3f2..e968b880e435b8753314d85b919a0abc
      @Override
      public void forceDifficulty() {
 -        this.setDifficulty(this.getProperties().difficulty, true);
-+        //this.a(this.getDedicatedServerProperties().difficulty, true); // Paper - Don't overwrite level.dat's difficulty, keep current
++        // this.setDifficulty(this.getProperties().difficulty, true); // Paper - Don't overwrite level.dat's difficulty, keep current
      }
  
      @Override
@@ -94,7 +97,7 @@ index 2f13055a39c26fe12d2c1094103186635e536166..6b0cb662d9163c360035e19c5faad59f
  
                  playerlist.sendPlayerPermissionLevel(this);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ec784bb54f7e4b4cb90a64e636392a752302cf86..1486ac77bf4621a3a2a5da6d53461bada44c27c1 100644
+index ec784bb54f7e4b4cb90a64e636392a752302cf86..22b9d2e44d4abc91a6c30a153441bce49423b66c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -3035,7 +3035,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -102,7 +105,7 @@ index ec784bb54f7e4b4cb90a64e636392a752302cf86..1486ac77bf4621a3a2a5da6d53461bad
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (this.player.hasPermissions(2) || this.isSingleplayerOwner()) {
 -            this.server.setDifficulty(packet.getDifficulty(), false);
-+            //this.minecraftServer.a(packetplayindifficultychange.b(), false); // Paper - don't allow clients to change this
++            // this.server.setDifficulty(packet.getDifficulty(), false); // Paper - don't allow clients to change this
          }
      }
  

--- a/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -529,7 +529,7 @@ index e66e4d1656e5f6f042c5c63715e13a6b5e7d81c5..aef2974ecec878a014ada9619d814ae3
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index 93a642cd6cf21a268074a73bff22249d32992ad3..7c66e4ed02c80521196b4ca797477dd9573752d8 100644
+index f35912ac4473775336f125fae9495bfe30d0cec9..b3fe2aae24890cf20a4201365bc1ef2912024d63 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
 @@ -127,6 +127,7 @@ public abstract class DistanceManager {
@@ -597,7 +597,7 @@ index 93a642cd6cf21a268074a73bff22249d32992ad3..7c66e4ed02c80521196b4ca797477dd9
          return removed; // CraftBukkit
      }
  
-@@ -286,6 +299,112 @@ public abstract class DistanceManager {
+@@ -288,6 +301,112 @@ public abstract class DistanceManager {
          });
      }
  
@@ -711,7 +711,7 @@ index 93a642cd6cf21a268074a73bff22249d32992ad3..7c66e4ed02c80521196b4ca797477dd9
          Ticket<ChunkPos> ticket = new Ticket<>(TicketType.FORCED, 31, pos);
          long i = pos.toLong();
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index fdc027bc5a7e9d691ac90c5fee0cdfebd959bc5f..0eca545278568f5521bd721ff5bdcd7090c75e6e 100644
+index 0854c690762cf603610cd3064b190026b2bede4f..5604638f0f7a0d2619615e97fa2d760e9ead741f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -601,6 +601,26 @@ public class ServerChunkCache extends ChunkSource {
@@ -1128,7 +1128,7 @@ index 8770fe0db46b01e8b608637df4f1a669a3f4cdde..3c1698ba0d3bc412ab957777d9b5211d
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index d06e43bfaf8d22e0374bb6ed2e62c65e15699ef5..373f1c600ecdf75293dbe5ff6ef676a0e35e2e80 100644
+index b7a048fad8239704103955bda82f5cc43c4216af..8e0b42d7f88c9156142d940656873ba9996e0532 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -175,6 +175,7 @@ public abstract class PlayerList {
@@ -1142,7 +1142,7 @@ index d06e43bfaf8d22e0374bb6ed2e62c65e15699ef5..373f1c600ecdf75293dbe5ff6ef676a0
 @@ -289,8 +290,8 @@ public abstract class PlayerList {
          net.minecraft.server.level.ChunkMap playerChunkMap = worldserver1.getChunkSource().chunkMap;
          net.minecraft.server.level.DistanceManager distanceManager = playerChunkMap.distanceManager;
-         distanceManager.addTicketAtLevel(net.minecraft.server.level.TicketType.LOGIN, pos, 31, pos.toLong());
+         distanceManager.addTicket(net.minecraft.server.level.TicketType.LOGIN, pos, 31, pos.toLong());
 -        worldserver1.getChunkSource().runDistanceManagerUpdates();
 -        worldserver1.getChunkSource().getChunkAtAsynchronously(chunkX, chunkZ, true, true).thenApply(chunk -> {
 +        worldserver1.getChunkSource().markAreaHighPriority(pos, 28, 3); // Paper - Chunk priority
@@ -1151,7 +1151,7 @@ index d06e43bfaf8d22e0374bb6ed2e62c65e15699ef5..373f1c600ecdf75293dbe5ff6ef676a0
              if (updatingChunk != null) {
                  return updatingChunk.getEntityTickingChunkFuture();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0b54c4e229aab803683101d7e2b1780ae41b42e0..cd1e850c1d55d203ecba40719a0578a69c33492c 100644
+index 25a3c1c7155ffa07692207fdac34d161370b0d17..32ceb2ce765eec7b235d4305557d3681d25175c0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -228,7 +228,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -1193,7 +1193,7 @@ index 6eaba33b7730d66bf631b6d5c6a7080f9f019f8b..8e03e63a00dd242791ba0d5a8a179222
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d4df7a712738d53aa7b9876a2fea9a09b9e3caf1..bbba0658990cf6f10d09b78204788c8b5ad08787 100644
+index 993b5a8281e535fb8ecddfa22bc64b05ed3fdd1d..6685e9eb07d49cec63864f9ccc5768d0a7f4266d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1989,6 +1989,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0502-Cache-block-data-strings.patch
+++ b/patches/server/0502-Cache-block-data-strings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Cache block data strings
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 95842327aa08d4717f86e9dcc0519ab24c41ca14..135b3e44fb6054d360327a0ce46decc451974e30 100644
+index a847cde07b31d328e1dfb39750250c930c02baaf..1139ae310d39a42624536036b9935acb10b6fa95 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1979,6 +1979,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1986,6 +1986,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.getPlayerList().reloadResources();
              this.functionManager.replaceLibrary(this.resources.getFunctionLibrary());
              this.structureManager.onResourceManagerReload(this.resources.getResourceManager());
@@ -17,7 +17,7 @@ index 95842327aa08d4717f86e9dcc0519ab24c41ca14..135b3e44fb6054d360327a0ce46decc4
  
          if (this.isSameThread()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-index 3594f432a25b580173e8577bf324be954f5eddd1..d62ba8d02228b2a00202190ff16a0efc342c7b83 100644
+index 275401f9bf7a78e69766e0547c94c3a115a8896c..afc69b0077f180c3e7ace3db11aa0eccc602516f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 @@ -494,9 +494,39 @@ public class CraftBlockData implements BlockData {

--- a/patches/server/0508-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0508-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f91b4081bb2d9e86cb6f1c3ab3eb654a83bf1dbe..046f68a7736a9897789ee1a08465ffdea24c8dc0 100644
+index 360ab2ddaad1ece2f6c6a37aa141639d11606908..b93c8a64460a285887da9bf13d56dccf0cbe065b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3992,4 +3992,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3993,4 +3993,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0510-Entity-isTicking.patch
+++ b/patches/server/0510-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 046f68a7736a9897789ee1a08465ffdea24c8dc0..56c138d69423cd7fc99003ff4ddf124ede1c5b95 100644
+index b93c8a64460a285887da9bf13d56dccf0cbe065b..3228378abd3a6ff381b2d3182e66fda61e9f0c59 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -53,6 +53,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index 046f68a7736a9897789ee1a08465ffdea24c8dc0..56c138d69423cd7fc99003ff4ddf124e
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -3997,5 +3998,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3998,5 +3999,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0511-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
+++ b/patches/server/0511-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix deop kicking non-whitelisted player when white list is
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 135b3e44fb6054d360327a0ce46decc451974e30..b75522558c5277c2e8ec725e5b12eb6d4cb2c36c 100644
+index 1139ae310d39a42624536036b9935acb10b6fa95..e501afc0ce45662ceb9fcc487d54b2568eea7e9a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2045,13 +2045,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2052,13 +2052,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          if (this.isEnforceWhitelist()) {
              PlayerList playerlist = source.getServer().getPlayerList();
              UserWhiteList whitelist = playerlist.getWhiteList();

--- a/patches/server/0546-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0546-MC-4-Fix-item-position-desync.patch
@@ -9,7 +9,7 @@ loss, which forces the server to lose the same precision as the client
 keeping them in sync.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index d5ae781d65016e0382cb3497cb8cac201680bc8c..266e52e1bf4d03ce7ad9dd329a18577b887cc767 100644
+index 4c2d11d04b63d0e5e2eeb3743a1f79fea301c5aa..c75005b934271e4b8864d949052d56465571f011 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -101,6 +101,11 @@ public class PaperConfig {
@@ -43,10 +43,10 @@ index b30c08bfb8c55161543a4ef09f2e462e0a1fe4ae..ec93f5300cc7d423ec0d292f0f8443f9
  
      public Vec3 updateEntityPosition(Vec3 orig) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 925f9b57e347bb609c159bb9d750a528ad2b87dd..6b1ea58389e32d6144e930adc72efeb4ba570d89 100644
+index 73e9ac4423aa8ede8f69ed49f0b0d59c265e4021..9eceab87d2d883a6d8d4cbeff90527d1b4197b6b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3811,6 +3811,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3812,6 +3812,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
          // Paper end

--- a/patches/server/0567-Added-ServerResourcesReloadedEvent.patch
+++ b/patches/server/0567-Added-ServerResourcesReloadedEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added ServerResourcesReloadedEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b75522558c5277c2e8ec725e5b12eb6d4cb2c36c..b5b7bb3c0147f95ac4036e7d2aa8f26ac755f4df 100644
+index e501afc0ce45662ceb9fcc487d54b2568eea7e9a..204e8db1b5b8c755dfd59f70564477fafc5e8bb8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1958,7 +1958,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1965,7 +1965,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          return this.functionManager;
      }
  
@@ -22,7 +22,7 @@ index b75522558c5277c2e8ec725e5b12eb6d4cb2c36c..b5b7bb3c0147f95ac4036e7d2aa8f26a
          CompletableFuture<Void> completablefuture = CompletableFuture.supplyAsync(() -> {
              Stream<String> stream = datapacks.stream(); // CraftBukkit - decompile error
              PackRepository resourcepackrepository = this.packRepository;
-@@ -1974,6 +1980,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1981,6 +1987,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.packRepository.setSelected(datapacks);
              this.worldData.setDataPackConfig(MinecraftServer.getSelectedPacks(this.packRepository));
              datapackresources.updateGlobals();

--- a/patches/server/0619-forced-whitelist-use-configurable-kick-message.patch
+++ b/patches/server/0619-forced-whitelist-use-configurable-kick-message.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] forced whitelist: use configurable kick message
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 18830fa8e43c70c9da417eb771d553353b06bb48..5de82c5d7da2ca6eeee4b804b916fa9d385cc25c 100644
+index 63549e0130baa12364ae912e4229a603989c8286..24135d37c7b67537400dd92846bf7718bda78358 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -73,7 +73,6 @@ import net.minecraft.nbt.NbtOps;
@@ -16,7 +16,7 @@ index 18830fa8e43c70c9da417eb771d553353b06bb48..5de82c5d7da2ca6eeee4b804b916fa9d
  import net.minecraft.network.protocol.game.ClientboundChangeDifficultyPacket;
  import net.minecraft.network.protocol.game.ClientboundSetTimePacket;
  import net.minecraft.network.protocol.status.ServerStatus;
-@@ -2061,7 +2060,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2068,7 +2067,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  ServerPlayer entityplayer = (ServerPlayer) iterator.next();
  
                  if (!whitelist.isWhiteListed(entityplayer.getGameProfile()) && !this.getPlayerList().isOp(entityplayer.getGameProfile())) { // Paper - Fix kicking ops when whitelist is reloaded (MC-171420)

--- a/patches/server/0666-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0666-Add-PlayerKickEvent-causes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 860540a50c3281ab35acffd845f536dadab285d7..79e5b8a05828bbc07468d2deeb0f4dad51ca12a5 100644
+index c2a4f98256f6f8529f596ac8e15ef6379884aa48..0fac96e4ea8fc1fde09ddb8fb3e408bd0df1ebff 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2064,7 +2064,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2071,7 +2071,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  ServerPlayer entityplayer = (ServerPlayer) iterator.next();
  
                  if (!whitelist.isWhiteListed(entityplayer.getGameProfile()) && !this.getPlayerList().isOp(entityplayer.getGameProfile())) { // Paper - Fix kicking ops when whitelist is reloaded (MC-171420)
@@ -57,7 +57,7 @@ index 708ac03d5a849bf09c49547306e4a8c5a5ef8d91..5a8df368a4a25839cd4ac9be6972da2e
          }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8a1041d8ef225131428cebf9e293563e540944bf..9862fc84a2b988983663bc2621a20b76c0132d28 100644
+index 7bab4e56142befa22c4352ac7d69556def64ac71..60532d519d23b20469b05441b4ed766aa17d6f5e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -318,7 +318,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -318,7 +318,7 @@ index 8a1041d8ef225131428cebf9e293563e540944bf..9862fc84a2b988983663bc2621a20b76
          }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3900e885988bc1f2865b95f825cba34d04919731..cad8a98951795706b89ff3ea3985033f511da58b 100644
+index b6c0291656ff332beffb3d759b97899aa9ba048a..2f83f60475ab5945e4e769e5dfb4a7dede647761 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -719,7 +719,7 @@ public abstract class PlayerList {

--- a/patches/server/0707-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0707-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c6f7c52b017d0f58ab84b3e213b5500b512bfab9..4d9e2881bfbda4efe8dc25c5efcdbda949b9c792 100644
+index d1c9dd462b1c4b1149495d5664110211afa5e36b..40d1ff1ae63ffd8872a74c2f2df5d57141f273a8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3517,26 +3517,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3518,26 +3518,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      private Stream<Entity> getIndirectPassengersStream() {

--- a/patches/server/0718-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0718-Add-back-EntityPortalExitEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4d9e2881bfbda4efe8dc25c5efcdbda949b9c792..296efe4970b1f0b6673e8e09ff0f6ac46e624c5f 100644
+index 40d1ff1ae63ffd8872a74c2f2df5d57141f273a8..f927812e2d92373196d7dbf3d40cf71886516d0e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3022,6 +3022,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3023,6 +3023,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
              } else {
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
@@ -32,7 +32,7 @@ index 4d9e2881bfbda4efe8dc25c5efcdbda949b9c792..296efe4970b1f0b6673e8e09ff0f6ac4
                  if (worldserver == this.level) {
                      // SPIGOT-6782: Just move the entity if a plugin changed the world to the one the entity is already in
                      this.moveTo(shapedetectorshape.pos.x, shapedetectorshape.pos.y, shapedetectorshape.pos.z, shapedetectorshape.yRot, shapedetectorshape.xRot);
-@@ -3041,8 +3058,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3042,8 +3059,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
  
                  if (entity != null) {
                      entity.restoreFrom(this);

--- a/patches/server/0742-Prevent-unload-calls-removing-tickets-for-sync-loads.patch
+++ b/patches/server/0742-Prevent-unload-calls-removing-tickets-for-sync-loads.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent unload() calls removing tickets for sync loads
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index b3b10baad56bf14a31a11a3375000195ce84d4d3..7c3a1622f161409e92c4ccfa13e8c1fc1d66c947 100644
+index 58641bb737a0a8106c94ca5c739ce096731c2838..a07965416a47e7fd387d407947f5c91eb52fffd2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -725,6 +725,8 @@ public class ServerChunkCache extends ChunkSource {
@@ -26,7 +26,7 @@ index b3b10baad56bf14a31a11a3375000195ce84d4d3..7c3a1622f161409e92c4ccfa13e8c1fc
              // CraftBukkit end
              this.distanceManager.addTicket(TicketType.UNKNOWN, chunkcoordintpair, l, chunkcoordintpair);
 +            identifier = Long.valueOf(this.syncLoadCounter++); // Paper - prevent plugin unloads from removing our ticket
-+            this.distanceManager.addTicketAtLevel(TicketType.REQUIRED_LOAD, chunkcoordintpair, l, identifier); // Paper - prevent plugin unloads from removing our ticket
++            this.distanceManager.addTicket(TicketType.REQUIRED_LOAD, chunkcoordintpair, l, identifier); // Paper - prevent plugin unloads from removing our ticket
              if (isUrgent) this.distanceManager.markUrgent(chunkcoordintpair); // Paper - Chunk priority
              if (this.chunkAbsent(playerchunk, l)) {
                  ProfilerFiller gameprofilerfiller = this.level.getProfiler();
@@ -34,7 +34,7 @@ index b3b10baad56bf14a31a11a3375000195ce84d4d3..7c3a1622f161409e92c4ccfa13e8c1fc
                  playerchunk = this.getVisibleChunkIfPresent(k);
                  gameprofilerfiller.pop();
                  if (this.chunkAbsent(playerchunk, l)) {
-+                    this.distanceManager.removeTicketAtLevel(TicketType.REQUIRED_LOAD, chunkcoordintpair, l, identifier); // Paper
++                    this.distanceManager.removeTicket(TicketType.REQUIRED_LOAD, chunkcoordintpair, l, identifier); // Paper
                      throw (IllegalStateException) Util.pauseInIde(new IllegalStateException("No chunk holder after ticket has been added"));
                  }
              }
@@ -46,7 +46,7 @@ index b3b10baad56bf14a31a11a3375000195ce84d4d3..7c3a1622f161409e92c4ccfa13e8c1fc
 +        // Paper start - prevent plugin unloads from removing our ticket
 +        if (create && !currentlyUnloading) {
 +            future.thenAcceptAsync((either) -> {
-+                ServerChunkCache.this.distanceManager.removeTicketAtLevel(TicketType.REQUIRED_LOAD, chunkcoordintpair, l, identifier);
++                ServerChunkCache.this.distanceManager.removeTicket(TicketType.REQUIRED_LOAD, chunkcoordintpair, l, identifier);
 +            }, ServerChunkCache.this.mainThreadProcessor);
 +        }
 +        // Paper end - prevent plugin unloads from removing our ticket

--- a/patches/server/0753-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0753-Detail-more-information-in-watchdog-dumps.patch
@@ -77,7 +77,7 @@ index bcf53ec07b8eeec7a88fb67e6fb908362e6f51b0..acc12307f61e1e055896b68fe16654c9
              });
              throw RunningOnDifferentThreadException.RUNNING_ON_DIFFERENT_THREAD;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index cb327920cfa8d4eec626af1fe42ec1cc5e8953c7..3735b80c6f827500a9c474d4139d6e748b14863b 100644
+index b5e60bd6c023cfc9d48fe8c567feff24b00b3a0e..78e68b11e80269323ecbab20277547683e5480c9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -976,7 +976,26 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -123,7 +123,7 @@ index cb327920cfa8d4eec626af1fe42ec1cc5e8953c7..3735b80c6f827500a9c474d4139d6e74
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9d16faa522cf627bc59df56b04d28b4d4896cb7c..e4d6133253fc982858a7b33c2d1104347b149a83 100644
+index c3a7ceca31acf50bb2b8f414f5f1653adf7ea3e2..213966441f937eafecbdad99504bd8b8ed263201 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -904,7 +904,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -183,7 +183,7 @@ index 9d16faa522cf627bc59df56b04d28b4d4896cb7c..e4d6133253fc982858a7b33c2d110434
      }
  
      protected boolean isHorizontalCollisionMinor(Vec3 adjustedMovement) {
-@@ -3869,7 +3911,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3870,7 +3912,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -193,7 +193,7 @@ index 9d16faa522cf627bc59df56b04d28b4d4896cb7c..e4d6133253fc982858a7b33c2d110434
      }
  
      public void setDeltaMovement(double x, double y, double z) {
-@@ -3945,7 +3989,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3946,7 +3990,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
          }
          // Paper end - fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {

--- a/patches/server/0828-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0828-Forward-CraftEntity-in-teleport-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fe6f2ec41c521c8f1ac17aa3af8bb7f7375e5a02..9b5bd68f328306e26eced7d3112b2c01301b543b 100644
+index c69f5dd1a3bd40a744c79dbbf4da4d62e0669cb1..cb21b60d3c16e2363bd70e113ea1b42a87612219 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3168,6 +3168,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3169,6 +3169,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
      }
  
      public void restoreFrom(Entity original) {
@@ -22,7 +22,7 @@ index fe6f2ec41c521c8f1ac17aa3af8bb7f7375e5a02..9b5bd68f328306e26eced7d3112b2c01
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3249,10 +3256,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -3250,10 +3257,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
                      if (worldserver.getTypeKey() == LevelStem.END) { // CraftBukkit
                          ServerLevel.makeObsidianPlatform(worldserver, this); // CraftBukkit
                      }

--- a/patches/server/0868-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0868-Replace-player-chunk-loader-system.patch
@@ -1627,7 +1627,7 @@ index 6a035b173cf0d288b2912f568078fede45d138f2..afef3ea6d1ae5f145261eaae3da720fd
                  double d2 = d0 * d0;
                  boolean flag = d1 <= d2 && this.entity.broadcastToPlayer(player);
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index 7c66e4ed02c80521196b4ca797477dd9573752d8..fd379155a67794288f7cdae3250767bc3615d421 100644
+index b3fe2aae24890cf20a4201365bc1ef2912024d63..7da090f14d8af22c3b2adb1c0aa97c0e7bc5b8c2 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
 @@ -49,8 +49,8 @@ public abstract class DistanceManager {
@@ -1671,25 +1671,25 @@ index 7c66e4ed02c80521196b4ca797477dd9573752d8..fd379155a67794288f7cdae3250767bc
          int i = Integer.MAX_VALUE - this.ticketTracker.runDistanceUpdates(Integer.MAX_VALUE);
          boolean flag = i != 0;
  
-@@ -282,7 +282,7 @@ public abstract class DistanceManager {
-         long j = pos.toLong();
+@@ -276,7 +276,7 @@ public abstract class DistanceManager {
+         long j = chunkcoordintpair.toLong();
  
-         this.addTicket(j, ticket);
+         boolean added = this.addTicket(j, ticket); // CraftBukkit
 -        this.tickingTicketsTracker.addTicket(j, ticket);
 +        //this.tickingTicketsTracker.addTicket(j, ticket); // Paper - no longer used
+         return added; // CraftBukkit
      }
  
-     public <T> void removeRegionTicket(TicketType<T> type, ChunkPos pos, int radius, T argument) {
-@@ -290,7 +290,7 @@ public abstract class DistanceManager {
-         long j = pos.toLong();
+@@ -291,7 +291,7 @@ public abstract class DistanceManager {
+         long j = chunkcoordintpair.toLong();
  
-         this.removeTicket(j, ticket);
+         boolean removed = this.removeTicket(j, ticket); // CraftBukkit
 -        this.tickingTicketsTracker.removeTicket(j, ticket);
 +        //this.tickingTicketsTracker.removeTicket(j, ticket); // Paper - no longer used
+         return removed; // CraftBukkit
      }
  
-     private SortedArraySet<Ticket<?>> getTickets(long position) {
-@@ -411,10 +411,10 @@ public abstract class DistanceManager {
+@@ -413,10 +413,10 @@ public abstract class DistanceManager {
  
          if (forced) {
              this.addTicket(i, ticket);
@@ -1702,7 +1702,7 @@ index 7c66e4ed02c80521196b4ca797477dd9573752d8..fd379155a67794288f7cdae3250767bc
          }
  
      }
-@@ -427,8 +427,8 @@ public abstract class DistanceManager {
+@@ -429,8 +429,8 @@ public abstract class DistanceManager {
              return new ObjectOpenHashSet();
          })).add(player);
          //this.f.update(i, 0, true); // Paper - no longer used
@@ -1713,7 +1713,7 @@ index 7c66e4ed02c80521196b4ca797477dd9573752d8..fd379155a67794288f7cdae3250767bc
      }
  
      public void removePlayer(SectionPos pos, ServerPlayer player) {
-@@ -441,8 +441,8 @@ public abstract class DistanceManager {
+@@ -443,8 +443,8 @@ public abstract class DistanceManager {
          if (objectset == null || objectset.isEmpty()) { // Paper
              this.playersPerChunk.remove(i);
              //this.f.update(i, Integer.MAX_VALUE, false); // Paper - no longer used
@@ -1724,7 +1724,7 @@ index 7c66e4ed02c80521196b4ca797477dd9573752d8..fd379155a67794288f7cdae3250767bc
          }
  
      }
-@@ -452,11 +452,17 @@ public abstract class DistanceManager {
+@@ -454,11 +454,17 @@ public abstract class DistanceManager {
      }
  
      public boolean inEntityTickingRange(long chunkPos) {
@@ -1744,7 +1744,7 @@ index 7c66e4ed02c80521196b4ca797477dd9573752d8..fd379155a67794288f7cdae3250767bc
      }
  
      protected String getTicketDebugString(long pos) {
-@@ -466,20 +472,16 @@ public abstract class DistanceManager {
+@@ -468,20 +474,16 @@ public abstract class DistanceManager {
      }
  
      protected void updatePlayerTickets(int viewDistance) {
@@ -1768,7 +1768,7 @@ index 7c66e4ed02c80521196b4ca797477dd9573752d8..fd379155a67794288f7cdae3250767bc
      }
      // Paper end
  
-@@ -536,10 +538,7 @@ public abstract class DistanceManager {
+@@ -538,10 +540,7 @@ public abstract class DistanceManager {
  
      }
  
@@ -1780,7 +1780,7 @@ index 7c66e4ed02c80521196b4ca797477dd9573752d8..fd379155a67794288f7cdae3250767bc
  
      // CraftBukkit start
      public <T> void removeAllTicketsFor(TicketType<T> ticketType, int ticketLevel, T ticketIdentifier) {
-@@ -606,6 +605,7 @@ public abstract class DistanceManager {
+@@ -608,6 +607,7 @@ public abstract class DistanceManager {
          }
      }
  
@@ -1788,7 +1788,7 @@ index 7c66e4ed02c80521196b4ca797477dd9573752d8..fd379155a67794288f7cdae3250767bc
      private class FixedPlayerDistanceChunkTracker extends ChunkTracker {
  
          protected final Long2ByteMap chunks = new Long2ByteOpenHashMap();
-@@ -779,4 +779,5 @@ public abstract class DistanceManager {
+@@ -781,4 +781,5 @@ public abstract class DistanceManager {
              return distance <= this.viewDistance - 2;
          }
      }
@@ -2079,7 +2079,7 @@ index 55c0e9655ded14e25b0f284ad0c1f99eb5d0b192..b47c4c9e9b82030cd82d72fe90d7c8bf
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 23bd74836e8396720747540829c7b8e27cfb00bd..2c3ce2065812de227c34506edddb439da9a07ba1 100644
+index 2e4dd6c06e8d4e54d1a9edc1b312adefc47feb77..763025b63c44fbcbd1660a1144d4f4afac82aa90 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -2215,37 +2215,55 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0870-Replace-ticket-level-propagator.patch
+++ b/patches/server/0870-Replace-ticket-level-propagator.patch
@@ -15,7 +15,7 @@ will be more effective, since more time will be allocated
 to actually processing chunk tasks vs the ticket level updates.
 
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index fd379155a67794288f7cdae3250767bc3615d421..d278e5b8b3386044e0fbc13add369794fd6f9cd7 100644
+index 7da090f14d8af22c3b2adb1c0aa97c0e7bc5b8c2..241fe3ed220bb3c195fc2e66ac2b81185a6806bf 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
 @@ -37,6 +37,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
@@ -238,7 +238,7 @@ index fd379155a67794288f7cdae3250767bc3615d421..d278e5b8b3386044e0fbc13add369794
          }
          // Paper end
          return removed; // CraftBukkit
-@@ -549,7 +623,7 @@ public abstract class DistanceManager {
+@@ -551,7 +625,7 @@ public abstract class DistanceManager {
              SortedArraySet<Ticket<?>> tickets = entry.getValue();
              if (tickets.remove(target)) {
                  // copied from removeTicket


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
0edc0e04 SPIGOT-6944: Correct TabCompleter docs

CraftBukkit Changes:
62d97624 SPIGOT-6900, SPIGOT-6330: Make /difficulty command per-world
d83e9d08 SPIGOT-6925: Add minecraft:match_tool in LootContext
38f204d8 SPIGOT-6936: Cancelling EntityAirChangeEvent doesn't stop player's bubbles from decreasing client side
3aabea17 SPIGOT-6937: Ramming goat does not throw EntityTargetLivingEntityEvent
af4d848f SPIGOT-6934: Bring plugin chunk tickets back in line with forceload tickets