### PR TITLE
Remove unneeded UOE when copying biome sources

### DIFF
--- a/patches/server/0006-CB-fixes.patch
+++ b/patches/server/0006-CB-fixes.patch
@@ -10,6 +10,8 @@ Subject: [PATCH] CB fixes
 
 * Fixed method signature of Marker#addPassenger
 
+* Removed unneeded UOE in CustomWorldChunkManager (extends BiomeSource)
+
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
 index a480e20ac456a3169c67d2d43c191b7807a8ef10..1427b76110a02cee15865173e06e7b7bb4231ae7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
@@ -39,7 +41,7 @@ index aef33a96cf8df9400cc60285ef1f7c5ded03b495..059c4c3b59f66ea2b2b23fe1eb106bf9
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/structure/StructureCheck.java b/src/main/java/net/minecraft/world/level/levelgen/structure/StructureCheck.java
-index 5862fd38fb2a5aeec0a63d001cc043aac62188bb..22e3ac8c5df5592e31ef3f00f102aa3a25e794b4 100644
+index ac1373b8c4411298f881f9d569bf984704eeadc4..469d3d7fb69829595abd221c700fcf79d2c42fd0 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/structure/StructureCheck.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/structure/StructureCheck.java
 @@ -45,7 +45,7 @@ public class StructureCheck {
@@ -60,6 +62,20 @@ index 5862fd38fb2a5aeec0a63d001cc043aac62188bb..22e3ac8c5df5592e31ef3f00f102aa3a
          this.storageAccess = chunkIoWorker;
          this.registryAccess = registryManager;
          this.structureManager = structureManager;
+diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CustomWorldChunkManager.java b/src/main/java/org/bukkit/craftbukkit/generator/CustomWorldChunkManager.java
+index 6f1855d1fed73b694b0eaf581231359a66ae48e2..0238db9d5ffebe597534ec283f173ee2da19946d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/generator/CustomWorldChunkManager.java
++++ b/src/main/java/org/bukkit/craftbukkit/generator/CustomWorldChunkManager.java
+@@ -45,8 +45,7 @@ public class CustomWorldChunkManager extends BiomeSource {
+ 
+     @Override
+     public BiomeSource withSeed(long seed) {
+-        // TODO check method further
+-        throw new UnsupportedOperationException("Cannot copy CustomWorldChunkManager");
++        return this; // Paper - Since this doesn't take a seed, no need to throw UOE
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java b/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
 index c93eec7a81ed83dc9190417dd51acb2780d3b60d..70d3949616c63038ad3e9bd1069db5ea2fb3f3b8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java


### PR DESCRIPTION
This UOE would probably just caused unnecessary trouble when trying to copy a chunk generator that uses this custom biome source. All other impls of BiomeSource except the end, just return this. The end returns a new instance because it actually uses a seed where the others don't. It should be safe to just return the same instance.