### PR TITLE
Fix PalettedContainer synchronization

### DIFF
--- a/patches/server/0663-Synchronize-PalettedContainer-instead-of-ThreadingDe.patch
+++ b/patches/server/0663-Synchronize-PalettedContainer-instead-of-ThreadingDe.patch
@@ -1,23 +1,28 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 29 May 2020 20:29:02 -0400
-Subject: [PATCH] Synchronize PalettedContainer instead of ReentrantLock
+Subject: [PATCH] Synchronize PalettedContainer instead of
+ ThreadingDetector/Semaphore
 
 Mojang has flaws in their logic about chunks being concurrently
 wrote to. So we constantly see crashes around multiple threads writing.
 
 Additionally, java has optimized synchronization so well that its
-in many times faster than trying to manage read wrote locks for low
+in many times faster than trying to manage read write locks for low
 contention situations.
 
 And this is extremely a low contention situation.
 
 diff --git a/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java b/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
-index 45a969f97b26e328e34f3d576557999c32b954a2..83dc9550f4ed2a138d4ece2765273e555cda994a 100644
+index 45a969f97b26e328e34f3d576557999c32b954a2..277b75940d0424051919889b2d0045f313027234 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
-@@ -35,11 +35,11 @@ public class PalettedContainer<T> implements PaletteResize<T> {
-     private final ThreadingDetector threadingDetector = new ThreadingDetector("PalettedContainer");
+@@ -32,14 +32,14 @@ public class PalettedContainer<T> implements PaletteResize<T> {
+     private final T @org.jetbrains.annotations.Nullable [] presetValues; // Paper - Anti-Xray - Add preset values
+     private volatile PalettedContainer.Data<T> data;
+     private final PalettedContainer.Strategy strategy;
+-    private final ThreadingDetector threadingDetector = new ThreadingDetector("PalettedContainer");
++    // private final ThreadingDetector threadingDetector = new ThreadingDetector("PalettedContainer"); // Paper - unused
  
      public void acquire() {
 -        this.threadingDetector.checkAndLock();
@@ -30,24 +35,33 @@ index 45a969f97b26e328e34f3d576557999c32b954a2..83dc9550f4ed2a138d4ece2765273e55
      }
  
      // Paper start - Anti-Xray - Add preset values
-@@ -143,7 +143,7 @@ public class PalettedContainer<T> implements PaletteResize<T> {
+@@ -113,7 +113,7 @@ public class PalettedContainer<T> implements PaletteResize<T> {
      }
-     // Paper end
  
--    public T getAndSet(int x, int y, int z, T value) {
-+    public synchronized T getAndSet(int x, int y, int z, T value) { // Paper - synchronize
-         this.acquire();
+     @Override
+-    public int onResize(int newBits, T object) {
++    public synchronized int onResize(int newBits, T object) { // Paper - synchronize
+         PalettedContainer.Data<T> data = this.data;
  
-         Object var5;
-@@ -166,7 +166,7 @@ public class PalettedContainer<T> implements PaletteResize<T> {
+         // Paper start - Anti-Xray - Add preset values
+@@ -160,7 +160,7 @@ public class PalettedContainer<T> implements PaletteResize<T> {
+         return this.getAndSet(this.strategy.getIndex(x, y, z), value);
+     }
+ 
+-    private T getAndSet(int index, T value) {
++    private synchronized T getAndSet(int index, T value) { // Paper - synchronize
+         int i = this.data.palette.idFor(value);
+         int j = this.data.storage.getAndSet(index, i);
          return this.data.palette.valueFor(j);
+@@ -177,7 +177,7 @@ public class PalettedContainer<T> implements PaletteResize<T> {
+ 
      }
  
--    public void set(int x, int y, int z, T value) {
-+    public synchronized void set(int x, int y, int z, T value) { // Paper - synchronize
-         this.acquire();
- 
-         try {
+-    private void set(int index, T value) {
++    private synchronized void set(int index, T value) { // Paper - synchronize
+         int i = this.data.palette.idFor(value);
+         this.data.storage.set(index, i);
+     }
 @@ -200,7 +200,7 @@ public class PalettedContainer<T> implements PaletteResize<T> {
          });
      }
@@ -66,15 +80,6 @@ index 45a969f97b26e328e34f3d576557999c32b954a2..83dc9550f4ed2a138d4ece2765273e55
          this.acquire();
  
          try {
-@@ -236,7 +236,7 @@ public class PalettedContainer<T> implements PaletteResize<T> {
- 
-     }
- 
--    private static <T> DataResult<PalettedContainer<T>> read(IdMap<T> idList, PalettedContainer.Strategy provider, PalettedContainer.DiscData<T> serialized, T defaultValue, T @org.jetbrains.annotations.Nullable [] presetValues) { // Paper - Anti-Xray - Add preset values
-+    private synchronized static <T> DataResult<PalettedContainer<T>> read(IdMap<T> idList, PalettedContainer.Strategy provider, PalettedContainer.DiscData<T> serialized, T defaultValue, T @org.jetbrains.annotations.Nullable [] presetValues) { // Paper - Anti-Xray - Add preset values // Paper - synchronize
-         List<T> list = serialized.paletteEntries();
-         int i = provider.size();
-         int j = provider.calculateBitsForSerialization(idList, list.size());
 @@ -275,7 +275,7 @@ public class PalettedContainer<T> implements PaletteResize<T> {
          return DataResult.success(new PalettedContainer<>(idList, provider, configuration, bitStorage, list, defaultValue, presetValues)); // Paper - Anti-Xray - Add preset values
      }


### PR DESCRIPTION
The original patch synchronized the private getAndSet method, making the writes done by both the standard and "unchecked" public getAndSet methods synchronized, this was incorrectly ported when updating to 1.17.

Also remove creation of unused `ThreadingDetector`s (2 per chunk section)