### PR TITLE
Add api to resolve components

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -553,10 +553,10 @@ index 0000000000000000000000000000000000000000..eb179aae1e1d2ce842442e49fe275827
 +}
 diff --git a/src/main/java/io/papermc/paper/text/PaperComponents.java b/src/main/java/io/papermc/paper/text/PaperComponents.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bff9a6295db367c6b89d69fb55459a40828265ea
+index 0000000000000000000000000000000000000000..d6ec841c3878bd682c52307356aeebca9666ac3a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/text/PaperComponents.java
-@@ -0,0 +1,112 @@
+@@ -0,0 +1,146 @@
 +package io.papermc.paper.text;
 +
 +import net.kyori.adventure.text.Component;
@@ -567,7 +567,12 @@ index 0000000000000000000000000000000000000000..bff9a6295db367c6b89d69fb55459a40
 +import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 +import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 +import org.bukkit.Bukkit;
++import org.bukkit.command.CommandSender;
++import org.bukkit.entity.Entity;
 +import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++import java.io.IOException;
 +
 +/**
 + * Paper API-specific methods for working with {@link Component}s and related.
@@ -575,6 +580,35 @@ index 0000000000000000000000000000000000000000..bff9a6295db367c6b89d69fb55459a40
 +public final class PaperComponents {
 +    private PaperComponents() {
 +        throw new RuntimeException("PaperComponents is not to be instantiated!");
++    }
++
++    /**
++     * Resolves a component with a specific command sender and subject.
++     * <p>
++     * Note that in Vanilla, elevated permissions are usually required to use
++     * '@' selectors in various component types, but this method should not
++     * check such permissions from the sender.
++     * <p>
++     * A {@link CommandSender} argument is required to resolve:
++     * <ul>
++     *     <li>{@link net.kyori.adventure.text.NBTComponent}</li>
++     *     <li>{@link net.kyori.adventure.text.ScoreComponent}</li>
++     *     <li>{@link net.kyori.adventure.text.SelectorComponent}</li>
++     * </ul>
++     * A {@link Entity} argument is optional to help resolve:
++     * <ul>
++     *     <li>{@link net.kyori.adventure.text.ScoreComponent}</li>
++     * </ul>
++     * {@link net.kyori.adventure.text.TranslatableComponent}s don't require any extra arguments.
++     *
++     * @param input the component to resolve
++     * @param context the command sender to resolve with
++     * @param scoreboardSubject the scoreboard subject to use (for use with {@link net.kyori.adventure.text.ScoreComponent}s)
++     * @return the resolved component
++     * @throws IOException if a syntax error tripped during resolving
++     */
++    public static @NotNull Component resolveWithContext(@NotNull Component input, @Nullable CommandSender context, @Nullable Entity scoreboardSubject) throws IOException {
++        return Bukkit.getUnsafe().resolveWithContext(input, context, scoreboardSubject);
 +    }
 +
 +    /**
@@ -1303,10 +1337,10 @@ index ac5e263d737973af077e3406a84a84baca4370db..2d91924b7f5ef16a91d40cdc1bfc3d68
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 01e11f882abb6c631f810584aa23646042688435..fa28b5bb0efd9d400277cd8969f38e039e6ea8ac 100644
+index 01e11f882abb6c631f810584aa23646042688435..13012488ca98157889f1348298f3f51a193ec5c9 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -22,6 +22,14 @@ import org.bukkit.plugin.PluginDescriptionFile;
+@@ -22,6 +22,15 @@ import org.bukkit.plugin.PluginDescriptionFile;
   */
  @Deprecated
  public interface UnsafeValues {
@@ -1317,6 +1351,7 @@ index 01e11f882abb6c631f810584aa23646042688435..fa28b5bb0efd9d400277cd8969f38e03
 +    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.gson.GsonComponentSerializer gsonComponentSerializer();
 +    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.gson.GsonComponentSerializer colorDownsamplingGsonComponentSerializer();
 +    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer legacyComponentSerializer();
++    net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject) throws java.io.IOException;
 +    // Paper end
  
      Material toLegacy(Material material);

--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -553,10 +553,10 @@ index 0000000000000000000000000000000000000000..eb179aae1e1d2ce842442e49fe275827
 +}
 diff --git a/src/main/java/io/papermc/paper/text/PaperComponents.java b/src/main/java/io/papermc/paper/text/PaperComponents.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d6ec841c3878bd682c52307356aeebca9666ac3a
+index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f12a2e6e06
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/text/PaperComponents.java
-@@ -0,0 +1,146 @@
+@@ -0,0 +1,177 @@
 +package io.papermc.paper.text;
 +
 +import net.kyori.adventure.text.Component;
@@ -608,7 +608,38 @@ index 0000000000000000000000000000000000000000..d6ec841c3878bd682c52307356aeebca
 +     * @throws IOException if a syntax error tripped during resolving
 +     */
 +    public static @NotNull Component resolveWithContext(@NotNull Component input, @Nullable CommandSender context, @Nullable Entity scoreboardSubject) throws IOException {
-+        return Bukkit.getUnsafe().resolveWithContext(input, context, scoreboardSubject);
++        return resolveWithContext(input, context, scoreboardSubject, true);
++    }
++
++    /**
++     * Resolves a component with a specific command sender and subject.
++     * <p>
++     * Note that in Vanilla, elevated permissions are required to use
++     * '@' selectors in various component types. If the boolean {@code bypassPermissions}
++     * argument is {@code false}, the {@link CommandSender} argument will be used to query
++     * those permissions.
++     * <p>
++     * A {@link CommandSender} argument is required to resolve:
++     * <ul>
++     *     <li>{@link net.kyori.adventure.text.NBTComponent}</li>
++     *     <li>{@link net.kyori.adventure.text.ScoreComponent}</li>
++     *     <li>{@link net.kyori.adventure.text.SelectorComponent}</li>
++     * </ul>
++     * A {@link Entity} argument is optional to help resolve:
++     * <ul>
++     *     <li>{@link net.kyori.adventure.text.ScoreComponent}</li>
++     * </ul>
++     * {@link net.kyori.adventure.text.TranslatableComponent}s don't require any extra arguments.
++     *
++     * @param input the component to resolve
++     * @param context the command sender to resolve with
++     * @param scoreboardSubject the scoreboard subject to use (for use with {@link net.kyori.adventure.text.ScoreComponent}s)
++     * @param bypassPermissions true to bypass permissions checks for resolving components
++     * @return the resolved component
++     * @throws IOException if a syntax error tripped during resolving
++     */
++    public static @NotNull Component resolveWithContext(@NotNull Component input, @Nullable CommandSender context, @Nullable Entity scoreboardSubject, boolean bypassPermissions) throws IOException {
++        return Bukkit.getUnsafe().resolveWithContext(input, context, scoreboardSubject, bypassPermissions);
 +    }
 +
 +    /**
@@ -1337,7 +1368,7 @@ index ac5e263d737973af077e3406a84a84baca4370db..2d91924b7f5ef16a91d40cdc1bfc3d68
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 01e11f882abb6c631f810584aa23646042688435..13012488ca98157889f1348298f3f51a193ec5c9 100644
+index 01e11f882abb6c631f810584aa23646042688435..4f339debf113d103ffe0b5fdb03dfc82eafd1bd5 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
 @@ -22,6 +22,15 @@ import org.bukkit.plugin.PluginDescriptionFile;
@@ -1351,7 +1382,7 @@ index 01e11f882abb6c631f810584aa23646042688435..13012488ca98157889f1348298f3f51a
 +    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.gson.GsonComponentSerializer gsonComponentSerializer();
 +    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.gson.GsonComponentSerializer colorDownsamplingGsonComponentSerializer();
 +    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer legacyComponentSerializer();
-+    net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject) throws java.io.IOException;
++    net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject, boolean bypassPermissions) throws java.io.IOException;
 +    // Paper end
  
      Material toLegacy(Material material);

--- a/patches/api/0007-Timings-v2.patch
+++ b/patches/api/0007-Timings-v2.patch
@@ -2834,18 +2834,18 @@ index 4d5c3af2e1f0030aa7415fbe9d11fe3580854fd5..a2ae6b84fe20e43292f1442401a472dc
           * Sends the component to the player
           *
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index fa28b5bb0efd9d400277cd8969f38e039e6ea8ac..c9ecd5b1908e05a1b39dadcded27241672adcddf 100644
+index 13012488ca98157889f1348298f3f51a193ec5c9..ae51bcad3e0ca5b2f7d266e8453ffa8598d8ca1f 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -31,6 +31,7 @@ public interface UnsafeValues {
-     @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer legacyComponentSerializer();
+@@ -32,6 +32,7 @@ public interface UnsafeValues {
+     net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject) throws java.io.IOException;
      // Paper end
  
 +    void reportTimings(); // Paper
      Material toLegacy(Material material);
  
      Material fromLegacy(Material material);
-@@ -86,4 +87,12 @@ public interface UnsafeValues {
+@@ -87,4 +88,12 @@ public interface UnsafeValues {
      Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(Material material, EquipmentSlot slot);
  
      CreativeCategory getCreativeCategory(Material material);

--- a/patches/api/0007-Timings-v2.patch
+++ b/patches/api/0007-Timings-v2.patch
@@ -2834,11 +2834,11 @@ index 4d5c3af2e1f0030aa7415fbe9d11fe3580854fd5..a2ae6b84fe20e43292f1442401a472dc
           * Sends the component to the player
           *
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 13012488ca98157889f1348298f3f51a193ec5c9..ae51bcad3e0ca5b2f7d266e8453ffa8598d8ca1f 100644
+index 4f339debf113d103ffe0b5fdb03dfc82eafd1bd5..d45cc92ca30e79173f30aae10724beeec6d22398 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
 @@ -32,6 +32,7 @@ public interface UnsafeValues {
-     net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject) throws java.io.IOException;
+     net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject, boolean bypassPermissions) throws java.io.IOException;
      // Paper end
  
 +    void reportTimings(); // Paper

--- a/patches/api/0011-Version-Command-2.0.patch
+++ b/patches/api/0011-Version-Command-2.0.patch
@@ -59,7 +59,7 @@ diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukk
 index c9ecd5b1908e05a1b39dadcded27241672adcddf..355c46f1c1f08072446f3cc92c0d22898933a7fc 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -94,5 +94,12 @@ public interface UnsafeValues {
+@@ -95,5 +95,12 @@ public interface UnsafeValues {
       * @return name
       */
      String getTimingsServerName();

--- a/patches/api/0123-Add-an-asterisk-to-legacy-API-plugins.patch
+++ b/patches/api/0123-Add-an-asterisk-to-legacy-API-plugins.patch
@@ -10,7 +10,7 @@ diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukk
 index 355c46f1c1f08072446f3cc92c0d22898933a7fc..cbf7df30a7ec8445c8492e3b9f108747dbe1717b 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -101,5 +101,11 @@ public interface UnsafeValues {
+@@ -102,5 +102,11 @@ public interface UnsafeValues {
      default com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {
          return new com.destroystokyo.paper.util.VersionFetcher.DummyVersionFetcher();
      }

--- a/patches/api/0191-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/api/0191-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Raw Byte ItemStack Serialization
 Serializes using NBT which is safer for server data migrations than bukkits format.
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index cbf7df30a7ec8445c8492e3b9f108747dbe1717b..1b5f36b78d81b688ded88ab91e36d9df8c5d64ee 100644
+index 5e2135cf4310eeea5da5ddb12d6e6bc32ecec93d..7c74163031cd8b49b9fe98241356697fd06c54c5 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -107,5 +107,9 @@ public interface UnsafeValues {
+@@ -108,5 +108,9 @@ public interface UnsafeValues {
      static boolean isLegacyPlugin(org.bukkit.plugin.Plugin plugin) {
          return !Bukkit.getUnsafe().isSupportedApiVersion(plugin.getDescription().getAPIVersion());
      }

--- a/patches/api/0220-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0220-Add-methods-to-get-translation-keys.patch
@@ -181,10 +181,10 @@ index 6eb0b9ba2b7ad5faba31220483c424203802e1d3..a4c7ff53b7e12e9d3ca649782008a4ce
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 1b5f36b78d81b688ded88ab91e36d9df8c5d64ee..e10edf17a87d18e9d9a22c6793d6ac78054d841b 100644
+index 7c74163031cd8b49b9fe98241356697fd06c54c5..b69e8210d6d7a534804af9ed1b877dab9d5bc139 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -111,5 +111,34 @@ public interface UnsafeValues {
+@@ -112,5 +112,34 @@ public interface UnsafeValues {
      byte[] serializeItem(ItemStack item);
  
      ItemStack deserializeItem(byte[] data);

--- a/patches/api/0223-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/api/0223-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index e10edf17a87d18e9d9a22c6793d6ac78054d841b..035dfcd9d483152a050e45409f15b015b135fb38 100644
+index b69e8210d6d7a534804af9ed1b877dab9d5bc139..0994d65c7ad94bcbf661ca66839ddfcc5c8b8899 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -140,5 +140,12 @@ public interface UnsafeValues {
+@@ -141,5 +141,12 @@ public interface UnsafeValues {
       * @return the translation key
       */
      String getTranslationKey(ItemStack itemStack);

--- a/patches/api/0256-Add-PaperRegistry.patch
+++ b/patches/api/0256-Add-PaperRegistry.patch
@@ -91,10 +91,10 @@ index 0000000000000000000000000000000000000000..f29e76a6b66ddfec12ddf8db6dcb2df6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 035dfcd9d483152a050e45409f15b015b135fb38..abe79e4a2233341d0030742b823a0cfb5af97f41 100644
+index 0994d65c7ad94bcbf661ca66839ddfcc5c8b8899..ab2b02ad179354c791dbb17963977a5c1478d553 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -147,5 +147,15 @@ public interface UnsafeValues {
+@@ -148,5 +148,15 @@ public interface UnsafeValues {
       * Use this when sending custom packets, so that there are no collisions on the client or server.
       */
      public int nextEntityId();

--- a/patches/api/0276-Expand-world-key-API.patch
+++ b/patches/api/0276-Expand-world-key-API.patch
@@ -78,10 +78,10 @@ index 50542df291d90a667af119fb9fcc3db2535ae6b5..723057dcc769bd29acdb82561ee0126e
       * Create a new virtual {@link WorldBorder}.
       * <p>
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index abe79e4a2233341d0030742b823a0cfb5af97f41..204ab103eeff976d3da4f5694c31beafab6e1fdd 100644
+index ab2b02ad179354c791dbb17963977a5c1478d553..0fe8efe3f5d16768dde497693c3f098dffbd1584 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -157,5 +157,10 @@ public interface UnsafeValues {
+@@ -158,5 +158,10 @@ public interface UnsafeValues {
       * @throws IllegalArgumentException if there isn't a registry for that type
       */
      <T extends Keyed> @org.jetbrains.annotations.NotNull Registry<T> registryFor(Class<T> classOfT);

--- a/patches/api/0277-Item-Rarity-API.patch
+++ b/patches/api/0277-Item-Rarity-API.patch
@@ -61,10 +61,10 @@ index 90367a01199ad90f0f10b977e214585a6e1ecf8a..f24f1d7a676f3b83ab05f655bd66b81b
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 204ab103eeff976d3da4f5694c31beafab6e1fdd..9616630817a3a302636a0d2fe8076cb7244b7996 100644
+index 0fe8efe3f5d16768dde497693c3f098dffbd1584..50397eecc867810ad6a89ce740814592082ad99e 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -162,5 +162,22 @@ public interface UnsafeValues {
+@@ -163,5 +163,22 @@ public interface UnsafeValues {
       * Just don't use it.
       */
      @org.jetbrains.annotations.NotNull String getMainLevelName();

--- a/patches/api/0278-Expose-protocol-version.patch
+++ b/patches/api/0278-Expose-protocol-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 9616630817a3a302636a0d2fe8076cb7244b7996..eadba6454530724619872034f6e680b4603b8a69 100644
+index 50397eecc867810ad6a89ce740814592082ad99e..3a515f13fe5ec6582ddeb38eb316e919062a0e16 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -179,5 +179,12 @@ public interface UnsafeValues {
+@@ -180,5 +180,12 @@ public interface UnsafeValues {
       * @return the itemstack rarity
       */
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);

--- a/patches/api/0296-ItemStack-repair-check-API.patch
+++ b/patches/api/0296-ItemStack-repair-check-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack repair check API
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index eadba6454530724619872034f6e680b4603b8a69..248453b259781aa45516133a0ed824f4e6f6a369 100644
+index 3a515f13fe5ec6582ddeb38eb316e919062a0e16..55e09755499cc49ecb9068fec2ff60c8258af587 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -180,6 +180,16 @@ public interface UnsafeValues {
+@@ -181,6 +181,16 @@ public interface UnsafeValues {
       */
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);
  

--- a/patches/api/0302-Attributes-API-for-item-defaults.patch
+++ b/patches/api/0302-Attributes-API-for-item-defaults.patch
@@ -31,10 +31,10 @@ index f24f1d7a676f3b83ab05f655bd66b81b0069f88c..163c3ed1974e50376b7c2b2805df2833
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 248453b259781aa45516133a0ed824f4e6f6a369..a3045b63c4e63f8eac902beb0f48367a5e3e5d20 100644
+index 55e09755499cc49ecb9068fec2ff60c8258af587..d71e2ef9b9274bfcf8d9885d1583dcb310849c43 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -190,6 +190,18 @@ public interface UnsafeValues {
+@@ -191,6 +191,18 @@ public interface UnsafeValues {
       */
      public boolean isValidRepairItemStack(@org.jetbrains.annotations.NotNull ItemStack itemToBeRepaired, @org.jetbrains.annotations.NotNull ItemStack repairMaterial);
  

--- a/patches/api/0329-Get-entity-default-attributes.patch
+++ b/patches/api/0329-Get-entity-default-attributes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Get entity default attributes
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index a3045b63c4e63f8eac902beb0f48367a5e3e5d20..0a9a50251093e1ea605a748eb8d899f34b26ef7b 100644
+index d71e2ef9b9274bfcf8d9885d1583dcb310849c43..7bd7bdf756f780752a127a786077f69cd85e1551 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -208,5 +208,22 @@ public interface UnsafeValues {
+@@ -209,5 +209,22 @@ public interface UnsafeValues {
       * @return the server's protocol version
       */
      int getProtocolVersion();

--- a/patches/api/0335-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/api/0335-Add-isCollidable-methods-to-various-places.patch
@@ -26,10 +26,10 @@ index 163c3ed1974e50376b7c2b2805df283322d41777..cb00e050cd5fff3a037a32ac34e02eee
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 0a9a50251093e1ea605a748eb8d899f34b26ef7b..be8d5c172b0a300648f21e2163ccf0a9cd7915ee 100644
+index 7bd7bdf756f780752a127a786077f69cd85e1551..057a4f1a374fcc240998c6ac3fe52d22389458c3 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -225,5 +225,14 @@ public interface UnsafeValues {
+@@ -226,5 +226,14 @@ public interface UnsafeValues {
       * @throws IllegalArgumentException if the entity does not exist of have default attributes (use {@link #hasDefaultEntityAttributes(NamespacedKey)} first)
       */
      @org.jetbrains.annotations.NotNull org.bukkit.attribute.Attributable getDefaultEntityAttributes(@org.jetbrains.annotations.NotNull NamespacedKey entityKey);

--- a/patches/api/0338-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/api/0338-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index be8d5c172b0a300648f21e2163ccf0a9cd7915ee..4fcafddf3792b66c618f91e04d102f374de565a8 100644
+index 057a4f1a374fcc240998c6ac3fe52d22389458c3..70103054057abfec37a99f30075123f9daa4e4ce 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -112,6 +112,14 @@ public interface UnsafeValues {
+@@ -113,6 +113,14 @@ public interface UnsafeValues {
  
      ItemStack deserializeItem(byte[] data);
  

--- a/patches/api/0390-Add-NamespacedKey-biome-methods.patch
+++ b/patches/api/0390-Add-NamespacedKey-biome-methods.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add NamespacedKey biome methods
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 4fcafddf3792b66c618f91e04d102f374de565a8..88acc4d2bd56748630840dc9f1c2cb253711eb38 100644
+index 70103054057abfec37a99f30075123f9daa4e4ce..9b6600853df559eb941eb85b33c71f98b8df4675 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -242,5 +242,32 @@ public interface UnsafeValues {
+@@ -243,5 +243,32 @@ public interface UnsafeValues {
       * @throws IllegalArgumentException if {@link Material#isBlock()} is false
       */
      boolean isCollidable(@org.jetbrains.annotations.NotNull Material material);

--- a/patches/server/0005-MC-Dev-fixes.patch
+++ b/patches/server/0005-MC-Dev-fixes.patch
@@ -128,6 +128,20 @@ index b552d2c0a07e322224ce6693e89f1dd6552c2037..672e296cec289abd3bf797d84e16983c
      private static final int MIN_PROTOCOL_ID = -1;
      private static final int MAX_PROTOCOL_ID = 2;
      private static final ConnectionProtocol[] LOOKUP = new ConnectionProtocol[4];
+diff --git a/src/main/java/net/minecraft/network/chat/ComponentUtils.java b/src/main/java/net/minecraft/network/chat/ComponentUtils.java
+index 9d3449dd92bbbef91b627caba752b87d8209011d..3364f5a113b5765300ee5b8957b995231b70d609 100644
+--- a/src/main/java/net/minecraft/network/chat/ComponentUtils.java
++++ b/src/main/java/net/minecraft/network/chat/ComponentUtils.java
+@@ -138,8 +138,7 @@ public class ComponentUtils {
+             ComponentContents string = text.getContents();
+             if (string instanceof TranslatableContents) {
+                 TranslatableContents translatableContents = (TranslatableContents)string;
+-                String string = translatableContents.getKey();
+-                return Language.getInstance().has(string);
++                return Language.getInstance().has(translatableContents.getKey()); // Paper - decompile fix
+             }
+         }
+ 
 diff --git a/src/main/java/net/minecraft/resources/RegistryLoader.java b/src/main/java/net/minecraft/resources/RegistryLoader.java
 index 82764c462f82163ee49f4e9466f383366cd23b8b..8da1226a6c293abb038d10c7921a77ed71ad06cc 100644
 --- a/src/main/java/net/minecraft/resources/RegistryLoader.java

--- a/patches/server/0009-Adventure.patch
+++ b/patches/server/0009-Adventure.patch
@@ -694,10 +694,10 @@ index 0000000000000000000000000000000000000000..2fd6c3e65354071af71c7d8ebb97b559
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dbfb8746355be22e11d05cac33d18e04b94aa985
+index 0000000000000000000000000000000000000000..184dcda55e076e716087222155fbb0f73b066cca
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
-@@ -0,0 +1,331 @@
+@@ -0,0 +1,348 @@
 +package io.papermc.paper.adventure;
 +
 +import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -726,17 +726,22 @@ index 0000000000000000000000000000000000000000..dbfb8746355be22e11d05cac33d18e04
 +import net.kyori.adventure.translation.Translator;
 +import net.kyori.adventure.util.Codec;
 +import net.minecraft.ChatFormatting;
++import net.minecraft.commands.CommandSourceStack;
 +import net.minecraft.locale.Language;
 +import net.minecraft.nbt.CompoundTag;
 +import net.minecraft.nbt.ListTag;
 +import net.minecraft.nbt.StringTag;
 +import net.minecraft.nbt.TagParser;
++import net.minecraft.network.chat.ComponentUtils;
 +import net.minecraft.resources.ResourceLocation;
 +import net.minecraft.sounds.SoundSource;
 +import net.minecraft.world.BossEvent;
 +import net.minecraft.world.item.ItemStack;
 +import net.minecraft.world.item.WrittenBookItem;
-+import org.bukkit.ChatColor;
++import org.bukkit.command.CommandSender;
++import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
++import org.bukkit.craftbukkit.entity.CraftEntity;
++import org.bukkit.entity.Entity;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -892,6 +897,18 @@ index 0000000000000000000000000000000000000000..dbfb8746355be22e11d05cac33d18e04
 +                ? locale
 +                : Locale.US
 +        );
++    }
++
++    public static Component resolveWithContext(final @NotNull Component component, final @Nullable CommandSender context, final @Nullable Entity scoreboardSubject) throws IOException {
++        final CommandSourceStack css = context != null ? VanillaCommandWrapper.getListener(context) : null;
++        if (css != null) css.bypassSelectorPermissions = true;
++        try {
++            return asAdventure(ComponentUtils.updateForEntity(css, asVanilla(component), scoreboardSubject == null ? null : ((CraftEntity) scoreboardSubject).getHandle(), 0));
++        } catch (CommandSyntaxException e) {
++            throw new IOException(e);
++        } finally {
++            if (css != null) css.bypassSelectorPermissions = false;
++        }
 +    }
 +
 +    // BossBar
@@ -1423,6 +1440,18 @@ index 98f2def9125d6faf5859572a004fa8d2fa066417..436f381c727cda72c04859c540dce471
      @Nullable
      public static ChatFormatting getById(int colorIndex) {
          if (colorIndex < 0) {
+diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
+index 3308d684fc6cd0a83e190a52693b29d30e0087cb..a5c31a999dd7fb30436b21c04e2cbc95ee4262d2 100644
+--- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
++++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
+@@ -60,6 +60,7 @@ public class CommandSourceStack implements SharedSuggestionProvider {
+     private final CommandSigningContext signingContext;
+     private final TaskChainer chatMessageChainer;
+     public volatile CommandNode currentCommand; // CraftBukkit
++    public boolean bypassSelectorPermissions = false; // Paper
+ 
+     public CommandSourceStack(CommandSource output, Vec3 pos, Vec2 rot, ServerLevel world, int level, String name, Component displayName, MinecraftServer server, @Nullable Entity entity) {
+         this(output, pos, rot, world, level, name, displayName, server, entity, false, (commandcontext, flag, j) -> {
 diff --git a/src/main/java/net/minecraft/commands/arguments/MessageArgument.java b/src/main/java/net/minecraft/commands/arguments/MessageArgument.java
 index 83ffb7a08630fdaf8655569d82974625c0eaf1ff..4da1ebcd0226897f8b03bd00a851f793df3506f4 100644
 --- a/src/main/java/net/minecraft/commands/arguments/MessageArgument.java
@@ -1445,6 +1474,19 @@ index 83ffb7a08630fdaf8655569d82974625c0eaf1ff..4da1ebcd0226897f8b03bd00a851f793
              MessageArgument.logResolutionFailure(source, completableFuture);
              return completableFuture;
          }
+diff --git a/src/main/java/net/minecraft/commands/arguments/selector/EntitySelector.java b/src/main/java/net/minecraft/commands/arguments/selector/EntitySelector.java
+index 35cc3bba20afd4a47160cc674415ba6a3a0ec0ec..40812e6518b8aacfbd2d8cd65a407d00bb19e991 100644
+--- a/src/main/java/net/minecraft/commands/arguments/selector/EntitySelector.java
++++ b/src/main/java/net/minecraft/commands/arguments/selector/EntitySelector.java
+@@ -90,7 +90,7 @@ public class EntitySelector {
+     }
+ 
+     private void checkPermissions(CommandSourceStack source) throws CommandSyntaxException {
+-        if (this.usesSelector && !source.hasPermission(2, "minecraft.command.selector")) { // CraftBukkit
++        if (source.bypassSelectorPermissions || (this.usesSelector && !source.hasPermission(2, "minecraft.command.selector"))) { // CraftBukkit // Paper
+             throw EntityArgument.ERROR_SELECTORS_NOT_ALLOWED.create();
+         }
+     }
 diff --git a/src/main/java/net/minecraft/network/FriendlyByteBuf.java b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 index c4854debe11b8bb61fa49c76c1854f94c1e7777f..42514a0c7066dc79050c0496d6463528b593f9e4 100644
 --- a/src/main/java/net/minecraft/network/FriendlyByteBuf.java
@@ -1693,6 +1735,22 @@ index 06736982f7625c1a532315afe94e5e0c45ec1331..e7d9e2d8c87ddf3658b1c2e0f2a3e98e
              JsonObject jsonobject = new JsonObject();
  
              if (!ichatbasecomponent.getStyle().isEmpty()) {
+diff --git a/src/main/java/net/minecraft/network/chat/ComponentUtils.java b/src/main/java/net/minecraft/network/chat/ComponentUtils.java
+index 3364f5a113b5765300ee5b8957b995231b70d609..10b133e95dbf2edb87764ea9d07974d8146bbed0 100644
+--- a/src/main/java/net/minecraft/network/chat/ComponentUtils.java
++++ b/src/main/java/net/minecraft/network/chat/ComponentUtils.java
+@@ -42,6 +42,11 @@ public class ComponentUtils {
+         if (depth > 100) {
+             return text.copy();
+         } else {
++            // Paper start
++            if (text instanceof io.papermc.paper.adventure.AdventureComponent adventureComponent) {
++                text = adventureComponent.deepConverted();
++            }
++            // Paper end
+             MutableComponent mutableComponent = text.getContents().resolve(source, sender, depth + 1);
+ 
+             for(Component component : text.getSiblings()) {
 diff --git a/src/main/java/net/minecraft/network/chat/OutgoingPlayerChatMessage.java b/src/main/java/net/minecraft/network/chat/OutgoingPlayerChatMessage.java
 index de717cf25308bbade7b2c0a9187cf89238663636..bd82f0316df85b621c1970ff30bbbec0d2712ccd 100644
 --- a/src/main/java/net/minecraft/network/chat/OutgoingPlayerChatMessage.java
@@ -2048,7 +2106,7 @@ index c20f7eb3ee60fce38be2c817278ecaac8982b279..d7e66a9669c67bf7d619bf69dc49daed
          // CraftBukkit end
          this.chatVisibility = packet.chatVisibility();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f63ade8d99295ce9d001aae6f5228a7374e16438..93d02b5de0721e3c5903e80bbf8b3b56ec3ab45d 100644
+index d88a7d01d5b37c13c773a22f8da551c7174af2ab..f1441c9fde9d736d4c053073a88a7a79222f5c5c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -188,6 +188,8 @@ import org.apache.commons.lang3.StringUtils;
@@ -2528,7 +2586,7 @@ index 4c62df5a3781ec9df4a5c5f1b528649e6e8a62d1..affd1b8c7589ba59330dc0b6fc803cce
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java b/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
-index 595b56b2ab9a813ba71399d306117294fa90dc65..3527d40102d512d0e276edc969ea3c189aa34ec2 100644
+index 510065ee6a6f6834443eec3e4cb96152b7ec7c3f..b8d33dc1dc31fb2bcde0d74504f3972b0cc28f17 100644
 --- a/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
 +++ b/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
 @@ -33,6 +33,7 @@ import net.minecraft.world.level.saveddata.SavedData;
@@ -4395,10 +4453,10 @@ index 78ea79b66cc9e90402ef5cdc2e5e04e0c74b1c26..4fede2161792ba3e7cdf0cc5a1f53318
  
          boolean hadFormat = false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index d805ac4274fb6149bf8efea6b771ecfe79aea76f..56a3dc9dcbd2229c60aa64e2d4c0ed147539a5ef 100644
+index d805ac4274fb6149bf8efea6b771ecfe79aea76f..7fde7a9b1cd1e8620077d93bea7513be5c43545d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -69,6 +69,38 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -69,6 +69,43 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      private CraftMagicNumbers() {}
  
@@ -4431,6 +4489,11 @@ index d805ac4274fb6149bf8efea6b771ecfe79aea76f..56a3dc9dcbd2229c60aa64e2d4c0ed14
 +    @Override
 +    public net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer legacyComponentSerializer() {
 +        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection();
++    }
++
++    @Override
++    public net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject) throws IOException {
++        return io.papermc.paper.adventure.PaperAdventure.resolveWithContext(component, context, scoreboardSubject);
 +    }
 +    // Paper end
 +

--- a/patches/server/0009-Adventure.patch
+++ b/patches/server/0009-Adventure.patch
@@ -694,10 +694,10 @@ index 0000000000000000000000000000000000000000..2fd6c3e65354071af71c7d8ebb97b559
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..184dcda55e076e716087222155fbb0f73b066cca
+index 0000000000000000000000000000000000000000..01e424792f68bac73ec41726031ebbb53df13da7
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
-@@ -0,0 +1,348 @@
+@@ -0,0 +1,354 @@
 +package io.papermc.paper.adventure;
 +
 +import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -899,15 +899,21 @@ index 0000000000000000000000000000000000000000..184dcda55e076e716087222155fbb0f7
 +        );
 +    }
 +
-+    public static Component resolveWithContext(final @NotNull Component component, final @Nullable CommandSender context, final @Nullable Entity scoreboardSubject) throws IOException {
++    public static Component resolveWithContext(final @NotNull Component component, final @Nullable CommandSender context, final @Nullable Entity scoreboardSubject, final boolean bypassPermissions) throws IOException {
 +        final CommandSourceStack css = context != null ? VanillaCommandWrapper.getListener(context) : null;
-+        if (css != null) css.bypassSelectorPermissions = true;
++        Boolean previous = null;
++        if (css != null && bypassPermissions) {
++            previous = css.bypassSelectorPermissions;
++            css.bypassSelectorPermissions = true;
++        }
 +        try {
 +            return asAdventure(ComponentUtils.updateForEntity(css, asVanilla(component), scoreboardSubject == null ? null : ((CraftEntity) scoreboardSubject).getHandle(), 0));
 +        } catch (CommandSyntaxException e) {
 +            throw new IOException(e);
 +        } finally {
-+            if (css != null) css.bypassSelectorPermissions = false;
++            if (css != null && previous != null) {
++                css.bypassSelectorPermissions = previous;
++            }
 +        }
 +    }
 +
@@ -4453,7 +4459,7 @@ index 78ea79b66cc9e90402ef5cdc2e5e04e0c74b1c26..4fede2161792ba3e7cdf0cc5a1f53318
  
          boolean hadFormat = false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index d805ac4274fb6149bf8efea6b771ecfe79aea76f..7fde7a9b1cd1e8620077d93bea7513be5c43545d 100644
+index d805ac4274fb6149bf8efea6b771ecfe79aea76f..ede9c2d8e98fd42a936045e82b3e2c174f7bac0b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -69,6 +69,43 @@ public final class CraftMagicNumbers implements UnsafeValues {
@@ -4492,8 +4498,8 @@ index d805ac4274fb6149bf8efea6b771ecfe79aea76f..7fde7a9b1cd1e8620077d93bea7513be
 +    }
 +
 +    @Override
-+    public net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject) throws IOException {
-+        return io.papermc.paper.adventure.PaperAdventure.resolveWithContext(component, context, scoreboardSubject);
++    public net.kyori.adventure.text.Component resolveWithContext(final net.kyori.adventure.text.Component component, final org.bukkit.command.CommandSender context, final org.bukkit.entity.Entity scoreboardSubject, final boolean bypassPermissions) throws IOException {
++        return io.papermc.paper.adventure.PaperAdventure.resolveWithContext(component, context, scoreboardSubject, bypassPermissions);
 +    }
 +    // Paper end
 +

--- a/patches/server/0012-Timings-v2.patch
+++ b/patches/server/0012-Timings-v2.patch
@@ -2038,7 +2038,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/
 index 56a3dc9dcbd2229c60aa64e2d4c0ed147539a5ef..e309a589e6ce76294187c906820a88367da25305 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -217,6 +217,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -222,6 +222,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
      // Paper end
      // ========================================================================
@@ -2051,7 +2051,7 @@ index 56a3dc9dcbd2229c60aa64e2d4c0ed147539a5ef..e309a589e6ce76294187c906820a8836
  
      public static byte toLegacyData(BlockState data) {
          return CraftLegacy.toLegacyData(data);
-@@ -410,6 +416,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -415,6 +421,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftCreativeCategory.fromNMS(category);
      }
  

--- a/patches/server/0026-Implement-Paper-VersionChecker.patch
+++ b/patches/server/0026-Implement-Paper-VersionChecker.patch
@@ -140,10 +140,10 @@ index 0000000000000000000000000000000000000000..351159bbdb0c8045f4983f54dee34430
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index e309a589e6ce76294187c906820a88367da25305..df814f6bd071cef89cd4275e11aadc8311abd0f4 100644
+index c379064ac439d17e641ba09c30e2e7df78ca2623..3efc8fbf22d7ae4c642348468a3af959e49cd640 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -421,6 +421,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -426,6 +426,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public String getTimingsServerName() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().timings.serverName;
      }

--- a/patches/server/0222-Add-CraftMagicNumbers.isSupportedApiVersion.patch
+++ b/patches/server/0222-Add-CraftMagicNumbers.isSupportedApiVersion.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add CraftMagicNumbers.isSupportedApiVersion()
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index df814f6bd071cef89cd4275e11aadc8311abd0f4..5893b764d3fceccef8704f1f90a5c826d6012166 100644
+index 3efc8fbf22d7ae4c642348468a3af959e49cd640..4d67e962e81d086f20624ee2ab9e921f9cd020e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -426,6 +426,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -431,6 +431,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {
          return new com.destroystokyo.paper.PaperVersionFetcher();
      }

--- a/patches/server/0297-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0297-Implement-Brigadier-Mojang-API.patch
@@ -59,7 +59,7 @@ index da6250df1c5f3385b683cffde47754bca4606f5e..3384501f83d445f45aa8233e98c7597d
      public void removeCommand(String name) {
          this.children.remove(name);
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index 3308d684fc6cd0a83e190a52693b29d30e0087cb..fa258155b1cbdd8efde15ec59986d0ab56245ddd 100644
+index a5c31a999dd7fb30436b21c04e2cbc95ee4262d2..891d1fb88d8de9d1b34f300ba640cfc6fbd8a4de 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 @@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec2;
@@ -71,7 +71,7 @@ index 3308d684fc6cd0a83e190a52693b29d30e0087cb..fa258155b1cbdd8efde15ec59986d0ab
  
      public static final SimpleCommandExceptionType ERROR_NOT_PLAYER = new SimpleCommandExceptionType(Component.translatable("permissions.requires.player"));
      public static final SimpleCommandExceptionType ERROR_NOT_ENTITY = new SimpleCommandExceptionType(Component.translatable("permissions.requires.entity"));
-@@ -172,6 +172,26 @@ public class CommandSourceStack implements SharedSuggestionProvider {
+@@ -173,6 +173,26 @@ public class CommandSourceStack implements SharedSuggestionProvider {
          return this.entity != null ? this.entity.asChatSender() : ChatSender.SYSTEM;
      }
  
@@ -131,7 +131,7 @@ index c4315531f93f4ed68b4621157b02572886e1ed30..b141d251eedd31bd115342b878afd68d
  
              if (commandnode2.canUse(source)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 61a0cee760d058e382c2756096a5acce050d9f9d..ac5f70ee86cc5a01b046e8e610434742448e3919 100644
+index d372d019e714a040d5ae05ed8653b4541717cd61..c959941b6ba5d9ed8e6ce88ff3902afc4c97d139 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -836,8 +836,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic

--- a/patches/server/0367-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/server/0367-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Raw Byte ItemStack Serialization
 Serializes using NBT which is safer for server data migrations than bukkits format.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 5893b764d3fceccef8704f1f90a5c826d6012166..6fefc65c6f9364d71e4e410972dfd79d97fdae3e 100644
+index 4d67e962e81d086f20624ee2ab9e921f9cd020e7..be1e6c050a4d80f330bb4a5ea5f79da3aefb9510 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -431,6 +431,53 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -436,6 +436,53 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public boolean isSupportedApiVersion(String apiVersion) {
          return apiVersion != null && SUPPORTED_API.contains(apiVersion);
      }

--- a/patches/server/0453-Thread-Safe-Vanilla-Command-permission-checking.patch
+++ b/patches/server/0453-Thread-Safe-Vanilla-Command-permission-checking.patch
@@ -26,7 +26,7 @@ index 20a7cdf87f307878d66922aaac0c60cff218e46c..39844531b03eb8a6c70700b4ecbf0ff1
          }
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index fa258155b1cbdd8efde15ec59986d0ab56245ddd..90d5d1de2f00be97e3ea0ff50caa7e7ba9438408 100644
+index 891d1fb88d8de9d1b34f300ba640cfc6fbd8a4de..2ff021966426dd6c7c1081fbcfacf4677b404264 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 @@ -59,7 +59,7 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
@@ -35,10 +35,10 @@ index fa258155b1cbdd8efde15ec59986d0ab56245ddd..90d5d1de2f00be97e3ea0ff50caa7e7b
      private final TaskChainer chatMessageChainer;
 -    public volatile CommandNode currentCommand; // CraftBukkit
 +    public java.util.Map<Thread, CommandNode> currentCommand = new java.util.concurrent.ConcurrentHashMap<>(); // CraftBukkit // Paper
+     public boolean bypassSelectorPermissions = false; // Paper
  
      public CommandSourceStack(CommandSource output, Vec3 pos, Vec2 rot, ServerLevel world, int level, String name, Component displayName, MinecraftServer server, @Nullable Entity entity) {
-         this(output, pos, rot, world, level, name, displayName, server, entity, false, (commandcontext, flag, j) -> {
-@@ -195,9 +195,11 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
+@@ -196,9 +196,11 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
      @Override
      public boolean hasPermission(int level) {
          // CraftBukkit start

--- a/patches/server/0477-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0477-Add-methods-to-get-translation-keys.patch
@@ -46,10 +46,10 @@ index a859a675b4bc543e139358223cc92ad5eee3ddb5..31a22f26070059e5379730c1940ff1c5
  
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 6fefc65c6f9364d71e4e410972dfd79d97fdae3e..c65cc24fbd8b6cb9828fbc978c21c3f7ef9171a3 100644
+index be1e6c050a4d80f330bb4a5ea5f79da3aefb9510..cb5cfcfc1a1ad5d4c0c07f187c8e36c4fc63248c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -478,6 +478,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -483,6 +483,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
          Preconditions.checkArgument(dataVersion <= getDataVersion(), "Newer version! Server downgrades are not supported!");
          return compound;
      }

--- a/patches/server/0484-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0484-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -21,10 +21,10 @@ index 5a43e57d2e2146d324685808cfe980178bde03a2..c99798ea88f7f6dd6db6c80666171e75
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index c65cc24fbd8b6cb9828fbc978c21c3f7ef9171a3..346f5f4b2afec3127c5d1b8e054eaacb1cb756e4 100644
+index cb5cfcfc1a1ad5d4c0c07f187c8e36c4fc63248c..bcb61aefa3e42d4a1fd3d97116802197fe94ae21 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -502,6 +502,10 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -507,6 +507,10 @@ public final class CraftMagicNumbers implements UnsafeValues {
          net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
          return nmsItemStack.getItem().getDescriptionId(nmsItemStack);
      }

--- a/patches/server/0503-Fix-client-lag-on-advancement-loading.patch
+++ b/patches/server/0503-Fix-client-lag-on-advancement-loading.patch
@@ -15,10 +15,10 @@ manually reload the advancement data for all players, which
 normally takes place as a part of the datapack reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 346f5f4b2afec3127c5d1b8e054eaacb1cb756e4..3f45ebeb31264f5f9a99123894fe07bd8e4c65d8 100644
+index bcb61aefa3e42d4a1fd3d97116802197fe94ae21..5656b0380c8a74084f5ff366c09419171b66f172 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -340,7 +340,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -345,7 +345,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
                      Bukkit.getLogger().log(Level.SEVERE, "Error saving advancement " + key, ex);
                  }
  

--- a/patches/server/0554-Add-PaperRegistry.patch
+++ b/patches/server/0554-Add-PaperRegistry.patch
@@ -205,10 +205,10 @@ index 17e0425a520bd95074bf34c262c36c5603266ea7..f05f5d13f23599dbb95a7062ebbb4133
              // Paper start
              if (Thread.currentThread() != this.serverThread) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 3f45ebeb31264f5f9a99123894fe07bd8e4c65d8..dc034bd793842e02f0fea54d1ae49ac7a66af597 100644
+index 5656b0380c8a74084f5ff366c09419171b66f172..bd6a65a15e581e0f342d7dd9572651fa21ce3961 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -512,6 +512,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -517,6 +517,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public int nextEntityId() {
          return net.minecraft.world.entity.Entity.nextEntityId();
      }

--- a/patches/server/0589-Expand-world-key-API.patch
+++ b/patches/server/0589-Expand-world-key-API.patch
@@ -67,10 +67,10 @@ index 462ffe647b11185001a08b09e74773b8831a3b46..e90ef57567928fdfd08fd16ce84503b0
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index dc034bd793842e02f0fea54d1ae49ac7a66af597..1343db872321fe14465ad2b1f363d41989096ed4 100644
+index bd6a65a15e581e0f342d7dd9572651fa21ce3961..45cf2df36af20e36ba8026f94e5598d1b5583d4b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -517,6 +517,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -522,6 +522,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public <T extends org.bukkit.Keyed> Registry<T> registryFor(Class<T> classOfT) {
          return io.papermc.paper.registry.PaperRegistry.getRegistry(classOfT);
      }

--- a/patches/server/0591-Item-Rarity-API.patch
+++ b/patches/server/0591-Item-Rarity-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Item Rarity API
 public net.minecraft.world.item.Item rarity
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 1343db872321fe14465ad2b1f363d41989096ed4..9e27257265dab677175b9b3d921e1fc3f3cb7817 100644
+index 45cf2df36af20e36ba8026f94e5598d1b5583d4b..cef2946c0fc5e52896635396dea4153b61da612e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -522,6 +522,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -527,6 +527,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public String getMainLevelName() {
          return ((net.minecraft.server.dedicated.DedicatedServer) net.minecraft.server.MinecraftServer.getServer()).getProperties().levelName;
      }

--- a/patches/server/0598-Expose-protocol-version.patch
+++ b/patches/server/0598-Expose-protocol-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 9e27257265dab677175b9b3d921e1fc3f3cb7817..7f747fbaa1da49ab930d2a9ff60200a445ca477c 100644
+index cef2946c0fc5e52896635396dea4153b61da612e..a01c4790d56bfae3f8dd4b4e8c54b9725d92b410 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -536,6 +536,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -541,6 +541,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(org.bukkit.inventory.ItemStack itemStack) {
          return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
      }

--- a/patches/server/0628-ItemStack-repair-check-API.patch
+++ b/patches/server/0628-ItemStack-repair-check-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack repair check API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 7f747fbaa1da49ab930d2a9ff60200a445ca477c..0ebcadd6daf244cd9b6c943ca0a2baaafb3eba50 100644
+index a01c4790d56bfae3f8dd4b4e8c54b9725d92b410..ec896bd1ce2b0fb101dcf3316a9981c92fbebcea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -537,6 +537,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -542,6 +542,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
      }
  

--- a/patches/server/0635-Attributes-API-for-item-defaults.patch
+++ b/patches/server/0635-Attributes-API-for-item-defaults.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Attributes API for item defaults
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 0ebcadd6daf244cd9b6c943ca0a2baaafb3eba50..6fd3bbc36cb6e270a10f778fe2764823f90cca9c 100644
+index ec896bd1ce2b0fb101dcf3316a9981c92fbebcea..4a2903d8cb7523abba2efd7024662d0d56871a43 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -545,6 +545,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -550,6 +550,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftMagicNumbers.getItem(itemToBeRepaired.getType()).isValidRepairItem(CraftItemStack.asNMSCopy(itemToBeRepaired), CraftItemStack.asNMSCopy(repairMaterial));
      }
  

--- a/patches/server/0692-Get-entity-default-attributes.patch
+++ b/patches/server/0692-Get-entity-default-attributes.patch
@@ -81,10 +81,10 @@ index 0000000000000000000000000000000000000000..cf9d28ea97d93cec05c9fb768d59e283
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 6fd3bbc36cb6e270a10f778fe2764823f90cca9c..51ecfd4c4afe6dfc42c3aa85e6fc55d0e965a5dc 100644
+index 4a2903d8cb7523abba2efd7024662d0d56871a43..6f4f95b000efb1270eda94d218e628b50921a272 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -562,6 +562,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -567,6 +567,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public int getProtocolVersion() {
          return net.minecraft.SharedConstants.getCurrentVersion().getProtocolVersion();
      }

--- a/patches/server/0698-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/server/0698-Add-isCollidable-methods-to-various-places.patch
@@ -39,10 +39,10 @@ index 7b9e943b391c061782fccd2b8d705ceec8db50fe..966ac60daebb7bb211ab8096fc0c5f33
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 51ecfd4c4afe6dfc42c3aa85e6fc55d0e965a5dc..0a3d447f87698dc786d6cab6ded27eb1b5780204 100644
+index 6f4f95b000efb1270eda94d218e628b50921a272..7b6231f7696fa949c657e05a1d35d0d7e482284e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -574,6 +574,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -579,6 +579,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
          var supplier = net.minecraft.world.entity.ai.attributes.DefaultAttributes.getSupplier((net.minecraft.world.entity.EntityType<? extends net.minecraft.world.entity.LivingEntity>) net.minecraft.core.Registry.ENTITY_TYPE.get(CraftNamespacedKey.toMinecraft(bukkitEntityKey)));
          return new io.papermc.paper.attribute.UnmodifiableAttributeMap(supplier);
      }

--- a/patches/server/0701-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0701-Add-Raw-Byte-Entity-Serialization.patch
@@ -45,10 +45,10 @@ index d34e1da89e04df311c1627f43790851c23fef0b0..8c273a7dc38c9c5dba83c998bab3427d
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 0a3d447f87698dc786d6cab6ded27eb1b5780204..d3b37adfe6d66e82db18d94f143af3aba4543f79 100644
+index 7b6231f7696fa949c657e05a1d35d0d7e482284e..d0c3b2582aba507dce69eb91d6c0803a4bb6ea06 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -457,6 +457,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -462,6 +462,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of((CompoundTag) converted.getValue()));
      }
  

--- a/patches/server/0781-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/patches/server/0781-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -10,10 +10,10 @@ when if this was fixed on the client, that wouldn't be needed.
 Mojira Issue: https://bugs.mojang.com/browse/MC-235045
 
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index 90d5d1de2f00be97e3ea0ff50caa7e7ba9438408..0d140dd7d55407b57fc3394ceb2eba5136e4fcaf 100644
+index 2ff021966426dd6c7c1081fbcfacf4677b404264..81f4e3c869623b6dd2d80886652fa41791fe7032 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-@@ -412,4 +412,20 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
+@@ -413,4 +413,20 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
          return this.source.getBukkitSender(this);
      }
      // CraftBukkit end

--- a/patches/server/0819-Fix-Fluid-tags-isTagged-method.patch
+++ b/patches/server/0819-Fix-Fluid-tags-isTagged-method.patch
@@ -18,10 +18,10 @@ index 89cb1ec575c0f58e9934d98b056621348dbbe27a..cdd474e9b0363641839a66d3e61fec46
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index d3b37adfe6d66e82db18d94f143af3aba4543f79..0a4e9b0957c9b0abbb88d472b5b3d7946c256af2 100644
+index d0c3b2582aba507dce69eb91d6c0803a4bb6ea06..747a6bfdf5555d82a07e55e600ae59d8172704bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -201,7 +201,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -206,7 +206,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftMagicNumbers.MATERIAL_BLOCK.get(material);
      }
  

--- a/patches/server/0897-Add-NamespacedKey-biome-methods.patch
+++ b/patches/server/0897-Add-NamespacedKey-biome-methods.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add NamespacedKey biome methods
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 0a4e9b0957c9b0abbb88d472b5b3d7946c256af2..1628913b1e9b91e68dcd942a38da4aed95b12d4a 100644
+index 747a6bfdf5555d82a07e55e600ae59d8172704bf..db8b186ef6586bcb9887bc3f3a94d43417eddbac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -604,6 +604,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -609,6 +609,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
          Preconditions.checkArgument(material.isBlock(), material + " is not a block");
          return getBlock(material).hasCollision;
      }

--- a/patches/server/0933-Fix-EntityArgument-suggestion-permissions-to-align-w.patch
+++ b/patches/server/0933-Fix-EntityArgument-suggestion-permissions-to-align-w.patch
@@ -9,7 +9,7 @@ suggestions, which especially matters when we force suggestions to
 the server for this type
 
 diff --git a/src/main/java/net/minecraft/commands/arguments/EntityArgument.java b/src/main/java/net/minecraft/commands/arguments/EntityArgument.java
-index a2ea64b7ec5f47224312a1e08dd64347be6f7c43..5d649058d3a0cc858f0c943e3ac1998d598f7270 100644
+index a2ea64b7ec5f47224312a1e08dd64347be6f7c43..b3c65f6b757c9ca7d26f5e95293c6021ab771a2f 100644
 --- a/src/main/java/net/minecraft/commands/arguments/EntityArgument.java
 +++ b/src/main/java/net/minecraft/commands/arguments/EntityArgument.java
 @@ -128,7 +128,12 @@ public class EntityArgument implements ArgumentType<EntitySelector> {
@@ -19,7 +19,7 @@ index a2ea64b7ec5f47224312a1e08dd64347be6f7c43..5d649058d3a0cc858f0c943e3ac1998d
 -            EntitySelectorParser argumentparserselector = new EntitySelectorParser(stringreader, icompletionprovider.hasPermission(2), true); // Paper
 +            // Paper start
 +            final boolean permission = object instanceof CommandSourceStack stack
-+                    ? stack.hasPermission(2, "minecraft.command.selector")
++                    ? stack.bypassSelectorPermissions || stack.hasPermission(2, "minecraft.command.selector")
 +                    : icompletionprovider.hasPermission(2);
 +            EntitySelectorParser argumentparserselector = new EntitySelectorParser(stringreader, permission, true); // Paper
 +            // Paper end


### PR DESCRIPTION
Resolves https://github.com/PaperMC/Paper/issues/5413

Perhaps some mention of the permission craftbukkit adds `minecraft.command.selector` since that will block the use of some components that make use of selectors if the CommandSender doesn't have that permission?