### PR TITLE
Fix world saving in unloadWorld

### DIFF
--- a/patches/server/0883-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0883-Fix-saving-in-unloadWorld.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Philip Kelley <philip@thoriumcube.org>
+Date: Wed, 16 Mar 2022 12:05:59 +0000
+Subject: [PATCH] Fix saving in unloadWorld
+
+Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 55c981f2c8070fc1bd9ecd4f4df140d9d0c68319..ff87e2690c696c2f055342c3828af5d6ff16b863 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1296,7 +1296,7 @@ public final class CraftServer implements Server {
+ 
+         try {
+             if (save) {
+-                handle.save(null, true, true);
++                handle.save(null, true, false); // Paper - don't disable saving
+             }
+ 
+             handle.getChunkSource().close(save);


### PR DESCRIPTION
This patch updates the unloadWorld method so that savingDisabled is set to false, which should then mean ServerLevel's saving logic is executed correctly.
PR in draft status as I'm still testing this change.