### PR TITLE
Fix cancelling ProjectileHitEvent for piercing arrows

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -318,3 +318,6 @@ public-f net.minecraft.world.inventory.AbstractContainerMenu remoteDataSlots
 
 # Fix falling block spawn methods
 public net.minecraft.world.entity.item.FallingBlockEntity <init>(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/level/block/state/BlockState;)V
+
+# Fix cancelling ProjectileHitEvent for piercing arrows
+protected net.minecraft.world.entity.projectile.Projectile hitCancelled

--- a/patches/server/0881-Fix-cancelling-ProjectileHitEvent-for-piercing-arrow.patch
+++ b/patches/server/0881-Fix-cancelling-ProjectileHitEvent-for-piercing-arrow.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 19 Feb 2022 19:05:59 -0800
+Subject: [PATCH] Fix cancelling ProjectileHitEvent for piercing arrows
+
+Piercing arrows search for multiple entities inside a while
+loop that is checking the projectile entity's removed state.
+If the hit event is cancelled on the first entity, the event will
+be called over and over again inside that while loop until the event
+is not cancelled. The solution here, is to make use of an
+already-existing field on AbstractArrow for tracking entities hit by
+piercing arrows to avoid duplicate damage being applied.
+
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
+index 3d3dcb47720055f550d17d1f106a2c0e59de2919..53d0024daf6963ac4dab575666b0d6a74a39a958 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
+@@ -299,6 +299,19 @@ public abstract class AbstractArrow extends Projectile {
+         }
+     }
+ 
++    // Paper start
++    @Override
++    protected void preOnHit(HitResult hitResult) {
++        super.preOnHit(hitResult);
++        if (hitResult instanceof EntityHitResult entityHitResult && this.hitCancelled && this.getPierceLevel() > 0) {
++            if (this.piercingIgnoreEntityIds == null) {
++                this.piercingIgnoreEntityIds = new IntOpenHashSet(5);
++            }
++            this.piercingIgnoreEntityIds.add(entityHitResult.getEntity().getId());
++        }
++    }
++    // Paper end
++
+     private boolean shouldFall() {
+         return this.inGround && this.level.noCollision((new AABB(this.position(), this.position())).inflate(0.06D));
+     }


### PR DESCRIPTION
Piercing arrows search for multiple entities inside a while
loop that is checking the projectile entity's removed state.
If the hit event is cancelled on the first entity, the event will
be called over and over again inside that while loop until the event
is not cancelled. The solution here, is to make use of an
already-existing field on AbstractArrow for tracking entities hit by
piercing arrows to avoid duplicate damage being applied.

Fixes https://github.com/PaperMC/Paper/issues/7474