### PR TITLE
Add javadoc linking for adventure-text-minimessage

### DIFF
--- a/patches/api/0008-Adventure.patch
+++ b/patches/api/0008-Adventure.patch
@@ -7,7 +7,7 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 98afa6a25131dc626ea7a5122f33df6bd2d39178..bacb5650f03827ac55f8c8c33f6ffda5b029a8a4 100644
+index 98afa6a25131dc626ea7a5122f33df6bd2d39178..f76f566519567e255669c97bcae3e3424539b17c 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -8,6 +8,19 @@ java {
@@ -43,12 +43,13 @@ index 98afa6a25131dc626ea7a5122f33df6bd2d39178..bacb5650f03827ac55f8c8c33f6ffda5
      // Paper end
  
      compileOnly("org.apache.maven:maven-resolver-provider:3.8.4")
-@@ -78,8 +97,22 @@ tasks.withType<Javadoc> {
+@@ -78,8 +97,23 @@ tasks.withType<Javadoc> {
          "https://javadoc.io/doc/org.yaml/snakeyaml/1.30/",
          "https://javadoc.io/doc/org.jetbrains/annotations/23.0.0/", // Paper - we don't want Java 5 annotations
          "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
 +        // Paper start
 +        "https://jd.adventure.kyori.net/api/$adventureVersion/",
++        "https://jd.adventure.kyori.net/text-minimessage/$adventureVersion/",
 +        "https://jd.adventure.kyori.net/text-serializer-gson/$adventureVersion/",
 +        "https://jd.adventure.kyori.net/text-serializer-legacy/$adventureVersion/",
 +        "https://jd.adventure.kyori.net/text-serializer-plain/$adventureVersion/",


### PR DESCRIPTION
Looks like the javadocs from text-minimessage are missing.

This will add the javadocs from here: https://jd.adventure.kyori.net/text-minimessage/4.10.0/