### PR TITLE
Implement Translatable on CreativeCategory

### DIFF
--- a/patches/api/0220-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0220-Add-methods-to-get-translation-keys.patch
@@ -336,6 +336,85 @@ index c799ac46dbe257d470d3b236cf55b41240f5fda8..d61855b83da0776fe910dee8cde184c7
      }
  
      // Paper start - Add villager reputation API
+diff --git a/src/main/java/org/bukkit/inventory/CreativeCategory.java b/src/main/java/org/bukkit/inventory/CreativeCategory.java
+index 5bd252c0ae3b09fe141d131360c67bb9bfbf5422..0ac1f47d1bea37630d1bb011e52eff90d7a31b41 100644
+--- a/src/main/java/org/bukkit/inventory/CreativeCategory.java
++++ b/src/main/java/org/bukkit/inventory/CreativeCategory.java
+@@ -3,51 +3,64 @@ package org.bukkit.inventory;
+ /**
+  * Represents a category in the creative inventory.
+  */
+-public enum CreativeCategory {
++public enum CreativeCategory implements net.kyori.adventure.translation.Translatable { // Paper
+ 
+     /**
+      * An assortment of building blocks including dirt, bricks, planks, ores
+      * slabs, etc.
+      */
+-    BUILDING_BLOCKS,
++    BUILDING_BLOCKS("buildingBlocks"), // Paper
+     /**
+      * Blocks and items typically used for decorative purposes including
+      * candles, saplings, flora, fauna, fences, walls, carpets, etc.
+      */
+-    DECORATIONS,
++    DECORATIONS("decorations"), // Paper
+     /**
+      * Blocks used and associated with redstone contraptions including buttons,
+      * levers, pressure plates, redstone components, pistons, etc.
+      */
+-    REDSTONE,
++    REDSTONE("redstone"), // Paper
+     /**
+      * Items pertaining to transportation including minecarts, rails, boats,
+      * elytra, etc.
+      */
+-    TRANSPORTATION,
++    TRANSPORTATION("transportation"), // Paper
+     /**
+      * Miscellaneous items and blocks that do not fit into other categories
+      * including gems, dyes, spawn eggs, discs, banner patterns, etc.
+      */
+-    MISC,
++    MISC("misc"), // Paper
+     /**
+      * Food items consumable by the player including meats, berries, edible
+      * drops from creatures, etc.
+      */
+-    FOOD,
++    FOOD("food"), // Paper
+     /**
+      * Equipment items meant for general utility including pickaxes, axes, hoes,
+      * flint and steel, and useful enchantment books for said tools.
+      */
+-    TOOLS,
++    TOOLS("tools"), // Paper
+     /**
+      * Equipment items meant for combat including armor, swords, bows, tipped
+      * arrows, and useful enchantment books for said equipment.
+      */
+-    COMBAT,
++    COMBAT("combat"), // Paper
+     /**
+      * All items related to brewing and potions including all types of potions,
+      * their variants, and ingredients to brew them.
+      */
+-    BREWING;
++    BREWING("brewing"); // Paper
++    // Paper start
++    private final String translationKey;
++
++    CreativeCategory(String translationKey) {
++        this.translationKey = "itemGroup." + translationKey;
++    }
++
++    @Override
++    public @org.jetbrains.annotations.NotNull String translationKey() {
++        return this.translationKey;
++    }
++    // Paper start
++
+ }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
 index f0ba7ba369aad67f6af0f946dc52b3e1c8958b15..d13cedfab28a4de469bbc3f6b141922979628333 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java

--- a/patches/server/0495-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0495-Add-methods-to-get-translation-keys.patch
@@ -77,19 +77,32 @@ index 3b4764986302194882e009fe20a9d6406cf2be8e..008c15164a7affb785964f604f8fea93
  
      /**
 diff --git a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
-index 6cd015dc5a2e012ac827c2b2d9aa5542b0591afb..b2e73df86683b88c83349b6d13456f5b051ac5d5 100644
+index 6cd015dc5a2e012ac827c2b2d9aa5542b0591afb..a5a4026a09b45d7af70a56ce65b8382ac4b22efc 100644
 --- a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
 +++ b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
-@@ -7,7 +7,7 @@ import org.bukkit.Difficulty;
+@@ -3,11 +3,20 @@ package io.papermc.paper.world;
+ import com.destroystokyo.paper.ClientOption;
+ import net.minecraft.network.chat.TranslatableComponent;
+ import net.minecraft.world.entity.player.ChatVisiblity;
++import net.minecraft.world.item.CreativeModeTab;
+ import org.bukkit.Difficulty;
++import org.bukkit.FireworkEffect;
++import org.bukkit.GameRule;
++import org.bukkit.attribute.Attribute;
++import org.bukkit.craftbukkit.inventory.CraftCreativeCategory;
++import org.bukkit.inventory.CreativeCategory;
++import org.bukkit.support.AbstractTestingBase;
  import org.junit.Assert;
  import org.junit.Test;
  
 -public class TranslationKeyTest {
-+public class TranslationKeyTest extends org.bukkit.support.AbstractTestingBase {
++import java.util.Objects;
++
++public class TranslationKeyTest extends AbstractTestingBase {
  
      @Test
      public void testChatVisibilityKeys() {
-@@ -16,4 +16,32 @@ public class TranslationKeyTest {
+@@ -16,4 +25,43 @@ public class TranslationKeyTest {
              Assert.assertEquals(chatVisibility + "'s translation key doesn't match", ChatVisiblity.valueOf(chatVisibility.name()).getKey(), chatVisibility.translationKey());
          }
      }
@@ -103,22 +116,33 @@ index 6cd015dc5a2e012ac827c2b2d9aa5542b0591afb..b2e73df86683b88c83349b6d13456f5b
 +
 +    @Test
 +    public void testGameruleKeys() {
-+        for (org.bukkit.GameRule<?> rule : org.bukkit.GameRule.values()) {
++        for (GameRule<?> rule : GameRule.values()) {
 +            Assert.assertEquals(rule.getName() + "'s translation doesn't match", org.bukkit.craftbukkit.CraftWorld.getGameRulesNMS().get(rule.getName()).getDescriptionId(), rule.translationKey());
 +        }
 +    }
 +
 +    @Test
 +    public void testAttributeKeys() {
-+        for (org.bukkit.attribute.Attribute attribute : org.bukkit.attribute.Attribute.values()) {
++        for (Attribute attribute : Attribute.values()) {
 +            Assert.assertEquals("translation key mismatch for " + attribute, org.bukkit.craftbukkit.attribute.CraftAttributeMap.toMinecraft(attribute).getDescriptionId(), attribute.translationKey());
 +        }
 +    }
 +
 +    @Test
 +    public void testFireworkEffectType() {
-+        for (org.bukkit.FireworkEffect.Type type : org.bukkit.FireworkEffect.Type.values()) {
++        for (FireworkEffect.Type type : FireworkEffect.Type.values()) {
 +            Assert.assertEquals("translation key mismatch for " + type, net.minecraft.world.item.FireworkRocketItem.Shape.byId(org.bukkit.craftbukkit.inventory.CraftMetaFirework.getNBT(type)).getName(), org.bukkit.FireworkEffect.Type.NAMES.key(type));
++        }
++    }
++
++    @Test
++    public void testCreativeCategory() {
++        for (CreativeModeTab tab : CreativeModeTab.TABS) {
++            if (tab == CreativeModeTab.TAB_SEARCH || tab == CreativeModeTab.TAB_HOTBAR || tab == CreativeModeTab.TAB_INVENTORY) { // not implemented in the api
++                continue;
++            }
++            CreativeCategory category = Objects.requireNonNull(CraftCreativeCategory.fromNMS(tab));
++            Assert.assertEquals("translation key mismatch for " + category, ((TranslatableComponent) tab.getDisplayName()).getKey(), category.translationKey());
 +        }
 +    }
  }


### PR DESCRIPTION
The 3 skipped `CreativeModeTabs` aren't implemented by the API and I don't really think they need to. The api is more of a categorization, and the other 3 aren't really categories in that sense.