### PR TITLE
Fix opening inv in PlayerRecipeBookClickEvent handler

### DIFF
--- a/patches/server/0441-Add-and-implement-PlayerRecipeBookClickEvent.patch
+++ b/patches/server/0441-Add-and-implement-PlayerRecipeBookClickEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add and implement PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a0597bf8d948f20becd7ccb748a78f8a14a54cf6..7c97e6eda860b0145d8d5700fcecdcea5e258a03 100644
+index a0597bf8d948f20becd7ccb748a78f8a14a54cf6..d55afdb09af8bc07361c06453a028da36ef934eb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2805,9 +2805,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -14,13 +14,14 @@ index a0597bf8d948f20becd7ccb748a78f8a14a54cf6..7c97e6eda860b0145d8d5700fcecdcea
          if (!this.player.isSpectator() && this.player.containerMenu.containerId == packet.getContainerId() && this.player.containerMenu instanceof RecipeBookMenu) {
 -            this.server.getRecipeManager().byKey(packet.getRecipe()).ifPresent((irecipe) -> {
 -                ((RecipeBookMenu) this.player.containerMenu).handlePlacement(packet.isShiftDown(), irecipe, this.player);
+-            });
 +            // Paper start - fire event for clicking recipes in the recipe book
 +            com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent event = new com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent(
 +                player.getBukkitEntity(), org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(packet.getRecipe()), packet.isShiftDown());
-+            if (event.callEvent()) {
++            if (event.callEvent() && this.player.containerMenu instanceof RecipeBookMenu<?> recipeBookMenu) { // check if inventory changed during event handling
 +                this.server.getRecipeManager().byKey(org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(event.getRecipe())).ifPresent((irecipe) -> {
-+                    ((RecipeBookMenu) this.player.containerMenu).handlePlacement(event.isMakeAll(), irecipe, this.player);
-             });
++                    recipeBookMenu.handlePlacement(event.isMakeAll(), irecipe, this.player);
++                });
 +            } // Paper end
          }
      }


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/7550

Checks if current open container is still an instance of `RecipeBookMenu` after the event is fired.