### PR TITLE
Properly lookup random-ticked precipitation blocks

### DIFF
--- a/patches/server/0764-Optimise-random-block-ticking.patch
+++ b/patches/server/0764-Optimise-random-block-ticking.patch
@@ -71,7 +71,7 @@ index 0000000000000000000000000000000000000000..e8b4053babe46999980b926431254050
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 9fa7a01db61ba91b79eda4f7e4fd4f0001712808..6dee3e414e378538e6b5ef93dc1414e0128cffbb 100644
+index 8f27ef86cac71e0a0002093f4eded83f8891876f..6b90582dd0aefccab7e1b5a1718f96854d1cdd81 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -645,6 +645,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -126,13 +126,13 @@ index 9fa7a01db61ba91b79eda4f7e4fd4f0001712808..6dee3e414e378538e6b5ef93dc1414e0
                  if (biomebase.shouldSnow(this, blockposition)) {
                      org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockFormEvent(this, blockposition, Blocks.SNOW.defaultBlockState(), null); // CraftBukkit
                  }
++                blockposition.setY(downY); // Paper
  
 -                BlockState iblockdata = this.getBlockState(blockposition1);
 +                BlockState iblockdata = this.getBlockState(blockposition); // Paper
                  Biome.Precipitation biomebase_precipitation = biomebase.getPrecipitation();
  
 -                if (biomebase_precipitation == Biome.Precipitation.RAIN && biomebase.coldEnoughToSnow(blockposition1)) {
-+                blockposition.setY(downY); // Paper
 +                if (biomebase_precipitation == Biome.Precipitation.RAIN && biomebase.coldEnoughToSnow(blockposition)) { // Paper
                      biomebase_precipitation = Biome.Precipitation.SNOW;
                  }


### PR DESCRIPTION
As part of the random block tick optimisation, a mutable block position
was introduced in favour of two block positions, one previously pointing
towards the highest motion blocking block at the x/z column while the
other points towards the empty block above.

To convert the mutable block position between the two previous positions
when executing logic, the optimisation patch switches their y value
between the lower and higher y value (which are one block apart).

However, the patch failed to properly mutate the shared block position
to the lower block after checking for needed snow layers, causing the
logic that is usually responsible for handling precipitation on blocks
to fetch the block data of the higher block (usually air) for executing
its logic.

Hence, previously to this commit, the game fails to handle any
precipitation on blocks (such as cauldrons) as their logic is never
executed (rather the non-motion blocking block above is used instead).

Resolves: #7605