### PR TITLE
Allow usage of MiniMessage in server configuration files

### DIFF
--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -5,45 +5,65 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 76d379cfc00157dd76ae981ebd839ac0954b4773..686235a2347ebeaa5654a14cdd717009f2c0105f 100644
+index 76d379cfc00157dd76ae981ebd839ac0954b4773..f504ab7d075c1bb49c3cdd50d3bcd2b7b8f7628e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2098,6 +2098,15 @@ public final class Bukkit {
+@@ -2098,6 +2098,26 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
 +    /**
 +     *
++     * @deprecated Use {@link #permissionMessage()}
 +     * @return the default no permission message used on the server
 +     */
 +    @NotNull
++    @Deprecated
 +    public static String getPermissionMessage() {
 +        return server.getPermissionMessage();
++    }
++
++    /**
++     *
++     * @return the default no permission message used on the server
++     */
++    @NotNull
++    public static net.kyori.adventure.text.Component permissionMessage() {
++        return server.permissionMessage();
 +    }
 +
      /**
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 818c37490d98c287ade9b56f3fc01001db1df773..f43720d07e80e3d2937f5b271664b5268d7af027 100644
+index 818c37490d98c287ade9b56f3fc01001db1df773..79995da5de73e0d7441549ba83349826791d9047 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1841,6 +1841,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1841,6 +1841,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  
 +    /**
 +     *
++     * @deprecated Use {@link #permissionMessage()}
 +     * @return the default no permission message used on the server
 +     */
 +    @NotNull
++    @Deprecated
 +    String getPermissionMessage();
++
++    /**
++     *
++     * @return the default no permission message used on the server
++     */
++    @NotNull
++    net.kyori.adventure.text.Component permissionMessage();
 +
      /**
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
-index b1152f4dede61383232cc6713d448840612eac13..95847fcb1ac2e430ee192f4f7ac94e981151c5db 100644
+index b1152f4dede61383232cc6713d448840612eac13..9e2e4d8082b014229976f92c213b3084e09e11eb 100644
 --- a/src/main/java/org/bukkit/command/Command.java
 +++ b/src/main/java/org/bukkit/command/Command.java
 @@ -184,10 +184,9 @@ public abstract class Command {
@@ -54,7 +74,7 @@ index b1152f4dede61383232cc6713d448840612eac13..95847fcb1ac2e430ee192f4f7ac94e98
 -            target.sendMessage(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is a mistake.");
              // Paper start - use components for permissionMessage
 -        } else if (!permissionMessage.equals(net.kyori.adventure.text.Component.empty())) {
-+        net.kyori.adventure.text.Component permissionMessage = this.permissionMessage != null ? this.permissionMessage : io.papermc.paper.text.PaperComponents.legacySectionSerializer().deserialize(Bukkit.getPermissionMessage());
++        net.kyori.adventure.text.Component permissionMessage = this.permissionMessage != null ? this.permissionMessage : Bukkit.permissionMessage();
 +        if (!permissionMessage.equals(net.kyori.adventure.text.Component.empty())) {
              target.sendMessage(permissionMessage.replaceText(net.kyori.adventure.text.TextReplacementConfig.builder().matchLiteral("<permission>").replacement(permission).build()));
              // Paper end

--- a/patches/api/0183-Expose-the-internal-current-tick.patch
+++ b/patches/api/0183-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index cf7f8a8f03adcbe466b59ea8b98b527fb54a0803..61877d9d64840408a7aec7bcc2a54779a9e820d8 100644
+index 9215375d0813840b06d11f6e14f8e660865f58cc..3e08b312895710584dca6d62becba2a31e297cfd 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2140,6 +2140,10 @@ public final class Bukkit {
+@@ -2151,6 +2151,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfile(uuid, name);
      }
@@ -20,10 +20,10 @@ index cf7f8a8f03adcbe466b59ea8b98b527fb54a0803..61877d9d64840408a7aec7bcc2a54779
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 49bcc2edea32ef2b31b9ed5c3a62140bcc81ffc9..73ec2a8541ae95e07e32327ad0fff3a30b091658 100644
+index b14cea527705b9aebacf58e8620ee06dbc88bb8b..1577ef077f9dc888649ebfe79e5850b7e94805ff 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1875,5 +1875,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1884,5 +1884,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0190-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0190-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 6971ecc8d285f81c476f1b3442159167102a5719..88d1b843d9c8db350f1b64da06bb1b568626d0ce 100644
+index 7ab74ccbe9ec5b18fa998fcc85bcdf899777ea5c..8acdce46cabbaffc93b8cc887211d5bf4679e822 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2163,6 +2163,15 @@ public final class Bukkit {
+@@ -2174,6 +2174,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index 6971ecc8d285f81c476f1b3442159167102a5719..88d1b843d9c8db350f1b64da06bb1b56
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a543d5ec7df410cad15affb22058b60ec6a5c570..ce8e0c4e90f59d7446f761d0df9ab1c73bbbb676 100644
+index 3638ea714fdf6684dc1ce26975213bf86a10751d..b29c030908c6d0c826ba7a55bb256af018fcbad6 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1897,5 +1897,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1906,5 +1906,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0200-Add-Mob-Goal-API.patch
+++ b/patches/api/0200-Add-Mob-Goal-API.patch
@@ -523,10 +523,10 @@ index 0000000000000000000000000000000000000000..8fd399f791b45eb7fc62693ca954eea0
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 111323f84fb6f34f5a61c5e24d1f1a058744416d..ed6dab65a21b9c089e69cf9fe2fda3919be4e5a3 100644
+index ac36161cf501256b8c9cbd4519aa289017c689d8..216e55a5986e597e2f83642de50645998fe76e7c 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2184,6 +2184,16 @@ public final class Bukkit {
+@@ -2195,6 +2195,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -544,10 +544,10 @@ index 111323f84fb6f34f5a61c5e24d1f1a058744416d..ed6dab65a21b9c089e69cf9fe2fda391
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5b52ec962c0ebd8cf8968dcbc31a9900eb15f6c0..705d30a68d6f10e5c5dd49b70535b320895c8502 100644
+index 77b3b0db6a17b064a5c832c96fe75791e7458be4..321fb0acc5ed7032fc5cb6d61b23f1c0e7c23dfe 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1914,5 +1914,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1923,5 +1923,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0296-Add-basic-Datapack-API.patch
+++ b/patches/api/0296-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c8ea04b06d7178c6cc992a9a1b0355a70a035152..7732d26277ca8b845898cb01c7623a2f175f0aaa 100644
+index 6a2561172d11da61b631c51fec35d4c6668c6425..96ff387af1faab47d251c2ff9b525c2b234d67ed 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2238,6 +2238,14 @@ public final class Bukkit {
+@@ -2249,6 +2249,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index c8ea04b06d7178c6cc992a9a1b0355a70a035152..7732d26277ca8b845898cb01c7623a2f
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 67c6443c5639beafade19bc39932f30bf1001a8d..ca4a9428e89b084436ef43099974ae7684648776 100644
+index f36c2bc738ed3afa50bda30ea8cdd3ee15892c85..02a9b71b26f29c9f0089ef79aa99720312a50303 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1961,5 +1961,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1970,5 +1970,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0372-Custom-Potion-Mixes.patch
+++ b/patches/api/0372-Custom-Potion-Mixes.patch
@@ -102,10 +102,10 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 795f8c0aa3929f6de4b4ea4b139bef8b672ab97a..944f9b87a11472ac6d7e328acc00bf09f899e648 100644
+index 905d0f1e3a33a6bfb8e804c81807caa73411da34..27cf4d08f69fbb7470d0fdb3be94b5eab2d800f3 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2297,6 +2297,15 @@ public final class Bukkit {
+@@ -2308,6 +2308,15 @@ public final class Bukkit {
      public static io.papermc.paper.datapack.DatapackManager getDatapackManager() {
          return server.getDatapackManager();
      }
@@ -122,10 +122,10 @@ index 795f8c0aa3929f6de4b4ea4b139bef8b672ab97a..944f9b87a11472ac6d7e328acc00bf09
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a62c27777672eff1c488517b37876e3a44a2d57d..cca362e54d6ff4a5a1e60f85a7eb1b3d222d3d48 100644
+index 62983f067d30b9205f638f665dc69a6178ddb314..ef7acf5ccc2fdc276ba3ff1318f7699c6390770b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1995,5 +1995,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2004,5 +2004,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -298,7 +298,7 @@ index 0000000000000000000000000000000000000000..bee2fa2bfbb61209381f24ed6508d3d1
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5c7b2850d311e4d54236ba9acce148bca05672fd
+index 0000000000000000000000000000000000000000..2568bed633a5872ac29570afc8c5ba3e65605bbc
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -0,0 +1,188 @@
@@ -364,8 +364,8 @@ index 0000000000000000000000000000000000000000..5c7b2850d311e4d54236ba9acce148bc
 +        commands = new HashMap<String, Command>();
 +        commands.put("paper", new PaperCommand("paper"));
 +
-+        version = getInt("config-version", 25);
-+        set("config-version", 25);
++        version = getInt("config-version", 26);
++        set("config-version", 26);
 +        readConfig(PaperConfig.class, null);
 +    }
 +

--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -7,7 +7,7 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5c7b2850d311e4d54236ba9acce148bca05672fd..15927e8b747e536a5136d9b59edc8d6f50354c42 100644
+index 2568bed633a5872ac29570afc8c5ba3e65605bbc..4184835ac414811906332658cc4716731094cf3f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -185,4 +185,13 @@ public class PaperConfig {
@@ -1360,6 +1360,26 @@ index c18bed4728f6813aa8d7cf4b1e5e53a092fb1354..082d2fe274a91a76bbef5597eec61d73
                  tileentitysign.isEditable = false;
              }
              // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
+index 02613b1f36ecd7f354ac00022af3c193b299c1b1..fa1f5299002b2f6c5e20fd87e850d4b41e3805e6 100644
+--- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
+@@ -76,12 +76,12 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
+                 }
+                 // CraftBukkit end
+                 if (packet.getProtocolVersion() != SharedConstants.getCurrentVersion().getProtocolVersion()) {
+-                    TranslatableComponent chatmessage;
++                    Component chatmessage; // Paper - Adventure
+ 
+                     if (packet.getProtocolVersion() < 754) {
+-                        chatmessage = new TranslatableComponent( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedClientMessage.replaceAll("'", "''"), SharedConstants.getCurrentVersion().getName() ) ); // Spigot
++                        chatmessage = new io.papermc.paper.adventure.AdventureComponent(org.spigotmc.SpigotConfig.outdatedClientMessage); // Spigot // Paper - Adventure
+                     } else {
+-                        chatmessage = new TranslatableComponent( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedServerMessage.replaceAll("'", "''"), SharedConstants.getCurrentVersion().getName() ) ); // Spigot
++                        chatmessage = new io.papermc.paper.adventure.AdventureComponent(org.spigotmc.SpigotConfig.outdatedServerMessage); // Spigot // Paper - Adventure
+                     }
+ 
+                     this.connection.send(new ClientboundLoginDisconnectPacket(chatmessage));
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 index 2b9b60c0010069916dbecd22efdb9cec71180363..627931ec09bfb1a84f0659981491cf3b6425aa32 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
@@ -1402,7 +1422,7 @@ index c9a8d64ef23def0ad8e986a97c34331b8d54c205..2b24a41587fbe1fba70a0ab42d3dc333
  
                  @Override
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ea119e5849c90b25b7e836eb5e7454a391865b81..be9a29f01d59584a1492d925248f0947610ce9d0 100644
+index ea119e5849c90b25b7e836eb5e7454a391865b81..7c4b2d0e086ad1ab9b572623e2414ec48996d513 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -8,6 +8,7 @@ import com.mojang.logging.LogUtils;
@@ -1491,7 +1511,7 @@ index ea119e5849c90b25b7e836eb5e7454a391865b81..be9a29f01d59584a1492d925248f0947
          } else if (!this.isWhiteListed(gameprofile)) {
              chatmessage = new TranslatableComponent("multiplayer.disconnect.not_whitelisted");
 -            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, org.spigotmc.SpigotConfig.whitelistMessage); // Spigot
-+            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, PaperAdventure.LEGACY_SECTION_UXRC.deserialize(org.spigotmc.SpigotConfig.whitelistMessage)); // Spigot // Paper - Adventure
++            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, org.spigotmc.SpigotConfig.whitelistMessage); // Spigot // Paper - Adventure
          } else if (this.getIpBans().isBanned(socketaddress) && !this.getIpBans().get(socketaddress).hasExpired()) {
              IpBanListEntry ipbanentry = this.ipBans.get(socketaddress);
  
@@ -1505,7 +1525,7 @@ index ea119e5849c90b25b7e836eb5e7454a391865b81..be9a29f01d59584a1492d925248f0947
              // return this.players.size() >= this.maxPlayers && !this.canBypassPlayerLimit(gameprofile) ? new ChatMessage("multiplayer.disconnect.server_full") : null;
              if (this.players.size() >= this.maxPlayers && !this.canBypassPlayerLimit(gameprofile)) {
 -                event.disallow(PlayerLoginEvent.Result.KICK_FULL, org.spigotmc.SpigotConfig.serverFullMessage); // Spigot
-+                event.disallow(PlayerLoginEvent.Result.KICK_FULL, PaperAdventure.LEGACY_SECTION_UXRC.deserialize(org.spigotmc.SpigotConfig.serverFullMessage)); // Spigot // Paper - Adventure
++                event.disallow(PlayerLoginEvent.Result.KICK_FULL, org.spigotmc.SpigotConfig.serverFullMessage); // Spigot // Paper - Adventure
              }
          }
  
@@ -1635,7 +1655,7 @@ index 595b56b2ab9a813ba71399d306117294fa90dc65..3527d40102d512d0e276edc969ea3c18
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e71bc0315f9e4559e2df6a83a3c11f1024d17de9..586bfdc39840170b6bb43ef99a1e1f72ec84b062 100644
+index e71bc0315f9e4559e2df6a83a3c11f1024d17de9..443afccde5a200ae15bfcccc4d4517b16ff01d7f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -585,8 +585,10 @@ public final class CraftServer implements Server {
@@ -1649,23 +1669,38 @@ index e71bc0315f9e4559e2df6a83a3c11f1024d17de9..586bfdc39840170b6bb43ef99a1e1f72
      }
  
      @Override
-@@ -1415,7 +1417,15 @@ public final class CraftServer implements Server {
+@@ -825,7 +827,7 @@ public final class CraftServer implements Server {
+         }
+ 
+         // Spigot start
+-        if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {
++        if (!org.spigotmc.SpigotConfig.unknownCommandMessage.equals(net.kyori.adventure.text.Component.empty())) { // Paper - Adventure
+             sender.sendMessage(org.spigotmc.SpigotConfig.unknownCommandMessage);
+         }
+         // Spigot end
+@@ -1415,9 +1417,20 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
 +    // Paper start
      @Override
 +    public net.kyori.adventure.text.Component shutdownMessage() {
-+        String msg = getShutdownMessage();
-+        return msg != null ? io.papermc.paper.adventure.PaperAdventure.LEGACY_SECTION_UXRC.deserialize(msg) : null;
++        String msg = this.configuration.getString("settings.shutdown-message");
++        return msg != null ? net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(msg) : null;
 +    }
 +    // Paper end
 +    @Override
 +    @Deprecated // Paper
      public String getShutdownMessage() {
-         return this.configuration.getString("settings.shutdown-message");
+-        return this.configuration.getString("settings.shutdown-message");
++        // Paper start
++        net.kyori.adventure.text.Component msg = shutdownMessage();
++        return msg != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(msg) : null;
++        // Paper end
      }
-@@ -1573,7 +1583,20 @@ public final class CraftServer implements Server {
+ 
+     @Override
+@@ -1573,7 +1586,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1686,7 +1721,7 @@ index e71bc0315f9e4559e2df6a83a3c11f1024d17de9..586bfdc39840170b6bb43ef99a1e1f72
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1581,14 +1604,14 @@ public final class CraftServer implements Server {
+@@ -1581,14 +1607,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -1703,7 +1738,7 @@ index e71bc0315f9e4559e2df6a83a3c11f1024d17de9..586bfdc39840170b6bb43ef99a1e1f72
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1839,6 +1862,14 @@ public final class CraftServer implements Server {
+@@ -1839,6 +1865,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -1718,7 +1753,7 @@ index e71bc0315f9e4559e2df6a83a3c11f1024d17de9..586bfdc39840170b6bb43ef99a1e1f72
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1851,13 +1882,28 @@ public final class CraftServer implements Server {
+@@ -1851,13 +1885,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -1747,7 +1782,7 @@ index e71bc0315f9e4559e2df6a83a3c11f1024d17de9..586bfdc39840170b6bb43ef99a1e1f72
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1917,6 +1963,12 @@ public final class CraftServer implements Server {
+@@ -1917,6 +1966,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -1760,7 +1795,7 @@ index e71bc0315f9e4559e2df6a83a3c11f1024d17de9..586bfdc39840170b6bb43ef99a1e1f72
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2358,5 +2410,15 @@ public final class CraftServer implements Server {
+@@ -2358,5 +2413,15 @@ public final class CraftServer implements Server {
              return null;
          }
      }
@@ -3535,3 +3570,78 @@ index 838d5b877c01be3ef353f434d98e27b46c0a3fb4..5c4c0ba05f10d2d83b22d3e86805cfa8
          HashSet<Player> reference = new HashSet<Player>(players.size());
          for (ServerPlayer player : players) {
              reference.add(player.getBukkitEntity());
+diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
+index 43aa6b0129892b8ab8ec25c16a131541c6607487..0e9fb1c8323e87118d58e5eb8437db8b7f8221cb 100644
+--- a/src/main/java/org/spigotmc/SpigotConfig.java
++++ b/src/main/java/org/spigotmc/SpigotConfig.java
+@@ -192,34 +192,58 @@ public class SpigotConfig
+         SpigotConfig.sendNamespaced = SpigotConfig.getBoolean( "commands.send-namespaced", true );
+     }
+ 
+-    public static String whitelistMessage;
+-    public static String unknownCommandMessage;
+-    public static String serverFullMessage;
+-    public static String outdatedClientMessage = "Outdated client! Please use {0}";
+-    public static String outdatedServerMessage = "Outdated server! I\'m still on {0}";
+-    private static String transform(String s)
++    // Paper start - Adventure
++    public static net.kyori.adventure.text.Component whitelistMessage;
++    public static net.kyori.adventure.text.Component unknownCommandMessage;
++    public static net.kyori.adventure.text.Component serverFullMessage;
++    public static net.kyori.adventure.text.Component outdatedClientMessage;
++    public static net.kyori.adventure.text.Component outdatedServerMessage;
++    private static net.kyori.adventure.text.Component transform(String s)
++    // Paper end
+     {
+-        return ChatColor.translateAlternateColorCodes( '&', s ).replaceAll( "\\\\n", "\n" );
++        return net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(s); // Paper - Migrate Spigot config to use MiniMessage
+     }
+     private static void messages()
+     {
+         if (SpigotConfig.version < 8)
+         {
+-            SpigotConfig.set( "messages.outdated-client", SpigotConfig.outdatedClientMessage );
+-            SpigotConfig.set( "messages.outdated-server", SpigotConfig.outdatedServerMessage );
++            // Paper start - Migrate Spigot config to use MiniMessage
++            SpigotConfig.set( "messages.outdated-client", "Outdated client! Please use <version>" );
++            SpigotConfig.set( "messages.outdated-server", "Outdated server! I'm still on <version>" );
++            // Paper end
+         }
+ 
+         SpigotConfig.whitelistMessage = SpigotConfig.transform( SpigotConfig.getString( "messages.whitelist", "You are not whitelisted on this server!" ) );
+         SpigotConfig.unknownCommandMessage = SpigotConfig.transform( SpigotConfig.getString( "messages.unknown-command", "Unknown command. Type \"/help\" for help." ) );
+         SpigotConfig.serverFullMessage = SpigotConfig.transform( SpigotConfig.getString( "messages.server-full", "The server is full!" ) );
+-        SpigotConfig.outdatedClientMessage = SpigotConfig.transform( SpigotConfig.getString( "messages.outdated-client", SpigotConfig.outdatedClientMessage ) );
+-        SpigotConfig.outdatedServerMessage = SpigotConfig.transform( SpigotConfig.getString( "messages.outdated-server", SpigotConfig.outdatedServerMessage ) );
++        // Paper start - Migrate Spigot config to use MiniMessage
++        SpigotConfig.outdatedClientMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(
++            SpigotConfig.getString(
++                "messages.outdated-client",
++                "Outdated client! Please use <version>"
++            ),
++            net.kyori.adventure.text.minimessage.tag.resolver.Placeholder.unparsed(
++                "version",
++                net.minecraft.SharedConstants.getCurrentVersion().getName()
++            )
++        );
++        SpigotConfig.outdatedServerMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(
++            SpigotConfig.getString(
++                "messages.outdated-server",
++                "Outdated server! I'm still on <version>"
++            ),
++            net.kyori.adventure.text.minimessage.tag.resolver.Placeholder.unparsed(
++                "version",
++                net.minecraft.SharedConstants.getCurrentVersion().getName()
++            )
++        );
++        // Paper end
+     }
+ 
+     public static int timeoutTime = 60;
+     public static boolean restartOnCrash = true;
+     public static String restartScript = "./start.sh";
+-    public static String restartMessage;
++    public static net.kyori.adventure.text.Component restartMessage; // Paper - Migrate Spigot config to use MiniMessage
+     private static void watchdog()
+     {
+         SpigotConfig.timeoutTime = SpigotConfig.getInt( "settings.timeout-time", SpigotConfig.timeoutTime );

--- a/patches/server/0012-Timings-v2.patch
+++ b/patches/server/0012-Timings-v2.patch
@@ -669,7 +669,7 @@ index 0000000000000000000000000000000000000000..0fda52841b5e1643efeda92106124998
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 64511d966043ca5a3c2b8588ef387ea37bf2de93..a0f55d6e1096af6f59e7e7ffdc27cdd29cbac9a6 100644
+index 1d3f07e3fb778facec2ea70c88b923678934b624..84c5791dff402d3e55ea61240f5fc3404732c804 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -14,12 +14,15 @@ import java.util.concurrent.TimeUnit;
@@ -1375,7 +1375,7 @@ index 082d2fe274a91a76bbef5597eec61d7368cbd06e..9b47d8ab57c3b290173247ba25ad7668
          // this.server.getCommands().performCommand(this.player.createCommandSourceStack(), s);
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index be9a29f01d59584a1492d925248f0947610ce9d0..bfec1beb0af39e2af6be7c6423bf1eaab32e1062 100644
+index 7c4b2d0e086ad1ab9b572623e2414ec48996d513..fd971f3d8c6bf06625c32040ed7d2e35c6813ce8 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1,5 +1,6 @@
@@ -1700,10 +1700,10 @@ index 95abf42577725383a2b49242c28b81beef487ee5..4e5cfc508e356691a9a249013553f97e
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 586bfdc39840170b6bb43ef99a1e1f72ec84b062..fe5454f9e2507824c78cab3e31428608bf229ce1 100644
+index 443afccde5a200ae15bfcccc4d4517b16ff01d7f..8f96a50261160f33f6779b2c15c8ed1dddc7e51b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2349,12 +2349,31 @@ public final class CraftServer implements Server {
+@@ -2352,12 +2352,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  

--- a/patches/server/0026-Further-improve-server-tick-loop.patch
+++ b/patches/server/0026-Further-improve-server-tick-loop.patch
@@ -144,10 +144,10 @@ index 8bacbb2289a9e5203766d71be6ba0a31f48b626e..18f03367174651b93682d5e5f4350d8c
                      this.startMetricsRecordingTick();
                      this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bb304601b3795349dd45d94c53f082a3bcc17273..3636921da74f5271a15d79d431c8a33a2c83cd96 100644
+index 3314a5700293101968620066d0b22fe2bd7bbad6..14223c34d328a13d9121d22778049139d3278a6a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2379,6 +2379,17 @@ public final class CraftServer implements Server {
+@@ -2382,6 +2382,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0050-Expose-server-CommandMap.patch
+++ b/patches/server/0050-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ee053cc0fd2fedd1d8c2212bac1b81ea3e140884..3fa2d14c67c211a7e145b02b84db84706e971761 100644
+index dbf88deaf314e4d020aee98b1ba9649690105ae7..822452e2ddc76d2d31c7ab39e4f0a2a4b01bd73c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1969,6 +1969,7 @@ public final class CraftServer implements Server {
+@@ -1972,6 +1972,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0064-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0064-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b89ca165b7103b8a0d6a8e49e62657c70329890a..17fe7e47d9e11ca7c82bde34dc478c590328fb00 100644
+index e233973e156d4163182e4cd0fc3a9f58295c96c3..ed76e280b0bd9529ad54c0e45f30e9977a4f870b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2509,5 +2509,23 @@ public final class CraftServer implements Server {
+@@ -2512,5 +2512,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0104-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0104-Add-setting-for-proxy-online-mode-status.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add setting for proxy online mode status
 TODO: Add isProxyOnlineMode check to Metrics
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a037c09a7616874d26b2a8eda9ebc795b8266431..2ec11634242ada8cbcf3bc2a15a56e59d219039a 100644
+index ffb2dc77d195e01dba18c5ae8e2d836486142435..48bed0daab673eddecb0c5ea7eec221c3989de4c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -23,6 +23,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
@@ -67,10 +67,10 @@ index b7b98832be6178a2bca534bf974519ede977b282..aa3caccc58f1cec8d5f396813d7fc40b
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ad851aa3a29b6aabfcfe7f95df15303437c48eaa..2b6df52d586acf28aaf531c39073cf9448c589f9 100644
+index c134a483dff7ad70180ef8b1884d2929fca5a5e3..e699ac80a4b841007052b1f095ab5e3d06acf88d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1697,7 +1697,7 @@ public final class CraftServer implements Server {
+@@ -1700,7 +1700,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0107-Configurable-flying-kick-messages.patch
+++ b/patches/server/0107-Configurable-flying-kick-messages.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable flying kick messages
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 06894c03b1d584c533355b3c4174b7fb05d67bc2..7612ee9bb6877dea0ff83d03f393180048ff960c 100644
+index 377f5ec8666072d87ca36a08ff21bbf0e33d4db6..bcb3282b9c7350a317dcf2e4239bf4f1c16c24a8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -273,4 +273,11 @@ public class PaperConfig {
@@ -13,11 +13,11 @@ index 06894c03b1d584c533355b3c4174b7fb05d67bc2..7612ee9bb6877dea0ff83d03f3931800
          packetInSpamThreshold = getInt("settings.incoming-packet-spam-threshold", 300);
      }
 +
-+    public static String flyingKickPlayerMessage = "Flying is not enabled on this server";
-+    public static String flyingKickVehicleMessage = "Flying is not enabled on this server";
++    public static net.kyori.adventure.text.Component flyingKickPlayerMessage;
++    public static net.kyori.adventure.text.Component flyingKickVehicleMessage;
 +    private static void flyingKickMessages() {
-+        flyingKickPlayerMessage = getString("messages.kick.flying-player", flyingKickPlayerMessage);
-+        flyingKickVehicleMessage = getString("messages.kick.flying-vehicle", flyingKickVehicleMessage);
++        flyingKickPlayerMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(getString("messages.kick.flying-player", "Flying is not enabled on this server"));
++        flyingKickVehicleMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(getString("messages.kick.flying-vehicle", "Flying is not enabled on this server"));
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java

--- a/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 630ff9daa7bbe55e0e52f6127c496fdd10876c6e..5ce9ce7169e346d0156559295ee1bae5c8d45870 100644
+index e699ac80a4b841007052b1f095ab5e3d06acf88d..0f0a8a2df088fe70ae5489e6180bea7b8c9a6d1a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2535,5 +2535,24 @@ public final class CraftServer implements Server {
+@@ -2538,5 +2538,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0137-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0137-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,12 +6,12 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 785660014a4a489decdf5e9febd3f6e4f82735fa..90b1803c111b26f299953eec15745bc4f180d4bd 100644
+index bcb3282b9c7350a317dcf2e4239bf4f1c16c24a8..c427ae941e86b116efa659502f46b6640c3a2883 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -280,4 +280,9 @@ public class PaperConfig {
-         flyingKickPlayerMessage = getString("messages.kick.flying-player", flyingKickPlayerMessage);
-         flyingKickVehicleMessage = getString("messages.kick.flying-vehicle", flyingKickVehicleMessage);
+         flyingKickPlayerMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(getString("messages.kick.flying-player", "Flying is not enabled on this server"));
+         flyingKickVehicleMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(getString("messages.kick.flying-vehicle", "Flying is not enabled on this server"));
      }
 +
 +    public static boolean suggestPlayersWhenNullTabCompletions = true;
@@ -20,10 +20,10 @@ index 785660014a4a489decdf5e9febd3f6e4f82735fa..90b1803c111b26f299953eec15745bc4
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5ce9ce7169e346d0156559295ee1bae5c8d45870..57999f25a820cc9b395f6c3037e0fcce9bc4a80c 100644
+index 0f0a8a2df088fe70ae5489e6180bea7b8c9a6d1a..512d8a0c413ccddaf95dd7521367e57885706201 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2554,5 +2554,10 @@ public final class CraftServer implements Server {
+@@ -2557,5 +2557,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0143-Add-UnknownCommandEvent.patch
+++ b/patches/server/0143-Add-UnknownCommandEvent.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 89d9ac790b28fedc7d30b54f30cc6235f9b12a64..40d9766bbf53f858a3debd83319152cbd11ef7ed 100644
+index e0e82a2c2b126e12deb74fb522597d2f5332d136..bd6a871662be3c891e244cada9c3b90020fa7d34 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -885,7 +885,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
-         if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {
+         if (!org.spigotmc.SpigotConfig.unknownCommandMessage.equals(net.kyori.adventure.text.Component.empty())) { // Paper - Adventure
 -            sender.sendMessage(org.spigotmc.SpigotConfig.unknownCommandMessage);
 +            // Paper start
 +            org.bukkit.event.command.UnknownCommandEvent event = new org.bukkit.event.command.UnknownCommandEvent(sender, commandLine, org.spigotmc.SpigotConfig.unknownCommandMessage);

--- a/patches/server/0144-Basic-PlayerProfile-API.patch
+++ b/patches/server/0144-Basic-PlayerProfile-API.patch
@@ -617,7 +617,7 @@ index c3e3a9950ee05dc97f15ab128e40854901f38a2f..95974d78196397136179f8d6acf1597c
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 179ba5ae2406d8babfdec386fc8125960043d586..24f361820f195e948f617cd134352e098b298b5d 100644
+index bd6a871662be3c891e244cada9c3b90020fa7d34..0cfa9f021fe006e2ac16f24fa9bf3ea39eda2a53 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -243,6 +243,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -638,7 +638,7 @@ index 179ba5ae2406d8babfdec386fc8125960043d586..24f361820f195e948f617cd134352e09
          CraftItemFactory.instance();
      }
  
-@@ -2568,5 +2572,24 @@ public final class CraftServer implements Server {
+@@ -2571,5 +2575,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }

--- a/patches/server/0147-Block-player-logins-during-server-shutdown.patch
+++ b/patches/server/0147-Block-player-logins-during-server-shutdown.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Block player logins during server shutdown
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 58ef6874cd6c90e6ccc7c39881cc3bf68fba284b..03dc5ae09c46ad7be8e444211728a8418f594733 100644
+index 58ef6874cd6c90e6ccc7c39881cc3bf68fba284b..2704e78ba1cd7e48517295df1d4593b6cfbe1f95 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -68,6 +68,12 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
@@ -14,7 +14,7 @@ index 58ef6874cd6c90e6ccc7c39881cc3bf68fba284b..03dc5ae09c46ad7be8e444211728a841
      public void tick() {
 +        // Paper start - Do not allow logins while the server is shutting down
 +        if (!MinecraftServer.getServer().isRunning()) {
-+            this.disconnect(org.bukkit.craftbukkit.util.CraftChatMessage.fromString(org.spigotmc.SpigotConfig.restartMessage)[0]);
++            this.disconnect((Component) org.spigotmc.SpigotConfig.restartMessage);
 +            return;
 +        }
 +        // Paper end

--- a/patches/server/0152-ProfileWhitelistVerifyEvent.patch
+++ b/patches/server/0152-ProfileWhitelistVerifyEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ProfileWhitelistVerifyEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 03fc0bca0c1a11db43d315236ca05dfea137ddb3..a1ca0c0c08f6793ce3440733f802a40f99890d85 100644
+index bbaf110624a063565ff86853836ecaa5e5d9cf01..54579073ee9fcd15ff046a05dff6654a44c177d5 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -615,9 +615,9 @@ public abstract class PlayerList {
@@ -14,7 +14,7 @@ index 03fc0bca0c1a11db43d315236ca05dfea137ddb3..a1ca0c0c08f6793ce3440733f802a40f
              event.disallow(PlayerLoginEvent.Result.KICK_BANNED, PaperAdventure.asAdventure(chatmessage)); // Paper - Adventure
 -        } else if (!this.isWhiteListed(gameprofile)) {
 -            chatmessage = new TranslatableComponent("multiplayer.disconnect.not_whitelisted");
--            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, PaperAdventure.LEGACY_SECTION_UXRC.deserialize(org.spigotmc.SpigotConfig.whitelistMessage)); // Spigot // Paper - Adventure
+-            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, org.spigotmc.SpigotConfig.whitelistMessage); // Spigot // Paper - Adventure
 +        } else if (!this.isWhitelisted(gameprofile, event)) { // Paper
 +            //chatmessage = new ChatMessage("multiplayer.disconnect.not_whitelisted"); // Paper
 +            //event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, org.spigotmc.SpigotConfig.whitelistMessage); // Spigot // Paper - moved to isWhitelisted
@@ -38,7 +38,7 @@ index 03fc0bca0c1a11db43d315236ca05dfea137ddb3..a1ca0c0c08f6793ce3440733f802a40f
 +        event.callEvent();
 +        if (!event.isWhitelisted()) {
 +            if (loginEvent != null) {
-+                loginEvent.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, PaperAdventure.LEGACY_SECTION_UXRC.deserialize(event.getKickMessage() == null ? org.spigotmc.SpigotConfig.whitelistMessage : event.getKickMessage()));
++                loginEvent.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, event.kickMessage() == null ? org.spigotmc.SpigotConfig.whitelistMessage : event.kickMessage());
 +            }
 +            return false;
 +        }

--- a/patches/server/0157-Allow-specifying-a-custom-authentication-servers-dow.patch
+++ b/patches/server/0157-Allow-specifying-a-custom-authentication-servers-dow.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow specifying a custom "authentication servers down" kick
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 352cec8559923189dcea5c97066ef2f90cc4023b..71288ac78dc0adb4fdb692d3f69debbff84ffa74 100644
+index c427ae941e86b116efa659502f46b6640c3a2883..5223527239a1121aaf9c026d9673192088a91c14 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -16,28 +16,32 @@ index 352cec8559923189dcea5c97066ef2f90cc4023b..71288ac78dc0adb4fdb692d3f69debbf
  import com.google.common.base.Throwables;
  
  import java.io.File;
-@@ -285,4 +286,9 @@ public class PaperConfig {
+@@ -285,4 +286,15 @@ public class PaperConfig {
      private static void suggestPlayersWhenNull() {
          suggestPlayersWhenNullTabCompletions = getBoolean("settings.suggest-player-names-when-null-tab-completions", suggestPlayersWhenNullTabCompletions);
      }
 +
-+    public static String authenticationServersDownKickMessage = ""; // empty = use translatable message
++    public static net.kyori.adventure.text.Component authenticationServersDownKickMessage;
 +    private static void authenticationServersDownKickMessage() {
-+        authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
++        String message = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", ""));
++
++        if (message == null) {
++            authenticationServersDownKickMessage = net.kyori.adventure.text.Component.translatable("multiplayer.disconnect.authservers_down");
++        } else {
++            authenticationServersDownKickMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message);
++        }
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 03dc5ae09c46ad7be8e444211728a8418f594733..6834c67b38f0679497bef4b2174817d9688cbbd8 100644
+index 2704e78ba1cd7e48517295df1d4593b6cfbe1f95..43975356d8d243c5ae873f10440146781c9a77e5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -304,6 +304,10 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+@@ -304,7 +304,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
                          ServerLoginPacketListenerImpl.this.gameProfile = ServerLoginPacketListenerImpl.this.createFakeProfile(gameprofile);
                          ServerLoginPacketListenerImpl.this.state = ServerLoginPacketListenerImpl.State.READY_TO_ACCEPT;
                      } else {
-+                            // Paper start
-+                            if (com.destroystokyo.paper.PaperConfig.authenticationServersDownKickMessage != null) {
-+                                ServerLoginPacketListenerImpl.this.disconnect(new TextComponent(com.destroystokyo.paper.PaperConfig.authenticationServersDownKickMessage));
-+                            } else // Paper end
-                         ServerLoginPacketListenerImpl.this.disconnect(new TranslatableComponent("multiplayer.disconnect.authservers_down"));
+-                        ServerLoginPacketListenerImpl.this.disconnect(new TranslatableComponent("multiplayer.disconnect.authservers_down"));
++                        ServerLoginPacketListenerImpl.this.disconnect((Component) com.destroystokyo.paper.PaperConfig.authenticationServersDownKickMessage); // Paper - Allow specifying a custom "authentication servers down" kick message
                          ServerLoginPacketListenerImpl.LOGGER.error("Couldn't verify username because servers are unavailable");
                      }
+                     // CraftBukkit start - catch all exceptions

--- a/patches/server/0158-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/patches/server/0158-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -15,7 +15,7 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index e7eca424ffa81f60a08a2ab655e085bd3e49983c..541357dff44a3ce86b6adf807c0e43df11b012ef 100644
+index 6c86bb7ff8c7bfcfc29fe79ea8c6f79656a3d7ae..5b009dc1b35e551ed78baf86b49d6470c4598a12 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -21,7 +21,7 @@ dependencies {
@@ -28,10 +28,10 @@ index e7eca424ffa81f60a08a2ab655e085bd3e49983c..541357dff44a3ce86b6adf807c0e43df
      implementation("org.apache.logging.log4j:log4j-iostreams:2.17.1") // Paper
      implementation("org.ow2.asm:asm:9.2")
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index 9d3d65de7cb0be25aa7fc40353390280943b55f4..cd5add5a38919dfcf7510758b2d3e2f7c40c18fd 100644
+index 607e8ed48289d42d7fe38286c8321820b30de8aa..e94e3b44a9e346ee9e671499920c15c66b7f9631 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
-@@ -290,7 +290,7 @@ public class SpigotConfig
+@@ -314,7 +314,7 @@ public class SpigotConfig
      private static void playerSample()
      {
          SpigotConfig.playerSample = SpigotConfig.getInt( "settings.sample-count", 12 );

--- a/patches/server/0170-AsyncTabCompleteEvent.patch
+++ b/patches/server/0170-AsyncTabCompleteEvent.patch
@@ -72,10 +72,10 @@ index 44e4cd2a3039be132ca5f03759801456b3290f72..4c89828089ddb8fbee78643df7d3b82d
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a380f59ea01cec492f2d2bef6bb6509a07998d07..f57050098a49757927fbb4609b7f97c19f5747d1 100644
+index 0cfa9f021fe006e2ac16f24fa9bf3ea39eda2a53..8e8c8cd44ffc03ef9c6465e20881162c0deb808b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2072,7 +2072,7 @@ public final class CraftServer implements Server {
+@@ -2075,7 +2075,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0183-Implement-extended-PaperServerListPingEvent.patch
+++ b/patches/server/0183-Implement-extended-PaperServerListPingEvent.patch
@@ -236,10 +236,10 @@ index 2b24a41587fbe1fba70a0ab42d3dc33358f2ba2e..4fa79d37ff4e70c61672cce7c55257c4
      }
  
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index cd5add5a38919dfcf7510758b2d3e2f7c40c18fd..b53e6955f35e1308814cdb31a5fa5f4d0c49493c 100644
+index e94e3b44a9e346ee9e671499920c15c66b7f9631..9016a6b71a1a7bf5502984f5bdb58a0417f4d5fc 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
-@@ -289,7 +289,7 @@ public class SpigotConfig
+@@ -313,7 +313,7 @@ public class SpigotConfig
      public static int playerSample;
      private static void playerSample()
      {

--- a/patches/server/0184-Ability-to-change-PlayerProfile-in-AsyncPreLoginEven.patch
+++ b/patches/server/0184-Ability-to-change-PlayerProfile-in-AsyncPreLoginEven.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ability to change PlayerProfile in AsyncPreLoginEvent
 This will allow you to change the players name or skin on login.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 73efc3084b04914f7f06875651269fd584b60989..d3462cdc5eee37cedbff80f35d5b9c51e8dcd1da 100644
+index f5d5628e26d09dc1ec770df53bbfc508fd83df07..9aa191c26277adb9f8face10c1d2c1bb329f1f74 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -343,8 +343,16 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+@@ -339,8 +339,16 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
                          java.util.UUID uniqueId = ServerLoginPacketListenerImpl.this.gameProfile.getId();
                          final org.bukkit.craftbukkit.CraftServer server = ServerLoginPacketListenerImpl.this.server.server;
  

--- a/patches/server/0185-Player.setPlayerProfile-API.patch
+++ b/patches/server/0185-Player.setPlayerProfile-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index d3462cdc5eee37cedbff80f35d5b9c51e8dcd1da..5ebc450432805d52457b9f8ff1e2b1981bdd78e6 100644
+index 9aa191c26277adb9f8face10c1d2c1bb329f1f74..47bf2d0978a95e164cd669bf1e6296ae94e82d93 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -344,11 +344,11 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+@@ -340,11 +340,11 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
                          final org.bukkit.craftbukkit.CraftServer server = ServerLoginPacketListenerImpl.this.server.server;
  
                          // Paper start

--- a/patches/server/0186-getPlayerUniqueId-API.patch
+++ b/patches/server/0186-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f57050098a49757927fbb4609b7f97c19f5747d1..23e33857b5cc888f4cbac273939fad81e3081103 100644
+index 8e8c8cd44ffc03ef9c6465e20881162c0deb808b..73c22e7a2927873664c001f085deb1d9ab984dd1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1699,6 +1699,25 @@ public final class CraftServer implements Server {
+@@ -1702,6 +1702,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0188-Upstream-config-migrations.patch
+++ b/patches/server/0188-Upstream-config-migrations.patch
@@ -7,12 +7,12 @@ This patch contains config migrations for when upstream adds options
 which Paper already had.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 71288ac78dc0adb4fdb692d3f69debbff84ffa74..61d6c4ed39fb7d3ebdeafd8f84fa2f40f3714201 100644
+index 5223527239a1121aaf9c026d9673192088a91c14..bec93044b8786af70c8336afefc45009d1a531c4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -291,4 +291,23 @@ public class PaperConfig {
-     private static void authenticationServersDownKickMessage() {
-         authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
+@@ -297,4 +297,23 @@ public class PaperConfig {
+             authenticationServersDownKickMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message);
+         }
      }
 +
 +    private static void savePlayerData() {

--- a/patches/server/0209-Configurable-Alternative-LootPool-Luck-Formula.patch
+++ b/patches/server/0209-Configurable-Alternative-LootPool-Luck-Formula.patch
@@ -36,10 +36,10 @@ This change will result in some major changes to fishing formulas.
 I would love to see this change in Vanilla, so Mojang please pull :)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 61d6c4ed39fb7d3ebdeafd8f84fa2f40f3714201..e933d54c309da046554029d1f232daa31659e537 100644
+index bec93044b8786af70c8336afefc45009d1a531c4..c0e7bd6cf4f0c69855e0d6867866a12097337122 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -310,4 +310,12 @@ public class PaperConfig {
+@@ -316,4 +316,12 @@ public class PaperConfig {
              SpigotConfig.save();
          }
      }

--- a/patches/server/0240-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/patches/server/0240-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -22,10 +22,10 @@ to take the burden of this into their own hand without having to rely on
 plugins doing unsafe things.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e933d54c309da046554029d1f232daa31659e537..9dba4eb0e9c4e4d974edaeaf41c370d3996dd94e 100644
+index c0e7bd6cf4f0c69855e0d6867866a12097337122..c68727393cf7a59f24eeadc26b2d88bcc95a0f8e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -318,4 +318,18 @@ public class PaperConfig {
+@@ -324,4 +324,18 @@ public class PaperConfig {
              Bukkit.getLogger().log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
          }
      }

--- a/patches/server/0244-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0244-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -9,7 +9,7 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 9dba4eb0e9c4e4d974edaeaf41c370d3996dd94e..62671d6c04f973594a6ca95446774c4b5a78a575 100644
+index c68727393cf7a59f24eeadc26b2d88bcc95a0f8e..b536dfebf5d55d7197f626e6bbbb2d333a8af6c5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -25,6 +25,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
@@ -20,7 +20,7 @@ index 9dba4eb0e9c4e4d974edaeaf41c370d3996dd94e..62671d6c04f973594a6ca95446774c4b
  
  public class PaperConfig {
  
-@@ -319,6 +320,14 @@ public class PaperConfig {
+@@ -325,6 +326,14 @@ public class PaperConfig {
          }
      }
  
@@ -48,7 +48,7 @@ index 61edb76381a83f36d0ade1c35e9999eaad58abd2..432f1d6e5989f861e762a8b919a0048b
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 104162d1641499af3559e51fe9ad32b91785416a..8d429d2ebe63a429912bafe20eb24688aae939a1 100644
+index 73c22e7a2927873664c001f085deb1d9ab984dd1..3db7605ce6605709fcc07bd9511da80d1e815f1a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -904,6 +904,7 @@ public final class CraftServer implements Server {
@@ -68,10 +68,10 @@ index 104162d1641499af3559e51fe9ad32b91785416a..8d429d2ebe63a429912bafe20eb24688
  
      @Override
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index b53e6955f35e1308814cdb31a5fa5f4d0c49493c..6f7b34f03e0d151e4da652b9ad73e0d7930fe5d3 100644
+index 9016a6b71a1a7bf5502984f5bdb58a0417f4d5fc..8ef09a81543d3b4fc5e766d4f9c30af25b083942 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
-@@ -229,7 +229,7 @@ public class SpigotConfig
+@@ -253,7 +253,7 @@ public class SpigotConfig
          SpigotConfig.restartScript = SpigotConfig.getString( "settings.restart-script", SpigotConfig.restartScript );
          SpigotConfig.restartMessage = SpigotConfig.transform( SpigotConfig.getString( "messages.restart", "Server is restarting" ) );
          SpigotConfig.commands.put( "restart", new RestartCommand( "restart" ) );

--- a/patches/server/0258-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0258-Asynchronous-chunk-IO-and-loading.patch
@@ -161,7 +161,7 @@ index 0fda52841b5e1643efeda92106124998abc4e0aa..fe79c0add4f7cb18d487c5bb9415c40c
  
      public static Timing getTickList(ServerLevel worldserver, String timingsType) {
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 62671d6c04f973594a6ca95446774c4b5a78a575..7682300eec0d097798c1bd68de519513c438fd17 100644
+index b536dfebf5d55d7197f626e6bbbb2d333a8af6c5..3dd3ebd3e0ad52eb12d263fe5d04d3fddb5516a3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -171,7 +171,7 @@ index 62671d6c04f973594a6ca95446774c4b5a78a575..7682300eec0d097798c1bd68de519513
  import com.google.common.base.Strings;
  import com.google.common.base.Throwables;
  
-@@ -341,4 +342,58 @@ public class PaperConfig {
+@@ -347,4 +348,58 @@ public class PaperConfig {
          }
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }

--- a/patches/server/0271-Configurable-connection-throttle-kick-message.patch
+++ b/patches/server/0271-Configurable-connection-throttle-kick-message.patch
@@ -5,23 +5,23 @@ Subject: [PATCH] Configurable connection throttle kick message
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 7682300eec0d097798c1bd68de519513c438fd17..83875260a131102612e700e7d620cc79a7452c5b 100644
+index 3dd3ebd3e0ad52eb12d263fe5d04d3fddb5516a3..9beee94f87925e99ffd50a07471e9d0d6096a1f4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -294,6 +294,11 @@ public class PaperConfig {
-         authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
+@@ -300,6 +300,11 @@ public class PaperConfig {
+         }
      }
  
-+    public static String connectionThrottleKickMessage = "Connection throttled! Please wait before reconnecting.";
++    public static net.kyori.adventure.text.Component connectionThrottleKickMessage;
 +    private static void connectionThrottleKickMessage() {
-+        connectionThrottleKickMessage = getString("messages.kick.connection-throttle", connectionThrottleKickMessage);
++        connectionThrottleKickMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(getString("messages.kick.connection-throttle", "Connection throttled! Please wait before reconnecting."));
 +    }
 +
      private static void savePlayerData() {
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index 85fea9b0bf84a8b40098f35eac503070914c98d8..687308a414095f95b567a2993b679d8b62856578 100644
+index 57cddbfcb2e51d1f89486795562ee7235281fa80..db1d8be076eb70d8005f7fa7a33d036246c07d5a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 @@ -50,7 +50,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
@@ -29,7 +29,7 @@ index 85fea9b0bf84a8b40098f35eac503070914c98d8..687308a414095f95b567a2993b679d8b
                          if (ServerHandshakePacketListenerImpl.throttleTracker.containsKey(address) && !"127.0.0.1".equals(address.getHostAddress()) && currentTime - ServerHandshakePacketListenerImpl.throttleTracker.get(address) < connectionThrottle) {
                              ServerHandshakePacketListenerImpl.throttleTracker.put(address, currentTime);
 -                            TranslatableComponent chatmessage = new TranslatableComponent("Connection throttled! Please wait before reconnecting.");
-+                            TranslatableComponent chatmessage = new TranslatableComponent(com.destroystokyo.paper.PaperConfig.connectionThrottleKickMessage); // Paper - Configurable connection throttle kick message
++                            Component chatmessage = (Component) com.destroystokyo.paper.PaperConfig.connectionThrottleKickMessage; // Paper - Configurable connection throttle kick message
                              this.connection.send(new ClientboundLoginDisconnectPacket(chatmessage));
                              this.connection.disconnect(chatmessage);
                              return;

--- a/patches/server/0279-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0279-Add-Velocity-IP-Forwarding-Support.patch
@@ -14,7 +14,7 @@ forwarding, and is integrated into the Minecraft login process by using the 1.13
 login plugin message packet.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 83875260a131102612e700e7d620cc79a7452c5b..c63b7b01094abaf41bc58c123d6ddeb68bc32195 100644
+index 9beee94f87925e99ffd50a07471e9d0d6096a1f4..78ff5528d8b000f57bb6503ef685c86f83dbec8e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -9,6 +9,7 @@ import java.io.IOException;
@@ -34,7 +34,7 @@ index 83875260a131102612e700e7d620cc79a7452c5b..c63b7b01094abaf41bc58c123d6ddeb6
      }
  
      public static int packetInSpamThreshold = 300;
-@@ -348,6 +349,20 @@ public class PaperConfig {
+@@ -354,6 +355,20 @@ public class PaperConfig {
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
  
@@ -128,7 +128,7 @@ index 0000000000000000000000000000000000000000..41d73aa91fb401612e087aa1b7278ba6
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 5ebc450432805d52457b9f8ff1e2b1981bdd78e6..4c06e62e967f28eb844d74237948834e61daeab0 100644
+index 47bf2d0978a95e164cd669bf1e6296ae94e82d93..9916e3623b1f2c19d7b237904b9432472b7291a1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -17,6 +17,7 @@ import javax.crypto.Cipher;
@@ -170,7 +170,7 @@ index 5ebc450432805d52457b9f8ff1e2b1981bdd78e6..4c06e62e967f28eb844d74237948834e
              // Spigot start
              // Paper start - Cache authenticator threads
              authenticatorPool.execute(new Runnable() {
-@@ -338,6 +349,12 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+@@ -334,6 +345,12 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
      public class LoginHandler {
  
          public void fireEvents() throws Exception {
@@ -183,7 +183,7 @@ index 5ebc450432805d52457b9f8ff1e2b1981bdd78e6..4c06e62e967f28eb844d74237948834e
                          String playerName = ServerLoginPacketListenerImpl.this.gameProfile.getName();
                          java.net.InetAddress address = ((java.net.InetSocketAddress) ServerLoginPacketListenerImpl.this.connection.getRemoteAddress()).getAddress();
                          java.util.UUID uniqueId = ServerLoginPacketListenerImpl.this.gameProfile.getId();
-@@ -385,6 +402,40 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+@@ -381,6 +398,40 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
      // Spigot end
  
      public void handleCustomQueryPacket(ServerboundCustomQueryPacket packet) {
@@ -225,7 +225,7 @@ index 5ebc450432805d52457b9f8ff1e2b1981bdd78e6..4c06e62e967f28eb844d74237948834e
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 53650ba59f05d8c7549a71d89c3734e02c6a7fea..532185882420c04c1a996a7d269af554ee106ed1 100644
+index 3db7605ce6605709fcc07bd9511da80d1e815f1a..c46e8130a4a487fffb215c0256ee748b6de8dca0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -759,7 +759,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0291-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0291-Make-the-default-permission-message-configurable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 1fa190e098079522e0fe3593fa261c1b7ad4e24b..1eb45df9dca5d0c31ac46709e706136a246cb8ea 100644
+index 1fa190e098079522e0fe3593fa261c1b7ad4e24b..a71fda98f21db51a296840c3af9cc52a4063a250 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -52,7 +52,7 @@ public class PaperCommand extends Command {
@@ -13,12 +13,12 @@ index 1fa190e098079522e0fe3593fa261c1b7ad4e24b..1eb45df9dca5d0c31ac46709e706136a
      private static boolean testPermission(CommandSender commandSender, String permission) {
          if (commandSender.hasPermission(BASE_PERM + permission) || commandSender.hasPermission("bukkit.command.paper")) return true;
 -        commandSender.sendMessage(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."); // Sorry, kashike
-+        commandSender.sendMessage(Bukkit.getPermissionMessage()); // Sorry, kashike
++        commandSender.sendMessage(Bukkit.permissionMessage()); // Sorry, kashike
          return false;
      }
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index d728c42ba986c5c354a205b1eb4c4d93b0b2d128..f938bd401c384d8e03c8ff90af08efc70629c77e 100644
+index 78ff5528d8b000f57bb6503ef685c86f83dbec8e..abdf42e804ac92bbbbadf0b10659466b747c7161 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -20,6 +20,7 @@ import java.util.regex.Pattern;
@@ -29,28 +29,33 @@ index d728c42ba986c5c354a205b1eb4c4d93b0b2d128..f938bd401c384d8e03c8ff90af08efc7
  import org.bukkit.command.Command;
  import org.bukkit.configuration.ConfigurationSection;
  import org.bukkit.configuration.InvalidConfigurationException;
-@@ -300,6 +301,11 @@ public class PaperConfig {
-         connectionThrottleKickMessage = getString("messages.kick.connection-throttle", connectionThrottleKickMessage);
+@@ -306,6 +307,11 @@ public class PaperConfig {
+         connectionThrottleKickMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(getString("messages.kick.connection-throttle", "Connection throttled! Please wait before reconnecting."));
      }
  
-+    public static String noPermissionMessage = "&cI'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.";
++    public static net.kyori.adventure.text.Component noPermissionMessage;
 +    private static void noPermissionMessage() {
-+        noPermissionMessage = ChatColor.translateAlternateColorCodes('&', getString("messages.no-permission", noPermissionMessage));
++        noPermissionMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(getString("messages.no-permission", "<red>I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."));
 +    }
 +
      private static void savePlayerData() {
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 39389c3389eb6b118b662cb77552d198b0b21c05..ba0b22c45e0bdcda7087a262a82405a9efe8cc61 100644
+index c46e8130a4a487fffb215c0256ee748b6de8dca0..b27e6b37ea9d1324271f75ce51aa7680c852a819 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2594,6 +2594,11 @@ public final class CraftServer implements Server {
+@@ -2597,6 +2597,16 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  
 +    @Override
 +    public String getPermissionMessage() {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(permissionMessage());
++    }
++
++    @Override
++    public net.kyori.adventure.text.Component permissionMessage() {
 +        return com.destroystokyo.paper.PaperConfig.noPermissionMessage;
 +    }
 +

--- a/patches/server/0296-Book-Size-Limits.patch
+++ b/patches/server/0296-Book-Size-Limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Book Size Limits
 Puts some limits on the size of books.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 0b0cdbea6693c18519212604a391e8100afbcc70..a3c3656ba4e8bb85bfb3186d6284f02f09975b13 100644
+index abdf42e804ac92bbbbadf0b10659466b747c7161..bde4bfda20bced2a8b3e64c145671e2122a76fc3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -369,6 +369,13 @@ public class PaperConfig {
+@@ -375,6 +375,13 @@ public class PaperConfig {
          }
      }
  

--- a/patches/server/0325-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0325-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -29,10 +29,10 @@ index 9be13843b17fff55cac404bd372581f7fadee4ac..6cb94b3b188a43535658dedf00b74236
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 879ad3ef7ea5fc9e047d2abfb77d2b08c5a71079..c35b22387c242d8322e58825a85b2f5289a41b9d 100644
+index b27e6b37ea9d1324271f75ce51aa7680c852a819..fcf9c48614578e9f7f4dd614d99da13a12561f64 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2061,7 +2061,7 @@ public final class CraftServer implements Server {
+@@ -2064,7 +2064,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0332-Expose-the-internal-current-tick.patch
+++ b/patches/server/0332-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 36b20b697850dff10910d7f4cd9543ba11e60568..8bf2f50e314061a2493d0ce89b9d6104994fe6b6 100644
+index fcf9c48614578e9f7f4dd614d99da13a12561f64..6bffdcdd06f55a81efe9d8d602918947942c585e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2617,5 +2617,10 @@ public final class CraftServer implements Server {
+@@ -2625,5 +2625,10 @@ public final class CraftServer implements Server {
          }
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
      }

--- a/patches/server/0361-Anti-Xray.patch
+++ b/patches/server/0361-Anti-Xray.patch
@@ -1597,10 +1597,10 @@ index f3c67a815c570beb14136905cbf5aa4046ee8394..f8f44cb6e823a0150f3abdab133f8ae2
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2cd64494b43a591c6471221bba649c7d74cfb64b..969a0fb7dba180b44cd5fe155b118ec28e0f61be 100644
+index 6bffdcdd06f55a81efe9d8d602918947942c585e..c9433dbf388b8dfebfd9deef924d7a5cb1e8f0c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2216,7 +2216,7 @@ public final class CraftServer implements Server {
+@@ -2219,7 +2219,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Validate.notNull(world, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();

--- a/patches/server/0381-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0381-Add-tick-times-API-and-mspt-command.patch
@@ -75,7 +75,7 @@ index 0000000000000000000000000000000000000000..d0211d4f39f9d6af1d751ac66342b42c
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f173e3e7d8ba8ffe1780e04dea41d8dbfe923917..483946af2d530bd5f311c0d76404a19deb69b7c2 100644
+index bde4bfda20bced2a8b3e64c145671e2122a76fc3..01979479c690d5d07125c0703f160abaef812c9e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -69,6 +69,7 @@ public class PaperConfig {
@@ -84,8 +84,8 @@ index f173e3e7d8ba8ffe1780e04dea41d8dbfe923917..483946af2d530bd5f311c0d76404a19d
          commands.put("paper", new PaperCommand("paper"));
 +        commands.put("mspt", new MSPTCommand("mspt"));
  
-         version = getInt("config-version", 25);
-         set("config-version", 25);
+         version = getInt("config-version", 26);
+         set("config-version", 26);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index e621d683df00a7d095cc72f74357224208b0dbca..1ab4e3a1d2e3a576ea5f05c2d92a1aae47b1f73e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -146,10 +146,10 @@ index e621d683df00a7d095cc72f74357224208b0dbca..1ab4e3a1d2e3a576ea5f05c2d92a1aae
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a523e50d0542e8aeca961ed57346c3d7ecf01979..d4442ba4f0fc9e062fd321dccd0f49c3d10fd28b 100644
+index c9433dbf388b8dfebfd9deef924d7a5cb1e8f0c5..4826e914334927f482dac2a4a1fe6454f9b787ac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2455,6 +2455,16 @@ public final class CraftServer implements Server {
+@@ -2458,6 +2458,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0382-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0382-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d4442ba4f0fc9e062fd321dccd0f49c3d10fd28b..6535d59e4fd04cce072de4d939b84e423b5ce52d 100644
+index 4826e914334927f482dac2a4a1fe6454f9b787ac..68e23c1955ea26c2c894cab2e1beba5049388ee7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2632,5 +2632,10 @@ public final class CraftServer implements Server {
+@@ -2640,5 +2640,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0393-Improved-Watchdog-Support.patch
+++ b/patches/server/0393-Improved-Watchdog-Support.patch
@@ -274,7 +274,7 @@ index 04596feb8667e3abbfa1c7343b46cacaf88ecce8..7e3f7b69fc7a608dd82b471d832cc401
                  list.stream().map((playerchunk) -> {
                      CompletableFuture completablefuture;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index e2991476289f04fce5aac307a95b4c6df9ede85f..903a816ec6f4d1a9c82b7e32bd2b4fc9b78f3a5c 100644
+index ab522c032c24b80c0acbdb8ae860f357e6308566..4c06d78c64275c8e7f10801800ab950843f7a15e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -512,7 +512,7 @@ public abstract class PlayerList {
@@ -323,10 +323,10 @@ index a909fea6e1cedd1282bf975be200031dde41f99a..76a15f9a3419c430a288b52b824aa723
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 20ee8418a40029d5bf962a8fa55b0c6a8aad0663..a4f3b793856042fccd072e76b65e02b6d2824c4f 100644
+index 68e23c1955ea26c2c894cab2e1beba5049388ee7..abb115275e4dce30ea0d2ae7b1bd34ee2ab5e48d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2061,7 +2061,7 @@ public final class CraftServer implements Server {
+@@ -2064,7 +2064,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0418-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0418-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index d84e04f2cf8870611d36834c5ea77a82e42df6d5..ce5d9bb9bc4dc724af7dac263c61bbb64bf81be3 100644
+index fd4b0c173be72516f22c6e5d540249e3079a7216..cf6c265714d8241f52e83de59094d7ae2cd56884 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,4 +1,6 @@
@@ -92,10 +92,10 @@ index d84e04f2cf8870611d36834c5ea77a82e42df6d5..ce5d9bb9bc4dc724af7dac263c61bbb6
      exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
  }
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 6cfaef1886b517c56ed9a96347be6e51efa84d9f..5fe5732bd6753e8ca37d8c3f7f24c6620b91d4e3 100644
+index 01979479c690d5d07125c0703f160abaef812c9e..46d91d9ebff03c5c5908e9b630d5a2cc374f2507 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -430,4 +430,9 @@ public class PaperConfig {
+@@ -436,4 +436,9 @@ public class PaperConfig {
              log("Async Chunks: Enabled - Chunks will be loaded much faster, without lag.");
          }
      }

--- a/patches/server/0419-Implement-Mob-Goal-API.patch
+++ b/patches/server/0419-Implement-Mob-Goal-API.patch
@@ -785,10 +785,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c48d2e560cd19fd7ac58844ed7e3c98597f09562..7f41a66e51c91fca6c6069f8072d215e6eaee7e3 100644
+index 7021c0f5c79609780a8a52e05507608942108e8b..bc2014f4aa0470f09143528cd358ab055a3927f6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2645,5 +2645,11 @@ public final class CraftServer implements Server {
+@@ -2653,5 +2653,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0428-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0428-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -13,10 +13,10 @@ A config is provided if you rather let players use these exploits, and let
 them destroy the worlds End Portals and get on top of the nether easy.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5fe5732bd6753e8ca37d8c3f7f24c6620b91d4e3..92f64c3d0fabd913f9640635f74396757263fac5 100644
+index 46d91d9ebff03c5c5908e9b630d5a2cc374f2507..2ba59112891938a6346fbd878b4e5faa73a429bb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -435,4 +435,15 @@ public class PaperConfig {
+@@ -441,4 +441,15 @@ public class PaperConfig {
      private static void loggerSettings() {
          deobfuscateStacktraces = getBoolean("settings.loggers.deobfuscate-stacktraces", deobfuscateStacktraces);
      }

--- a/patches/server/0432-Add-option-for-console-having-all-permissions.patch
+++ b/patches/server/0432-Add-option-for-console-having-all-permissions.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option for console having all permissions
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 92f64c3d0fabd913f9640635f74396757263fac5..dcc2b48f7784473c3c62fe062b66891e835694c4 100644
+index 2ba59112891938a6346fbd878b4e5faa73a429bb..af23e46f3c372776238b69423889d5595bcdadf1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -446,4 +446,9 @@ public class PaperConfig {
+@@ -452,4 +452,9 @@ public class PaperConfig {
          config.set("settings.unsupported-settings.allow-permanent-block-break-exploits-readme", "This setting controls if players should be able to break bedrock, end portals and other intended to be permanent blocks.");
          allowBlockPermanentBreakingExploits = getBoolean("settings.unsupported-settings.allow-permanent-block-break-exploits", allowBlockPermanentBreakingExploits);
      }

--- a/patches/server/0442-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/patches/server/0442-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -32,10 +32,10 @@ This patch fixes https://bugs.mojang.com/browse/MC-188840
 This patch also fixes rail duping and carpet duping.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index dcc2b48f7784473c3c62fe062b66891e835694c4..df1337c89c943a80a31d127c844f061c1e56eb91 100644
+index af23e46f3c372776238b69423889d5595bcdadf1..40a052a2863a390d8d87dbc844ca277d06b8812a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -451,4 +451,12 @@ public class PaperConfig {
+@@ -457,4 +457,12 @@ public class PaperConfig {
      private static void consoleHasAllPermissions() {
          consoleHasAllPermissions = getBoolean("settings.console-has-all-permissions", consoleHasAllPermissions);
      }

--- a/patches/server/0457-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0457-incremental-chunk-and-player-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] incremental chunk and player saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index df1337c89c943a80a31d127c844f061c1e56eb91..cb967380155d34ff511346d54b61e1c2109780f3 100644
+index 40a052a2863a390d8d87dbc844ca277d06b8812a..3276dfebeb7e05a7869d26541265620d095dd497 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -459,4 +459,14 @@ public class PaperConfig {
+@@ -465,4 +465,14 @@ public class PaperConfig {
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
  
@@ -355,7 +355,7 @@ index 5a4eeb46543d9458e309e2d4cc56086b5cf528c6..d11b5c9e64b6695a44cc2db588bed2e8
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      public ServerGamePacketListenerImpl connection;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index e9470af5a168f54c78383553ca634e77ae2a4cf5..f19c9489d0b982a28e2ee8fac6940ecc11fac6af 100644
+index 4288a132ccca3dfc559325deb19a50d5c91d6b36..50810411fda951e01d6bb01d57a9d879253afe94 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -560,6 +560,7 @@ public abstract class PlayerList {

--- a/patches/server/0492-Prevent-headless-pistons-from-being-created.patch
+++ b/patches/server/0492-Prevent-headless-pistons-from-being-created.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent headless pistons from being created
 Prevent headless pistons from being created by explosions or tree/mushroom growth.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index cb967380155d34ff511346d54b61e1c2109780f3..3029cd3138f9ae806666c741ce8a11de963f4aef 100644
+index 3276dfebeb7e05a7869d26541265620d095dd497..3636290f3cb3f6374560617c9a3f337b27fde353 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -469,4 +469,10 @@ public class PaperConfig {
+@@ -475,4 +475,10 @@ public class PaperConfig {
              maxPlayerAutoSavePerTick = (playerAutoSaveRate == -1 || playerAutoSaveRate > 100) ? 10 : 20;
          }
      }

--- a/patches/server/0497-Fix-hex-colors-not-working-in-some-kick-messages.patch
+++ b/patches/server/0497-Fix-hex-colors-not-working-in-some-kick-messages.patch
@@ -4,37 +4,8 @@ Date: Thu, 27 Aug 2020 16:57:25 -0400
 Subject: [PATCH] Fix hex colors not working in some kick messages
 
 
-diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index 86f99fbe3eb7a6c7ef288d7bff1d653df6f34790..8060d6461835d5b5b4429e9b280d08eae4e435e9 100644
---- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-+++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-@@ -50,7 +50,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
-                     synchronized (ServerHandshakePacketListenerImpl.throttleTracker) {
-                         if (ServerHandshakePacketListenerImpl.throttleTracker.containsKey(address) && !"127.0.0.1".equals(address.getHostAddress()) && currentTime - ServerHandshakePacketListenerImpl.throttleTracker.get(address) < connectionThrottle) {
-                             ServerHandshakePacketListenerImpl.throttleTracker.put(address, currentTime);
--                            TranslatableComponent chatmessage = new TranslatableComponent(com.destroystokyo.paper.PaperConfig.connectionThrottleKickMessage); // Paper - Configurable connection throttle kick message
-+                            Component chatmessage = org.bukkit.craftbukkit.util.CraftChatMessage.fromString(com.destroystokyo.paper.PaperConfig.connectionThrottleKickMessage, true)[0]; // Paper - Configurable connection throttle kick message // Paper - Fix hex colors not working in some kick messages
-                             this.connection.send(new ClientboundLoginDisconnectPacket(chatmessage));
-                             this.connection.disconnect(chatmessage);
-                             return;
-@@ -76,12 +76,12 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
-                 }
-                 // CraftBukkit end
-                 if (packet.getProtocolVersion() != SharedConstants.getCurrentVersion().getProtocolVersion()) {
--                    TranslatableComponent chatmessage;
-+                    Component chatmessage; // Paper - Fix hex colors not working in some kick messages
- 
-                     if (packet.getProtocolVersion() < 754) {
--                        chatmessage = new TranslatableComponent( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedClientMessage.replaceAll("'", "''"), SharedConstants.getCurrentVersion().getName() ) ); // Spigot
-+                        chatmessage = org.bukkit.craftbukkit.util.CraftChatMessage.fromString( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedClientMessage.replaceAll("'", "''"), SharedConstants.getCurrentVersion().getName() ) , true )[0]; // Spigot // Paper - Fix hex colors not working in some kick messages
-                     } else {
--                        chatmessage = new TranslatableComponent( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedServerMessage.replaceAll("'", "''"), SharedConstants.getCurrentVersion().getName() ) ); // Spigot
-+                        chatmessage = org.bukkit.craftbukkit.util.CraftChatMessage.fromString( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedServerMessage.replaceAll("'", "''"), SharedConstants.getCurrentVersion().getName() ) , true )[0]; // Spigot // Paper - Fix hex colors not working in some kick messages
-                     }
- 
-                     this.connection.send(new ClientboundLoginDisconnectPacket(chatmessage));
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index d21f45d983bf3047811d2d73f4a38deb108ac402..ab21f25a3eb0575d08aeac717ba2b74160f54fa9 100644
+index b8541725c46733e5bcb297c920659f7c23c24bb7..2a8cc7cf83eeb8b4018a7c5ba6f4eb2d7683f33c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -102,14 +102,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener

--- a/patches/server/0525-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0525-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 18cd4950472d91d711c301a80f0946520dd87f84..6124142faeeb792c0f7f6c167f8da47af446cba9 100644
+index 94ca675a38aa8e40e1ebbb55ce1c71a337782939..ec20589a07cfb579c526cb909daab74dcfde9108 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1794,6 +1794,28 @@ public final class CraftServer implements Server {
+@@ -1797,6 +1797,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0545-Limit-recipe-packets.patch
+++ b/patches/server/0545-Limit-recipe-packets.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit recipe packets
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 7a99db37a91edd12ef4a5d8cad690f6e62d31ba0..4c2d11d04b63d0e5e2eeb3743a1f79fea301c5aa 100644
+index 0cc23647d0daa8a84c9104c9ab7c47bd7dbd5cd0..83975d8331e286c6d89280a34d3ed3e55878760c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -366,6 +366,13 @@ public class PaperConfig {
+@@ -372,6 +372,13 @@ public class PaperConfig {
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
  

--- a/patches/server/0649-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/server/0649-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add raw address to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index ab21f25a3eb0575d08aeac717ba2b74160f54fa9..4e23e9ac3579dd0cedf0dfdbb231f6fae111745c 100644
+index 2a8cc7cf83eeb8b4018a7c5ba6f4eb2d7683f33c..54a14876ab46edc26c960dc71fd7efcfca67336c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -355,12 +355,13 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+@@ -351,12 +351,13 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
                              // Paper end
                          String playerName = ServerLoginPacketListenerImpl.this.gameProfile.getName();
                          java.net.InetAddress address = ((java.net.InetSocketAddress) ServerLoginPacketListenerImpl.this.connection.getRemoteAddress()).getAddress();

--- a/patches/server/0654-Add-basic-Datapack-API.patch
+++ b/patches/server/0654-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 48e2d5e2b53e32af53387f2e63c67ff9e0a7c5bb..486fe0d067dc11b42263b26592039e210acce06b 100644
+index f790baf40641af2beb95c8eb4adba285b78194aa..e88eecfcd9281ae2197db64f3063c84d0c8a52d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -280,6 +280,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index 48e2d5e2b53e32af53387f2e63c67ff9e0a7c5bb..486fe0d067dc11b42263b26592039e21
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2718,5 +2720,11 @@ public final class CraftServer implements Server {
+@@ -2726,5 +2728,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0677-Make-item-validations-configurable.patch
+++ b/patches/server/0677-Make-item-validations-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make item validations configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4a7e4c2038dd4a7496ed4084a19f31a611ee319a..b33ece9a98f94d0c09b837bc95dbfab82ff6cabe 100644
+index f1da1700706bbea1744579e5f9e2d775c60ee4d3..9b4de96ee19a53793e805d5d2cd316907f6ae557 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -504,4 +504,19 @@ public class PaperConfig {
+@@ -510,4 +510,19 @@ public class PaperConfig {
          config.set("settings.unsupported-settings.allow-headless-pistons-readme", "This setting controls if players should be able to create headless pistons.");
          allowHeadlessPistons = getBoolean("settings.unsupported-settings.allow-headless-pistons", false);
      }

--- a/patches/server/0691-Fix-incorrect-message-for-outdated-client.patch
+++ b/patches/server/0691-Fix-incorrect-message-for-outdated-client.patch
@@ -5,15 +5,15 @@ Subject: [PATCH] Fix incorrect message for outdated client
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index 97ee159867c4800c8fdec9a5fa42f648112be186..150050fb343ef6119204b7d5220207765a6937bc 100644
+index fb9756da8b9692dc739bcbb248b170c3e3906bf4..9e62a9754ef9a1fdb5d39f462ad2f7c44d1b4652 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 @@ -81,7 +81,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
                  if (packet.getProtocolVersion() != SharedConstants.getCurrentVersion().getProtocolVersion()) {
-                     Component chatmessage; // Paper - Fix hex colors not working in some kick messages
+                     Component chatmessage; // Paper - Adventure
  
 -                    if (packet.getProtocolVersion() < 754) {
 +                    if (packet.getProtocolVersion() < SharedConstants.getCurrentVersion().getProtocolVersion()) { // Paper - Fix incorrect message for outdated clients
-                         chatmessage = org.bukkit.craftbukkit.util.CraftChatMessage.fromString( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedClientMessage.replaceAll("'", "''"), SharedConstants.getCurrentVersion().getName() ) , true )[0]; // Spigot // Paper - Fix hex colors not working in some kick messages
+                         chatmessage = new io.papermc.paper.adventure.AdventureComponent(org.spigotmc.SpigotConfig.outdatedClientMessage); // Spigot // Paper - Adventure
                      } else {
-                         chatmessage = org.bukkit.craftbukkit.util.CraftChatMessage.fromString( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedServerMessage.replaceAll("'", "''"), SharedConstants.getCurrentVersion().getName() ) , true )[0]; // Spigot // Paper - Fix hex colors not working in some kick messages
+                         chatmessage = new io.papermc.paper.adventure.AdventureComponent(org.spigotmc.SpigotConfig.outdatedServerMessage); // Spigot // Paper - Adventure

--- a/patches/server/0742-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0742-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -10,7 +10,7 @@ Also has a hover text on each mob category listing what entity types are
 in said category
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index f436ab35798c9b6e6cb2eb60d2c02cbf9b742e69..be1da6ebf8c1468182cbb92a16e4866bfb2ecfc3 100644
+index 0d5d22199e75a19a027c9bc7b2b413f93b6b095c..9f65476e1f53f3f0c0f7ef26265facfc11ea830f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -3,6 +3,7 @@ package com.destroystokyo.paper;
@@ -293,10 +293,10 @@ index 1622450b53e0f0f48c3ca107e4d705b4ad29dadf..f6a225eed29eed364b7e2ea6bc85d55d
      public static void spawnCategoryForChunk(MobCategory group, ServerLevel world, LevelChunk chunk, NaturalSpawner.SpawnPredicate checker, NaturalSpawner.AfterSpawnCallback runner) {
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1b2aec9215d82a8ad60439a8ac38651319c0bdef..492f398a1c2dbe7b821dd40be1c1c6952f056c3a 100644
+index 9f9f97dc3b6f5f68af3e9eb0aaaa3343c27f78d4..55ebb04ae2da9323126348f636fa60c0dbdf8250 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2137,6 +2137,11 @@ public final class CraftServer implements Server {
+@@ -2140,6 +2140,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {

--- a/patches/server/0759-Add-packet-limiter-config.patch
+++ b/patches/server/0759-Add-packet-limiter-config.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add packet limiter config
 
 Example config:
 packet-limiter:
-  kick-message: '&cSent too many packets'
+  kick-message: '<red>Sent too many packets'
   limits:
     all:
       interval: 7.0
@@ -24,10 +24,10 @@ and an action can be defined: DROP or KICK
 If interval or rate are less-than 0, the limit is ignored
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index b33ece9a98f94d0c09b837bc95dbfab82ff6cabe..52dcb9d05dd6ca449850b6ad3c50d8f4192f13bb 100644
+index 9b4de96ee19a53793e805d5d2cd316907f6ae557..ea310260cf978c7938df2e2086b4a2aa4d0fa5e7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -519,4 +519,102 @@ public class PaperConfig {
+@@ -525,4 +525,102 @@ public class PaperConfig {
          itemValidationBookAuthorLength = getInt("settings.item-validation.book.author", itemValidationBookAuthorLength);
          itemValidationBookPageLength = getInt("settings.item-validation.book.page", itemValidationBookPageLength);
      }
@@ -48,13 +48,13 @@ index b33ece9a98f94d0c09b837bc95dbfab82ff6cabe..52dcb9d05dd6ca449850b6ad3c50d8f4
 +        }
 +    }
 +
-+    public static String kickMessage;
++    public static net.kyori.adventure.text.Component kickMessage;
 +    public static PacketLimit allPacketsLimit;
 +    public static java.util.Map<Class<? extends net.minecraft.network.protocol.Packet<?>>, PacketLimit> packetSpecificLimits = new java.util.HashMap<>();
 +
 +    private static void packetLimiter() {
 +        packetSpecificLimits.clear();
-+        kickMessage = org.bukkit.ChatColor.translateAlternateColorCodes('&', getString("settings.packet-limiter.kick-message", "&cSent too many packets"));
++        kickMessage = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(getString("settings.packet-limiter.kick-message", "<red>Sent too many packets"));
 +        allPacketsLimit = new PacketLimit(
 +            getDouble("settings.packet-limiter.limits.all.interval", 7.0),
 +            getDouble("settings.packet-limiter.limits.all.max-packet-rate", 500.0),
@@ -131,7 +131,7 @@ index b33ece9a98f94d0c09b837bc95dbfab82ff6cabe..52dcb9d05dd6ca449850b6ad3c50d8f4
 +    }
  }
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 47eadb4a08953a45300d769518af22b1463f4d11..b27610cde8eaa7ff35c777039a0ca9d8eab748fe 100644
+index 47eadb4a08953a45300d769518af22b1463f4d11..1f6044539f8e548c86a8aece29d37c1e1d958996 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -136,6 +136,22 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -147,8 +147,8 @@ index 47eadb4a08953a45300d769518af22b1463f4d11..b27610cde8eaa7ff35c777039a0ca9d8
 +
 +    private boolean stopReadingPackets;
 +    private void killForPacketSpam() {
-+        this.sendPacket(new ClientboundDisconnectPacket(org.bukkit.craftbukkit.util.CraftChatMessage.fromString(com.destroystokyo.paper.PaperConfig.kickMessage, true)[0]), (future) -> {
-+            this.disconnect(org.bukkit.craftbukkit.util.CraftChatMessage.fromString(com.destroystokyo.paper.PaperConfig.kickMessage, true)[0]);
++        this.sendPacket(new ClientboundDisconnectPacket((Component) com.destroystokyo.paper.PaperConfig.kickMessage), (future) -> {
++            this.disconnect((Component) com.destroystokyo.paper.PaperConfig.kickMessage);
 +        });
 +        this.setReadOnly();
 +        this.stopReadingPackets = true;

--- a/patches/server/0760-Lag-compensate-block-breaking.patch
+++ b/patches/server/0760-Lag-compensate-block-breaking.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Lag compensate block breaking
 Use time instead of ticks if ticks fall behind
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 52dcb9d05dd6ca449850b6ad3c50d8f4192f13bb..4444356a6bd44afdbe67593136c18b803a0ddd66 100644
+index ea310260cf978c7938df2e2086b4a2aa4d0fa5e7..96f2bfe1d714d63dd1c94196b6638ea6819d40b4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -617,4 +617,10 @@ public class PaperConfig {
+@@ -623,4 +623,10 @@ public class PaperConfig {
              }
          }
      }

--- a/patches/server/0766-Send-full-pos-packets-for-hard-colliding-entities.patch
+++ b/patches/server/0766-Send-full-pos-packets-for-hard-colliding-entities.patch
@@ -9,10 +9,10 @@ Configurable under
 `send-full-pos-for-hard-colliding-entities`
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4444356a6bd44afdbe67593136c18b803a0ddd66..8c2065a906d9ad8bd0b480a675b76b38680088e0 100644
+index 96f2bfe1d714d63dd1c94196b6638ea6819d40b4..627fca1d2586418e96e990250ead81bc87fb0cd3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -623,4 +623,10 @@ public class PaperConfig {
+@@ -629,4 +629,10 @@ public class PaperConfig {
      private static void lagCompensateBlockBreaking() {
          lagCompensateBlockBreaking = getBoolean("settings.lag-compensate-block-breaking", true);
      }

--- a/patches/server/0789-Don-t-log-debug-logging-being-disabled.patch
+++ b/patches/server/0789-Don-t-log-debug-logging-being-disabled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't log debug logging being disabled
 
 
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index 6f7b34f03e0d151e4da652b9ad73e0d7930fe5d3..d509187ca63963fdd7f1a44d89d2aa1a1b1ce3bd 100644
+index 8ef09a81543d3b4fc5e766d4f9c30af25b083942..dd502e7a0ed270b9b85d814e3a60e164bcee0cd3 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
-@@ -382,7 +382,7 @@ public class SpigotConfig
+@@ -406,7 +406,7 @@ public class SpigotConfig
              Bukkit.getLogger().info( "Debug logging is enabled" );
          } else
          {

--- a/patches/server/0818-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0818-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 492f398a1c2dbe7b821dd40be1c1c6952f056c3a..fba20c4228a34d4c956ce2a440eb6e495182f8f2 100644
+index 55ebb04ae2da9323126348f636fa60c0dbdf8250..2d59835104c5015e101722c27a0d747de4655e02 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2305,6 +2305,90 @@ public final class CraftServer implements Server {
+@@ -2308,6 +2308,90 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0832-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/patches/server/0832-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -10,10 +10,10 @@ when if this was fixed on the client, that wouldn't be needed.
 Mojira Issue: https://bugs.mojang.com/browse/MC-235045
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 3916d3e7773f4a3b6d5c5347d6a12a707bffcdad..04cb8282efae69aa62ae1dad4c39220f658ec575 100644
+index eea0f76fc626f96893861889b5210be15a11f585..23857fc167c8ddb043f9eb76b642c362ec3367f8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -525,6 +525,11 @@ public class PaperConfig {
+@@ -531,6 +531,11 @@ public class PaperConfig {
          itemValidationBookPageLength = getInt("settings.item-validation.book.page", itemValidationBookPageLength);
      }
  

--- a/patches/server/0840-Validate-usernames.patch
+++ b/patches/server/0840-Validate-usernames.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Validate usernames
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 04cb8282efae69aa62ae1dad4c39220f658ec575..48eeeb832127f681f6cb8162cbe3954fc14bb47d 100644
+index 23857fc167c8ddb043f9eb76b642c362ec3367f8..616c84ecea6601f5602579266428aadf83a067ae 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -493,6 +493,12 @@ public class PaperConfig {
+@@ -499,6 +499,12 @@ public class PaperConfig {
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
  
@@ -22,7 +22,7 @@ index 04cb8282efae69aa62ae1dad4c39220f658ec575..48eeeb832127f681f6cb8162cbe3954f
      public static int maxPlayerAutoSavePerTick = 10;
      private static void playerAutoSaveRate() {
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index f5c1dff1d571e89f960f11400edbcbbea0620575..7065aa4522431d08018fec8e591ba7c255398140 100644
+index 0a176e3b93b57ccabd64f0f4f62086bd98c12d08..b6561f24c9b17640ef03580e50d3824f07e101bc 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -61,6 +61,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
@@ -74,7 +74,7 @@ index f5c1dff1d571e89f960f11400edbcbbea0620575..7065aa4522431d08018fec8e591ba7c2
              this.state = ServerLoginPacketListenerImpl.State.KEY;
              this.connection.send(new ClientboundHelloPacket("", this.server.getKeyPair().getPublic().getEncoded(), this.nonce));
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6a3d444fcac8c7d561dcadb02f64eaa3c3d7b1cd..fae67931849eb0c19598def9f538c7971c36c575 100644
+index c04dda70916bd16d80bf8e934bdf313ab6a5c8d9..77eebd99174b976b0c3d63212170f5257eba7574 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -707,7 +707,7 @@ public abstract class PlayerList {

--- a/patches/server/0844-Add-config-option-for-worlds-affected-by-time-cmd.patch
+++ b/patches/server/0844-Add-config-option-for-worlds-affected-by-time-cmd.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config option for worlds affected by time cmd
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 48eeeb832127f681f6cb8162cbe3954fc14bb47d..66501c3b0eb92d946ef77bbd3f36ebcc0d3023af 100644
+index 616c84ecea6601f5602579266428aadf83a067ae..680333d05a3654e14348bbad3923a3a272baddb7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -645,4 +645,9 @@ public class PaperConfig {
+@@ -651,4 +651,9 @@ public class PaperConfig {
      private static void sendFullPosForHardCollidingEntities() {
          sendFullPosForHardCollidingEntities = getBoolean("settings.send-full-pos-for-hard-colliding-entities", true);
      }

--- a/patches/server/0849-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/server/0849-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added getHostname to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 7065aa4522431d08018fec8e591ba7c255398140..befcb501b4b1b6330bf3cd53e00e30b01efade6f 100644
+index b6561f24c9b17640ef03580e50d3824f07e101bc..af970bfae3b62f39bf5cb853df3d4a7b84354daf 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -395,7 +395,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+@@ -391,7 +391,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
  
                          // Paper start
                          com.destroystokyo.paper.profile.PlayerProfile profile = com.destroystokyo.paper.profile.CraftPlayerProfile.asBukkitMirror(ServerLoginPacketListenerImpl.this.gameProfile);

--- a/patches/server/0858-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0858-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -123,10 +123,10 @@ index 0000000000000000000000000000000000000000..f7c86155ce0cfd9b4bf8a2b79d77a656
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2e803b3b5356c197be05999e9d4749a94041b258..32bc72e930b5876116a9e7da816ff11d8d44a410 100644
+index 5a9b003b16a6038d3ed22dcb4990a2386737ad64..8600716b17120ee1cf7fb0c820590582ae45b9b3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1976,6 +1976,13 @@ public final class CraftServer implements Server {
+@@ -1979,6 +1979,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  

--- a/patches/server/0863-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0863-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 32bc72e930b5876116a9e7da816ff11d8d44a410..3b7b4a578346a162afbeb5781633c163d0c46177 100644
+index 8600716b17120ee1cf7fb0c820590582ae45b9b3..a95cf39fc5f0b08d88c3fca55b6f6b518eac030e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2145,6 +2145,8 @@ public final class CraftServer implements Server {
+@@ -2148,6 +2148,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start

--- a/patches/server/0864-Add-GameEvent-tags.patch
+++ b/patches/server/0864-Add-GameEvent-tags.patch
@@ -41,7 +41,7 @@ index 0000000000000000000000000000000000000000..d5d3c66afb408026513ac436eb1f4fdd
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1e7d817479c58c7fc070322328fbff7d0cdc419b..4b86fb9ace58533c5d85aa05cc8a4af7644c66de 100644
+index a95cf39fc5f0b08d88c3fca55b6f6b518eac030e..1f861fdce48a66d34f5f448d3e235c7a562f78e3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -97,6 +97,7 @@ import net.minecraft.world.level.biome.BiomeSource;
@@ -52,7 +52,7 @@ index 1e7d817479c58c7fc070322328fbff7d0cdc419b..4b86fb9ace58533c5d85aa05cc8a4af7
  import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
  import net.minecraft.world.level.levelgen.PatrolSpawner;
  import net.minecraft.world.level.levelgen.PhantomSpawner;
-@@ -2551,6 +2552,15 @@ public final class CraftServer implements Server {
+@@ -2554,6 +2555,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(Registry.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -68,7 +68,7 @@ index 1e7d817479c58c7fc070322328fbff7d0cdc419b..4b86fb9ace58533c5d85aa05cc8a4af7
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2583,6 +2593,13 @@ public final class CraftServer implements Server {
+@@ -2586,6 +2596,13 @@ public final class CraftServer implements Server {
                  Registry<EntityType<?>> entityTags = Registry.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0865-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0865-Replace-player-chunk-loader-system.patch
@@ -84,10 +84,10 @@ index 5e3b7fb2e0b7608610555cd23e7ad25a05883181..1cb0aae3e0c619a715766e0fa604dfd9
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 66501c3b0eb92d946ef77bbd3f36ebcc0d3023af..153f07bac06093b43a1f5b0f8e1a46ffbe6407e5 100644
+index 680333d05a3654e14348bbad3923a3a272baddb7..d934e36d19fbae9e4ff6c3d13b54cf71065aefcb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -650,4 +650,33 @@ public class PaperConfig {
+@@ -656,4 +656,33 @@ public class PaperConfig {
      private static void timeCommandAffectsAllWorlds() {
          timeCommandAffectsAllWorlds = getBoolean("settings.time-command-affects-all-worlds", timeCommandAffectsAllWorlds);
      }
@@ -1236,7 +1236,7 @@ index 0000000000000000000000000000000000000000..bdd4cc040111d18b82d3ebeb5dbe2537
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 42400b6f0b693dd0ec4a2303a82bd131753a24ba..9bbf990212ee55a267d0eb1e863618c50fa706da 100644
+index ee95998081057cf4cf4150e7af31838fe3ef398c..718b77daf1dd4174ef77301b0e2af604cd81403a 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -105,6 +105,28 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -1919,7 +1919,7 @@ index b4d20c06a19e021317cff64a9789f0579b5f921d..e74c13e7aaa144fcd07036de70e80beb
 +    public final int getViewDistance() { throw new UnsupportedOperationException("Use PlayerChunkLoader"); } // Paper - placeholder
  }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index fae67931849eb0c19598def9f538c7971c36c575..f5852341161b0d632e22af9b3e625ca1e786bd63 100644
+index 77eebd99174b976b0c3d63212170f5257eba7574..53b836957af6919dddd4631b311d360d5cdbae7d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -271,7 +271,7 @@ public abstract class PlayerList {

--- a/patches/server/0871-Option-to-have-default-CustomSpawners-in-custom-worl.patch
+++ b/patches/server/0871-Option-to-have-default-CustomSpawners-in-custom-worl.patch
@@ -10,10 +10,10 @@ just looking at the LevelStem key, look at the DimensionType key which
 is one level below that. Defaults to off to keep vanilla behavior.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 153f07bac06093b43a1f5b0f8e1a46ffbe6407e5..a7ebf6d9f79ce50a90c3c903563e00a10607f9f2 100644
+index d934e36d19fbae9e4ff6c3d13b54cf71065aefcb..f2193603037c54fe89eb85096516527f2d641ab7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -679,4 +679,9 @@ public class PaperConfig {
+@@ -685,4 +685,9 @@ public class PaperConfig {
          }
          globalMaxConcurrentChunkLoads = getDouble("settings.chunk-loading.global-max-concurrent-loads", 500.0);
      }
@@ -24,7 +24,7 @@ index 153f07bac06093b43a1f5b0f8e1a46ffbe6407e5..a7ebf6d9f79ce50a90c3c903563e00a1
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 63c86ae637eabb07095a46852da530b53acb9ff3..3a0b022880e250fc8afeb74c18272573d08c4166 100644
+index b69af9a2f1a0e3d578aaade1fb040d3d4230a941..7ca233fa8a76a0734964957fcd8e09e7a44a39e8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -619,7 +619,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/0874-Custom-Potion-Mixes.patch
+++ b/patches/server/0874-Custom-Potion-Mixes.patch
@@ -164,7 +164,7 @@ index 287205bce7f655f9a6b815f40d349c3db4c1e788..5c0f1488c8a8100cd39a03adeccded99
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 278a025f141b2011dc2b4e35e70a8013b918a33e..55c981f2c8070fc1bd9ecd4f4df140d9d0c68319 100644
+index 9ace91ced9d87a367dbd52ea7f62d3655bb249e6..eea05214f9e6c0b834affd6293e8e26f1fca7804 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -284,6 +284,7 @@ public final class CraftServer implements Server {
@@ -184,7 +184,7 @@ index 278a025f141b2011dc2b4e35e70a8013b918a33e..55c981f2c8070fc1bd9ecd4f4df140d9
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2846,5 +2847,10 @@ public final class CraftServer implements Server {
+@@ -2854,5 +2855,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  


### PR DESCRIPTION
Allows the messages in `bukkit.yml`, `spigot.yml`, and `paper.yml` to be written using the MiniMessage format.

~~In order to maintain compatibility with existing configuration files the option `configuration-uses-minimessage` option has been added to `paper.yml`. This option defaults to `false` for any configuration files before config version 26.~~

New configuration files use MiniMessage by default, and the default messages have been converted to use it.

This also includes 2 minor API changes:
- `Bukkit#getPermissionMessage` which returned a `String` has been deprecated in favor of `Bukkit#permissionMessage` which returns a `Component`
- `Server#getPermissionMessage` which returned a `String` has been deprecated in favor of `Server#permissionMessage` which returns a `Component`

Closes #7520