### PR TITLE
Add more collision code skipping logic

### DIFF
--- a/patches/server/0382-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0382-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -3,18 +3,31 @@ From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Wed, 15 Apr 2020 17:56:07 -0700
 Subject: [PATCH] Don't run entity collision code if not needed
 
-Will not run if max entity craming is disabled and
-the max collisions per entity is less than or equal to 0
+Will not run if:
+Max entity cramming is disabled and the max collisions per entity is less than or equal to 0.
+Entity#isPushable() returns false, meaning all entities will not be able to collide with this
+entity anyways.
+The entity's current team collision rule causes them to NEVER collide.
+
+Co-authored-by: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 24a16dbfc0852a566dd527639974fcba44bd43fe..8de0a71566d2b095e74c8f8cf15dfac26a5a31c2 100644
+index 24a16dbfc0852a566dd527639974fcba44bd43fe..5c6ed31e0fa8b089c3962326f2a4973fa83701ac 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3340,10 +3340,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3340,10 +3340,24 @@ public abstract class LivingEntity extends Entity {
      protected void serverAiStep() {}
  
      protected void pushEntities() {
 +        // Paper start - don't run getEntities if we're not going to use its result
++        if (!this.isPushable()) {
++            return;
++        }
++        net.minecraft.world.scores.Team team = this.getTeam();
++        if (team != null && team.getCollisionRule() == net.minecraft.world.scores.Team.CollisionRule.NEVER) {
++            return;
++        }
++
 +        int i = this.level.getGameRules().getInt(GameRules.RULE_MAX_ENTITY_CRAMMING);
 +        if (i <= 0 && level.paperConfig().collisions.maxEntityCollisions <= 0) {
 +            return;

--- a/patches/server/0449-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0449-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 03194c5acd46f6014f0a1d964d079b114f86c951..8910fed602d6055911d87eb3d12e1d707b5e8ea9 100644
+index 908d1c840301bfbd8aaed571e7cae7d1c16b5c19..8271a130fb14894259a4beb095627bd9f60bc48c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3438,7 +3438,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3446,7 +3446,7 @@ public abstract class LivingEntity extends Entity {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - suppress

--- a/patches/server/0516-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0516-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -22,7 +22,7 @@ index 9b1ee67e9963f31c107f5bc310f6840d58906477..648d08635e2ec9c4847ada7709b7452f
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/EntitySelector.java b/src/main/java/net/minecraft/world/entity/EntitySelector.java
-index 22f36cd3df49160f1b6668befdd05c2268edaa49..e39965c2e50bc8ee424ea07819346e0611398e28 100644
+index 302676ef78ed5b3b7fc1b04851447ca72eed10c0..a00c3d96f2fc7131d1f4afa7af4e41ace3cfce89 100644
 --- a/src/main/java/net/minecraft/world/entity/EntitySelector.java
 +++ b/src/main/java/net/minecraft/world/entity/EntitySelector.java
 @@ -45,11 +45,17 @@ public final class EntitySelector {
@@ -45,10 +45,10 @@ index 22f36cd3df49160f1b6668befdd05c2268edaa49..e39965c2e50bc8ee424ea07819346e06
              } else if (entity.level.isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8910fed602d6055911d87eb3d12e1d707b5e8ea9..0896cbe04be6a5471088c321296506415fccbed6 100644
+index 8271a130fb14894259a4beb095627bd9f60bc48c..75c76534e326255bbf432b6fe7ce2b9819846f06 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3360,7 +3360,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3368,7 +3368,7 @@ public abstract class LivingEntity extends Entity {
              return;
          }
          // Paper end - don't run getEntities if we're not going to use its result
@@ -57,7 +57,7 @@ index 8910fed602d6055911d87eb3d12e1d707b5e8ea9..0896cbe04be6a5471088c32129650641
  
          if (!list.isEmpty()) {
              // Paper - move up
-@@ -3523,9 +3523,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3531,9 +3531,16 @@ public abstract class LivingEntity extends Entity {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0600-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0600-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cc930b8a22b3e3540b9fb24c6eaa329895c075cb..93ba2f0bc5fec094933f0fa25e084df2998e0949 100644
+index 427326d1795bd5262ac96bfeb30de0e02c48e04e..901075b2a494efa54c4468336f2aa85ef31a0d64 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3781,6 +3781,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3789,6 +3789,7 @@ public abstract class LivingEntity extends Entity {
                          level.getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {

--- a/patches/server/0650-Line-Of-Sight-Changes.patch
+++ b/patches/server/0650-Line-Of-Sight-Changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 93ba2f0bc5fec094933f0fa25e084df2998e0949..914fa03592e006c86c35c4ef1f3879130ad6ee00 100644
+index 901075b2a494efa54c4468336f2aa85ef31a0d64..aeb1d0559e58d6839aa9fcfc899f5ad7ba33e891 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3509,7 +3509,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3517,7 +3517,8 @@ public abstract class LivingEntity extends Entity {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  

--- a/patches/server/0853-Add-PlayerStopUsingItemEvent.patch
+++ b/patches/server/0853-Add-PlayerStopUsingItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerStopUsingItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 66a566af1dd6684bd7c0dd8b3104543e20b64295..780cff9638fe717e98a97f1241cf65337b55382c 100644
+index 9cefacd1db700402d6a7eef18be123c2e037716e..0a2ff3b8412b7e3ccca26d1e32d9d5bc7d5c2ee2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3930,6 +3930,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3938,6 +3938,7 @@ public abstract class LivingEntity extends Entity {
  
      public void releaseUsingItem() {
          if (!this.useItem.isEmpty()) {


### PR DESCRIPTION
Resolves https://github.com/PaperMC/Paper/issues/7424

Skips pushEntities logic if:
1. The entity cannot collide in the first place
2. The entity is on a team that can never collide (this does a hashmap call, but should return null in most instances)

This logic was stolen from the pushable predicate, wherein cases that were independent of the entity that is being pushed would return false.
For example, the predicate checks if ``!entity.canCollideWithBukkit(entity1)`` which leads to the isCollidable method, so we can confirm that we can move it to the front here.