### PR TITLE
replace bungeecord-chat dependency with deprecated version

### DIFF
--- a/patches/api/0008-Adventure.patch
+++ b/patches/api/0008-Adventure.patch
@@ -7,10 +7,10 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 98afa6a25131dc626ea7a5122f33df6bd2d39178..f76f566519567e255669c97bcae3e3424539b17c 100644
+index 98afa6a25131dc626ea7a5122f33df6bd2d39178..ac7ecca1a046182e385e2fc77120813e4f59442e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -8,6 +8,19 @@ java {
+@@ -8,18 +8,37 @@ java {
      withJavadocJar()
  }
  
@@ -30,7 +30,13 @@ index 98afa6a25131dc626ea7a5122f33df6bd2d39178..f76f566519567e255669c97bcae3e342
  dependencies {
      // api dependencies are listed transitively to API consumers
      api("commons-lang:commons-lang:2.6")
-@@ -20,6 +33,12 @@ dependencies {
+     api("com.google.guava:guava:31.0.1-jre")
+     api("com.google.code.gson:gson:2.8.9")
+-    api("net.md-5:bungeecord-chat:1.16-R0.4")
++    api("net.md-5:bungeecord-chat:1.16-R0.4-deprecated+build.6") // Paper
+     api("org.yaml:snakeyaml:1.30")
+     // Paper start
+     api("com.googlecode.json-simple:json-simple:1.1.1") {
          isTransitive = false // includes junit
      }
      api("it.unimi.dsi:fastutil:8.5.6")
@@ -43,11 +49,13 @@ index 98afa6a25131dc626ea7a5122f33df6bd2d39178..f76f566519567e255669c97bcae3e342
      // Paper end
  
      compileOnly("org.apache.maven:maven-resolver-provider:3.8.4")
-@@ -78,8 +97,23 @@ tasks.withType<Javadoc> {
+@@ -77,9 +96,24 @@ tasks.withType<Javadoc> {
+         "https://guava.dev/releases/31.0.1-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/1.30/",
          "https://javadoc.io/doc/org.jetbrains/annotations/23.0.0/", // Paper - we don't want Java 5 annotations
-         "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
+-        "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
 +        // Paper start
++        //"https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/", // don't link to bungee chat
 +        "https://jd.adventure.kyori.net/api/$adventureVersion/",
 +        "https://jd.adventure.kyori.net/text-minimessage/$adventureVersion/",
 +        "https://jd.adventure.kyori.net/text-serializer-gson/$adventureVersion/",


### PR DESCRIPTION
This helps to make it clear that the bungee chat API as a whole is deprecated, rather than just the methods accepting bungee chat types