### PR TITLE
Pass ServerLevel for gamerule callbacks

### DIFF
--- a/patches/server/0894-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0894-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -1,0 +1,181 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sun, 27 Mar 2022 13:51:09 -0400
+Subject: [PATCH] Pass ServerLevel for gamerule callbacks
+
+
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index e28e09aae1d95d9bed50a137e999e6d457e62478..257c94f7c1cb00c9a91ab82e311dfd8eca29c538 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -319,7 +319,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+ 
+             //DedicatedServer.LOGGER.info("Done ({})! For help, type \"help\"", s); // Paper moved to after init
+             if (dedicatedserverproperties.announcePlayerAchievements != null) {
+-                ((GameRules.BooleanValue) this.getGameRules().getRule(GameRules.RULE_ANNOUNCE_ADVANCEMENTS)).set(dedicatedserverproperties.announcePlayerAchievements, this);
++                ((GameRules.BooleanValue) this.getGameRules().getRule(GameRules.RULE_ANNOUNCE_ADVANCEMENTS)).set(dedicatedserverproperties.announcePlayerAchievements, null); // Paper
+             }
+ 
+             if (dedicatedserverproperties.enableQuery) {
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index ca876d0916b7b888e8df58fb6b115fa0ab5b79d3..9df5b678ce4343d0bb54133393f6bbe40fe5366b 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -2603,7 +2603,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+                     this.player = this.server.getPlayerList().respawn(this.player, false);
+                     if (this.server.isHardcore()) {
+                         this.player.setGameMode(GameType.SPECTATOR, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.HARDCORE_DEATH, null); // Paper
+-                        ((GameRules.BooleanValue) this.player.getLevel().getGameRules().getRule(GameRules.RULE_SPECTATORSGENERATECHUNKS)).set(false, this.server);
++                        ((GameRules.BooleanValue) this.player.getLevel().getGameRules().getRule(GameRules.RULE_SPECTATORSGENERATECHUNKS)).set(false, this.player.getLevel()); // Paper
+                     }
+                 }
+                 break;
+diff --git a/src/main/java/net/minecraft/world/level/GameRules.java b/src/main/java/net/minecraft/world/level/GameRules.java
+index 798afc145c54306fcf0838d8daef2bdf17763da9..22feab6477bad023c2d6cc9ac99d392d0afe0a31 100644
+--- a/src/main/java/net/minecraft/world/level/GameRules.java
++++ b/src/main/java/net/minecraft/world/level/GameRules.java
+@@ -51,7 +51,7 @@ public class GameRules {
+     public static final GameRules.Key<GameRules.BooleanValue> RULE_SENDCOMMANDFEEDBACK = GameRules.register("sendCommandFeedback", GameRules.Category.CHAT, GameRules.BooleanValue.create(true));
+     public static final GameRules.Key<GameRules.BooleanValue> RULE_REDUCEDDEBUGINFO = GameRules.register("reducedDebugInfo", GameRules.Category.MISC, GameRules.BooleanValue.create(false, (minecraftserver, gamerules_gameruleboolean) -> {
+         int i = gamerules_gameruleboolean.get() ? 22 : 23;
+-        Iterator iterator = minecraftserver.getPlayerList().getPlayers().iterator();
++        Iterator iterator = minecraftserver.players().iterator(); // Paper
+ 
+         while (iterator.hasNext()) {
+             ServerPlayer entityplayer = (ServerPlayer) iterator.next();
+@@ -71,7 +71,7 @@ public class GameRules {
+     public static final GameRules.Key<GameRules.BooleanValue> RULE_DISABLE_RAIDS = GameRules.register("disableRaids", GameRules.Category.MOBS, GameRules.BooleanValue.create(false));
+     public static final GameRules.Key<GameRules.BooleanValue> RULE_DOINSOMNIA = GameRules.register("doInsomnia", GameRules.Category.SPAWNING, GameRules.BooleanValue.create(true));
+     public static final GameRules.Key<GameRules.BooleanValue> RULE_DO_IMMEDIATE_RESPAWN = GameRules.register("doImmediateRespawn", GameRules.Category.PLAYER, GameRules.BooleanValue.create(false, (minecraftserver, gamerules_gameruleboolean) -> {
+-        Iterator iterator = minecraftserver.getPlayerList().getPlayers().iterator();
++        Iterator iterator = minecraftserver.players().iterator(); // Paper
+ 
+         while (iterator.hasNext()) {
+             ServerPlayer entityplayer = (ServerPlayer) iterator.next();
+@@ -156,13 +156,13 @@ public class GameRules {
+         ((GameRules.Type<T>) type).callVisitor(consumer, (GameRules.Key<T>) key); // CraftBukkit - decompile error
+     }
+ 
+-    public void assignFrom(GameRules rules, @Nullable MinecraftServer server) {
++    public void assignFrom(GameRules rules, @Nullable net.minecraft.server.level.ServerLevel server) { // Paper
+         rules.rules.keySet().forEach((gamerules_gamerulekey) -> {
+             this.assignCap(gamerules_gamerulekey, rules, server);
+         });
+     }
+ 
+-    private <T extends GameRules.Value<T>> void assignCap(GameRules.Key<T> key, GameRules rules, @Nullable MinecraftServer server) {
++    private <T extends GameRules.Value<T>> void assignCap(GameRules.Key<T> key, GameRules rules, @Nullable net.minecraft.server.level.ServerLevel server) { // Paper
+         T t0 = rules.getRule(key);
+ 
+         this.getRule(key).setFrom(t0, server);
+@@ -230,10 +230,10 @@ public class GameRules {
+ 
+         private final Supplier<ArgumentType<?>> argument;
+         private final Function<GameRules.Type<T>, T> constructor;
+-        final BiConsumer<MinecraftServer, T> callback;
++        final BiConsumer<net.minecraft.server.level.ServerLevel, T> callback; // Paper
+         private final GameRules.VisitorCaller<T> visitorCaller;
+ 
+-        Type(Supplier<ArgumentType<?>> argumentType, Function<GameRules.Type<T>, T> ruleFactory, BiConsumer<MinecraftServer, T> changeCallback, GameRules.VisitorCaller<T> ruleAcceptor) {
++        Type(Supplier<ArgumentType<?>> argumentType, Function<GameRules.Type<T>, T> ruleFactory, BiConsumer<net.minecraft.server.level.ServerLevel, T> changeCallback, GameRules.VisitorCaller<T> ruleAcceptor) { // Paper
+             this.argument = argumentType;
+             this.constructor = ruleFactory;
+             this.callback = changeCallback;
+@@ -265,10 +265,10 @@ public class GameRules {
+ 
+         public void setFromArgument(CommandContext<CommandSourceStack> context, String name, GameRules.Key<T> gameRuleKey) { // Paper
+             this.updateFromArgument(context, name, gameRuleKey); // Paper
+-            this.onChanged(((CommandSourceStack) context.getSource()).getServer());
++            this.onChanged(((CommandSourceStack) context.getSource()).getLevel()); // Paper
+         }
+ 
+-        public void onChanged(@Nullable MinecraftServer server) {
++        public void onChanged(@Nullable net.minecraft.server.level.ServerLevel server) { // Paper
+             if (server != null) {
+                 this.type.callback.accept(server, this.getSelf());
+             }
+@@ -289,7 +289,7 @@ public class GameRules {
+ 
+         protected abstract T copy();
+ 
+-        public abstract void setFrom(T rule, @Nullable MinecraftServer server);
++        public abstract void setFrom(T rule, @Nullable net.minecraft.server.level.ServerLevel level); // Paper
+     }
+ 
+     public interface GameRuleTypeVisitor {
+@@ -305,7 +305,7 @@ public class GameRules {
+ 
+         private boolean value;
+ 
+-        static GameRules.Type<GameRules.BooleanValue> create(boolean initialValue, BiConsumer<MinecraftServer, GameRules.BooleanValue> changeCallback) {
++        static GameRules.Type<GameRules.BooleanValue> create(boolean initialValue, BiConsumer<net.minecraft.server.level.ServerLevel, GameRules.BooleanValue> changeCallback) { // Paper
+             return new GameRules.Type<>(BoolArgumentType::bool, (gamerules_gameruledefinition) -> {
+                 return new GameRules.BooleanValue(gamerules_gameruledefinition, initialValue);
+             }, changeCallback, GameRules.GameRuleTypeVisitor::visitBoolean);
+@@ -333,7 +333,7 @@ public class GameRules {
+             return this.value;
+         }
+ 
+-        public void set(boolean value, @Nullable MinecraftServer server) {
++        public void set(boolean value, @Nullable net.minecraft.server.level.ServerLevel server) { // Paper
+             this.value = value;
+             this.onChanged(server);
+         }
+@@ -363,7 +363,7 @@ public class GameRules {
+             return new GameRules.BooleanValue(this.type, this.value);
+         }
+ 
+-        public void setFrom(GameRules.BooleanValue rule, @Nullable MinecraftServer server) {
++        public void setFrom(GameRules.BooleanValue rule, @Nullable net.minecraft.server.level.ServerLevel server) { // Paper
+             this.value = rule.value;
+             this.onChanged(server);
+         }
+@@ -373,7 +373,7 @@ public class GameRules {
+ 
+         private int value;
+ 
+-        private static GameRules.Type<GameRules.IntegerValue> create(int initialValue, BiConsumer<MinecraftServer, GameRules.IntegerValue> changeCallback) {
++        private static GameRules.Type<GameRules.IntegerValue> create(int initialValue, BiConsumer<net.minecraft.server.level.ServerLevel, GameRules.IntegerValue> changeCallback) { // Paper
+             return new GameRules.Type<>(IntegerArgumentType::integer, (gamerules_gameruledefinition) -> {
+                 return new GameRules.IntegerValue(gamerules_gameruledefinition, initialValue);
+             }, changeCallback, GameRules.GameRuleTypeVisitor::visitInteger);
+@@ -401,7 +401,7 @@ public class GameRules {
+             return this.value;
+         }
+ 
+-        public void set(int value, @Nullable MinecraftServer server) {
++        public void set(int value, @Nullable net.minecraft.server.level.ServerLevel server) { // Paper
+             this.value = value;
+             this.onChanged(server);
+         }
+@@ -452,7 +452,7 @@ public class GameRules {
+             return new GameRules.IntegerValue(this.type, this.value);
+         }
+ 
+-        public void setFrom(GameRules.IntegerValue rule, @Nullable MinecraftServer server) {
++        public void setFrom(GameRules.IntegerValue rule, @Nullable net.minecraft.server.level.ServerLevel server) { // Paper
+             this.value = rule.value;
+             this.onChanged(server);
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 21db68e58d053b83d8688b3fc71984ff36dda048..de4f750cbad3baa8ca22f485567751ed2da8df29 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -1916,7 +1916,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+         // Paper end
+         GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule));
+         handle.deserialize(event.getValue()); // Paper
+-        handle.onChanged(this.getHandle().getServer());
++        handle.onChanged(this.getHandle()); // Paper
+         return true;
+     }
+ 
+@@ -1956,7 +1956,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+         // Paper end
+         GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule.getName()));
+         handle.deserialize(event.getValue()); // Paper
+-        handle.onChanged(this.getHandle().getServer());
++        handle.onChanged(this.getHandle()); // Paper
+         return true;
+     }
+ 


### PR DESCRIPTION
Fixes gamerule callbacks affecting all worlds, for example when updating the game rule in the overworld players in the nether are affected too.


