### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0054-Fix-upstream-javadocs.patch
+++ b/patches/api/0054-Fix-upstream-javadocs.patch
@@ -76,7 +76,7 @@ index be9334a8b5fba9181ad63c211697e798be63da25..0514a141cb93a650be38c63d4336d46e
       * Instructs this Mob to set the specified LivingEntity as its target.
       * <p>
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index a0777f9dc7cb6d4274635d794cf66de714535cde..2ba2c61dd1e8180d9dfbced8dc1642c75aaff6f7 100644
+index 2a4cbda6cf881b850c293e54c142c3fe7a5165bd..9eb3903ec290cb43f129f44c6ef0cd99b5769b5f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -753,7 +753,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -122,16 +122,3 @@ index 1b2267f4e8ebded198773ec80e2bff2c861c7084..1a58734d919fae247eeb85dd785fd599
      public Location getTo() {
          return to;
      }
-diff --git a/src/main/java/org/bukkit/inventory/PlayerInventory.java b/src/main/java/org/bukkit/inventory/PlayerInventory.java
-index 99d900b2394b6c210ccf845768dae72864f32270..515587a958041e94f03c48ae87812abc39e1791c 100644
---- a/src/main/java/org/bukkit/inventory/PlayerInventory.java
-+++ b/src/main/java/org/bukkit/inventory/PlayerInventory.java
-@@ -106,7 +106,7 @@ public interface PlayerInventory extends Inventory {
-      *
-      * @return the ItemStack in the given slot
-      */
--    @NotNull
-+    @Nullable
-     public ItemStack getItem(@NotNull EquipmentSlot slot);
- 
-     /**

--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -212,7 +212,7 @@ index 487e6a6391123a4792c3bdeba869aa2bcb5922cc..3dd8205dd070901be82c2bef390df5df
          return this.meta == null ? Bukkit.getItemFactory().getItemMeta(this.type) : this.meta.clone();
      }
 diff --git a/src/main/java/org/bukkit/inventory/PlayerInventory.java b/src/main/java/org/bukkit/inventory/PlayerInventory.java
-index 515587a958041e94f03c48ae87812abc39e1791c..5652786f43c10d03b3b1cf065548efb1a950ed7a 100644
+index 62fbd7f6d8195bebcab7f704a0a485a1bbeca26c..8b5385e39f64c4df8e235a8832d91e55642421ce 100644
 --- a/src/main/java/org/bukkit/inventory/PlayerInventory.java
 +++ b/src/main/java/org/bukkit/inventory/PlayerInventory.java
 @@ -14,8 +14,7 @@ public interface PlayerInventory extends Inventory {
@@ -235,6 +235,18 @@ index 515587a958041e94f03c48ae87812abc39e1791c..5652786f43c10d03b3b1cf065548efb1
  
      /**
       * Return the ItemStack from the helmet slot
+@@ -104,9 +102,9 @@ public interface PlayerInventory extends Inventory {
+      *
+      * @param slot the slot to get the ItemStack
+      *
+-     * @return the ItemStack in the given slot or null if there is not one
++     * @return the ItemStack in the given slot
+      */
+-    @Nullable
++    @NotNull // Paper
+     public ItemStack getItem(@NotNull EquipmentSlot slot);
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 index 01b462fccce71cef3398dd43944046f322b8e57e..8c48a5c61b5afb5407ebf5d734858a0177e3ffa1 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java

--- a/patches/server/0007-MC-Utils.patch
+++ b/patches/server/0007-MC-Utils.patch
@@ -5893,7 +5893,7 @@ index 2015e527044db26bed960b2915b5422a7d7ad0e3..94d717f43336ace9375409b48d1e0e42
      @Override
      public ChunkAccess getChunk(int x, int z, ChunkStatus leastStatus, boolean create) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4c775aca50d8ff75c2c885bbf9fbbc6c8829d66f..7564d58b7cbf48c2aaa2e6f823dc88122aecdd6c 100644
+index 1427b76110a02cee15865173e06e7b7bb4231ae7..de0f49f3e9134c068aa479067ee2986c981167b8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -160,6 +160,7 @@ import org.bukkit.event.server.MapInitializeEvent;
@@ -6002,11 +6002,11 @@ index 4c775aca50d8ff75c2c885bbf9fbbc6c8829d66f..7564d58b7cbf48c2aaa2e6f823dc8812
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<Level> resourcekey, Holder<DimensionType> holder, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider) {
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 146d72d8d44cda5fc3f357f52e5fb3775be620f2..9d7d7a44616b2b7849c1abd3b9ac77305fdb0815 100644
+index 8845ed9c2cf835d7c1deeb61bf10addbfe34041c..2eebeb696e853c2ba17a9a65ca8d0fd7dff9baa9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -232,6 +232,8 @@ public class ServerPlayer extends Player {
-     public Integer clientViewDistance;
+@@ -233,6 +233,8 @@ public class ServerPlayer extends Player {
+     public String kickLeaveMessage = null; // SPIGOT-3034: Forward leave message to PlayerQuitEvent
      // CraftBukkit end
  
 +    public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<ServerPlayer> cachedSingleHashSet; // Paper
@@ -6014,7 +6014,7 @@ index 146d72d8d44cda5fc3f357f52e5fb3775be620f2..9d7d7a44616b2b7849c1abd3b9ac7730
      public ServerPlayer(MinecraftServer server, ServerLevel world, GameProfile profile) {
          super(world, world.getSharedSpawnPos(), world.getSharedSpawnAngle(), profile);
          this.chatVisibility = ChatVisiblity.FULL;
-@@ -295,6 +297,8 @@ public class ServerPlayer extends Player {
+@@ -296,6 +298,8 @@ public class ServerPlayer extends Player {
          this.maxUpStep = 1.0F;
          this.fudgeSpawnLocation(world);
  
@@ -6067,7 +6067,7 @@ index 0d33910768b111863816f84393613c0cc5142691..8fdda1e5805534d08c0a06b15e89d85b
      public BlockState getBlockState(BlockPos pos) {
          return this.getChunk(SectionPos.blockToSectionCoord(pos.getX()), SectionPos.blockToSectionCoord(pos.getZ())).getBlockState(pos);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c79c4e170a8213fd47e78c43827ddc86d24f7b61..c18bed4728f6813aa8d7cf4b1e5e53a092fb1354 100644
+index 2f752027a4e4399faab9c8012264b92106961cb3..0753fdff0fe7b660af8bc09ad98a95701b1aaa01 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -218,9 +218,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -7,7 +7,7 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5c7b2850d311e4d54236ba9acce148bca05672fd..15927e8b747e536a5136d9b59edc8d6f50354c42 100644
+index 23410c6ee34fcd9c50c2dbf35d8ff4d0c9ca408c..557ab97176944209c55f02dd106131ece2c01119 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -185,4 +185,13 @@ public class PaperConfig {
@@ -1163,7 +1163,7 @@ index 762a9392ffac3042356709dddd15bb3516048bed..3544e2dc2522e9d6305d727d56e73490
          buf.writeComponent(this.footer);
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 9d7d7a44616b2b7849c1abd3b9ac77305fdb0815..592b288c5ded992dc3fdf0db5ed0845884c5be93 100644
+index 2eebeb696e853c2ba17a9a65ca8d0fd7dff9baa9..25bc0d6a09def9820106bd5889fdcca4aeeba19f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -145,6 +145,7 @@ import net.minecraft.world.scores.Score;
@@ -1182,7 +1182,7 @@ index 9d7d7a44616b2b7849c1abd3b9ac77305fdb0815..592b288c5ded992dc3fdf0db5ed08458
      public Component listName;
      public org.bukkit.Location compassTarget;
      public int newExp = 0;
-@@ -301,6 +303,7 @@ public class ServerPlayer extends Player {
+@@ -302,6 +304,7 @@ public class ServerPlayer extends Player {
  
          // CraftBukkit start
          this.displayName = this.getScoreboardName();
@@ -1190,7 +1190,7 @@ index 9d7d7a44616b2b7849c1abd3b9ac77305fdb0815..592b288c5ded992dc3fdf0db5ed08458
          this.bukkitPickUpLoot = true;
          this.maxHealthCache = this.getMaxHealth();
      }
-@@ -772,22 +775,17 @@ public class ServerPlayer extends Player {
+@@ -773,22 +776,17 @@ public class ServerPlayer extends Player {
  
          String deathmessage = defaultMessage.getString();
          this.keepLevel = keepInventory; // SPIGOT-2222: pre-set keepLevel
@@ -1217,7 +1217,7 @@ index 9d7d7a44616b2b7849c1abd3b9ac77305fdb0815..592b288c5ded992dc3fdf0db5ed08458
  
              this.connection.send(new ClientboundPlayerCombatKillPacket(this.getCombatTracker(), ichatbasecomponent), (future) -> {
                  if (!future.isSuccess()) {
-@@ -1729,6 +1727,7 @@ public class ServerPlayer extends Player {
+@@ -1730,6 +1728,7 @@ public class ServerPlayer extends Player {
      }
  
      public String locale = "en_us"; // CraftBukkit - add, lowercase
@@ -1225,7 +1225,7 @@ index 9d7d7a44616b2b7849c1abd3b9ac77305fdb0815..592b288c5ded992dc3fdf0db5ed08458
      public void updateOptions(ServerboundClientInformationPacket packet) {
          // CraftBukkit start
          if (getMainArm() != packet.mainHand()) {
-@@ -1740,6 +1739,10 @@ public class ServerPlayer extends Player {
+@@ -1741,6 +1740,10 @@ public class ServerPlayer extends Player {
              this.server.server.getPluginManager().callEvent(event);
          }
          this.locale = packet.language;
@@ -1237,7 +1237,7 @@ index 9d7d7a44616b2b7849c1abd3b9ac77305fdb0815..592b288c5ded992dc3fdf0db5ed08458
          // CraftBukkit end
          this.chatVisibility = packet.chatVisibility();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c18bed4728f6813aa8d7cf4b1e5e53a092fb1354..082d2fe274a91a76bbef5597eec61d7368cbd06e 100644
+index 0753fdff0fe7b660af8bc09ad98a95701b1aaa01..91c1447c9e365345e02b9162e3b9e72140f7fcc8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -155,6 +155,8 @@ import org.apache.commons.lang3.StringUtils;
@@ -1282,9 +1282,9 @@ index c18bed4728f6813aa8d7cf4b1e5e53a092fb1354..082d2fe274a91a76bbef5597eec61d73
  
          if (this.cserver.getServer().isRunning()) {
              this.cserver.getPluginManager().callEvent(event);
-@@ -409,8 +414,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
-             return;
+@@ -410,8 +415,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
+         this.player.kickLeaveMessage = event.getLeaveMessage(); // CraftBukkit - SPIGOT-3034: Forward leave message to PlayerQuitEvent
          // Send the possibly modified leave message
 -        s = event.getReason();
 -        final Component ichatbasecomponent = CraftChatMessage.fromString(s, true)[0];
@@ -1292,7 +1292,7 @@ index c18bed4728f6813aa8d7cf4b1e5e53a092fb1354..082d2fe274a91a76bbef5597eec61d73
          // CraftBukkit end
  
          this.connection.send(new ClientboundDisconnectPacket(ichatbasecomponent), (future) -> {
-@@ -1685,9 +1689,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1686,9 +1690,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          */
  
          this.player.disconnect();
@@ -1307,7 +1307,7 @@ index c18bed4728f6813aa8d7cf4b1e5e53a092fb1354..082d2fe274a91a76bbef5597eec61d73
          }
          // CraftBukkit end
          this.player.getTextFilter().leave();
-@@ -1869,7 +1875,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1870,7 +1876,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              this.handleCommand(s);
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
@@ -1321,7 +1321,7 @@ index c18bed4728f6813aa8d7cf4b1e5e53a092fb1354..082d2fe274a91a76bbef5597eec61d73
              Player player = this.getCraftPlayer();
              AsyncPlayerChatEvent event = new AsyncPlayerChatEvent(async, player, s, new LazyPlayerSet(this.server));
              this.cserver.getPluginManager().callEvent(event);
-@@ -2668,30 +2679,30 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2669,30 +2680,30 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  return;
              }
  
@@ -1402,7 +1402,7 @@ index c9a8d64ef23def0ad8e986a97c34331b8d54c205..2b24a41587fbe1fba70a0ab42d3dc333
  
                  @Override
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ea119e5849c90b25b7e836eb5e7454a391865b81..be9a29f01d59584a1492d925248f0947610ce9d0 100644
+index 60b4044e3d914ff83a4f37499e278fbcbc65e5c1..be9a29f01d59584a1492d925248f0947610ce9d0 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -8,6 +8,7 @@ import com.mojang.logging.LogUtils;
@@ -1468,7 +1468,7 @@ index ea119e5849c90b25b7e836eb5e7454a391865b81..be9a29f01d59584a1492d925248f0947
              entityplayer.closeContainer();
          }
  
--        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), "\u00A7e" + entityplayer.getScoreboardName() + " left the game");
+-        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), entityplayer.kickLeaveMessage != null ? entityplayer.kickLeaveMessage : "\u00A7e" + entityplayer.getScoreboardName() + " left the game");
 +        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
          this.cserver.getPluginManager().callEvent(playerQuitEvent);
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
@@ -1808,7 +1808,7 @@ index 794ed40db102370338ee227ffa4e1801fd741284..5963fa56e7dcd61336a14fa1035c6c14
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 70aa37fe043f56ef1b2f722ca946c4ac2cf4a98b..1039517ead86512a34e07b44b131981c1dea7b00 100644
+index 7861f86a47597883a3813d32f462c514a76eb8ef..339ee79ec1da8a9c865fd5444dc00c206983fcd8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -19,6 +19,12 @@ public class Main {
@@ -3133,7 +3133,7 @@ index 00445fc7373c70f4cecc4114f9bcfb4b6f27c0e8..b132c151e4fb6c64b633a0712100c3ae
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index f9626f2ec5e26685660c1c96d2fc507c06a20a1b..39d2cd4acbce96cd7b9bd76bddf85b9b8729855a 100644
+index 0057d6f91fd75555b59dfe25bc96a6fc21f948fa..911a732065a908545ac6a7c10262980a59bd157e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -746,6 +746,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {

--- a/patches/server/0012-Timings-v2.patch
+++ b/patches/server/0012-Timings-v2.patch
@@ -1210,7 +1210,7 @@ index 94d717f43336ace9375409b48d1e0e4291072656..3bbee4d08f4125a6499c0a8790c6bda6
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 7564d58b7cbf48c2aaa2e6f823dc88122aecdd6c..74571a05f8d69e068c615179782def0902b26a09 100644
+index de0f49f3e9134c068aa479067ee2986c981167b8..0750cf27c1b2cac723d68d0e6c2204cbb5795571 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1,6 +1,8 @@
@@ -1326,7 +1326,7 @@ index 7564d58b7cbf48c2aaa2e6f823dc88122aecdd6c..74571a05f8d69e068c615179782def09
                  this.entityManager.saveAll();
              } else {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 082d2fe274a91a76bbef5597eec61d7368cbd06e..9b47d8ab57c3b290173247ba25ad7668f3529903 100644
+index 91c1447c9e365345e02b9162e3b9e72140f7fcc8..5a321df55ce16c20d7235bea630058b3aa390475 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -210,6 +210,7 @@ import org.bukkit.inventory.CraftingInventory;
@@ -1353,7 +1353,7 @@ index 082d2fe274a91a76bbef5597eec61d7368cbd06e..9b47d8ab57c3b290173247ba25ad7668
  
      }
  
-@@ -1945,7 +1944,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1946,7 +1945,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      // CraftBukkit end
  
      private void handleCommand(String input) {
@@ -1362,7 +1362,7 @@ index 082d2fe274a91a76bbef5597eec61d7368cbd06e..9b47d8ab57c3b290173247ba25ad7668
          // CraftBukkit start - whole method
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + input);
-@@ -1956,7 +1955,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1957,7 +1956,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          this.cserver.getPluginManager().callEvent(event);
  
          if (event.isCancelled()) {
@@ -1371,7 +1371,7 @@ index 082d2fe274a91a76bbef5597eec61d7368cbd06e..9b47d8ab57c3b290173247ba25ad7668
              return;
          }
  
-@@ -1969,7 +1968,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1970,7 +1969,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              java.util.logging.Logger.getLogger(ServerGamePacketListenerImpl.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
              return;
          } finally {

--- a/patches/server/0032-Configurable-end-credits.patch
+++ b/patches/server/0032-Configurable-end-credits.patch
@@ -20,10 +20,10 @@ index 1b090f2e38a8857ef74403e1f3db8c2ba7127297..bc35bdd9cbd544ae2ab27ad042d7d1b3
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 592b288c5ded992dc3fdf0db5ed0845884c5be93..fcbd7a78477ed51a91aee626ac62529f106a40cb 100644
+index 25bc0d6a09def9820106bd5889fdcca4aeeba19f..000ea770aeb9510c89d13e31bd9d769f7f884ceb 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -974,6 +974,7 @@ public class ServerPlayer extends Player {
+@@ -975,6 +975,7 @@ public class ServerPlayer extends Player {
              this.unRide();
              this.getLevel().removePlayerImmediately(this, Entity.RemovalReason.CHANGED_DIMENSION);
              if (!this.wonGame) {

--- a/patches/server/0039-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0039-Implement-PlayerLocaleChangeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement PlayerLocaleChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index fcbd7a78477ed51a91aee626ac62529f106a40cb..e3e9f082102d16a8e16df3b35772430c6d102243 100644
+index 000ea770aeb9510c89d13e31bd9d769f7f884ceb..bb2a788d3687977a0607b83150ad1bf1eb8803f2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1727,7 +1727,7 @@ public class ServerPlayer extends Player {
+@@ -1728,7 +1728,7 @@ public class ServerPlayer extends Player {
          return s;
      }
  
@@ -17,7 +17,7 @@ index fcbd7a78477ed51a91aee626ac62529f106a40cb..e3e9f082102d16a8e16df3b35772430c
      public java.util.Locale adventure$locale = java.util.Locale.US; // Paper
      public void updateOptions(ServerboundClientInformationPacket packet) {
          // CraftBukkit start
-@@ -1735,9 +1735,10 @@ public class ServerPlayer extends Player {
+@@ -1736,9 +1736,10 @@ public class ServerPlayer extends Player {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
              this.server.server.getPluginManager().callEvent(event);
          }

--- a/patches/server/0040-Per-Player-View-Distance-API-placeholders.patch
+++ b/patches/server/0040-Per-Player-View-Distance-API-placeholders.patch
@@ -7,10 +7,10 @@ I hope to look at this more in-depth soon. It appears doable.
 However this should not block the update.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e3e9f082102d16a8e16df3b35772430c6d102243..ba0fc93333fbe3ef1d9677de42f00648a58dcc14 100644
+index bb2a788d3687977a0607b83150ad1bf1eb8803f2..42e69a8e3e93e2da9f4ee576900795b8798b8022 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2198,4 +2198,6 @@ public class ServerPlayer extends Player {
+@@ -2199,4 +2199,6 @@ public class ServerPlayer extends Player {
          return (CraftPlayer) super.getBukkitEntity();
      }
      // CraftBukkit end

--- a/patches/server/0042-Configurable-container-update-tick-rate.patch
+++ b/patches/server/0042-Configurable-container-update-tick-rate.patch
@@ -19,7 +19,7 @@ index e7b7f0a1a35f782a0da4627b4f02e673ca73693e..1b51f717ec2a0538d9037dd1d4328030
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ba0fc93333fbe3ef1d9677de42f00648a58dcc14..fa3344c71a9715ad465f39be92cb724368ae2b03 100644
+index 42e69a8e3e93e2da9f4ee576900795b8798b8022..75810e7c5bc554bed91774484ad70b35ab9913d4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -218,6 +218,7 @@ public class ServerPlayer extends Player {
@@ -30,7 +30,7 @@ index ba0fc93333fbe3ef1d9677de42f00648a58dcc14..fa3344c71a9715ad465f39be92cb7243
  
      // CraftBukkit start
      public String displayName;
-@@ -589,7 +590,12 @@ public class ServerPlayer extends Player {
+@@ -590,7 +591,12 @@ public class ServerPlayer extends Player {
              --this.invulnerableTime;
          }
  

--- a/patches/server/0047-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0047-Ensure-commands-are-not-ran-async.patch
@@ -14,10 +14,10 @@ big slowdown in execution but throwing an exception at same time to raise awaren
 that it is happening so that plugin authors can fix their code to stop executing commands async.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9b47d8ab57c3b290173247ba25ad7668f3529903..6f99b1b54fe893240143282563cb59e6c9cd4122 100644
+index 5a321df55ce16c20d7235bea630058b3aa390475..44039e85bbb53e7bf89f9572c29c21fb4b147cc7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1871,6 +1871,29 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1872,6 +1872,29 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
  
          if (!async && s.startsWith("/")) {

--- a/patches/server/0061-Complete-resource-pack-API.patch
+++ b/patches/server/0061-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6f99b1b54fe893240143282563cb59e6c9cd4122..0429a019d8f25dc9df6c3a9d7e28eea739431a71 100644
+index 44039e85bbb53e7bf89f9572c29c21fb4b147cc7..1ff86d507700ac39752efcbfbbc9b29dcbeb1fc1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1653,8 +1653,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1654,8 +1654,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              ServerGamePacketListenerImpl.LOGGER.info("Disconnecting {} due to resource pack rejection", this.player.getName());
              this.disconnect(new TranslatableComponent("multiplayer.requiredTexturePrompt.disconnect"));
          }

--- a/patches/server/0079-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0079-Add-PlayerUseUnknownEntityEvent.patch
@@ -20,10 +20,10 @@ index 8834ed411a7db86b4d2b88183a1315317107d719..c45b5ab6776f3ac79f856c3a6467c510
      static final ServerboundInteractPacket.Action ATTACK_ACTION = new ServerboundInteractPacket.Action() {
          @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0429a019d8f25dc9df6c3a9d7e28eea739431a71..8e976184215b2db7684bb0488e4a8124b5dedde0 100644
+index 1ff86d507700ac39752efcbfbbc9b29dcbeb1fc1..2dbccb6320374acd90f85e4ee06dbad6cbf0650d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2219,8 +2219,37 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2220,8 +2220,37 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  });
              }
          }

--- a/patches/server/0104-Configurable-packet-in-spam-threshold.patch
+++ b/patches/server/0104-Configurable-packet-in-spam-threshold.patch
@@ -23,10 +23,10 @@ index 96fbac179e6970f4eeeed9fdc07c1ac1d8e8be0a..081761cd2177bd3cea5a489a85e7088c
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8e976184215b2db7684bb0488e4a8124b5dedde0..350a8194ef52242be6a70a16d2692e17216178fb 100644
+index 2dbccb6320374acd90f85e4ee06dbad6cbf0650d..66fa0c05da7b5ca6a9a89b45bd796b50afe55a39 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1502,13 +1502,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1503,13 +1503,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      // Spigot start - limit place/interactions
      private int limitedPackets;
      private long lastLimitedPacket = -1;

--- a/patches/server/0119-Properly-fix-item-duplication-bug.patch
+++ b/patches/server/0119-Properly-fix-item-duplication-bug.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Properly fix item duplication bug
 Credit to prplz for figuring out the real issue
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index fa3344c71a9715ad465f39be92cb724368ae2b03..2fbe90ba893393e04b72b9feeff5f6be09d65e16 100644
+index 75810e7c5bc554bed91774484ad70b35ab9913d4..eafc1fd7200ca93d0524801536669ea4f5ba1408 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2156,7 +2156,7 @@ public class ServerPlayer extends Player {
+@@ -2157,7 +2157,7 @@ public class ServerPlayer extends Player {
  
      @Override
      public boolean isImmobile() {
@@ -19,10 +19,10 @@ index fa3344c71a9715ad465f39be92cb724368ae2b03..2fbe90ba893393e04b72b9feeff5f6be
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 47d8ae1eb7edea51a81ddfaef3cd1c4b06ad12a3..6995539a536f0019839a177ffb6e633c8013a8fb 100644
+index 2259f6d9be2390aaa8ffc43b3c2e37b0036b43ac..3f8dcf091ac81c431bbe572d9c2bd65ea003b86a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2845,7 +2845,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2846,7 +2846,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      }
  
      public final boolean isDisconnected() {

--- a/patches/server/0131-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0131-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -26,10 +26,10 @@ index 72501b05d1d5d9304e4ac31bbf694f5ca1637c0f..f459b23282e5353f0f57bd228af7e8d5
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6995539a536f0019839a177ffb6e633c8013a8fb..da776d740ca0e684a08d7df58e50f862eb031ee7 100644
+index 3f8dcf091ac81c431bbe572d9c2bd65ea003b86a..0abdb8524dcd9d7bb62c200cd96e2d156bddfd0e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2069,6 +2069,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2070,6 +2070,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          switch (packet.getAction()) {
              case PRESS_SHIFT_KEY:
                  this.player.setShiftKeyDown(true);
@@ -44,7 +44,7 @@ index 6995539a536f0019839a177ffb6e633c8013a8fb..da776d740ca0e684a08d7df58e50f862
              case RELEASE_SHIFT_KEY:
                  this.player.setShiftKeyDown(false);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index cf8b0c50bf44d28dcca6a759e5dc67c0a8d484c4..b15fd75ccbe54ea9169593e02631d2952b0d239a 100644
+index df753a2d39332464f16207615175bc95d35f61e8..fe715c81ea755f83fae0020e66f5e61304c51867 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -578,7 +578,7 @@ public abstract class Player extends LivingEntity {

--- a/patches/server/0155-Add-PlayerJumpEvent.patch
+++ b/patches/server/0155-Add-PlayerJumpEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerJumpEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index da776d740ca0e684a08d7df58e50f862eb031ee7..e0e00be58d4cb36b1cde2aa329fc10a0adc91b27 100644
+index 0abdb8524dcd9d7bb62c200cd96e2d156bddfd0e..acca4c663d4c6141c77b591bcb0c35157e5dd8fc 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1185,7 +1185,34 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1186,7 +1186,34 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              boolean flag = d8 > 0.0D;
  
                              if (this.player.isOnGround() && !packet.isOnGround() && flag) {

--- a/patches/server/0156-handle-PacketPlayInKeepAlive-async.patch
+++ b/patches/server/0156-handle-PacketPlayInKeepAlive-async.patch
@@ -15,10 +15,10 @@ also adding some additional logging in order to help work out what is causing
 random disconnections for clients.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e0e00be58d4cb36b1cde2aa329fc10a0adc91b27..f75027fc9f6457fbf46c97a381729ff043a1b413 100644
+index acca4c663d4c6141c77b591bcb0c35157e5dd8fc..4ab220e1a0f4d6fe2686657e6e282b9cc5c03c15 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2804,14 +2804,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2805,14 +2805,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleKeepAlive(ServerboundKeepAlivePacket packet) {

--- a/patches/server/0165-AsyncTabCompleteEvent.patch
+++ b/patches/server/0165-AsyncTabCompleteEvent.patch
@@ -14,10 +14,10 @@ completion, such as offline players.
 Also adds isCommand and getLocation to the sync TabCompleteEvent
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 44e4cd2a3039be132ca5f03759801456b3290f72..4c89828089ddb8fbee78643df7d3b82d1a68f8f9 100644
+index 205b8643df701fd4ee7f31e257ad7867afa10f73..586692eff023d9e6bb9c6ecaa051bd0c90ab0e37 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -707,10 +707,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -708,10 +708,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleCustomCommandSuggestions(ServerboundCommandSuggestionPacket packet) {
@@ -30,7 +30,7 @@ index 44e4cd2a3039be132ca5f03759801456b3290f72..4c89828089ddb8fbee78643df7d3b82d
              return;
          }
          // CraftBukkit end
-@@ -720,12 +720,35 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -721,12 +721,35 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              stringreader.skip();
          }
  

--- a/patches/server/0168-PlayerNaturallySpawnCreaturesEvent.patch
+++ b/patches/server/0168-PlayerNaturallySpawnCreaturesEvent.patch
@@ -60,7 +60,7 @@ index 3bbee4d08f4125a6499c0a8790c6bda6935e5ccc..efb735f2cf0d232db83ade7332250e45
  
              while (iterator1.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2fbe90ba893393e04b72b9feeff5f6be09d65e16..7f2d96722d3f835980ee841a285a585938acfe1a 100644
+index eafc1fd7200ca93d0524801536669ea4f5ba1408..5a37f139148531a51cb02b060739a4b7af183ba7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1,5 +1,6 @@
@@ -70,9 +70,9 @@ index 2fbe90ba893393e04b72b9feeff5f6be09d65e16..7f2d96722d3f835980ee841a285a5859
  import com.google.common.collect.Lists;
  import com.mojang.authlib.GameProfile;
  import com.mojang.datafixers.util.Either;
-@@ -234,6 +235,7 @@ public class ServerPlayer extends Player {
-     public boolean sentListPacket = false;
+@@ -235,6 +236,7 @@ public class ServerPlayer extends Player {
      public Integer clientViewDistance;
+     public String kickLeaveMessage = null; // SPIGOT-3034: Forward leave message to PlayerQuitEvent
      // CraftBukkit end
 +    public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
  

--- a/patches/server/0189-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
+++ b/patches/server/0189-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix exploit that allowed colored signs to be created
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4c89828089ddb8fbee78643df7d3b82d1a68f8f9..a0d7f02bf8765733521fa144c80cf48c6593f91c 100644
+index 586692eff023d9e6bb9c6ecaa051bd0c90ab0e37..4c428351426177f647c483f6178512fe4fad42fa 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2810,9 +2810,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2811,9 +2811,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  TextFilter.FilteredText currentLine = signText.get(i);
  
                  if (this.player.isTextFilteringEnabled()) {

--- a/patches/server/0215-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0215-InventoryCloseEvent-Reason-API.patch
@@ -29,10 +29,10 @@ index d8b0f6ae1604a158ef1be02701c8c605192e7fe1..4d69b6b35f04c904ee9ca9c896baaa98
              }
              // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 7f2d96722d3f835980ee841a285a585938acfe1a..005856931c27d4e2dbffec65ae59191782508e06 100644
+index 5a37f139148531a51cb02b060739a4b7af183ba7..76dcc8dc647a57d3dce978a6d960bb8138bf691d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -599,7 +599,7 @@ public class ServerPlayer extends Player {
+@@ -600,7 +600,7 @@ public class ServerPlayer extends Player {
          }
          // Paper end
          if (!this.level.isClientSide && !this.containerMenu.stillValid(this)) {
@@ -41,7 +41,7 @@ index 7f2d96722d3f835980ee841a285a585938acfe1a..005856931c27d4e2dbffec65ae591917
              this.containerMenu = this.inventoryMenu;
          }
  
-@@ -787,7 +787,7 @@ public class ServerPlayer extends Player {
+@@ -788,7 +788,7 @@ public class ServerPlayer extends Player {
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.containerMenu != this.inventoryMenu) {
@@ -50,7 +50,7 @@ index 7f2d96722d3f835980ee841a285a585938acfe1a..005856931c27d4e2dbffec65ae591917
          }
  
          net.kyori.adventure.text.Component deathMessage = event.deathMessage() != null ? event.deathMessage() : net.kyori.adventure.text.Component.empty(); // Paper - Adventure
-@@ -1427,7 +1427,7 @@ public class ServerPlayer extends Player {
+@@ -1428,7 +1428,7 @@ public class ServerPlayer extends Player {
          }
          // CraftBukkit end
          if (this.containerMenu != this.inventoryMenu) {
@@ -59,7 +59,7 @@ index 7f2d96722d3f835980ee841a285a585938acfe1a..005856931c27d4e2dbffec65ae591917
          }
  
          // this.nextContainerCounter(); // CraftBukkit - moved up
-@@ -1455,7 +1455,13 @@ public class ServerPlayer extends Player {
+@@ -1456,7 +1456,13 @@ public class ServerPlayer extends Player {
  
      @Override
      public void closeContainer() {
@@ -75,7 +75,7 @@ index 7f2d96722d3f835980ee841a285a585938acfe1a..005856931c27d4e2dbffec65ae591917
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a0d7f02bf8765733521fa144c80cf48c6593f91c..b280cb3250928367efa02cd1d9ce1607e6fb547d 100644
+index 4c428351426177f647c483f6178512fe4fad42fa..2faa2a9980d7139695be3583f80b05d99b6179d8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -188,6 +188,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -86,7 +86,7 @@ index a0d7f02bf8765733521fa144c80cf48c6593f91c..b280cb3250928367efa02cd1d9ce1607
  import org.bukkit.event.inventory.InventoryCreativeEvent;
  import org.bukkit.event.inventory.InventoryType.SlotType;
  import org.bukkit.event.inventory.SmithItemEvent;
-@@ -2349,10 +2350,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2350,10 +2351,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleContainerClose(ServerboundContainerClosePacket packet) {

--- a/patches/server/0217-Refresh-player-inventory-when-cancelling-PlayerInter.patch
+++ b/patches/server/0217-Refresh-player-inventory-when-cancelling-PlayerInter.patch
@@ -16,10 +16,10 @@ Refresh the player inventory when PlayerInteractEntityEvent is
 cancelled to avoid this problem.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b280cb3250928367efa02cd1d9ce1607e6fb547d..dced761b1f74de28a784dfcffed1bbc002e5a586 100644
+index 2faa2a9980d7139695be3583f80b05d99b6179d8..76628de17e8fb374801b5b9e25f7ff6bd1465c30 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2234,6 +2234,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2235,6 +2235,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          }
  
                          if (event.isCancelled()) {

--- a/patches/server/0235-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/patches/server/0235-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -45,7 +45,7 @@ index 114a65963b65597ff915ec3a0d75bb78f33bd774..d654affc5565622cfabde9b838aa2b40
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index dced761b1f74de28a784dfcffed1bbc002e5a586..8a1da2b1e667420df97e432b5a5fd9563cadda91 100644
+index 76628de17e8fb374801b5b9e25f7ff6bd1465c30..4cd752ca349fb3cfd0d28f3a993531372e688d79 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -227,6 +227,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -64,7 +64,7 @@ index dced761b1f74de28a784dfcffed1bbc002e5a586..8a1da2b1e667420df97e432b5a5fd956
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -710,7 +712,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -711,7 +713,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleCustomCommandSuggestions(ServerboundCommandSuggestionPacket packet) {
          // PlayerConnectionUtils.ensureMainThread(packetplayintabcomplete, this, this.player.getWorldServer()); // Paper - run this async
          // CraftBukkit start

--- a/patches/server/0253-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0253-Asynchronous-chunk-IO-and-loading.patch
@@ -2762,7 +2762,7 @@ index efb735f2cf0d232db83ade7332250e455c276bea..b6737c0b74e821c948919ca4184dfe02
          } finally {
              chunkMap.callbackExecutor.run();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index abff89e99d9f62a82c65a397016ab956f9ef42aa..d997ab37e49b43f692b30536ffb4d2563eab30f1 100644
+index 5f58aa648a5f0c3e61f6d9d5853583ca003e3620..98094546bb2867b20f89a1bc0efe911cdb6c9b79 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -310,6 +310,78 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -2866,10 +2866,10 @@ index 0d536d72ac918fbd403397ff369d10143ee9c204..be677d437d17b74c6188ce1bd5fc6fdc
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8a1da2b1e667420df97e432b5a5fd9563cadda91..f1d2c9274f4968adab689a08c86bea7a16b76b39 100644
+index 4cd752ca349fb3cfd0d28f3a993531372e688d79..a7ee0d00e2688bf84efd25c1c4d679213a783b1b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -716,6 +716,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -717,6 +717,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              server.scheduleOnMain(() -> this.disconnect(new TranslatableComponent("disconnect.spam", new Object[0]))); // Paper
              return;
          }

--- a/patches/server/0256-Improve-death-events.patch
+++ b/patches/server/0256-Improve-death-events.patch
@@ -19,7 +19,7 @@ maybe more (please check patch overrides for drops for more):
 - players, armor stands, foxes, chested donkeys/llamas
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 005856931c27d4e2dbffec65ae59191782508e06..36517924b6e1d32bc969b9bc7314a88d531accb2 100644
+index 76dcc8dc647a57d3dce978a6d960bb8138bf691d..de0d38f045f4f21c1c7a290a74826483a4ec8471 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -220,6 +220,10 @@ public class ServerPlayer extends Player {
@@ -33,7 +33,7 @@ index 005856931c27d4e2dbffec65ae59191782508e06..36517924b6e1d32bc969b9bc7314a88d
  
      // CraftBukkit start
      public String displayName;
-@@ -784,6 +788,15 @@ public class ServerPlayer extends Player {
+@@ -785,6 +789,15 @@ public class ServerPlayer extends Player {
          String deathmessage = defaultMessage.getString();
          this.keepLevel = keepInventory; // SPIGOT-2222: pre-set keepLevel
          org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), defaultMessage.getString(), keepInventory); // Paper - Adventure
@@ -49,7 +49,7 @@ index 005856931c27d4e2dbffec65ae59191782508e06..36517924b6e1d32bc969b9bc7314a88d
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.containerMenu != this.inventoryMenu) {
-@@ -931,8 +944,17 @@ public class ServerPlayer extends Player {
+@@ -932,8 +945,17 @@ public class ServerPlayer extends Player {
                          }
                      }
                  }

--- a/patches/server/0272-Call-player-spectator-target-events-and-improve-impl.patch
+++ b/patches/server/0272-Call-player-spectator-target-events-and-improve-impl.patch
@@ -19,10 +19,10 @@ spectate the target entity.
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 36517924b6e1d32bc969b9bc7314a88d531accb2..c2a4d209b4d736c0c0a8a0f1bf703dd822a84790 100644
+index de0d38f045f4f21c1c7a290a74826483a4ec8471..618194bf17817f8dcb37b6d3725be1443b70f774 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1848,14 +1848,58 @@ public class ServerPlayer extends Player {
+@@ -1849,14 +1849,58 @@ public class ServerPlayer extends Player {
      }
  
      public void setCamera(@Nullable Entity entity) {

--- a/patches/server/0277-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/patches/server/0277-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -20,10 +20,10 @@ index 8c50036896602ab6b00979351918878d08c9c75e..a4b20f8616b6fe2046e7a5f00306565b
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f1d2c9274f4968adab689a08c86bea7a16b76b39..7a0625c4aeb788b791734c13d7bca1e993c5b248 100644
+index a7ee0d00e2688bf84efd25c1c4d679213a783b1b..02d072816d7599204dd8f4d7b2da1a4598c7d984 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -497,9 +497,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -498,9 +498,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  double d0 = entity.getX();
                  double d1 = entity.getY();
                  double d2 = entity.getZ();
@@ -36,7 +36,7 @@ index f1d2c9274f4968adab689a08c86bea7a16b76b39..7a0625c4aeb788b791734c13d7bca1e9
                  float f = Mth.wrapDegrees(packet.getYRot());
                  float f1 = Mth.wrapDegrees(packet.getXRot());
                  double d6 = d3 - this.vehicleFirstGoodX;
-@@ -534,6 +534,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -535,6 +535,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
                  speed *= 2f; // TODO: Get the speed of the vehicle instead of the player
  
@@ -53,7 +53,7 @@ index f1d2c9274f4968adab689a08c86bea7a16b76b39..7a0625c4aeb788b791734c13d7bca1e9
                  if (d10 - d9 > Math.max(100.0D, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
                  // CraftBukkit end
                      ServerGamePacketListenerImpl.LOGGER.warn("{} (vehicle of {}) moved too quickly! {},{},{}", new Object[]{entity.getName().getString(), this.player.getName().getString(), d6, d7, d8});
-@@ -1148,9 +1158,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1149,9 +1159,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                      this.allowedPlayerTicks = 20; // CraftBukkit
                  } else {
                      this.awaitingTeleportTime = this.tickCount;
@@ -66,7 +66,7 @@ index f1d2c9274f4968adab689a08c86bea7a16b76b39..7a0625c4aeb788b791734c13d7bca1e9
                      float f = Mth.wrapDegrees(packet.getYRot(this.player.getYRot()));
                      float f1 = Mth.wrapDegrees(packet.getXRot(this.player.getXRot()));
  
-@@ -1206,6 +1216,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1207,6 +1217,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              } else {
                                  speed = this.player.getAbilities().walkingSpeed * 10f;
                              }

--- a/patches/server/0278-Reset-players-airTicks-on-respawn.patch
+++ b/patches/server/0278-Reset-players-airTicks-on-respawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset players airTicks on respawn
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index c2a4d209b4d736c0c0a8a0f1bf703dd822a84790..28a5255626b1a4ed893ac66850ed42adbf573a1c 100644
+index 618194bf17817f8dcb37b6d3725be1443b70f774..31e6fefae574e6c3b233425ed39dff428e856cbd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2250,6 +2250,7 @@ public class ServerPlayer extends Player {
+@@ -2251,6 +2251,7 @@ public class ServerPlayer extends Player {
  
          this.setHealth(this.getMaxHealth());
          this.stopUsingItem(); // CraftBukkit - SPIGOT-6682: Clear active item on reset

--- a/patches/server/0285-Don-t-allow-digging-into-unloaded-chunks.patch
+++ b/patches/server/0285-Don-t-allow-digging-into-unloaded-chunks.patch
@@ -59,10 +59,10 @@ index 91d6885da13138e1def16e1876910ef893ce244d..eb58536e37af9da5e3ae7e43f874a1ef
  
                  this.level.destroyBlockProgress(this.player.getId(), pos, -1);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 7a0625c4aeb788b791734c13d7bca1e993c5b248..69c492e228ad726e51f5644e91e6aac3bf10c758 100644
+index 02d072816d7599204dd8f4d7b2da1a4598c7d984..95561ebe675957a9553ef0802c701ab0385dfbec 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1566,7 +1566,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1567,7 +1567,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              case START_DESTROY_BLOCK:
              case ABORT_DESTROY_BLOCK:
              case STOP_DESTROY_BLOCK:

--- a/patches/server/0289-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0289-force-entity-dismount-during-teleportation.patch
@@ -20,10 +20,10 @@ this is going to be the best soultion all around.
 Improvements/suggestions welcome!
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 28a5255626b1a4ed893ac66850ed42adbf573a1c..119a32c11aff63a764eadeca59d5f50fab89cb72 100644
+index 31e6fefae574e6c3b233425ed39dff428e856cbd..295f597fb1ecf9210287d14837c286ae173655f1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1321,11 +1321,13 @@ public class ServerPlayer extends Player {
+@@ -1322,11 +1322,13 @@ public class ServerPlayer extends Player {
          }
      }
  

--- a/patches/server/0291-Book-Size-Limits.patch
+++ b/patches/server/0291-Book-Size-Limits.patch
@@ -24,10 +24,10 @@ index 36719c689a24c63e7d9a5b40f8c262c182a31b21..83bf428abd3be89e34cf42638bd1357a
      private static void asyncChunks() {
          ConfigurationSection section;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 69c492e228ad726e51f5644e91e6aac3bf10c758..167e20fd558aad856c3973ea00ff6a34354aaae5 100644
+index 95561ebe675957a9553ef0802c701ab0385dfbec..934c59f0f65b3751f74dab17b9f730d333d7a0fb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1015,6 +1015,45 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1016,6 +1016,45 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handleEditBook(ServerboundEditBookPacket packet) {

--- a/patches/server/0295-Workaround-for-vehicle-tracking-issue-on-disconnect.patch
+++ b/patches/server/0295-Workaround-for-vehicle-tracking-issue-on-disconnect.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Workaround for vehicle tracking issue on disconnect
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 4e51975dbab2f4904246a2bcff12d923cd629909..889881c6835a68b1ada3b613fa7e9ed9cdf82c2a 100644
+index 7d9e65b073feb8ff473f23eaca88f20c0411d386..7a187691057a90b71c910dbdcaa6539d334b04ad 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1563,6 +1563,13 @@ public class ServerPlayer extends Player {
+@@ -1564,6 +1564,13 @@ public class ServerPlayer extends Player {
      public void disconnect() {
          this.disconnected = true;
          this.ejectPassengers();

--- a/patches/server/0299-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0299-Implement-Brigadier-Mojang-API.patch
@@ -81,10 +81,10 @@ index f3bbe012541a71ab75c1863990d0c056c62d8c6e..4bc28b66788d06d1446284f5adef6a44
          event.getPlayer().getServer().getPluginManager().callEvent(event);
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 167e20fd558aad856c3973ea00ff6a34354aaae5..bfce81dec52011230f8a82c64c409f36fb576ee3 100644
+index 934c59f0f65b3751f74dab17b9f730d333d7a0fb..10cb5886aa040db25863ee8664ea7529a0f1649f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -756,8 +756,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -757,8 +757,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                      ParseResults<CommandSourceStack> parseresults = this.server.getCommands().getDispatcher().parse(stringreader, this.player.createCommandSourceStack());
  
                      this.server.getCommands().getDispatcher().getCompletionSuggestions(parseresults).thenAccept((suggestions) -> {
@@ -99,7 +99,7 @@ index 167e20fd558aad856c3973ea00ff6a34354aaae5..bfce81dec52011230f8a82c64c409f36
                      });
                  });
              }
-@@ -766,7 +770,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -767,7 +771,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              builder = builder.createOffset(builder.getInput().lastIndexOf(' ') + 1);
              completions.forEach(builder::suggest);

--- a/patches/server/0301-Limit-Client-Sign-length-more.patch
+++ b/patches/server/0301-Limit-Client-Sign-length-more.patch
@@ -22,7 +22,7 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index bfce81dec52011230f8a82c64c409f36fb576ee3..a8a05a2ff0f8900f31a3d137520cd52bd6005342 100644
+index 10cb5886aa040db25863ee8664ea7529a0f1649f..7634492e62cdc0a6e309f8bcc096efd905e82135 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -254,6 +254,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -33,7 +33,7 @@ index bfce81dec52011230f8a82c64c409f36fb576ee3..a8a05a2ff0f8900f31a3d137520cd52b
      private static final long KEEPALIVE_LIMIT = Long.getLong("paper.playerconnection.keepalive", 30) * 1000; // Paper - provide property to set keepalive limit
  
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
-@@ -2892,6 +2893,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2893,6 +2894,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              for (int i = 0; i < signText.size(); ++i) {
                  TextFilter.FilteredText currentLine = signText.get(i);

--- a/patches/server/0309-Update-entity-Metadata-for-all-tracked-players.patch
+++ b/patches/server/0309-Update-entity-Metadata-for-all-tracked-players.patch
@@ -22,10 +22,10 @@ index 861f3790179e18f6192ac8b2fb5d2ecbc54484ad..5e3f489964489e0facc93a823a1cb84b
          this.broadcast.accept(packet);
          if (this.entity instanceof ServerPlayer) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a8a05a2ff0f8900f31a3d137520cd52bd6005342..5d19461d7165f62f157b995efb97d9d05aece258 100644
+index 7634492e62cdc0a6e309f8bcc096efd905e82135..97ccab168e609577347b155c22040efc028d3cf8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2308,7 +2308,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2309,7 +2309,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                          if (event.isCancelled() || ServerGamePacketListenerImpl.this.player.getInventory().getSelected() == null || ServerGamePacketListenerImpl.this.player.getInventory().getSelected().getItem() != origItem) {
                              // Refresh the current entity metadata

--- a/patches/server/0314-PlayerDeathEvent-getItemsToKeep.patch
+++ b/patches/server/0314-PlayerDeathEvent-getItemsToKeep.patch
@@ -8,10 +8,10 @@ Exposes a mutable array on items a player should keep on death
 Example Usage: https://gist.github.com/aikar/5bb202de6057a051a950ce1f29feb0b4
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 889881c6835a68b1ada3b613fa7e9ed9cdf82c2a..16c29e372aa71e25d24cde9485520fdb368a6f8c 100644
+index 7a187691057a90b71c910dbdcaa6539d334b04ad..9441eae174c4441f7f4c9be69d39b415db01910c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -760,6 +760,46 @@ public class ServerPlayer extends Player {
+@@ -761,6 +761,46 @@ public class ServerPlayer extends Player {
          });
      }
  
@@ -58,7 +58,7 @@ index 889881c6835a68b1ada3b613fa7e9ed9cdf82c2a..16c29e372aa71e25d24cde9485520fdb
      @Override
      public void die(DamageSource source) {
          boolean flag = this.level.getGameRules().getBoolean(GameRules.RULE_SHOWDEATHMESSAGES);
-@@ -845,7 +885,12 @@ public class ServerPlayer extends Player {
+@@ -846,7 +886,12 @@ public class ServerPlayer extends Player {
          this.dropExperience();
          // we clean the player's inventory after the EntityDeathEvent is called so plugins can get the exact state of the inventory.
          if (!event.getKeepInventory()) {

--- a/patches/server/0318-Fix-CB-call-to-changed-postToMainThread-method.patch
+++ b/patches/server/0318-Fix-CB-call-to-changed-postToMainThread-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CB call to changed postToMainThread method
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4fcfe654f8199ead2d2309d37f6b5866ba540e45..070451db9f8dff9bb73ec8d71a1e97e9bdcc9f4c 100644
+index 97ccab168e609577347b155c22040efc028d3cf8..e668eb2d9734d1b2251f651aa3f2744ac5cf4ce2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -438,7 +438,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -439,7 +439,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          Objects.requireNonNull(this.connection);
          // CraftBukkit - Don't wait

--- a/patches/server/0335-Dont-send-unnecessary-sign-update.patch
+++ b/patches/server/0335-Dont-send-unnecessary-sign-update.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Dont send unnecessary sign update
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 5336ec0d30d386854c22ce227dcfd242d351b294..4376236a89f520e29c9227d2117d21884730e3f7 100644
+index e668eb2d9734d1b2251f651aa3f2744ac5cf4ce2..6ba2266ea2a40cc4e4ad366803420861c2899345 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2887,6 +2887,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2888,6 +2888,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              if (!tileentitysign.isEditable() || !this.player.getUUID().equals(tileentitysign.getPlayerWhoMayEdit())) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Player {} just tried to change non-editable sign", this.player.getName().getString());

--- a/patches/server/0337-Fix-AssertionError-when-player-hand-set-to-empty-typ.patch
+++ b/patches/server/0337-Fix-AssertionError-when-player-hand-set-to-empty-typ.patch
@@ -7,10 +7,10 @@ Fixes an AssertionError when setting the player's item in hand to null or a new 
 Fixes GH-2718
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4376236a89f520e29c9227d2117d21884730e3f7..a53537d459774a85800753fd6e8e460e2d71477c 100644
+index 6ba2266ea2a40cc4e4ad366803420861c2899345..0a41746f630442ed411e0d0c5efe90959191ae99 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1756,6 +1756,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1757,6 +1757,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  this.player.getBukkitEntity().updateInventory(); // SPIGOT-2524
                  return;
              }

--- a/patches/server/0343-PlayerDeathEvent-shouldDropExperience.patch
+++ b/patches/server/0343-PlayerDeathEvent-shouldDropExperience.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerDeathEvent#shouldDropExperience
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 16c29e372aa71e25d24cde9485520fdb368a6f8c..1d0dc77947d1b7fc89d41e5edb660aea86282562 100644
+index 9441eae174c4441f7f4c9be69d39b415db01910c..910991b0c153a74d35cf097e0ac5a02559729a2e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -882,7 +882,7 @@ public class ServerPlayer extends Player {
+@@ -883,7 +883,7 @@ public class ServerPlayer extends Player {
              this.tellNeutralMobsThatIDied();
          }
          // SPIGOT-5478 must be called manually now

--- a/patches/server/0360-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0360-implement-optional-per-player-mob-spawns.patch
@@ -269,7 +269,7 @@ index 0000000000000000000000000000000000000000..11de56afaf059b00fa5bec293516bcdc
 +    }
 +} 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 6dae228c0d0460d74ed49aee5a38dfd7b145d891..c7114fc8045feab770dde30669d2711313bff189 100644
+index f1bf847a498023ce8729315c6ec68f1d16cab822..a0ffdeaad5c375539857d6a5a94832216d09f024 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -155,6 +155,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -394,7 +394,7 @@ index b6737c0b74e821c948919ca4184dfe0281a19894..cbb8adea5e867a92e1dc4c94a0e7e116
  
              this.lastSpawnState = spawnercreature_d;
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 1d0dc77947d1b7fc89d41e5edb660aea86282562..49f272d37fb59fd4c13466217389e626b6ca1e2d 100644
+index 910991b0c153a74d35cf097e0ac5a02559729a2e..9815bb19b8210493d549bed5b2baa95331d71469 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -225,6 +225,11 @@ public class ServerPlayer extends Player {
@@ -409,7 +409,7 @@ index 1d0dc77947d1b7fc89d41e5edb660aea86282562..49f272d37fb59fd4c13466217389e626
  
      // CraftBukkit start
      public String displayName;
-@@ -314,6 +319,7 @@ public class ServerPlayer extends Player {
+@@ -315,6 +320,7 @@ public class ServerPlayer extends Player {
          this.adventure$displayName = net.kyori.adventure.text.Component.text(this.getScoreboardName()); // Paper
          this.bukkitPickUpLoot = true;
          this.maxHealthCache = this.getMaxHealth();

--- a/patches/server/0383-Don-t-tick-dead-players.patch
+++ b/patches/server/0383-Don-t-tick-dead-players.patch
@@ -7,10 +7,10 @@ Causes sync chunk loads and who knows what all else.
 This is safe because Spectators are skipped in unloaded chunks too in vanilla.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index f0c9610fe9e2475c13f897cb2d77978a0caa53a2..249f49a551ea94705a4f5dfc687fcefe3e789a07 100644
+index c16203295915df53f4b332af8235db215dab181d..078ac9596e1e6a3271a7e5e41bda317aadcf2ddf 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -641,7 +641,7 @@ public class ServerPlayer extends Player {
+@@ -642,7 +642,7 @@ public class ServerPlayer extends Player {
  
      public void doTick() {
          try {

--- a/patches/server/0386-Don-t-move-existing-players-to-world-spawn.patch
+++ b/patches/server/0386-Don-t-move-existing-players-to-world-spawn.patch
@@ -10,10 +10,10 @@ larger than the keep loaded range.
 By skipping this, we avoid potential for a large spike on server start.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 249f49a551ea94705a4f5dfc687fcefe3e789a07..3ddbfbf537351bcd97801e4018c85c14f7ab463c 100644
+index 078ac9596e1e6a3271a7e5e41bda317aadcf2ddf..65794caf8fec677037c283eec2802838a0c9ce43 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -311,7 +311,7 @@ public class ServerPlayer extends Player {
+@@ -312,7 +312,7 @@ public class ServerPlayer extends Player {
          this.stats = server.getPlayerList().getPlayerStats(this);
          this.advancements = server.getPlayerList().getPlayerAdvancements(this);
          this.maxUpStep = 1.0F;
@@ -22,7 +22,7 @@ index 249f49a551ea94705a4f5dfc687fcefe3e789a07..3ddbfbf537351bcd97801e4018c85c14
  
          this.cachedSingleHashSet = new com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<>(this); // Paper
  
-@@ -529,7 +529,7 @@ public class ServerPlayer extends Player {
+@@ -530,7 +530,7 @@ public class ServerPlayer extends Player {
                  position = Vec3.atCenterOf(((ServerLevel) world).getSharedSpawnPos());
              }
              this.level = world;

--- a/patches/server/0392-Prevent-opening-inventories-when-frozen.patch
+++ b/patches/server/0392-Prevent-opening-inventories-when-frozen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent opening inventories when frozen
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3ddbfbf537351bcd97801e4018c85c14f7ab463c..9b3f8b6ff7a2522e74bdbc914e35d566ab9c7697 100644
+index 65794caf8fec677037c283eec2802838a0c9ce43..97d7237060f2a9a03180b5d15bcec54246b1645b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -610,7 +610,7 @@ public class ServerPlayer extends Player {
+@@ -611,7 +611,7 @@ public class ServerPlayer extends Player {
              containerUpdateDelay = level.paperConfig.containerUpdateTickRate;
          }
          // Paper end
@@ -17,7 +17,7 @@ index 3ddbfbf537351bcd97801e4018c85c14f7ab463c..9b3f8b6ff7a2522e74bdbc914e35d566
              this.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.CANT_USE); // Paper
              this.containerMenu = this.inventoryMenu;
          }
-@@ -1477,7 +1477,7 @@ public class ServerPlayer extends Player {
+@@ -1478,7 +1478,7 @@ public class ServerPlayer extends Player {
              } else {
                  // CraftBukkit start
                  this.containerMenu = container;

--- a/patches/server/0395-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0395-Implement-Player-Client-Options-API.patch
@@ -85,10 +85,10 @@ index 0000000000000000000000000000000000000000..b6f4400df3d8ec7e06a996de54f8cabb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 9b3f8b6ff7a2522e74bdbc914e35d566ab9c7697..e800229c294a04581c863349119f67270da1a6ca 100644
+index 97d7237060f2a9a03180b5d15bcec54246b1645b..36753bedf0be050f0bdf2baf26bdeba833967323 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1828,6 +1828,7 @@ public class ServerPlayer extends Player {
+@@ -1829,6 +1829,7 @@ public class ServerPlayer extends Player {
      public String locale = null; // CraftBukkit - add, lowercase // Paper - default to null
      public java.util.Locale adventure$locale = java.util.Locale.US; // Paper
      public void updateOptions(ServerboundClientInformationPacket packet) {

--- a/patches/server/0399-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/patches/server/0399-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -40,7 +40,7 @@ index 43e5e148f1289ff5e42311981c597c66d98447aa..f4b14d77d5c256852677bd9bc6dbda2b
          if (!(entity instanceof EnderDragonPart)) {
              EntityType<?> entitytypes = entity.getType();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e800229c294a04581c863349119f67270da1a6ca..fae4880a645c9ea83fc1fa55cbc483543369b12e 100644
+index 36753bedf0be050f0bdf2baf26bdeba833967323..d51c012f13664b33f2b2b9a25cb0dffc4b24a117 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -244,6 +244,7 @@ public class ServerPlayer extends Player {
@@ -49,8 +49,8 @@ index e800229c294a04581c863349119f67270da1a6ca..fae4880a645c9ea83fc1fa55cbc48354
      public boolean sentListPacket = false;
 +    public boolean supressTrackerForLogin = false; // Paper
      public Integer clientViewDistance;
+     public String kickLeaveMessage = null; // SPIGOT-3034: Forward leave message to PlayerQuitEvent
      // CraftBukkit end
-     public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
 index bb7260a179de2652accb79b5bd0f0e6624163ab4..e7904870da5134b397f93c4de29d804775830947 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java

--- a/patches/server/0400-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0400-Load-Chunks-for-Login-Asynchronously.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Load Chunks for Login Asynchronously
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index fae4880a645c9ea83fc1fa55cbc483543369b12e..89156bd30cc41dd80de47c7e6e45db034904dbf3 100644
+index d51c012f13664b33f2b2b9a25cb0dffc4b24a117..78dea901bf3a9fdf723be87b0156af2fba5dcdc4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -172,6 +172,7 @@ public class ServerPlayer extends Player {
@@ -22,8 +22,8 @@ index fae4880a645c9ea83fc1fa55cbc483543369b12e..89156bd30cc41dd80de47c7e6e45db03
      public boolean supressTrackerForLogin = false; // Paper
 +    public boolean didPlayerJoinEvent = false; // Paper
      public Integer clientViewDistance;
+     public String kickLeaveMessage = null; // SPIGOT-3034: Forward leave message to PlayerQuitEvent
      // CraftBukkit end
-     public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
 diff --git a/src/main/java/net/minecraft/server/level/TicketType.java b/src/main/java/net/minecraft/server/level/TicketType.java
 index be677d437d17b74c6188ce1bd5fc6fdc228fd92f..78fbb4c3e52e900956ae0811aaf934c81ee5ea48 100644
 --- a/src/main/java/net/minecraft/server/level/TicketType.java
@@ -37,7 +37,7 @@ index be677d437d17b74c6188ce1bd5fc6fdc228fd92f..78fbb4c3e52e900956ae0811aaf934c8
      public static final TicketType<ChunkPos> UNKNOWN = TicketType.create("unknown", Comparator.comparingLong(ChunkPos::toLong), 1);
      public static final TicketType<Unit> PLUGIN = TicketType.create("plugin", (a, b) -> 0); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f961a0f5b571d86c8d2b57f489b421fbfb01ca3d..a041e73798e2c52026a8b9b3ff5c41bb7fa7263d 100644
+index 0a41746f630442ed411e0d0c5efe90959191ae99..33d5538c17272d69cdc6207de9fb32fb1bc304c2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -220,6 +220,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0407-Validate-PickItem-Packet-and-kick-for-invalid.patch
+++ b/patches/server/0407-Validate-PickItem-Packet-and-kick-for-invalid.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Validate PickItem Packet and kick for invalid
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3c45c6c6f10408ddcc077787865c68a323c6e901..fd53b03b69a929793c3115e8ee4dfd502d15125b 100644
+index 33d5538c17272d69cdc6207de9fb32fb1bc304c2..11448b0263f5354b6d6e6ef9df560ce24c940a3a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -884,7 +884,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -885,7 +885,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      @Override
      public void handlePickItem(ServerboundPickItemPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());

--- a/patches/server/0412-Prevent-teleporting-dead-entities.patch
+++ b/patches/server/0412-Prevent-teleporting-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent teleporting dead entities
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index fd53b03b69a929793c3115e8ee4dfd502d15125b..e1ae88a2c71a2fb804a8d7e467eb1232d10b4a53 100644
+index 11448b0263f5354b6d6e6ef9df560ce24c940a3a..f1be2494f254b1d5fc5c602bb6674829a86751b9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1527,6 +1527,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1528,6 +1528,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      }
  
      private void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<ClientboundPlayerPositionPacket.RelativeArgument> set, boolean flag) {

--- a/patches/server/0428-Optimize-anyPlayerCloseEnoughForSpawning-to-use-dist.patch
+++ b/patches/server/0428-Optimize-anyPlayerCloseEnoughForSpawning-to-use-dist.patch
@@ -357,10 +357,10 @@ index 1b6fb81079d3ad5d3c33be67a1c05111f9dd5f2d..1d5587bb9cf785de4b6d59234eb700c2
                      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 89156bd30cc41dd80de47c7e6e45db034904dbf3..a7a3c17cf97486f9f1af0cdc00686c22b37449b6 100644
+index 78dea901bf3a9fdf723be87b0156af2fba5dcdc4..2f90a93224cbbd24d06eb25614e9a0a28300d639 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -251,6 +251,7 @@ public class ServerPlayer extends Player {
+@@ -252,6 +252,7 @@ public class ServerPlayer extends Player {
      // CraftBukkit end
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
  

--- a/patches/server/0439-Prevent-position-desync-in-playerconnection-causing-.patch
+++ b/patches/server/0439-Prevent-position-desync-in-playerconnection-causing-.patch
@@ -14,10 +14,10 @@ behaviour, we need to move all of this dangerous logic outside
 of the move call and into an appropriate place in the tick method.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e1ae88a2c71a2fb804a8d7e467eb1232d10b4a53..ce8cf709797cd996dacffd2e527f7a4dc65a5562 100644
+index f1be2494f254b1d5fc5c602bb6674829a86751b9..a0597bf8d948f20becd7ccb748a78f8a14a54cf6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1341,6 +1341,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1342,6 +1342,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                              this.player.move(MoverType.PLAYER, new Vec3(d7, d8, d9));
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move

--- a/patches/server/0442-Add-and-implement-PlayerRecipeBookClickEvent.patch
+++ b/patches/server/0442-Add-and-implement-PlayerRecipeBookClickEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add and implement PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ce8cf709797cd996dacffd2e527f7a4dc65a5562..c38858f0ca67d2e87985bdebf39d26286409636c 100644
+index a0597bf8d948f20becd7ccb748a78f8a14a54cf6..7c97e6eda860b0145d8d5700fcecdcea5e258a03 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2804,9 +2804,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2805,9 +2805,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          this.player.resetLastActionTime();
          if (!this.player.isSpectator() && this.player.containerMenu.containerId == packet.getContainerId() && this.player.containerMenu instanceof RecipeBookMenu) {

--- a/patches/server/0444-Add-permission-for-command-blocks.patch
+++ b/patches/server/0444-Add-permission-for-command-blocks.patch
@@ -18,10 +18,10 @@ index d4f57fde2f02071dfde08cb2a5c8359984056aef..176e5bbac94cf39805dcacfcae3a3daa
                  return false;
              } else if (this.player.blockActionRestricted(this.level, pos, this.gameModeForPlayer)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c38858f0ca67d2e87985bdebf39d26286409636c..3f9c4295db46f3ff6e9c7bc241eb6b0926bd5054 100644
+index 7c97e6eda860b0145d8d5700fcecdcea5e258a03..e2446434e0db09d303c4a831c8f60819ade18f9a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -795,7 +795,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -796,7 +796,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (!this.server.isCommandBlockEnabled()) {
              this.player.sendMessage(new TranslatableComponent("advMode.notEnabled"), Util.NIL_UUID);
@@ -30,7 +30,7 @@ index c38858f0ca67d2e87985bdebf39d26286409636c..3f9c4295db46f3ff6e9c7bc241eb6b09
              this.player.sendMessage(new TranslatableComponent("advMode.notAllowed"), Util.NIL_UUID);
          } else {
              BaseCommandBlock commandblocklistenerabstract = null;
-@@ -862,7 +862,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -863,7 +863,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (!this.server.isCommandBlockEnabled()) {
              this.player.sendMessage(new TranslatableComponent("advMode.notEnabled"), Util.NIL_UUID);

--- a/patches/server/0446-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0446-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -76,10 +76,10 @@ index cec0082718c2a729044d6f19d74b8e4425816725..8eca8825008713467a20f84d71ed0f32
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index a7a3c17cf97486f9f1af0cdc00686c22b37449b6..5a4eeb46543d9458e309e2d4cc56086b5cf528c6 100644
+index 2f90a93224cbbd24d06eb25614e9a0a28300d639..dda1bf2406f8899d73f26c642f6a4ec03dea0415 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1114,7 +1114,7 @@ public class ServerPlayer extends Player {
+@@ -1115,7 +1115,7 @@ public class ServerPlayer extends Player {
                  this.isChangingDimension = true; // CraftBukkit - Set teleport invulnerability only if player changing worlds
  
                  this.connection.send(new ClientboundRespawnPacket(worldserver.dimensionTypeRegistration(), worldserver.dimension(), BiomeManager.obfuscateSeed(worldserver.getSeed()), this.gameMode.getGameModeForPlayer(), this.gameMode.getPreviousGameModeForPlayer(), worldserver.isDebug(), worldserver.isFlat(), true));
@@ -89,10 +89,10 @@ index a7a3c17cf97486f9f1af0cdc00686c22b37449b6..5a4eeb46543d9458e309e2d4cc56086b
  
                  playerlist.sendPlayerPermissionLevel(this);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3f9c4295db46f3ff6e9c7bc241eb6b0926bd5054..aae07a82b8fa9d504e3f457bacb78e159d08ee41 100644
+index e2446434e0db09d303c4a831c8f60819ade18f9a..33c0db5e7dc0d824e10577fc73406134d54d62bc 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3062,7 +3062,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3063,7 +3063,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleChangeDifficulty(ServerboundChangeDifficultyPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (this.player.hasPermissions(2) || this.isSingleplayerOwner()) {

--- a/patches/server/0466-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0466-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -796,7 +796,7 @@ index 9fdd2a39e3590b3098fa31b9b0e0081160819630..1b81ae617a43aa4723a879c150ce8e61
          boolean flag1 = this.chunkMap.promoteChunkMap();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index d11b5c9e64b6695a44cc2db588bed2e8a870c607..1136a3e406b3683ba7498a7903ed32e7053ffd1d 100644
+index b290262b4f765c85847f8846d26f4341f39a826a..2c5117c8e58c540d4f82aad16a13719853be7354 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -184,6 +184,7 @@ public class ServerPlayer extends Player {
@@ -807,7 +807,7 @@ index d11b5c9e64b6695a44cc2db588bed2e8a870c607..1136a3e406b3683ba7498a7903ed32e7
      private float lastSentHealth = -1.0E8F;
      private int lastSentFood = -99999999;
      private boolean lastFoodSaturationZero = true;
-@@ -327,6 +328,21 @@ public class ServerPlayer extends Player {
+@@ -328,6 +329,21 @@ public class ServerPlayer extends Player {
          this.maxHealthCache = this.getMaxHealth();
          this.cachedSingleMobDistanceMap = new com.destroystokyo.paper.util.PooledHashSets.PooledObjectLinkedOpenHashSet<>(this); // Paper
      }

--- a/patches/server/0471-Move-range-check-for-block-placing-up.patch
+++ b/patches/server/0471-Move-range-check-for-block-placing-up.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Move range check for block placing up
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index aae07a82b8fa9d504e3f457bacb78e159d08ee41..3b2e91b7ba431c4096d8ea03d8475bf30b46d0ac 100644
+index 33c0db5e7dc0d824e10577fc73406134d54d62bc..48e4ed91def1cfda0d7f10d00e13c415f74dbca2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1685,6 +1685,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1686,6 +1686,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      }
      // Spigot end
  
@@ -25,7 +25,7 @@ index aae07a82b8fa9d504e3f457bacb78e159d08ee41..3b2e91b7ba431c4096d8ea03d8475bf3
      @Override
      public void handleUseItemOn(ServerboundUseItemOnPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
-@@ -1698,6 +1708,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1699,6 +1709,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          BlockPos blockposition = movingobjectpositionblock.getBlockPos();
          Vec3 vec3d1 = vec3d.subtract(Vec3.atCenterOf(blockposition));
  

--- a/patches/server/0480-Brand-support.patch
+++ b/patches/server/0480-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3b2e91b7ba431c4096d8ea03d8475bf30b46d0ac..32dac718c49ab6693aae8a56991792dfe7d4ff87 100644
+index 48e4ed91def1cfda0d7f10d00e13c415f74dbca2..82ef4b4f99216eee00c867565d55e133bf7d8bcb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -38,6 +38,7 @@ import net.minecraft.nbt.CompoundTag;
@@ -25,7 +25,7 @@ index 3b2e91b7ba431c4096d8ea03d8475bf30b46d0ac..32dac718c49ab6693aae8a56991792df
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
          this.server = server;
          this.connection = connection;
-@@ -3036,6 +3039,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3037,6 +3040,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      private static final ResourceLocation CUSTOM_REGISTER = new ResourceLocation("register");
      private static final ResourceLocation CUSTOM_UNREGISTER = new ResourceLocation("unregister");
  
@@ -34,7 +34,7 @@ index 3b2e91b7ba431c4096d8ea03d8475bf30b46d0ac..32dac718c49ab6693aae8a56991792df
      @Override
      public void handleCustomPayload(ServerboundCustomPayloadPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
-@@ -3063,6 +3068,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3064,6 +3069,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              try {
                  byte[] data = new byte[packet.data.readableBytes()];
                  packet.data.readBytes(data);
@@ -50,7 +50,7 @@ index 3b2e91b7ba431c4096d8ea03d8475bf30b46d0ac..32dac718c49ab6693aae8a56991792df
                  this.cserver.getMessenger().dispatchIncomingMessage(this.player.getBukkitEntity(), packet.identifier.toString(), data);
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
-@@ -3072,6 +3086,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3073,6 +3087,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      }
  

--- a/patches/server/0499-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0499-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -9,10 +9,10 @@ as this is how Vanilla teleports entities.
 Cancel any pending motion when teleported.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 32dac718c49ab6693aae8a56991792dfe7d4ff87..fd936bc83b325f8cd7ead03afb9ef2a966c01c06 100644
+index 82ef4b4f99216eee00c867565d55e133bf7d8bcb..9d073564faa0f8dbd46ea6f9590a8260368fcbb0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -688,7 +688,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -689,7 +689,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleAcceptTeleportPacket(ServerboundAcceptTeleportationPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (packet.getId() == this.awaitingTeleport && this.awaitingPositionFromClient != null) { // CraftBukkit
@@ -21,7 +21,7 @@ index 32dac718c49ab6693aae8a56991792dfe7d4ff87..fd936bc83b325f8cd7ead03afb9ef2a9
              this.lastGoodX = this.awaitingPositionFromClient.x;
              this.lastGoodY = this.awaitingPositionFromClient.y;
              this.lastGoodZ = this.awaitingPositionFromClient.z;
-@@ -1572,7 +1572,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1573,7 +1573,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // CraftBukkit end
  
          this.awaitingTeleportTime = this.tickCount;

--- a/patches/server/0510-Fix-for-large-move-vectors-crashing-server.patch
+++ b/patches/server/0510-Fix-for-large-move-vectors-crashing-server.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix for large move vectors crashing server
 Check movement distance also based on current position.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index fd936bc83b325f8cd7ead03afb9ef2a966c01c06..341137b1cba0432c246006dd56cd63dab2b82ae8 100644
+index 9d073564faa0f8dbd46ea6f9590a8260368fcbb0..cdc210f1a2a1c34044ee27e377b234ffafb30b81 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -508,9 +508,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -509,9 +509,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              if (entity != this.player && entity.getControllingPassenger() == this.player && entity == this.lastVehicle) {
                  ServerLevel worldserver = this.player.getLevel();
@@ -22,7 +22,7 @@ index fd936bc83b325f8cd7ead03afb9ef2a966c01c06..341137b1cba0432c246006dd56cd63da
                  double d3 = ServerGamePacketListenerImpl.clampHorizontal(packet.getX()); final double toX = d3; // Paper - OBFHELPER
                  double d4 = ServerGamePacketListenerImpl.clampVertical(packet.getY()); final double toY = d4; // Paper - OBFHELPER
                  double d5 = ServerGamePacketListenerImpl.clampHorizontal(packet.getZ()); final double toZ = d5; // Paper - OBFHELPER
-@@ -520,8 +520,19 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -521,8 +521,19 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  double d7 = d4 - this.vehicleFirstGoodY;
                  double d8 = d5 - this.vehicleFirstGoodZ;
                  double d9 = entity.getDeltaMovement().lengthSqr();
@@ -44,7 +44,7 @@ index fd936bc83b325f8cd7ead03afb9ef2a966c01c06..341137b1cba0432c246006dd56cd63da
  
                  // CraftBukkit start - handle custom speeds and skipped ticks
                  this.allowedPlayerTicks += (System.currentTimeMillis() / 50) - this.lastTick;
-@@ -567,9 +578,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -568,9 +579,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                  boolean flag = worldserver.noCollision(entity, entity.getBoundingBox().deflate(0.0625D));
  
@@ -57,7 +57,7 @@ index fd936bc83b325f8cd7ead03afb9ef2a966c01c06..341137b1cba0432c246006dd56cd63da
                  boolean flag1 = entity.verticalCollisionBelow;
  
                  entity.move(MoverType.PLAYER, new Vec3(d6, d7, d8));
-@@ -1252,7 +1263,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1253,7 +1264,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          double d8 = d1 - this.firstGoodY;
                          double d9 = d2 - this.firstGoodZ;
                          double d10 = this.player.getDeltaMovement().lengthSqr();
@@ -77,7 +77,7 @@ index fd936bc83b325f8cd7ead03afb9ef2a966c01c06..341137b1cba0432c246006dd56cd63da
  
                          if (this.player.isSleeping()) {
                              if (d11 > 1.0D) {
-@@ -1304,9 +1326,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1305,9 +1327,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                              AABB axisalignedbb = this.player.getBoundingBox();
  

--- a/patches/server/0527-Add-API-for-quit-reason.patch
+++ b/patches/server/0527-Add-API-for-quit-reason.patch
@@ -25,10 +25,10 @@ index 1c63947958d202d00593e2b76d113c8b327706d7..932b494ea2a5e849b233c73bd2472d5c
                          Connection.LOGGER.debug("Failed to sent packet", throwable);
                          ConnectionProtocol enumprotocol = this.getCurrentProtocol();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 1136a3e406b3683ba7498a7903ed32e7053ffd1d..8874f9a3d64b706fdc857c805fe279316da99dd8 100644
+index 2c5117c8e58c540d4f82aad16a13719853be7354..139e1c3ea0a3693f533f7f276b2998e1d24fc253 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -255,6 +255,7 @@ public class ServerPlayer extends Player {
+@@ -256,6 +256,7 @@ public class ServerPlayer extends Player {
  
      public double lastEntitySpawnRadiusSquared; // Paper - optimise isOutsideRange, this field is in blocks
      public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<ServerPlayer> cachedSingleHashSet; // Paper
@@ -37,10 +37,10 @@ index 1136a3e406b3683ba7498a7903ed32e7053ffd1d..8874f9a3d64b706fdc857c805fe27931
      public ServerPlayer(MinecraftServer server, ServerLevel world, GameProfile profile) {
          super(world, world.getSharedSpawnPos(), world.getSharedSpawnAngle(), profile);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index def6838c09a859e5b3297b8251432f921720235e..8095858836774dd2b34c0361408a4adfec3c3bc6 100644
+index cdc210f1a2a1c34044ee27e377b234ffafb30b81..869e74ae1eaf7ad9c923ac1c102e2801402d77b3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -441,6 +441,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -442,6 +442,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          final Component ichatbasecomponent = PaperAdventure.asVanilla(event.reason()); // Paper - Adventure
          // CraftBukkit end
  

--- a/patches/server/0540-Limit-recipe-packets.patch
+++ b/patches/server/0540-Limit-recipe-packets.patch
@@ -23,7 +23,7 @@ index d58429ef5c7e866ce36a00fd55462cb024043a71..7413cbbcf0ab572483adc0ab91597859
      public static boolean velocityOnlineMode;
      public static byte[] velocitySecretKey;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 87fb3ecc9f0365dafccdd17ff51ba3d6a60a00f8..f8275d35b198665b32696a1fb49e1821c383705d 100644
+index 869e74ae1eaf7ad9c923ac1c102e2801402d77b3..ae2ceff37d4dbadc18078672dcb428dc75c45a8f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -230,6 +230,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -42,7 +42,7 @@ index 87fb3ecc9f0365dafccdd17ff51ba3d6a60a00f8..f8275d35b198665b32696a1fb49e1821
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -2846,6 +2848,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2847,6 +2849,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void handlePlaceRecipe(ServerboundPlaceRecipePacket packet) {

--- a/patches/server/0543-Player-Chunk-Load-Unload-Events.patch
+++ b/patches/server/0543-Player-Chunk-Load-Unload-Events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player Chunk Load/Unload Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 8874f9a3d64b706fdc857c805fe279316da99dd8..5f02f0d179d40c63d785c53090833efdab627f27 100644
+index 139e1c3ea0a3693f533f7f276b2998e1d24fc253..f343a52a325aa338a590ec8e35c0fa2a7f4703f3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2107,11 +2107,21 @@ public class ServerPlayer extends Player {
+@@ -2108,11 +2108,21 @@ public class ServerPlayer extends Player {
  
      public void trackChunk(ChunkPos chunkPos, Packet<?> chunkDataPacket) {
          this.connection.send(chunkDataPacket);

--- a/patches/server/0557-Fix-interact-event-not-being-called-in-adventure.patch
+++ b/patches/server/0557-Fix-interact-event-not-being-called-in-adventure.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix interact event not being called in adventure
 Call PlayerInteractEvent when left-clicking on a block in adventure mode
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f8275d35b198665b32696a1fb49e1821c383705d..cf01bc6e0b0f626647699e00e6839930be6afb23 100644
+index ae2ceff37d4dbadc18078672dcb428dc75c45a8f..c58a01989e1aa9999534fbf4b718244778dd9497 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1763,7 +1763,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1764,7 +1764,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              MutableComponent ichatmutablecomponent = (new TranslatableComponent("build.tooHigh", new Object[]{i - 1})).withStyle(ChatFormatting.RED);
  
                              this.player.sendMessage(ichatmutablecomponent, ChatType.GAME_INFO, Util.NIL_UUID);
@@ -18,7 +18,7 @@ index f8275d35b198665b32696a1fb49e1821c383705d..cf01bc6e0b0f626647699e00e6839930
                              this.player.swing(enumhand, true);
                          }
                      }
-@@ -2241,7 +2241,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2242,7 +2242,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          Vec3 vec3d1 = vec3d.add((double) f7 * d3, (double) f6 * d3, (double) f8 * d3);
          HitResult movingobjectposition = this.player.level.clip(new ClipContext(vec3d, vec3d1, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, this.player));
  

--- a/patches/server/0586-Reset-shield-blocking-on-dimension-change.patch
+++ b/patches/server/0586-Reset-shield-blocking-on-dimension-change.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset shield blocking on dimension change
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 5f02f0d179d40c63d785c53090833efdab627f27..1dd7bebbedd8cf5e8b7b72738d9ebf869509ce24 100644
+index f343a52a325aa338a590ec8e35c0fa2a7f4703f3..95f339da3a6978da3e1bcd7e6cd1c6b70cbe91aa 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1167,6 +1167,11 @@ public class ServerPlayer extends Player {
+@@ -1168,6 +1168,11 @@ public class ServerPlayer extends Player {
                  this.level.getCraftServer().getPluginManager().callEvent(changeEvent);
                  // CraftBukkit end
              }

--- a/patches/server/0608-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0608-Allow-using-signs-inside-spawn-protection.patch
@@ -19,10 +19,10 @@ index cdcb877e374bcd2dd944c754bfc91e23ef6986ae..3ea410faba8412fa5aa1c1b6bcdd3aed
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index cf01bc6e0b0f626647699e00e6839930be6afb23..cb0c6202b25933aa7770060873c7873f9790f5a1 100644
+index c58a01989e1aa9999534fbf4b718244778dd9497..efee98799e5196c9f1adf73a0f4ff0590ed96b5f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1755,7 +1755,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1756,7 +1756,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  int i = this.player.level.getMaxBuildHeight();
  
                  if (blockposition.getY() < i) {

--- a/patches/server/0616-Don-t-ignore-result-of-PlayerEditBookEvent.patch
+++ b/patches/server/0616-Don-t-ignore-result-of-PlayerEditBookEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't ignore result of PlayerEditBookEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index cb0c6202b25933aa7770060873c7873f9790f5a1..444c92e067dd20d0e2e9e1b3d249f2a9a8d86c4f 100644
+index efee98799e5196c9f1adf73a0f4ff0590ed96b5f..424b7df06f98bb5157b91026854e03cd8c4e3deb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1190,7 +1190,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1191,7 +1191,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
  
          itemstack.addTagElement("pages", nbttaglist);

--- a/patches/server/0619-Allow-for-Component-suggestion-tooltips-in-AsyncTabC.patch
+++ b/patches/server/0619-Allow-for-Component-suggestion-tooltips-in-AsyncTabC.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow for Component suggestion tooltips in
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 444c92e067dd20d0e2e9e1b3d249f2a9a8d86c4f..4b07e134ce85e4650896e5a75c33321aa36fa18f 100644
+index 424b7df06f98bb5157b91026854e03cd8c4e3deb..c1a01129070f20bc7f17929b2683bd9ed1591961 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -770,12 +770,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -771,12 +771,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          // Paper start - async tab completion
          com.destroystokyo.paper.event.server.AsyncTabCompleteEvent event;
@@ -24,7 +24,7 @@ index 444c92e067dd20d0e2e9e1b3d249f2a9a8d86c4f..4b07e134ce85e4650896e5a75c33321a
          // If the event isn't handled, we can assume that we have no completions, and so we'll ask the server
          if (!event.isHandled()) {
              if (!event.isCancelled()) {
-@@ -794,10 +793,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -795,10 +794,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  });
              }
          } else if (!completions.isEmpty()) {

--- a/patches/server/0629-fix-PlayerItemHeldEvent-firing-twice.patch
+++ b/patches/server/0629-fix-PlayerItemHeldEvent-firing-twice.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] fix PlayerItemHeldEvent firing twice
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4b07e134ce85e4650896e5a75c33321aa36fa18f..06cda3132d811019a94ea8212e6569da1be3ac62 100644
+index c1a01129070f20bc7f17929b2683bd9ed1591961..6e5394d50309dbdfc378ac5d16e75d5cac99cd61 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1962,6 +1962,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1963,6 +1963,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (this.player.isImmobile()) return; // CraftBukkit
          if (packet.getSlot() >= 0 && packet.getSlot() < Inventory.getSelectionSize()) {

--- a/patches/server/0636-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/server/0636-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add RespawnFlags to PlayerRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 06cda3132d811019a94ea8212e6569da1be3ac62..63a459e13e183107c4626f1df36c795af4b4948c 100644
+index 6e5394d50309dbdfc378ac5d16e75d5cac99cd61..20a1c0e3926e3853c74e0d6484333bca02c76a2f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2500,7 +2500,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2501,7 +2501,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              case PERFORM_RESPAWN:
                  if (this.player.wonGame) {
                      this.player.wonGame = false;

--- a/patches/server/0644-call-PortalCreateEvent-players-and-end-platform.patch
+++ b/patches/server/0644-call-PortalCreateEvent-players-and-end-platform.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] call PortalCreateEvent players and end platform
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 1dd7bebbedd8cf5e8b7b72738d9ebf869509ce24..160b1a7396472b682236d5f626ebf267bc8a5aea 100644
+index 95f339da3a6978da3e1bcd7e6cd1c6b70cbe91aa..246556a0018fbe5164379fab8d06c9135ae9b19f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1194,15 +1194,21 @@ public class ServerPlayer extends Player {
+@@ -1195,15 +1195,21 @@ public class ServerPlayer extends Player {
      private void createEndPlatform(ServerLevel world, BlockPos centerPos) {
          BlockPos.MutableBlockPos blockposition_mutableblockposition = centerPos.mutable();
  

--- a/patches/server/0649-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0649-additions-to-PlayerGameModeChangeEvent.patch
@@ -45,10 +45,10 @@ index d75f78d2e3fb1376e8f6a8668c98a04a693c99e1..79f6089b934124c3309c6bee2e48b36b
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 160b1a7396472b682236d5f626ebf267bc8a5aea..f1661e228ed982f38e0bc3e9e0c1720608e0b4a4 100644
+index 246556a0018fbe5164379fab8d06c9135ae9b19f..75b3f8a68bb7017c25ffd4190f9969c066bc5e3f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1803,8 +1803,15 @@ public class ServerPlayer extends Player {
+@@ -1804,8 +1804,15 @@ public class ServerPlayer extends Player {
      }
  
      public boolean setGameMode(GameType gameMode) {
@@ -66,7 +66,7 @@ index 160b1a7396472b682236d5f626ebf267bc8a5aea..f1661e228ed982f38e0bc3e9e0c17206
          } else {
              this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.CHANGE_GAME_MODE, (float) gameMode.getId()));
              if (gameMode == GameType.SPECTATOR) {
-@@ -1816,7 +1823,7 @@ public class ServerPlayer extends Player {
+@@ -1817,7 +1824,7 @@ public class ServerPlayer extends Player {
  
              this.onUpdateAbilities();
              this.updateEffectVisibility();
@@ -75,7 +75,7 @@ index 160b1a7396472b682236d5f626ebf267bc8a5aea..f1661e228ed982f38e0bc3e9e0c17206
          }
      }
  
-@@ -2198,6 +2205,16 @@ public class ServerPlayer extends Player {
+@@ -2199,6 +2206,16 @@ public class ServerPlayer extends Player {
      }
  
      public void loadGameTypes(@Nullable CompoundTag nbt) {
@@ -126,10 +126,10 @@ index f97d97426144527cff9ebb91b26fe8541a9c6d9b..b6eef41079120fffd63f06f681378b1b
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 63a459e13e183107c4626f1df36c795af4b4948c..2eee1e57895f53416b7c5820f5fd59e8555387c1 100644
+index 20a1c0e3926e3853c74e0d6484333bca02c76a2f..50797b32b71b2c8a73f34313021457b27fc90660 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2509,7 +2509,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2510,7 +2510,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
                      this.player = this.server.getPlayerList().respawn(this.player, false);
                      if (this.server.isHardcore()) {

--- a/patches/server/0660-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0660-Add-PlayerKickEvent-causes.patch
@@ -57,7 +57,7 @@ index 708ac03d5a849bf09c49547306e4a8c5a5ef8d91..5a8df368a4a25839cd4ac9be6972da2e
          }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4a4b0427e 100644
+index 50797b32b71b2c8a73f34313021457b27fc90660..7ad1b8b836d692b1168609e96e4eb72e037be4c9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -318,7 +318,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -131,7 +131,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
  
          if (this.cserver.getServer().isRunning()) {
              this.cserver.getPluginManager().callEvent(event);
-@@ -505,7 +513,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -506,7 +514,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleMoveVehicle(ServerboundMoveVehiclePacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (ServerGamePacketListenerImpl.containsInvalidValues(packet.getX(), packet.getY(), packet.getZ(), packet.getYRot(), packet.getXRot())) {
@@ -140,7 +140,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
          } else {
              Entity entity = this.player.getRootVehicle();
  
-@@ -751,13 +759,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -752,13 +760,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // PlayerConnectionUtils.ensureMainThread(packetplayintabcomplete, this, this.player.getWorldServer()); // Paper - run this async
          // CraftBukkit start
          if (this.chatSpamTickCount.addAndGet(com.destroystokyo.paper.PaperConfig.tabSpamIncrement) > com.destroystokyo.paper.PaperConfig.tabSpamLimit && !this.server.getPlayerList().isOp(this.player.getGameProfile())) { // Paper start - split and make configurable
@@ -156,7 +156,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
              return;
          }
          // Paper end
-@@ -909,7 +917,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -910,7 +918,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Paper start - validate pick item position
          if (!(packet.getSlot() >= 0 && packet.getSlot() < this.player.getInventory().items.size())) {
              ServerGamePacketListenerImpl.LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
@@ -165,7 +165,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
              return;
          }
          this.player.getInventory().pickSlot(packet.getSlot()); // Paper - Diff above if changed
-@@ -1074,7 +1082,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1075,7 +1083,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  int byteLength = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
                  if (byteLength > 256 * 4) {
                      ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send a book with with a page too large!");
@@ -174,7 +174,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
                      return;
                  }
                  byteTotal += byteLength;
-@@ -1097,14 +1105,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1098,14 +1106,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
              if (byteTotal > byteAllowed) {
                  ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send too large of a book. Book Size: " + byteTotal + " - Allowed:  "+ byteAllowed + " - Pages: " + pageList.size());
@@ -191,7 +191,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
              return;
          }
          this.lastBookTick = MinecraftServer.currentTick;
-@@ -1228,7 +1236,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1229,7 +1237,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
      public void handleMovePlayer(ServerboundMovePlayerPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (ServerGamePacketListenerImpl.containsInvalidValues(packet.getX(0.0D), packet.getY(0.0D), packet.getZ(0.0D), packet.getYRot(0.0F), packet.getXRot(0.0F))) {
@@ -200,7 +200,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
          } else {
              ServerLevel worldserver = this.player.getLevel();
  
-@@ -1655,7 +1663,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1656,7 +1664,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          this.dropCount++;
                          if (this.dropCount >= 20) {
                              ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " dropped their items too quickly!");
@@ -209,7 +209,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
                              return;
                          }
                      }
-@@ -1874,7 +1882,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1875,7 +1883,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (packet.getAction() == ServerboundResourcePackPacket.Action.DECLINED && this.server.isResourcePackRequired()) {
              ServerGamePacketListenerImpl.LOGGER.info("Disconnecting {} due to resource pack rejection", this.player.getName());
@@ -218,7 +218,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
          }
          // Paper start
          PlayerResourcePackStatusEvent.Status packStatus = PlayerResourcePackStatusEvent.Status.values()[packet.action.ordinal()];
-@@ -1979,7 +1987,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1980,7 +1988,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              this.player.resetLastActionTime();
          } else {
              ServerGamePacketListenerImpl.LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
@@ -227,7 +227,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
          }
      }
  
-@@ -1995,7 +2003,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1996,7 +2004,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          for (int i = 0; i < s.length(); ++i) {
              if (!SharedConstants.isAllowedChatCharacter(s.charAt(i))) {
@@ -236,7 +236,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
                  return;
              }
          }
-@@ -2068,7 +2076,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2069,7 +2077,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                      Waitable waitable = new Waitable() {
                          @Override
                          protected Object evaluate() {
@@ -245,7 +245,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
                              return null;
                          }
                      };
-@@ -2083,7 +2091,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2084,7 +2092,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                          throw new RuntimeException(e);
                      }
                  } else {
@@ -254,7 +254,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
                  }
                  // CraftBukkit end
              }
-@@ -2356,7 +2364,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2357,7 +2365,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Spigot Start
          if ( entity == this.player && !this.player.isSpectator() )
          {
@@ -263,7 +263,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
              return;
          }
          // Spigot End
-@@ -2451,7 +2459,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2452,7 +2460,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                              }
                              // CraftBukkit end
                          } else {
@@ -272,7 +272,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
                              ServerGamePacketListenerImpl.LOGGER.warn("Player {} tried to attack an invalid entity", ServerGamePacketListenerImpl.this.player.getName().getString());
                          }
                      }
-@@ -2857,7 +2865,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2858,7 +2866,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Paper start
          if (!org.bukkit.Bukkit.isPrimaryThread()) {
              if (recipeSpamPackets.addAndGet(com.destroystokyo.paper.PaperConfig.autoRecipeIncrement) > com.destroystokyo.paper.PaperConfig.autoRecipeLimit) {
@@ -281,7 +281,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
                  return;
              }
          }
-@@ -3045,7 +3053,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3046,7 +3054,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          } else if (!this.isSingleplayerOwner()) {
              // Paper start - This needs to be handled on the main thread for plugins
              server.submit(() -> {
@@ -290,7 +290,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
              });
              // Paper end
          }
-@@ -3091,7 +3099,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3092,7 +3100,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t register custom payload", ex);
@@ -299,7 +299,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
              }
          } else if (packet.identifier.equals(CUSTOM_UNREGISTER)) {
              try {
-@@ -3101,7 +3109,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3102,7 +3110,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  }
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t unregister custom payload", ex);
@@ -308,7 +308,7 @@ index 2eee1e57895f53416b7c5820f5fd59e8555387c1..f5231c0e0352bb0e8dd89a3a7db756b4
              }
          } else {
              try {
-@@ -3119,7 +3127,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -3120,7 +3128,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
                  this.cserver.getMessenger().dispatchIncomingMessage(this.player.getBukkitEntity(), packet.identifier.toString(), data);
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);

--- a/patches/server/0675-Fix-PlayerDropItemEvent-using-wrong-item.patch
+++ b/patches/server/0675-Fix-PlayerDropItemEvent-using-wrong-item.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix PlayerDropItemEvent using wrong item
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index f1661e228ed982f38e0bc3e9e0c1720608e0b4a4..ca9a30a279e7d12c63b351e437fb9dcc11e2ed56 100644
+index 75b3f8a68bb7017c25ffd4190f9969c066bc5e3f..174f0f1bbe32e8753e360db0194c5ec20fbf22bd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2174,7 +2174,7 @@ public class ServerPlayer extends Player {
+@@ -2175,7 +2175,7 @@ public class ServerPlayer extends Player {
  
              if (retainOwnership) {
                  if (!itemstack1.isEmpty()) {

--- a/patches/server/0677-Ensure-disconnect-for-book-edit-is-called-on-main.patch
+++ b/patches/server/0677-Ensure-disconnect-for-book-edit-is-called-on-main.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure disconnect for book edit is called on main
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f5231c0e0352bb0e8dd89a3a7db756b4a4b0427e..a4a565a83b67a652e045e0af80d8a4d30bd0c7fe 100644
+index 7ad1b8b836d692b1168609e96e4eb72e037be4c9..9186a593c787afc40a69cd442a27622fef6fa986 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1112,7 +1112,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1113,7 +1113,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          // Paper end
          // CraftBukkit start
          if (this.lastBookTick + 20 > MinecraftServer.currentTick) {

--- a/patches/server/0681-Adds-PlayerArmSwingEvent.patch
+++ b/patches/server/0681-Adds-PlayerArmSwingEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Adds PlayerArmSwingEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a4a565a83b67a652e045e0af80d8a4d30bd0c7fe..8a60c81c80ecf6c8d29cc1e24e9a8d63c5edaecb 100644
+index 9186a593c787afc40a69cd442a27622fef6fa986..f6c8ce420c8cbe977897c78f1575b917ee9632ac 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2260,7 +2260,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -2261,7 +2261,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
  
          // Arm swing animation

--- a/patches/server/0682-Fixes-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0682-Fixes-kick-event-leave-message-not-being-sent.patch
@@ -4,11 +4,31 @@ Date: Wed, 7 Jul 2021 16:19:41 -0700
 Subject: [PATCH] Fixes kick event leave message not being sent
 
 
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 174f0f1bbe32e8753e360db0194c5ec20fbf22bd..ca9a30a279e7d12c63b351e437fb9dcc11e2ed56 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -250,7 +250,6 @@ public class ServerPlayer extends Player {
+     public boolean supressTrackerForLogin = false; // Paper
+     public boolean didPlayerJoinEvent = false; // Paper
+     public Integer clientViewDistance;
+-    public String kickLeaveMessage = null; // SPIGOT-3034: Forward leave message to PlayerQuitEvent
+     // CraftBukkit end
+     public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
+ 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8a60c81c80ecf6c8d29cc1e24e9a8d63c5edaecb..d9eec6be067b858001c31f25788a63f2d50051ce 100644
+index f6c8ce420c8cbe977897c78f1575b917ee9632ac..d9eec6be067b858001c31f25788a63f2d50051ce 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -455,7 +455,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -447,7 +447,6 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+             // Do not kick the player
+             return;
+         }
+-        this.player.kickLeaveMessage = event.getLeaveMessage(); // CraftBukkit - SPIGOT-3034: Forward leave message to PlayerQuitEvent
+         // Send the possibly modified leave message
+         final Component ichatbasecomponent = PaperAdventure.asVanilla(event.reason()); // Paper - Adventure
+         // CraftBukkit end
+@@ -456,7 +455,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          this.connection.send(new ClientboundDisconnectPacket(ichatbasecomponent), (future) -> {
              this.connection.disconnect(ichatbasecomponent);
          });
@@ -17,7 +37,7 @@ index 8a60c81c80ecf6c8d29cc1e24e9a8d63c5edaecb..d9eec6be067b858001c31f25788a63f2
          this.connection.setReadOnly();
          MinecraftServer minecraftserver = this.server;
          Connection networkmanager = this.connection;
-@@ -1907,6 +1907,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1908,6 +1907,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
      @Override
      public void onDisconnect(Component reason) {
@@ -29,7 +49,7 @@ index 8a60c81c80ecf6c8d29cc1e24e9a8d63c5edaecb..d9eec6be067b858001c31f25788a63f2
          // CraftBukkit start - Rarely it would send a disconnect line twice
          if (this.processedDisconnect) {
              return;
-@@ -1923,7 +1928,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -1924,7 +1928,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
  
          this.player.disconnect();
          // Paper start - Adventure

--- a/patches/server/0880-Make-some-itemstacks-nonnull.patch
+++ b/patches/server/0880-Make-some-itemstacks-nonnull.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 15 Mar 2022 01:38:15 -0700
+Subject: [PATCH] Make some itemstacks nonnull
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
+index d6a228473ca6f425757683a4b17b035a53ab117f..8801d3f7ff6d2ff810f3e34a821dfb659c03f844 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
+@@ -156,13 +156,13 @@ public class CraftInventoryPlayer extends CraftInventory implements org.bukkit.i
+             case OFF_HAND:
+                 return this.getItemInOffHand();
+             case FEET:
+-                return this.getBoots();
++                return java.util.Objects.requireNonNullElseGet(this.getBoots(), () -> new ItemStack(org.bukkit.Material.AIR)); // Paper - make nonnull
+             case LEGS:
+-                return this.getLeggings();
++                return java.util.Objects.requireNonNullElseGet(this.getLeggings(), () -> new ItemStack(org.bukkit.Material.AIR)); // Paper - make nonnull
+             case CHEST:
+-                return this.getChestplate();
++                return java.util.Objects.requireNonNullElseGet(this.getChestplate(), () -> new ItemStack(org.bukkit.Material.AIR)); // Paper - make nonnull
+             case HEAD:
+-                return this.getHelmet();
++                return java.util.Objects.requireNonNullElseGet(this.getHelmet(), () -> new ItemStack(org.bukkit.Material.AIR)); // Paper - make nonnull
+             default:
+                 throw new IllegalArgumentException("Not implemented. This is a bug");
+         }

--- a/scripts/upstreamCommit.sh
+++ b/scripts/upstreamCommit.sh
@@ -5,7 +5,7 @@ PS1="$"
 
 function changelog() {
     base=$(git ls-tree HEAD $1  | cut -d' ' -f3 | cut -f1)
-    cd $1 && git log --oneline ${base}...HEAD | sed 's/\(^[0-9a-f]\{8,\}\s\|Revert\s"\)#\([0-9]\+\)/\1PR-\2/'
+    cd $1 && git log --oneline ${base}...HEAD | sed -E 's/(^[0-9a-f]{8,} |Revert ")#([0-9]+)/\1PR-\2/'
 }
 bukkit=$(changelog work/Bukkit)
 cb=$(changelog work/CraftBukkit)


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
33a2b476 PR-734: Make PlayerInventory#getItem Nullable

CraftBukkit Changes:
953d3ddc SPIGOT-3034: PlayerKickEvent.setLeaveMessage(String) doesn't actually do anything
2c47af0c SPIGOT-6963: CraftMetaBlockState#getBlockState applied TileEntity ids without the minecraft namespace prefix.
