### PR TITLE
Undeprecate Material#isLegacy

### DIFF
--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -9,7 +9,7 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 686235a2347ebeaa5654a14cdd717009f2c0105f..cf7f8a8f03adcbe466b59ea8b98b527fb54a0803 100644
+index 52f5750e1cbce6000c72f5f1b4bde41b9fa66b23..19771a9a7a212a71f4cad33981c3b72341d80093 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1684,7 +1684,7 @@ public final class Bukkit {
@@ -31,7 +31,7 @@ index 686235a2347ebeaa5654a14cdd717009f2c0105f..cf7f8a8f03adcbe466b59ea8b98b527f
          return server.getTag(registry, tag, clazz);
      }
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 88b3e0323dbc4f0fce31b147c7aaa08d65745852..23ca89dde7f6ac9082d4b97fce2959425f3680cb 100644
+index 57cb548683f7b2972c998afd34176952426f8b47..d4c87bfed81b2d73919705912f59fab05c0ee61b 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -46,7 +46,7 @@ public class Location implements Cloneable, ConfigurationSerializable {
@@ -61,8 +61,26 @@ index 88b3e0323dbc4f0fce31b147c7aaa08d65745852..23ca89dde7f6ac9082d4b97fce295942
      public World getWorld() {
          if (this.world == null) {
              return null;
+diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
+index 53d1609e2a75c007cb7e5e8f963b0deb53bae5f7..a8561434d56f7db7e4f52283759b282e9c2116a2 100644
+--- a/src/main/java/org/bukkit/Material.java
++++ b/src/main/java/org/bukkit/Material.java
+@@ -4003,11 +4003,11 @@ public enum Material implements Keyed {
+     }
+ 
+     /**
+-     * Do not use for any reason.
++     * Checks if this constant is a legacy material.
+      *
+      * @return legacy status
+      */
+-    @Deprecated
++    // @Deprecated // Paper - this is useful, don't deprecate
+     public boolean isLegacy() {
+         return legacy;
+     }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f43720d07e80e3d2937f5b271664b5268d7af027..4cd7dae2e6f530a402de460f61d57a27f5763b73 100644
+index ef10f62a00f19b6a2ca61c3984465f5cd9fa7479..790c09d8fc67dfe6325faff419be7d980415bad8 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1429,7 +1429,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi


### PR DESCRIPTION
This method shouldn't be deprecated because it does serve a purpose. when creating lists of Materials and you have to filter out the legacy ones for example.