### PR TITLE
Add EntityDyeEvent and CollarColorable interface

### DIFF
--- a/patches/api/0381-Add-EntityDyeEvent-and-CollarColorable-interface.patch
+++ b/patches/api/0381-Add-EntityDyeEvent-and-CollarColorable-interface.patch
@@ -1,0 +1,262 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 18 Mar 2022 21:16:38 -0700
+Subject: [PATCH] Add EntityDyeEvent and CollarColorable interface
+
+
+diff --git a/src/main/java/io/papermc/paper/entity/CollarColorable.java b/src/main/java/io/papermc/paper/entity/CollarColorable.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..bb68e6a2528eee81eb3f26f22b9c35508f1e69c1
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/entity/CollarColorable.java
+@@ -0,0 +1,25 @@
++package io.papermc.paper.entity;
++
++import org.bukkit.DyeColor;
++import org.bukkit.entity.LivingEntity;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Entities that can have their collars colored.
++ */
++public interface CollarColorable extends LivingEntity {
++
++    /**
++     * Get the collar color of this entity
++     *
++     * @return the color of the collar
++     */
++    @NotNull DyeColor getCollarColor();
++
++    /**
++     * Set the collar color of this entity
++     *
++     * @param color the color to apply
++     */
++    void setCollarColor(@NotNull DyeColor color);
++}
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityDyeEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityDyeEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..aefbaccd32f1ab25a4da63bdc878922e0c220478
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityDyeEvent.java
+@@ -0,0 +1,75 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.DyeColor;
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when an entity is dyed. Currently, this is called for {@link org.bukkit.entity.Sheep}
++ * being dyed, and {@link org.bukkit.entity.Wolf}/{@link org.bukkit.entity.Cat} collars being dyed.
++ */
++public class EntityDyeEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private DyeColor dyeColor;
++    private final Player player;
++    private boolean cancel;
++
++    public EntityDyeEvent(@NotNull Entity entity, @NotNull DyeColor dyeColor, @Nullable Player player) {
++        super(entity);
++        this.dyeColor = dyeColor;
++        this.player = player;
++    }
++
++    /**
++     * Gets the DyeColor the entity is being dyed
++     *
++     * @return the DyeColor the entity is being dyed
++     */
++    public @NotNull DyeColor getColor() {
++        return this.dyeColor;
++    }
++
++    /**
++     * Sets the DyeColor the entity is being dyed
++     *
++     * @param dyeColor the DyeColor the entity will be dyed
++     */
++    public void setColor(@NotNull DyeColor dyeColor) {
++        this.dyeColor = dyeColor;
++    }
++
++    /**
++     * Returns the player dyeing the entity, if available.
++     *
++     * @return player or null
++     */
++    public @Nullable Player getPlayer() {
++        return player;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancel;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}
+diff --git a/src/main/java/org/bukkit/entity/Cat.java b/src/main/java/org/bukkit/entity/Cat.java
+index c340fecb61bac66baf0f44189d21bc85289b1269..97b0d8ccd3fd3a711ec5fa4ce3d8703515895081 100644
+--- a/src/main/java/org/bukkit/entity/Cat.java
++++ b/src/main/java/org/bukkit/entity/Cat.java
+@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Meow.
+  */
+-public interface Cat extends Tameable, Sittable {
++public interface Cat extends Tameable, Sittable, io.papermc.paper.entity.CollarColorable { // Paper - CollarColorable
+ 
+     /**
+      * Gets the current type of this cat.
+@@ -29,6 +29,7 @@ public interface Cat extends Tameable, Sittable {
+      * @return the color of the collar
+      */
+     @NotNull
++    @Override // Paper
+     public DyeColor getCollarColor();
+ 
+     /**
+@@ -36,6 +37,7 @@ public interface Cat extends Tameable, Sittable {
+      *
+      * @param color the color to apply
+      */
++    @Override // Paper
+     public void setCollarColor(@NotNull DyeColor color);
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/entity/Wolf.java b/src/main/java/org/bukkit/entity/Wolf.java
+index 490395f38c4d9977d30a6f48585a4ea0e7faff0f..297b65a6cf7d25f02bbd824ea507c5c083e0abec 100644
+--- a/src/main/java/org/bukkit/entity/Wolf.java
++++ b/src/main/java/org/bukkit/entity/Wolf.java
+@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Represents a Wolf
+  */
+-public interface Wolf extends Tameable, Sittable {
++public interface Wolf extends Tameable, Sittable, io.papermc.paper.entity.CollarColorable { // Paper - CollarColorable
+ 
+     /**
+      * Checks if this wolf is angry
+@@ -31,6 +31,7 @@ public interface Wolf extends Tameable, Sittable {
+      * @return the color of the collar
+      */
+     @NotNull
++    @Override // Paper
+     public DyeColor getCollarColor();
+ 
+     /**
+@@ -38,6 +39,7 @@ public interface Wolf extends Tameable, Sittable {
+      *
+      * @param color the color to apply
+      */
++    @Override // Paper
+     public void setCollarColor(@NotNull DyeColor color);
+ 
+     // Paper start
+diff --git a/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java b/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java
+index 10d2466fb69919cead26af2fcdf6bd2e678f2927..ddf4aec01e4873aa799721ce615f5d7c929dc915 100644
+--- a/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java
++++ b/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java
+@@ -11,11 +11,8 @@ import org.jetbrains.annotations.Nullable;
+ /**
+  * Called when a sheep's wool is dyed
+  */
+-public class SheepDyeWoolEvent extends EntityEvent implements Cancellable {
+-    private static final HandlerList handlers = new HandlerList();
+-    private boolean cancel;
+-    private DyeColor color;
+-    private final Player player;
++public class SheepDyeWoolEvent extends io.papermc.paper.event.entity.EntityDyeEvent implements Cancellable {
++    // Paper - move everything to superclass
+ 
+     @Deprecated
+     public SheepDyeWoolEvent(@NotNull final Sheep sheep, @NotNull final DyeColor color) {
+@@ -23,20 +20,7 @@ public class SheepDyeWoolEvent extends EntityEvent implements Cancellable {
+     }
+ 
+     public SheepDyeWoolEvent(@NotNull final Sheep sheep, @NotNull final DyeColor color, @Nullable Player player) {
+-        super(sheep);
+-        this.cancel = false;
+-        this.color = color;
+-        this.player = player;
+-    }
+-
+-    @Override
+-    public boolean isCancelled() {
+-        return cancel;
+-    }
+-
+-    @Override
+-    public void setCancelled(boolean cancel) {
+-        this.cancel = cancel;
++        super(sheep, color, player); // Paper
+     }
+ 
+     @NotNull
+@@ -44,45 +28,4 @@ public class SheepDyeWoolEvent extends EntityEvent implements Cancellable {
+     public Sheep getEntity() {
+         return (Sheep) entity;
+     }
+-
+-    /**
+-     * Returns the player dyeing the sheep, if available.
+-     *
+-     * @return player or null
+-     */
+-    @Nullable
+-    public Player getPlayer() {
+-        return player;
+-    }
+-
+-    /**
+-     * Gets the DyeColor the sheep is being dyed
+-     *
+-     * @return the DyeColor the sheep is being dyed
+-     */
+-    @NotNull
+-    public DyeColor getColor() {
+-        return color;
+-    }
+-
+-    /**
+-     * Sets the DyeColor the sheep is being dyed
+-     *
+-     * @param color the DyeColor the sheep will be dyed
+-     */
+-    public void setColor(@NotNull DyeColor color) {
+-        this.color = color;
+-    }
+-
+-    @NotNull
+-    @Override
+-    public HandlerList getHandlers() {
+-        return handlers;
+-    }
+-
+-    @NotNull
+-    public static HandlerList getHandlerList() {
+-        return handlers;
+-    }
+-
+ }

--- a/patches/server/0899-Add-EntityDyeEvent-and-CollarColorable-interface.patch
+++ b/patches/server/0899-Add-EntityDyeEvent-and-CollarColorable-interface.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 18 Mar 2022 21:15:55 -0700
+Subject: [PATCH] Add EntityDyeEvent and CollarColorable interface
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Cat.java b/src/main/java/net/minecraft/world/entity/animal/Cat.java
+index e4eac546836b73b5e9c8fd68ca0d32c01148313e..9f5180271ca8a790aa52763ac46d31b905c9d477 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Cat.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Cat.java
+@@ -432,6 +432,13 @@ public class Cat extends TamableAnimal {
+                     DyeColor enumcolor = ((DyeItem) item).getDyeColor();
+ 
+                     if (enumcolor != this.getCollarColor()) {
++                        // Paper start
++                        final io.papermc.paper.event.entity.EntityDyeEvent event = new io.papermc.paper.event.entity.EntityDyeEvent(this.getBukkitEntity(), org.bukkit.DyeColor.getByWoolData((byte) enumcolor.getId()), ((net.minecraft.server.level.ServerPlayer) player).getBukkitEntity());
++                        if (!event.callEvent()) {
++                            return InteractionResult.FAIL;
++                        }
++                        enumcolor = DyeColor.byId(event.getColor().getWoolData());
++                        // Paper end
+                         this.setCollarColor(enumcolor);
+                         if (!player.getAbilities().instabuild) {
+                             itemstack.shrink(1);
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Wolf.java b/src/main/java/net/minecraft/world/entity/animal/Wolf.java
+index aaf7096835bab3a42d617553dd83e048e4a83766..249ef89342d2811614507090b79250adf78e33ce 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Wolf.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Wolf.java
+@@ -393,6 +393,13 @@ public class Wolf extends TamableAnimal implements NeutralMob {
+                 DyeColor enumcolor = ((DyeItem) item).getDyeColor();
+ 
+                 if (enumcolor != this.getCollarColor()) {
++                    // Paper start
++                    final io.papermc.paper.event.entity.EntityDyeEvent event = new io.papermc.paper.event.entity.EntityDyeEvent(this.getBukkitEntity(), org.bukkit.DyeColor.getByWoolData((byte) enumcolor.getId()), ((net.minecraft.server.level.ServerPlayer) player).getBukkitEntity());
++                    if (!event.callEvent()) {
++                        return InteractionResult.FAIL;
++                    }
++                    enumcolor = DyeColor.byId(event.getColor().getWoolData());
++                    // Paper end
+                     this.setCollarColor(enumcolor);
+                     if (!player.getAbilities().instabuild) {
+                         itemstack.shrink(1);


### PR DESCRIPTION
Resolves https://github.com/PaperMC/Paper/issues/7477

Adds EntityDyeEvent and makes it the super type for SheepDyeWoolEvent. Also adds CollarColorable interface for Wolf/Cat. 

EntityDyeEvent is called for sheep, wolf, and cat currently. Shulkers can be dyed, but not naturally so they were excluded.