### PR TITLE
Fix setting the view distance to 32 with the API

### DIFF
--- a/patches/server/0865-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0865-Replace-player-chunk-loader-system.patch
@@ -1381,7 +1381,7 @@ index 36b6e7295cf7484675c8c2b9624c1f6fea7aed1d..38db3905f47fefb5c958fa24aef2313e
  
      public CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> getOrScheduleFuture(ChunkStatus targetStatus, ChunkMap chunkStorage) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index a29b97f941eadb1ede5db805d32f2917469cccb9..edc6235288f0843608dae4552e05915e4067cbf2 100644
+index a29b97f941eadb1ede5db805d32f2917469cccb9..eb469eabf7a5888a4249a6267de0c993e65b2ad0 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -217,6 +217,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1467,7 +1467,7 @@ index a29b97f941eadb1ede5db805d32f2917469cccb9..edc6235288f0843608dae4552e05915e
 -                    this.updateChunkTracking(entityplayer, chunkcoordintpair, mutableobject, flag, flag1);
 -                });
 -            }
-+            this.playerChunkManager.setLoadDistance(Mth.clamp(this.viewDistance, 2, 32)); // Paper - replace player loader system
++            this.playerChunkManager.setLoadDistance(this.viewDistance); // Paper - replace player loader system
          }
  
      }


### PR DESCRIPTION
Currently, setting the view distance to 32 with `World#SetViewDistance` actually sets the view distance to 31. This is because the view distance has 1 added to it, is clamped between 3 and 33, and then is clamped again between 2 and 32. This PR removes the second clamp - which I don't think should be there?