### PR TITLE
Fix treasure maps discovered settings

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -201,10 +201,10 @@ index 0000000000000000000000000000000000000000..80a3d5890aab91e6a48d573414018785
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1dc56bee6827f6552cfa93a92fe8d0b5f94ab596
+index 0000000000000000000000000000000000000000..0853ff7641103447f458b2dc08076c27e3937074
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -0,0 +1,99 @@
+@@ -0,0 +1,104 @@
 +package com.destroystokyo.paper;
 +
 +import java.util.List;
@@ -259,8 +259,13 @@ index 0000000000000000000000000000000000000000..1dc56bee6827f6552cfa93a92fe8d0b5
 +    }
 +
 +    private boolean getBoolean(String path, boolean def) {
-+        config.addDefault("world-settings.default." + path, def);
-+        return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
++        return this.getBoolean(path, def, true);
++    }
++    private boolean getBoolean(String path, boolean def, boolean setDefault) {
++        if (setDefault) {
++            config.addDefault("world-settings.default." + path, def);
++        }
++        return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path, def));
 +    }
 +
 +    private double getDouble(String path, double def) {

--- a/patches/server/0014-Configurable-cactus-bamboo-and-reed-growth-heights.patch
+++ b/patches/server/0014-Configurable-cactus-bamboo-and-reed-growth-heights.patch
@@ -7,10 +7,10 @@ Bamboo - Both the minimum fully-grown heights and the maximum are configurable
 - Machine_Maker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1dc56bee6827f6552cfa93a92fe8d0b5f94ab596..e8b2ad7b454113c279733fb8f385d0d3f217e0f5 100644
+index 0853ff7641103447f458b2dc08076c27e3937074..3f7ec17466e4fae7139672854e2c8223ada16b76 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -96,4 +96,16 @@ public class PaperWorldConfig {
+@@ -101,4 +101,16 @@ public class PaperWorldConfig {
          config.addDefault("world-settings.default." + path, def.stream().map(Enum::name).collect(Collectors.toList()));
          return ((List<String>) (config.getList("world-settings." + worldName + "." + path, config.getList("world-settings.default." + path)))).stream().map(s -> Enum.valueOf(type, s)).collect(Collectors.toList());
      }

--- a/patches/server/0015-Configurable-baby-zombie-movement-speed.patch
+++ b/patches/server/0015-Configurable-baby-zombie-movement-speed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable baby zombie movement speed
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e8b2ad7b454113c279733fb8f385d0d3f217e0f5..aba9f77878bd5475a63af1fa3f60580674ea63ad 100644
+index 3f7ec17466e4fae7139672854e2c8223ada16b76..4d787f0596be1a44724ade309cc00e115778a797 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -108,4 +108,15 @@ public class PaperWorldConfig {
+@@ -113,4 +113,15 @@ public class PaperWorldConfig {
          bambooMinHeight = getInt("max-growth-height.bamboo.min", 11);
          log("Max height for cactus growth " + cactusMaxHeight + ". Max height for reed growth " + reedMaxHeight + ". Max height for bamboo growth " + bambooMaxHeight + ". Min height for fully-grown bamboo " + bambooMinHeight + ".");
      }

--- a/patches/server/0016-Configurable-fishing-time-ranges.patch
+++ b/patches/server/0016-Configurable-fishing-time-ranges.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable fishing time ranges
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index aba9f77878bd5475a63af1fa3f60580674ea63ad..f92f936c4b7e4fea63eef65c4ae8c10eeacb36b0 100644
+index 4d787f0596be1a44724ade309cc00e115778a797..4b9122a3e094aa9e0a789f35fb6b0f9a7a53f772 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -119,4 +119,12 @@ public class PaperWorldConfig {
+@@ -124,4 +124,12 @@ public class PaperWorldConfig {
  
          log("Baby zombies will move at the speed of " + babyZombieMovementModifier);
      }

--- a/patches/server/0017-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
+++ b/patches/server/0017-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow nerfed mobs to jump and take water damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f92f936c4b7e4fea63eef65c4ae8c10eeacb36b0..adb1f1bf96bd37b571fb53419db063d79a041bbf 100644
+index 4b9122a3e094aa9e0a789f35fb6b0f9a7a53f772..d2ac0123812224181afae8fca96058ddc8cdff1e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -127,4 +127,9 @@ public class PaperWorldConfig {
+@@ -132,4 +132,9 @@ public class PaperWorldConfig {
          fishingMaxTicks = getInt("fishing-time-range.MaximumTicks", 600);
          log("Fishing time ranges are between " + fishingMinTicks +" and " + fishingMaxTicks + " ticks");
      }

--- a/patches/server/0018-Add-configurable-despawn-distances-for-living-entiti.patch
+++ b/patches/server/0018-Add-configurable-despawn-distances-for-living-entiti.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add configurable despawn distances for living entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index adb1f1bf96bd37b571fb53419db063d79a041bbf..309fdf93b0a148d00cda58ffd31557f349d12907 100644
+index d2ac0123812224181afae8fca96058ddc8cdff1e..3afadc8d916714398974d77aa0f1093729e008ca 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -3,6 +3,9 @@ package com.destroystokyo.paper;
@@ -32,7 +32,7 @@ index adb1f1bf96bd37b571fb53419db063d79a041bbf..309fdf93b0a148d00cda58ffd31557f3
          if (needsSave) {
              saveConfig();
          }
-@@ -132,4 +142,31 @@ public class PaperWorldConfig {
+@@ -137,4 +147,31 @@ public class PaperWorldConfig {
      private void nerfedMobsShouldJump() {
          nerfedMobsShouldJump = getBoolean("spawner-nerfed-mobs-should-jump", false);
      }

--- a/patches/server/0019-Allow-for-toggling-of-spawn-chunks.patch
+++ b/patches/server/0019-Allow-for-toggling-of-spawn-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow for toggling of spawn chunks
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 309fdf93b0a148d00cda58ffd31557f349d12907..9d1039c25423fde234962533bddc3f965992716f 100644
+index 3afadc8d916714398974d77aa0f1093729e008ca..f32726275d18772904883b618be66893ca5d84fd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -169,4 +169,10 @@ public class PaperWorldConfig {
+@@ -174,4 +174,10 @@ public class PaperWorldConfig {
              hardDespawnDistances.put(category, hardDistance);
          }
      }

--- a/patches/server/0020-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/patches/server/0020-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Drop falling block and tnt entities at the specified height
 * Dec 2, 2020 Added tnt nerf for tnt minecarts - Machine_Maker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9d1039c25423fde234962533bddc3f965992716f..70bcd7cae2777c2c7fbf995b8783ece31d9349e5 100644
+index f32726275d18772904883b618be66893ca5d84fd..b41f6074e0d88b6becb5b931fc4ee94a1f9f2f0b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -175,4 +175,14 @@ public class PaperWorldConfig {
+@@ -180,4 +180,14 @@ public class PaperWorldConfig {
          keepSpawnInMemory = getBoolean("keep-spawn-loaded", true);
          log("Keep spawn chunk loaded: " + keepSpawnInMemory);
      }

--- a/patches/server/0029-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0029-Configurable-top-of-nether-void-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable top of nether void damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 70bcd7cae2777c2c7fbf995b8783ece31d9349e5..0ba54e24944c9e30bc06dc2556e9c856d2b335bc 100644
+index b41f6074e0d88b6becb5b931fc4ee94a1f9f2f0b..10c08ed945f950b9c2a5e308f8caa11955cb0088 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -185,4 +185,19 @@ public class PaperWorldConfig {
+@@ -190,4 +190,19 @@ public class PaperWorldConfig {
          if (fallingBlockHeightNerf != 0) log("Falling Block Height Limit set to Y: " + fallingBlockHeightNerf);
          if (entityTNTHeightNerf != 0) log("TNT Entity Height Limit set to Y: " + entityTNTHeightNerf);
      }

--- a/patches/server/0032-Configurable-end-credits.patch
+++ b/patches/server/0032-Configurable-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable end credits
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0ba54e24944c9e30bc06dc2556e9c856d2b335bc..cb6add86fadcb4684ed917a8b05ada84a75c0a27 100644
+index 10c08ed945f950b9c2a5e308f8caa11955cb0088..067234ed44cae4454acc76b9ebe83ee1394fb913 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -200,4 +200,10 @@ public class PaperWorldConfig {
+@@ -205,4 +205,10 @@ public class PaperWorldConfig {
              }
          }
      }

--- a/patches/server/0034-Optimize-explosions.patch
+++ b/patches/server/0034-Optimize-explosions.patch
@@ -10,10 +10,10 @@ This patch adds a per-tick cache that is used for storing and retrieving
 an entity's exposure during an explosion.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cb6add86fadcb4684ed917a8b05ada84a75c0a27..e4873fa644790d6d1db0160688123fc5a60d0bb0 100644
+index 067234ed44cae4454acc76b9ebe83ee1394fb913..73dda3becdf29dac35f4a0ceea070d174c546c8b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -206,4 +206,10 @@ public class PaperWorldConfig {
+@@ -211,4 +211,10 @@ public class PaperWorldConfig {
          disableEndCredits = getBoolean("game-mechanics.disable-end-credits", false);
          log("End credits disabled: " + disableEndCredits);
      }

--- a/patches/server/0035-Disable-explosion-knockback.patch
+++ b/patches/server/0035-Disable-explosion-knockback.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable explosion knockback
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e4873fa644790d6d1db0160688123fc5a60d0bb0..230f89329c31a65813b25addb4f6552e3f181069 100644
+index 73dda3becdf29dac35f4a0ceea070d174c546c8b..1d91adcfa636455bf67c6f7ac7d51baaa6db047f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -212,4 +212,9 @@ public class PaperWorldConfig {
+@@ -217,4 +217,9 @@ public class PaperWorldConfig {
          optimizeExplosions = getBoolean("optimize-explosions", false);
          log("Optimize explosions: " + optimizeExplosions);
      }

--- a/patches/server/0036-Disable-thunder.patch
+++ b/patches/server/0036-Disable-thunder.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable thunder
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 230f89329c31a65813b25addb4f6552e3f181069..5019413dc5973dcc8fe0f1381ba2463862499b88 100644
+index 1d91adcfa636455bf67c6f7ac7d51baaa6db047f..a591d52ed44213d7932690136796d3e068b06987 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -217,4 +217,9 @@ public class PaperWorldConfig {
+@@ -222,4 +222,9 @@ public class PaperWorldConfig {
      private void disableExplosionKnockback(){
          disableExplosionKnockback = getBoolean("disable-explosion-knockback", false);
      }

--- a/patches/server/0037-Disable-ice-and-snow.patch
+++ b/patches/server/0037-Disable-ice-and-snow.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable ice and snow
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5019413dc5973dcc8fe0f1381ba2463862499b88..38b8b7bd59381c13a919c9b2e125d804be9b6e89 100644
+index a591d52ed44213d7932690136796d3e068b06987..18e7960624e4e882677145c3bedd00263a57b051 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -222,4 +222,9 @@ public class PaperWorldConfig {
+@@ -227,4 +227,9 @@ public class PaperWorldConfig {
      private void disableThunder() {
          disableThunder = getBoolean("disable-thunder", false);
      }

--- a/patches/server/0038-Configurable-mob-spawner-tick-rate.patch
+++ b/patches/server/0038-Configurable-mob-spawner-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable mob spawner tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 38b8b7bd59381c13a919c9b2e125d804be9b6e89..6b527d72309a38eec35de5d8d30a9def9f6df783 100644
+index 18e7960624e4e882677145c3bedd00263a57b051..fcbb0d6cd09a9c80a8725c9cf0c503fa0532f1e3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -227,4 +227,9 @@ public class PaperWorldConfig {
+@@ -232,4 +232,9 @@ public class PaperWorldConfig {
      private void disableIceAndSnow(){
          disableIceAndSnow = getBoolean("disable-ice-and-snow", false);
      }

--- a/patches/server/0042-Configurable-container-update-tick-rate.patch
+++ b/patches/server/0042-Configurable-container-update-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable container update tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6b527d72309a38eec35de5d8d30a9def9f6df783..421e51892ca431409b9b52e7901ca42c44d9e6dd 100644
+index fcbb0d6cd09a9c80a8725c9cf0c503fa0532f1e3..156059d4951fa01b10cc36d70cd439037c636e4c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -232,4 +232,9 @@ public class PaperWorldConfig {
+@@ -237,4 +237,9 @@ public class PaperWorldConfig {
      private void mobSpawnerTickRate() {
          mobSpawnerTickRate = getInt("mob-spawner-tick-rate", 1);
      }

--- a/patches/server/0046-Configurable-Disabling-Cat-Chest-Detection.patch
+++ b/patches/server/0046-Configurable-Disabling-Cat-Chest-Detection.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Disabling Cat Chest Detection
 Offers a gameplay feature to stop cats from blocking chests
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 421e51892ca431409b9b52e7901ca42c44d9e6dd..35a693ababf975c747ff2411d0fce7f7b1e1950b 100644
+index 156059d4951fa01b10cc36d70cd439037c636e4c..adf5a83fc1b62e55ba4524893f8704ad6cd81e97 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -237,4 +237,9 @@ public class PaperWorldConfig {
+@@ -242,4 +242,9 @@ public class PaperWorldConfig {
      private void containerUpdateTickRate() {
          containerUpdateTickRate = getInt("container-update-tick-rate", 1);
      }

--- a/patches/server/0048-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/patches/server/0048-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] All chunks are slime spawn chunks toggle
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 35a693ababf975c747ff2411d0fce7f7b1e1950b..21b1430b9565e87ac052bc75ba013cf94176d6c9 100644
+index adf5a83fc1b62e55ba4524893f8704ad6cd81e97..567bad50508870001c3337bf109a407b6b4cde0e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -242,4 +242,9 @@ public class PaperWorldConfig {
+@@ -247,4 +247,9 @@ public class PaperWorldConfig {
      private void disableChestCatDetection() {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }

--- a/patches/server/0053-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0053-Add-configurable-portal-search-radius.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 21b1430b9565e87ac052bc75ba013cf94176d6c9..d05dd815900dbdc78d1315eb13212d4e7cdf04d9 100644
+index 567bad50508870001c3337bf109a407b6b4cde0e..66dd2ebda5692157e397f7ddafd96a492e53c9e9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -247,4 +247,13 @@ public class PaperWorldConfig {
+@@ -252,4 +252,13 @@ public class PaperWorldConfig {
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }

--- a/patches/server/0055-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0055-Configurable-inter-world-teleportation-safety.patch
@@ -16,10 +16,10 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d05dd815900dbdc78d1315eb13212d4e7cdf04d9..b0bb68bdbd1a64a639c5fd2173c86f8e52291c20 100644
+index 66dd2ebda5692157e397f7ddafd96a492e53c9e9..45b51fea6ba4381e4d245d70b5671f6e42c1f718 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -256,4 +256,9 @@ public class PaperWorldConfig {
+@@ -261,4 +261,9 @@ public class PaperWorldConfig {
          portalCreateRadius = getInt("portal-create-radius", 16);
          portalSearchVanillaDimensionScaling = getBoolean("portal-search-vanilla-dimension-scaling", true);
      }

--- a/patches/server/0058-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/patches/server/0058-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b0bb68bdbd1a64a639c5fd2173c86f8e52291c20..7bd8c3a02a3024aea72b70366569dc399dd4f9a6 100644
+index 45b51fea6ba4381e4d245d70b5671f6e42c1f718..397995fe4c360d837282535b9b7aaf7f3d93f85f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -261,4 +261,9 @@ public class PaperWorldConfig {
+@@ -266,4 +266,9 @@ public class PaperWorldConfig {
      private void disableTeleportationSuffocationCheck() {
          disableTeleportationSuffocationCheck = getBoolean("disable-teleportation-suffocation-check", false);
      }

--- a/patches/server/0066-Configurable-Non-Player-Arrow-Despawn-Rate.patch
+++ b/patches/server/0066-Configurable-Non-Player-Arrow-Despawn-Rate.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Non Player Arrow Despawn Rate
 Can set a much shorter despawn rate for arrows that players can not pick up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7bd8c3a02a3024aea72b70366569dc399dd4f9a6..b38dd476f9fc08173230e0108f9d8addc65b1977 100644
+index 397995fe4c360d837282535b9b7aaf7f3d93f85f..4c4385d3d20556a2695f69c95d6b3cff087d26d9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -266,4 +266,19 @@ public class PaperWorldConfig {
+@@ -271,4 +271,19 @@ public class PaperWorldConfig {
      private void nonPlayerEntitiesOnScoreboards() {
          nonPlayerEntitiesOnScoreboards = getBoolean("allow-non-player-entities-on-scoreboards", false);
      }

--- a/patches/server/0071-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/patches/server/0071-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b38dd476f9fc08173230e0108f9d8addc65b1977..1162490776712755dad0ec25b40a1420c0a01488 100644
+index 4c4385d3d20556a2695f69c95d6b3cff087d26d9..fa730fd8b969e39cf063a560d9820d3655709398 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -281,4 +281,12 @@ public class PaperWorldConfig {
+@@ -286,4 +286,12 @@ public class PaperWorldConfig {
          log("Non Player Arrow Despawn Rate: " + nonPlayerArrowDespawnRate);
          log("Creative Arrow Despawn Rate: " + creativeArrowDespawnRate);
      }

--- a/patches/server/0075-Configurable-Chunk-Inhabited-Time.patch
+++ b/patches/server/0075-Configurable-Chunk-Inhabited-Time.patch
@@ -11,10 +11,10 @@ For people who want all chunks to be treated equally, you can chose a fixed valu
 This allows to fine-tune vanilla gameplay.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1162490776712755dad0ec25b40a1420c0a01488..1471965911d9fd3bfad9c4d85607c02ec19fbf1f 100644
+index fa730fd8b969e39cf063a560d9820d3655709398..3e7a98073c86d94881e7c03786e3745db2c445cd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -289,4 +289,14 @@ public class PaperWorldConfig {
+@@ -294,4 +294,14 @@ public class PaperWorldConfig {
              skeleHorseSpawnChance = 0.01D; // Vanilla value
          }
      }

--- a/patches/server/0080-Configurable-Grass-Spread-Tick-Rate.patch
+++ b/patches/server/0080-Configurable-Grass-Spread-Tick-Rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Grass Spread Tick Rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1471965911d9fd3bfad9c4d85607c02ec19fbf1f..1496ad80007b93255d105942fef19f4f1a069206 100644
+index 3e7a98073c86d94881e7c03786e3745db2c445cd..8dcb136f3f77bc69d5976cc17ecdafb91b5be1bc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -299,4 +299,10 @@ public class PaperWorldConfig {
+@@ -304,4 +304,10 @@ public class PaperWorldConfig {
          }
          fixedInhabitedTime = getInt("fixed-chunk-inhabited-time", -1);
      }

--- a/patches/server/0083-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/patches/server/0083-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -12,10 +12,10 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1496ad80007b93255d105942fef19f4f1a069206..f0be60905effc3489ec0050cc456ae884b2b5b90 100644
+index 8dcb136f3f77bc69d5976cc17ecdafb91b5be1bc..8381b1c9ffa5d9f28281336d5a3df4d01253dd92 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -305,4 +305,9 @@ public class PaperWorldConfig {
+@@ -310,4 +310,9 @@ public class PaperWorldConfig {
          grassUpdateRate = Math.max(0, getInt("grass-spread-tick-rate", grassUpdateRate));
          log("Grass Spread Tick Rate: " + grassUpdateRate);
      }

--- a/patches/server/0088-Add-ability-to-configure-frosted_ice-properties.patch
+++ b/patches/server/0088-Add-ability-to-configure-frosted_ice-properties.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ability to configure frosted_ice properties
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f0be60905effc3489ec0050cc456ae884b2b5b90..62437bd21994781379913e1bd3477b33cead2c18 100644
+index 8381b1c9ffa5d9f28281336d5a3df4d01253dd92..2c7cdf91288eb9a88d1d453accc87a8d77e6daac 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -310,4 +310,14 @@ public class PaperWorldConfig {
+@@ -315,4 +315,14 @@ public class PaperWorldConfig {
      private void useVanillaScoreboardColoring() {
          useVanillaScoreboardColoring = getBoolean("use-vanilla-world-scoreboard-name-coloring", false);
      }

--- a/patches/server/0091-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0091-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -11,10 +11,10 @@ This feature is good for long term worlds so that newer players
 do not suffer with "Every chest has been looted"
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 62437bd21994781379913e1bd3477b33cead2c18..929a9b775ddb10397929c2c5ce25cf03eaec4b1a 100644
+index 2c7cdf91288eb9a88d1d453accc87a8d77e6daac..a491af30f70f41e5f7b198ae4d40acfb6eec9b38 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -320,4 +320,26 @@ public class PaperWorldConfig {
+@@ -325,4 +325,26 @@ public class PaperWorldConfig {
          this.frostedIceDelayMax = this.getInt("frosted-ice.delay.max", this.frostedIceDelayMax);
          log("Frosted Ice: " + (this.frostedIceEnabled ? "enabled" : "disabled") + " / delay: min=" + this.frostedIceDelayMin + ", max=" + this.frostedIceDelayMax);
      }

--- a/patches/server/0095-Optional-TNT-doesn-t-move-in-water.patch
+++ b/patches/server/0095-Optional-TNT-doesn-t-move-in-water.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 929a9b775ddb10397929c2c5ce25cf03eaec4b1a..97b02b5a4808fc0b7fd2d2a88817716cba61054b 100644
+index a491af30f70f41e5f7b198ae4d40acfb6eec9b38..45712eb3967d61541580db57e1e9f84e6f5b9762 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -342,4 +342,14 @@ public class PaperWorldConfig {
+@@ -347,4 +347,14 @@ public class PaperWorldConfig {
              );
          }
      }

--- a/patches/server/0107-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/patches/server/0107-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 97b02b5a4808fc0b7fd2d2a88817716cba61054b..fd64a7c1ee7617285990fd5066f768f0bcf2dbcf 100644
+index 45712eb3967d61541580db57e1e9f84e6f5b9762..0b5e223594ff95b8ba7c300d4a66ca7a17e53802 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -352,4 +352,12 @@ public class PaperWorldConfig {
+@@ -357,4 +357,12 @@ public class PaperWorldConfig {
          preventTntFromMovingInWater = getBoolean("prevent-tnt-from-moving-in-water", false);
          log("Prevent TNT from moving in water: " + preventTntFromMovingInWater);
      }

--- a/patches/server/0115-Configurable-Cartographer-Treasure-Maps.patch
+++ b/patches/server/0115-Configurable-Cartographer-Treasure-Maps.patch
@@ -9,26 +9,49 @@ Also allow turning off treasure maps all together as they can eat up Map ID's
 which are limited in quantity.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fd64a7c1ee7617285990fd5066f768f0bcf2dbcf..cfe37643eea0fbff097ecf770977f9fefd94dece 100644
+index 0b5e223594ff95b8ba7c300d4a66ca7a17e53802..8451982ba4fc9522f2d77f68fc63a0e12558955f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -360,4 +360,14 @@ public class PaperWorldConfig {
+@@ -56,6 +56,11 @@ public class PaperWorldConfig {
+             set("despawn-ranges.hard", null);
+         }
+ 
++        if (this.config.isSet("world-settings.default.treasure-maps-return-already-discovered") || this.config.isSet("world-settings." + worldName + ".treasure-maps-return-already-discovered")) {
++            set("treasure-maps-return-already-discovered", null);
++            needsSave = true;
++        }
++
+         if (needsSave) {
+             saveConfig();
+         }
+@@ -365,4 +370,25 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("Spawn Egg and Armor Stand NBT filtering disabled, this is a potential security risk");
          }
      }
 +
 +    public boolean enableTreasureMaps = true;
-+    public boolean treasureMapsAlreadyDiscovered = false;
++    public boolean treasureMapsAlreadyDiscoveredVillager = false;
++    public Boolean treasureMapsAlreadyDiscoveredLootTable = null;
++    private Boolean getBooleanOrNull(String path, Boolean defaultValue) {
++        this.config.addDefault("world-settings.default." + path, defaultValue == null ? "default" : defaultValue);
++        final Object value = this.config.get("world-settings." + worldName + "." + path, this.config.get("world-settings.default." + path));
++        if (value instanceof Boolean bool) {
++            return bool;
++        }
++        return null;
++    }
 +    private void treasureMapsAlreadyDiscovered() {
 +        enableTreasureMaps = getBoolean("enable-treasure-maps", true);
-+        treasureMapsAlreadyDiscovered = getBoolean("treasure-maps-return-already-discovered", false);
-+        if (treasureMapsAlreadyDiscovered) {
-+            log("Treasure Maps will return already discovered locations");
++        if (getBoolean("treasure-maps-return-already-discovered", false, false)) {
++            treasureMapsAlreadyDiscoveredLootTable = true;
++            treasureMapsAlreadyDiscoveredVillager = true;
 +        }
++        treasureMapsAlreadyDiscoveredVillager = getBoolean("treasure-maps-find-already-discovered.villager-trade", treasureMapsAlreadyDiscoveredVillager);
++        treasureMapsAlreadyDiscoveredLootTable = getBooleanOrNull("treasure-maps-find-already-discovered.loot-tables", treasureMapsAlreadyDiscoveredLootTable);
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/npc/VillagerTrades.java b/src/main/java/net/minecraft/world/entity/npc/VillagerTrades.java
-index 7eda0af21ce7662e9bb6d47c79e175a060a8bb13..52382b5b8149351ecf981d5414a0a50025f181c7 100644
+index 7eda0af21ce7662e9bb6d47c79e175a060a8bb13..d595c82f850bb04657a86748d7e04695f934846f 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/VillagerTrades.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/VillagerTrades.java
 @@ -386,7 +386,8 @@ public class VillagerTrades {
@@ -37,12 +60,12 @@ index 7eda0af21ce7662e9bb6d47c79e175a060a8bb13..52382b5b8149351ecf981d5414a0a500
                  ServerLevel serverLevel = (ServerLevel)entity.level;
 -                BlockPos blockPos = serverLevel.findNearestMapFeature(this.destination, entity.blockPosition(), 100, true);
 +                if (!serverLevel.paperConfig.enableTreasureMaps) return null; // Paper
-+                BlockPos blockPos = serverLevel.findNearestMapFeature(this.destination, entity.blockPosition(), 100, !serverLevel.paperConfig.treasureMapsAlreadyDiscovered); // Paper
++                BlockPos blockPos = serverLevel.findNearestMapFeature(this.destination, entity.blockPosition(), 100, !serverLevel.paperConfig.treasureMapsAlreadyDiscoveredVillager); // Paper
                  if (blockPos != null) {
                      ItemStack itemStack = MapItem.create(serverLevel, blockPos.getX(), blockPos.getZ(), (byte)2, true, true);
                      MapItem.renderBiomePreviewMap(serverLevel, itemStack);
 diff --git a/src/main/java/net/minecraft/world/level/storage/loot/functions/ExplorationMapFunction.java b/src/main/java/net/minecraft/world/level/storage/loot/functions/ExplorationMapFunction.java
-index 385cae45ef8cbaf9f09472585e6f639eea3e0331..722930d400a35140542b742ae8ae1784ecfa0e33 100644
+index 385cae45ef8cbaf9f09472585e6f639eea3e0331..a84cef6a10e3d7fdcd02ef6774163785dc3c350c 100644
 --- a/src/main/java/net/minecraft/world/level/storage/loot/functions/ExplorationMapFunction.java
 +++ b/src/main/java/net/minecraft/world/level/storage/loot/functions/ExplorationMapFunction.java
 @@ -68,7 +68,16 @@ public class ExplorationMapFunction extends LootItemConditionalFunction {
@@ -59,7 +82,7 @@ index 385cae45ef8cbaf9f09472585e6f639eea3e0331..722930d400a35140542b742ae8ae1784
 +                    return stack;
 +                }
 +                // Paper end
-+                BlockPos blockPos = serverLevel.findNearestMapFeature(this.destination, new BlockPos(vec3), this.searchRadius, !serverLevel.paperConfig.treasureMapsAlreadyDiscovered && this.skipKnownStructures); // Paper
++                BlockPos blockPos = serverLevel.findNearestMapFeature(this.destination, new BlockPos(vec3), this.searchRadius, serverLevel.paperConfig.treasureMapsAlreadyDiscoveredLootTable == null ? this.skipKnownStructures : serverLevel.paperConfig.treasureMapsAlreadyDiscoveredLootTable); // Paper
                  if (blockPos != null) {
                      ItemStack itemStack = MapItem.create(serverLevel, blockPos.getX(), blockPos.getZ(), this.zoom, true, true);
                      MapItem.renderBiomePreviewMap(serverLevel, itemStack);

--- a/patches/server/0126-Cap-Entity-Collisions.patch
+++ b/patches/server/0126-Cap-Entity-Collisions.patch
@@ -12,12 +12,12 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cfe37643eea0fbff097ecf770977f9fefd94dece..9a3940e93e87a0b2b17d4a35bd71f0a40a139cea 100644
+index 8451982ba4fc9522f2d77f68fc63a0e12558955f..ee8ce0e5bdb0acb7d6ef3439a388e108ea1807de 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -370,4 +370,10 @@ public class PaperWorldConfig {
-             log("Treasure Maps will return already discovered locations");
-         }
+@@ -391,4 +391,10 @@ public class PaperWorldConfig {
+         treasureMapsAlreadyDiscoveredVillager = getBoolean("treasure-maps-find-already-discovered.villager-trade", treasureMapsAlreadyDiscoveredVillager);
+         treasureMapsAlreadyDiscoveredLootTable = getBooleanOrNull("treasure-maps-find-already-discovered.loot-tables", treasureMapsAlreadyDiscoveredLootTable);
      }
 +
 +    public int maxCollisionsPerEntity = 8;

--- a/patches/server/0131-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0131-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9a3940e93e87a0b2b17d4a35bd71f0a40a139cea..49c4d84266c000b26dac30074076057bd1e6e119 100644
+index ee8ce0e5bdb0acb7d6ef3439a388e108ea1807de..aa8a02c9fab8938e8064a60f1faf5421aab3892c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -376,4 +376,10 @@ public class PaperWorldConfig {
+@@ -397,4 +397,10 @@ public class PaperWorldConfig {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", this.maxCollisionsPerEntity, false) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }

--- a/patches/server/0134-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/patches/server/0134-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] provide a configurable option to disable creeper lingering
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 49c4d84266c000b26dac30074076057bd1e6e119..9ef33cc086fee0742ca5c3ad609fc60040e04f41 100644
+index aa8a02c9fab8938e8064a60f1faf5421aab3892c..99ce64e4d01b58d887506841451e561c2796c413 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -382,4 +382,10 @@ public class PaperWorldConfig {
+@@ -403,4 +403,10 @@ public class PaperWorldConfig {
          parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
          log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
      }

--- a/patches/server/0176-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/patches/server/0176-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggleable player crits, helps mitigate hacked clients.
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9ef33cc086fee0742ca5c3ad609fc60040e04f41..558912febee89f2626795ee2688352c738dc4b7b 100644
+index 99ce64e4d01b58d887506841451e561c2796c413..665b7f4cddfef1631ba2fad6eebeb19392cf8759 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -243,6 +243,11 @@ public class PaperWorldConfig {
+@@ -253,6 +253,11 @@ public class PaperWorldConfig {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }
  

--- a/patches/server/0188-Configurable-sprint-interruption-on-attack.patch
+++ b/patches/server/0188-Configurable-sprint-interruption-on-attack.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 558912febee89f2626795ee2688352c738dc4b7b..c795973a1d52a60f731b14b1dbfb2dc7429dc8a5 100644
+index 665b7f4cddfef1631ba2fad6eebeb19392cf8759..7dbd03897bf98ef19509972fb8d09aa071d7de3a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -393,4 +393,9 @@ public class PaperWorldConfig {
+@@ -414,4 +414,9 @@ public class PaperWorldConfig {
          disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }

--- a/patches/server/0192-Block-Enderpearl-Travel-Exploit.patch
+++ b/patches/server/0192-Block-Enderpearl-Travel-Exploit.patch
@@ -12,10 +12,10 @@ This disables that by not saving the thrower when the chunk is unloaded.
 This is mainly useful for survival servers that do not allow freeform teleporting.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c795973a1d52a60f731b14b1dbfb2dc7429dc8a5..7a25d602a016c4113cf93f58fa5dfcb8613067fe 100644
+index 7dbd03897bf98ef19509972fb8d09aa071d7de3a..0129a469d991225a0cef281e0e0eeb069fe4cfb5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -398,4 +398,10 @@ public class PaperWorldConfig {
+@@ -419,4 +419,10 @@ public class PaperWorldConfig {
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
      }

--- a/patches/server/0206-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0206-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7a25d602a016c4113cf93f58fa5dfcb8613067fe..9b2f958b70eaf44d3686c5dafc29f81fa23a8979 100644
+index 0129a469d991225a0cef281e0e0eeb069fe4cfb5..ecb00a7fb5146296fe3087b1c7eedc34e7249e2c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -404,4 +404,9 @@ public class PaperWorldConfig {
+@@ -425,4 +425,9 @@ public class PaperWorldConfig {
          disableEnderpearlExploit = getBoolean("game-mechanics.disable-unloaded-chunk-enderpearl-exploit", disableEnderpearlExploit);
          log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
      }

--- a/patches/server/0213-Add-config-to-disable-ender-dragon-legacy-check.patch
+++ b/patches/server/0213-Add-config-to-disable-ender-dragon-legacy-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config to disable ender dragon legacy check
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9b2f958b70eaf44d3686c5dafc29f81fa23a8979..e457ffae1c5c7ce3e14205af7088ed1206a6b36c 100644
+index ecb00a7fb5146296fe3087b1c7eedc34e7249e2c..f0b2c5ae854ee7f3321b2b39a3680af5c747732e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -409,4 +409,9 @@ public class PaperWorldConfig {
+@@ -430,4 +430,9 @@ public class PaperWorldConfig {
      private void shieldBlockingDelay() {
          shieldBlockingDelay = getInt("game-mechanics.shield-blocking-delay", 5);
      }

--- a/patches/server/0226-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/patches/server/0226-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e457ffae1c5c7ce3e14205af7088ed1206a6b36c..6f0d3af10905161d9359d67ac17ce32da923d447 100644
+index f0b2c5ae854ee7f3321b2b39a3680af5c747732e..7372f826b346bf684eb5987dedb4b907076ef2c0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -414,4 +414,9 @@ public class PaperWorldConfig {
+@@ -435,4 +435,9 @@ public class PaperWorldConfig {
      private void scanForLegacyEnderDragon() {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }

--- a/patches/server/0228-Allow-disabling-armour-stand-ticking.patch
+++ b/patches/server/0228-Allow-disabling-armour-stand-ticking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6f0d3af10905161d9359d67ac17ce32da923d447..ff194e8c43ba576b2dc812bae7b1ae145115bf5e 100644
+index 7372f826b346bf684eb5987dedb4b907076ef2c0..6e7eb2134186e530f31eef6f86e30e8dbf523c4d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -419,4 +419,10 @@ public class PaperWorldConfig {
+@@ -440,4 +440,10 @@ public class PaperWorldConfig {
      private void armorStandEntityLookups() {
          armorStandEntityLookups = getBoolean("armor-stands-do-collision-entity-lookups", true);
      }

--- a/patches/server/0246-Configurable-speed-for-water-flowing-over-lava.patch
+++ b/patches/server/0246-Configurable-speed-for-water-flowing-over-lava.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable speed for water flowing over lava
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ff194e8c43ba576b2dc812bae7b1ae145115bf5e..dcd64f7d4b3ad4265d82ae82fb0014ab75939161 100644
+index 6e7eb2134186e530f31eef6f86e30e8dbf523c4d..85ad9a1a29d0cb11f552d8f34b210f1bf4bdd810 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -425,4 +425,10 @@ public class PaperWorldConfig {
+@@ -446,4 +446,10 @@ public class PaperWorldConfig {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
          log("ArmorStand ticking is " + (this.armorStandTick ? "enabled" : "disabled") + " by default");
      }

--- a/patches/server/0277-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/patches/server/0277-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index dcd64f7d4b3ad4265d82ae82fb0014ab75939161..881cd17e2e9b54683941d58820b8bf0baf043f03 100644
+index 85ad9a1a29d0cb11f552d8f34b210f1bf4bdd810..0078fb8df378058a6ddeb5dbea4132c8c9c3fa64 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -431,4 +431,9 @@ public class PaperWorldConfig {
+@@ -452,4 +452,9 @@ public class PaperWorldConfig {
          waterOverLavaFlowSpeed = getInt("water-over-lava-flow-speed", 5);
          log("Water over lava flow speed: " + waterOverLavaFlowSpeed);
      }

--- a/patches/server/0323-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0323-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Keep Spawn Loaded range per world
 This lets you disable it for some worlds and lower it for others.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 881cd17e2e9b54683941d58820b8bf0baf043f03..bf85efd8ebfafe567c06b54425b9968daab6b2b1 100644
+index 0078fb8df378058a6ddeb5dbea4132c8c9c3fa64..321dedb7bea65c85aaeac338b88e85c6d453325d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -61,6 +61,12 @@ public class PaperWorldConfig {
+@@ -66,6 +66,12 @@ public class PaperWorldConfig {
          }
      }
  
@@ -20,8 +20,8 @@ index 881cd17e2e9b54683941d58820b8bf0baf043f03..bf85efd8ebfafe567c06b54425b9968d
 +    }
 +
      private boolean getBoolean(String path, boolean def) {
-         config.addDefault("world-settings.default." + path, def);
-         return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
+         return this.getBoolean(path, def, true);
+     }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index 99b4f6ad3a973e400e37d53b977e19573bdfd694..30c10b151503a1710d3adce81640bfbd727eabe0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java

--- a/patches/server/0330-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/patches/server/0330-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -17,10 +17,10 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bf85efd8ebfafe567c06b54425b9968daab6b2b1..a460aa0c7573e4e8251d902c4394b0580a3282f5 100644
+index 321dedb7bea65c85aaeac338b88e85c6d453325d..98f81bc3277096493ff0a942361bf79525000431 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -442,4 +442,15 @@ public class PaperWorldConfig {
+@@ -463,4 +463,15 @@ public class PaperWorldConfig {
      private void preventMovingIntoUnloadedChunks() {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }

--- a/patches/server/0331-Configurable-projectile-relative-velocity.patch
+++ b/patches/server/0331-Configurable-projectile-relative-velocity.patch
@@ -25,10 +25,10 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a460aa0c7573e4e8251d902c4394b0580a3282f5..c057be04a2663b6dc14c6b5bda98312a28e86e66 100644
+index 98f81bc3277096493ff0a942361bf79525000431..b230c79a830375a1d3b9262620f51039c30102ce 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -452,5 +452,10 @@ public class PaperWorldConfig {
+@@ -473,5 +473,10 @@ public class PaperWorldConfig {
              log("Using improved mob spawn limits (Only Natural Spawns impact spawn limits for more natural spawns)");
          }
      }

--- a/patches/server/0336-Add-option-to-disable-pillager-patrols.patch
+++ b/patches/server/0336-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c057be04a2663b6dc14c6b5bda98312a28e86e66..711614ec2dc4d8db4be3d1270a26286c782d1d01 100644
+index b230c79a830375a1d3b9262620f51039c30102ce..50f6eb50a20773bab78e96e9c4cbac79a5893310 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -457,5 +457,10 @@ public class PaperWorldConfig {
+@@ -478,5 +478,10 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }

--- a/patches/server/0338-Flat-bedrock-generator-settings.patch
+++ b/patches/server/0338-Flat-bedrock-generator-settings.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Flat bedrock generator settings
 Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 711614ec2dc4d8db4be3d1270a26286c782d1d01..b68d72aa17a7c5e6fefb068c99eb8d89cdf0626e 100644
+index 50f6eb50a20773bab78e96e9c4cbac79a5893310..68448d9ae6650beabcc62128772c6a18754788c4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -462,5 +462,10 @@ public class PaperWorldConfig {
+@@ -483,5 +483,10 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/patches/server/0340-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/patches/server/0340-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b68d72aa17a7c5e6fefb068c99eb8d89cdf0626e..433ec51768081e4d4a5836b8f27f581d9541f641 100644
+index 68448d9ae6650beabcc62128772c6a18754788c4..297adb65c486abccd42cdb3b042e651a767c69cf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -467,5 +467,10 @@ public class PaperWorldConfig {
+@@ -488,5 +488,10 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", this.generateFlatBedrock);
      }

--- a/patches/server/0341-Duplicate-UUID-Resolve-Option.patch
+++ b/patches/server/0341-Duplicate-UUID-Resolve-Option.patch
@@ -33,10 +33,10 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 433ec51768081e4d4a5836b8f27f581d9541f641..90dafb6056a6ca2f60a441e26f9ebfecf18f8ced 100644
+index 297adb65c486abccd42cdb3b042e651a767c69cf..ce892ab0a2f5c648c1e6f4b3d4332102ae7b8be2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -443,6 +443,45 @@ public class PaperWorldConfig {
+@@ -464,6 +464,45 @@ public class PaperWorldConfig {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }
  

--- a/patches/server/0342-Optimize-Hoppers.patch
+++ b/patches/server/0342-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 90dafb6056a6ca2f60a441e26f9ebfecf18f8ced..34c933dcd7d7adf5c9e631f8b8f60ba4d4ab53ba 100644
+index ce892ab0a2f5c648c1e6f4b3d4332102ae7b8be2..4e90cc3970c77d8a488ac8bbcbaacf78b147f8b2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -511,5 +511,17 @@ public class PaperWorldConfig {
+@@ -532,5 +532,17 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }

--- a/patches/server/0354-Increase-Light-Queue-Size.patch
+++ b/patches/server/0354-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 34c933dcd7d7adf5c9e631f8b8f60ba4d4ab53ba..763b54e0d35730186bab3fc69babd9b5f0af0cf4 100644
+index 4e90cc3970c77d8a488ac8bbcbaacf78b147f8b2..60d76eb048186d2f1bc0f1ed02741f8a2fd763b0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -523,5 +523,10 @@ public class PaperWorldConfig {
+@@ -544,5 +544,10 @@ public class PaperWorldConfig {
          hoppersIgnoreOccludingBlocks = getBoolean("hopper.ignore-occluding-blocks", hoppersIgnoreOccludingBlocks);
          log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }

--- a/patches/server/0356-Anti-Xray.patch
+++ b/patches/server/0356-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 763b54e0d35730186bab3fc69babd9b5f0af0cf4..0e5091b50b19cb2c0b491479321ac978f272c04c 100644
+index 60d76eb048186d2f1bc0f1ed02741f8a2fd763b0..9e1db210ded0830d0dcfaa34936e66bbf51fc1fc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,11 +1,13 @@
@@ -22,7 +22,7 @@ index 763b54e0d35730186bab3fc69babd9b5f0af0cf4..0e5091b50b19cb2c0b491479321ac978
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -528,5 +530,40 @@ public class PaperWorldConfig {
+@@ -549,5 +551,40 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/patches/server/0357-Implement-alternative-item-despawn-rate.patch
+++ b/patches/server/0357-Implement-alternative-item-despawn-rate.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0e5091b50b19cb2c0b491479321ac978f272c04c..91a36bf77095f6c0c0b15dbed941bc95b3fb3bfe 100644
+index 9e1db210ded0830d0dcfaa34936e66bbf51fc1fc..5918a319d34f8f30cce2f458dd061d83cd838ad0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -565,5 +565,74 @@ public class PaperWorldConfig {
+@@ -586,5 +586,74 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("You have enabled permission-based Anti-Xray checking - depending on your permission plugin, this may cause performance issues");
          }
      }

--- a/patches/server/0360-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0360-implement-optional-per-player-mob-spawns.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] implement optional per player mob spawns
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 91a36bf77095f6c0c0b15dbed941bc95b3fb3bfe..2c8feeb15c71277e2daebdba5597b7302f9d7eda 100644
+index 5918a319d34f8f30cce2f458dd061d83cd838ad0..a9b3442a49dc359959496d1f6adadefa76bfc863 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -635,4 +635,12 @@ public class PaperWorldConfig {
+@@ -656,4 +656,12 @@ public class PaperWorldConfig {
              log("Alternative item despawn rate of " + key.getPath() + ": " + altItemDespawnRateMap.get(key));
          }
      }

--- a/patches/server/0368-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0368-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2c8feeb15c71277e2daebdba5597b7302f9d7eda..90aad7af5c08968f921c8eba8bba7d677ac76584 100644
+index a9b3442a49dc359959496d1f6adadefa76bfc863..62dfb6afe204c078f579a3dae944d9350aaf72d0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -526,6 +526,11 @@ public class PaperWorldConfig {
+@@ -547,6 +547,11 @@ public class PaperWorldConfig {
          log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
  

--- a/patches/server/0372-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
+++ b/patches/server/0372-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to allow iron golems to spawn in air
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 90aad7af5c08968f921c8eba8bba7d677ac76584..78dfee9892f56adcbe7c5567a40dec6b4779d004 100644
+index 62dfb6afe204c078f579a3dae944d9350aaf72d0..82d8299d949ee26eefba2952b625650c1aca0e6a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -423,6 +423,11 @@ public class PaperWorldConfig {
+@@ -444,6 +444,11 @@ public class PaperWorldConfig {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
  

--- a/patches/server/0373-Configurable-chance-of-villager-zombie-infection.patch
+++ b/patches/server/0373-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 78dfee9892f56adcbe7c5567a40dec6b4779d004..8a78ae8481d0ede674eb9aa56b9c8d5de5f730e9 100644
+index 82d8299d949ee26eefba2952b625650c1aca0e6a..6e7699e5a725eac05de3e809ae9a45a45891892b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -536,6 +536,11 @@ public class PaperWorldConfig {
+@@ -557,6 +557,11 @@ public class PaperWorldConfig {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }
  

--- a/patches/server/0379-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/patches/server/0379-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8a78ae8481d0ede674eb9aa56b9c8d5de5f730e9..45770f3511bc2ed3da31bda195e8043a0fe29702 100644
+index 6e7699e5a725eac05de3e809ae9a45a45891892b..07a912cd9f7af3464ecd0de1d789fdcd8c56f86d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -505,8 +505,18 @@ public class PaperWorldConfig {
+@@ -526,8 +526,18 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;

--- a/patches/server/0404-Add-phantom-creative-and-insomniac-controls.patch
+++ b/patches/server/0404-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 45770f3511bc2ed3da31bda195e8043a0fe29702..c16233c8cabab2efca9846988c5c843aa9441133 100644
+index 07a912cd9f7af3464ecd0de1d789fdcd8c56f86d..a8dd2a9beb48f464033c812d99c197332175fc09 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -668,4 +668,11 @@ public class PaperWorldConfig {
+@@ -689,4 +689,11 @@ public class PaperWorldConfig {
          }
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", true);
      }

--- a/patches/server/0416-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0416-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c16233c8cabab2efca9846988c5c843aa9441133..fcd5d4e54f339b3435888a2e9842f64aec46170f 100644
+index a8dd2a9beb48f464033c812d99c197332175fc09..ffe0ee1bd44d47abbe6b94aadab9ee7eca7c7612 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -675,4 +675,10 @@ public class PaperWorldConfig {
+@@ -696,4 +696,10 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }

--- a/patches/server/0431-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/patches/server/0431-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fcd5d4e54f339b3435888a2e9842f64aec46170f..634affda96921a5453f89ddcc72fc482b162a085 100644
+index ffe0ee1bd44d47abbe6b94aadab9ee7eca7c7612..7839ee18955725463fa420a19927019f9814ee24 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -681,4 +681,13 @@ public class PaperWorldConfig {
+@@ -702,4 +702,13 @@ public class PaperWorldConfig {
          expMergeMaxValue = getInt("experience-merge-max-value", -1);
          log("Experience Merge Max Value: " + expMergeMaxValue);
      }

--- a/patches/server/0452-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0452-incremental-chunk-and-player-saving.patch
@@ -24,10 +24,10 @@ index c639557108ad9c59ccdd0b543b5507fbab1e0fa4..5e531f9fc67bd3092b39f1d3b46b9490
 +    }
  }
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 634affda96921a5453f89ddcc72fc482b162a085..0167b3f0c3f52f540edc381e532d777b90279201 100644
+index 7839ee18955725463fa420a19927019f9814ee24..536fc6bf1451ea84af6084b1976eee32bf328ab0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -69,6 +69,21 @@ public class PaperWorldConfig {
+@@ -74,6 +74,21 @@ public class PaperWorldConfig {
          log( "Keep Spawn Loaded Range: " + (keepLoadedRange/16));
      }
  
@@ -47,8 +47,8 @@ index 634affda96921a5453f89ddcc72fc482b162a085..0167b3f0c3f52f540edc381e532d777b
 +    }
 +
      private boolean getBoolean(String path, boolean def) {
-         config.addDefault("world-settings.default." + path, def);
-         return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
+         return this.getBoolean(path, def, true);
+     }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index f85ee370c89b59ad58f182da2ff6d0d11c6e3a8b..5edb1f4be4d0306a22827d1330a08251e5cb1fbe 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java

--- a/patches/server/0489-Add-zombie-targets-turtle-egg-config.patch
+++ b/patches/server/0489-Add-zombie-targets-turtle-egg-config.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add zombie targets turtle egg config
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0167b3f0c3f52f540edc381e532d777b90279201..d6976656f10707da25e4b4ce51893d2d1bf80f2e 100644
+index 536fc6bf1451ea84af6084b1976eee32bf328ab0..12a77caa7899bc6d000d48d13a504476c3f125ab 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -63,6 +63,11 @@ public class PaperWorldConfig {
+@@ -68,6 +68,11 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0491-Eigencraft-redstone-implementation.patch
+++ b/patches/server/0491-Eigencraft-redstone-implementation.patch
@@ -19,10 +19,10 @@ Aside from making the obvious class/function renames and obfhelpers I didn't nee
 Just added Bukkit's event system and took a few liberties with dead code and comment misspellings.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d6976656f10707da25e4b4ce51893d2d1bf80f2e..cc54f13a59463dd4b40b0808086fa3c9f2ecf2b3 100644
+index 12a77caa7899bc6d000d48d13a504476c3f125ab..34754f8d3cc03a93d148d026780eacc7dc0a20e0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -68,6 +68,40 @@ public class PaperWorldConfig {
+@@ -73,6 +73,40 @@ public class PaperWorldConfig {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }
  

--- a/patches/server/0522-Toggle-for-removing-existing-dragon.patch
+++ b/patches/server/0522-Toggle-for-removing-existing-dragon.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggle for removing existing dragon
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cc54f13a59463dd4b40b0808086fa3c9f2ecf2b3..f0e9a8664e5d36b8adb98a0afd9de9edff7f9e6a 100644
+index 34754f8d3cc03a93d148d026780eacc7dc0a20e0..6d89bc4804dc0b23ab86b93a6ad030e1e633d61c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -102,6 +102,14 @@ public class PaperWorldConfig {
+@@ -107,6 +107,14 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0528-Add-Wandering-Trader-spawn-rate-config-options.patch
+++ b/patches/server/0528-Add-Wandering-Trader-spawn-rate-config-options.patch
@@ -11,10 +11,10 @@ in IWorldServerData are removed as they were only used in certain places, with h
 values used in other places.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f0e9a8664e5d36b8adb98a0afd9de9edff7f9e6a..789a92e4e2d586e6cd4c71e8ce72429b16141f08 100644
+index 6d89bc4804dc0b23ab86b93a6ad030e1e633d61c..9147b408b35b7d15ced3749e34706087d2cdffd8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -110,6 +110,19 @@ public class PaperWorldConfig {
+@@ -115,6 +115,19 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0536-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0536-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 789a92e4e2d586e6cd4c71e8ce72429b16141f08..7a61a46fdfbd597ed6d76f8142c8159e05eba1d3 100644
+index 9147b408b35b7d15ced3749e34706087d2cdffd8..340e610b6af2dab7d916c530d3cce9aac003aa4d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -123,6 +123,11 @@ public class PaperWorldConfig {
+@@ -128,6 +128,11 @@ public class PaperWorldConfig {
          wanderingTraderSpawnChanceMax = getInt("wandering-trader.spawn-chance-max", wanderingTraderSpawnChanceMax);
      }
  

--- a/patches/server/0539-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/patches/server/0539-Fix-curing-zombie-villager-discount-exploit.patch
@@ -8,10 +8,10 @@ and curing a villager on repeat by simply resetting the relevant part of
 the reputation when it is cured.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7a61a46fdfbd597ed6d76f8142c8159e05eba1d3..99730237e0e447159282b70a179bc9cb44e538ea 100644
+index 340e610b6af2dab7d916c530d3cce9aac003aa4d..d6cbd9ea2eb70e25a5e37e0bdda2396a99b3342e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -128,6 +128,11 @@ public class PaperWorldConfig {
+@@ -133,6 +133,11 @@ public class PaperWorldConfig {
          fixClimbingBypassingCrammingRule = getBoolean("fix-climbing-bypassing-cramming-rule", fixClimbingBypassingCrammingRule);
      }
  

--- a/patches/server/0554-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
+++ b/patches/server/0554-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling mob spawner spawn egg transformation
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 99730237e0e447159282b70a179bc9cb44e538ea..163307c9cf8893282375a3dfa81f4c68c7561b3b 100644
+index d6cbd9ea2eb70e25a5e37e0bdda2396a99b3342e..5fe4d2005e87a7b69e98dcd68e0fff3cc26a8c96 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -133,6 +133,11 @@ public class PaperWorldConfig {
+@@ -138,6 +138,11 @@ public class PaperWorldConfig {
          fixCuringZombieVillagerDiscountExploit = getBoolean("game-mechanics.fix-curing-zombie-villager-discount-exploit", fixCuringZombieVillagerDiscountExploit);
      }
  

--- a/patches/server/0564-Added-world-settings-for-mobs-picking-up-loot.patch
+++ b/patches/server/0564-Added-world-settings-for-mobs-picking-up-loot.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added world settings for mobs picking up loot
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 163307c9cf8893282375a3dfa81f4c68c7561b3b..bd28bbab098441bdede682c6b269c1d19a2dd062 100644
+index 5fe4d2005e87a7b69e98dcd68e0fff3cc26a8c96..f4559f3bc7751da48a84d75a949c9df298ee48b4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -766,6 +766,14 @@ public class PaperWorldConfig {
+@@ -787,6 +787,14 @@ public class PaperWorldConfig {
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }
  

--- a/patches/server/0568-Configurable-door-breaking-difficulty.patch
+++ b/patches/server/0568-Configurable-door-breaking-difficulty.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable door breaking difficulty
 Co-authored-by: Doc <nachito94@msn.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bd28bbab098441bdede682c6b269c1d19a2dd062..13fc7c21283f09fd135a12649776bb1355da4154 100644
+index f4559f3bc7751da48a84d75a949c9df298ee48b4..96fd9803810db0f8a4b25e070a56da05862e1e4e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -137,6 +137,27 @@ public class PaperWorldConfig {
+@@ -142,6 +142,27 @@ public class PaperWorldConfig {
      private void disableMobSpawnerSpawnEggTransformation() {
          disableMobSpawnerSpawnEggTransformation = getBoolean("game-mechanics.disable-mob-spawner-spawn-egg-transformation", disableMobSpawnerSpawnEggTransformation);
      }

--- a/patches/server/0576-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0576-Collision-option-for-requiring-a-player-participant.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index 13fc7c21283f09fd135a12649776bb1355da4154..0bd01fb0582c27890fa94ed779103fa75472b482 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -110,6 +110,18 @@ public class PaperWorldConfig {
+@@ -115,6 +115,18 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0580-Configurable-max-leash-distance.patch
+++ b/patches/server/0580-Configurable-max-leash-distance.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index 0bd01fb0582c27890fa94ed779103fa75472b482..ede5c95818c6021d2317a9c7b181d0b6f1b4b7b7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -332,6 +332,12 @@ public class PaperWorldConfig {
+@@ -342,6 +342,12 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0583-Add-toggle-for-always-placing-the-dragon-egg.patch
+++ b/patches/server/0583-Add-toggle-for-always-placing-the-dragon-egg.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index ede5c95818c6021d2317a9c7b181d0b6f1b4b7b7..247d2d2c938394b4aa0d02c89ee2f7e68876ce3f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -798,6 +798,11 @@ public class PaperWorldConfig {
+@@ -819,6 +819,11 @@ public class PaperWorldConfig {
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", true);
      }
  

--- a/patches/server/0589-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/patches/server/0589-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index 247d2d2c938394b4aa0d02c89ee2f7e68876ce3f..09e8305cee635c1fb0b490de531eee79d9b15137 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -803,6 +803,11 @@ public class PaperWorldConfig {
+@@ -824,6 +824,11 @@ public class PaperWorldConfig {
          enderDragonsDeathAlwaysPlacesDragonEgg = getBoolean("ender-dragons-death-always-places-dragon-egg", enderDragonsDeathAlwaysPlacesDragonEgg);
      }
  

--- a/patches/server/0608-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0608-Allow-using-signs-inside-spawn-protection.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index 09e8305cee635c1fb0b490de531eee79d9b15137..cea095aae3f9ba4ed8be88282d48925ad667f0d9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -837,4 +837,9 @@ public class PaperWorldConfig {
+@@ -858,4 +858,9 @@ public class PaperWorldConfig {
              delayChunkUnloadsBy *= 20;
          }
      }

--- a/patches/server/0617-Entity-load-save-limit-per-chunk.patch
+++ b/patches/server/0617-Entity-load-save-limit-per-chunk.patch
@@ -21,7 +21,7 @@ index cea095aae3f9ba4ed8be88282d48925ad667f0d9..80840cd2d2c74e6778df2cd2082b5318
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -171,6 +173,38 @@ public class PaperWorldConfig {
+@@ -176,6 +178,38 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0659-Limit-item-frame-cursors-on-maps.patch
+++ b/patches/server/0659-Limit-item-frame-cursors-on-maps.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index 80840cd2d2c74e6778df2cd2082b5318e273ad3a..a39819cef95fc70c5703b392afd5530ce6e3a622 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -876,4 +876,9 @@ public class PaperWorldConfig {
+@@ -897,4 +897,9 @@ public class PaperWorldConfig {
      private void allowUsingSignsInsideSpawnProtection() {
          allowUsingSignsInsideSpawnProtection = getBoolean("allow-using-signs-inside-spawn-protection", allowUsingSignsInsideSpawnProtection);
      }

--- a/patches/server/0664-Add-option-to-fix-items-merging-through-walls.patch
+++ b/patches/server/0664-Add-option-to-fix-items-merging-through-walls.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index a39819cef95fc70c5703b392afd5530ce6e3a622..306013994f397ba855acbd4e1aba791850b8d78b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -881,4 +881,9 @@ public class PaperWorldConfig {
+@@ -902,4 +902,9 @@ public class PaperWorldConfig {
      private void mapItemFrameCursorLimit() {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }

--- a/patches/server/0666-Fix-invulnerable-end-crystals.patch
+++ b/patches/server/0666-Fix-invulnerable-end-crystals.patch
@@ -9,7 +9,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index 306013994f397ba855acbd4e1aba791850b8d78b..ccbd0bd60cbc1212d9683667ce4744350eda90bb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -886,4 +886,9 @@ public class PaperWorldConfig {
+@@ -907,4 +907,9 @@ public class PaperWorldConfig {
      private void fixItemsMergingThroughWalls() {
          fixItemsMergingThroughWalls = getBoolean("fix-items-merging-through-walls", fixItemsMergingThroughWalls);
      }

--- a/patches/server/0672-add-per-world-spawn-limits.patch
+++ b/patches/server/0672-add-per-world-spawn-limits.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] add per world spawn limits
 Taken from #2982. Credit to Chasewhip8
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ccbd0bd60cbc1212d9683667ce4744350eda90bb..1f74b1b2fc9ecfbb83710665ef0171886eab0097 100644
+index b68c2f46c7b595fe860f609b5681524ba310003e..1ae2e1599cb5b8612ca5b45c37367377d7f26dbf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -58,6 +58,11 @@ public class PaperWorldConfig {
@@ -20,8 +20,8 @@ index ccbd0bd60cbc1212d9683667ce4744350eda90bb..1f74b1b2fc9ecfbb83710665ef017188
 +            set("spawn-limits.water-ambient", null);
          }
  
-         if (needsSave) {
-@@ -714,6 +719,21 @@ public class PaperWorldConfig {
+         if (this.config.isSet("world-settings.default.treasure-maps-return-already-discovered") || this.config.isSet("world-settings." + worldName + ".treasure-maps-return-already-discovered")) {
+@@ -735,6 +740,21 @@ public class PaperWorldConfig {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }
  

--- a/patches/server/0680-Fix-commands-from-signs-not-firing-command-events.patch
+++ b/patches/server/0680-Fix-commands-from-signs-not-firing-command-events.patch
@@ -13,7 +13,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index 1f74b1b2fc9ecfbb83710665ef0171886eab0097..c651c8750f357883c6e92b6a19e087090c4b324a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -911,4 +911,9 @@ public class PaperWorldConfig {
+@@ -932,4 +932,9 @@ public class PaperWorldConfig {
      private void fixInvulnerableEndCrystalExploit() {
          fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
      }

--- a/patches/server/0683-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0683-Add-config-for-mobs-immune-to-default-effects.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index c651c8750f357883c6e92b6a19e087090c4b324a..f7ce18d165733329e7c656885cf5ed1b06d35a47 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -709,6 +709,21 @@ public class PaperWorldConfig {
+@@ -730,6 +730,21 @@ public class PaperWorldConfig {
          log("Hopper Ignore Container Entities inside Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
  

--- a/patches/server/0685-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0685-Don-t-apply-cramming-damage-to-players.patch
@@ -14,7 +14,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index f7ce18d165733329e7c656885cf5ed1b06d35a47..40b3c6ef824e96747d3c01129e4dbaaaa3d3613a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -931,4 +931,9 @@ public class PaperWorldConfig {
+@@ -952,4 +952,9 @@ public class PaperWorldConfig {
      private void showSignClickCommandFailureMessagesToPlayer() {
          showSignClickCommandFailureMessagesToPlayer = getBoolean("show-sign-click-command-failure-msgs-to-player", showSignClickCommandFailureMessagesToPlayer);
      }

--- a/patches/server/0686-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0686-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,7 +28,7 @@ index b47b7dce26805badd422c1867733ff4bfd00e9f4..b27021a42cbed3f0648a8d0903d00d03
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 40b3c6ef824e96747d3c01129e4dbaaaa3d3613a..3dc62c72e9d3db93d3e118814cfada6c275b8e3f 100644
+index b05b400dbee7963c48478368bd4950f2910b69bc..d1a00ef7ef9ffe4f474ce3d5513df912faacf871 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -9,8 +9,10 @@ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
@@ -42,7 +42,7 @@ index 40b3c6ef824e96747d3c01129e4dbaaaa3d3613a..3dc62c72e9d3db93d3e118814cfada6c
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -936,4 +938,57 @@ public class PaperWorldConfig {
+@@ -957,4 +959,57 @@ public class PaperWorldConfig {
      private void playerCrammingDamage() {
          allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
      }

--- a/patches/server/0699-Config-option-for-Piglins-guarding-chests.patch
+++ b/patches/server/0699-Config-option-for-Piglins-guarding-chests.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index 3dc62c72e9d3db93d3e118814cfada6c275b8e3f..68982f44fac2a3da621503cffb7921498a6f8666 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -77,6 +77,11 @@ public class PaperWorldConfig {
+@@ -82,6 +82,11 @@ public class PaperWorldConfig {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }
  

--- a/patches/server/0703-Configurable-item-frame-map-cursor-update-interval.patch
+++ b/patches/server/0703-Configurable-item-frame-map-cursor-update-interval.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/m
 index 68982f44fac2a3da621503cffb7921498a6f8666..4b84f633e647db439ad9390b963de6af543c8d83 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -924,6 +924,11 @@ public class PaperWorldConfig {
+@@ -945,6 +945,11 @@ public class PaperWorldConfig {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }
  

--- a/patches/server/0784-Preserve-overstacked-loot.patch
+++ b/patches/server/0784-Preserve-overstacked-loot.patch
@@ -10,10 +10,10 @@ chunk bans via the large amount of NBT created by unstacking the items.
 Fixes GH-5140 and GH-4748.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4b84f633e647db439ad9390b963de6af543c8d83..bd3a33e191ff2583ef7a658a0e198e11362b7e38 100644
+index a3e25ebe096a687de0b63f9618c49198ebea2074..98bcdc50770d9ebd5a07b20f872cfc7ef78daa94 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -949,6 +949,11 @@ public class PaperWorldConfig {
+@@ -970,6 +970,11 @@ public class PaperWorldConfig {
          allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
      }
  

--- a/patches/server/0790-Configurable-feature-seeds.patch
+++ b/patches/server/0790-Configurable-feature-seeds.patch
@@ -19,10 +19,10 @@ index 4092a227a540a1c5cfb95efcc2a36e049b9a979c..e2f60115370f19e935eb3b14d5de99aa
              }
              final Object val = config.get(key);
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bd3a33e191ff2583ef7a658a0e198e11362b7e38..01f25f5b87b986075f3100ff930cf492bc28ccd9 100644
+index 98bcdc50770d9ebd5a07b20f872cfc7ef78daa94..409cffcf74b32beba09b2fe800d1329ee64426f8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -994,6 +994,55 @@ public class PaperWorldConfig {
+@@ -1015,6 +1015,55 @@ public class PaperWorldConfig {
          return table;
      }
  

--- a/patches/server/0801-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0801-Hide-unnecessary-itemmeta-from-clients.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Hide unnecessary itemmeta from clients
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 01f25f5b87b986075f3100ff930cf492bc28ccd9..0bae3add15f81c31e0f42dc4eb9a2c4164dcde44 100644
+index 409cffcf74b32beba09b2fe800d1329ee64426f8..99008ac6943c56f74f912e739709a4724da322ef 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -964,6 +964,13 @@ public class PaperWorldConfig {
+@@ -985,6 +985,13 @@ public class PaperWorldConfig {
          behaviorTickRates = loadTickRates("behavior");
      }
  

--- a/patches/server/0822-Configurable-max-block-light-for-monster-spawning.patch
+++ b/patches/server/0822-Configurable-max-block-light-for-monster-spawning.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable max block light for monster spawning
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0bae3add15f81c31e0f42dc4eb9a2c4164dcde44..1161f91ad09fa5b9a769bea1e80a7edb5da76fcf 100644
+index 99008ac6943c56f74f912e739709a4724da322ef..b2d9dbf4e006899a932bd6bed40228d4f744d865 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -1062,4 +1062,9 @@ public class PaperWorldConfig {
+@@ -1083,4 +1083,9 @@ public class PaperWorldConfig {
          Integer rate = table.get(columnKey, rowKey);
          return rate != null && rate > -1 ? rate : def;
      }

--- a/patches/server/0831-Make-water-animal-spawn-height-configurable.patch
+++ b/patches/server/0831-Make-water-animal-spawn-height-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make water animal spawn height configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1161f91ad09fa5b9a769bea1e80a7edb5da76fcf..6ad81087e1ca9c6d7420443318c50bebba451c76 100644
+index b2d9dbf4e006899a932bd6bed40228d4f744d865..100de7e366c4ea8ce158b0fc0258e4db0ee83249 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -416,6 +416,24 @@ public class PaperWorldConfig {
+@@ -426,6 +426,24 @@ public class PaperWorldConfig {
          mobSpawnerTickRate = getInt("mob-spawner-tick-rate", 1);
      }
  

--- a/patches/server/0837-Add-configurable-height-for-slime-spawn.patch
+++ b/patches/server/0837-Add-configurable-height-for-slime-spawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable height for slime spawn
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6ad81087e1ca9c6d7420443318c50bebba451c76..3bec90dbf3456416d10e2234f4848122110f5c21 100644
+index 100de7e366c4ea8ce158b0fc0258e4db0ee83249..b13d4dc311f25f9d3132697381e52beb06122b30 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -454,6 +454,16 @@ public class PaperWorldConfig {
+@@ -464,6 +464,16 @@ public class PaperWorldConfig {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }
  

--- a/patches/server/0904-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/0904-Add-Alternate-Current-redstone-implementation.patch
@@ -1831,10 +1831,10 @@ index 0000000000000000000000000000000000000000..6b5bffd288e2f815d8c3788e73530e69
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3bec90dbf3456416d10e2234f4848122110f5c21..fba36a0fd7036ba516e14c8d3521b470b0df17d1 100644
+index b13d4dc311f25f9d3132697381e52beb06122b30..1fa17557091e430559ed7645090b26a0bcb2c8fc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -83,7 +83,7 @@ public class PaperWorldConfig {
+@@ -88,7 +88,7 @@ public class PaperWorldConfig {
      }
  
      public enum RedstoneImplementation {
@@ -1843,7 +1843,7 @@ index 3bec90dbf3456416d10e2234f4848122110f5c21..fba36a0fd7036ba516e14c8d3521b470
      }
      public RedstoneImplementation redstoneImplementation = RedstoneImplementation.VANILLA;
      private void redstoneImplementation() {
-@@ -104,7 +104,7 @@ public class PaperWorldConfig {
+@@ -109,7 +109,7 @@ public class PaperWorldConfig {
          }
          switch (implementation) {
              default:
@@ -1852,7 +1852,7 @@ index 3bec90dbf3456416d10e2234f4848122110f5c21..fba36a0fd7036ba516e14c8d3521b470
              case "vanilla":
                  redstoneImplementation = RedstoneImplementation.VANILLA;
                  log("Using the Vanilla redstone implementation.");
-@@ -113,6 +113,10 @@ public class PaperWorldConfig {
+@@ -118,6 +118,10 @@ public class PaperWorldConfig {
                  redstoneImplementation = RedstoneImplementation.EIGENCRAFT;
                  log("Using Eigencraft's redstone implementation by theosib.");
                  break;


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/7349

Splits the setting into 2 settings, one true or false (for villager trades), and one true, false, or "default" since that is configurable on a per-loot-table basis via datapacks.