### PR TITLE
Fix duplicate world keys via createWorld

### DIFF
--- a/patches/server/0608-Add-methods-to-get-world-by-key.patch
+++ b/patches/server/0608-Add-methods-to-get-world-by-key.patch
@@ -5,10 +5,28 @@ Subject: [PATCH] Add methods to get world by key
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f904ce285548a81835b1d3af9c05f00f84d5d3da..3e26f9a4c93f616f4f02edbbd851cf0b9ab0cdb1 100644
+index f904ce285548a81835b1d3af9c05f00f84d5d3da..6f30668471c2076e2bbd8af79791bbe362f4d08e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1232,7 +1232,7 @@ public final class CraftServer implements Server {
+@@ -1138,9 +1138,15 @@ public final class CraftServer implements Server {
+         File folder = new File(this.getWorldContainer(), name);
+         World world = this.getWorld(name);
+ 
+-        if (world != null) {
+-            return world;
++        // Paper start
++        World worldByKey = this.getWorld(creator.key());
++        if (world != null || worldByKey != null) {
++            if (world == worldByKey) {
++                return world;
++            }
++            throw new IllegalArgumentException("Cannot create a world with key " + creator.key() + " and name " + name + " one (or both) already match a world that exists");
+         }
++        // Paper end
+ 
+         if ((folder.exists()) && (!folder.isDirectory())) {
+             throw new IllegalArgumentException("File exists with the name '" + name + "' and isn't a folder");
+@@ -1232,7 +1238,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -17,7 +35,7 @@ index f904ce285548a81835b1d3af9c05f00f84d5d3da..3e26f9a4c93f616f4f02edbbd851cf0b
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, holder, this.getServer().progressListenerFactory.create(11),
-@@ -1324,6 +1324,15 @@ public final class CraftServer implements Server {
+@@ -1324,6 +1330,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0646-Add-basic-Datapack-API.patch
+++ b/patches/server/0646-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3e26f9a4c93f616f4f02edbbd851cf0b9ab0cdb1..8cf01762342c848ce7610d32e033f9a36953077b 100644
+index 6f30668471c2076e2bbd8af79791bbe362f4d08e..3cb0b4797015eff95632355e4b78b955a8280a02 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -281,6 +281,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index 3e26f9a4c93f616f4f02edbbd851cf0b9ab0cdb1..8cf01762342c848ce7610d32e033f9a3
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2737,5 +2739,11 @@ public final class CraftServer implements Server {
+@@ -2743,5 +2745,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0651-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0651-Fix-and-optimise-world-force-upgrading.patch
@@ -357,10 +357,10 @@ index 4bc33c31d497aa7d69226ab870fd78902bedfd5b..089e8414c7bdc102ba0d914af576df1a
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 48f991bd9b6ec689b462f6a546ec1379d2e30002..ecffb6e2c779d520e25c79d04f10d408a7c778c6 100644
+index 3cb0b4797015eff95632355e4b78b955a8280a02..d4be39b4cb6a6c7f8b27ddd6dfb60541e9ac8834 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1193,12 +1193,7 @@ public final class CraftServer implements Server {
+@@ -1199,12 +1199,7 @@ public final class CraftServer implements Server {
          }
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().shouldReportAsModified());
@@ -374,7 +374,7 @@ index 48f991bd9b6ec689b462f6a546ec1379d2e30002..ecffb6e2c779d520e25c79d04f10d408
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1227,6 +1222,14 @@ public final class CraftServer implements Server {
+@@ -1233,6 +1228,14 @@ public final class CraftServer implements Server {
              }
          }
  

--- a/patches/server/0733-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0733-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -293,10 +293,10 @@ index ce6051531f021bf20851bc5ab763e732ee10427d..87d1f5b2717fc82203b5674ac0bf2704
      public static void spawnCategoryForChunk(MobCategory group, ServerLevel world, LevelChunk chunk, NaturalSpawner.SpawnPredicate checker, NaturalSpawner.AfterSpawnCallback runner) {
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4fb0ad44672e0fed8c5d523d03801df725cc136f..7b1bccfbf44c5b431f52f4ed974f9143c12a8300 100644
+index 0bf0bdc72c85bbf726fa86a778c8bcf5ed534be0..c99a522c7839b2a9cf131913172baabfc0658eeb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2143,6 +2143,11 @@ public final class CraftServer implements Server {
+@@ -2149,6 +2149,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {

--- a/patches/server/0806-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0806-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7b1bccfbf44c5b431f52f4ed974f9143c12a8300..72bb60f5bf4cf67bd2951228287693cfc52e2b2b 100644
+index c99a522c7839b2a9cf131913172baabfc0658eeb..2747a420f2c1ba4cf103f6340c5db671af3ade81 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2311,6 +2311,90 @@ public final class CraftServer implements Server {
+@@ -2317,6 +2317,90 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0831-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0831-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,10 +18,10 @@ index df955666723a8cb1e612311f0b8e77fb577d6be5..01aefce226ae82d707b38b0d56d2580d
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 72bb60f5bf4cf67bd2951228287693cfc52e2b2b..07f5c20d28120acad34d36d371ba7f95f62ff71d 100644
+index 2747a420f2c1ba4cf103f6340c5db671af3ade81..7dc79e7c552d7ebc2dea9248c2d5647b5a6895e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1211,7 +1211,7 @@ public final class CraftServer implements Server {
+@@ -1217,7 +1217,7 @@ public final class CraftServer implements Server {
              chunkgenerator = worlddimension.generator();
          }
  
@@ -31,7 +31,7 @@ index 72bb60f5bf4cf67bd2951228287693cfc52e2b2b..07f5c20d28120acad34d36d371ba7f95
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 760149102313626831e3692936c6a984f04d252a..fbfd094a938a96c03d614059fb1cd5a720865a83 100644
+index 0ebacc6f35591b3f1fc740d484f30c7c2337392a..bd24cf74dfc0974f5bc132994deac45b4ec7b344 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -212,6 +212,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0846-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0846-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -123,10 +123,10 @@ index 0000000000000000000000000000000000000000..f7c86155ce0cfd9b4bf8a2b79d77a656
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 07f5c20d28120acad34d36d371ba7f95f62ff71d..782f9519b942e027de4d51acdb1ef5f994506838 100644
+index 7dc79e7c552d7ebc2dea9248c2d5647b5a6895e0..66d931bf247cfc07c40ef4721ab24e163e6038ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1982,6 +1982,13 @@ public final class CraftServer implements Server {
+@@ -1988,6 +1988,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  

--- a/patches/server/0851-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0851-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 782f9519b942e027de4d51acdb1ef5f994506838..125a150779ee20763383acb53633aa1e2cbce166 100644
+index 66d931bf247cfc07c40ef4721ab24e163e6038ea..6b43fcb230cdc562585fbdc01a5db43b9cb6eca2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2151,6 +2151,8 @@ public final class CraftServer implements Server {
+@@ -2157,6 +2157,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start

--- a/patches/server/0852-Add-GameEvent-tags.patch
+++ b/patches/server/0852-Add-GameEvent-tags.patch
@@ -45,7 +45,7 @@ index 0000000000000000000000000000000000000000..cb78a3d4e21376ea24347187478525d5
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 125a150779ee20763383acb53633aa1e2cbce166..95f8685ad1c817ccb195b3124283e5b809ef7dcd 100644
+index 6b43fcb230cdc562585fbdc01a5db43b9cb6eca2..196640c203b3c33c1e967b2f1bf1fa360dc6952b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -97,6 +97,7 @@ import net.minecraft.world.level.biome.BiomeSource;
@@ -56,7 +56,7 @@ index 125a150779ee20763383acb53633aa1e2cbce166..95f8685ad1c817ccb195b3124283e5b8
  import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
  import net.minecraft.world.level.levelgen.PatrolSpawner;
  import net.minecraft.world.level.levelgen.PhantomSpawner;
-@@ -2557,6 +2558,15 @@ public final class CraftServer implements Server {
+@@ -2563,6 +2564,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(Registry.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -72,7 +72,7 @@ index 125a150779ee20763383acb53633aa1e2cbce166..95f8685ad1c817ccb195b3124283e5b8
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2589,6 +2599,13 @@ public final class CraftServer implements Server {
+@@ -2595,6 +2605,13 @@ public final class CraftServer implements Server {
                  Registry<EntityType<?>> entityTags = Registry.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0860-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0860-Put-world-into-worldlist-before-initing-the-world.patch
@@ -23,10 +23,10 @@ index 443fb9cdce8bf542ca6216aa65c3e48c66dde654..e4461fb3485391ec0a9d902d5b896bb9
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 95f8685ad1c817ccb195b3124283e5b809ef7dcd..7775041c067e17da3d442fb8127f1ed2bba4f78c 100644
+index 196640c203b3c33c1e967b2f1bf1fa360dc6952b..c5b9770669f9ed51408ea4f10d03f2e737ba9eb9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1249,10 +1249,11 @@ public final class CraftServer implements Server {
+@@ -1255,10 +1255,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0862-Custom-Potion-Mixes.patch
+++ b/patches/server/0862-Custom-Potion-Mixes.patch
@@ -164,7 +164,7 @@ index 287205bce7f655f9a6b815f40d349c3db4c1e788..5c0f1488c8a8100cd39a03adeccded99
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7775041c067e17da3d442fb8127f1ed2bba4f78c..cafef315ccc714afd9c3554cbfb19ca26085b597 100644
+index c5b9770669f9ed51408ea4f10d03f2e737ba9eb9..dcc59692a5ab968cb8f2d53347fc300db67241da 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -285,6 +285,7 @@ public final class CraftServer implements Server {
@@ -184,7 +184,7 @@ index 7775041c067e17da3d442fb8127f1ed2bba4f78c..cafef315ccc714afd9c3554cbfb19ca2
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2865,5 +2866,10 @@ public final class CraftServer implements Server {
+@@ -2871,5 +2872,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0877-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0877-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cafef315ccc714afd9c3554cbfb19ca26085b597..fd3d1eb87d613a20458a837371d7df3aadfb94b0 100644
+index dcc59692a5ab968cb8f2d53347fc300db67241da..a7f8f4eafaaa89838fb9c0f10da83d62e6540ba7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1297,7 +1297,7 @@ public final class CraftServer implements Server {
+@@ -1303,7 +1303,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0893-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0893-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fd3d1eb87d613a20458a837371d7df3aadfb94b0..15278bb897e6169bc5d02bf47b455634baec7be1 100644
+index a7f8f4eafaaa89838fb9c0f10da83d62e6540ba7..512fb526cd4c3e5ce9db14b7ab9dc0107013f547 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1256,6 +1256,7 @@ public final class CraftServer implements Server {
+@@ -1262,6 +1262,7 @@ public final class CraftServer implements Server {
          internal.setSpawnSettings(true, true);
          // Paper - move up
  


### PR DESCRIPTION
Now requires that the level name and world key return the same world when checking for an existing world in Bukkit's createWorld method.

On a side note, there isn't a requirement that level names be unique except for the Map kept on CraftServer that uses the level name as the key.

Fixes https://github.com/PaperMC/Paper/issues/7502