### PR TITLE
Add allow server listing client option

### DIFF
--- a/patches/api/0194-Add-Player-Client-Options-API.patch
+++ b/patches/api/0194-Add-Player-Client-Options-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Player Client Options API
 
 diff --git a/src/main/java/com/destroystokyo/paper/ClientOption.java b/src/main/java/com/destroystokyo/paper/ClientOption.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..cedb51f9f3a9150035c2b44970a096448c441dd9
+index 0000000000000000000000000000000000000000..f89bfeba29e6988db849957a508ca97ff5322242
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/ClientOption.java
-@@ -0,0 +1,50 @@
+@@ -0,0 +1,52 @@
 +package com.destroystokyo.paper;
 +
 +import net.kyori.adventure.translation.Translatable;
@@ -26,6 +26,8 @@ index 0000000000000000000000000000000000000000..cedb51f9f3a9150035c2b44970a09644
 +    public static final ClientOption<String> LOCALE = new ClientOption<>(String.class);
 +    public static final ClientOption<MainHand> MAIN_HAND = new ClientOption<>(MainHand.class);
 +    public static final ClientOption<Integer> VIEW_DISTANCE = new ClientOption<>(Integer.class);
++    public static final ClientOption<Boolean> ALLOW_SERVER_LISTINGS = new ClientOption<>(Boolean.class);
++    public static final ClientOption<Boolean> TEXT_FILTERING_ENABLED = new ClientOption<>(Boolean.class);
 +
 +    private final Class<T> type;
 +
@@ -88,25 +90,25 @@ index 0000000000000000000000000000000000000000..4a0c39405d4fbed457787e3c6ded4cc6
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f17202f28
+index 0000000000000000000000000000000000000000..cf67dc7d465223710adbf2b798109f525d3b057d
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java
-@@ -0,0 +1,100 @@
+@@ -0,0 +1,134 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import com.destroystokyo.paper.ClientOption;
 +import com.destroystokyo.paper.ClientOption.ChatVisibility;
 +import com.destroystokyo.paper.SkinParts;
-+
-+import org.jetbrains.annotations.NotNull;
-+
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.MainHand;
++import org.jetbrains.annotations.NotNull;
++
++import java.util.Map;
 +
 +/**
-+ * Called when the player changes his client settings
++ * Called when the player changes their client settings
 + */
 +public class PlayerClientOptionsChangeEvent extends PlayerEvent {
 +
@@ -118,7 +120,10 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    private final boolean chatColors;
 +    private final SkinParts skinparts;
 +    private final MainHand mainHand;
++    private final boolean allowsServerListings;
++    private final boolean textFilteringEnabled;
 +
++    @Deprecated
 +    public PlayerClientOptionsChangeEvent(@NotNull Player player, @NotNull String locale, int viewDistance, @NotNull ChatVisibility chatVisibility, boolean chatColors, @NotNull SkinParts skinParts, @NotNull MainHand mainHand) {
 +        super(player);
 +        this.locale = locale;
@@ -127,6 +132,21 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +        this.chatColors = chatColors;
 +        this.skinparts = skinParts;
 +        this.mainHand = mainHand;
++        this.allowsServerListings = false;
++        this.textFilteringEnabled = false;
++    }
++
++    public PlayerClientOptionsChangeEvent(@NotNull Player player, @NotNull Map<ClientOption<?>, ?> options) {
++        super(player);
++
++        this.locale = (String) options.get(ClientOption.LOCALE);
++        this.viewDistance = (int) options.get(ClientOption.VIEW_DISTANCE);
++        this.chatVisibility = (ChatVisibility) options.get(ClientOption.CHAT_VISIBILITY);
++        this.chatColors = (boolean) options.get(ClientOption.CHAT_COLORS_ENABLED);
++        this.skinparts = (SkinParts) options.get(ClientOption.SKIN_PARTS);
++        this.mainHand = (MainHand) options.get(ClientOption.MAIN_HAND);
++        this.allowsServerListings = (boolean) options.get(ClientOption.ALLOW_SERVER_LISTINGS);
++        this.textFilteringEnabled = (boolean) options.get(ClientOption.TEXT_FILTERING_ENABLED);
 +    }
 +
 +    @NotNull
@@ -179,6 +199,22 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +
 +    public boolean hasMainHandChanged() {
 +        return mainHand != player.getClientOption(ClientOption.MAIN_HAND);
++    }
++
++    public boolean allowsServerListings() {
++        return allowsServerListings;
++    }
++
++    public boolean hasAllowServerListingsChanged() {
++        return allowsServerListings != player.getClientOption(ClientOption.ALLOW_SERVER_LISTINGS);
++    }
++
++    public boolean hasTextFilteringEnabled() {
++        return textFilteringEnabled;
++    }
++
++    public boolean hasTextFilteringChanged() {
++        return textFilteringEnabled != player.getClientOption(ClientOption.TEXT_FILTERING_ENABLED);
 +    }
 +
 +    @Override

--- a/patches/removed/1.19.2-legacy-chunksystem/0020-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/removed/1.19.2-legacy-chunksystem/0020-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -67,95 +67,11 @@ index af40e473521f408aa0e112953c43bdbce164a48b..68860a3b6db2aa50373d71aec9502c18
          }
      }
  
-diff --git a/src/main/java/net/minecraft/server/ChunkSystem.java b/src/main/java/net/minecraft/server/ChunkSystem.java
-index 7f76c304f5eb3c2f27b348918588ab67b795b1ba..1b1bfd5f92f85f46ad9661a0a64a2a1b4c33a80d 100644
---- a/src/main/java/net/minecraft/server/ChunkSystem.java
-+++ b/src/main/java/net/minecraft/server/ChunkSystem.java
-@@ -55,6 +55,19 @@ public final class ChunkSystem {
- 
-     static final TicketType<Long> CHUNK_LOAD = TicketType.create("chunk_load", Long::compareTo);
- 
-+    // Paper start - priority
-+    private static int getPriorityBoost(final PrioritisedExecutor.Priority priority) {
-+        if (priority.isLowerOrEqualPriority(PrioritisedExecutor.Priority.NORMAL)) {
-+            return 0;
-+        }
-+
-+        int dist = PrioritisedExecutor.Priority.BLOCKING.ordinal() - PrioritisedExecutor.Priority.NORMAL.ordinal();
-+
-+
-+        return (net.minecraft.server.level.DistanceManager.URGENT_PRIORITY * (priority.ordinal() - PrioritisedExecutor.Priority.NORMAL.ordinal())) / dist;
-+    }
-+    // Paper end - priority
-+
-     private static long chunkLoadCounter = 0L;
-     public static void scheduleChunkLoad(final ServerLevel level, final int chunkX, final int chunkZ, final ChunkStatus toStatus,
-                                          final boolean addTicket, final PrioritisedExecutor.Priority priority, final Consumer<ChunkAccess> onComplete) {
-@@ -68,12 +81,19 @@ public final class ChunkSystem {
-         final int minLevel = 33 + ChunkStatus.getDistance(toStatus);
-         final Long chunkReference = addTicket ? Long.valueOf(++chunkLoadCounter) : null;
-         final ChunkPos chunkPos = new ChunkPos(chunkX, chunkZ);
-+        final int priorityBoost = getPriorityBoost(priority);
- 
-         if (addTicket) {
-             level.chunkSource.addTicketAtLevel(CHUNK_LOAD, chunkPos, minLevel, chunkReference);
-         }
-         level.chunkSource.runDistanceManagerUpdates();
- 
-+        if (priorityBoost == net.minecraft.server.level.DistanceManager.URGENT_PRIORITY) {
-+            level.chunkSource.markUrgent(chunkPos);
-+        } else if (priorityBoost != 0) {
-+            level.chunkSource.markHighPriority(chunkPos, priorityBoost);
-+        }
-+
-         final Consumer<ChunkAccess> loadCallback = (final ChunkAccess chunk) -> {
-             try {
-                 if (onComplete != null) {
-@@ -89,6 +109,11 @@ public final class ChunkSystem {
-                     level.chunkSource.addTicketAtLevel(TicketType.UNKNOWN, chunkPos, minLevel, chunkPos);
-                     level.chunkSource.removeTicketAtLevel(CHUNK_LOAD, chunkPos, minLevel, chunkReference);
-                 }
-+                if (priorityBoost == net.minecraft.server.level.DistanceManager.URGENT_PRIORITY) {
-+                    level.chunkSource.clearUrgent(chunkPos);
-+                } else if (priorityBoost != 0) {
-+                    level.chunkSource.clearPriorityTickets(chunkPos);
-+                }
-             }
-         };
- 
-@@ -135,12 +160,17 @@ public final class ChunkSystem {
-         final int radius = toStatus.ordinal() - 1;
-         final Long chunkReference = addTicket ? Long.valueOf(++chunkLoadCounter) : null;
-         final ChunkPos chunkPos = new ChunkPos(chunkX, chunkZ);
-+        final int priorityBoost = getPriorityBoost(priority);
- 
-         if (addTicket) {
-             level.chunkSource.addTicketAtLevel(CHUNK_LOAD, chunkPos, minLevel, chunkReference);
-         }
-         level.chunkSource.runDistanceManagerUpdates();
- 
-+        if (priorityBoost != 0) {
-+            level.chunkSource.markAreaHighPriority(chunkPos, priorityBoost, radius);
-+        }
-+
-         final Consumer<LevelChunk> loadCallback = (final LevelChunk chunk) -> {
-             try {
-                 if (onComplete != null) {
-@@ -156,6 +186,9 @@ public final class ChunkSystem {
-                     level.chunkSource.addTicketAtLevel(TicketType.UNKNOWN, chunkPos, minLevel, chunkPos);
-                     level.chunkSource.removeTicketAtLevel(CHUNK_LOAD, chunkPos, minLevel, chunkReference);
-                 }
-+                if (priorityBoost != 0) {
-+                    level.chunkSource.clearAreaPriorityTickets(chunkPos, radius);
-+                }
-             }
-         };
- 
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 2e56c52e3ee45b0304a9e6a5eab863ef96b2aab0..5eb6ce20ee17d87db0f6c2dcee96d6d0891d6c50 100644
+index 4e29c0a983727fc839a4bcde01d3286396b3587d..613988c9ea892ab15516e1c8b4f376d52415ae34 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
-@@ -634,6 +634,7 @@ public final class MCUtil {
+@@ -681,6 +681,7 @@ public final class MCUtil {
                  chunkData.addProperty("x", playerChunk.pos.x);
                  chunkData.addProperty("z", playerChunk.pos.z);
                  chunkData.addProperty("ticket-level", playerChunk.getTicketLevel());
@@ -164,7 +80,7 @@ index 2e56c52e3ee45b0304a9e6a5eab863ef96b2aab0..5eb6ce20ee17d87db0f6c2dcee96d6d0
                  chunkData.addProperty("queued-for-unload", chunkMap.toDrop.contains(playerChunk.pos.longKey));
                  chunkData.addProperty("status", status == null ? "unloaded" : status.toString());
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index e30893d6cbe3b42338d04453d0f452babeb61d8a..a52932d665ca45a5e066d7cef0ec0313d1c3f69f 100644
+index 36a9d52d9af3bc398010c52dc16ab23e53f2702a..ece4cd0de061969d4d2f07560e6cf38e631098b3 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -60,7 +60,7 @@ public class ChunkHolder {
@@ -184,7 +100,7 @@ index e30893d6cbe3b42338d04453d0f452babeb61d8a..a52932d665ca45a5e066d7cef0ec0313
      boolean isUpdateQueued = false; // Paper
      private final ChunkMap chunkMap; // Paper
  
-@@ -438,12 +439,18 @@ public class ChunkHolder {
+@@ -448,12 +449,18 @@ public class ChunkHolder {
          });
      }
  
@@ -203,7 +119,7 @@ index e30893d6cbe3b42338d04453d0f452babeb61d8a..a52932d665ca45a5e066d7cef0ec0313
          ChunkStatus chunkstatus = ChunkHolder.getStatus(this.oldTicketLevel);
          ChunkStatus chunkstatus1 = ChunkHolder.getStatus(this.ticketLevel);
          boolean flag = this.oldTicketLevel <= ChunkMap.MAX_CHUNK_DISTANCE;
-@@ -454,9 +461,22 @@ public class ChunkHolder {
+@@ -464,9 +471,22 @@ public class ChunkHolder {
          // ChunkUnloadEvent: Called before the chunk is unloaded: isChunkLoaded is still true and chunk can still be modified by plugins.
          if (playerchunk_state.isOrAfter(ChunkHolder.FullChunkStatus.BORDER) && !playerchunk_state1.isOrAfter(ChunkHolder.FullChunkStatus.BORDER)) {
              this.getFutureIfPresentUnchecked(ChunkStatus.FULL).thenAccept((either) -> {
@@ -227,21 +143,22 @@ index e30893d6cbe3b42338d04453d0f452babeb61d8a..a52932d665ca45a5e066d7cef0ec0313
                          // Minecraft will apply the chunks tick lists to the world once the chunk got loaded, and then store the tick
                          // lists again inside the chunk once the chunk becomes inaccessible and set the chunk's needsSaving flag.
                          // These actions may however happen deferred, so we manually set the needsSaving flag already here.
-@@ -501,11 +521,13 @@ public class ChunkHolder {
+@@ -523,12 +543,14 @@ public class ChunkHolder {
              this.scheduleFullChunkPromotion(chunkStorage, this.fullChunkFuture, executor, ChunkHolder.FullChunkStatus.BORDER);
              // Paper start - cache ticking ready status
              this.fullChunkFuture.thenAccept(either -> {
 +                io.papermc.paper.util.TickThread.ensureTickThread("Async full chunk future completion"); // Paper
                  final Optional<LevelChunk> left = either.left();
                  if (left.isPresent() && ChunkHolder.this.fullChunkCreateCount == expectCreateCount) {
+                     // note: Here is a very good place to add callbacks to logic waiting on this.
                      LevelChunk fullChunk = either.left().get();
                      ChunkHolder.this.isFullChunkReady = true;
-                     net.minecraft.server.ChunkSystem.onChunkBorder(fullChunk, this);
-+                    this.chunkMap.distanceManager.clearPriorityTickets(pos); // Paper - chunk priority
+                     fullChunk.playerChunk = ChunkHolder.this;
++                    this.chunkMap.distanceManager.clearPriorityTickets(pos);
                  }
              });
              this.updateChunkToSave(this.fullChunkFuture, "full");
-@@ -531,6 +553,7 @@ public class ChunkHolder {
+@@ -549,6 +571,7 @@ public class ChunkHolder {
              this.scheduleFullChunkPromotion(chunkStorage, this.tickingChunkFuture, executor, ChunkHolder.FullChunkStatus.TICKING);
              // Paper start - cache ticking ready status
              this.tickingChunkFuture.thenAccept(either -> {
@@ -249,15 +166,15 @@ index e30893d6cbe3b42338d04453d0f452babeb61d8a..a52932d665ca45a5e066d7cef0ec0313
                  either.ifLeft(chunk -> {
                      // note: Here is a very good place to add callbacks to logic waiting on this.
                      ChunkHolder.this.isTickingReady = true;
-@@ -563,6 +586,7 @@ public class ChunkHolder {
+@@ -584,6 +607,7 @@ public class ChunkHolder {
              this.scheduleFullChunkPromotion(chunkStorage, this.entityTickingChunkFuture, executor, ChunkHolder.FullChunkStatus.ENTITY_TICKING);
              // Paper start - cache ticking ready status
              this.entityTickingChunkFuture.thenAccept(either -> {
 +                io.papermc.paper.util.TickThread.ensureTickThread("Async full chunk future completion"); // Paper
                  either.ifLeft(chunk -> {
                      ChunkHolder.this.isEntityTickingReady = true;
-                     net.minecraft.server.ChunkSystem.onChunkEntityTicking(chunk, this);
-@@ -586,16 +610,45 @@ public class ChunkHolder {
+                     // Paper start - entity ticking chunk set
+@@ -610,16 +634,45 @@ public class ChunkHolder {
              this.demoteFullChunk(chunkStorage, playerchunk_state1);
          }
  
@@ -306,7 +223,7 @@ index e30893d6cbe3b42338d04453d0f452babeb61d8a..a52932d665ca45a5e066d7cef0ec0313
                      });
                  }
              }).exceptionally((throwable) -> {
-@@ -696,7 +749,134 @@ public class ChunkHolder {
+@@ -744,7 +797,134 @@ public class ChunkHolder {
          };
      }
  
@@ -443,10 +360,10 @@ index e30893d6cbe3b42338d04453d0f452babeb61d8a..a52932d665ca45a5e066d7cef0ec0313
          return this.isEntityTickingReady;
      }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d913376c63a 100644
+index eb74a831fc439c56fe1ac2d4769ebefa1e5759a3..349c311e70758d99ebb4c61ad509a3a975fda04b 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -131,6 +131,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -134,6 +134,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
      public final ServerLevel level;
      private final ThreadedLevelLightEngine lightEngine;
      private final BlockableEventLoop<Runnable> mainThreadExecutor;
@@ -454,7 +371,7 @@ index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d91
      public ChunkGenerator generator;
      private RandomState randomState;
      public final Supplier<DimensionDataStorage> overworldDataStorage;
-@@ -267,6 +268,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -337,6 +338,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          }
  
          this.mainThreadExecutor = mainThreadExecutor;
@@ -470,7 +387,7 @@ index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d91
          ProcessorMailbox<Runnable> threadedmailbox = ProcessorMailbox.create(executor, "worldgen");
  
          Objects.requireNonNull(mainThreadExecutor);
-@@ -309,6 +319,37 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -452,6 +462,37 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          });
      }
  
@@ -505,10 +422,10 @@ index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d91
 +    }
 +    // Paper end
 +
-     private static double euclideanDistanceSquared(ChunkPos pos, Entity entity) {
-         double d0 = (double) SectionPos.sectionToBlockCoord(pos.x, 8);
-         double d1 = (double) SectionPos.sectionToBlockCoord(pos.z, 8);
-@@ -399,6 +440,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+     // Paper start
+     public void updatePlayerMobTypeMap(Entity entity) {
+         if (!this.level.paperConfig().entities.spawning.perPlayerMobSpawns) {
+@@ -562,6 +603,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          List<ChunkHolder> list1 = new ArrayList();
          int j = centerChunk.x;
          int k = centerChunk.z;
@@ -516,7 +433,7 @@ index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d91
  
          for (int l = -margin; l <= margin; ++l) {
              for (int i1 = -margin; i1 <= margin; ++i1) {
-@@ -417,6 +459,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -580,6 +622,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
                  ChunkStatus chunkstatus = (ChunkStatus) distanceToStatus.apply(j1);
                  CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> completablefuture = playerchunk.getOrScheduleFuture(chunkstatus, this);
@@ -531,7 +448,7 @@ index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d91
  
                  list1.add(playerchunk);
                  list.add(completablefuture);
-@@ -733,11 +783,19 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -937,11 +987,19 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          if (requiredStatus == ChunkStatus.EMPTY) {
              return this.scheduleChunkLoad(chunkcoordintpair);
          } else {
@@ -552,7 +469,7 @@ index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d91
  
              if (optional.isPresent() && ((ChunkAccess) optional.get()).getStatus().isOrAfter(requiredStatus)) {
                  CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> completablefuture = requiredStatus.load(this.level, this.structureTemplateManager, this.lightEngine, (ichunkaccess) -> {
-@@ -749,6 +807,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -953,6 +1011,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              } else {
                  return this.scheduleChunkGeneration(holder, requiredStatus);
              }
@@ -560,7 +477,7 @@ index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d91
          }
      }
  
-@@ -788,14 +847,24 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -992,14 +1051,24 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          };
  
          CompletableFuture<CompoundTag> chunkSaveFuture = this.level.asyncChunkTaskManager.getChunkSaveFuture(pos.x, pos.z);
@@ -590,7 +507,7 @@ index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d91
          return ret;
          // Paper end - Async chunk io
      }
-@@ -874,7 +943,10 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1078,7 +1147,10 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                  this.releaseLightTicket(chunkcoordintpair);
                  return CompletableFuture.completedFuture(Either.right(playerchunk_failure));
              });
@@ -602,7 +519,7 @@ index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d91
      }
  
      protected void releaseLightTicket(ChunkPos pos) {
-@@ -957,7 +1029,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1162,7 +1234,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              long i = chunkHolder.getPos().toLong();
  
              Objects.requireNonNull(chunkHolder);
@@ -612,10 +529,10 @@ index c3bbaf32373a32417f8b83f386f8cf327c6e0893..46bfaf04867d913c1782d851de101d91
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index 1d6ab658c48bb765f66624f276ec7b05cf33c1d5..b9b56068cdacd984f873cfb2a06a312e9912893d 100644
+index 9bc956068df3baabb9f8e02ee74a6397de2bf587..b2df5e18ce5260a9781052db7afb0b9786fb887c 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
-@@ -114,6 +114,7 @@ public abstract class DistanceManager {
+@@ -128,6 +128,7 @@ public abstract class DistanceManager {
      }
  
      private static int getTicketLevelAt(SortedArraySet<Ticket<?>> tickets) {
@@ -623,15 +540,15 @@ index 1d6ab658c48bb765f66624f276ec7b05cf33c1d5..b9b56068cdacd984f873cfb2a06a312e
          return !tickets.isEmpty() ? ((Ticket) tickets.first()).getTicketLevel() : ChunkMap.MAX_CHUNK_DISTANCE + 1;
      }
  
-@@ -128,6 +129,7 @@ public abstract class DistanceManager {
+@@ -142,6 +143,7 @@ public abstract class DistanceManager {
      public boolean runAllUpdates(ChunkMap chunkStorage) {
-         this.naturalSpawnChunkCounter.runAllUpdates();
+         //this.f.a(); // Paper - no longer used
          this.tickingTicketsTracker.runAllUpdates();
 +        org.spigotmc.AsyncCatcher.catchOp("DistanceManagerTick"); // Paper
          this.playerTicketManager.runAllUpdates();
          int i = Integer.MAX_VALUE - this.ticketTracker.runDistanceUpdates(Integer.MAX_VALUE);
          boolean flag = i != 0;
-@@ -138,11 +140,13 @@ public abstract class DistanceManager {
+@@ -152,11 +154,13 @@ public abstract class DistanceManager {
  
          // Paper start
          if (!this.pendingChunkUpdates.isEmpty()) {
@@ -645,7 +562,7 @@ index 1d6ab658c48bb765f66624f276ec7b05cf33c1d5..b9b56068cdacd984f873cfb2a06a312e
              // Paper end
              return true;
          } else {
-@@ -178,8 +182,10 @@ public abstract class DistanceManager {
+@@ -192,8 +196,10 @@ public abstract class DistanceManager {
              return flag;
          }
      }
@@ -656,7 +573,7 @@ index 1d6ab658c48bb765f66624f276ec7b05cf33c1d5..b9b56068cdacd984f873cfb2a06a312e
          SortedArraySet<Ticket<?>> arraysetsorted = this.getTickets(i);
          int j = DistanceManager.getTicketLevelAt(arraysetsorted);
          Ticket<?> ticket1 = (Ticket) arraysetsorted.addOrGet(ticket);
-@@ -193,7 +199,9 @@ public abstract class DistanceManager {
+@@ -207,7 +213,9 @@ public abstract class DistanceManager {
      }
  
      boolean removeTicket(long i, Ticket<?> ticket) { // CraftBukkit - void -> boolean
@@ -666,7 +583,7 @@ index 1d6ab658c48bb765f66624f276ec7b05cf33c1d5..b9b56068cdacd984f873cfb2a06a312e
  
          boolean removed = false; // CraftBukkit
          if (arraysetsorted.remove(ticket)) {
-@@ -225,7 +233,12 @@ public abstract class DistanceManager {
+@@ -239,7 +247,12 @@ public abstract class DistanceManager {
              this.tickets.remove(i);
          }
  
@@ -680,7 +597,7 @@ index 1d6ab658c48bb765f66624f276ec7b05cf33c1d5..b9b56068cdacd984f873cfb2a06a312e
          return removed; // CraftBukkit
      }
  
-@@ -275,6 +288,112 @@ public abstract class DistanceManager {
+@@ -289,6 +302,112 @@ public abstract class DistanceManager {
          });
      }
  
@@ -794,12 +711,12 @@ index 1d6ab658c48bb765f66624f276ec7b05cf33c1d5..b9b56068cdacd984f873cfb2a06a312e
          Ticket<ChunkPos> ticket = new Ticket<>(TicketType.FORCED, 31, pos);
          long i = pos.toLong();
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 07671ac54f598872dba2b22ec8f82db3dd037d7f..5057053bcd3fc205e62edd9519a9545c16ce60c7 100644
+index 585892f19bc0aea89889a358c0407f2975b9efe5..918fda0fbbafa39ce0f421dcaf10f8dcf1e5dabb 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -409,6 +409,30 @@ public class ServerChunkCache extends ChunkSource {
- 
-         return ret;
+@@ -590,6 +590,26 @@ public class ServerChunkCache extends ChunkSource {
+             return CompletableFuture.completedFuture(either);
+         }, this.mainThreadProcessor);
      }
 +
 +    public boolean markUrgent(ChunkPos coords) {
@@ -821,14 +738,10 @@ index 07671ac54f598872dba2b22ec8f82db3dd037d7f..5057053bcd3fc205e62edd9519a9545c
 +    public void clearPriorityTickets(ChunkPos coords) {
 +        this.distanceManager.clearPriorityTickets(coords);
 +    }
-+
-+    public void clearUrgent(ChunkPos coords) {
-+        this.distanceManager.clearUrgent(coords);
-+    }
      // Paper end - async chunk io
  
      @Nullable
-@@ -443,6 +467,8 @@ public class ServerChunkCache extends ChunkSource {
+@@ -630,6 +650,8 @@ public class ServerChunkCache extends ChunkSource {
              Objects.requireNonNull(completablefuture);
              if (!completablefuture.isDone()) { // Paper
                  // Paper start - async chunk io/loading
@@ -837,7 +750,7 @@ index 07671ac54f598872dba2b22ec8f82db3dd037d7f..5057053bcd3fc205e62edd9519a9545c
                  this.level.asyncChunkTaskManager.raisePriority(x1, z1, com.destroystokyo.paper.io.PrioritizedTaskQueue.HIGHEST_PRIORITY);
                  com.destroystokyo.paper.io.chunk.ChunkTaskManager.pushChunkWait(this.level, x1, z1);
                  // Paper end
-@@ -450,6 +476,8 @@ public class ServerChunkCache extends ChunkSource {
+@@ -638,6 +660,8 @@ public class ServerChunkCache extends ChunkSource {
              chunkproviderserver_b.managedBlock(completablefuture::isDone);
                  com.destroystokyo.paper.io.chunk.ChunkTaskManager.popChunkWait(); // Paper - async chunk debug
                  this.level.timings.syncChunkLoad.stopTiming(); // Paper
@@ -846,7 +759,7 @@ index 07671ac54f598872dba2b22ec8f82db3dd037d7f..5057053bcd3fc205e62edd9519a9545c
              } // Paper
              ichunkaccess = (ChunkAccess) ((Either) completablefuture.join()).map((ichunkaccess1) -> {
                  return ichunkaccess1;
-@@ -555,10 +583,12 @@ public class ServerChunkCache extends ChunkSource {
+@@ -711,10 +735,12 @@ public class ServerChunkCache extends ChunkSource {
          if (create && !currentlyUnloading) {
              // CraftBukkit end
              this.distanceManager.addTicket(TicketType.UNKNOWN, chunkcoordintpair, l, chunkcoordintpair);
@@ -859,7 +772,7 @@ index 07671ac54f598872dba2b22ec8f82db3dd037d7f..5057053bcd3fc205e62edd9519a9545c
                  this.runDistanceManagerUpdates();
                  playerchunk = this.getVisibleChunkIfPresent(k);
                  gameprofilerfiller.pop();
-@@ -568,7 +598,13 @@ public class ServerChunkCache extends ChunkSource {
+@@ -724,7 +750,13 @@ public class ServerChunkCache extends ChunkSource {
              }
          }
  
@@ -874,7 +787,7 @@ index 07671ac54f598872dba2b22ec8f82db3dd037d7f..5057053bcd3fc205e62edd9519a9545c
      }
  
      private boolean chunkAbsent(@Nullable ChunkHolder holder, int maxLevel) {
-@@ -620,6 +656,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -776,6 +808,7 @@ public class ServerChunkCache extends ChunkSource {
      }
  
      public boolean runDistanceManagerUpdates() {
@@ -883,10 +796,10 @@ index 07671ac54f598872dba2b22ec8f82db3dd037d7f..5057053bcd3fc205e62edd9519a9545c
          boolean flag1 = this.chunkMap.promoteChunkMap();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 9ab4588e4e512176b881ad4c252e400ff6ea97bd..4adf2d503015cac85b12fbaae833b33eeeb44403 100644
+index 792ca370a918867e20dc8b020e7ed76535d4742b..63d06fda90816e79026387bc06e88eeb6ad21506 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -191,6 +191,7 @@ public class ServerPlayer extends Player {
+@@ -192,6 +192,7 @@ public class ServerPlayer extends Player {
      private int lastRecordedArmor = Integer.MIN_VALUE;
      private int lastRecordedLevel = Integer.MIN_VALUE;
      private int lastRecordedExperience = Integer.MIN_VALUE;
@@ -894,9 +807,9 @@ index 9ab4588e4e512176b881ad4c252e400ff6ea97bd..4adf2d503015cac85b12fbaae833b33e
      private float lastSentHealth = -1.0E8F;
      private int lastSentFood = -99999999;
      private boolean lastFoodSaturationZero = true;
-@@ -318,6 +319,21 @@ public class ServerPlayer extends Player {
-         this.bukkitPickUpLoot = true;
+@@ -336,6 +337,21 @@ public class ServerPlayer extends Player {
          this.maxHealthCache = this.getMaxHealth();
+         this.cachedSingleMobDistanceMap = new com.destroystokyo.paper.util.PooledHashSets.PooledObjectLinkedOpenHashSet<>(this); // Paper
      }
 +    // Paper start - Chunk priority
 +    public BlockPos getPointInFront(double inFront) {
@@ -1186,7 +1099,7 @@ index f1128f0d4a9a0241ac6c9bc18dd13b431c616bb1..2b2b7851d5f68bcdb41d58bcc64740ba
      protected Ticket(TicketType<T> type, int level, T argument) {
          this.type = type;
 diff --git a/src/main/java/net/minecraft/server/level/TicketType.java b/src/main/java/net/minecraft/server/level/TicketType.java
-index 10fa6cec911950f72407ae7f45c8cf48caa9421a..478109526cff7ceb0565cea3b5e97b9a07fbf8d1 100644
+index 8770fe0db46b01e8b608637df4f1a669a3f4cdde..3c1698ba0d3bc412ab957777d9b5211dbc555208 100644
 --- a/src/main/java/net/minecraft/server/level/TicketType.java
 +++ b/src/main/java/net/minecraft/server/level/TicketType.java
 @@ -9,6 +9,8 @@ import net.minecraft.world.level.ChunkPos;
@@ -1199,22 +1112,33 @@ index 10fa6cec911950f72407ae7f45c8cf48caa9421a..478109526cff7ceb0565cea3b5e97b9a
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 5833cc3d5014dad82607afc4d643b6bed885be64..8e0f73dcef189442450b4518437fb3a1c34b9a47 100644
+index 0b301b1f164853bfd23300993288a2958824e287..ec48afe87b5d159b5bdbe035e214ea7c9024fadb 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -177,6 +177,7 @@ public abstract class PlayerList {
+@@ -178,6 +178,7 @@ public abstract class PlayerList {
      }
  
      public void placeNewPlayer(Connection connection, ServerPlayer player) {
 +        player.isRealPlayer = true; // Paper - Chunk priority
-         GameProfile gameprofile = player.getGameProfile();
-         GameProfileCache usercache = this.server.getProfileCache();
-         Optional<GameProfile> optional = usercache.get(gameprofile.getId());
+         ServerPlayer prev = pendingPlayers.put(player.getUUID(), player);// Paper
+         if (prev != null) {
+             disconnectPendingPlayer(prev);
+@@ -292,8 +293,8 @@ public abstract class PlayerList {
+         net.minecraft.server.level.ChunkMap playerChunkMap = worldserver1.getChunkSource().chunkMap;
+         net.minecraft.server.level.DistanceManager distanceManager = playerChunkMap.distanceManager;
+         distanceManager.addTicket(net.minecraft.server.level.TicketType.LOGIN, pos, 31, pos.toLong());
+-        worldserver1.getChunkSource().runDistanceManagerUpdates();
+-        worldserver1.getChunkSource().getChunkAtAsynchronously(chunkX, chunkZ, true, true).thenApply(chunk -> {
++        worldserver1.getChunkSource().markAreaHighPriority(pos, 28, 3); // Paper - Chunk priority
++        worldserver1.getChunkSource().getChunkAtAsynchronously(chunkX, chunkZ, true, false).thenApply(chunk -> { // Paper - Chunk priority
+             net.minecraft.server.level.ChunkHolder updatingChunk = playerChunkMap.getUpdatingChunkIfPresent(pos.toLong());
+             if (updatingChunk != null) {
+                 return updatingChunk.getEntityTickingChunkFuture();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1a44c98b69398ba5dcb4115f0e8fdcf3f62fd920..9878aded49d0049b066fa608c7eaf25a55fcf12e 100644
+index 173824e96c51c4f1a9f43401cfa3fc79a2432600..c1bf81770f9d00f4e3ba5844260812bb4f6026ca 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -212,7 +212,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -293,7 +293,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      private BlockPos blockPosition;
      private ChunkPos chunkPosition;
      private Vec3 deltaMovement;
@@ -1224,10 +1148,10 @@ index 1a44c98b69398ba5dcb4115f0e8fdcf3f62fd920..9878aded49d0049b066fa608c7eaf25a
      public float yRotO;
      public float xRotO;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 58a245b2ca6e65d491694142ad04d38236b46434..893051059df51133a127b0870e27ab67461052fa 100644
+index 797ff36295412ac8429d573e039d870fd85eb569..3591ac3b7823e109e01ebfa54ac70aa4deabd4f6 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-@@ -134,7 +134,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -141,7 +141,7 @@ public class LevelChunk extends ChunkAccess {
          return NEIGHBOUR_CACHE_RADIUS;
      }
  
@@ -1236,7 +1160,7 @@ index 58a245b2ca6e65d491694142ad04d38236b46434..893051059df51133a127b0870e27ab67
      private long neighbourChunksLoadedBitset;
      private final LevelChunk[] loadedNeighbourChunks = new LevelChunk[(NEIGHBOUR_CACHE_RADIUS * 2 + 1) * (NEIGHBOUR_CACHE_RADIUS * 2 + 1)];
  
-@@ -653,6 +653,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -693,6 +693,7 @@ public class LevelChunk extends ChunkAccess {
  
      // CraftBukkit start
      public void loadCallback() {
@@ -1244,7 +1168,7 @@ index 58a245b2ca6e65d491694142ad04d38236b46434..893051059df51133a127b0870e27ab67
          // Paper start - neighbour cache
          int chunkX = this.chunkPos.x;
          int chunkZ = this.chunkPos.z;
-@@ -707,6 +708,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -747,6 +748,7 @@ public class LevelChunk extends ChunkAccess {
      }
  
      public void unloadCallback() {
@@ -1252,3 +1176,41 @@ index 58a245b2ca6e65d491694142ad04d38236b46434..893051059df51133a127b0870e27ab67
          org.bukkit.Server server = this.level.getCraftServer();
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index b234ba968e82ddf1e8f7c84d3a17659e3beda2b3..af22fa8aa8ddef4d592564b14d0114cc6f903fca 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -2077,6 +2077,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+             return future;
+         }
+ 
++        // Paper start - Chunk priority
++        if (!urgent) {
++            // If not urgent, at least use a slightly boosted priority
++            world.getChunkSource().markHighPriority(new ChunkPos(x, z), 1);
++        }
++        // Paper end
+         return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
+             net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
+             if (chunk != null) addTicket(x, z); // Paper
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 7ed67bcf9d0afb684e9c070fc1149d5f000aa8da..1b789e43707979a440ec64b3a09db317274abc36 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1039,6 +1039,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
+     }
+ 
++    // Paper start - Chunk priority
++    @Override
++    public java.util.concurrent.CompletableFuture<Boolean> teleportAsync(Location loc, @javax.annotation.Nonnull PlayerTeleportEvent.TeleportCause cause) {
++        ((CraftWorld)loc.getWorld()).getHandle().getChunkSource().markAreaHighPriority(
++            new net.minecraft.world.level.ChunkPos(net.minecraft.util.Mth.floor(loc.getX()) >> 4,
++            net.minecraft.util.Mth.floor(loc.getZ()) >> 4), 28, 3); // Load area high priority
++        return super.teleportAsync(loc, cause);
++    }
++    // Paper end
++
+     @Override
+     public boolean teleport(Location location, PlayerTeleportEvent.TeleportCause cause) {
+         Preconditions.checkArgument(location != null, "location");

--- a/patches/removed/1.19.2-legacy-chunksystem/0853-Replace-player-chunk-loader-system.patch
+++ b/patches/removed/1.19.2-legacy-chunksystem/0853-Replace-player-chunk-loader-system.patch
@@ -1218,10 +1218,10 @@ index 0000000000000000000000000000000000000000..b53402903eb6845df361daf6b05a6686
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 66afd752fd7d327e141d49b477f07e1ff3645d02..2a26d03fba2f3b37f176be9e47954ef9a6cd7b3e 100644
+index 9549e8ed4b245176b340ab2f22f4bdefdbe28a9e..b65a3626d2e0817cd1e223ec3b10e82fa0339663 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -100,6 +100,28 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -104,6 +104,28 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      public boolean queueImmunity = false;
      public ConnectionProtocol protocol;
      // Paper end
@@ -1250,7 +1250,7 @@ index 66afd752fd7d327e141d49b477f07e1ff3645d02..2a26d03fba2f3b37f176be9e47954ef9
  
      // Paper start - allow controlled flushing
      volatile boolean canFlush = true;
-@@ -488,6 +510,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -479,6 +501,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
          return false;
      }
      private boolean processQueue() {
@@ -1258,7 +1258,7 @@ index 66afd752fd7d327e141d49b477f07e1ff3645d02..2a26d03fba2f3b37f176be9e47954ef9
          if (this.queue.isEmpty()) return true;
          // Paper start - make only one flush call per sendPacketQueue() call
          final boolean needsFlush = this.canFlush;
-@@ -519,6 +542,12 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -510,6 +533,12 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
              }
          }
          return true;
@@ -1272,10 +1272,10 @@ index 66afd752fd7d327e141d49b477f07e1ff3645d02..2a26d03fba2f3b37f176be9e47954ef9
      // Paper end
  
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index b575d73ae0ff2e4f09a6a1f6fb061ca3da2cedf1..6939ef9b1fe782980e77c351d8a385a573d6a8e6 100644
+index 1eb71004a19866590a3d27fa6e72842934989177..7034af8ad42940c5af6b9032b9873ce36c55a2a7 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
-@@ -636,7 +636,8 @@ public final class MCUtil {
+@@ -647,7 +647,8 @@ public final class MCUtil {
              });
  
              worldData.addProperty("name", world.getWorld().getName());
@@ -1284,9 +1284,9 @@ index b575d73ae0ff2e4f09a6a1f6fb061ca3da2cedf1..6939ef9b1fe782980e77c351d8a385a5
 +            worldData.addProperty("tick-view-distance", world.getChunkSource().chunkMap.playerChunkManager.getTargetTickViewDistance()); // Paper - replace chunk loader system
              worldData.addProperty("keep-spawn-loaded", world.keepSpawnInMemory);
              worldData.addProperty("keep-spawn-loaded-range", world.paperConfig().spawn.keepSpawnLoadedRange * 16);
-             worldData.addProperty("visible-chunk-count", allChunks.size());
+             worldData.addProperty("visible-chunk-count", visibleChunks.size());
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 73712d6b9c828427d4c066c6d8672534575f3793..a041161dee9a857d43c83fb677dba7e90a6a5d24 100644
+index 5482be03a667939ff009b6810d5cc90c8601e983..11cd31691307749e925930c4b6e10e3f3b4fad25 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -76,6 +76,17 @@ public class ChunkHolder {
@@ -1305,9 +1305,9 @@ index 73712d6b9c828427d4c066c6d8672534575f3793..a041161dee9a857d43c83fb677dba7e9
 +    }
 +    // Paper end - no-tick view distance
  
-     // Paper start
-     public void onChunkAdd() {
-@@ -273,7 +284,7 @@ public class ChunkHolder {
+     // Paper start - optimise anyPlayerCloseEnoughForSpawning
+     // cached here to avoid a map lookup
+@@ -268,7 +279,7 @@ public class ChunkHolder {
  
      public void blockChanged(BlockPos pos) {
          if (!pos.isInsideBuildHeightAndWorldBoundsHorizontal(levelHeightAccessor)) return; // Paper - SPIGOT-6086 for all invalid locations; avoid acquiring locks
@@ -1316,7 +1316,7 @@ index 73712d6b9c828427d4c066c6d8672534575f3793..a041161dee9a857d43c83fb677dba7e9
  
          if (chunk != null) {
              int i = this.levelHeightAccessor.getSectionIndex(pos.getY());
-@@ -289,14 +300,15 @@ public class ChunkHolder {
+@@ -284,14 +295,15 @@ public class ChunkHolder {
      }
  
      public void sectionLightChanged(LightLayer lightType, int y) {
@@ -1336,7 +1336,7 @@ index 73712d6b9c828427d4c066c6d8672534575f3793..a041161dee9a857d43c83fb677dba7e9
  
                  if (chunk != null) {
                      int j = this.lightEngine.getMinLightSection();
-@@ -399,9 +411,28 @@ public class ChunkHolder {
+@@ -394,9 +406,28 @@ public class ChunkHolder {
      }
  
      public void broadcast(Packet<?> packet, boolean onlyOnWatchDistanceEdge) {
@@ -1369,10 +1369,10 @@ index 73712d6b9c828427d4c066c6d8672534575f3793..a041161dee9a857d43c83fb677dba7e9
  
      public CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> getOrScheduleFuture(ChunkStatus targetStatus, ChunkMap chunkStorage) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1a12111b4 100644
+index 4f6473398edd9987dfbb6cef79ed1bc93c3dd809..d98c489a58c8c2e657a8879b991aa57ef78f5015 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -218,6 +218,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -221,6 +221,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
      public final com.destroystokyo.paper.util.misc.PlayerAreaMap playerMobSpawnMap; // this map is absent from updateMaps since it's controlled at the start of the chunkproviderserver tick
      public final com.destroystokyo.paper.util.misc.PlayerAreaMap playerChunkTickRangeMap;
      // Paper end - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
@@ -1380,7 +1380,7 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
      // Paper start - use distance map to optimise tracker
      public static boolean isLegacyTrackingEntity(Entity entity) {
          return entity.isLegacyTrackingEntity;
-@@ -237,6 +238,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -240,6 +241,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
      // Paper end - use distance map to optimise tracker
  
      void addPlayerToDistanceMaps(ServerPlayer player) {
@@ -1388,7 +1388,7 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
          int chunkX = MCUtil.getChunkCoordinate(player.getX());
          int chunkZ = MCUtil.getChunkCoordinate(player.getZ());
          // Paper start - use distance map to optimise entity tracker
-@@ -244,7 +246,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -247,7 +249,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              com.destroystokyo.paper.util.misc.PlayerAreaMap trackMap = this.playerEntityTrackerTrackMaps[i];
              int trackRange = this.entityTrackerTrackRanges[i];
  
@@ -1397,7 +1397,7 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
          }
          // Paper end - use distance map to optimise entity tracker
          // Note: players need to be explicitly added to distance maps before they can be updated
-@@ -274,6 +276,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -277,6 +279,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              this.playerMobDistanceMap.remove(player);
          }
          // Paper end - per player mob spawning
@@ -1405,7 +1405,7 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
      }
  
      void updateMaps(ServerPlayer player) {
-@@ -285,7 +288,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -288,7 +291,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              com.destroystokyo.paper.util.misc.PlayerAreaMap trackMap = this.playerEntityTrackerTrackMaps[i];
              int trackRange = this.entityTrackerTrackRanges[i];
  
@@ -1414,7 +1414,7 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
          }
          // Paper end - use distance map to optimise entity tracker
          this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, DistanceManager.MOB_SPAWN_RANGE); // Paper - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
-@@ -295,6 +298,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -298,6 +301,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              this.playerMobDistanceMap.update(player, chunkX, chunkZ, this.distanceManager.getSimulationDistance());
          }
          // Paper end - per player mob spawning
@@ -1422,7 +1422,7 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
      }
      // Paper end
      // Paper start
-@@ -1447,11 +1451,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1452,11 +1456,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          completablefuture1.thenAcceptAsync((either) -> {
              either.ifLeft((chunk) -> {
                  this.tickingGenerated.getAndIncrement();
@@ -1435,12 +1435,12 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
              });
          }, (runnable) -> {
              this.mainThreadMailbox.tell(ChunkTaskPriorityQueueSorter.message(holder, runnable));
-@@ -1620,33 +1620,24 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1625,33 +1625,24 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              int k = this.viewDistance;
  
              this.viewDistance = j;
 -            this.distanceManager.updatePlayerTickets(this.viewDistance + 1);
--            Iterator objectiterator = net.minecraft.server.ChunkSystem.getUpdatingChunkHolders(this.level).iterator(); // Paper
+-            Iterator objectiterator = this.updatingChunks.getVisibleValuesCopy().iterator(); // Paper
 -
 -            while (objectiterator.hasNext()) {
 -                ChunkHolder playerchunk = (ChunkHolder) objectiterator.next();
@@ -1478,16 +1478,16 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
  
                      if (chunk != null) {
                          this.playerLoadedChunk(player, packet, chunk);
-@@ -1677,7 +1668,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1682,7 +1673,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
      void dumpChunks(Writer writer) throws IOException {
          CsvOutput csvwriter = CsvOutput.builder().addColumn("x").addColumn("z").addColumn("level").addColumn("in_memory").addColumn("status").addColumn("full_status").addColumn("accessible_ready").addColumn("ticking_ready").addColumn("entity_ticking_ready").addColumn("ticket").addColumn("spawning").addColumn("block_entity_count").addColumn("ticking_ticket").addColumn("ticking_level").addColumn("block_ticks").addColumn("fluid_ticks").build(writer);
 -        TickingTracker tickingtracker = this.distanceManager.tickingTracker();
 +        // Paper - replace loader system
-         Iterator<ChunkHolder> objectbidirectionaliterator = net.minecraft.server.ChunkSystem.getVisibleChunkHolders(this.level).iterator(); // Paper
+         ObjectBidirectionalIterator objectbidirectionaliterator = this.updatingChunks.getVisibleMap().clone().long2ObjectEntrySet().fastIterator(); // Paper
  
          while (objectbidirectionaliterator.hasNext()) {
-@@ -1693,7 +1684,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1698,7 +1689,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              // CraftBukkit - decompile error
              csvwriter.writeRow(chunkcoordintpair.x, chunkcoordintpair.z, playerchunk.getTicketLevel(), optional.isPresent(), optional.map(ChunkAccess::getStatus).orElse(null), optional1.map(LevelChunk::getFullStatus).orElse(null), ChunkMap.printFuture(playerchunk.getFullChunkFuture()), ChunkMap.printFuture(playerchunk.getTickingChunkFuture()), ChunkMap.printFuture(playerchunk.getEntityTickingChunkFuture()), this.distanceManager.getTicketDebugString(i), this.anyPlayerCloseEnoughForSpawning(chunkcoordintpair), optional1.map((chunk) -> {
                  return chunk.getBlockEntities().size();
@@ -1496,7 +1496,7 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
                  return chunk.getBlockTicks().count();
              }).orElse(0), optional1.map((chunk) -> {
                  return chunk.getFluidTicks().count();
-@@ -1927,15 +1918,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1932,15 +1923,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              this.removePlayerFromDistanceMaps(player); // Paper - distance maps
          }
  
@@ -1513,7 +1513,7 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
  
      }
  
-@@ -1943,7 +1926,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1948,7 +1931,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          SectionPos sectionposition = SectionPos.of((EntityAccess) player);
  
          player.setLastSectionPos(sectionposition);
@@ -1522,7 +1522,7 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
          return sectionposition;
      }
  
-@@ -1988,65 +1971,40 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1993,65 +1976,40 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          int k1;
          int l1;
  
@@ -1610,7 +1610,7 @@ index a5e74d30045a171f5ed66a115fbd429e9ab412af..47657f20652a80f50a2e46207c9c05d1
      }
  
      public void addEntity(Entity entity) {
-@@ -2415,7 +2373,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -2420,7 +2378,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                  double vec3d_dx = player.getX() - this.entity.getX();
                  double vec3d_dz = player.getZ() - this.entity.getZ();
                  // Paper end - remove allocation of Vec3D here
@@ -1797,10 +1797,10 @@ index f581a9f79b2357118d912a15344ff94df3b0c50e..d1b5c25b7455174e908cd6ed66789fa7
 +     */ // Paper - replace old loader system
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 4c82f17313e18c9dfd9b28653715b8a3242b826c..efcb80efc69a1e5ffc81b579bf535fd94e8144d7 100644
+index 96a232f22b1c270b91635ce9c7c6cacc63b026cc..59acbf6249f8f5285504c0ddea448a3433d1d68d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -667,17 +667,10 @@ public class ServerChunkCache extends ChunkSource {
+@@ -844,17 +844,10 @@ public class ServerChunkCache extends ChunkSource {
      // Paper end
  
      public boolean isPositionTicking(long pos) {
@@ -1822,7 +1822,7 @@ index 4c82f17313e18c9dfd9b28653715b8a3242b826c..efcb80efc69a1e5ffc81b579bf535fd9
      }
  
      public void save(boolean flush) {
-@@ -734,6 +727,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -911,6 +904,7 @@ public class ServerChunkCache extends ChunkSource {
          this.level.getProfiler().popPush("chunks");
          if (tickChunks) {
              this.level.timings.chunks.startTiming(); // Paper - timings
@@ -1830,7 +1830,7 @@ index 4c82f17313e18c9dfd9b28653715b8a3242b826c..efcb80efc69a1e5ffc81b579bf535fd9
              this.tickChunks();
              this.level.timings.chunks.stopTiming(); // Paper - timings
          }
-@@ -847,13 +841,13 @@ public class ServerChunkCache extends ChunkSource {
+@@ -1024,13 +1018,13 @@ public class ServerChunkCache extends ChunkSource {
                  // Paper end - optimise chunk tick iteration
                  ChunkPos chunkcoordintpair = chunk1.getPos();
  
@@ -1846,7 +1846,7 @@ index 4c82f17313e18c9dfd9b28653715b8a3242b826c..efcb80efc69a1e5ffc81b579bf535fd9
                          this.level.tickChunk(chunk1, k);
                          if ((chunksTicked++ & 1) == 0) net.minecraft.server.MinecraftServer.getServer().executeMidTickTasks(); // Paper
                      }
-@@ -1082,6 +1076,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -1259,6 +1253,7 @@ public class ServerChunkCache extends ChunkSource {
          public boolean pollTask() {
          try {
              boolean execChunkTask = com.destroystokyo.paper.io.chunk.ChunkTaskManager.pollChunkWaitQueue() || ServerChunkCache.this.level.asyncChunkTaskManager.pollNextChunkTask(); // Paper
@@ -1855,10 +1855,10 @@ index 4c82f17313e18c9dfd9b28653715b8a3242b826c..efcb80efc69a1e5ffc81b579bf535fd9
                  return true;
              } else {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 3bb6dbdd05ed981f70556c8f905d1eeeeade30b8..e71ae32d9827d8a6fb8543abdba7627897ac9f2e 100644
+index 01fd17fa845d4f03f3e7e599f42e56f51dd52ff6..b021fc77687cf7f569e5bf6fbb481c486e27e5a6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -682,7 +682,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -676,7 +676,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                          gameprofilerfiller.push("checkDespawn");
                          entity.checkDespawn();
                          gameprofilerfiller.pop();
@@ -1867,7 +1867,7 @@ index 3bb6dbdd05ed981f70556c8f905d1eeeeade30b8..e71ae32d9827d8a6fb8543abdba76278
                              Entity entity1 = entity.getVehicle();
  
                              if (entity1 != null) {
-@@ -715,7 +715,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -709,7 +709,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
      @Override
      public boolean shouldTickBlocksAt(long chunkPos) {
@@ -1879,7 +1879,7 @@ index 3bb6dbdd05ed981f70556c8f905d1eeeeade30b8..e71ae32d9827d8a6fb8543abdba76278
      }
  
      protected void tickTime() {
-@@ -2459,7 +2462,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2453,7 +2456,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      private boolean isPositionTickingWithEntitiesLoaded(long chunkPos) {
          // Paper start - optimize is ticking ready type functions
          ChunkHolder chunkHolder = this.chunkSource.chunkMap.getVisibleChunkIfPresent(chunkPos);
@@ -1889,10 +1889,10 @@ index 3bb6dbdd05ed981f70556c8f905d1eeeeade30b8..e71ae32d9827d8a6fb8543abdba76278
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b35b36527294dd697d146d2ad817d7911145ae8c..18c3d4aecf498f78040c27336d2ea56fd911d034 100644
+index de72b42065d1b24d195e79f3627c7fa2d276fb1e..f5bfd027759a28fd83c244d58e941a24142a3d05 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2475,5 +2475,5 @@ public class ServerPlayer extends Player {
+@@ -2495,5 +2495,5 @@ public class ServerPlayer extends Player {
      }
      // CraftBukkit end
  
@@ -1900,10 +1900,10 @@ index b35b36527294dd697d146d2ad817d7911145ae8c..18c3d4aecf498f78040c27336d2ea56f
 +    public final int getViewDistance() { throw new UnsupportedOperationException("Use PlayerChunkLoader"); } // Paper - placeholder
  }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 67f90c75aa4858bf1575bf7b0a62b8113de7c2ea..b588e14b2826bda5b03b4fc497efcb96b566541a 100644
+index c0ed1103e649e619c58f59c7bedd6a18a58f71ea..e57636efacedf1c6f1ccd4f01f7e94d6fda2ff4f 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -276,7 +276,7 @@ public abstract class PlayerList {
+@@ -273,7 +273,7 @@ public abstract class PlayerList {
          boolean flag1 = gamerules.getBoolean(GameRules.RULE_REDUCEDDEBUGINFO);
  
          // Spigot - view distance
@@ -1912,7 +1912,7 @@ index 67f90c75aa4858bf1575bf7b0a62b8113de7c2ea..b588e14b2826bda5b03b4fc497efcb96
          player.getBukkitEntity().sendSupportedChannels(); // CraftBukkit
          playerconnection.send(new ClientboundCustomPayloadPacket(ClientboundCustomPayloadPacket.BRAND, (new FriendlyByteBuf(Unpooled.buffer())).writeUtf(this.getServer().getServerModName())));
          playerconnection.send(new ClientboundChangeDifficultyPacket(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
-@@ -949,8 +949,8 @@ public abstract class PlayerList {
+@@ -942,8 +942,8 @@ public abstract class PlayerList {
          // CraftBukkit start
          LevelData worlddata = worldserver1.getLevelData();
          entityplayer1.connection.send(new ClientboundRespawnPacket(worldserver1.dimensionTypeId(), worldserver1.dimension(), BiomeManager.obfuscateSeed(worldserver1.getSeed()), entityplayer1.gameMode.getGameModeForPlayer(), entityplayer1.gameMode.getPreviousGameModeForPlayer(), worldserver1.isDebug(), worldserver1.isFlat(), flag, entityplayer1.getLastDeathLocation()));
@@ -1923,7 +1923,7 @@ index 67f90c75aa4858bf1575bf7b0a62b8113de7c2ea..b588e14b2826bda5b03b4fc497efcb96
          entityplayer1.spawnIn(worldserver1);
          entityplayer1.unsetRemoved();
          entityplayer1.connection.teleport(new Location(worldserver1.getWorld(), entityplayer1.getX(), entityplayer1.getY(), entityplayer1.getZ(), entityplayer1.getYRot(), entityplayer1.getXRot()));
-@@ -1519,7 +1519,7 @@ public abstract class PlayerList {
+@@ -1485,7 +1485,7 @@ public abstract class PlayerList {
  
      public void setViewDistance(int viewDistance) {
          this.viewDistance = viewDistance;
@@ -1932,7 +1932,7 @@ index 67f90c75aa4858bf1575bf7b0a62b8113de7c2ea..b588e14b2826bda5b03b4fc497efcb96
          Iterator iterator = this.server.getAllLevels().iterator();
  
          while (iterator.hasNext()) {
-@@ -1534,7 +1534,7 @@ public abstract class PlayerList {
+@@ -1500,7 +1500,7 @@ public abstract class PlayerList {
  
      public void setSimulationDistance(int simulationDistance) {
          this.simulationDistance = simulationDistance;
@@ -1984,10 +1984,10 @@ index 0b3e9e4ed162a6d9e1f3f55b9522b75c94d13254..fa1ff2e79954089552974cefedfcbff2
                          double deltaZ = soundPos.getZ() - player.getZ();
                          double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 931de769a3b7c993d151f3ee8e1038d95d3899a3..30140ae5a74a511c9031b8e772e724b25e56de3d 100644
+index 13c4b7aee9b9802edbaf7e4df9e9355667e727bb..9c036f7be422fd8447726478eee15a77637fdb9c 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -627,6 +627,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -628,6 +628,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
              if ((i & 2) != 0 && (!this.isClientSide || (i & 4) == 0) && (this.isClientSide || chunk == null || (chunk.getFullStatus() != null && chunk.getFullStatus().isOrAfter(ChunkHolder.FullChunkStatus.TICKING)))) { // allow chunk to be null here as chunk.isReady() is false when we send our notification during block placement
                  this.sendBlockUpdated(blockposition, iblockdata1, iblockdata, i);
@@ -2000,7 +2000,7 @@ index 931de769a3b7c993d151f3ee8e1038d95d3899a3..30140ae5a74a511c9031b8e772e724b2
  
              if ((i & 1) != 0) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index d870cefbe5b7485f423817f4f639e3e2a304640c..2292cb0e0c1a3e0ed34b941f028136bfb0bff13e 100644
+index 0de0519c01886a39399233b275db44b95e2f3d96..c46cbbf9ac4c5661933b03bc0b2559f7ade8c798 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -191,6 +191,43 @@ public class LevelChunk extends ChunkAccess {
@@ -2079,38 +2079,10 @@ index d870cefbe5b7485f423817f4f639e3e2a304640c..2292cb0e0c1a3e0ed34b941f028136bf
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 73e7181655b78f5bff90d07edfe6c5408cc08235..cf6fce4f3bddcbbae59fd128cf661e4506b9d2c5 100644
+index 6e36b6c722e647fe3672d782447a09030381137e..17b85478749be5be2bec19e49f26e03ebae29852 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -483,10 +483,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-         ChunkHolder playerChunk = this.world.getChunkSource().chunkMap.getVisibleChunkIfPresent(ChunkPos.asLong(x, z));
-         if (playerChunk == null) return false;
- 
--        playerChunk.getTickingChunkFuture().thenAccept(either -> {
--            either.left().ifPresent(chunk -> {
-+        // Paper start - rewrite player chunk loader
-+        net.minecraft.world.level.chunk.LevelChunk chunk = playerChunk.getSendingChunk();
-+        if (chunk == null) {
-+            return false;
-+        }
-+        // Paper end - rewrite player chunk loader
-                 List<ServerPlayer> playersInRange = playerChunk.playerProvider.getPlayers(playerChunk.getPos(), false);
--                if (playersInRange.isEmpty()) return;
-+                if (playersInRange.isEmpty()) return true; // Paper - rewrite player chunk loader
- 
-                 // Paper start - Anti-Xray - Bypass
-                 Map<Object, ClientboundLevelChunkWithLightPacket> refreshPackets = new HashMap<>();
-@@ -499,8 +503,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-                     }));
-                     // Paper end
-                 }
--            });
--        });
-+        // Paper - rewrite player chunk loader
- 
-         return true;
-     }
-@@ -2234,43 +2237,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2280,43 +2280,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {
@@ -2176,10 +2148,10 @@ index 73e7181655b78f5bff90d07edfe6c5408cc08235..cf6fce4f3bddcbbae59fd128cf661e45
      // Paper end - view distance api
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b318842214ede551215fd68af033feb1c8ef6604..4f5760d782bdfeee25839c50b614301eeb8ba42f 100644
+index 9312484b50949403372ce6441aca4a4bec056b19..58acaaa4925baa0b83b7eda4beec02f13cefaaa7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -546,45 +546,80 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -584,46 +584,80 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2264,7 +2236,8 @@ index b318842214ede551215fd68af033feb1c8ef6604..4f5760d782bdfeee25839c50b614301e
 +
 +        data.setTargetSendViewDistance(viewDistance);
      }
+-    // Paper end
 +    // Paper end - implement view distances
  
      @Override
-     public <T> T getClientOption(com.destroystokyo.paper.ClientOption<T> type) {
+     public void setCompassTarget(Location loc) {

--- a/patches/server/0384-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0384-Implement-Player-Client-Options-API.patch
@@ -85,40 +85,61 @@ index 0000000000000000000000000000000000000000..b6f4400df3d8ec7e06a996de54f8cabb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index baff31a9dd003eef6191b59598523e387bc759a1..867deadfc38e069931211a2b0db4350acd96247f 100644
+index baff31a9dd003eef6191b59598523e387bc759a1..a25be75e636fa1bac4890da3fa9db9267382c46d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1856,6 +1856,7 @@ public class ServerPlayer extends Player {
+@@ -1853,9 +1853,24 @@ public class ServerPlayer extends Player {
+         return s;
+     }
+ 
++    // Paper start - Client option API
++    private java.util.Map<com.destroystokyo.paper.ClientOption<?>, ?> getClientOptionMap(String locale, int viewDistance, com.destroystokyo.paper.ClientOption.ChatVisibility chatVisibility, boolean chatColors, com.destroystokyo.paper.PaperSkinParts skinParts, org.bukkit.inventory.MainHand mainHand, boolean allowsServerListing, boolean textFilteringEnabled) {
++        java.util.Map<com.destroystokyo.paper.ClientOption<?>, Object> map = new java.util.HashMap<>();
++        map.put(com.destroystokyo.paper.ClientOption.LOCALE, locale);
++        map.put(com.destroystokyo.paper.ClientOption.VIEW_DISTANCE, viewDistance);
++        map.put(com.destroystokyo.paper.ClientOption.CHAT_VISIBILITY, chatVisibility);
++        map.put(com.destroystokyo.paper.ClientOption.CHAT_COLORS_ENABLED, chatColors);
++        map.put(com.destroystokyo.paper.ClientOption.SKIN_PARTS, skinParts);
++        map.put(com.destroystokyo.paper.ClientOption.MAIN_HAND, mainHand);
++        map.put(com.destroystokyo.paper.ClientOption.ALLOW_SERVER_LISTINGS, allowsServerListing);
++        map.put(com.destroystokyo.paper.ClientOption.TEXT_FILTERING_ENABLED, textFilteringEnabled);
++        return map;
++    }
++    // Paper end
      public String locale = null; // CraftBukkit - add, lowercase // Paper - default to null
      public java.util.Locale adventure$locale = java.util.Locale.US; // Paper
      public void updateOptions(ServerboundClientInformationPacket packet) {
-+        new com.destroystokyo.paper.event.player.PlayerClientOptionsChangeEvent(getBukkitEntity(), packet.language, packet.viewDistance, com.destroystokyo.paper.ClientOption.ChatVisibility.valueOf(packet.chatVisibility().name()), packet.chatColors(), new com.destroystokyo.paper.PaperSkinParts(packet.modelCustomisation()), packet.mainHand() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT).callEvent(); // Paper - settings event
++        new com.destroystokyo.paper.event.player.PlayerClientOptionsChangeEvent(getBukkitEntity(), getClientOptionMap(packet.language, packet.viewDistance, com.destroystokyo.paper.ClientOption.ChatVisibility.valueOf(packet.chatVisibility().name()), packet.chatColors(), new com.destroystokyo.paper.PaperSkinParts(packet.modelCustomisation()), packet.mainHand() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT, packet.allowsListing(), packet.textFilteringEnabled())).callEvent(); // Paper - settings event
          // CraftBukkit start
          if (getMainArm() != packet.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cdc4ef88c8369b3bd1c607ff5301fc1b04ec4582..5338f9245c00366c68e208a1e0c780c7ca362548 100644
+index cdc4ef88c8369b3bd1c607ff5301fc1b04ec4582..a9ec1f77b7b9e60d735c72a01f0bce32d3083cb9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -615,6 +615,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -615,6 +615,28 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              connection.disconnect(message == null ? net.kyori.adventure.text.Component.empty() : message);
          }
      }
 +
 +    @Override
 +    public <T> T getClientOption(com.destroystokyo.paper.ClientOption<T> type) {
-+        if(com.destroystokyo.paper.ClientOption.SKIN_PARTS.equals(type)) {
++        if (com.destroystokyo.paper.ClientOption.SKIN_PARTS == type) {
 +            return type.getType().cast(new com.destroystokyo.paper.PaperSkinParts(getHandle().getEntityData().get(net.minecraft.world.entity.player.Player.DATA_PLAYER_MODE_CUSTOMISATION)));
-+        } else if(com.destroystokyo.paper.ClientOption.CHAT_COLORS_ENABLED.equals(type)) {
++        } else if (com.destroystokyo.paper.ClientOption.CHAT_COLORS_ENABLED == type) {
 +            return type.getType().cast(getHandle().canChatInColor());
-+        } else if(com.destroystokyo.paper.ClientOption.CHAT_VISIBILITY.equals(type)) {
++        } else if (com.destroystokyo.paper.ClientOption.CHAT_VISIBILITY == type) {
 +            return type.getType().cast(getHandle().getChatVisibility() == null ? com.destroystokyo.paper.ClientOption.ChatVisibility.UNKNOWN : com.destroystokyo.paper.ClientOption.ChatVisibility.valueOf(getHandle().getChatVisibility().name()));
-+        } else if(com.destroystokyo.paper.ClientOption.LOCALE.equals(type)) {
++        } else if (com.destroystokyo.paper.ClientOption.LOCALE == type) {
 +            return type.getType().cast(getLocale());
-+        } else if(com.destroystokyo.paper.ClientOption.MAIN_HAND.equals(type)) {
++        } else if (com.destroystokyo.paper.ClientOption.MAIN_HAND == type) {
 +            return type.getType().cast(getMainHand());
-+        } else if(com.destroystokyo.paper.ClientOption.VIEW_DISTANCE.equals(type)) {
++        } else if (com.destroystokyo.paper.ClientOption.VIEW_DISTANCE == type) {
 +            return type.getType().cast(getClientViewDistance());
++        } else if (com.destroystokyo.paper.ClientOption.ALLOW_SERVER_LISTINGS == type) {
++            return type.getType().cast(getHandle().allowsListing());
++        } else if (com.destroystokyo.paper.ClientOption.TEXT_FILTERING_ENABLED == type) {
++            return type.getType().cast(getHandle().isTextFilteringEnabled());
 +        }
 +        throw new RuntimeException("Unknown settings type");
 +    }

--- a/patches/server/0463-Brand-support.patch
+++ b/patches/server/0463-Brand-support.patch
@@ -56,10 +56,10 @@ index c59e90ba0de83eeda3719b6303bee9796b4a1af0..da6a0171bd63ac68635de1c23fc9eafa
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5338f9245c00366c68e208a1e0c780c7ca362548..f90ea94c8bf6fe167698501f670d1e1f10799005 100644
+index a9ec1f77b7b9e60d735c72a01f0bce32d3083cb9..d06d1bb3c426304aa222721285574368db24368e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2760,6 +2760,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2764,6 +2764,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0498-Player-elytra-boost-API.patch
+++ b/patches/server/0498-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f90ea94c8bf6fe167698501f670d1e1f10799005..2d111c46fcc705b8f161f4b5d83ac66c1ffbb05f 100644
+index d06d1bb3c426304aa222721285574368db24368e..34868d08ea4d17c63e9fdac2701d08269f39c115 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -633,6 +633,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -637,6 +637,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/patches/server/0512-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0512-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2d111c46fcc705b8f161f4b5d83ac66c1ffbb05f..87938df67f0d52081f6052b5670313adc7d5d988 100644
+index 34868d08ea4d17c63e9fdac2701d08269f39c115..d425dd49cc023a703b283d31f541dfea0256822e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2342,7 +2342,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2346,7 +2346,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0523-Player-Chunk-Load-Unload-Events.patch
+++ b/patches/server/0523-Player-Chunk-Load-Unload-Events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player Chunk Load/Unload Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 26caa90f9a7ffd1b8576b9de74476b681e13d429..e79d93940ca728a6a9867148510d969082ddbfd6 100644
+index c841cfba25d6f448fec929b3ca9653775d3e0ac9..826dcafaf65cef8bbff4f231f71305e851de0902 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2119,11 +2119,21 @@ public class ServerPlayer extends Player {
+@@ -2133,11 +2133,21 @@ public class ServerPlayer extends Player {
  
      public void trackChunk(ChunkPos chunkPos, Packet<?> chunkDataPacket) {
          this.connection.send(chunkDataPacket);

--- a/patches/server/0554-Add-sendOpLevel-API.patch
+++ b/patches/server/0554-Add-sendOpLevel-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 2732af0971dcac3fab8043b1e1ae2a57925699a2..a199dee07c67e4e66bbdccd2c5f77223cbc6fecf 100644
+index 2048964e21cc8db6fccc233506cdf84eab84f0ce..1bdde339c0a021fef850944556d7a353e5a9d7bd 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1130,6 +1130,11 @@ public abstract class PlayerList {
@@ -32,10 +32,10 @@ index 2732af0971dcac3fab8043b1e1ae2a57925699a2..a199dee07c67e4e66bbdccd2c5f77223
  
      public boolean isWhiteListed(GameProfile profile) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 87938df67f0d52081f6052b5670313adc7d5d988..41167d0da3d88466d4251c0adc56b4fd215c3bce 100644
+index d425dd49cc023a703b283d31f541dfea0256822e..93b65c81dd57a09d3566f3be26926481ed37d959 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -647,6 +647,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -651,6 +651,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/patches/server/0629-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0629-additions-to-PlayerGameModeChangeEvent.patch
@@ -45,7 +45,7 @@ index 65089c0e78c9913a92ae9c66d664f48e2112ad92..7882ee2b7813d437d3b7580f046f38e7
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ee6581758784c5aeab40fb35775b18031fb191ea..73864c47e7f13a48243478bc24d4887aa70791b3 100644
+index 498194b77e0efd97e59ef2adbcbc08526e925ace..4090b258672ac136172f3148bf1e297f270d4d93 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1795,8 +1795,15 @@ public class ServerPlayer extends Player {
@@ -75,7 +75,7 @@ index ee6581758784c5aeab40fb35775b18031fb191ea..73864c47e7f13a48243478bc24d4887a
          }
      }
  
-@@ -2210,6 +2217,16 @@ public class ServerPlayer extends Player {
+@@ -2224,6 +2231,16 @@ public class ServerPlayer extends Player {
      }
  
      public void loadGameTypes(@Nullable CompoundTag nbt) {
@@ -139,10 +139,10 @@ index 161b5d6f0d420ac7b6ed112d1b03d42c3aaec421..de4c3849cc60151de8f3a873adad2bc3
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 41167d0da3d88466d4251c0adc56b4fd215c3bce..3be62930b3f69fda6ab8b21eae43e2544b2706cf 100644
+index 93b65c81dd57a09d3566f3be26926481ed37d959..e2556cadaee17eebeb34a224132b2e183c6d973e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1465,7 +1465,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1469,7 +1469,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0641-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0641-Add-PlayerKickEvent-causes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b108b4ce54570a841086adffac542d8f7f2f2c6d..79c4ee2dd842fcf29eb91a69e536960c814c1a0d 100644
+index adacd9a7234b98124cbd8cf9af2efd4b9db6b5b4..1203076f688a16af17b7e55d913c9248e3f0fec7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2112,7 +2112,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -367,7 +367,7 @@ index 3ef39ebeb76f43d521266402e170bd1af6af2348..55c5348e793fa560d7042cf90076a8f7
          }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4c2c495d936cb84d85fb3e9f91e101a0fd796026..e316acab310fcf689f7a31f73bb3bc2b5e7eff0e 100644
+index 74a5363ee64ddc31746dc7e12b6bab14882e2649..0bc9383e02088569fc1b789ed3f58dcb872518df 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -726,7 +726,7 @@ public abstract class PlayerList {
@@ -391,7 +391,7 @@ index 4c2c495d936cb84d85fb3e9f91e101a0fd796026..e316acab310fcf689f7a31f73bb3bc2b
          // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3be62930b3f69fda6ab8b21eae43e2544b2706cf..9aa34da34b3a71c4c685ad5059f0bc69ce8352a0 100644
+index e2556cadaee17eebeb34a224132b2e183c6d973e..ed51d20ebe72cd5f94882127968006fca2acec08 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -597,7 +597,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0656-Fix-PlayerDropItemEvent-using-wrong-item.patch
+++ b/patches/server/0656-Fix-PlayerDropItemEvent-using-wrong-item.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix PlayerDropItemEvent using wrong item
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 73864c47e7f13a48243478bc24d4887aa70791b3..f5905fd32f1fbbc62e4578a735aae3c45a65a3f9 100644
+index 4090b258672ac136172f3148bf1e297f270d4d93..3ad77356734253f98cc92dd734d1171060dca62d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2186,7 +2186,7 @@ public class ServerPlayer extends Player {
+@@ -2200,7 +2200,7 @@ public class ServerPlayer extends Player {
  
              if (retainOwnership) {
                  if (!itemstack1.isEmpty()) {

--- a/patches/server/0677-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0677-Add-PlayerSetSpawnEvent.patch
@@ -32,7 +32,7 @@ index ce1c7512cc368e196ae94ee22c6a228c975b4980..1e41de9523c5fa3b9cfced798a5c35a2
          String string = resourceKey.location().toString();
          if (targets.size() == 1) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index a02b02c71ac6dddcccb10a6aa7993337ed04b829..3fdb52e31e4e845ddf61fc3695c0c85362eab708 100644
+index 95e2cbe6f80e64c00e8e261a3e1731c73845fc83..218a71cbd62795fdf3b9b3ad224e201b1e97a5b6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1272,7 +1272,7 @@ public class ServerPlayer extends Player {
@@ -44,7 +44,7 @@ index a02b02c71ac6dddcccb10a6aa7993337ed04b829..3fdb52e31e4e845ddf61fc3695c0c853
                  if (this.level.isDay()) {
                      return Either.left(Player.BedSleepingProblem.NOT_POSSIBLE_NOW);
                  } else {
-@@ -2113,12 +2113,33 @@ public class ServerPlayer extends Player {
+@@ -2127,12 +2127,33 @@ public class ServerPlayer extends Player {
          return this.respawnForced;
      }
  
@@ -80,7 +80,7 @@ index a02b02c71ac6dddcccb10a6aa7993337ed04b829..3fdb52e31e4e845ddf61fc3695c0c853
              }
  
              this.respawnPosition = pos;
-@@ -2132,6 +2153,7 @@ public class ServerPlayer extends Player {
+@@ -2146,6 +2167,7 @@ public class ServerPlayer extends Player {
              this.respawnForced = false;
          }
  
@@ -89,7 +89,7 @@ index a02b02c71ac6dddcccb10a6aa7993337ed04b829..3fdb52e31e4e845ddf61fc3695c0c853
  
      public void trackChunk(ChunkPos chunkPos, Packet<?> chunkDataPacket) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f0fe73f53d26ed8a527d0791a41ca0c9773319ca..3b583f3070cecf1e9c751c9a80592aadb8376ba4 100644
+index 157c263649d56ee47a4ccf91d76ba6cfa783f87f..e756066c9ed33cfd5ff3c5911421ff8433b0d2d7 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -902,13 +902,13 @@ public abstract class PlayerList {
@@ -129,10 +129,10 @@ index c3e49a781f838e6a46cb89744f3f1846de182275..c2f3d3a09327e7cb7d3167609eb3ce68
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9aa34da34b3a71c4c685ad5059f0bc69ce8352a0..8ac816295ce5bc9f2696fe790f4319e5ba16116f 100644
+index ed51d20ebe72cd5f94882127968006fca2acec08..44d2473625420490e35e79f0388a9890bff18fa8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1285,9 +1285,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1289,9 +1289,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0768-Add-player-health-update-API.patch
+++ b/patches/server/0768-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8ac816295ce5bc9f2696fe790f4319e5ba16116f..9b9fe738a20bfd2c9f954539362d35d7c83e8eb1 100644
+index 44d2473625420490e35e79f0388a9890bff18fa8..5fc912dcb196b10f33a738951bdad124df449ec5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2221,9 +2221,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2225,9 +2225,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index 8ac816295ce5bc9f2696fe790f4319e5ba16116f..9b9fe738a20bfd2c9f954539362d35d7
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2231,7 +2233,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2235,7 +2237,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          // Paper end
      }

--- a/patches/server/0801-Multi-Block-Change-API-Implementation.patch
+++ b/patches/server/0801-Multi-Block-Change-API-Implementation.patch
@@ -25,10 +25,10 @@ index 285da70a15f6e4c868747af9d40ac30bd4e42ef4..a0aeac9c29300a0cf6bad55133019e8c
      public void write(FriendlyByteBuf buf) {
          buf.writeLong(this.sectionPos.asLong());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9b9fe738a20bfd2c9f954539362d35d7c83e8eb1..2dc1f092576a2432563224d895729ad7c4cfc3bd 100644
+index 5fc912dcb196b10f33a738951bdad124df449ec5..e88fc016d8f928e378747ce26b808192f22597a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -923,6 +923,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -927,6 +927,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  

--- a/patches/server/0884-More-Teleport-API.patch
+++ b/patches/server/0884-More-Teleport-API.patch
@@ -69,10 +69,10 @@ index 2015147126f463f11202d04ca475cc86e5ac12c2..a1e2664c9a6cc41edf0dfb92cd2b9d77
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2dc1f092576a2432563224d895729ad7c4cfc3bd..3834952589a0becf88a4fdc328ca4f3e6c5b1aa6 100644
+index e88fc016d8f928e378747ce26b808192f22597a7..f6d728be8deb18d4e81c064e60eb6b35bf9831ff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1178,13 +1178,92 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1182,13 +1182,92 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setRotation(float yaw, float pitch) {
@@ -166,7 +166,7 @@ index 2dc1f092576a2432563224d895729ad7c4cfc3bd..3834952589a0becf88a4fdc328ca4f3e
          location.checkFinite();
  
          ServerPlayer entity = this.getHandle();
-@@ -1197,7 +1276,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1201,7 +1280,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
             return false;
          }
  
@@ -175,7 +175,7 @@ index 2dc1f092576a2432563224d895729ad7c4cfc3bd..3834952589a0becf88a4fdc328ca4f3e
              return false;
          }
  
-@@ -1215,7 +1294,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1219,7 +1298,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          // If this player is riding another entity, we must dismount before teleporting.
@@ -184,7 +184,7 @@ index 2dc1f092576a2432563224d895729ad7c4cfc3bd..3834952589a0becf88a4fdc328ca4f3e
  
          // SPIGOT-5509: Wakeup, similar to riding
          if (this.isSleeping()) {
-@@ -1237,7 +1316,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1241,7 +1320,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Check if the fromWorld and toWorld are the same.
          if (fromWorld == toWorld) {

--- a/patches/server/0889-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/server/0889-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3834952589a0becf88a4fdc328ca4f3e6c5b1aa6..781c0e10b523c55989f368b4507137343dcffdab 100644
+index f6d728be8deb18d4e81c064e60eb6b35bf9831ff..af439ea7800a8d4d606ac6cbfb6a621c5175d3de 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -659,6 +659,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -663,6 +663,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          this.getHandle().getServer().getPlayerList().sendPlayerPermissionLevel(this.getHandle(), level, false);
      }

--- a/patches/server/0903-Add-custom-destroyerIdentity-to-sendBlockDamage.patch
+++ b/patches/server/0903-Add-custom-destroyerIdentity-to-sendBlockDamage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add custom destroyerIdentity to sendBlockDamage
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 781c0e10b523c55989f368b4507137343dcffdab..968aa80b57a31d89852c6f4bc0ec5ed4a98c6530 100644
+index af439ea7800a8d4d606ac6cbfb6a621c5175d3de..e5248ea5abfe693f62175d69288f5b686f3ebebe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1008,13 +1008,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1012,13 +1012,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void sendBlockDamage(Location loc, float progress) {

--- a/patches/server/0924-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0924-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 968aa80b57a31d89852c6f4bc0ec5ed4a98c6530..b1136b9c39b16cbb9dfe460f88000f74ccd4f571 100644
+index e5248ea5abfe693f62175d69288f5b686f3ebebe..66830ccee464083879f79db4111e08fecee417ec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2932,6 +2932,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2936,6 +2936,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  


### PR DESCRIPTION
Adds the `ALLOWS_SERVER_LISTINGS` client option from #7268. Also addresses [MM's comment](https://github.com/PaperMC/Paper/pull/7268#discussion_r777680170) by adding a constructor that takes a map as an argument. I'm not entirely sure how I feel about this map approach, but it's definitely better than adding a new constructor every time.