### PR TITLE
Fix handling message in PlayerHandshakeEvent

### DIFF
--- a/patches/server/0087-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
+++ b/patches/server/0087-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add handshake event to allow plugins to handle client
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index 02613b1f36ecd7f354ac00022af3c193b299c1b1..27d304316bec097fea4b950cb4e0ac80cb219f70 100644
+index 02613b1f36ecd7f354ac00022af3c193b299c1b1..63cc89c7769bfcc9d663a1827ad525e3ddd82fe5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 @@ -88,9 +88,36 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
@@ -24,9 +24,9 @@ index 02613b1f36ecd7f354ac00022af3c193b299c1b1..27d304316bec097fea4b950cb4e0ac80
 +                    if (event.callEvent()) {
 +                        // If we've failed somehow, let the client know so and go no further.
 +                        if (event.isFailed()) {
-+                            TranslatableComponent chatmessage = new TranslatableComponent(event.getFailMessage());
-+                            this.connection.send(new ClientboundLoginDisconnectPacket(chatmessage));
-+                            this.connection.disconnect(chatmessage);
++                            Component component = io.papermc.paper.adventure.PaperAdventure.asVanilla(event.failMessage());
++                            this.connection.send(new ClientboundLoginDisconnectPacket(component));
++                            this.connection.disconnect(component);
 +                            return;
 +                        }
 +

--- a/patches/server/0497-Fix-hex-colors-not-working-in-some-kick-messages.patch
+++ b/patches/server/0497-Fix-hex-colors-not-working-in-some-kick-messages.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix hex colors not working in some kick messages
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index 687308a414095f95b567a2993b679d8b62856578..54de844431cf9cc88d6e82014d5eb69babd7784c 100644
+index 86f99fbe3eb7a6c7ef288d7bff1d653df6f34790..8060d6461835d5b5b4429e9b280d08eae4e435e9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 @@ -50,7 +50,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
@@ -33,15 +33,6 @@ index 687308a414095f95b567a2993b679d8b62856578..54de844431cf9cc88d6e82014d5eb69b
                      }
  
                      this.connection.send(new ClientboundLoginDisconnectPacket(chatmessage));
-@@ -99,7 +99,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
-                     if (event.callEvent()) {
-                         // If we've failed somehow, let the client know so and go no further.
-                         if (event.isFailed()) {
--                            TranslatableComponent chatmessage = new TranslatableComponent(event.getFailMessage());
-+                            Component chatmessage = org.bukkit.craftbukkit.util.CraftChatMessage.fromString(event.getFailMessage(), true)[0]; // Paper - Fix hex colors not working in some kick messages
-                             this.connection.send(new ClientboundLoginDisconnectPacket(chatmessage));
-                             this.connection.disconnect(chatmessage);
-                             return;
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 index d21f45d983bf3047811d2d73f4a38deb108ac402..ab21f25a3eb0575d08aeac717ba2b74160f54fa9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java


### PR DESCRIPTION
``getFailMessage()`` simply converts failMessage() to legacy text
This code was causing it to be converted to legacy text then converted back to a component.

Now use the component directly provided by the ``failMessage()`` method.