### PR TITLE
Fix issues with CreeperIgniteEvent

### DIFF
--- a/patches/api/0142-Add-More-Creeper-API.patch
+++ b/patches/api/0142-Add-More-Creeper-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add More Creeper API
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/CreeperIgniteEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/CreeperIgniteEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ff10251b6ded533b08048ec533525176eff03707
+index 0000000000000000000000000000000000000000..e9768c919a1860881802ab68eff559874590ac1c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/CreeperIgniteEvent.java
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,56 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Creeper;
@@ -19,7 +19,9 @@ index 0000000000000000000000000000000000000000..ff10251b6ded533b08048ec533525176
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Called when a Creeper is ignite flag is changed (armed/disarmed to explode).
++ * Called when a Creeper is ignited either by a
++ * flint and steel, {@link Creeper#ignite()} or
++ * {@link Creeper#setIgnited(boolean)}.
 + */
 +public class CreeperIgniteEvent extends EntityEvent implements Cancellable {
 +    private static final HandlerList handlers = new HandlerList();

--- a/patches/server/0249-Add-More-Creeper-API.patch
+++ b/patches/server/0249-Add-More-Creeper-API.patch
@@ -8,6 +8,15 @@ diff --git a/src/main/java/net/minecraft/world/entity/monster/Creeper.java b/src
 index bc493838420a6857ebc86f84cabdc1b6e3e637a4..8c328d72c42ccaa6891249cc700b70bb34c09545 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Creeper.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
+@@ -133,7 +133,7 @@ public class Creeper extends Monster implements PowerableMob {
+         }
+ 
+         if (nbt.getBoolean("ignited")) {
+-            this.ignite();
++            this.entityData.set(Creeper.DATA_IS_IGNITED, true); // Paper - set directly to avoid firing event
+         }
+ 
+     }
 @@ -309,7 +309,18 @@ public class Creeper extends Monster implements PowerableMob {
      }
  


### PR DESCRIPTION
Clarified documentation for when the event is fired, and
prevented the event from firing when a Creeper is loaded.

Fixes https://github.com/PaperMC/Paper/issues/7461