### PR TITLE
Properly create profiles with custom name/uuid

### DIFF
--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -289,16 +289,20 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b175f07b99a07ba50c4721c38f9e6330f02942f8..aae3eec8d28a0047bc590ecc55d87d11ee6d08f0 100644
+index b175f07b99a07ba50c4721c38f9e6330f02942f8..88720b2fa92f387714c11a11cba8c9bf0a25e797 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2080,6 +2080,40 @@ public final class Bukkit {
+@@ -2080,6 +2080,50 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
 +
 +    /**
-+     * Creates a PlayerProfile for the specified uuid, with name as null
++     * Creates a PlayerProfile for the specified uuid, with name as null.
++     *
++     * If a player with the passed uuid exists on the server at the time of creation, the returned player profile will
++     * be populated with the properties of said player.
++     *
 +     * @param uuid UUID to create profile for
 +     * @return A PlayerProfile object
 +     */
@@ -308,7 +312,11 @@ index b175f07b99a07ba50c4721c38f9e6330f02942f8..aae3eec8d28a0047bc590ecc55d87d11
 +    }
 +
 +    /**
-+     * Creates a PlayerProfile for the specified name, with UUID as null
++     * Creates a PlayerProfile for the specified name, with UUID as null.
++     *
++     * If a player with the passed name exists on the server at the time of creation, the returned player profile will
++     * be populated with the properties of said player.
++     *
 +     * @param name Name to create profile for
 +     * @return A PlayerProfile object
 +     */
@@ -321,6 +329,8 @@ index b175f07b99a07ba50c4721c38f9e6330f02942f8..aae3eec8d28a0047bc590ecc55d87d11
 +     * Creates a PlayerProfile for the specified name/uuid
 +     *
 +     * Both UUID and Name can not be null at same time. One must be supplied.
++     * If a player with the passed uuid or name exists on the server at the time of creation, the returned player
++     * profile will be populated with the properties of said player.
 +     *
 +     * @param uuid UUID to create profile for
 +     * @param name Name to create profile for
@@ -334,16 +344,20 @@ index b175f07b99a07ba50c4721c38f9e6330f02942f8..aae3eec8d28a0047bc590ecc55d87d11
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 24e68d5cb4f713984b25ab19330cb77f1eddb5cf..51c96a0b6645cf31f4ca051f6a8c75b5f188484c 100644
+index 24e68d5cb4f713984b25ab19330cb77f1eddb5cf..29886928ab33edf9965b93e89482a84bd82e4fd2 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1825,5 +1825,33 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1825,5 +1825,43 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
 +
 +    /**
-+     * Creates a PlayerProfile for the specified uuid, with name as null
++     * Creates a PlayerProfile for the specified uuid, with name as null.
++     *
++     * If a player with the passed uuid exists on the server at the time of creation, the returned player profile will
++     * be populated with the properties of said player.
++     *
 +     * @param uuid UUID to create profile for
 +     * @return A PlayerProfile object
 +     */
@@ -351,7 +365,11 @@ index 24e68d5cb4f713984b25ab19330cb77f1eddb5cf..51c96a0b6645cf31f4ca051f6a8c75b5
 +    com.destroystokyo.paper.profile.PlayerProfile createProfile(@NotNull UUID uuid);
 +
 +    /**
-+     * Creates a PlayerProfile for the specified name, with UUID as null
++     * Creates a PlayerProfile for the specified name, with UUID as null.
++     *
++     * If a player with the passed name exists on the server at the time of creation, the returned player profile will
++     * be populated with the properties of said player.
++     *
 +     * @param name Name to create profile for
 +     * @return A PlayerProfile object
 +     */
@@ -362,6 +380,8 @@ index 24e68d5cb4f713984b25ab19330cb77f1eddb5cf..51c96a0b6645cf31f4ca051f6a8c75b5
 +     * Creates a PlayerProfile for the specified name/uuid
 +     *
 +     * Both UUID and Name can not be null at same time. One must be supplied.
++     * If a player with the passed uuid or name exists on the server at the time of creation, the returned player
++     * profile will be populated with the properties of said player.
 +     *
 +     * @param uuid UUID to create profile for
 +     * @param name Name to create profile for

--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 76d379cfc00157dd76ae981ebd839ac0954b4773..686235a2347ebeaa5654a14cdd717009f2c0105f 100644
+index d82d06894e3dd09fe57448fd5bc09fabbff08e62..52f5750e1cbce6000c72f5f1b4bde41b9fa66b23 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -2098,6 +2098,15 @@ public final class Bukkit {
@@ -22,10 +22,10 @@ index 76d379cfc00157dd76ae981ebd839ac0954b4773..686235a2347ebeaa5654a14cdd717009
 +    }
 +
      /**
-      * Creates a PlayerProfile for the specified uuid, with name as null
-      * @param uuid UUID to create profile for
+      * Creates a PlayerProfile for the specified uuid, with name as null.
+      *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 818c37490d98c287ade9b56f3fc01001db1df773..f43720d07e80e3d2937f5b271664b5268d7af027 100644
+index 9d5e22d1a4b87476a4c0d83dfdf42821131b30b1..ef10f62a00f19b6a2ca61c3984465f5cd9fa7479 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1841,6 +1841,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -40,8 +40,8 @@ index 818c37490d98c287ade9b56f3fc01001db1df773..f43720d07e80e3d2937f5b271664b526
 +    String getPermissionMessage();
 +
      /**
-      * Creates a PlayerProfile for the specified uuid, with name as null
-      * @param uuid UUID to create profile for
+      * Creates a PlayerProfile for the specified uuid, with name as null.
+      *
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
 index b1152f4dede61383232cc6713d448840612eac13..95847fcb1ac2e430ee192f4f7ac94e981151c5db 100644
 --- a/src/main/java/org/bukkit/command/Command.java

--- a/patches/api/0183-Expose-the-internal-current-tick.patch
+++ b/patches/api/0183-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index cf7f8a8f03adcbe466b59ea8b98b527fb54a0803..61877d9d64840408a7aec7bcc2a54779a9e820d8 100644
+index 19771a9a7a212a71f4cad33981c3b72341d80093..0f77744ac6ea1d41f3e8713236bb85ec182f4010 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2140,6 +2140,10 @@ public final class Bukkit {
+@@ -2150,6 +2150,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfile(uuid, name);
      }
@@ -20,10 +20,10 @@ index cf7f8a8f03adcbe466b59ea8b98b527fb54a0803..61877d9d64840408a7aec7bcc2a54779
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 49bcc2edea32ef2b31b9ed5c3a62140bcc81ffc9..73ec2a8541ae95e07e32327ad0fff3a30b091658 100644
+index 790c09d8fc67dfe6325faff419be7d980415bad8..fcc48b9a512c756f22075d58021cad23d1ac1091 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1875,5 +1875,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1885,5 +1885,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0190-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0190-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 6971ecc8d285f81c476f1b3442159167102a5719..88d1b843d9c8db350f1b64da06bb1b568626d0ce 100644
+index 3ed3d7eb10f601dcb32e5ca7b053afeb5b0db729..bc4c76eb8b5329b4eeefe62828fed45b8b1c5154 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2163,6 +2163,15 @@ public final class Bukkit {
+@@ -2173,6 +2173,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index 6971ecc8d285f81c476f1b3442159167102a5719..88d1b843d9c8db350f1b64da06bb1b56
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a543d5ec7df410cad15affb22058b60ec6a5c570..ce8e0c4e90f59d7446f761d0df9ab1c73bbbb676 100644
+index 84bcfb8f8220700c0336a378eec41be765db844a..9e459ea23dc480996ebea314e5bc98dd891c020a 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1897,5 +1897,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1907,5 +1907,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0200-Add-Mob-Goal-API.patch
+++ b/patches/api/0200-Add-Mob-Goal-API.patch
@@ -523,10 +523,10 @@ index 0000000000000000000000000000000000000000..8fd399f791b45eb7fc62693ca954eea0
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 111323f84fb6f34f5a61c5e24d1f1a058744416d..ed6dab65a21b9c089e69cf9fe2fda3919be4e5a3 100644
+index b6707f205757eb3ab09d15a20f8f93d1ba5cfff8..640e4cb43b278a06416303d96c73e50e12f6a853 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2184,6 +2184,16 @@ public final class Bukkit {
+@@ -2194,6 +2194,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -544,10 +544,10 @@ index 111323f84fb6f34f5a61c5e24d1f1a058744416d..ed6dab65a21b9c089e69cf9fe2fda391
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5b52ec962c0ebd8cf8968dcbc31a9900eb15f6c0..705d30a68d6f10e5c5dd49b70535b320895c8502 100644
+index 35e3a1814ad3d4891d9e07be23a019ab650c31ff..e6c491c3c6246784f6741a99120b0e1f09f71232 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1914,5 +1914,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1924,5 +1924,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0295-Add-basic-Datapack-API.patch
+++ b/patches/api/0295-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c8ea04b06d7178c6cc992a9a1b0355a70a035152..7732d26277ca8b845898cb01c7623a2f175f0aaa 100644
+index 8106fd5806fc47cb7138e01d9d5c458153afa3d5..adc8ed72acbb1ca788d44fa9542d287dbbafc669 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2238,6 +2238,14 @@ public final class Bukkit {
+@@ -2248,6 +2248,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index c8ea04b06d7178c6cc992a9a1b0355a70a035152..7732d26277ca8b845898cb01c7623a2f
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 75aba8c3db5198c11e0bb9c262388632a47d93e6..1d2970dc4d18122e95db8cc9830aa5c41a59e24b 100644
+index d43f785471d3671bad6eb270a87a70b27f85adcb..1446fe0be113f5d0b98f34b1da19900acc7f015d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1961,5 +1961,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1971,5 +1971,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0371-Custom-Potion-Mixes.patch
+++ b/patches/api/0371-Custom-Potion-Mixes.patch
@@ -102,10 +102,10 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 795f8c0aa3929f6de4b4ea4b139bef8b672ab97a..944f9b87a11472ac6d7e328acc00bf09f899e648 100644
+index 41be35164aa240ab1ea69bac96b667183960d9cd..c093ba024cfd951be1afc4100d899ed8f70ab003 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2297,6 +2297,15 @@ public final class Bukkit {
+@@ -2307,6 +2307,15 @@ public final class Bukkit {
      public static io.papermc.paper.datapack.DatapackManager getDatapackManager() {
          return server.getDatapackManager();
      }
@@ -122,10 +122,10 @@ index 795f8c0aa3929f6de4b4ea4b139bef8b672ab97a..944f9b87a11472ac6d7e328acc00bf09
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 79120b42a3993beda1e3474fa4b722402e9d849f..f63587cfa651a3893d2efa3730dc80f271d56b1c 100644
+index 25e5fa7b6ebebdf86070d95330e8ae272fc0c593..cb511df257b389e06a4f947b6e837cb5986b28db 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1995,5 +1995,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2005,5 +2005,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();

--- a/patches/server/0139-Basic-PlayerProfile-API.patch
+++ b/patches/server/0139-Basic-PlayerProfile-API.patch
@@ -621,7 +621,7 @@ index c4142568c3188c89142799cc4911dd7eae32a45f..f379e108ec3c762940bddea878a0a711
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 179ba5ae2406d8babfdec386fc8125960043d586..24f361820f195e948f617cd134352e098b298b5d 100644
+index 179ba5ae2406d8babfdec386fc8125960043d586..3ebb9ee5938d9cd14f352cba4cb8c74e6aa9c60f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -243,6 +243,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -642,7 +642,7 @@ index 179ba5ae2406d8babfdec386fc8125960043d586..24f361820f195e948f617cd134352e09
          CraftItemFactory.instance();
      }
  
-@@ -2568,5 +2572,24 @@ public final class CraftServer implements Server {
+@@ -2568,5 +2572,29 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
@@ -660,10 +660,15 @@ index 179ba5ae2406d8babfdec386fc8125960043d586..24f361820f195e948f617cd134352e09
 +    @Override
 +    public com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
 +        Player player = uuid != null ? Bukkit.getPlayer(uuid) : (name != null ? Bukkit.getPlayerExact(name) : null);
-+        if (player != null) {
-+            return new com.destroystokyo.paper.profile.CraftPlayerProfile((CraftPlayer)player);
++        if (player == null) return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
++
++        if (Objects.equals(uuid, player.getUniqueId()) && Objects.equals(name, player.getName())) {
++            return new com.destroystokyo.paper.profile.CraftPlayerProfile((CraftPlayer) player);
 +        }
-+        return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
++
++        final com.mojang.authlib.GameProfile profile = new com.mojang.authlib.GameProfile(uuid, name);
++        profile.getProperties().putAll(((CraftPlayer)player).getHandle().getGameProfile().getProperties());
++        return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
 +    }
      // Paper end
  }

--- a/patches/server/0327-Expose-the-internal-current-tick.patch
+++ b/patches/server/0327-Expose-the-internal-current-tick.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 36b20b697850dff10910d7f4cd9543ba11e60568..8bf2f50e314061a2493d0ce89b9d6104994fe6b6 100644
+index 1efe81c2bec0920477d3062c0ea5829bd45ebc4d..66132ce8beb96c6880a72514d8e43438d962c547 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2617,5 +2617,10 @@ public final class CraftServer implements Server {
-         }
-         return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
+@@ -2622,5 +2622,10 @@ public final class CraftServer implements Server {
+         profile.getProperties().putAll(((CraftPlayer)player).getHandle().getGameProfile().getProperties());
+         return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }
 +
 +    @Override

--- a/patches/server/0377-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0377-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d4442ba4f0fc9e062fd321dccd0f49c3d10fd28b..6535d59e4fd04cce072de4d939b84e423b5ce52d 100644
+index 827cc40bfba2c277a9329d63b8224e2aa6296fa4..f1c435ef799b3f7db63c0c73474b9b35b21bba24 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2632,5 +2632,10 @@ public final class CraftServer implements Server {
+@@ -2637,5 +2637,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0414-Implement-Mob-Goal-API.patch
+++ b/patches/server/0414-Implement-Mob-Goal-API.patch
@@ -785,10 +785,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c48d2e560cd19fd7ac58844ed7e3c98597f09562..7f41a66e51c91fca6c6069f8072d215e6eaee7e3 100644
+index 0784e79d0c99a29ea3a04a9b4e360dc385bdfa3a..6521ee7a5f84b72b90b022198d47854d27facc38 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2645,5 +2645,11 @@ public final class CraftServer implements Server {
+@@ -2650,5 +2650,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0647-Add-basic-Datapack-API.patch
+++ b/patches/server/0647-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 48e2d5e2b53e32af53387f2e63c67ff9e0a7c5bb..486fe0d067dc11b42263b26592039e210acce06b 100644
+index 555015be2b9f83834b70ecb415aca3807520a6bd..bfa7fb378612b4d25e55da6d1346b72763d39dbb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -280,6 +280,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index 48e2d5e2b53e32af53387f2e63c67ff9e0a7c5bb..486fe0d067dc11b42263b26592039e21
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2718,5 +2720,11 @@ public final class CraftServer implements Server {
+@@ -2723,5 +2725,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0867-Custom-Potion-Mixes.patch
+++ b/patches/server/0867-Custom-Potion-Mixes.patch
@@ -24,7 +24,7 @@ index 0000000000000000000000000000000000000000..6b0bed550763f34e18c9e92f9a47ec0c
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 93a4b1f94e86aa2b747a8c511de0ff6b11cf7f36..2285fb8bc025fafc0531f2ce1b658c3a458e02d0 100644
+index e4461fb3485391ec0a9d902d5b896bb95e7512b5..b079677723ff65f64adec044e7d89656ecc49e4d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2055,6 +2055,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -164,7 +164,7 @@ index 287205bce7f655f9a6b815f40d349c3db4c1e788..5c0f1488c8a8100cd39a03adeccded99
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 278a025f141b2011dc2b4e35e70a8013b918a33e..55c981f2c8070fc1bd9ecd4f4df140d9d0c68319 100644
+index 8cef872ed7bd324aa2a664704e475acdf4fffeb8..abfb76ce53897a71b82a4b70bde5346d234ff62d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -284,6 +284,7 @@ public final class CraftServer implements Server {
@@ -184,7 +184,7 @@ index 278a025f141b2011dc2b4e35e70a8013b918a33e..55c981f2c8070fc1bd9ecd4f4df140d9
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2846,5 +2847,10 @@ public final class CraftServer implements Server {
+@@ -2851,5 +2852,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  


### PR DESCRIPTION
Ensure that the server properly creates custom player profiles if either
the uuid or name match an online player. Previously the server would
directly shortcut to the players profile if either their uuid or name
matched, ignoring differences in the respective alternative identifier
like a custom name or a different uuid.

To keep the previous functionality, the method does populate the profile
with the online players properties if either the uuid or name match.

Resolves: #7557 