### PR TITLE
Fix Nullability Annotations for PrepareItemEnchantEvent

### DIFF
--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -9,7 +9,7 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 686235a2347ebeaa5654a14cdd717009f2c0105f..cf7f8a8f03adcbe466b59ea8b98b527fb54a0803 100644
+index 52f5750e1cbce6000c72f5f1b4bde41b9fa66b23..19771a9a7a212a71f4cad33981c3b72341d80093 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1684,7 +1684,7 @@ public final class Bukkit {
@@ -31,7 +31,7 @@ index 686235a2347ebeaa5654a14cdd717009f2c0105f..cf7f8a8f03adcbe466b59ea8b98b527f
          return server.getTag(registry, tag, clazz);
      }
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 88b3e0323dbc4f0fce31b147c7aaa08d65745852..23ca89dde7f6ac9082d4b97fce2959425f3680cb 100644
+index 57cb548683f7b2972c998afd34176952426f8b47..d4c87bfed81b2d73919705912f59fab05c0ee61b 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -46,7 +46,7 @@ public class Location implements Cloneable, ConfigurationSerializable {
@@ -62,7 +62,7 @@ index 88b3e0323dbc4f0fce31b147c7aaa08d65745852..23ca89dde7f6ac9082d4b97fce295942
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f43720d07e80e3d2937f5b271664b5268d7af027..4cd7dae2e6f530a402de460f61d57a27f5763b73 100644
+index ef10f62a00f19b6a2ca61c3984465f5cd9fa7479..790c09d8fc67dfe6325faff419be7d980415bad8 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1429,7 +1429,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -85,9 +85,18 @@ index f124b35ec76e6cb6a1a0dc464005087043c3efd0..94a2fef0dc9e13c754cd31d5eabc1bde
 +@Deprecated // Paper
  public interface LingeringPotion extends ThrownPotion { }
 diff --git a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
-index 2ff1b1308571d8f8056d3359e8a8ba4a589c3726..e669ad8ecd182c6899c7820414e6ee1f7312d699 100644
+index 2ff1b1308571d8f8056d3359e8a8ba4a589c3726..8eb6f4090578d9e1b12aff813840108fdeece730 100644
 --- a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
 +++ b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
+@@ -23,7 +23,7 @@ public class PrepareItemEnchantEvent extends InventoryEvent implements Cancellab
+     private boolean cancelled;
+     private final Player enchanter;
+ 
+-    public PrepareItemEnchantEvent(@NotNull final Player enchanter, @NotNull InventoryView view, @NotNull final Block table, @NotNull final ItemStack item, @NotNull final EnchantmentOffer[] offers, final int bonus) {
++    public PrepareItemEnchantEvent(@NotNull final Player enchanter, @NotNull InventoryView view, @NotNull final Block table, @NotNull final ItemStack item, @org.jetbrains.annotations.Nullable final EnchantmentOffer @NotNull [] offers, final int bonus) { // Paper - offers can contain null values
+         super(view);
+         this.enchanter = enchanter;
+         this.table = table;
 @@ -68,6 +68,7 @@ public class PrepareItemEnchantEvent extends InventoryEvent implements Cancellab
       * @return experience level costs offered
       * @deprecated Use {@link #getOffers()} instead of this method
@@ -96,6 +105,16 @@ index 2ff1b1308571d8f8056d3359e8a8ba4a589c3726..e669ad8ecd182c6899c7820414e6ee1f
      @NotNull
      public int[] getExpLevelCostsOffered() {
          int[] levelOffers = new int[offers.length];
+@@ -85,8 +86,7 @@ public class PrepareItemEnchantEvent extends InventoryEvent implements Cancellab
+      *
+      * @return list of available enchantment offers
+      */
+-    @NotNull
+-    public EnchantmentOffer[] getOffers() {
++    public @org.jetbrains.annotations.Nullable EnchantmentOffer @NotNull [] getOffers() { // Paper offers can contain null values
+         return offers;
+     }
+ 
 diff --git a/src/main/java/org/bukkit/inventory/CraftingInventory.java b/src/main/java/org/bukkit/inventory/CraftingInventory.java
 index df81bac9ecff697f98941e5c8490e10391e90090..a32977ba3ba60a1c9aee6e469d5d6cd1887c55a2 100644
 --- a/src/main/java/org/bukkit/inventory/CraftingInventory.java


### PR DESCRIPTION
The return value is marked as NotNull causing Kotlin to disallow me from setting an item in the array to null, despite the JavaDoc saying the contents of the array may be null. This should fix that.