### PR TITLE
Move some methods to RegionAccessor

### DIFF
--- a/patches/api/0215-Add-moon-phase-API.patch
+++ b/patches/api/0215-Add-moon-phase-API.patch
@@ -46,20 +46,20 @@ index 0000000000000000000000000000000000000000..df05153397b42930cd53d37b30824c7e
 +        return BY_DAY.get(day % 8L);
 +    }
 +}
-diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index fe2b9b88ad854f29e9162a316ca952b9f0b38121..85c1f5b33e933b23946cad3c5ad37cc350ee5d3c 100644
---- a/src/main/java/org/bukkit/World.java
-+++ b/src/main/java/org/bukkit/World.java
-@@ -70,6 +70,12 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
-      * @return The amount of Players in this world
+diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
+index e55f6e2baf35dbd91c433ab9e62713eaac85435b..2fa3de66107162ccaa158b369e2c4a926ecaff92 100644
+--- a/src/main/java/org/bukkit/RegionAccessor.java
++++ b/src/main/java/org/bukkit/RegionAccessor.java
+@@ -376,4 +376,12 @@ public interface RegionAccessor {
       */
-     int getPlayerCount();
+     @NotNull
+     public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz, boolean randomizeData, @Nullable Consumer<T> function) throws IllegalArgumentException;
 +
++    // Paper start
 +    /**
 +     * @return the current moon phase at the current time in the world
 +     */
 +    @NotNull
 +    io.papermc.paper.world.MoonPhase getMoonPhase();
-     // Paper end
- 
-     /**
++    // Paper end
+ }

--- a/patches/api/0276-Expand-world-key-API.patch
+++ b/patches/api/0276-Expand-world-key-API.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Wed, 6 Jan 2021 00:34:10 -0800
-Subject: [PATCH] Add methods to get world by key
+Subject: [PATCH] Expand world key API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 8072924c977e0a23ee743ca8d613b9ea5de885fa..c7fe6865e1a14116b61ae69c26d4af2d8af11955 100644
+index 37a295b2bbf7127713e19f224e788e0adb8823f4..3a2137c6505ef0e14875f7eaa7809509750fb625 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -791,6 +791,18 @@ public final class Bukkit {
@@ -27,6 +27,34 @@ index 8072924c977e0a23ee743ca8d613b9ea5de885fa..c7fe6865e1a14116b61ae69c26d4af2d
  
      /**
       * Create a new virtual {@link WorldBorder}.
+diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
+index 2fa3de66107162ccaa158b369e2c4a926ecaff92..aa534b1a9a1fb84a2fbd4b372f313bb4b63325fa 100644
+--- a/src/main/java/org/bukkit/RegionAccessor.java
++++ b/src/main/java/org/bukkit/RegionAccessor.java
+@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
+  * A RegionAccessor gives access to getting, modifying and spawning {@link Biome}, {@link BlockState} and {@link Entity},
+  * as well as generating some basic structures.
+  */
+-public interface RegionAccessor {
++public interface RegionAccessor extends Keyed { // Paper
+ 
+     /**
+      * Gets the {@link Biome} at the given {@link Location}.
+@@ -383,5 +383,14 @@ public interface RegionAccessor {
+      */
+     @NotNull
+     io.papermc.paper.world.MoonPhase getMoonPhase();
++
++    /**
++     * Get the world's key
++     *
++     * @return the world's key
++     */
++    @NotNull
++    @Override
++    NamespacedKey getKey();
+     // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
 index afed6bcf923166065ac9f63dd96191cd42eefcb9..181493def187f72b6ff89c3849598428f35d31f3 100644
 --- a/src/main/java/org/bukkit/Server.java

--- a/patches/api/0284-More-World-API.patch
+++ b/patches/api/0284-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index c31c58ea83845ef032bc477e33aa94713454f194..7a519e242a6fb2de41fd1e9cd6e7a237f78ef004 100644
+index f463450c35e6fbba95c57a3a27192b667cb9e093..6864f71977196a2d8b685da5ea9ddc435ae5bc06 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3639,6 +3639,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3633,6 +3633,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public Location locateNearestStructure(@NotNull Location origin, @NotNull StructureType structureType, int radius, boolean findUnexplored);
  

--- a/patches/api/0310-Add-more-line-of-sight-methods.patch
+++ b/patches/api/0310-Add-more-line-of-sight-methods.patch
@@ -4,14 +4,14 @@ Date: Sat, 29 May 2021 14:33:18 -0500
 Subject: [PATCH] Add more line of sight methods
 
 
-diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index def9f0f9803e71cbe57abcffeb9114a5ab462e54..d149dd1d3d2703a428006e0c3ab5f9251e560882 100644
---- a/src/main/java/org/bukkit/World.java
-+++ b/src/main/java/org/bukkit/World.java
-@@ -76,6 +76,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
-      */
+diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
+index aa534b1a9a1fb84a2fbd4b372f313bb4b63325fa..43b53c21af01e0f496c8aaacff82dfdfadaf40f6 100644
+--- a/src/main/java/org/bukkit/RegionAccessor.java
++++ b/src/main/java/org/bukkit/RegionAccessor.java
+@@ -392,5 +392,13 @@ public interface RegionAccessor extends Keyed { // Paper
      @NotNull
-     io.papermc.paper.world.MoonPhase getMoonPhase();
+     @Override
+     NamespacedKey getKey();
 +
 +    /**
 +     * Tell whether a line of sight exists between the given locations
@@ -21,8 +21,7 @@ index def9f0f9803e71cbe57abcffeb9114a5ab462e54..d149dd1d3d2703a428006e0c3ab5f925
 +     */
 +    public boolean lineOfSightExists(@NotNull Location from, @NotNull Location to);
      // Paper end
- 
-     /**
+ }
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
 index 330eab77547ae059f716418f71ad1d3391a57a9b..cda05df6784dd4d6a09710a416dcb71c016dabfc 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java

--- a/patches/api/0330-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/api/0330-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 4b4b286e9373da2624a29e17df7e54f5e47c3f7d..2007e09322624184ea35186a9b1c2ee80294a38f 100644
+index 6864f71977196a2d8b685da5ea9ddc435ae5bc06..6b8b26305dfd9b2b4e3b3e2c6ab48e0dda2864e1 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -760,6 +760,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -746,6 +746,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public LightningStrike strikeLightningEffect(@NotNull Location loc);
  

--- a/patches/api/0365-Implement-regenerateChunk.patch
+++ b/patches/api/0365-Implement-regenerateChunk.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement regenerateChunk
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 887ad76c3ea44f0dcfcd21f30c0883e023f1ac3a..3421be8309c9083c0aaa80afec13c8acc4fc85dd 100644
+index 6b8b26305dfd9b2b4e3b3e2c6ab48e0dda2864e1..7ad1cabe05277c1f3238da6e121c35d8a9f0d952 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -509,8 +509,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -495,8 +495,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return Whether the chunk was actually regenerated
       *
       * @deprecated regenerating a single chunk is not likely to produce the same

--- a/patches/api/0374-Add-getComputedBiome-API.patch
+++ b/patches/api/0374-Add-getComputedBiome-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getComputedBiome API
 
 
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index e55f6e2baf35dbd91c433ab9e62713eaac85435b..1d7560a3b2de23e16486608f3785a5dccc296158 100644
+index 43b53c21af01e0f496c8aaacff82dfdfadaf40f6..3f7e860de4e28745fcdf8d2f41f4a8c210f48909 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
-@@ -26,6 +26,7 @@ public interface RegionAccessor {
+@@ -26,6 +26,7 @@ public interface RegionAccessor extends Keyed { // Paper
       *
       * @param location the location of the biome
       * @return Biome at the given location
@@ -16,7 +16,7 @@ index e55f6e2baf35dbd91c433ab9e62713eaac85435b..1d7560a3b2de23e16486608f3785a5dc
       */
      @NotNull
      Biome getBiome(@NotNull Location location);
-@@ -37,10 +38,33 @@ public interface RegionAccessor {
+@@ -37,10 +38,33 @@ public interface RegionAccessor extends Keyed { // Paper
       * @param y Y-coordinate of the block
       * @param z Z-coordinate of the block
       * @return Biome at the given coordinates

--- a/patches/server/0485-Add-moon-phase-API.patch
+++ b/patches/server/0485-Add-moon-phase-API.patch
@@ -4,19 +4,19 @@ Date: Sun, 23 Aug 2020 16:32:11 +0200
 Subject: [PATCH] Add moon phase API
 
 
-diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f7d5c6aa18ee44e0a6651ed73c922a973bb809b3..c39d5dd9602fe35b4936f01089a3b2048ef0c9bf 100644
---- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-+++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -195,6 +195,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-     public int getPlayerCount() {
-         return world.players().size();
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+index 9d247664e5867a31376b3681b7ed0c3404ea46d8..89f75b79e8501097d2411b12ae79bb073cadba7a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+@@ -907,4 +907,11 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+ 
+         throw new IllegalArgumentException("Cannot spawn an entity for " + clazz.getName());
      }
 +
++    // Paper start
 +    @Override
 +    public io.papermc.paper.world.MoonPhase getMoonPhase() {
-+        return io.papermc.paper.world.MoonPhase.getPhase(getFullTime() / 24000L);
++        return io.papermc.paper.world.MoonPhase.getPhase(this.getHandle().dayTime() / 24000L);
 +    }
-     // Paper end
- 
-     private static final Random rand = new Random();
++    // Paper end
+ }

--- a/patches/server/0562-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0562-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 74e10d581f8c1b0b026d8f940194971efbdef434..798afc145c54306fcf0838d8daef2bdf
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c39d5dd9602fe35b4936f01089a3b2048ef0c9bf..b0e5da5c4515b580b2655cf5a9cb74d1bd9dd9a1 100644
+index f7d5c6aa18ee44e0a6651ed73c922a973bb809b3..6777b678efebc5eee72b2aa368309aea3191157f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1803,8 +1803,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1798,8 +1798,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index c39d5dd9602fe35b4936f01089a3b2048ef0c9bf..b0e5da5c4515b580b2655cf5a9cb74d1
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1839,8 +1844,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1834,8 +1839,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0609-Expand-world-key-API.patch
+++ b/patches/server/0609-Expand-world-key-API.patch
@@ -1,11 +1,26 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Wed, 6 Jan 2021 00:34:04 -0800
-Subject: [PATCH] Add methods to get world by key
+Subject: [PATCH] Expand world key API
 
 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+index 89f75b79e8501097d2411b12ae79bb073cadba7a..cd359e6576e69184935b0852ffc6b9fb57181730 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+@@ -913,5 +913,10 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+     public io.papermc.paper.world.MoonPhase getMoonPhase() {
+         return io.papermc.paper.world.MoonPhase.getPhase(this.getHandle().dayTime() / 24000L);
+     }
++
++    @Override
++    public org.bukkit.NamespacedKey getKey() {
++        return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(this.getHandle().getLevel().dimension().location());
++    }
+     // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ce93a00aba502b6d3e962c9396a82ae2587a6b52..b651a9d86a5b0e7ec2b10d2e756bbac4624f7f9c 100644
+index a4e34932e8fadf834545db6533219ecf2bf52921..6fa21f806567bc41bacd2949d7171979bc34ac6e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1138,9 +1138,15 @@ public final class CraftServer implements Server {

--- a/patches/server/0631-More-World-API.patch
+++ b/patches/server/0631-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b0e5da5c4515b580b2655cf5a9cb74d1bd9dd9a1..cda29b242989153f32f8f1a87d5cfd5dc9b2f599 100644
+index 6777b678efebc5eee72b2aa368309aea3191157f..07c90f6a98819c835b2341bd5c144609655b33e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1972,6 +1972,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1967,6 +1967,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0657-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0657-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -95,10 +95,10 @@ index 1bd338c7860adf3b846cd6caa33312b3269ac3ef..95635cc7367b757d149bb2c81326a041
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index cda29b242989153f32f8f1a87d5cfd5dc9b2f599..19e4abd0175a19e75521b5adc9ea47bb00abf3c9 100644
+index 07c90f6a98819c835b2341bd5c144609655b33e7..a557bc8b5fab1fb3516476793c965aa3c068edf9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1194,7 +1194,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1189,7 +1189,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index cda29b242989153f32f8f1a87d5cfd5dc9b2f599..19e4abd0175a19e75521b5adc9ea47bb
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1216,7 +1216,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1211,7 +1211,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0671-Line-Of-Sight-Changes.patch
+++ b/patches/server/0671-Line-Of-Sight-Changes.patch
@@ -18,29 +18,27 @@ index b079f9cd9dd3c818b859010df74172a84eee544d..2e304d845878ff58a574c11dfa4424ba
          }
      }
  
-diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 19e4abd0175a19e75521b5adc9ea47bb00abf3c9..f7a7f68edebd304f7ca996cba58979d3fb854217 100644
---- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-+++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -200,6 +200,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-     public io.papermc.paper.world.MoonPhase getMoonPhase() {
-         return io.papermc.paper.world.MoonPhase.getPhase(getFullTime() / 24000L);
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+index b43fcdf2ab50f66f13d0e140375260d64c140f63..0b45a72fa6fac0f6bdd73ee16e7a7742c139c319 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+@@ -919,5 +919,16 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+     public org.bukkit.NamespacedKey getKey() {
+         return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(this.getHandle().getLevel().dimension().location());
      }
 +
-+    @Override
 +    public boolean lineOfSightExists(Location from, Location to) {
-+        Validate.notNull(from, "from parameter in lineOfSightExists cannot be null");
-+        Validate.notNull(to, "to parameter in lineOfSightExists cannot be null");
++        Preconditions.checkArgument(from != null, "from parameter in lineOfSightExists cannot be null");
++        Preconditions.checkArgument(to != null, "to parameter in lineOfSightExists cannot be null");
 +        if (from.getWorld() != to.getWorld()) return false;
-+        Vec3 vec3d = new Vec3(from.getX(), from.getY(), from.getZ());
-+        Vec3 vec3d1 = new Vec3(to.getX(), to.getY(), to.getZ());
++        net.minecraft.world.phys.Vec3 vec3d = new net.minecraft.world.phys.Vec3(from.getX(), from.getY(), from.getZ());
++        net.minecraft.world.phys.Vec3 vec3d1 = new net.minecraft.world.phys.Vec3(to.getX(), to.getY(), to.getZ());
 +        if (vec3d1.distanceToSqr(vec3d) > 128D * 128D) return false; //Return early if the distance is greater than 128 blocks
 +
-+        return this.getHandle().clip(new ClipContext(vec3d, vec3d1, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, null)).getType() == HitResult.Type.MISS;
++        return this.getHandle().clip(new net.minecraft.world.level.ClipContext(vec3d, vec3d1, net.minecraft.world.level.ClipContext.Block.COLLIDER, net.minecraft.world.level.ClipContext.Fluid.NONE, null)).getType() == net.minecraft.world.phys.HitResult.Type.MISS;
 +    }
      // Paper end
- 
-     private static final Random rand = new Random();
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 index 8fe1f5deddfee329c020d93c990dc686fe2b458e..ca176b9331345e343c19a02b6ba2ea886d20962d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java

--- a/patches/server/0672-add-per-world-spawn-limits.patch
+++ b/patches/server/0672-add-per-world-spawn-limits.patch
@@ -44,10 +44,10 @@ index ccbd0bd60cbc1212d9683667ce4744350eda90bb..1f74b1b2fc9ecfbb83710665ef017188
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f7a7f68edebd304f7ca996cba58979d3fb854217..cff763bd0ac8dff62c8d6e7ad94fc0e453df7abe 100644
+index a557bc8b5fab1fb3516476793c965aa3c068edf9..047be408426750fcc4a84372e7250b749e747369 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -222,6 +222,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -205,6 +205,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          this.biomeProvider = biomeProvider;
  
          this.environment = env;

--- a/patches/server/0712-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0712-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -29,10 +29,10 @@ index 384222f321f1678803d62187b76bf3dee1970c0c..b10c0099ba0691cb167e78b8decafe39
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index cff763bd0ac8dff62c8d6e7ad94fc0e453df7abe..31110d739f0b3436461c267a62db1d592f4904a2 100644
+index 047be408426750fcc4a84372e7250b749e747369..c38f9db699240f203c8353019df82a0fc824a510 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -708,6 +708,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -691,6 +691,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0734-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0734-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -296,7 +296,7 @@ index ce6051531f021bf20851bc5ab763e732ee10427d..87d1f5b2717fc82203b5674ac0bf2704
      public static void spawnCategoryForChunk(MobCategory group, ServerLevel world, LevelChunk chunk, NaturalSpawner.SpawnPredicate checker, NaturalSpawner.AfterSpawnCallback runner) {
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 674154ae0ceb8da37e41be69179b546ab2872be5..c0427bfe4f93b501aaacb66c131d2736dce6b5e0 100644
+index 538e5663e7e23a1bcc2c832930d4c1489a48c07a..83bbe0e65760a7f380e19da5a3938b1a30e5d679 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2149,6 +2149,11 @@ public final class CraftServer implements Server {
@@ -312,10 +312,10 @@ index 674154ae0ceb8da37e41be69179b546ab2872be5..c0427bfe4f93b501aaacb66c131d2736
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 31110d739f0b3436461c267a62db1d592f4904a2..f316bd615b2801365c0c2d23521ba471ed320968 100644
+index c38f9db699240f203c8353019df82a0fc824a510..42434152c79f8318009b02e9a39326fd9d4ff466 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1723,9 +1723,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1706,9 +1706,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(spawnCategory, "SpawnCategory cannot be null");
          Validate.isTrue(CraftSpawnCategory.isValidForLimits(spawnCategory), "SpawnCategory." + spawnCategory + " are not supported.");
  

--- a/patches/server/0743-Do-not-copy-visible-chunks.patch
+++ b/patches/server/0743-Do-not-copy-visible-chunks.patch
@@ -186,7 +186,7 @@ index ef28e0f57ba593265a3eca4d3f21d0b1b51e8740..f4c1316ae1cadc1a7a7fed16e0e99704
          while (objectbidirectionaliterator.hasNext()) {
              Entry<ChunkHolder> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f316bd615b2801365c0c2d23521ba471ed320968..d7624db77ffde9ce7fa4ece8318c7e75e065feed 100644
+index 42434152c79f8318009b02e9a39326fd9d4ff466..f05ff9891d59cd7ae4e37c05c690dda0c75962fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -161,7 +161,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -207,7 +207,7 @@ index f316bd615b2801365c0c2d23521ba471ed320968..d7624db77ffde9ce7fa4ece8318c7e75
              if (chunkHolder.getTickingChunk() != null) {
                  ++ret;
              }
-@@ -356,7 +356,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -339,7 +339,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {
@@ -227,7 +227,7 @@ index f316bd615b2801365c0c2d23521ba471ed320968..d7624db77ffde9ce7fa4ece8318c7e75
          return chunks.values().stream().map(ChunkHolder::getFullChunkNow).filter(Objects::nonNull).map(net.minecraft.world.level.chunk.LevelChunk::getBukkitChunk).toArray(Chunk[]::new);
      }
  
-@@ -432,7 +443,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -415,7 +426,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean refreshChunk(int x, int z) {

--- a/patches/server/0832-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0832-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,7 +18,7 @@ index df955666723a8cb1e612311f0b8e77fb577d6be5..01aefce226ae82d707b38b0d56d2580d
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 825a3b688099a3021ff422dd123038b6cca3e14f..168893fe1790edac8fee884b1fae4e6b7a1bd5c6 100644
+index 8769e15a395b1c6e72f3e4a7f96b8c90c34e7569..b4133f8dde5edb75b8d2d1008c50db7810276913 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1217,7 +1217,7 @@ public final class CraftServer implements Server {
@@ -31,12 +31,12 @@ index 825a3b688099a3021ff422dd123038b6cca3e14f..168893fe1790edac8fee884b1fae4e6b
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d7624db77ffde9ce7fa4ece8318c7e75e065feed..b9ba6937a6acdccfff89b63ef7821553012a5a97 100644
+index f05ff9891d59cd7ae4e37c05c690dda0c75962fe..925907eff49e26cac48e895f44c55f80b9a6f81e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -212,6 +212,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
- 
-         return this.getHandle().clip(new ClipContext(vec3d, vec3d1, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, null)).getType() == HitResult.Type.MISS;
+@@ -195,6 +195,31 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+     public int getPlayerCount() {
+         return world.players().size();
      }
 +
 +    @Override

--- a/patches/server/0849-Implement-regenerateChunk.patch
+++ b/patches/server/0849-Implement-regenerateChunk.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement regenerateChunk
 Co-authored-by: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b9ba6937a6acdccfff89b63ef7821553012a5a97..bde90fa06a77e403ee97f2ed3b9fd1d6e5a4af81 100644
+index 925907eff49e26cac48e895f44c55f80b9a6f81e..7414bb0ba5754b4e3be468d3986a2a979de7c983 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -133,6 +133,7 @@ import org.bukkit.util.Vector;
@@ -17,7 +17,7 @@ index b9ba6937a6acdccfff89b63ef7821553012a5a97..bde90fa06a77e403ee97f2ed3b9fd1d6
  
      private final ServerLevel world;
      private WorldBorder worldBorder;
-@@ -443,27 +444,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -426,27 +427,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean regenerateChunk(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk regenerate"); // Spigot

--- a/patches/server/0854-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0854-Replace-player-chunk-loader-system.patch
@@ -2120,10 +2120,10 @@ index 72b5d63127fbcd2913309f2c3c438b88728b4673..f667dafd44b6652788d3367cbbc76eef
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index bde90fa06a77e403ee97f2ed3b9fd1d6e5a4af81..d09e7a0470799acbca59723444fbf03f6e9593d7 100644
+index 7414bb0ba5754b4e3be468d3986a2a979de7c983..dd3aac2b8058f09fdd6dce9c1c683725b3594cfd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2219,43 +2219,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2202,43 +2202,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {

--- a/patches/server/0865-Fix-World-locateNearestStructure.patch
+++ b/patches/server/0865-Fix-World-locateNearestStructure.patch
@@ -45,10 +45,10 @@ index 344c5bafe291a2542c4940e4d80232644de7b877..00e6f60e13f50c727530de37ab9692ad
                  return pair != null ? (BlockPos) pair.getFirst() : null;
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d09e7a0470799acbca59723444fbf03f6e9593d7..19175ed6adabfa4417e5db4947ba797b78c21ba8 100644
+index dd3aac2b8058f09fdd6dce9c1c683725b3594cfd..1a07887345f46582949090b685dae507aaba84f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2077,10 +2077,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2060,10 +2060,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      }
  

--- a/patches/server/0867-Fix-falling-block-spawn-methods.patch
+++ b/patches/server/0867-Fix-falling-block-spawn-methods.patch
@@ -8,7 +8,7 @@ Restores the API behavior from previous versions of the server
 - Do not replace the existing block in the world
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index 850131e601047ab1c585a6f8883ac3c0d0e97ba1..99cb7625d50d5da4ce0999e10fb84403958a7ffe 100644
+index ca080cbc219605331dc8a0d7e8366de02c1d2ced..dc05818c17ad9ac67ef6b4783acdbb0bcceacba3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 @@ -549,7 +549,7 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
@@ -21,10 +21,10 @@ index 850131e601047ab1c585a6f8883ac3c0d0e97ba1..99cb7625d50d5da4ce0999e10fb84403
              if (Snowball.class.isAssignableFrom(clazz)) {
                  entity = new net.minecraft.world.entity.projectile.Snowball(world, x, y, z);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 19175ed6adabfa4417e5db4947ba797b78c21ba8..3d8a06f9725f1f39e86f3f1ac78f39f58d975288 100644
+index 1a07887345f46582949090b685dae507aaba84f4..f5a6250350a5f0b6236c1fe0f149b1190de34880 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1428,7 +1428,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1411,7 +1411,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(material, "Material cannot be null");
          Validate.isTrue(material.isBlock(), "Material must be a block");
  
@@ -38,7 +38,7 @@ index 19175ed6adabfa4417e5db4947ba797b78c21ba8..3d8a06f9725f1f39e86f3f1ac78f39f5
          return (FallingBlock) entity.getBukkitEntity();
      }
  
-@@ -1437,7 +1442,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1420,7 +1425,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(location, "Location cannot be null");
          Validate.notNull(data, "BlockData cannot be null");
  

--- a/patches/server/0892-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0892-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -18,7 +18,7 @@ index e28e09aae1d95d9bed50a137e999e6d457e62478..257c94f7c1cb00c9a91ab82e311dfd8e
  
              if (dedicatedserverproperties.enableQuery) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c75a3b42272776ef2a2b516555c723c1913c8bf9..0545c7fb227665dd23c7b5034a1520ed10f962b9 100644
+index 4e3ee857b7c328d857aee8ff066758b19ef81da2..1169149f0316e683ba5ac3b1e95a8a00a3c2dafa 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2604,7 +2604,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -158,10 +158,10 @@ index 798afc145c54306fcf0838d8daef2bdf17763da9..22feab6477bad023c2d6cc9ac99d392d
              this.onChanged(server);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3d8a06f9725f1f39e86f3f1ac78f39f58d975288..15d740a605c7257bcc7117c7dfb3612b472ba664 100644
+index f5a6250350a5f0b6236c1fe0f149b1190de34880..43244a479a112786539a905a22cb12e3cf55b2dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1932,7 +1932,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1915,7 +1915,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule));
          handle.deserialize(event.getValue()); // Paper
@@ -170,7 +170,7 @@ index 3d8a06f9725f1f39e86f3f1ac78f39f58d975288..15d740a605c7257bcc7117c7dfb3612b
          return true;
      }
  
-@@ -1972,7 +1972,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1955,7 +1955,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule.getName()));
          handle.deserialize(event.getValue()); // Paper


### PR DESCRIPTION
Moves several methods to RegionAccessor (but were added in Paper patches before that existed)

* getMoonPhase
* getKey
* lineOfSightExists

There are plenty more that should be moved, these are just the simple ones *from paper patches*