### PR TITLE
Add option for disabling nerfing portal-based mob farms

### DIFF
--- a/patches/server/0879-Add-setting-to-disable-nerfing-of-portal-based-mob-f.patch
+++ b/patches/server/0879-Add-setting-to-disable-nerfing-of-portal-based-mob-f.patch
@@ -2,6 +2,9 @@ From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gilles Braun <450164+gillesbraun@users.noreply.github.com>
 Date: Thu, 3 Mar 2022 16:44:14 +0100
 Subject: [PATCH] Add setting to disable nerfing of portal based mob farms
+Marks entities that teleport through a nether portal with `fromNetherPortal`. Mobs with that flag that are prevented
+from despawning if the config value is set, effectively working around the hard entity despawn range limit. Defaults
+to the old behaviour of just deleting mobs that are beyond the hard range limit.
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java

--- a/patches/server/0879-Add-setting-to-disable-nerfing-of-portal-based-mob-f.patch
+++ b/patches/server/0879-Add-setting-to-disable-nerfing-of-portal-based-mob-f.patch
@@ -1,15 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Gilles Braun <450164+gillesbraun@users.noreply.github.com>
-Date: Thu, 3 Mar 2022 16:44:14 +0100
+Date: Thu, 3 Mar 2022 18:59:24 +0100
 Subject: [PATCH] Add setting to disable nerfing of portal based mob farms
-Marks entities that teleport through a nether portal with `fromNetherPortal`. Mobs with that flag that are prevented
-from despawning if the config value is set, effectively working around the hard entity despawn range limit. Defaults
-to the old behaviour of just deleting mobs that are beyond the hard range limit.
+ Marks entities that teleport through a nether portal with `fromNetherPortal`.
+ Mobs with that flag that are prevented from despawning if the config value is
+ set, effectively working around the hard entity despawn range limit. Defaults
+ to the old behaviour of just deleting mobs that are beyond the hard range
+ limit.
 
-This allows mob farms that are set up in the nether to teleport mobs into the overworld, without them instantly
-despawning due to the hard despawn limit. Without this patch it requires another player to sit in the overworld
-to prevent the mobs from despawning.
-
+This allows mob farms that are set up in the nether to teleport mobs into the overworld, without them instantly despawning due to the hard despawn limit. Without this patch it requires another player to sit in the overworld to prevent the mobs from despawning.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 index d7dcf36c8c972e30320c56e447822cf26f6d5fb3..dddca3c0f6180cf65e5e503cfc795061fd1634cc 100644
@@ -41,16 +40,15 @@ index 9ca080e2745686fc2e39485965ec54c5de0bae6e..4932b0f689dcb2ef1a9418943c272a32
                      }
                      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 850a4f8a9bd1dc30b13205e158fcbfaa872d6157..0f4d95b82f852a11621bdae560e6c444572008b6 100644
+index 850a4f8a9bd1dc30b13205e158fcbfaa872d6157..7f911a47b147d34cdcca091fade6865d44097957 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -804,7 +804,8 @@ public abstract class Mob extends LivingEntity {
+@@ -804,7 +804,7 @@ public abstract class Mob extends LivingEntity {
                  int i = this.level.paperConfig.hardDespawnDistances.getInt(this.getType().getCategory()); // Paper - custom despawn distances
                  int j = i * i;
  
 -                if (d0 > (double) j) { // CraftBukkit - remove isTypeNotPersistent() check
-+                // Paper - nerf portal mob farms
-+                if (d0 > (double) j && (!fromNetherPortal || level.paperConfig.nerfPortalMobFarms)) { // CraftBukkit - remove isTypeNotPersistent() check
++                if (d0 > (double) j && (!fromNetherPortal || level.paperConfig.nerfPortalMobFarms)) { // CraftBukkit - remove isTypeNotPersistent() check // Paper - nerf portal mob farms
                      this.discard();
                  }
  

--- a/patches/server/0879-Add-setting-to-disable-nerfing-of-portal-based-mob-f.patch
+++ b/patches/server/0879-Add-setting-to-disable-nerfing-of-portal-based-mob-f.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gilles Braun <450164+gillesbraun@users.noreply.github.com>
+Date: Thu, 3 Mar 2022 16:44:14 +0100
+Subject: [PATCH] Add setting to disable nerfing of portal based mob farms
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index d7dcf36c8c972e30320c56e447822cf26f6d5fb3..dddca3c0f6180cf65e5e503cfc795061fd1634cc 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -135,6 +135,12 @@ public class PaperWorldConfig {
+         disableMobSpawnerSpawnEggTransformation = getBoolean("game-mechanics.disable-mob-spawner-spawn-egg-transformation", disableMobSpawnerSpawnEggTransformation);
+     }
+ 
++    public boolean nerfPortalMobFarms;
++    private void nerfPortalMobFarms() {
++        nerfPortalMobFarms = getBoolean("game-mechanics.nerf-portal-mob-farms", true);
++        log("Nerf portal based mob farms: " + nerfPortalMobFarms);
++    }
++
+     public List<net.minecraft.world.Difficulty> zombieBreakDoors;
+     public List<net.minecraft.world.Difficulty> vindicatorBreakDoors;
+     private void setupEntityBreakingDoors() {
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 9ca080e2745686fc2e39485965ec54c5de0bae6e..4932b0f689dcb2ef1a9418943c272a3298d41bd1 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -2749,6 +2749,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+                     if (this instanceof ServerPlayer) {
+                         ((ServerPlayer) this).changeDimension(worldserver1, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL);
+                     } else {
++                        fromNetherPortal = true; // Paper - nerf portal mob farms
+                         this.changeDimension(worldserver1);
+                     }
+                     // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
+index 850a4f8a9bd1dc30b13205e158fcbfaa872d6157..0f4d95b82f852a11621bdae560e6c444572008b6 100644
+--- a/src/main/java/net/minecraft/world/entity/Mob.java
++++ b/src/main/java/net/minecraft/world/entity/Mob.java
+@@ -804,7 +804,8 @@ public abstract class Mob extends LivingEntity {
+                 int i = this.level.paperConfig.hardDespawnDistances.getInt(this.getType().getCategory()); // Paper - custom despawn distances
+                 int j = i * i;
+ 
+-                if (d0 > (double) j) { // CraftBukkit - remove isTypeNotPersistent() check
++                // Paper - nerf portal mob farms
++                if (d0 > (double) j && (!fromNetherPortal || level.paperConfig.nerfPortalMobFarms)) { // CraftBukkit - remove isTypeNotPersistent() check
+                     this.discard();
+                 }
+ 

--- a/patches/server/0879-Add-setting-to-disable-nerfing-of-portal-based-mob-f.patch
+++ b/patches/server/0879-Add-setting-to-disable-nerfing-of-portal-based-mob-f.patch
@@ -6,6 +6,10 @@ Marks entities that teleport through a nether portal with `fromNetherPortal`. Mo
 from despawning if the config value is set, effectively working around the hard entity despawn range limit. Defaults
 to the old behaviour of just deleting mobs that are beyond the hard range limit.
 
+This allows mob farms that are set up in the nether to teleport mobs into the overworld, without them instantly
+despawning due to the hard despawn limit. Without this patch it requires another player to sit in the overworld
+to prevent the mobs from despawning.
+
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 index d7dcf36c8c972e30320c56e447822cf26f6d5fb3..dddca3c0f6180cf65e5e503cfc795061fd1634cc 100644


### PR DESCRIPTION
Adds a configuration option `game-mechanics.nerf-portal-mob-farms` defaulting to true (current behavior), which prevents mobs that travelled through a portal to be instantly despawned.

Rationale: Mob farms that [use portals](https://youtu.be/uh3X0Pmr9yc?t=904) to transport them to the overworld require 2 players, one in nether and one in the overworld. This is due to the hard despawn range limit of 128 for monsters.
