### PR TITLE
Clarify exception messages for invalid view distances

### DIFF
--- a/patches/server/0865-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0865-Replace-player-chunk-loader-system.patch
@@ -123,7 +123,7 @@ index 66501c3b0eb92d946ef77bbd3f36ebcc0d3023af..153f07bac06093b43a1f5b0f8e1a46ff
  }
 diff --git a/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java b/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9ad84dc6f0463dbbbdd53723edcc2a3ebc63de24
+index 0000000000000000000000000000000000000000..bdd4cc040111d18b82d3ebeb5dbe2537cf148090
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java
 @@ -0,0 +1,1108 @@
@@ -326,7 +326,7 @@ index 0000000000000000000000000000000000000000..9ad84dc6f0463dbbbdd53723edcc2a3e
 +
 +    public void setSendDistance(final int distance) {
 +        if (distance != -1 && (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE + 1)) {
-+            throw new IllegalArgumentException(Integer.toString(distance));
++            throw new IllegalArgumentException("Send distance must be a number between " + MIN_VIEW_DISTANCE + " and " + (MAX_VIEW_DISTANCE + 1) + ", or -1, got: " + distance);
 +        }
 +        this.rawSendDistance = distance;
 +    }
@@ -338,7 +338,7 @@ index 0000000000000000000000000000000000000000..9ad84dc6f0463dbbbdd53723edcc2a3e
 +
 +    public void setLoadDistance(final int distance) {
 +        if (distance != -1 && (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE + 1)) {
-+            throw new IllegalArgumentException(Integer.toString(distance));
++            throw new IllegalArgumentException("Load distance must be a number between " + MIN_VIEW_DISTANCE + " and " + (MAX_VIEW_DISTANCE + 1) + ", or -1, got: " + distance);
 +        }
 +        this.rawLoadDistance = distance;
 +    }
@@ -349,7 +349,7 @@ index 0000000000000000000000000000000000000000..9ad84dc6f0463dbbbdd53723edcc2a3e
 +
 +    public void setTickDistance(final int distance) {
 +        if (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE) {
-+            throw new IllegalArgumentException(Integer.toString(distance));
++            throw new IllegalArgumentException("View distance must be a number between " + MIN_VIEW_DISTANCE + " and " + MAX_VIEW_DISTANCE + ", got: " + distance);
 +        }
 +        this.rawTickDistance = distance;
 +    }
@@ -942,7 +942,7 @@ index 0000000000000000000000000000000000000000..9ad84dc6f0463dbbbdd53723edcc2a3e
 +
 +        public void setTargetSendViewDistance(final int distance) {
 +            if (distance != -1 && (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE + 1)) {
-+                throw new IllegalArgumentException(Integer.toString(distance));
++                throw new IllegalArgumentException("Send view distance must be a number between " + MIN_VIEW_DISTANCE + " and " + (MAX_VIEW_DISTANCE + 1) + " or -1, got: " + distance);
 +            }
 +            this.sendViewDistance = distance;
 +        }
@@ -953,7 +953,7 @@ index 0000000000000000000000000000000000000000..9ad84dc6f0463dbbbdd53723edcc2a3e
 +
 +        public void setTargetNoTickViewDistance(final int distance) {
 +            if (distance != -1 && (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE)) {
-+                throw new IllegalArgumentException(Integer.toString(distance));
++                throw new IllegalArgumentException("Simulation distance must be a number between " + MIN_VIEW_DISTANCE + " and " + MAX_VIEW_DISTANCE + " or -1, got: " + distance);
 +            }
 +            this.loadViewDistance = distance == -1 ? -1 : distance + 1;
 +        }
@@ -964,7 +964,7 @@ index 0000000000000000000000000000000000000000..9ad84dc6f0463dbbbdd53723edcc2a3e
 +
 +        public void setTargetTickViewDistance(final int distance) {
 +            if (distance != -1 && (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE)) {
-+                throw new IllegalArgumentException(Integer.toString(distance));
++                throw new IllegalArgumentException("View distance must be a number between " + MIN_VIEW_DISTANCE + " and " + MAX_VIEW_DISTANCE + " or -1, got: " + distance);
 +            }
 +            this.tickViewDistance = distance;
 +        }


### PR DESCRIPTION
I've seen a few cases in #paper-help where people set their view/simulation distance to a number below two, only to then get an unclear exception message. This should hopefully help in these scenarios.