### PR TITLE
Fix async entity add due to fungus trees

### DIFF
--- a/patches/server/0945-Fix-async-entity-add-due-to-fungus-trees.patch
+++ b/patches/server/0945-Fix-async-entity-add-due-to-fungus-trees.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 18 Mar 2022 21:30:00 -0700
+Subject: [PATCH] Fix async entity add due to fungus trees
+
+
+diff --git a/src/main/java/net/minecraft/server/level/WorldGenRegion.java b/src/main/java/net/minecraft/server/level/WorldGenRegion.java
+index 80c1e0e47818486a68e0114b063395290365346b..0d3587e2d454fb0994ecff930b5e496a3999746a 100644
+--- a/src/main/java/net/minecraft/server/level/WorldGenRegion.java
++++ b/src/main/java/net/minecraft/server/level/WorldGenRegion.java
+@@ -227,6 +227,7 @@ public class WorldGenRegion implements WorldGenLevel {
+         if (iblockdata.isAir()) {
+             return false;
+         } else {
++            if (drop) LOGGER.warn("Potential async entity add during worldgen", new Throwable()); // Paper - log when this happens
+             if (false) { // CraftBukkit - SPIGOT-6833: Do not drop during world generation
+                 BlockEntity tileentity = iblockdata.hasBlockEntity() ? this.getBlockEntity(pos) : null;
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+index 62bca85da6c5d9877e21fecb702370506ddf671c..c73468450bfe23e6f3a99d15c3e39a2a1ddf0c77 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+@@ -372,10 +372,10 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+                 ((ChorusFlowerBlock) Blocks.CHORUS_FLOWER).generatePlant(access, pos, random, 8);
+                 return true;
+             case CRIMSON_FUNGUS:
+-                gen = TreeFeatures.CRIMSON_FUNGUS_PLANTED;
++                gen = this.isNormalWorld() ? TreeFeatures.CRIMSON_FUNGUS_PLANTED : TreeFeatures.CRIMSON_FUNGUS; // Paper - if world gen, don't use planted version
+                 break;
+             case WARPED_FUNGUS:
+-                gen = TreeFeatures.WARPED_FUNGUS_PLANTED;
++                gen = this.isNormalWorld() ? TreeFeatures.WARPED_FUNGUS_PLANTED : TreeFeatures.WARPED_FUNGUS; // Paper - if world gen, don't use planted version
+                 break;
+             case AZALEA:
+                 gen = TreeFeatures.AZALEA_TREE;


### PR DESCRIPTION
the `_PLANTED` features shouldn't be used during worldgen.

I **didn't** undo upstream's change to not allow items dropping during worldgen. The only two reported causes have been resolved, https://github.com/PaperMC/Paper/issues/7001 via [MC-214289 ](https://bugs.mojang.com/browse/MC-214289), and this fixes https://github.com/PaperMC/Paper/issues/7458. Am now logging when that happens.