### PR TITLE
Improved Update Folder behaviour (Update Folder Uses Plugin Name)

### DIFF
--- a/patches/api/0379-Update-Folder-Uses-Plugin-Name.patch
+++ b/patches/api/0379-Update-Folder-Uses-Plugin-Name.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Xemorr <31805746+Xemorr@users.noreply.github.com>
+Date: Fri, 1 Apr 2022 19:57:40 +0100
+Subject: [PATCH] Update Folder Uses Plugin Name
+
+
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index 42da20011544075a9bea63a12ae86f2f21720667..bea2e464861771383f8fcf143fa817340cb8ab1d 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -400,7 +400,7 @@ public final class SimplePluginManager implements PluginManager {
+     public synchronized Plugin loadPlugin(@NotNull File file) throws InvalidPluginException, UnknownDependencyException {
+         Validate.notNull(file, "File cannot be null");
+ 
+-        checkUpdate(file);
++        file = checkUpdate(file); // Paper - update the reference in case checkUpdate renamed it
+ 
+         Set<Pattern> filters = fileAssociations.keySet();
+         Plugin result = null;
+@@ -427,16 +427,50 @@ public final class SimplePluginManager implements PluginManager {
+         return result;
+     }
+ 
+-    private void checkUpdate(@NotNull File file) {
++    // Paper start - Update Folder Uses Plugin Name to replace
++    /**
++     * Replaces a plugin with a plugin of the same plugin name in the update folder.
++     * @param file
++     * @throws InvalidPluginException
++     */
++    private File checkUpdate(@NotNull File file) throws InvalidPluginException {
+         if (updateDirectory == null || !updateDirectory.isDirectory()) {
+-            return;
++            return file;
+         }
++        PluginLoader pluginLoader = getPluginLoader(file);
++        try {
++            String pluginName = pluginLoader.getPluginDescription(file).getName();
++            for (File updateFile : updateDirectory.listFiles()) {
++                if (!updateFile.isFile()) continue;
++                PluginLoader updatePluginLoader = getPluginLoader(updateFile);
++                if (updatePluginLoader == null) continue;
++                String updatePluginName = updatePluginLoader.getPluginDescription(updateFile).getName();
++                if (!pluginName.equals(updatePluginName)) continue;
++                if (!FileUtil.copy(updateFile, file)) continue;
++                File newName = new File(file.getParentFile(), updateFile.getName());
++                file.renameTo(newName);
++                updateFile.delete();
++                return newName;
++            }
++        }
++        catch (InvalidDescriptionException e) {
++            throw new InvalidPluginException(e);
++        }
++        return file;
++    }
+ 
+-        File updateFile = new File(updateDirectory, file.getName());
+-        if (updateFile.isFile() && FileUtil.copy(updateFile, file)) {
+-            updateFile.delete();
++    @Nullable
++    private PluginLoader getPluginLoader(File file) {
++        Set<Pattern> filters = fileAssociations.keySet();
++        for (Pattern filter : filters) {
++            Matcher match = filter.matcher(file.getName());
++            if (match.find()) {
++                return fileAssociations.get(filter);
++            }
+         }
++        return null;
+     }
++    // Paper end
+ 
+     /**
+      * Checks if the given plugin is loaded and returns it when applicable


### PR DESCRIPTION
This is just a reopening of https://github.com/PaperMC/Paper/pull/6575 (to put it plainly, I'm not amazing at git and didn't want to deal with rebasing when I couldn't remember how I set my project up back in September so decided to just reimplement the patch on a fresh Paper installation).