### PR TITLE
Fix generator settings string for flat-type worlds

### DIFF
--- a/patches/server/0005-MC-Dev-fixes.patch
+++ b/patches/server/0005-MC-Dev-fixes.patch
@@ -345,3 +345,16 @@ index e6b1663d4ccdd3842f711ad7547df8ccf973e4b1..524f3c42964eb83c9109bcc548a1075f
                  }
              }
  
+diff --git a/src/main/java/net/minecraft/world/level/levelgen/WorldGenSettings.java b/src/main/java/net/minecraft/world/level/levelgen/WorldGenSettings.java
+index f1aee097318f91d582aa143a77662ec12e812c93..3f46bf0358fd9bb4d0fa41026f138ffd21952bde 100644
+--- a/src/main/java/net/minecraft/world/level/levelgen/WorldGenSettings.java
++++ b/src/main/java/net/minecraft/world/level/levelgen/WorldGenSettings.java
+@@ -35,7 +35,7 @@ import org.apache.commons.lang3.StringUtils;
+ import org.slf4j.Logger;
+ 
+ public class WorldGenSettings {
+-    public static final Codec<WorldGenSettings> CODEC = RecordCodecBuilder.create((instance) -> {
++    public static final Codec<WorldGenSettings> CODEC = RecordCodecBuilder.<WorldGenSettings>create((instance) -> { // Paper - decompile fix
+         return instance.group(Codec.LONG.fieldOf("seed").stable().forGetter(WorldGenSettings::seed), Codec.BOOL.fieldOf("generate_features").orElse(true).stable().forGetter(WorldGenSettings::generateFeatures), Codec.BOOL.fieldOf("bonus_chest").orElse(false).stable().forGetter(WorldGenSettings::generateBonusChest), RegistryCodecs.dataPackAwareCodec(Registry.LEVEL_STEM_REGISTRY, Lifecycle.stable(), LevelStem.CODEC).xmap(LevelStem::sortMap, Function.identity()).fieldOf("dimensions").forGetter(WorldGenSettings::dimensions), Codec.STRING.optionalFieldOf("legacy_custom_options").stable().forGetter((worldGenSettings) -> {
+             return worldGenSettings.legacyCustomOptions;
+         })).apply(instance, instance.stable(WorldGenSettings::new));

--- a/patches/server/0885-Fix-generator-settings-string-for-flat-type-worlds.patch
+++ b/patches/server/0885-Fix-generator-settings-string-for-flat-type-worlds.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 9 Mar 2022 12:51:29 -0800
+Subject: [PATCH] Fix generator settings string for flat-type worlds
+
+Fixes MC-195468
+
+diff --git a/src/main/java/net/minecraft/world/level/levelgen/WorldGenSettings.java b/src/main/java/net/minecraft/world/level/levelgen/WorldGenSettings.java
+index 3f46bf0358fd9bb4d0fa41026f138ffd21952bde..3ef58c932cc0a34cc6f0e0297ed91fd260101efc 100644
+--- a/src/main/java/net/minecraft/world/level/levelgen/WorldGenSettings.java
++++ b/src/main/java/net/minecraft/world/level/levelgen/WorldGenSettings.java
+@@ -196,7 +196,7 @@ public class WorldGenSettings {
+         String var8 = worldGenProperties.levelType();
+         switch(var8) {
+         case "flat":
+-            Dynamic<JsonElement> dynamic = new Dynamic<>(JsonOps.INSTANCE, worldGenProperties.generatorSettings());
++            Dynamic<JsonElement> dynamic = new Dynamic<>(net.minecraft.resources.RegistryOps.create(JsonOps.INSTANCE, registryManager), worldGenProperties.generatorSettings()); // Paper - needs RegistryOps to access biome registry inside FlatLevelGeneratorSettings's Codec, Fixes MC-195468
+             return new WorldGenSettings(l, worldGenProperties.generateStructures(), false, withOverworld(registry, registry4, new FlatLevelSource(registry3, FlatLevelGeneratorSettings.CODEC.parse(dynamic).resultOrPartial(LOGGER::error).orElseGet(() -> {
+                 return FlatLevelGeneratorSettings.getDefault(registry2, registry3);
+             }))));


### PR DESCRIPTION
Fixes [MC-195468](https://bugs.mojang.com/browse/MC-195468)
Fixes https://github.com/PaperMC/Paper/issues/7565

##### Test Steps
1. New server
2. Start and then stop
3. Edit `server.properties`, setting `level-type=flat`, and `generator-settings={"structure_overrides"\:[],"layers"\:[{"block"\:"minecraft\:bedrock","height"\:1},{"block"\:"minecraft\:dirt","height"\:48},{"block"\:"minecraft\:grass_block","height"\:1}],"biome"\:"plains"}`
4. Delete generated worlds
5. Start server
6. Verify that the dirt is 48 blocks high, and that no structures have spawned (use `level-seed=-8491285921874972263` to have a village right next to spawn w/o those generator-settings)