### PR TITLE
Add some missing deprecations to the adventure patch

### DIFF
--- a/patches/api/0008-Adventure.patch
+++ b/patches/api/0008-Adventure.patch
@@ -732,7 +732,7 @@ index 32c92621c2c15eec14c50965f5ecda00c46e6c80..e076d447da62445764a9776ee2554c07
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Nameable.java b/src/main/java/org/bukkit/Nameable.java
-index fee814e01a653d2b53c56e8b566383ca44aa5346..2acdf2a6d3955923c721222b9da784f3278f6418 100644
+index fee814e01a653d2b53c56e8b566383ca44aa5346..b71b780792b672b37c8fe65d43489b860a227381 100644
 --- a/src/main/java/org/bukkit/Nameable.java
 +++ b/src/main/java/org/bukkit/Nameable.java
 @@ -4,6 +4,30 @@ import org.jetbrains.annotations.Nullable;
@@ -766,6 +766,27 @@ index fee814e01a653d2b53c56e8b566383ca44aa5346..2acdf2a6d3955923c721222b9da784f3
      /**
       * Gets the custom name on a mob or block. If there is no name this method
       * will return null.
+@@ -11,8 +35,10 @@ public interface Nameable {
+      * This value has no effect on players, they will always use their real
+      * name.
+      *
++     * @deprecated in favour of {@link #customName()}
+      * @return name of the mob/block or null
+      */
++    @Deprecated // Paper
+     @Nullable
+     public String getCustomName();
+ 
+@@ -25,7 +51,9 @@ public interface Nameable {
+      * This value has no effect on players, they will always use their real
+      * name.
+      *
++     * @deprecated in favour of {@link #customName(net.kyori.adventure.text.Component)}
+      * @param name the name to set
+      */
++    @Deprecated // Paper
+     public void setCustomName(@Nullable String name);
+ }
 diff --git a/src/main/java/org/bukkit/NamespacedKey.java b/src/main/java/org/bukkit/NamespacedKey.java
 index 803fa0019869127ee8c7e4fb1777a59c43e66f8a..c65f0d6569c130b4920a9e71ad24af6427f1f030 100644
 --- a/src/main/java/org/bukkit/NamespacedKey.java
@@ -1599,7 +1620,7 @@ index 922d33ff4fa9d901d3c5c0a9f8399ad8aef62c37..cd287978c34873c7122794e4f3e76291
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf9e5705ac 100644
+index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..ac7a076d92bfb1d9c6ce8836d08e11f52befabc3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -35,7 +35,28 @@ import org.jetbrains.annotations.Nullable;
@@ -1893,8 +1914,19 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException;
  
      /**
-@@ -1041,6 +1212,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1026,6 +1197,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      *     pack correctly.
+      * </ul>
+      *
++     * @deprecated in favour of {@link #setResourcePack(String, byte[], Component)}
+      * @param url The URL from which the client will download the resource
+      *     pack. The string must contain only US-ASCII characters and should
+      *     be encoded as per RFC 1738.
+@@ -1039,8 +1211,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
+      *     long.
       */
++    @Deprecated // Paper
      public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt);
  
 +    // Paper start
@@ -1948,11 +1980,22 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
      /**
       * Request that the player's client download and switch resource packs.
       * <p>
-@@ -1132,6 +1351,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1115,6 +1336,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      *     pack correctly.
+      * </ul>
+      *
++     * @deprecated in favour of {@link #setResourcePack(String, byte[], Component, boolean)}
+      * @param url The URL from which the client will download the resource
+      *     pack. The string must contain only US-ASCII characters and should
+      *     be encoded as per RFC 1738.
+@@ -1130,8 +1352,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
+      *     long.
       */
++    @Deprecated // Paper
      public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt, boolean force);
  
-+    // Paper end
++    // Paper start
 +    /**
 +     * Request that the player's client download and switch resource packs.
 +     * <p>
@@ -2003,7 +2046,7 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
      /**
       * Gets the Scoreboard displayed to this player
       *
-@@ -1225,7 +1492,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1225,7 +1496,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param title Title text
       * @param subtitle Subtitle text
@@ -2012,7 +2055,7 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
       */
      @Deprecated
      public void sendTitle(@Nullable String title, @Nullable String subtitle);
-@@ -1244,7 +1511,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1244,7 +1515,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param fadeIn time in ticks for titles to fade in. Defaults to 10.
       * @param stay time in ticks for titles to stay. Defaults to 70.
       * @param fadeOut time in ticks for titles to fade out. Defaults to 20.
@@ -2022,7 +2065,7 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
      public void sendTitle(@Nullable String title, @Nullable String subtitle, int fadeIn, int stay, int fadeOut);
  
      /**
-@@ -1471,6 +1740,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1471,6 +1744,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -2037,7 +2080,7 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1496,8 +1773,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1496,8 +1777,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -2048,7 +2091,7 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
      public String getLocale();
  
      /**
-@@ -1539,6 +1818,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1539,6 +1822,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public boolean isAllowingServerListings();
  
@@ -2063,7 +2106,7 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1593,11 +1880,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1593,11 +1884,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -2077,7 +2120,7 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1608,7 +1897,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1608,7 +1901,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -2087,7 +2130,7 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1618,7 +1909,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1618,7 +1913,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -2097,7 +2140,7 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1629,7 +1922,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1629,7 +1926,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -2107,7 +2150,7 @@ index 7b256be5b82e34a4591d0cc46a2d49aa1269e844..23a5a2f6dc4f734606a9a6cb6c6f95bf
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1640,7 +1935,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1640,7 +1939,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send
@@ -3370,23 +3413,10 @@ index f70a6a22b85ff0da76e67e9b223ad4e0b020b5c4..a15abec467bac70116a6fc21a300d493
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/meta/BookMeta.java b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
-index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c10d87ba4 100644
+index 94852d50e88d0594b84b581cd627174043629995..36bcbb3f3acedf7ebecbf6f6b358cf64af0edfb2 100644
 --- a/src/main/java/org/bukkit/inventory/meta/BookMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
-@@ -1,8 +1,12 @@
- package org.bukkit.inventory.meta;
- 
- import java.util.List;
-+
-+import net.kyori.adventure.inventory.Book;
- import net.md_5.bungee.api.chat.BaseComponent;
- import org.bukkit.Material;
-+import org.checkerframework.checker.nullness.qual.NonNull;
-+import org.checkerframework.common.returnsreceiver.qual.This;
- import org.jetbrains.annotations.NotNull;
- import org.jetbrains.annotations.Nullable;
- 
-@@ -10,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
   * Represents a book ({@link Material#WRITABLE_BOOK} or {@link
   * Material#WRITTEN_BOOK}) that can have a title, an author, and pages.
   */
@@ -3395,7 +3425,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
  
      /**
       * Represents the generation (or level of copying) of a written book
-@@ -119,6 +123,117 @@ public interface BookMeta extends ItemMeta {
+@@ -119,6 +119,118 @@ public interface BookMeta extends ItemMeta {
       */
      boolean hasPages();
  
@@ -3422,7 +3452,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
 +     */
 +    @NotNull
 +    @Override
-+    @This BookMeta title(@Nullable net.kyori.adventure.text.Component title);
++    @org.checkerframework.common.returnsreceiver.qual.This BookMeta title(@Nullable net.kyori.adventure.text.Component title);
 +
 +    /**
 +     * Gets the author of the book.
@@ -3444,7 +3474,8 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
 +     */
 +    @NotNull
 +    @Override
-+    @This BookMeta author(@Nullable net.kyori.adventure.text.Component author);
++    @org.checkerframework.common.returnsreceiver.qual.This BookMeta author(@Nullable net.kyori.adventure.text.Component author);
++
 +    /**
 +     * Gets the specified page in the book. The page must exist.
 +     * <p>
@@ -3505,7 +3536,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
 +    }
 +
 +    @Override
-+    @NonNull
++    @org.checkerframework.checker.nullness.qual.NonNull
 +    BookMetaBuilder toBuilder();
 +
 +    // Paper end
@@ -3513,7 +3544,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
      /**
       * Gets the specified page in the book. The given page must exist.
       * <p>
-@@ -126,8 +241,10 @@ public interface BookMeta extends ItemMeta {
+@@ -126,8 +238,10 @@ public interface BookMeta extends ItemMeta {
       *
       * @param page the page number to get, in range [1, getPageCount()]
       * @return the page from the book
@@ -3524,7 +3555,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
      String getPage(int page);
  
      /**
-@@ -141,15 +258,19 @@ public interface BookMeta extends ItemMeta {
+@@ -141,15 +255,19 @@ public interface BookMeta extends ItemMeta {
       *
       * @param page the page number to set, in range [1, getPageCount()]
       * @param data the data to set for that page
@@ -3544,7 +3575,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
      List<String> getPages();
  
      /**
-@@ -157,7 +278,9 @@ public interface BookMeta extends ItemMeta {
+@@ -157,7 +275,9 @@ public interface BookMeta extends ItemMeta {
       * pages. Maximum 100 pages with 256 characters per page.
       *
       * @param pages A list of pages to set the book to use
@@ -3554,7 +3585,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
      void setPages(@NotNull List<String> pages);
  
      /**
-@@ -165,7 +288,9 @@ public interface BookMeta extends ItemMeta {
+@@ -165,7 +285,9 @@ public interface BookMeta extends ItemMeta {
       * pages. Maximum 50 pages with 256 characters per page.
       *
       * @param pages A list of strings, each being a page
@@ -3564,7 +3595,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
      void setPages(@NotNull String... pages);
  
      /**
-@@ -173,7 +298,9 @@ public interface BookMeta extends ItemMeta {
+@@ -173,7 +295,9 @@ public interface BookMeta extends ItemMeta {
       * 256 characters per page.
       *
       * @param pages A list of strings, each being a page
@@ -3574,7 +3605,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
      void addPage(@NotNull String... pages);
  
      /**
-@@ -195,8 +322,10 @@ public interface BookMeta extends ItemMeta {
+@@ -195,8 +319,10 @@ public interface BookMeta extends ItemMeta {
           *
           * @param page the page number to get
           * @return the page from the book
@@ -3585,7 +3616,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
          public BaseComponent[] getPage(int page) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -210,7 +339,9 @@ public interface BookMeta extends ItemMeta {
+@@ -210,7 +336,9 @@ public interface BookMeta extends ItemMeta {
           *
           * @param page the page number to set
           * @param data the data to set for that page
@@ -3595,7 +3626,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
          public void setPage(int page, @Nullable BaseComponent... data) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -219,8 +350,10 @@ public interface BookMeta extends ItemMeta {
+@@ -219,8 +347,10 @@ public interface BookMeta extends ItemMeta {
           * Gets all the pages in the book.
           *
           * @return list of all the pages in the book
@@ -3606,7 +3637,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
          public List<BaseComponent[]> getPages() {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -230,7 +363,9 @@ public interface BookMeta extends ItemMeta {
+@@ -230,7 +360,9 @@ public interface BookMeta extends ItemMeta {
           * pages. Maximum 50 pages with 256 characters per page.
           *
           * @param pages A list of pages to set the book to use
@@ -3616,7 +3647,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
          public void setPages(@NotNull List<BaseComponent[]> pages) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -240,7 +375,9 @@ public interface BookMeta extends ItemMeta {
+@@ -240,7 +372,9 @@ public interface BookMeta extends ItemMeta {
           * pages. Maximum 50 pages with 256 characters per page.
           *
           * @param pages A list of component arrays, each being a page
@@ -3626,7 +3657,7 @@ index 94852d50e88d0594b84b581cd627174043629995..4947251f347d83fa326a67735293401c
          public void setPages(@NotNull BaseComponent[]... pages) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -250,7 +387,9 @@ public interface BookMeta extends ItemMeta {
+@@ -250,7 +384,9 @@ public interface BookMeta extends ItemMeta {
           * with 256 characters per page.
           *
           * @param pages A list of component arrays, each being a page

--- a/patches/api/0009-Player-affects-spawning-API.patch
+++ b/patches/api/0009-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 23a5a2f6dc4f734606a9a6cb6c6f95bf9e5705ac..43d91f578b0aefd18f7f5ecd120a366af4ee98e6 100644
+index ac7a076d92bfb1d9c6ce8836d08e11f52befabc3..fb071f098989c797e9766f2e6f9cf87a57265d31 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1779,6 +1779,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1783,6 +1783,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0014-Add-view-distance-API.patch
+++ b/patches/api/0014-Add-view-distance-API.patch
@@ -75,10 +75,10 @@ index cf6fe1b5a1531e8d30c0386e36c023d003458b7e..ad342ecd8b86903276c62644624cff55
      public class Spigot {
  
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 43d91f578b0aefd18f7f5ecd120a366af4ee98e6..9f861fcc350b803e63b08631f7a6c30d13b4cb7c 100644
+index fb071f098989c797e9766f2e6f9cf87a57265d31..135a928dd24cebf8741e2961db1b7ca710d41b64 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1793,6 +1793,78 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1797,6 +1797,78 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0025-Complete-resource-pack-API.patch
+++ b/patches/api/0025-Complete-resource-pack-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 29bd571bd270b9c6ed05d95122d42d9bc0c797f6..fd8a40bacaaa39c20428bbebe8611ba8cdd33e0b 100644
+index 983070a0d83808cf710aa407a1912e94b52fbe5c..fd288cc72e048c6277d78c6fb1cc9b6284f67ee9 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1284,7 +1284,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -18,7 +18,7 @@ index 29bd571bd270b9c6ed05d95122d42d9bc0c797f6..fd8a40bacaaa39c20428bbebe8611ba8
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -2074,6 +2076,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2078,6 +2080,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0045-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0045-Add-String-based-Action-Bar-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index fd8a40bacaaa39c20428bbebe8611ba8cdd33e0b..d6a2e66e07590013bf1596012a96ec1018493e06 100644
+index fd288cc72e048c6277d78c6fb1cc9b6284f67ee9..2a4cbda6cf881b850c293e54c142c3fe7a5165bd 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -3,6 +3,7 @@ package org.bukkit.entity;
@@ -68,7 +68,7 @@ index fd8a40bacaaa39c20428bbebe8611ba8cdd33e0b..d6a2e66e07590013bf1596012a96ec10
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }
-@@ -2265,6 +2301,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2269,6 +2305,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends the component to the specified screen position of this player
           *
@@ -76,7 +76,7 @@ index fd8a40bacaaa39c20428bbebe8611ba8cdd33e0b..d6a2e66e07590013bf1596012a96ec10
           * @param position the screen position
           * @param component the components to send
           * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
-@@ -2277,6 +2314,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2281,6 +2318,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends an array of components as a single message to the specified screen position of this player
           *

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -62,10 +62,10 @@ index 51c96a0b6645cf31f4ca051f6a8c75b5f188484c..80d474a979add473c99692ccde93439d
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c16716e77427d0968c004a5b30600a40a36d5137..888a60fe60e6242680c153fd8edd95f6e37e26d5 100644
+index a22519fdf3bad46ac5d96546a755f453e7503506..30813ac7fbfbefe221bec334cf257862da5b4e1c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2251,6 +2251,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2255,6 +2255,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
@@ -24,10 +24,10 @@ index 8a479c7dfd3825fab8bb057d8afa5ae0cb01b071..6ef0d7f3dcb779fb7dc5786e74332620
      /**
       * Make the entity drop the item in their hand.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 888a60fe60e6242680c153fd8edd95f6e37e26d5..87f62e65dbf8128d684abaf4fde88cfa566f7a1f 100644
+index 30813ac7fbfbefe221bec334cf257862da5b4e1c..49c1cbef4f1b7e9e52a3a0c262c773caf79323ba 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2106,7 +2106,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2110,7 +2110,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Open a Sign for editing by the Player.
       *

--- a/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 81b3d2da2bb92c874845688a8b8a2b15b2a4bd59..ffbc26048e359044be6b0c96f3bd8cd1048fb316 100644
+index 6119f8c5b1c14418e14eec3a7ec56beed8ed8df5..b1c1e4644154567beb5fdcac4540229fab0b4763 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2421,6 +2421,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2425,6 +2425,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull com.destroystokyo.paper.profile.PlayerProfile profile);

--- a/patches/api/0194-Add-Player-Client-Options-API.patch
+++ b/patches/api/0194-Add-Player-Client-Options-API.patch
@@ -193,7 +193,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ffbc26048e359044be6b0c96f3bd8cd1048fb316..db12ce34a7fa4f309e7cc52c953bb409e9b6ab0c 100644
+index b1c1e4644154567beb5fdcac4540229fab0b4763..6176fde69072ca37df803109acfcc145528f583a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -204,7 +204,7 @@ index ffbc26048e359044be6b0c96f3bd8cd1048fb316..db12ce34a7fa4f309e7cc52c953bb409
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import org.bukkit.DyeColor;
-@@ -2441,6 +2442,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2445,6 +2446,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0218-Brand-support.patch
+++ b/patches/api/0218-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index db12ce34a7fa4f309e7cc52c953bb409e9b6ab0c..6983b3d6d5402ea1ed3646bffdd4d8bc613a6121 100644
+index 6176fde69072ca37df803109acfcc145528f583a..201ac1cba11037e4baec5d059ac72077a70fe67f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2576,6 +2576,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2580,6 +2580,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0227-Player-elytra-boost-API.patch
+++ b/patches/api/0227-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6983b3d6d5402ea1ed3646bffdd4d8bc613a6121..167ea1fe8d5d16098559745a67e5128e4ef78082 100644
+index 201ac1cba11037e4baec5d059ac72077a70fe67f..6fbc96e3641dd3ca127efe3dbd573e56ba0ffe54 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2448,6 +2448,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2452,6 +2452,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull ClientOption<T> option);

--- a/patches/api/0255-Add-sendOpLevel-API.patch
+++ b/patches/api/0255-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 167ea1fe8d5d16098559745a67e5128e4ef78082..6efcd4c5b89af422c630a566e8a851062e05b69a 100644
+index 6fbc96e3641dd3ca127efe3dbd573e56ba0ffe54..d881ae7fb0c17242998c0a495ccd81802611410a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2461,6 +2461,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2465,6 +2465,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0342-Add-player-health-update-API.patch
+++ b/patches/api/0342-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c7d02e196d57f41c35d37e9a16d8e079a5c176ae..5a1b733934bfe4388dad59125caa9c2d45df5dd1 100644
+index 35be51b2b57acfc5dc165b22e16f499fac906e34..3a96d1fe95952a1b0be0ef7b3cdf431e5bb8b54f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1849,6 +1849,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1853,6 +1853,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public double getHealthScale();
  


### PR DESCRIPTION
^
Scrolled through the entire patch, these seem to be the only methods that also have a string variant without a deprecation notice.

Also cleans up some imports and fixes a paper comment.