### PR TITLE
Prevent entity loading causing async lookups

### DIFF
--- a/patches/server/0881-Prevent-entity-loading-causing-async-lookups.patch
+++ b/patches/server/0881-Prevent-entity-loading-causing-async-lookups.patch
@@ -17,10 +17,10 @@ index 84fce7dccf9232209f939a32acfc3131e62eb27c..34847add2a35e535b001f581677c4953
          if (this.isPassenger() && this.getVehicle().isRemoved()) {
              this.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/NeutralMob.java b/src/main/java/net/minecraft/world/entity/NeutralMob.java
-index dedf76de5d6f46b9626ca4a98cfffe125b90dd0c..f02224c1993b7953f6d7c4bad1edc6c41cc8bbf2 100644
+index dedf76de5d6f46b9626ca4a98cfffe125b90dd0c..78632fd681049fbd49d0030c23ed204dbc515a44 100644
 --- a/src/main/java/net/minecraft/world/entity/NeutralMob.java
 +++ b/src/main/java/net/minecraft/world/entity/NeutralMob.java
-@@ -42,18 +42,6 @@ public interface NeutralMob {
+@@ -42,18 +42,7 @@ public interface NeutralMob {
                  UUID uuid = nbt.getUUID("AngryAt");
  
                  this.setPersistentAngerTarget(uuid);
@@ -36,10 +36,11 @@ index dedf76de5d6f46b9626ca4a98cfffe125b90dd0c..f02224c1993b7953f6d7c4bad1edc6c4
 -                    }
 -
 -                }
++                // Paper - Moved diff to separate method
              }
          }
      }
-@@ -127,4 +115,26 @@ public interface NeutralMob {
+@@ -127,4 +116,26 @@ public interface NeutralMob {
  
      @Nullable
      LivingEntity getTarget();

--- a/patches/server/0881-Prevent-entity-loading-causing-async-lookups.patch
+++ b/patches/server/0881-Prevent-entity-loading-causing-async-lookups.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sun, 6 Mar 2022 11:09:09 -0500
+Subject: [PATCH] Prevent entity loading causing async lookups
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 84fce7dccf9232209f939a32acfc3131e62eb27c..34847add2a35e535b001f581677c4953dd384800 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -725,6 +725,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+ 
+     public void baseTick() {
+         this.level.getProfiler().push("entityBaseTick");
++        if (firstTick && this instanceof net.minecraft.world.entity.NeutralMob neutralMob) neutralMob.tickInitialPersistentAnger(level); // Paper - Update last hurt when ticking
+         this.feetBlockState = null;
+         if (this.isPassenger() && this.getVehicle().isRemoved()) {
+             this.stopRiding();
+diff --git a/src/main/java/net/minecraft/world/entity/NeutralMob.java b/src/main/java/net/minecraft/world/entity/NeutralMob.java
+index dedf76de5d6f46b9626ca4a98cfffe125b90dd0c..f02224c1993b7953f6d7c4bad1edc6c41cc8bbf2 100644
+--- a/src/main/java/net/minecraft/world/entity/NeutralMob.java
++++ b/src/main/java/net/minecraft/world/entity/NeutralMob.java
+@@ -42,18 +42,6 @@ public interface NeutralMob {
+                 UUID uuid = nbt.getUUID("AngryAt");
+ 
+                 this.setPersistentAngerTarget(uuid);
+-                Entity entity = ((ServerLevel) world).getEntity(uuid);
+-
+-                if (entity != null) {
+-                    if (entity instanceof Mob) {
+-                        this.setLastHurtByMob((Mob) entity);
+-                    }
+-
+-                    if (entity.getType() == EntityType.PLAYER) {
+-                        this.setLastHurtByPlayer((Player) entity);
+-                    }
+-
+-                }
+             }
+         }
+     }
+@@ -127,4 +115,26 @@ public interface NeutralMob {
+ 
+     @Nullable
+     LivingEntity getTarget();
++
++    // Paper start - Update last hurt when ticking
++    default void tickInitialPersistentAnger(Level level) {
++        UUID target = getPersistentAngerTarget();
++        if (target == null) {
++            return;
++        }
++
++        Entity entity = ((ServerLevel) level).getEntity(target);
++
++        if (entity != null) {
++            if (entity instanceof Mob) {
++                this.setLastHurtByMob((Mob) entity);
++            }
++
++            if (entity.getType() == EntityType.PLAYER) {
++                this.setLastHurtByPlayer((Player) entity);
++            }
++
++        }
++    }
++    // Paper end
+ }

--- a/patches/server/0909-Prevent-entity-loading-causing-async-lookups.patch
+++ b/patches/server/0909-Prevent-entity-loading-causing-async-lookups.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent entity loading causing async lookups
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 84fce7dccf9232209f939a32acfc3131e62eb27c..34847add2a35e535b001f581677c4953dd384800 100644
+index 86a2eddf344503cbe75a5243a114f6fe1578185f..dfd1f37757af1bd808cc2e2d8bf97123adf638bb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -725,6 +725,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
+@@ -725,6 +725,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
      public void baseTick() {
          this.level.getProfiler().push("entityBaseTick");


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/7137

This just moves the code to instead run when the entity is ticked for the first time instead.

Tested with wolves & enderman and it appears there is no behavior change.