### PR TITLE
Add MORE missing entity API

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -223,6 +223,7 @@ public net.minecraft.world.entity.animal.Panda getEatCounter()I
 public net.minecraft.world.entity.animal.Panda setEatCounter(I)V
 public net.minecraft.world.entity.animal.Bee isRolling()Z
 public net.minecraft.world.entity.animal.Bee setRolling(Z)V
+public net.minecraft.world.entity.monster.piglin.Piglin isChargingCrossbow()Z
 
 # Cook speed multipler API
 public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity recipeType

--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -221,6 +221,8 @@ public net.minecraft.world.entity.animal.Fox isFaceplanted()Z
 public net.minecraft.world.entity.animal.Fox setFaceplanted(Z)V
 public net.minecraft.world.entity.animal.Panda getEatCounter()I
 public net.minecraft.world.entity.animal.Panda setEatCounter(I)V
+public net.minecraft.world.entity.animal.Bee isRolling()Z
+public net.minecraft.world.entity.animal.Bee setRolling(Z)V
 
 # Cook speed multipler API
 public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity recipeType

--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -224,6 +224,8 @@ public net.minecraft.world.entity.animal.Panda setEatCounter(I)V
 public net.minecraft.world.entity.animal.Bee isRolling()Z
 public net.minecraft.world.entity.animal.Bee setRolling(Z)V
 public net.minecraft.world.entity.monster.piglin.Piglin isChargingCrossbow()Z
+public net.minecraft.world.entity.monster.Vex hasLimitedLife
+public net.minecraft.world.entity.monster.Vex limitedLifeTicks
 
 # Cook speed multipler API
 public net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity recipeType

--- a/patches/api/0312-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0312-Missing-Entity-Behavior-API.patch
@@ -561,6 +561,48 @@ index 28cdb3b544572ba7aeb9061e3163e3895ac7d4e6..c8015ff610e3c1222cb368ea1d8a0c2f
 +    void setLoyaltyLevel(int loyaltyLevel);
 +}
 +// Paper end
+diff --git a/src/main/java/org/bukkit/entity/Vex.java b/src/main/java/org/bukkit/entity/Vex.java
+index c34a3ea7b4d16817b4bee25d5c69787e22ec44d8..6a39042f1ea18b4849c4b6d2343938e0f430aefb 100644
+--- a/src/main/java/org/bukkit/entity/Vex.java
++++ b/src/main/java/org/bukkit/entity/Vex.java
+@@ -40,5 +40,37 @@ public interface Vex extends Monster {
+      * @param summoner New summoner
+      */
+     void setSummoner(@Nullable Mob summoner);
++
++    /**
++     * Gets if this vex should start to take damage
++     * once {@link Vex#getLimitedLifetimeTicks()} is less than or equal to 0.
++     * 
++     * @return will take damage
++     */
++    boolean hasLimitedLifetime();
++
++    /**
++     * Sets if this vex should start to take damage
++     * once {@link Vex#getLimitedLifetimeTicks()} is less than or equal to 0.
++     *      
++     * @param hasLimitedLifetime should take damage
++     */
++    void setLimitedLifetime(boolean hasLimitedLifetime);
++
++    /**
++     * Gets the number of ticks remaining until the vex will start
++     * to take damage.
++     * 
++     * @return ticks until the vex will start to take damage
++     */
++    int getLimitedLifetimeTicks();
++
++    /**
++     * Sets the number of ticks remaining until the vex takes damage.
++     * This number is ticked down only if {@link Vex#hasLimitedLifetime()} is true.
++     * 
++     * @param ticks ticks remaining
++     */
++    void setLimitedLifetimeTicks(int ticks);
+     // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/entity/Wither.java b/src/main/java/org/bukkit/entity/Wither.java
 index 426d3693317cd303d35d8203026b528d87e401d5..8c95cd6933f11076de936854f379e6fc8600b525 100644
 --- a/src/main/java/org/bukkit/entity/Wither.java

--- a/patches/api/0312-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0312-Missing-Entity-Behavior-API.patch
@@ -70,21 +70,21 @@ index 0d88dce9978243a1f995c5fb448c5d71b01136eb..cad47139de57642fb3bb483e7a5acaa7
 +    // Paper end - Horse API
  }
 diff --git a/src/main/java/org/bukkit/entity/Bee.java b/src/main/java/org/bukkit/entity/Bee.java
-index adb20a9abba33c32d553f620fa82b27dff64ab5f..063ae8627f53c733b0f691a259e6062a223537af 100644
+index adb20a9abba33c32d553f620fa82b27dff64ab5f..973bf0f451a44c31591d89ee2339984fe4b4efce 100644
 --- a/src/main/java/org/bukkit/entity/Bee.java
 +++ b/src/main/java/org/bukkit/entity/Bee.java
-@@ -93,4 +93,20 @@ public interface Bee extends Animals {
+@@ -93,4 +93,27 @@ public interface Bee extends Animals {
       * @param ticks Ticks the bee cannot enter a hive for
       */
      void setCannotEnterHiveTicks(int ticks);
 +
 +    // Paper start
 +    /**
-+     * Sets if the bee is currently rolling.
++     * Sets the override for if the bee is currently rolling.
 +     *
-+     * @param rolling is rolling
++     * @param rolling is rolling, or unset for vanilla behavior
 +     */
-+    void setRolling(boolean rolling);
++    void setRollingOverride(net.kyori.adventure.util.TriState rolling);
 +
 +    /**
 +     * Gets if the bee is currently rolling.
@@ -92,6 +92,13 @@ index adb20a9abba33c32d553f620fa82b27dff64ab5f..063ae8627f53c733b0f691a259e6062a
 +     * @return is rolling
 +     */
 +    boolean isRolling();
++
++    /**
++     * Gets the plugin set override for if the bee is currently rolling.
++     *
++     * @return plugin set rolling override
++     */
++    net.kyori.adventure.util.TriState getRollingOverride();
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Cat.java b/src/main/java/org/bukkit/entity/Cat.java
@@ -425,6 +432,36 @@ index a6a7429ed2e1eefb2b12b7480ed74fcc3963a864..1dcc2c8f4899da029af8b1c1b2ff1b5e
 +    boolean isSitting();
 +    // Paper end - Panda API
  }
+diff --git a/src/main/java/org/bukkit/entity/Piglin.java b/src/main/java/org/bukkit/entity/Piglin.java
+index 6fdc0e0bb62189dbf3cf9ce7a87b7fbb995956a3..d4cb4b0ed1d9766a87867dcf1a3a839526ba9332 100644
+--- a/src/main/java/org/bukkit/entity/Piglin.java
++++ b/src/main/java/org/bukkit/entity/Piglin.java
+@@ -90,4 +90,25 @@ public interface Piglin extends PiglinAbstract, InventoryHolder, com.destroystok
+      */
+     @NotNull
+     public Set<Material> getBarterList();
++
++    // Paper start
++    /**
++     * Causes the piglin to appear as if they are charging
++     * a crossbow.
++     * <p>
++     * This works with any item currently held in the piglin's hand.
++     *
++     * @param chargingCrossbow is charging
++     */
++    void setChargingCrossbow(boolean chargingCrossbow);
++
++    /**
++     * Gets if the piglin is currently charging the
++     * item in their hand.
++     *
++     * @return is charging
++     */
++    boolean isChargingCrossbow();
++    // Paper end
++
+ }
 diff --git a/src/main/java/org/bukkit/entity/PolarBear.java b/src/main/java/org/bukkit/entity/PolarBear.java
 index 479f7a7c54c85cb685f56e60906650d1989c03ff..60267ee382de80fab86b440ff72a2455f427d148 100644
 --- a/src/main/java/org/bukkit/entity/PolarBear.java
@@ -560,5 +597,32 @@ index 426d3693317cd303d35d8203026b528d87e401d5..8c95cd6933f11076de936854f379e6fc
 +     * @param value whether the wither can travel through portals
 +     */
 +    void setCanTravelThroughPortals(boolean value);
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/entity/Wolf.java b/src/main/java/org/bukkit/entity/Wolf.java
+index 0e5decadf31140d6cb121c298f935ccc12c7a7e7..490395f38c4d9977d30a6f48585a4ea0e7faff0f 100644
+--- a/src/main/java/org/bukkit/entity/Wolf.java
++++ b/src/main/java/org/bukkit/entity/Wolf.java
+@@ -39,4 +39,22 @@ public interface Wolf extends Tameable, Sittable {
+      * @param color the color to apply
+      */
+     public void setCollarColor(@NotNull DyeColor color);
++
++    // Paper start
++    /**
++     * Sets if the wolf is interested.
++     * <p>
++     * This causes the wolf to tilt its head to the side.
++     *
++     * @param interested is interested
++     */
++    void setInterested(boolean interested);
++
++    /**
++     * Gets if the wolf is interested.
++     *
++     * @return is interested
++     */
++    boolean isInterested();
 +    // Paper end
  }

--- a/patches/api/0312-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0312-Missing-Entity-Behavior-API.patch
@@ -69,6 +69,31 @@ index 0d88dce9978243a1f995c5fb448c5d71b01136eb..cad47139de57642fb3bb483e7a5acaa7
 +    public void setEating(boolean eating);
 +    // Paper end - Horse API
  }
+diff --git a/src/main/java/org/bukkit/entity/Bee.java b/src/main/java/org/bukkit/entity/Bee.java
+index adb20a9abba33c32d553f620fa82b27dff64ab5f..063ae8627f53c733b0f691a259e6062a223537af 100644
+--- a/src/main/java/org/bukkit/entity/Bee.java
++++ b/src/main/java/org/bukkit/entity/Bee.java
+@@ -93,4 +93,20 @@ public interface Bee extends Animals {
+      * @param ticks Ticks the bee cannot enter a hive for
+      */
+     void setCannotEnterHiveTicks(int ticks);
++
++    // Paper start
++    /**
++     * Sets if the bee is currently rolling.
++     *
++     * @param rolling is rolling
++     */
++    void setRolling(boolean rolling);
++
++    /**
++     * Gets if the bee is currently rolling.
++     *
++     * @return is rolling
++     */
++    boolean isRolling();
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/entity/Cat.java b/src/main/java/org/bukkit/entity/Cat.java
 index c2a566b864c82ffb094b7334d9e6e25a1bfc87d1..c340fecb61bac66baf0f44189d21bc85289b1269 100644
 --- a/src/main/java/org/bukkit/entity/Cat.java

--- a/patches/api/0312-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0312-Missing-Entity-Behavior-API.patch
@@ -70,10 +70,10 @@ index 0d88dce9978243a1f995c5fb448c5d71b01136eb..cad47139de57642fb3bb483e7a5acaa7
 +    // Paper end - Horse API
  }
 diff --git a/src/main/java/org/bukkit/entity/Bee.java b/src/main/java/org/bukkit/entity/Bee.java
-index adb20a9abba33c32d553f620fa82b27dff64ab5f..973bf0f451a44c31591d89ee2339984fe4b4efce 100644
+index adb20a9abba33c32d553f620fa82b27dff64ab5f..ca6baec5ce00b4d169ab4ff416f616db32615010 100644
 --- a/src/main/java/org/bukkit/entity/Bee.java
 +++ b/src/main/java/org/bukkit/entity/Bee.java
-@@ -93,4 +93,27 @@ public interface Bee extends Animals {
+@@ -93,4 +93,28 @@ public interface Bee extends Animals {
       * @param ticks Ticks the bee cannot enter a hive for
       */
      void setCannotEnterHiveTicks(int ticks);
@@ -84,7 +84,15 @@ index adb20a9abba33c32d553f620fa82b27dff64ab5f..973bf0f451a44c31591d89ee2339984f
 +     *
 +     * @param rolling is rolling, or unset for vanilla behavior
 +     */
-+    void setRollingOverride(net.kyori.adventure.util.TriState rolling);
++    void setRollingOverride(@org.jetbrains.annotations.NotNull net.kyori.adventure.util.TriState rolling);
++
++    /**
++     * Gets the plugin set override for if the bee is currently rolling.
++     *
++     * @return plugin set rolling override
++     */
++    @org.jetbrains.annotations.NotNull
++    net.kyori.adventure.util.TriState getRollingOverride();
 +
 +    /**
 +     * Gets if the bee is currently rolling.
@@ -92,13 +100,6 @@ index adb20a9abba33c32d553f620fa82b27dff64ab5f..973bf0f451a44c31591d89ee2339984f
 +     * @return is rolling
 +     */
 +    boolean isRolling();
-+
-+    /**
-+     * Gets the plugin set override for if the bee is currently rolling.
-+     *
-+     * @return plugin set rolling override
-+     */
-+    net.kyori.adventure.util.TriState getRollingOverride();
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Cat.java b/src/main/java/org/bukkit/entity/Cat.java

--- a/patches/server/0676-Missing-Entity-Behavior-API.patch
+++ b/patches/server/0676-Missing-Entity-Behavior-API.patch
@@ -6,6 +6,24 @@ Subject: [PATCH] Missing Entity Behavior API
 Co-authored-by: Nassim Jahnke <jahnke.nassim@gmail.com>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Bee.java b/src/main/java/net/minecraft/world/entity/animal/Bee.java
+index c49e7ea3e2efc4459f5ed1d4ebd83c9d23420611..79a9fa2a2257925685e45329365d2828ccd4c48c 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Bee.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Bee.java
+@@ -539,11 +539,13 @@ public class Bee extends Animal implements NeutralMob, FlyingAnimal {
+         this.setFlag(4, hasStung);
+     }
+ 
++    public net.kyori.adventure.util.TriState rollingOverride = net.kyori.adventure.util.TriState.NOT_SET; // Paper - Rolling override
+     public boolean isRolling() {
+         return this.getFlag(2);
+     }
+ 
+     public void setRolling(boolean nearTarget) {
++        nearTarget = rollingOverride.toBooleanOrElse(nearTarget); // Paper - Rolling override
+         this.setFlag(2, nearTarget);
+     }
+ 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/horse/AbstractHorse.java b/src/main/java/net/minecraft/world/entity/animal/horse/AbstractHorse.java
 index cd278a859c87fc89c421378ffab1bd36a45bd65d..a726006888bbbdb290bcda3ac4fd45d68ba51b79 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/horse/AbstractHorse.java
@@ -167,22 +185,29 @@ index 254d4f2e45d7c8f572a4368eccd84560d4d0d836..299ab868252c8f326e3a56e878c9ee23
 +    // Paper end - Horse API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
-index 8ada3dfbe89c8b55d85c31c71e365af0cbf66d19..b24cbb50e336e9dc844b1880bda916231744758c 100644
+index 8ada3dfbe89c8b55d85c31c71e365af0cbf66d19..b5d3a00a48d3b7618f974bb0f6909aa7c304b012 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
-@@ -91,4 +91,15 @@ public class CraftBee extends CraftAnimals implements Bee {
+@@ -91,4 +91,22 @@ public class CraftBee extends CraftAnimals implements Bee {
      public void setCannotEnterHiveTicks(int ticks) {
          this.getHandle().setStayOutOfHiveCountdown(ticks);
      }
 +    // Paper start
 +    @Override
-+    public void setRolling(boolean rolling) {
-+        this.getHandle().setRolling(rolling);
++    public void setRollingOverride(net.kyori.adventure.util.TriState rolling) {
++        this.getHandle().rollingOverride = rolling;
++
++        this.getHandle().setRolling(this.getHandle().isRolling()); // Refresh rolling state
 +    }
 +
 +    @Override
 +    public boolean isRolling() {
-+        return this.getHandle().isRolling();
++        return this.getRollingOverride().toBooleanOrElse(this.getHandle().isRolling());
++    }
++
++    @Override
++    public net.kyori.adventure.util.TriState getRollingOverride() {
++        return this.getHandle().rollingOverride;
 +    }
 +    // Paper end
  }
@@ -413,6 +438,26 @@ index 2d2620dbb16aec850e8afda02174508a4be5a313..ba4e6deaaa725296be830324d2c64868
  
      public static Gene fromNms(net.minecraft.world.entity.animal.Panda.Gene gene) {
          Preconditions.checkArgument(gene != null, "Gene may not be null");
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java
+index aeda5fc001fe4ce55ee467240b275b6050a29f98..48d0a4e42e1b90d1323784d1284acabfe9497dd6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java
+@@ -90,4 +90,15 @@ public class CraftPiglin extends CraftPiglinAbstract implements Piglin, com.dest
+     public String toString() {
+         return "CraftPiglin";
+     }
++    // Paper start
++    @Override
++    public void setChargingCrossbow(boolean chargingCrossbow) {
++        this.getHandle().setChargingCrossbow(chargingCrossbow);
++    }
++
++    @Override
++    public boolean isChargingCrossbow() {
++        return this.getHandle().isChargingCrossbow();
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPolarBear.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPolarBear.java
 index da1488c9cae53bd554727c850da2192adda2478a..30a0eac179c86b0fe94a2a40b5bfcd3eee01e53b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPolarBear.java
@@ -520,6 +565,26 @@ index 640b0860fbe3412da32d03187e6f355ba8f099ea..299d5e47489cfe489ac130a33a08cdb2
 +    @Override
 +    public void setCanTravelThroughPortals(boolean value) {
 +        getHandle().setCanTravelThroughPortals(value);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWolf.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWolf.java
+index f856b42201c17f8da21251e54fcf052336916e70..a3bec00368aef0f8cc6aa21cce1389938d15f91b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWolf.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftWolf.java
+@@ -43,4 +43,15 @@ public class CraftWolf extends CraftTameableAnimal implements Wolf {
+     public void setCollarColor(DyeColor color) {
+         this.getHandle().setCollarColor(net.minecraft.world.item.DyeColor.byId(color.getWoolData()));
+     }
++    // Paper start
++    @Override
++    public void setInterested(boolean interested) {
++        this.getHandle().setIsInterested(interested);
++    }
++
++    @Override
++    public boolean isInterested() {
++        return this.getHandle().isInterested();
 +    }
 +    // Paper end
  }

--- a/patches/server/0676-Missing-Entity-Behavior-API.patch
+++ b/patches/server/0676-Missing-Entity-Behavior-API.patch
@@ -532,6 +532,37 @@ index bf5b2fd6676c4430578db4cc6c603c501cc5e349..832981b07ef5c633ef00a382f56798ee
 +    }
 +    // Paper end
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
+index 0f5c81c0d599d3b58f7864d1527391ad50983c4e..606d8485a5fc67b59f8fed38a739d6bc5888d99d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
+@@ -26,6 +26,26 @@ public class CraftVex extends CraftMonster implements Vex {
+     public void setSummoner(org.bukkit.entity.Mob summoner) {
+         getHandle().setOwner(summoner == null ? null : ((CraftMob) summoner).getHandle());
+     }
++
++    @Override
++    public boolean hasLimitedLifetime() {
++        return this.getHandle().hasLimitedLife;
++    }
++
++    @Override
++    public void setLimitedLifetime(boolean hasLimitedLifetime) {
++        this.getHandle().hasLimitedLife = hasLimitedLifetime;
++    }
++
++    @Override
++    public int getLimitedLifetimeTicks() {
++        return this.getHandle().limitedLifeTicks;
++    }
++
++    @Override
++    public void setLimitedLifetimeTicks(int ticks) {
++        this.getHandle().limitedLifeTicks = ticks;
++    }
+     // Paper end
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
 index 640b0860fbe3412da32d03187e6f355ba8f099ea..299d5e47489cfe489ac130a33a08cdb29ba76d72 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java

--- a/patches/server/0676-Missing-Entity-Behavior-API.patch
+++ b/patches/server/0676-Missing-Entity-Behavior-API.patch
@@ -166,6 +166,26 @@ index 254d4f2e45d7c8f572a4368eccd84560d4d0d836..299ab868252c8f326e3a56e878c9ee23
 +    }
 +    // Paper end - Horse API
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
+index 8ada3dfbe89c8b55d85c31c71e365af0cbf66d19..b24cbb50e336e9dc844b1880bda916231744758c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftBee.java
+@@ -91,4 +91,15 @@ public class CraftBee extends CraftAnimals implements Bee {
+     public void setCannotEnterHiveTicks(int ticks) {
+         this.getHandle().setStayOutOfHiveCountdown(ticks);
+     }
++    // Paper start
++    @Override
++    public void setRolling(boolean rolling) {
++        this.getHandle().setRolling(rolling);
++    }
++
++    @Override
++    public boolean isRolling() {
++        return this.getHandle().isRolling();
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftCat.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftCat.java
 index a4f909123de26d911aea7cd767d2315ed1f697c9..0eee53c068bca070a86645d0ba54fb1ad49a6a5b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftCat.java


### PR DESCRIPTION
Adds:

Bee rolling override (Normally triggered when bees are nearby their attacker.)
Context: https://discordapp.com/channels/289587909051416579/925530366192779286/952619743490236426
![image](https://user-images.githubusercontent.com/23108066/158069700-3f52d936-0bc6-4fae-aa26-7d57bec545ed.png)

Piglin get/setIsChargingCrossbow
![image](https://user-images.githubusercontent.com/23108066/158071847-f33c1e47-e164-42ca-8083-cf55a1021837.png)

Wolf get/setIsInterested
![image](https://user-images.githubusercontent.com/23108066/158071875-66c9ca6a-dd14-4f1b-880b-7f928900b8ee.png)
