### PR TITLE
Fix NPE for BlockDataMeta#getBlockData

### DIFF
--- a/patches/server/0897-Fix-NPE-for-BlockDataMeta-getBlockData.patch
+++ b/patches/server/0897-Fix-NPE-for-BlockDataMeta-getBlockData.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 27 Mar 2022 16:00:28 -0700
+Subject: [PATCH] Fix NPE for BlockDataMeta#getBlockData
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+index 1fe46049cc33c24db04fbfcde36ab275c03177bf..5607dc10dc1c9d2dbf4e3007890e5e89a175605e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -1093,7 +1093,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+     @Override
+     public BlockData getBlockData(Material material) {
+-        return CraftBlockData.fromData(BlockItem.getBlockState(CraftMagicNumbers.getBlock(material).defaultBlockState(), blockData));
++        // Paper start - fix NPE if this.blockData is null
++        final net.minecraft.world.level.block.state.BlockState defaultBlockState = CraftMagicNumbers.getBlock(material).defaultBlockState();
++        return CraftBlockData.fromData(this.blockData == null ? defaultBlockState : BlockItem.getBlockState(defaultBlockState, blockData));
++        // Paper end
+     }
+ 
+     @Override


### PR DESCRIPTION
idk if it should be fixed here, or fixed in CraftMetaItem to not have a null CompoundTag for blockData