### PR TITLE
Backport PaperMC#7492 to 1.17.1

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -255,3 +255,6 @@ public net.minecraft.world.level.block.state.BlockBehaviour hasCollision
 
 # add per world spawn limits
 public net.minecraft.world.level.NaturalSpawner SPAWNING_CATEGORIES
+
+# Fix cancelling ProjectileHitEvent for piercing arrows
+protected net.minecraft.world.entity.projectile.Projectile hitCancelled

--- a/patches/server/0849-Fix-cancelling-ProjectileHitEvent-for-piercing-arrow.patch
+++ b/patches/server/0849-Fix-cancelling-ProjectileHitEvent-for-piercing-arrow.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 19 Feb 2022 19:05:59 -0800
+Subject: [PATCH] Fix cancelling ProjectileHitEvent for piercing arrows
+
+Piercing arrows search for multiple entities inside a while
+loop that is checking the projectile entity's removed state.
+If the hit event is cancelled on the first entity, the event will
+be called over and over again inside that while loop until the event
+is not cancelled. The solution here, is to make use of an
+already-existing field on AbstractArrow for tracking entities hit by
+piercing arrows to avoid duplicate damage being applied.
+
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
+index 3d3dcb47720055f550d17d1f106a2c0e59de2919..53d0024daf6963ac4dab575666b0d6a74a39a958 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
+@@ -299,6 +299,19 @@ public abstract class AbstractArrow extends Projectile {
+         }
+     }
+ 
++    // Paper start
++    @Override
++    protected void preOnHit(HitResult hitResult) {
++        super.preOnHit(hitResult);
++        if (hitResult instanceof EntityHitResult entityHitResult && this.hitCancelled && this.getPierceLevel() > 0) {
++            if (this.piercingIgnoreEntityIds == null) {
++                this.piercingIgnoreEntityIds = new IntOpenHashSet(5);
++            }
++            this.piercingIgnoreEntityIds.add(entityHitResult.getEntity().getId());
++        }
++    }
++    // Paper end
++
+     private boolean shouldFall() {
+         return this.inGround && this.level.noCollision((new AABB(this.position(), this.position())).inflate(0.06D));
+     }


### PR DESCRIPTION
Fix cancelling ProjectileHitEvents on Pierced arrows.