### PR TITLE
Don't tick despawned entities

### DIFF
--- a/patches/server/0882-Dont-tick-despawned-entities.patch
+++ b/patches/server/0882-Dont-tick-despawned-entities.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Thu, 10 Mar 2022 21:39:26 -0500
+Subject: [PATCH] Dont tick despawned entities
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index dce7452d58d6081f1a83baddafb1596ebd423d21..dc56201641dd8ef09dbc6c6aa35554f5124ff3d6 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -658,6 +658,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+                         gameprofilerfiller.push("checkDespawn");
+                         entity.checkDespawn();
+                         gameprofilerfiller.pop();
++                        if (entity.isRemoved()) return; // Paper - Don't tick entities that are removed in the checkDespawn method.
+                         if (true || this.chunkSource.chunkMap.getDistanceManager().inEntityTickingRange(entity.chunkPosition().toLong())) { // Paper - now always true if in the ticking list
+                             Entity entity1 = entity.getVehicle();
+ 


### PR DESCRIPTION
Before 1.17, mc checked if the entity was not dead before ticking it, as there was despawn logic that could be run which could cause the entity to be removed.
![image](https://user-images.githubusercontent.com/23108066/157792250-d0975e7c-c58f-4506-83d1-527ebb4c6d47.png)

However, as of 1.17 there is no longer a check, causing entities that were despawned to be ticked.
![image](https://user-images.githubusercontent.com/23108066/157792333-d2b61e8a-e2da-4c7b-8e0b-9bac7cba7e92.png)

It's unknown if there is any behavior that relies on this, but looking myself I couldn't find anything. If anyone can find any logic here that may rely on this, it would be appreciated. 

Context can be seen at: https://canary.discord.com/channels/289587909051416579/925530366192779286/951663121146191983