### PR TITLE
Remove World#refreshChunk deprecation

### DIFF
--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -92,6 +92,21 @@ index ef10f62a00f19b6a2ca61c3984465f5cd9fa7479..790c09d8fc67dfe6325faff419be7d98
      ScoreboardManager getScoreboardManager();
  
      /**
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index f36eb8896ee84c1d3bbce17b11ed05c5f99f2e29..b8c4d25d49ea65d36b052faba8863efa813d9bc5 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -427,9 +427,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+      * @param z Z-coordinate of the chunk
+      * @return Whether the chunk was actually refreshed
+      *
+-     * @deprecated This method is not guaranteed to work suitably across all client implementations.
+      */
+-    @Deprecated
++    //@Deprecated // Paper
+     public boolean refreshChunk(int x, int z);
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/entity/LingeringPotion.java b/src/main/java/org/bukkit/entity/LingeringPotion.java
 index f124b35ec76e6cb6a1a0dc464005087043c3efd0..94a2fef0dc9e13c754cd31d5eabc1bde2dbbe6a5 100644
 --- a/src/main/java/org/bukkit/entity/LingeringPotion.java

--- a/patches/api/0276-Implement-Keyed-on-World.patch
+++ b/patches/api/0276-Implement-Keyed-on-World.patch
@@ -50,7 +50,7 @@ index 36fb8f14da0ed8192a91d509bcee94f99bea9354..d43f785471d3671bad6eb270a87a70b2
       * Gets the map from the given item ID.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 513de620accbee93a04ef729dd386dadba566a8f..caa674ed1e4b3a940cee05a79d1af47b20e3badb 100644
+index eed79cbb4e8955755bc3969ff70a728f275b4af9..3c74768ebf6690056576e8fceb7f2e2ee2a70492 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -43,7 +43,7 @@ import org.jetbrains.annotations.Nullable;
@@ -62,7 +62,7 @@ index 513de620accbee93a04ef729dd386dadba566a8f..caa674ed1e4b3a940cee05a79d1af47b
  
      // Paper start
      /**
-@@ -1529,6 +1529,15 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1528,6 +1528,15 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
  
      @NotNull
      java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent);
@@ -79,7 +79,7 @@ index 513de620accbee93a04ef729dd386dadba566a8f..caa674ed1e4b3a940cee05a79d1af47b
  
      /**
 diff --git a/src/main/java/org/bukkit/WorldCreator.java b/src/main/java/org/bukkit/WorldCreator.java
-index 60bed20c2845f9dc15ecbed81157a63d75a4c4f4..14986911b4d0099ea2c91ab2196a771b7dee4c50 100644
+index cbe6b3a1ba7b04826d97c3558e8eb4e5ba11f92f..9fab6eed92c27ec9dd123171f5c4e1e7cda723e4 100644
 --- a/src/main/java/org/bukkit/WorldCreator.java
 +++ b/src/main/java/org/bukkit/WorldCreator.java
 @@ -12,6 +12,7 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0284-More-World-API.patch
+++ b/patches/api/0284-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index caa674ed1e4b3a940cee05a79d1af47b20e3badb..a1922fd862872442ec9dd07b6c24b0d764b11b71 100644
+index 3c74768ebf6690056576e8fceb7f2e2ee2a70492..9161b01781aab56611937d021a0cca0736ce782c 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3647,6 +3647,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3646,6 +3646,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public Location locateNearestStructure(@NotNull Location origin, @NotNull StructureType structureType, int radius, boolean findUnexplored);
  

--- a/patches/api/0330-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/api/0330-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 2173d1e675bdb90f3117614e6e52dac61b4fada9..887ad76c3ea44f0dcfcd21f30c0883e023f1ac3a 100644
+index 4b4b286e9373da2624a29e17df7e54f5e47c3f7d..2007e09322624184ea35186a9b1c2ee80294a38f 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -761,6 +761,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -760,6 +760,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public LightningStrike strikeLightningEffect(@NotNull Location loc);
  


### PR DESCRIPTION
Was fixed in https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/c86a3f7a5877acb5406147923ac48d91c2f6e7d4

This deprecation reason doesn't really make sense either.