### PR TITLE
Fix setting certain custom inventory names

### DIFF
--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -7,7 +7,7 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5c7b2850d311e4d54236ba9acce148bca05672fd..15927e8b747e536a5136d9b59edc8d6f50354c42 100644
+index 23410c6ee34fcd9c50c2dbf35d8ff4d0c9ca408c..557ab97176944209c55f02dd106131ece2c01119 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -185,4 +185,13 @@ public class PaperConfig {
@@ -3247,7 +3247,7 @@ index 4e705b7367b78c2da98d0b174807ecbce75f3a59..4972ce5d876d74e04a4fbfeb860f1d44
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java b/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
-index 1980240d3dc0331ddf2ff56e163e2bfbd3b231ab..7a7f3f53aef601f124d474d9890e23d87dd96900 100644
+index 1980240d3dc0331ddf2ff56e163e2bfbd3b231ab..3a54c6c2ef8365c66732d387bcda279d03f27a51 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
 @@ -31,6 +31,18 @@ public abstract class CraftTileInventoryConverter implements CraftInventoryCreat
@@ -3258,8 +3258,8 @@ index 1980240d3dc0331ddf2ff56e163e2bfbd3b231ab..7a7f3f53aef601f124d474d9890e23d8
 +    @Override
 +    public Inventory createInventory(InventoryHolder owner, InventoryType type, net.kyori.adventure.text.Component title) {
 +        Container te = getTileEntity();
-+        if (te instanceof RandomizableContainerBlockEntity) {
-+            ((RandomizableContainerBlockEntity) te).setCustomName(io.papermc.paper.adventure.PaperAdventure.asVanilla(title));
++        if (te instanceof net.minecraft.world.level.block.entity.BaseContainerBlockEntity baseBlockEntity) {
++            baseBlockEntity.setCustomName(io.papermc.paper.adventure.PaperAdventure.asVanilla(title));
 +        }
 +
 +        return getInventory(te);

--- a/patches/server/0287-Restore-custom-InventoryHolder-support.patch
+++ b/patches/server/0287-Restore-custom-InventoryHolder-support.patch
@@ -246,7 +246,7 @@ index 08fc05836b26f5f93ae74324705d5f593b57315a..fdde2b3f2320393ab4acf450d08ab674
      static class MinecraftInventory implements Container {
          private final NonNullList<ItemStack> items;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java b/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
-index 7a7f3f53aef601f124d474d9890e23d87dd96900..54e61b9b058bee2167461aaaf828ed7a00949c29 100644
+index 3a54c6c2ef8365c66732d387bcda279d03f27a51..8e65d0c23874c44af240a976d3f425b840b4549b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
 @@ -28,7 +28,7 @@ public abstract class CraftTileInventoryConverter implements CraftInventoryCreat
@@ -259,7 +259,7 @@ index 7a7f3f53aef601f124d474d9890e23d87dd96900..54e61b9b058bee2167461aaaf828ed7a
  
      // Paper start
 @@ -39,7 +39,7 @@ public abstract class CraftTileInventoryConverter implements CraftInventoryCreat
-             ((RandomizableContainerBlockEntity) te).setCustomName(io.papermc.paper.adventure.PaperAdventure.asVanilla(title));
+             baseBlockEntity.setCustomName(io.papermc.paper.adventure.PaperAdventure.asVanilla(title));
          }
  
 -        return getInventory(te);

--- a/patches/server/0882-Fix-certain-custom-inventory-name-setting.patch
+++ b/patches/server/0882-Fix-certain-custom-inventory-name-setting.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Wed, 9 Mar 2022 18:43:10 -0500
+Subject: [PATCH] Fix certain custom inventory name setting
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java b/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
+index 8e65d0c23874c44af240a976d3f425b840b4549b..c84157c1599fac4368d0e997a8164e089389869d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
+@@ -46,8 +46,8 @@ public abstract class CraftTileInventoryConverter implements CraftInventoryCreat
+     @Override
+     public Inventory createInventory(InventoryHolder holder, InventoryType type, String title) {
+         Container te = this.getTileEntity();
+-        if (te instanceof RandomizableContainerBlockEntity) {
+-            ((RandomizableContainerBlockEntity) te).setCustomName(CraftChatMessage.fromStringOrNull(title));
++        if (te instanceof net.minecraft.world.level.block.entity.BaseContainerBlockEntity baseBlockEntity) {
++            baseBlockEntity.setCustomName(CraftChatMessage.fromStringOrNull(title));
+         }
+ 
+         return this.getInventory(holder, type, te); // Paper


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23108066/157557589-1d18edc2-fe0d-495c-9756-293678b7facc.png)

For some inventories, their name isn't set when they are created. This is because most "named" inventories rely on being set by ``CraftTileInventoryConverter#createInventory``, where if they extend RandomizableContainerBlockEntity they are correctly set. 

This is not an issue for inventories like Furnaces + Brewing Stands, as they have their own custom converter which manually sets the title (See Furnace/BrewingStand inner class).
This change uses a better parent class, which should correctly set block entities that can be named instead of creating custom converters for each one.

Also, should I have the patch that fixes it for the deprecated spigot method? I'm not sure if we should just fix it for the adventure one or not.