### PR TITLE
Deprecate duplicate SoundGroup API

### DIFF
--- a/patches/api/0180-Add-BlockSoundGroup-interface.patch
+++ b/patches/api/0180-Add-BlockSoundGroup-interface.patch
@@ -7,10 +7,10 @@ This PR adds the getSoundGroup() method in Block which returns a BlockSoundGroup
 
 diff --git a/src/main/java/com/destroystokyo/paper/block/BlockSoundGroup.java b/src/main/java/com/destroystokyo/paper/block/BlockSoundGroup.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8cf87d228a7006658d52ce0da16c2d74f4706545
+index 0000000000000000000000000000000000000000..ec36942128cbacae171584c89480b4aae3ae3e2f
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/block/BlockSoundGroup.java
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,64 @@
 +package com.destroystokyo.paper.block;
 +
 +import org.bukkit.Sound;
@@ -21,53 +21,65 @@ index 0000000000000000000000000000000000000000..8cf87d228a7006658d52ce0da16c2d74
 + * Represents the sounds that a {@link Block} makes in certain situations
 + * <p>
 + * The sound group includes break, step, place, hit, and fall sounds.
++ * @deprecated use {@link org.bukkit.SoundGroup}
 + */
++@Deprecated(forRemoval = true)
 +public interface BlockSoundGroup {
 +    /**
 +     * Gets the sound that plays when breaking this block
 +     *
 +     * @return The break sound
++     * @deprecated use {@link org.bukkit.SoundGroup#getBreakSound()}
 +     */
 +    @NotNull
++    @Deprecated(forRemoval = true)
 +    Sound getBreakSound();
 +
 +    /**
 +     * Gets the sound that plays when stepping on this block
 +     *
 +     * @return The step sound
++     * @deprecated use {@link org.bukkit.SoundGroup#getStepSound()}
 +     */
 +    @NotNull
++    @Deprecated(forRemoval = true)
 +    Sound getStepSound();
 +
 +    /**
 +     * Gets the sound that plays when placing this block
 +     *
 +     * @return The place sound
++     * @deprecated use {@link org.bukkit.SoundGroup#getPlaceSound()}
 +     */
 +    @NotNull
++    @Deprecated(forRemoval = true)
 +    Sound getPlaceSound();
 +
 +    /**
 +     * Gets the sound that plays when hitting this block
 +     *
 +     * @return The hit sound
++     * @deprecated use {@link org.bukkit.SoundGroup#getHitSound()}
 +     */
 +    @NotNull
++    @Deprecated(forRemoval = true)
 +    Sound getHitSound();
 +
 +    /**
 +     * Gets the sound that plays when this block falls
 +     *
 +     * @return The fall sound
++     * @deprecated use {@link org.bukkit.SoundGroup#getFallSound()}
 +     */
 +    @NotNull
++    @Deprecated(forRemoval = true)
 +    Sound getFallSound();
 +}
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index b101f5264bdde8bd14913d5161c1047020830f8d..7ea765d5d653b1b84e73fd8c4d9d923049bd06ff 100644
+index b101f5264bdde8bd14913d5161c1047020830f8d..db441e463b02ee734f85c855f5538cd41041dbae 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -606,4 +606,16 @@ public interface Block extends Metadatable {
+@@ -606,4 +606,25 @@ public interface Block extends Metadatable {
       * @return <code>true</code> if the block data can be placed here
       */
      boolean canPlace(@NotNull BlockData data);
@@ -79,8 +91,17 @@ index b101f5264bdde8bd14913d5161c1047020830f8d..7ea765d5d653b1b84e73fd8c4d9d9230
 +     * This object contains the block, step, place, hit, and fall sounds.
 +     *
 +     * @return the sound group for this block
++     * @deprecated use {@link #getBlockSoundGroup()}
 +     */
 +    @NotNull
++    @Deprecated(forRemoval = true)
 +    com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup();
++
++    /**
++     * Gets the {@link org.bukkit.SoundGroup} for this block.
++     *
++     * @return the sound group for this block
++     */
++    @NotNull org.bukkit.SoundGroup getBlockSoundGroup();
 +    // Paper end
  }

--- a/patches/api/0220-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0220-Add-methods-to-get-translation-keys.patch
@@ -212,7 +212,7 @@ index 13eac9ad2c1672051635d1c35cc49239252e7a61..107e36ef02a9481954bd770ce9a55a0b
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index c88c4223928c2e47f1a85b73165cf433806677df..7124f7134a0afb355c01cac9e0187164f9630bcd 100644
+index 1e7ee68e56f8d4399c2cbf26aa45bf8b599b3b02..2c837ea822f3b0c4ec312f0c956fe1b778cbd5e9 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
@@ -224,10 +224,10 @@ index c88c4223928c2e47f1a85b73165cf433806677df..7124f7134a0afb355c01cac9e0187164
  
      /**
       * Gets the metadata for this block
-@@ -637,5 +637,15 @@ public interface Block extends Metadatable {
+@@ -646,5 +646,15 @@ public interface Block extends Metadatable {
+      * @return the sound group for this block
       */
-     @NotNull
-     com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup();
+     @NotNull org.bukkit.SoundGroup getBlockSoundGroup();
 +
 +    /**
 +     * Return the translation key for the Block, so the client can translate it into the active

--- a/patches/api/0233-Add-Destroy-Speed-API.patch
+++ b/patches/api/0233-Add-Destroy-Speed-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 7124f7134a0afb355c01cac9e0187164f9630bcd..839867cd0a92fc0ea2b9ea009b67a841f8c7edd6 100644
+index 3f1c58e813afe90eaf467e0b76949ed8df752939..68a91de4ab068fd32dc883a9427475c07218941e 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -647,5 +647,29 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
+@@ -656,5 +656,29 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
      @NotNull
      @Deprecated
      String getTranslationKey();

--- a/patches/server/0321-Implement-CraftBlockSoundGroup.patch
+++ b/patches/server/0321-Implement-CraftBlockSoundGroup.patch
@@ -6,16 +6,17 @@ Subject: [PATCH] Implement CraftBlockSoundGroup
 
 diff --git a/src/main/java/com/destroystokyo/paper/block/CraftBlockSoundGroup.java b/src/main/java/com/destroystokyo/paper/block/CraftBlockSoundGroup.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9a516520d975f52169e346adc4ec6d9db843db2f
+index 0000000000000000000000000000000000000000..c5b07ec346105d1b95c1c938ffca12a21642040c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/block/CraftBlockSoundGroup.java
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,39 @@
 +package com.destroystokyo.paper.block;
 +
 +import net.minecraft.world.level.block.SoundType;
 +import org.bukkit.Sound;
 +import org.bukkit.craftbukkit.CraftSound;
 +
++@Deprecated(forRemoval = true)
 +public class CraftBlockSoundGroup implements BlockSoundGroup {
 +    private final SoundType soundEffectType;
 +
@@ -49,10 +50,10 @@ index 0000000000000000000000000000000000000000..9a516520d975f52169e346adc4ec6d9d
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index ba8f9ffed49bf377be8b37532d4f2bdcb8c44d82..250185af0abcfea380cc00e670c0076f7fe87446 100644
+index ba8f9ffed49bf377be8b37532d4f2bdcb8c44d82..4ae3c0b2c240f01a1fcea0b02616e91e057a297a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -644,4 +644,11 @@ public class CraftBlock implements Block {
+@@ -644,4 +644,16 @@ public class CraftBlock implements Block {
  
          return iblockdata.canSurvive(world, this.position);
      }
@@ -61,6 +62,11 @@ index ba8f9ffed49bf377be8b37532d4f2bdcb8c44d82..250185af0abcfea380cc00e670c0076f
 +    @Override
 +    public com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup() {
 +        return new com.destroystokyo.paper.block.CraftBlockSoundGroup(getNMS().getBlock().defaultBlockState().getSoundType());
++    }
++
++    @Override
++    public org.bukkit.SoundGroup getBlockSoundGroup() {
++        return org.bukkit.craftbukkit.CraftSoundGroup.getSoundGroup(this.getNMS().getSoundType());
 +    }
 +    // Paper end
  }

--- a/patches/server/0495-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0495-Add-methods-to-get-translation-keys.patch
@@ -6,12 +6,12 @@ Subject: [PATCH] Add methods to get translation keys
 Co-authored-by: MeFisto94 <MeFisto94@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 945553bfe218a16ebe4abbb11e0723b6d8fc4910..e116ccfa4878636073cc4cdcf680683cda88d314 100644
+index ea3358905dcd39a1a855d98570457c65dcd7513d..396fb96abed1e77893d8ee8a15cff18cad804475 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -663,5 +663,15 @@ public class CraftBlock implements Block {
-     public com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup() {
-         return new com.destroystokyo.paper.block.CraftBlockSoundGroup(getNMS().getBlock().defaultBlockState().getSoundType());
+@@ -668,5 +668,15 @@ public class CraftBlock implements Block {
+     public org.bukkit.SoundGroup getBlockSoundGroup() {
+         return org.bukkit.craftbukkit.CraftSoundGroup.getSoundGroup(this.getNMS().getSoundType());
      }
 +
 +    @Override

--- a/patches/server/0530-Add-Destroy-Speed-API.patch
+++ b/patches/server/0530-Add-Destroy-Speed-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 4bbaf22f449af42eba1307604e3860ea8b60a38c..25794fca0c10b262a696ecec9c736a991e8f357d 100644
+index 2c1efaecf220588d8b74946194bf340871e57004..653dcec33f83ab490af424faa6ede7df07d41742 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -673,5 +673,26 @@ public class CraftBlock implements Block {
+@@ -678,5 +678,26 @@ public class CraftBlock implements Block {
      public String translationKey() {
          return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
      }

--- a/patches/server/0606-Add-Block-isValidTool.patch
+++ b/patches/server/0606-Add-Block-isValidTool.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/ma
 index 3430bf2c05f9dc47a7483327bee4c04e4d87349e..56fd99224edf9041104a540fd14ba3468af4805e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -713,5 +713,9 @@ public class CraftBlock implements Block {
+@@ -718,5 +718,9 @@ public class CraftBlock implements Block {
          }
          return speed;
      }


### PR DESCRIPTION
Upstream added API for SoundGroups and our existing API wasn't
properly replaced by it.