### PR TITLE
Fix EntityChangeBlockEvent#getBlockData for when sheep eats grass block

### DIFF
--- a/patches/server/0886-Fix-new-block-data-for-EntityChangeBlockEvent-when-s.patch
+++ b/patches/server/0886-Fix-new-block-data-for-EntityChangeBlockEvent-when-s.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Mon, 21 Mar 2022 20:00:53 +0200
+Subject: [PATCH] Fix new block data for EntityChangeBlockEvent when sheep eats
+ grass block
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/EatBlockGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/EatBlockGoal.java
+index 14ed3f0524773e22a792efb8b41a9217bad50f27..99044ebe2c37ce951566e3463ddbfaeec46d2b3c 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/goal/EatBlockGoal.java
++++ b/src/main/java/net/minecraft/world/entity/ai/goal/EatBlockGoal.java
+@@ -81,7 +81,7 @@ public class EatBlockGoal extends Goal {
+ 
+                 if (this.level.getBlockState(blockposition1).is(Blocks.GRASS_BLOCK)) {
+                     // CraftBukkit
+-                    if (!CraftEventFactory.callEntityChangeBlockEvent(this.mob, blockposition1, Blocks.AIR.defaultBlockState(), !this.level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)).isCancelled()) {
++                    if (!CraftEventFactory.callEntityChangeBlockEvent(this.mob, blockposition1, Blocks.DIRT.defaultBlockState(), !this.level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)).isCancelled()) { // Paper - Fix wrong block state
+                         this.level.levelEvent(2001, blockposition1, Block.getId(Blocks.GRASS_BLOCK.defaultBlockState()));
+                         this.level.setBlock(blockposition1, Blocks.DIRT.defaultBlockState(), 2);
+                     }


### PR DESCRIPTION
Fixes `EntityChangeBlockEvent#getBlockData` to return dirt instead of air when sheep eats grass block.

Ideally should be fixed within CraftBukkit, but I don't have access to its repository 😛