### PR TITLE
Readd StructureLocateEvent

### DIFF
--- a/patches/api/0256-Add-StructureLocateEvent.patch
+++ b/patches/api/0256-Add-StructureLocateEvent.patch
@@ -6,12 +6,13 @@ Subject: [PATCH] Add StructureLocateEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/world/StructureLocateEvent.java b/src/main/java/io/papermc/paper/event/world/StructureLocateEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..45b6694fc5741831e2df638b1f760a3ca28a4907
+index 0000000000000000000000000000000000000000..05ad8981ef4a15215bdd23b87ec7e8ddfb1b7684
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/world/StructureLocateEvent.java
-@@ -0,0 +1,155 @@
+@@ -0,0 +1,177 @@
 +package io.papermc.paper.event.world;
 +
++import io.papermc.paper.world.structure.ConfiguredStructure;
 +import org.bukkit.Location;
 +import org.bukkit.StructureType;
 +import org.bukkit.World;
@@ -35,15 +36,15 @@ index 0000000000000000000000000000000000000000..45b6694fc5741831e2df638b1f760a3c
 +    private static final HandlerList handlers = new HandlerList();
 +    private final Location origin;
 +    private Location result = null;
-+    private StructureType type;
++    private ConfiguredStructure configuredStructure;
 +    private int radius;
 +    private boolean findUnexplored;
 +    private boolean cancelled = false;
 +
-+    public StructureLocateEvent(@NotNull World world, @NotNull Location origin, @NotNull StructureType structureType, int radius, boolean findUnexplored) {
++    public StructureLocateEvent(@NotNull World world, @NotNull Location origin, @NotNull ConfiguredStructure structure, int radius, boolean findUnexplored) {
 +        super(world);
 +        this.origin = origin;
-+        this.type = structureType;
++        this.configuredStructure = structure;
 +        this.radius = radius;
 +        this.findUnexplored = findUnexplored;
 +    }
@@ -83,22 +84,43 @@ index 0000000000000000000000000000000000000000..45b6694fc5741831e2df638b1f760a3c
 +    }
 +
 +    /**
-+     * Gets the {@link StructureType} that is to be located.
++     * Gets the type of the structure that is to be located.
 +     *
 +     * @return the structure type.
++     * @see ConfiguredStructure#getStructureType()
 +     */
 +    @NotNull
 +    public StructureType getType() {
-+        return type;
++        return this.configuredStructure.getStructureType();
 +    }
 +
 +    /**
 +     * Sets the {@link StructureType} that is to be located.
 +     *
 +     * @param type the structure type.
++     * @deprecated use {@link #setConfiguredStructure(ConfiguredStructure)}
 +     */
++    @Deprecated(forRemoval = true)
 +    public void setType(@NotNull StructureType type) {
-+        this.type = type;
++        throw new UnsupportedOperationException("You must use #setConfiguredStructure as of 1.18.2");
++    }
++
++    /**
++     * Gets the configured structure being located.
++     *
++     * @return the structure
++     */
++    public @NotNull ConfiguredStructure getConfiguredStructure() {
++        return this.configuredStructure;
++    }
++
++    /**
++     * Sets the configured structure being located.
++     *
++     * @param configuredStructure the structure
++     */
++    public void setConfiguredStructure(@NotNull ConfiguredStructure configuredStructure) {
++        this.configuredStructure = configuredStructure;
 +    }
 +
 +    /**
@@ -165,3 +187,129 @@ index 0000000000000000000000000000000000000000..45b6694fc5741831e2df638b1f760a3c
 +        this.cancelled = cancel;
 +    }
 +}
+diff --git a/src/main/java/io/papermc/paper/world/structure/ConfiguredStructure.java b/src/main/java/io/papermc/paper/world/structure/ConfiguredStructure.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..5f808d544dbc7edf45d2e00212f57465560d5318
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/world/structure/ConfiguredStructure.java
+@@ -0,0 +1,91 @@
++package io.papermc.paper.world.structure;
++
++import org.bukkit.Keyed;
++import org.bukkit.NamespacedKey;
++import org.bukkit.StructureType;
++import org.jetbrains.annotations.NotNull;
++
++import java.util.HashMap;
++import java.util.Map;
++
++public final class ConfiguredStructure implements Keyed {
++
++    private static final Map<NamespacedKey, ConfiguredStructure> CONFIGURED_STRUCTURE_MAP = new HashMap<>();
++
++    public static final ConfiguredStructure PILLAGER_OUTPOST = create("pillager_outpost", StructureType.PILLAGER_OUTPOST);
++    public static final ConfiguredStructure MINESHAFT = create("mineshaft", StructureType.MINESHAFT);
++    public static final ConfiguredStructure MINESHAFT_MESA = create("mineshaft_mesa", StructureType.MINESHAFT);
++    public static final ConfiguredStructure WOODLAND_MANSION = create("mansion", StructureType.WOODLAND_MANSION);
++    public static final ConfiguredStructure JUNGLE_TEMPLE = create("jungle_pyramid", StructureType.JUNGLE_PYRAMID);
++    public static final ConfiguredStructure DESERT_PYRAMID = create("desert_pyramid", StructureType.DESERT_PYRAMID);
++    public static final ConfiguredStructure IGLOO = create("igloo", StructureType.IGLOO);
++    public static final ConfiguredStructure SHIPWRECK = create("shipwreck", StructureType.SHIPWRECK);
++    public static final ConfiguredStructure SHIPWRECK_BEACHED = create("shipwreck_beached", StructureType.SHIPWRECK);
++    public static final ConfiguredStructure SWAMP_HUT = create("swamp_hut", StructureType.SWAMP_HUT);
++    public static final ConfiguredStructure STRONGHOLD = create("stronghold", StructureType.STRONGHOLD);
++    public static final ConfiguredStructure OCEAN_MONUMENT = create("monument", StructureType.OCEAN_MONUMENT);
++    public static final ConfiguredStructure OCEAN_RUIN_COLD = create("ocean_ruin_cold", StructureType.OCEAN_RUIN);
++    public static final ConfiguredStructure OCEAN_RUIN_WARM = create("ocean_ruin_warm", StructureType.OCEAN_RUIN);
++    public static final ConfiguredStructure FORTRESS = create("fortress", StructureType.NETHER_FORTRESS);
++    public static final ConfiguredStructure NETHER_FOSSIL = create("nether_fossil", StructureType.NETHER_FOSSIL);
++    public static final ConfiguredStructure END_CITY = create("end_city", StructureType.END_CITY);
++    public static final ConfiguredStructure BURIED_TREASURE = create("buried_treasure", StructureType.BURIED_TREASURE);
++    public static final ConfiguredStructure BASTION_REMNANT = create("bastion_remnant", StructureType.BASTION_REMNANT);
++    public static final ConfiguredStructure VILLAGE_PLAINS = create("village_plains", StructureType.VILLAGE);
++    public static final ConfiguredStructure VILLAGE_DESERT = create("village_desert", StructureType.VILLAGE);
++    public static final ConfiguredStructure VILLAGE_SAVANNA = create("village_savanna", StructureType.VILLAGE);
++    public static final ConfiguredStructure VILLAGE_SNOWY = create("village_snowy", StructureType.VILLAGE);
++    public static final ConfiguredStructure VILLAGE_TAIGA = create("village_taiga", StructureType.VILLAGE);
++    public static final ConfiguredStructure RUINED_PORTAL_STANDARD = create("ruined_portal", StructureType.RUINED_PORTAL);
++    public static final ConfiguredStructure RUINED_PORTAL_DESERT = create("ruined_portal_desert", StructureType.RUINED_PORTAL);
++    public static final ConfiguredStructure RUINED_PORTAL_JUNGLE = create("ruined_portal_jungle", StructureType.RUINED_PORTAL);
++    public static final ConfiguredStructure RUINED_PORTAL_SWAMP = create("ruined_portal_swamp", StructureType.RUINED_PORTAL);
++    public static final ConfiguredStructure RUINED_PORTAL_MOUNTAIN = create("ruined_portal_mountain", StructureType.RUINED_PORTAL);
++    public static final ConfiguredStructure RUINED_PORTAL_OCEAN = create("ruined_portal_ocean", StructureType.RUINED_PORTAL);
++    public static final ConfiguredStructure RUINED_PORTAL_NETHER = create("ruined_portal_nether", StructureType.RUINED_PORTAL);
++
++    private final NamespacedKey key;
++    private final StructureType structureType;
++
++    private ConfiguredStructure(@NotNull NamespacedKey key, @NotNull StructureType structureType) {
++        this.key = key;
++        this.structureType = structureType;
++    }
++
++    @Override
++    public @NotNull NamespacedKey getKey() {
++        return this.key;
++    }
++
++    /**
++     * Gets the structure type for this configure structure.
++     *
++     * @return the structure type
++     */
++    public @NotNull StructureType getStructureType() {
++        return this.structureType;
++    }
++
++    @Override
++    public String toString() {
++        return "ConfiguredStructure{" +
++            "key=" + this.key +
++            ", structureType=" + this.structureType +
++            '}';
++    }
++
++    /**
++     * Gets all configure structures.
++     *
++     * @return an immutable map
++     */
++    public static @NotNull Map<NamespacedKey, ConfiguredStructure> getConfiguredStructures() {
++        return Map.copyOf(CONFIGURED_STRUCTURE_MAP);
++    }
++
++    private static @NotNull ConfiguredStructure create(@NotNull String key, @NotNull StructureType type) {
++        final ConfiguredStructure structure = new ConfiguredStructure(NamespacedKey.minecraft(key), type);
++        CONFIGURED_STRUCTURE_MAP.put(structure.key, structure);
++        return structure;
++    }
++}
+diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
+index a696fcaffa03af9e6c92e2ef3e12b38eb59e5db4..e7dce6055db29eb698b6fc1b6a91cb4e2e6a05cd 100644
+--- a/src/main/java/org/bukkit/Registry.java
++++ b/src/main/java/org/bukkit/Registry.java
+@@ -189,6 +189,24 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+             return GameEvent.getByKey(key);
+         }
+     };
++    // Paper start
++    /**
++     * Configured structures.
++     * @see io.papermc.paper.world.structure.ConfiguredStructure
++     */
++    Registry<io.papermc.paper.world.structure.ConfiguredStructure> CONFIGURED_STRUCTURE = new Registry<io.papermc.paper.world.structure.ConfiguredStructure>() {
++        @Override
++        public @Nullable io.papermc.paper.world.structure.ConfiguredStructure get(@NotNull NamespacedKey key) {
++            return io.papermc.paper.world.structure.ConfiguredStructure.getConfiguredStructures().get(key);
++        }
++
++        @NotNull
++        @Override
++        public Iterator<io.papermc.paper.world.structure.ConfiguredStructure> iterator() {
++            return io.papermc.paper.world.structure.ConfiguredStructure.getConfiguredStructures().values().iterator();
++        }
++    };
++    // Paper end
+ 
+     /**
+      * Get the object by its key.

--- a/patches/api/0362-More-PotionEffectType-API.patch
+++ b/patches/api/0362-More-PotionEffectType-API.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] More PotionEffectType API
 
 
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index a696fcaffa03af9e6c92e2ef3e12b38eb59e5db4..6242336de18fdd708cc3d7b745cbbace13140bc0 100644
+index e7dce6055db29eb698b6fc1b6a91cb4e2e6a05cd..27bfe7536cee2b8414ed9c0a2e5b4e6b05f09c2a 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -189,6 +189,27 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
-             return GameEvent.getByKey(key);
+@@ -206,6 +206,26 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+             return io.papermc.paper.world.structure.ConfiguredStructure.getConfiguredStructures().values().iterator();
          }
      };
-+    // Paper start
++
 +    /**
 +     * Potion effect types.
 +     *
@@ -32,10 +32,9 @@ index a696fcaffa03af9e6c92e2ef3e12b38eb59e5db4..6242336de18fdd708cc3d7b745cbbace
 +            return Arrays.stream(org.bukkit.potion.PotionEffectType.values()).iterator();
 +        }
 +    };
-+    // Paper end
+     // Paper end
  
      /**
-      * Get the object by its key.
 diff --git a/src/main/java/org/bukkit/potion/PotionEffectType.java b/src/main/java/org/bukkit/potion/PotionEffectType.java
 index 22c28a503732671bc84c51372262e909d035c1fa..06e0f13d658b63b1fa984abb515eb0de704f9215 100644
 --- a/src/main/java/org/bukkit/potion/PotionEffectType.java

--- a/patches/api/0363-Expand-the-Registry-API.patch
+++ b/patches/api/0363-Expand-the-Registry-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expand the Registry API
 
 
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 6242336de18fdd708cc3d7b745cbbace13140bc0..661d424c609a01ad9bee837b4069d9e4e98d20c0 100644
+index 27bfe7536cee2b8414ed9c0a2e5b4e6b05f09c2a..ee28706d65c57084b1f1d2af5309844e213f53fc 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -209,6 +209,25 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -226,6 +226,25 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
              return Arrays.stream(org.bukkit.potion.PotionEffectType.values()).iterator();
          }
      };

--- a/patches/server/0579-Add-StructureLocateEvent.patch
+++ b/patches/server/0579-Add-StructureLocateEvent.patch
@@ -5,27 +5,143 @@ Subject: [PATCH] Add StructureLocateEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
-index f9fc2fc63080a60fe61ebb08ddd93c4f189df84d..4864fce027b0871e50b2060880be9e24bfdd3887 100644
+index f9fc2fc63080a60fe61ebb08ddd93c4f189df84d..50d79550b35cff703d43a515c9cfbfcfbd3fedcb 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
-@@ -294,6 +294,20 @@ public abstract class ChunkGenerator implements BiomeManager.NoiseBiomeSource {
+@@ -294,6 +294,38 @@ public abstract class ChunkGenerator implements BiomeManager.NoiseBiomeSource {
  
      @Nullable
      public Pair<BlockPos, Holder<ConfiguredStructureFeature<?, ?>>> findNearestMapFeature(ServerLevel worldserver, HolderSet<ConfiguredStructureFeature<?, ?>> holderset, BlockPos center, int radius, boolean skipExistingChunks) {
-+        // Paper start
-+        /*org.bukkit.World world1 = worldserver.getWorld();
-+        org.bukkit.Location originLocation = new org.bukkit.Location(world1, center.getX(), center.getY(), center.getZ());
-+        io.papermc.paper.event.world.StructureLocateEvent event = new io.papermc.paper.event.world.StructureLocateEvent(world1, originLocation, org.bukkit.StructureType.getStructureTypes().get(structureFeature.getFeatureName()), radius, skipExistingChunks);
-+        if(!event.callEvent()) return null;
-+        // If event call set a final location, skip structure finding and just return set result.
-+        if(event.getResult() != null) return new BlockPos(event.getResult().getBlockX(), event.getResult().getBlockY(), event.getResult().getBlockZ());
-+        // Get origin location (re)defined by event call.
-+        center = new BlockPos(event.getOrigin().getBlockX(), event.getOrigin().getBlockY(), event.getOrigin().getBlockZ());
-+        // Get radius and whether to find unexplored structures (re)defined by event call.
-+        radius = event.getRadius();
-+        skipExistingChunks = event.shouldFindUnexplored();
-+        structureFeature = StructureFeature.STRUCTURES_REGISTRY.get(event.getType().getName());*/
++        // Paper start - StructureLocateEvent
++        final org.bukkit.World world = worldserver.getWorld();
++        final org.bukkit.Location origin = net.minecraft.server.MCUtil.toLocation(worldserver, center);
++        final Registry<ConfiguredStructureFeature<?, ?>> configuredStructureFeatureRegistry = worldserver.registryAccess().registryOrThrow(Registry.CONFIGURED_STRUCTURE_FEATURE_REGISTRY);
++        final List<Holder<ConfiguredStructureFeature<?, ?>>> holders = new ArrayList<>();
++        for (Holder<net.minecraft.world.level.levelgen.feature.ConfiguredStructureFeature<?, ?>> holder : holderset) {
++            final net.minecraft.resources.ResourceLocation configuredStructureResourceLoc = configuredStructureFeatureRegistry.getKey(holder.value());
++            if (configuredStructureResourceLoc != null) {
++                final org.bukkit.NamespacedKey configuredStructureKey = org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(configuredStructureResourceLoc);
++                final io.papermc.paper.event.world.StructureLocateEvent event = new io.papermc.paper.event.world.StructureLocateEvent(world, origin, Objects.requireNonNull(org.bukkit.Registry.CONFIGURED_STRUCTURE.get(configuredStructureKey)), radius, skipExistingChunks);
++                if (!event.callEvent()) {
++                    continue;
++                }
++                if (event.getResult() != null) {
++                    return Pair.of(net.minecraft.server.MCUtil.toBlockPosition(event.getResult()), holder);
++                }
++                center = net.minecraft.server.MCUtil.toBlockPosition(event.getOrigin());
++                radius = event.getRadius();
++                skipExistingChunks = event.shouldFindUnexplored();
++                if (event.getConfiguredStructure().getKey().equals(configuredStructureKey)) {
++                    holders.add(holder);
++                } else {
++                    holders.add(configuredStructureFeatureRegistry.getHolderOrThrow(ResourceKey.create(Registry.CONFIGURED_STRUCTURE_FEATURE_REGISTRY, org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(event.getConfiguredStructure().getKey()))));
++                }
++            }
++        }
++        if (holders.isEmpty()) {
++            return null;
++        } else {
++            holderset = HolderSet.direct(holders);
++        }
 +        // Paper end
          Set<Holder<Biome>> set = (Set) holderset.stream().flatMap((holder) -> {
              return ((ConfiguredStructureFeature) holder.value()).biomes().stream();
          }).collect(Collectors.toSet());
+diff --git a/src/test/java/io/papermc/paper/world/structure/ConfiguredStructureTest.java b/src/test/java/io/papermc/paper/world/structure/ConfiguredStructureTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..696b986ab32c478ef54cf25c34f6236c67967e1c
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/world/structure/ConfiguredStructureTest.java
+@@ -0,0 +1,92 @@
++package io.papermc.paper.world.structure;
++
++import net.minecraft.data.BuiltinRegistries;
++import net.minecraft.resources.ResourceKey;
++import net.minecraft.resources.ResourceLocation;
++import net.minecraft.server.Bootstrap;
++import net.minecraft.world.level.levelgen.feature.ConfiguredStructureFeature;
++import net.minecraft.world.level.levelgen.structure.BuiltinStructures;
++import org.bukkit.NamespacedKey;
++import org.bukkit.Registry;
++import org.bukkit.StructureType;
++import org.bukkit.craftbukkit.util.CraftNamespacedKey;
++import org.bukkit.support.AbstractTestingBase;
++import org.junit.AfterClass;
++import org.junit.BeforeClass;
++import org.junit.Test;
++
++import java.io.PrintStream;
++import java.lang.reflect.Field;
++import java.util.LinkedHashMap;
++import java.util.Map;
++import java.util.Objects;
++import java.util.StringJoiner;
++
++import static org.junit.Assert.assertEquals;
++import static org.junit.Assert.assertNotNull;
++import static org.junit.Assert.assertTrue;
++
++public class ConfiguredStructureTest extends AbstractTestingBase {
++
++    private static final Map<ResourceLocation, String> BUILT_IN_STRUCTURES = new LinkedHashMap<>();
++    private static final Map<StructureType, String> API_STRUCTURE_TYPES = new LinkedHashMap<>();
++    private static PrintStream out;
++
++    @BeforeClass
++    public static void collectStructures() throws ReflectiveOperationException {
++        out = System.out;
++        System.setOut(Bootstrap.STDOUT);
++        for (Field field : BuiltinStructures.class.getDeclaredFields()) {
++            if (field.getType().equals(ResourceKey.class)) {
++                BUILT_IN_STRUCTURES.put(((ResourceKey<ConfiguredStructureFeature<?, ?>>) field.get(null)).location(), field.getName());
++            }
++        }
++
++        for (Field field : StructureType.class.getDeclaredFields()) {
++            if (field.getType().equals(StructureType.class)) {
++                API_STRUCTURE_TYPES.put((StructureType) field.get(null), field.getName());
++            }
++        }
++    }
++
++    @Test
++    public void testMinecraftToApi() {
++        assertEquals("configured structure maps should be the same size", BUILT_IN_STRUCTURES.size(), BuiltinRegistries.CONFIGURED_STRUCTURE_FEATURE.size());
++        assertEquals("api structure types map should be the same size", API_STRUCTURE_TYPES.size(), StructureType.getStructureTypes().size());
++
++        Map<ResourceLocation, ConfiguredStructureFeature<?, ?>> missing = new LinkedHashMap<>();
++        for (ConfiguredStructureFeature<?, ?> feature : BuiltinRegistries.CONFIGURED_STRUCTURE_FEATURE) {
++            final ResourceLocation key = BuiltinRegistries.CONFIGURED_STRUCTURE_FEATURE.getKey(feature);
++            assertNotNull("Missing built-in registry key", key);
++            if (Registry.CONFIGURED_STRUCTURE.get(CraftNamespacedKey.fromMinecraft(key)) == null) {
++                missing.put(key, feature);
++            }
++        }
++
++        assertTrue(printMissing(missing), missing.isEmpty());
++    }
++
++    @Test
++    public void testApiToMinecraft() {
++        for (NamespacedKey apiKey : ConfiguredStructure.getConfiguredStructures().keySet()) {
++            assertTrue(apiKey + " does not have a minecraft counterpart", BuiltinRegistries.CONFIGURED_STRUCTURE_FEATURE.containsKey(CraftNamespacedKey.toMinecraft(apiKey)));
++        }
++    }
++
++    private static String printMissing(Map<ResourceLocation, ConfiguredStructureFeature<?, ?>> missing) {
++        final StringJoiner joiner = new StringJoiner("\n", "Missing: \n", "");
++
++        missing.forEach((key, configuredFeature) -> {
++            final ResourceLocation featureKey = Objects.requireNonNull(net.minecraft.core.Registry.STRUCTURE_FEATURE.getKey(configuredFeature.feature));
++            final StructureType type = StructureType.getStructureTypes().get(featureKey.getPath());
++            joiner.add("public static final ConfiguredStructure " + BUILT_IN_STRUCTURES.get(key) + " = create(\"" + key.getPath() + "\", StructureType." + API_STRUCTURE_TYPES.get(type) +");");
++        });
++
++        return joiner.toString();
++    }
++
++    @AfterClass
++    public static void after() {
++        System.setOut(out);
++    }
++}

--- a/patches/server/0800-Configurable-feature-seeds.patch
+++ b/patches/server/0800-Configurable-feature-seeds.patch
@@ -79,10 +79,10 @@ index e5eeab49d167a9a151301ca910e1421550e14245..0a70dfd7880f5fcf1292dd2fdae2964b
          return getIntOrDefault(behaviorTickRates, typeName, entityType, def);
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
-index 4864fce027b0871e50b2060880be9e24bfdd3887..eb2f0bc997a6823c74f32ec01330ced39a14fdd0 100644
+index 50d79550b35cff703d43a515c9cfbfcfbd3fedcb..83e093a5e659b7b1e75c08ecae0ab4eacc4b4a14 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
-@@ -521,7 +521,7 @@ public abstract class ChunkGenerator implements BiomeManager.NoiseBiomeSource {
+@@ -539,7 +539,7 @@ public abstract class ChunkGenerator implements BiomeManager.NoiseBiomeSource {
              int j = list.size();
  
              try {
@@ -91,7 +91,7 @@ index 4864fce027b0871e50b2060880be9e24bfdd3887..eb2f0bc997a6823c74f32ec01330ced3
                  int k = Math.max(GenerationStep.Decoration.values().length, j);
  
                  for (int l = 0; l < k; ++l) {
-@@ -594,7 +594,15 @@ public abstract class ChunkGenerator implements BiomeManager.NoiseBiomeSource {
+@@ -612,7 +612,15 @@ public abstract class ChunkGenerator implements BiomeManager.NoiseBiomeSource {
                                  return (String) optional.orElseGet(placedfeature::toString);
                              };
  


### PR DESCRIPTION
So there are some things to look at here.

StructureLocateEvent is now fired multiple times since its searching for a collection of `ConfiguredStructureFeature`s instead of just a `StructureFeature`. This means that only the final event fire's radius, search-only-explored values are taken into account, and I don't see a clean way of having those values be per-configued structure without just having it run the logic multiple times which would be a significant perf hit I assume.

Also, the `setType(StructureType)` method now throws a UOE because it doesn't really make sense in this context anymore.