### PR TITLE
Various improvements to console color formatting

### DIFF
--- a/patches/server/0596-Add-support-for-hex-color-codes-in-console.patch
+++ b/patches/server/0596-Add-support-for-hex-color-codes-in-console.patch
@@ -5,20 +5,82 @@ Subject: [PATCH] Add support for hex color codes in console
 
 Converts upstream's hex color code legacy format into actual hex color codes in the console.
 
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index a0a3cec47c8f9e379a5bc1d43eeda5eb9d81f814..23d849872109e43d6e22a953d3a4298565d4621d 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -454,8 +454,10 @@ public class PaperConfig {
+     }
+ 
+     public static boolean deobfuscateStacktraces = true;
++    public static boolean useRgbForNamedTextColors = true;
+     private static void loggerSettings() {
+         deobfuscateStacktraces = getBoolean("settings.loggers.deobfuscate-stacktraces", deobfuscateStacktraces);
++        useRgbForNamedTextColors = getBoolean("settings.loggers.use-rgb-for-named-text-colors", useRgbForNamedTextColors);
+     }
+ 
+     public static boolean allowBlockPermanentBreakingExploits = false;
+diff --git a/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java b/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java
+index 685deaa0e5d1ddc13e3a7c0471b1cfcf1710c869..aa574c646ee9c9951d183c80e1a0fe10c21850a0 100644
+--- a/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java
++++ b/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java
+@@ -1,5 +1,11 @@
+ package com.destroystokyo.paper.console;
+ 
++import io.papermc.paper.adventure.PaperAdventure;
++import io.papermc.paper.console.HexFormattingConverter;
++import net.kyori.adventure.audience.MessageType;
++import net.kyori.adventure.identity.Identity;
++import net.kyori.adventure.text.Component;
++import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ import org.bukkit.craftbukkit.command.CraftConsoleCommandSender;
+@@ -7,11 +13,21 @@ import org.bukkit.craftbukkit.command.CraftConsoleCommandSender;
+ public class TerminalConsoleCommandSender extends CraftConsoleCommandSender {
+ 
+     private static final Logger LOGGER = LogManager.getRootLogger();
++    private static final LegacyComponentSerializer SERIALIZER = LegacyComponentSerializer.builder()
++        .hexColors()
++        .flattener(PaperAdventure.FLATTENER)
++        .character(HexFormattingConverter.COLOR_CHAR)
++        .build();
+ 
+     @Override
+     public void sendRawMessage(String message) {
+-        // TerminalConsoleAppender supports color codes directly in log messages
+-        LOGGER.info(message);
++        final Component msg = PaperAdventure.LEGACY_SECTION_UXRC.deserialize(message);
++        this.sendMessage(Identity.nil(), msg, MessageType.SYSTEM);
++    }
++
++    @Override
++    public void sendMessage(Identity identity, Component message, MessageType type) {
++        LOGGER.info(SERIALIZER.serialize(message));
+     }
+ 
+ }
 diff --git a/src/main/java/io/papermc/paper/console/HexFormattingConverter.java b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a4315961b7a465fb4872a4d67e7c26d4b4ed1fb9
+index 0000000000000000000000000000000000000000..7800125d0ce59547b9a12b74b9de851ce2ee2f92
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
-@@ -0,0 +1,178 @@
+@@ -0,0 +1,205 @@
 +package io.papermc.paper.console;
 +
++import com.destroystokyo.paper.PaperConfig;
++import net.kyori.adventure.text.format.NamedTextColor;
++import net.kyori.adventure.text.format.TextColor;
 +import net.minecrell.terminalconsole.TerminalConsoleAppender;
 +import org.apache.logging.log4j.core.LogEvent;
 +import org.apache.logging.log4j.core.config.Configuration;
 +import org.apache.logging.log4j.core.config.plugins.Plugin;
 +import org.apache.logging.log4j.core.layout.PatternLayout;
-+import org.apache.logging.log4j.core.pattern.*;
++import org.apache.logging.log4j.core.pattern.ConverterKeys;
++import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
++import org.apache.logging.log4j.core.pattern.PatternConverter;
++import org.apache.logging.log4j.core.pattern.PatternFormatter;
++import org.apache.logging.log4j.core.pattern.PatternParser;
 +import org.apache.logging.log4j.util.PerformanceSensitive;
 +import org.apache.logging.log4j.util.PropertiesUtil;
 +
@@ -30,10 +92,10 @@ index 0000000000000000000000000000000000000000..a4315961b7a465fb4872a4d67e7c26d4
 +
 +/**
 + * Modified version of <a href="https://github.com/Minecrell/TerminalConsoleAppender/blob/master/src/main/java/net/minecrell/terminalconsole/MinecraftFormattingConverter.java">
-+ *     TerminalConsoleAppender's MinecraftFormattingConverter</a> to support hex color codes using the md_5 &x&r&r&g&g&b&b format.
++ * TerminalConsoleAppender's MinecraftFormattingConverter</a> to support hex color codes using the Adventure [char]#rrggbb format.
 + */
 +@Plugin(name = "paperMinecraftFormatting", category = PatternConverter.CATEGORY)
-+@ConverterKeys({ "paperMinecraftFormatting" })
++@ConverterKeys({"paperMinecraftFormatting"})
 +@PerformanceSensitive("allocation")
 +public final class HexFormattingConverter extends LogEventPatternConverter {
 +
@@ -41,14 +103,38 @@ index 0000000000000000000000000000000000000000..a4315961b7a465fb4872a4d67e7c26d4
 +
 +    private static final String ANSI_RESET = "\u001B[m";
 +
-+    private static final char COLOR_CHAR = '§';
++    public static final char COLOR_CHAR = 0x7f;
 +    private static final String LOOKUP = "0123456789abcdefklmnor";
 +
 +    private static final String RGB_ANSI = "\u001B[38;2;%d;%d;%dm";
 +    private static final Pattern NAMED_PATTERN = Pattern.compile(COLOR_CHAR + "[0-9a-fk-orA-FK-OR]");
-+    private static final Pattern RGB_PATTERN = Pattern.compile(COLOR_CHAR + "x(" + COLOR_CHAR + "[0-9a-fA-F]){6}");
++    private static final Pattern RGB_PATTERN = Pattern.compile(COLOR_CHAR + "#([0-9a-fA-F]){6}");
 +
-+    private static final String[] ansiCodes = new String[] {
++    private static final String[] RGB_ANSI_CODES = new String[]{
++        formatHexAnsi(NamedTextColor.BLACK),         // Black §0
++        formatHexAnsi(NamedTextColor.DARK_BLUE),     // Dark Blue §1
++        formatHexAnsi(NamedTextColor.DARK_GREEN),    // Dark Green §2
++        formatHexAnsi(NamedTextColor.DARK_AQUA),     // Dark Aqua §3
++        formatHexAnsi(NamedTextColor.DARK_RED),      // Dark Red §4
++        formatHexAnsi(NamedTextColor.DARK_PURPLE),   // Dark Purple §5
++        formatHexAnsi(NamedTextColor.GOLD),          // Gold §6
++        formatHexAnsi(NamedTextColor.GRAY),          // Gray §7
++        formatHexAnsi(NamedTextColor.DARK_GRAY),     // Dark Gray §8
++        formatHexAnsi(NamedTextColor.BLUE),          // Blue §9
++        formatHexAnsi(NamedTextColor.GREEN),         // Green §a
++        formatHexAnsi(NamedTextColor.AQUA),          // Aqua §b
++        formatHexAnsi(NamedTextColor.RED),           // Red §c
++        formatHexAnsi(NamedTextColor.LIGHT_PURPLE),  // Light Purple §d
++        formatHexAnsi(NamedTextColor.YELLOW),        // Yellow §e
++        formatHexAnsi(NamedTextColor.WHITE),         // White §f
++        "\u001B[5m",                                 // Obfuscated §k
++        "\u001B[21m",                                // Bold §l
++        "\u001B[9m",                                 // Strikethrough §m
++        "\u001B[4m",                                 // Underline §n
++        "\u001B[3m",                                 // Italic §o
++        ANSI_RESET,                                  // Reset §r
++    };
++    private static final String[] ANSI_ANSI_CODES = new String[]{
 +        "\u001B[0;30m",    // Black §0
 +        "\u001B[0;34m",    // Dark Blue §1
 +        "\u001B[0;32m",    // Dark Green §2
@@ -107,30 +193,26 @@ index 0000000000000000000000000000000000000000..a4315961b7a465fb4872a4d67e7c26d4
 +        format(content, toAppendTo, start, useAnsi);
 +    }
 +
-+    private static String convertRGBColors(String input) {
-+        Matcher matcher = RGB_PATTERN.matcher(input);
-+        StringBuffer buffer = new StringBuffer();
-+        while (matcher.find()) {
-+            String s = matcher.group().replace(String.valueOf(COLOR_CHAR), "").replace('x', '#');
-+            int hex = Integer.decode(s);
-+            int red = (hex >> 16) & 0xFF;
-+            int green = (hex >> 8) & 0xFF;
-+            int blue = hex & 0xFF;
-+            String replacement = String.format(RGB_ANSI, red, green, blue);
-+            matcher.appendReplacement(buffer, replacement);
-+        }
-+        matcher.appendTail(buffer);
-+        return buffer.toString();
++    private static String convertRGBColors(final String input) {
++        return RGB_PATTERN.matcher(input).replaceAll(result -> {
++            final int hex = Integer.decode(result.group().substring(1));
++            return formatHexAnsi(hex);
++        });
 +    }
 +
-+    private static String stripRGBColors(String input) {
-+        Matcher matcher = RGB_PATTERN.matcher(input);
-+        StringBuffer buffer = new StringBuffer();
-+        while (matcher.find()) {
-+            matcher.appendReplacement(buffer, "");
-+        }
-+        matcher.appendTail(buffer);
-+        return buffer.toString();
++    private static String formatHexAnsi(final TextColor color) {
++        return formatHexAnsi(color.value());
++    }
++
++    private static String formatHexAnsi(final int color) {
++        final int red = color >> 16 & 0xFF;
++        final int green = color >> 8 & 0xFF;
++        final int blue = color & 0xFF;
++        return String.format(RGB_ANSI, red, green, blue);
++    }
++
++    private static String stripRGBColors(final String input) {
++        return RGB_PATTERN.matcher(input).replaceAll("");
 +    }
 +
 +    static void format(String content, StringBuilder result, int start, boolean ansi) {
@@ -146,7 +228,8 @@ index 0000000000000000000000000000000000000000..a4315961b7a465fb4872a4d67e7c26d4
 +        }
 +
 +        Matcher matcher = NAMED_PATTERN.matcher(content);
-+        StringBuffer buffer = new StringBuffer();
++        StringBuilder buffer = new StringBuilder();
++        final String[] ansiCodes = PaperConfig.useRgbForNamedTextColors ? RGB_ANSI_CODES : ANSI_ANSI_CODES;
 +        while (matcher.find()) {
 +            int format = LOOKUP.indexOf(Character.toLowerCase(matcher.group().charAt(1)));
 +            if (format != -1) {
@@ -156,7 +239,7 @@ index 0000000000000000000000000000000000000000..a4315961b7a465fb4872a4d67e7c26d4
 +        matcher.appendTail(buffer);
 +
 +        result.setLength(start);
-+        result.append(buffer.toString());
++        result.append(buffer);
 +        if (ansi) {
 +            result.append(ANSI_RESET);
 +        }
@@ -169,7 +252,6 @@ index 0000000000000000000000000000000000000000..a4315961b7a465fb4872a4d67e7c26d4
 +     * @param config  The current configuration
 +     * @param options The pattern options
 +     * @return The new instance
-+     *
 +     * @see HexFormattingConverter
 +     */
 +    public static HexFormattingConverter newInstance(Configuration config, String[] options) {

--- a/patches/server/0671-Make-item-validations-configurable.patch
+++ b/patches/server/0671-Make-item-validations-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make item validations configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5f22fdedd5456ffde94b038d294fe14ac9c6ad20..bb66ecc34e2f618444ea0a3b106e6e4a2d5a0c70 100644
+index fae61ada619d86b6721c7a57fecd485188919a25..3d1319af2dbade4234025793303333cb95d9c019 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -504,4 +504,19 @@ public class PaperConfig {
+@@ -506,4 +506,19 @@ public class PaperConfig {
          config.set("settings.unsupported-settings.allow-headless-pistons-readme", "This setting controls if players should be able to create headless pistons.");
          allowHeadlessPistons = getBoolean("settings.unsupported-settings.allow-headless-pistons", false);
      }

--- a/patches/server/0753-Add-packet-limiter-config.patch
+++ b/patches/server/0753-Add-packet-limiter-config.patch
@@ -24,10 +24,10 @@ and an action can be defined: DROP or KICK
 If interval or rate are less-than 0, the limit is ignored
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index bb66ecc34e2f618444ea0a3b106e6e4a2d5a0c70..d9a63e0574676357265c5b971b061b9595081d7d 100644
+index 3d1319af2dbade4234025793303333cb95d9c019..cd601be6604fd81be8d58f6a46d39008fa8ecc20 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -519,4 +519,102 @@ public class PaperConfig {
+@@ -521,4 +521,102 @@ public class PaperConfig {
          itemValidationBookAuthorLength = getInt("settings.item-validation.book.author", itemValidationBookAuthorLength);
          itemValidationBookPageLength = getInt("settings.item-validation.book.page", itemValidationBookPageLength);
      }

--- a/patches/server/0754-Lag-compensate-block-breaking.patch
+++ b/patches/server/0754-Lag-compensate-block-breaking.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Lag compensate block breaking
 Use time instead of ticks if ticks fall behind
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index d9a63e0574676357265c5b971b061b9595081d7d..780754f1c6252fa567d27389978f59dbd71abc94 100644
+index cd601be6604fd81be8d58f6a46d39008fa8ecc20..cff9872882f9057ec2bfd44c15c1d66d8cefa721 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -617,4 +617,10 @@ public class PaperConfig {
+@@ -619,4 +619,10 @@ public class PaperConfig {
              }
          }
      }

--- a/patches/server/0760-Send-full-pos-packets-for-hard-colliding-entities.patch
+++ b/patches/server/0760-Send-full-pos-packets-for-hard-colliding-entities.patch
@@ -9,10 +9,10 @@ Configurable under
 `send-full-pos-for-hard-colliding-entities`
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 780754f1c6252fa567d27389978f59dbd71abc94..8b641e13f5b13eae2f2969ccb4b4551afcb50299 100644
+index cff9872882f9057ec2bfd44c15c1d66d8cefa721..b8029b11764c67c0fe39bd1a07950f491691c938 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -623,4 +623,10 @@ public class PaperConfig {
+@@ -625,4 +625,10 @@ public class PaperConfig {
      private static void lagCompensateBlockBreaking() {
          lagCompensateBlockBreaking = getBoolean("settings.lag-compensate-block-breaking", true);
      }

--- a/patches/server/0826-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/patches/server/0826-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -10,10 +10,10 @@ when if this was fixed on the client, that wouldn't be needed.
 Mojira Issue: https://bugs.mojang.com/browse/MC-235045
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index b7db009e9002bf517ce085fe250a9eba0da58807..7d80480de7a37f1fa0d1fdedf6a967488e4977a3 100644
+index 5de84dfb6f18f3a0afdd33bf6bf640f48efc6e6b..24ddf8cfdbe6ed2fb148f57f0d7dd98446b07bbc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -525,6 +525,11 @@ public class PaperConfig {
+@@ -527,6 +527,11 @@ public class PaperConfig {
          itemValidationBookPageLength = getInt("settings.item-validation.book.page", itemValidationBookPageLength);
      }
  

--- a/patches/server/0834-Validate-usernames.patch
+++ b/patches/server/0834-Validate-usernames.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Validate usernames
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 7d80480de7a37f1fa0d1fdedf6a967488e4977a3..29932d3b80b26481fd54631d33fec4ead42a3b41 100644
+index 24ddf8cfdbe6ed2fb148f57f0d7dd98446b07bbc..da6346cacf08e12f7f1fabe2d5b1c66c82fab679 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -493,6 +493,12 @@ public class PaperConfig {
+@@ -495,6 +495,12 @@ public class PaperConfig {
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
  

--- a/patches/server/0838-Add-config-option-for-worlds-affected-by-time-cmd.patch
+++ b/patches/server/0838-Add-config-option-for-worlds-affected-by-time-cmd.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config option for worlds affected by time cmd
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 29932d3b80b26481fd54631d33fec4ead42a3b41..4587e9a43d2a6ddc9aadd5e1a84ed7a77248967a 100644
+index da6346cacf08e12f7f1fabe2d5b1c66c82fab679..2e68fe31fc788a3ff1fe4ac52140e5e518f660b1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -645,4 +645,9 @@ public class PaperConfig {
+@@ -647,4 +647,9 @@ public class PaperConfig {
      private static void sendFullPosForHardCollidingEntities() {
          sendFullPosForHardCollidingEntities = getBoolean("settings.send-full-pos-for-hard-colliding-entities", true);
      }

--- a/patches/server/0859-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0859-Replace-player-chunk-loader-system.patch
@@ -84,10 +84,10 @@ index 309dbf5fce3ce940d5e1b57d267b9d6b2c5ff5b6..5ba64e1083b7cb1eec64d1925095c6ca
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4587e9a43d2a6ddc9aadd5e1a84ed7a77248967a..78fdf24658ca8f72ad12f69c502b15bd16a73c57 100644
+index 2e68fe31fc788a3ff1fe4ac52140e5e518f660b1..9bff729df7156b071b08913549838024bb17c3c9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -650,4 +650,33 @@ public class PaperConfig {
+@@ -652,4 +652,33 @@ public class PaperConfig {
      private static void timeCommandAffectsAllWorlds() {
          timeCommandAffectsAllWorlds = getBoolean("settings.time-command-affects-all-worlds", timeCommandAffectsAllWorlds);
      }

--- a/patches/server/0865-Option-to-have-default-CustomSpawners-in-custom-worl.patch
+++ b/patches/server/0865-Option-to-have-default-CustomSpawners-in-custom-worl.patch
@@ -10,10 +10,10 @@ just looking at the LevelStem key, look at the DimensionType key which
 is one level below that. Defaults to off to keep vanilla behavior.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 78fdf24658ca8f72ad12f69c502b15bd16a73c57..73bc7a82254114ab8a5cddaac02322438517d8a3 100644
+index 9bff729df7156b071b08913549838024bb17c3c9..88a4dda44e59fbe6215d7ac2e5af0c54527a2fc7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -679,4 +679,9 @@ public class PaperConfig {
+@@ -681,4 +681,9 @@ public class PaperConfig {
          }
          globalMaxConcurrentChunkLoads = getDouble("settings.chunk-loading.global-max-concurrent-loads", 500.0);
      }


### PR DESCRIPTION
- Use Adventure's [char]#rrggbb RGB format internally instead of the unusual x repeated characters format
- Option (default true) to use actual color for NamedTextColors instead of closest ANSI code
- Use a rarely used character (0x7f) instead of section symbol for internal format