### PR TITLE
Deprecating remaining blockkey methods

### DIFF
--- a/patches/api/0139-Allow-Blocks-to-be-accessed-via-a-long-key.patch
+++ b/patches/api/0139-Allow-Blocks-to-be-accessed-via-a-long-key.patch
@@ -18,7 +18,7 @@ Y range: [0, 1023]
 X, Z range: [-67 108 864, 67 108 863]
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 36ed248f0716f2cc465c08ab851b7d83d4c7c0a7..58728a0f0722b378efa129e26f0c822b63d1af36 100644
+index 36ed248f0716f2cc465c08ab851b7d83d4c7c0a7..5c5e05673e0912f4dbd6c728f4c3b7fcdae8f0e8 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -15,7 +15,6 @@ import org.jetbrains.annotations.Nullable;
@@ -29,7 +29,7 @@ index 36ed248f0716f2cc465c08ab851b7d83d4c7c0a7..58728a0f0722b378efa129e26f0c822b
  import java.util.function.Predicate;
  import org.bukkit.entity.Entity;
  import org.bukkit.entity.LivingEntity;
-@@ -605,6 +604,17 @@ public class Location implements Cloneable, ConfigurationSerializable {
+@@ -605,6 +604,19 @@ public class Location implements Cloneable, ConfigurationSerializable {
          blockLoc.setZ(getBlockZ());
          return blockLoc;
      }
@@ -38,7 +38,9 @@ index 36ed248f0716f2cc465c08ab851b7d83d4c7c0a7..58728a0f0722b378efa129e26f0c822b
 +    /**
 +     * @return The block key for this location's block location.
 +     * @see Block#getBlockKey(int, int, int)
++     * @deprecated only encodes y block ranges from -512 to 511 and represents an already changed implementation detail
 +     */
++    @Deprecated
 +    public long toBlockKey() {
 +        return Block.getBlockKey(getBlockX(), getBlockY(), getBlockZ());
 +    }
@@ -48,10 +50,10 @@ index 36ed248f0716f2cc465c08ab851b7d83d4c7c0a7..58728a0f0722b378efa129e26f0c822b
       * @return A new location where X/Y/Z are the center of the block
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index ee277a464b1ecaaa7948c333a04e347e6255c904..7d77647dfe085cde87a9d2adb4c02b1f441940d7 100644
+index a501384906fa01ddc83476ef2dbbb8d11a03fb8c..449d6882c8f41d9e0f46436c430e071b85eb2775 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -92,6 +92,38 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -92,6 +92,40 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Block getBlockAt(@NotNull Location location);
  
@@ -62,8 +64,10 @@ index ee277a464b1ecaaa7948c333a04e347e6255c904..7d77647dfe085cde87a9d2adb4c02b1f
 +     * @param key The block key. See {@link Block#getBlockKey()}
 +     * @return Block at the key
 +     * @see Block#getBlockKey(int, int, int)
++     * @deprecated only encodes y block ranges from -512 to 511 and represents an already changed implementation detail
 +     */
 +    @NotNull
++    @Deprecated
 +    public default Block getBlockAtKey(long key) {
 +        int x = Block.getBlockKeyX(key);
 +        int y = Block.getBlockKeyY(key);

--- a/patches/api/0144-isChunkGenerated-API.patch
+++ b/patches/api/0144-isChunkGenerated-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] isChunkGenerated API
 
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 58728a0f0722b378efa129e26f0c822b63d1af36..88b3e0323dbc4f0fce31b147c7aaa08d65745852 100644
+index 5c5e05673e0912f4dbd6c728f4c3b7fcdae8f0e8..57cb548683f7b2972c998afd34176952426f8b47 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -3,6 +3,7 @@ package org.bukkit;
@@ -34,10 +34,10 @@ index 58728a0f0722b378efa129e26f0c822b63d1af36..88b3e0323dbc4f0fce31b147c7aaa08d
      /**
       * Sets the position of this Location and returns itself
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 7d77647dfe085cde87a9d2adb4c02b1f441940d7..39f7817838c73c78f138c98546a1b797e7529550 100644
+index 449d6882c8f41d9e0f46436c430e071b85eb2775..dcca66c345b3c51d7b9956ddd3ac2bf0b789899c 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -255,6 +255,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -257,6 +257,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      public default Chunk getChunkAt(long chunkKey) {
          return getChunkAt((int) chunkKey, (int) (chunkKey >> 32));
      }

--- a/patches/api/0146-Async-Chunks-API.patch
+++ b/patches/api/0146-Async-Chunks-API.patch
@@ -8,10 +8,10 @@ Adds API's to load or generate chunks asynchronously.
 Also adds utility methods to Entity to teleport asynchronously.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 39f7817838c73c78f138c98546a1b797e7529550..fc8631f45abaaabe2cdb7653c43b98b36a80ec78 100644
+index dcca66c345b3c51d7b9956ddd3ac2bf0b789899c..04583189f7ed9a446ed649780e2b99cb5e1ab3ad 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -964,6 +964,482 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -966,6 +966,482 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
          }
          return nearby;
      }

--- a/patches/api/0159-Add-sun-related-API.patch
+++ b/patches/api/0159-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index fc8631f45abaaabe2cdb7653c43b98b36a80ec78..656b39a3ca70afb2cb00c3c827e850912ebc4d0e 100644
+index 04583189f7ed9a446ed649780e2b99cb5e1ab3ad..f36eb8896ee84c1d3bbce17b11ed05c5f99f2e29 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1791,6 +1791,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1793,6 +1793,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public void setFullTime(long time);
  

--- a/patches/api/0178-Add-Heightmap-API.patch
+++ b/patches/api/0178-Add-Heightmap-API.patch
@@ -51,10 +51,10 @@ index 0000000000000000000000000000000000000000..709e44ea1b14ab6917501c928e689cc6
 +    SOLID_OR_LIQUID_NO_LEAVES;
 +}
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 23ca89dde7f6ac9082d4b97fce2959425f3680cb..8321441b8f528a05e297f485672f928e76fe017d 100644
+index d4c87bfed81b2d73919705912f59fab05c0ee61b..ef0cb00ca4cb7d2f5e4ec1c950cce036566d1ae4 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
-@@ -638,6 +638,47 @@ public class Location implements Cloneable, ConfigurationSerializable {
+@@ -640,6 +640,47 @@ public class Location implements Cloneable, ConfigurationSerializable {
          return centerLoc;
      }
  
@@ -103,10 +103,10 @@ index 23ca89dde7f6ac9082d4b97fce2959425f3680cb..8321441b8f528a05e297f485672f928e
       * Creates explosion at this location with given power
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 656b39a3ca70afb2cb00c3c827e850912ebc4d0e..fe2b9b88ad854f29e9162a316ca952b9f0b38121 100644
+index f36eb8896ee84c1d3bbce17b11ed05c5f99f2e29..23fd3f85288ef1fbfb104df7a636ad69042704a7 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -162,6 +162,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -164,6 +164,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Block getHighestBlockAt(@NotNull Location location);
  

--- a/patches/api/0276-Implement-Keyed-on-World.patch
+++ b/patches/api/0276-Implement-Keyed-on-World.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 0aa141c590cf61a1fc99bec4cf8d5590a3ab6519..c8ea04b06d7178c6cc992a9a1b0355a70a035152 100644
+index e02ad513d0bc20f1f847d9cffe3f7dbf3269b530..8106fd5806fc47cb7138e01d9d5c458153afa3d5 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -791,6 +791,18 @@ public final class Bukkit {
@@ -28,7 +28,7 @@ index 0aa141c590cf61a1fc99bec4cf8d5590a3ab6519..c8ea04b06d7178c6cc992a9a1b0355a7
      /**
       * Gets the map from the given item ID.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 76e42cc79bf3f7e677e06f136fd6c1fe0d94f260..75aba8c3db5198c11e0bb9c262388632a47d93e6 100644
+index 36fb8f14da0ed8192a91d509bcee94f99bea9354..d43f785471d3671bad6eb270a87a70b27f85adcb 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -673,6 +673,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -50,7 +50,7 @@ index 76e42cc79bf3f7e677e06f136fd6c1fe0d94f260..75aba8c3db5198c11e0bb9c262388632
       * Gets the map from the given item ID.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 37f0acb893f886ac0605838eb03b4a935b96f85b..47b9b8b476cbc7a4ef329dbd7629195851c8f4ea 100644
+index 513de620accbee93a04ef729dd386dadba566a8f..caa674ed1e4b3a940cee05a79d1af47b20e3badb 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -43,7 +43,7 @@ import org.jetbrains.annotations.Nullable;
@@ -62,7 +62,7 @@ index 37f0acb893f886ac0605838eb03b4a935b96f85b..47b9b8b476cbc7a4ef329dbd76291958
  
      // Paper start
      /**
-@@ -1527,6 +1527,15 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1529,6 +1529,15 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
  
      @NotNull
      java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent);

--- a/patches/api/0284-More-World-API.patch
+++ b/patches/api/0284-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 47b9b8b476cbc7a4ef329dbd7629195851c8f4ea..def9f0f9803e71cbe57abcffeb9114a5ab462e54 100644
+index caa674ed1e4b3a940cee05a79d1af47b20e3badb..a1922fd862872442ec9dd07b6c24b0d764b11b71 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3645,6 +3645,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3647,6 +3647,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public Location locateNearestStructure(@NotNull Location origin, @NotNull StructureType structureType, int radius, boolean findUnexplored);
  

--- a/patches/api/0330-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/api/0330-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index d149dd1d3d2703a428006e0c3ab5f9251e560882..22191f733bbda0710ffae425fda1861e3c2ec87f 100644
+index 2173d1e675bdb90f3117614e6e52dac61b4fada9..887ad76c3ea44f0dcfcd21f30c0883e023f1ac3a 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -759,6 +759,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -761,6 +761,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public LightningStrike strikeLightningEffect(@NotNull Location loc);
  

--- a/patches/api/0365-Implement-regenerateChunk.patch
+++ b/patches/api/0365-Implement-regenerateChunk.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement regenerateChunk
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 22191f733bbda0710ffae425fda1861e3c2ec87f..8a688583e65cd22e0417f9fd24e51803486d095e 100644
+index 887ad76c3ea44f0dcfcd21f30c0883e023f1ac3a..3421be8309c9083c0aaa80afec13c8acc4fc85dd 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -507,8 +507,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -509,8 +509,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return Whether the chunk was actually regenerated
       *
       * @deprecated regenerating a single chunk is not likely to produce the same


### PR DESCRIPTION
The methods these use were deprecated when Y value ranges were increased. I think these were just missed.