### PR TITLE
Strip enderpearl owners when they are no longer ticked

### DIFF
--- a/patches/server/0191-Block-Enderpearl-Travel-Exploit.patch
+++ b/patches/server/0191-Block-Enderpearl-Travel-Exploit.patch
@@ -26,6 +26,23 @@ index ef9f6712046a22a8d0dfcf95d8e2d12403345532..ea426792b751fd7591bf09f2256dd6bd
 +        log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
 +    }
  }
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index c0ec21a8110ed54489361cfae1e1112fe448150a..164e3261fb6b7a30c86baffde62045b1c6081232 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -1987,6 +1987,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
+ 
+         public void onTickingEnd(Entity entity) {
+             ServerLevel.this.entityTickList.remove(entity);
++            // Paper start - Reset pearls when they stop being ticked
++            if (paperConfig.disableEnderpearlExploit && entity instanceof net.minecraft.world.entity.projectile.ThrownEnderpearl pearl) {
++                pearl.cachedOwner = null;
++                pearl.ownerUUID = null;
++            }
++            // Paper end
+         }
+ 
+         public void onTrackingStart(Entity entity) {
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 index 1c3ae7c61c06f486e50e57f434b9f360c6cf55be..bdefda914a7f93b8393a06f112ea9239d9685d51 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
@@ -38,24 +55,3 @@ index 1c3ae7c61c06f486e50e57f434b9f360c6cf55be..bdefda914a7f93b8393a06f112ea9239
          }
  
          this.leftOwner = nbt.getBoolean("LeftOwner");
-diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
-index 23f77dfc6df93ef6a70e14a7e410263d39fae2cb..834ba402decb556a5f77809b37fa00578b67432e 100644
---- a/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
-+++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownEnderpearl.java
-@@ -108,6 +108,16 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
-             super.tick();
-         }
- 
-+        // Paper start
-+        if (this.level.paperConfig.disableEnderpearlExploit) {
-+            final net.minecraft.server.level.ChunkHolder chunkHolder = ((net.minecraft.server.level.ServerChunkCache) this.level.getChunkSource()).chunkMap.getVisibleChunkIfPresent(net.minecraft.world.level.ChunkPos.asLong(this.blockPosition()));
-+            if (chunkHolder == null || !net.minecraft.server.level.ChunkHolder.getFullChunkStatus(chunkHolder.getTicketLevel()).isOrAfter(net.minecraft.server.level.ChunkHolder.FullChunkStatus.ENTITY_TICKING)) {
-+                this.cachedOwner = null;
-+                this.ownerUUID = null;
-+            }
-+        }
-+        // Paper end
-+
-     }
- 
-     @Nullable

--- a/patches/server/0191-Block-Enderpearl-Travel-Exploit.patch
+++ b/patches/server/0191-Block-Enderpearl-Travel-Exploit.patch
@@ -27,10 +27,10 @@ index ef9f6712046a22a8d0dfcf95d8e2d12403345532..ea426792b751fd7591bf09f2256dd6bd
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c0ec21a8110ed54489361cfae1e1112fe448150a..164e3261fb6b7a30c86baffde62045b1c6081232 100644
+index 9769977c9db77aa52b99b793ca4f5d0c7b54528f..eb6981ca27d27946c748047660ced880c4dea01a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1987,6 +1987,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1991,6 +1991,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          public void onTickingEnd(Entity entity) {
              ServerLevel.this.entityTickList.remove(entity);

--- a/patches/server/0214-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0214-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d8b0f6ae1604a158ef1be02701c8c605192e7fe1..4d69b6b35f04c904ee9ca9c896baaa9892f8ef9c 100644
+index 3cb4a84a08cbf76e39da5f25fea490c26c77a289..1d29f6c12d2c9de7918669ec03da7307a899e9ab 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1137,7 +1137,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -19,7 +19,7 @@ index d8b0f6ae1604a158ef1be02701c8c605192e7fe1..4d69b6b35f04c904ee9ca9c896baaa98
                  }
              }
          }
-@@ -2074,7 +2074,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2080,7 +2080,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // Spigot Start
              if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder && (!(entity instanceof ServerPlayer) || entity.getRemovalReason() != Entity.RemovalReason.KILLED)) { // SPIGOT-6876: closeInventory clears death message
                  for (org.bukkit.entity.HumanEntity h : Lists.newArrayList(((org.bukkit.inventory.InventoryHolder) entity.getBukkitEntity()).getInventory().getViewers())) {

--- a/patches/server/0381-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
+++ b/patches/server/0381-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
@@ -26,10 +26,10 @@ index a0ffdeaad5c375539857d6a5a94832216d09f024..5346109670bedf88f13b4eff47c52921
              EntityType<?> entitytypes = entity.getType();
              int i = entitytypes.clientTrackingRange() * 16;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index e0e6915320264da3fefb3f449f27efb8477e1e63..5c5f9cf3539aeba4911d27111b0580d99a61f577 100644
+index 0a7dbafd938141b34dc66d0b4af26dba92a21c06..5009ad1a758e192eaf6ca59baab26d2ba58a6c66 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2204,7 +2204,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2210,7 +2210,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          public void onTrackingStart(Entity entity) {
              org.spigotmc.AsyncCatcher.catchOp("entity register"); // Spigot
@@ -38,7 +38,7 @@ index e0e6915320264da3fefb3f449f27efb8477e1e63..5c5f9cf3539aeba4911d27111b0580d9
              if (entity instanceof ServerPlayer) {
                  ServerPlayer entityplayer = (ServerPlayer) entity;
  
-@@ -2237,6 +2237,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2243,6 +2243,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              }
  
              entity.valid = true; // CraftBukkit

--- a/patches/server/0766-Optimise-WorldServer-notify.patch
+++ b/patches/server/0766-Optimise-WorldServer-notify.patch
@@ -110,7 +110,7 @@ index bc6a4bfe7df804ee22791fb767f059a541a3900f..a578ff8a88ef944516150303e96f8b49
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c780af51c50c019e7fa0e5aee3d05e3374f79948..524a4bb83afacf02c331f719be2e2c4320626afe 100644
+index 6053b7797cc4f6ed1ffbfc35048bab1a96586254..7922ecc1bfeb2d00a7a1bce0431efec4f8c57eec 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1096,6 +1096,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -179,9 +179,9 @@ index c780af51c50c019e7fa0e5aee3d05e3374f79948..524a4bb83afacf02c331f719be2e2c43
          public void onTickingEnd(Entity entity) {
              ServerLevel.this.entityTickList.remove(entity);
 +            ServerLevel.this.entityManager.removeNavigatorsFromData(entity); // Paper - optimise notify
-         }
- 
-         public void onTrackingStart(Entity entity) {
+             // Paper start - Reset pearls when they stop being ticked
+             if (paperConfig.disableEnderpearlExploit && entity instanceof net.minecraft.world.entity.projectile.ThrownEnderpearl pearl) {
+                 pearl.cachedOwner = null;
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 index b47cd6d8ed02875bd9af54d27b7c1cda340e7f9f..d35032a8d2612d555c3dad1fe496d7ae1c5a285b 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java

--- a/patches/server/0774-Fix-merchant-inventory-not-closing-on-entity-removal.patch
+++ b/patches/server/0774-Fix-merchant-inventory-not-closing-on-entity-removal.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix merchant inventory not closing on entity removal
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 524a4bb83afacf02c331f719be2e2c4320626afe..46db8458478de3dee83fc03478245ba914c79999 100644
+index 7922ecc1bfeb2d00a7a1bce0431efec4f8c57eec..4c9832ccede082a468e97870b5f6b07bbed652f3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2485,6 +2485,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2491,6 +2491,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // Spigot end
              // Spigot Start
              if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder && (!(entity instanceof ServerPlayer) || entity.getRemovalReason() != Entity.RemovalReason.KILLED)) { // SPIGOT-6876: closeInventory clears death message


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/6920
Supercedes https://github.com/PaperMC/Paper/pull/6924

Currently, the fix is to check if the entity is no longer ticked... in the tick method?
This causes it to never actually be run because the entity tick method is no longer called when the chunk is in this state.

This change makes it so that this logic is run directly when they are no longer ticked (the callback method).