### PR TITLE
fix player loottables running when mob loot gamerule is false

### DIFF
--- a/patches/server/0886-fix-player-loottables-running-when-mob-loot-gamerule.patch
+++ b/patches/server/0886-fix-player-loottables-running-when-mob-loot-gamerule.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 22 Mar 2022 09:50:40 -0700
+Subject: [PATCH] fix player loottables running when mob loot gamerule is false
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index e74c13e7aaa144fcd07036de70e80bebf0be698a..fd8675f74ea787906b83d863940959efbf8bfac9 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -846,12 +846,14 @@ public class ServerPlayer extends Player {
+                 }
+             }
+         }
++        if (this.shouldDropLoot() && this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) { // Paper - preserve this check from vanilla
+         // SPIGOT-5071: manually add player loot tables (SPIGOT-5195 - ignores keepInventory rule)
+         this.dropFromLootTable(source, this.lastHurtByPlayerTime > 0);
+         for (org.bukkit.inventory.ItemStack item : this.drops) {
+             loot.add(item);
+         }
+         this.drops.clear(); // SPIGOT-5188: make sure to clear
++        } // Paper
+ 
+         Component defaultMessage = this.getCombatTracker().getDeathMessage();
+ 


### PR DESCRIPTION
In vanilla, the player loot table is only run if the shouldDropLoot is true (always for vanilla players) and the mob loot game rule is true. when [upstream fixed the loot table running](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/f2757f95b3089d9beb17b5effe72ea183a18b224#nms-patches/EntityPlayer.patch), they didn't add the check.