### PR TITLE
fix datapacks not being able to modify nether/end

### DIFF
--- a/patches/server/0005-MC-Dev-fixes.patch
+++ b/patches/server/0005-MC-Dev-fixes.patch
@@ -182,6 +182,30 @@ index 2a6969baca7c07c52223672de58886dd05c032eb..a620e53021e02da1663b8d8b68d429b2
      @Override
      public void write(FriendlyByteBuf buf) {
          buf.writeInt(this.playerId);
+diff --git a/src/main/java/net/minecraft/resources/RegistryLoader.java b/src/main/java/net/minecraft/resources/RegistryLoader.java
+index 858037070db0b0fed07bf542294b76028f0018f9..75f72b568ee2b27c5042da688b62d4e3c5732e09 100644
+--- a/src/main/java/net/minecraft/resources/RegistryLoader.java
++++ b/src/main/java/net/minecraft/resources/RegistryLoader.java
+@@ -73,7 +73,7 @@ public class RegistryLoader {
+     }
+ 
+     private <E> RegistryLoader.ReadCache<E> readCache(ResourceKey<? extends Registry<E>> registryRef) {
+-        return this.readCache.computeIfAbsent(registryRef, (ref) -> {
++        return (RegistryLoader.ReadCache<E>) this.readCache.computeIfAbsent(registryRef, (ref) -> { // Paper - decompile fix
+             return new RegistryLoader.ReadCache();
+         });
+     }
+@@ -83,10 +83,6 @@ public class RegistryLoader {
+     }
+ 
+     public static record Bound(RegistryAccess.Writable access, RegistryLoader loader) {
+-        public Bound(RegistryAccess.Writable writable, RegistryLoader registryLoader) {
+-            this.access = writable;
+-            this.loader = registryLoader;
+-        }
+ 
+         public <E> DataResult<? extends Registry<E>> overrideRegistryFromResources(ResourceKey<? extends Registry<E>> registryRef, Codec<E> codec, DynamicOps<JsonElement> ops) {
+             WritableRegistry<E> writableRegistry = this.access.ownedWritableRegistryOrThrow(registryRef);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index ef128de5fe17231b39edb12a7014291d03cf79ec..868f6799a0e406401eecf18bc939fbdf88f534a2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java

--- a/patches/server/0754-Use-correct-LevelStem-registry-when-loading-default-.patch
+++ b/patches/server/0754-Use-correct-LevelStem-registry-when-loading-default-.patch
@@ -4,9 +4,27 @@ Date: Sat, 16 Oct 2021 17:38:35 -0700
 Subject: [PATCH] Use correct LevelStem registry when loading default
  end/nether
 
+Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
+diff --git a/src/main/java/net/minecraft/resources/RegistryLoader.java b/src/main/java/net/minecraft/resources/RegistryLoader.java
+index 75f72b568ee2b27c5042da688b62d4e3c5732e09..8c3555842202d67793d818c96feda4daa2f08a0c 100644
+--- a/src/main/java/net/minecraft/resources/RegistryLoader.java
++++ b/src/main/java/net/minecraft/resources/RegistryLoader.java
+@@ -42,6 +42,12 @@ public class RegistryLoader {
+         RegistryLoader.ReadCache<E> readCache = this.readCache(registryRef);
+         DataResult<Holder<E>> dataResult = readCache.values.get(entryKey);
+         if (dataResult != null) {
++            // Paper start - register in registry due to craftbukkit running this 3 times instead of once
++            if (registryRef == (ResourceKey) Registry.LEVEL_STEM_REGISTRY && dataResult.result().isPresent()) {
++                // OptionalInt.empty() because the LevelStem registry is only loaded from the resource manager, not the InMemory resource access
++                registry.registerOrOverride(java.util.OptionalInt.empty(), entryKey, dataResult.result().get().value(), dataResult.lifecycle());
++            }
++            // Paper end
+             return dataResult;
+         } else {
+             Holder<E> holder = registry.getOrCreateHolder(entryKey);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a279368fe144bd41d15e5fe5e565412f8b4ef9f7..f877b956859643b4f3d969992f2e515dc490f90c 100644
+index fddb279d161b30d6944495f0de9f6b7e21761a80..df955666723a8cb1e612311f0b8e77fb577d6be5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -563,7 +563,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/6880

Ok, so root of the issue here is... the `WorldGenSettings` codec uses something called a "data pack aware codec" to create its registry of `LevelStem`. This is like the *only* place on the server where the MappedRegistry ctor is used except in the internal register methods. And then the registry is filled up with defaults, and then sent to the `RegistryLoader` to be overriden by any possible data packs. Now this `RegistryLoader` has a cache, and if it's read in something at a particular location before, it skips it, and doesn't bother adding it to the registry, assuming its done that before. The problem is, craftbukkit runs this loading process 4 times. once at the beginning (like vanilla), but then one more time for each of the default worlds. This means that the override LevelStem isn't added to the registry in the WorldGenSettings for the other two worlds. 

All this does, is ignore any cached results if its trying to fill a LevelStem registry. As far as I can tell, the only time a new instance of registry will be passed into this `RegistryLoader`, will be a LevelStem one, others may get loaded multiple times, but it will be the same *instance* of registry, so it won't matter that it's skipped.