### PR TITLE
Prevent despawned navigators being readded

### DIFF
--- a/patches/server/0774-Optimise-WorldServer-notify.patch
+++ b/patches/server/0774-Optimise-WorldServer-notify.patch
@@ -8,7 +8,7 @@ Instead, only iterate over navigators in the current region that are
 eligible for repathing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 9a269f0ab59b4ea2ce01957f89677d2f304ebf02..b6a17bb19a45ccd4bfc4be5f177a792a9a3727f5 100644
+index 43373e6bbe20e467043e750e0d7a11cd5a0ea1bc..952286cca1ce9e893f4a9e5939c552efe975abb4 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -301,15 +301,81 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -110,14 +110,14 @@ index 9a269f0ab59b4ea2ce01957f89677d2f304ebf02..b6a17bb19a45ccd4bfc4be5f177a792a
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index ea665ae89b0963e5605ff0bc87f906fdddeb2c9a..ae1de6544f488ff14202fd9df6267b2c98b81111 100644
+index ea665ae89b0963e5605ff0bc87f906fdddeb2c9a..ca9c43f48ab269430accbefe0ed470bc62efade9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1096,6 +1096,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      public void tickNonPassenger(Entity entity) {
          // Paper start - log detailed entity tick information
          io.papermc.paper.util.TickThread.ensureTickThread("Cannot tick an entity off-main");
-+        this.entityManager.updateNavigatorsInRegion(entity); // Paper - optimise notify
++        if (!entity.isRemoved()) this.entityManager.updateNavigatorsInRegion(entity); // Paper - optimise notify
          try {
              if (currentlyTickingEntity.get() == null) {
                  currentlyTickingEntity.lazySet(entity);


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/6983

Relevant conversation and testing can be seen at: https://canary.discord.com/channels/289587909051416579/925530366192779286/951639613284425779

It is currently unknown why despawned entities are still ticked in the first place, and is something that needs to be looked into.