### PR TITLE
Add missing javadoc deprecation msgs for PlayerProfile

### DIFF
--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -9,24 +9,33 @@ diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Buk
 index 621420d35378e0038c33892c185216894912f023..82387e0c8477f5baa6bd473505b0e0aad6e78268 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1178,6 +1178,7 @@ public final class Bukkit {
+@@ -1176,8 +1176,10 @@ public final class Bukkit {
+      * @return the new PlayerProfile
+      * @throws IllegalArgumentException if both the unique id is
       * <code>null</code> and the name is <code>null</code> or blank
++     * @deprecated use {@link #createProfile(UUID, String)}
       */
      @NotNull
 +    @Deprecated // Paper
      public static PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name) {
          return server.createPlayerProfile(uniqueId, name);
      }
-@@ -1190,6 +1191,7 @@ public final class Bukkit {
+@@ -1188,8 +1190,10 @@ public final class Bukkit {
+      * @param uniqueId the unique id
+      * @return the new PlayerProfile
       * @throws IllegalArgumentException if the unique id is <code>null</code>
++     * @deprecated use {@link #createProfile(UUID)}
       */
      @NotNull
 +    @Deprecated // Paper
      public static PlayerProfile createPlayerProfile(@NotNull UUID uniqueId) {
          return server.createPlayerProfile(uniqueId);
      }
-@@ -1203,6 +1205,7 @@ public final class Bukkit {
+@@ -1201,8 +1205,10 @@ public final class Bukkit {
+      * @return the new PlayerProfile
+      * @throws IllegalArgumentException if the name is <code>null</code> or
       * blank
++     * @deprecated use {@link #createProfile(String)}
       */
      @NotNull
 +    @Deprecated // Paper
@@ -37,24 +46,33 @@ diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Ser
 index 58c8e74b61dd4d952919a854a374ae7b4c3e02c0..e196903e2e4d619603f445713cee36ea402fc55e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1003,6 +1003,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1001,8 +1001,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @return the new PlayerProfile
+      * @throws IllegalArgumentException if both the unique id is
       * <code>null</code> and the name is <code>null</code> or blank
++     * @deprecated use {@link #createProfile(UUID, String)}
       */
      @NotNull
 +    @Deprecated // Paper
      PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name);
  
      /**
-@@ -1013,6 +1014,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1011,8 +1013,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @param uniqueId the unique id
+      * @return the new PlayerProfile
       * @throws IllegalArgumentException if the unique id is <code>null</code>
++     * @deprecated use {@link #createProfile(UUID)}
       */
      @NotNull
 +    @Deprecated // Paper
      PlayerProfile createPlayerProfile(@NotNull UUID uniqueId);
  
      /**
-@@ -1024,6 +1026,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1022,8 +1026,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @return the new PlayerProfile
+      * @throws IllegalArgumentException if the name is <code>null</code> or
       * blank
++     * @deprecated use {@link #createProfile(String)}
       */
      @NotNull
 +    @Deprecated

--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index d09e87803b086df48301a0e7dafe58546e33e70e..c1e106a7af9acf3d84b9c3e377608fa0c3f7eb17 100644
+index 098a09baa481f76e63991268d3dfabc413626fcf..ca6f3a18ca8902b99c1c8c21b6da5def7fdb2aa8 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2110,6 +2110,15 @@ public final class Bukkit {
+@@ -2113,6 +2113,15 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
@@ -25,10 +25,10 @@ index d09e87803b086df48301a0e7dafe58546e33e70e..c1e106a7af9acf3d84b9c3e377608fa0
       * Creates a PlayerProfile for the specified uuid, with name as null.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e3f0efd3cc65b26f62af84cbeb7e6767a4bf34a6..71b32c1ca960a58ae9757e470626fa3e16d3c28b 100644
+index 2642be263b4201ce572386bbaf3434b5af836e8d..28be40d6844f801c26e8359e509afc5e3dedd71f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1854,6 +1854,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1857,6 +1857,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  

--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -9,10 +9,10 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 29e62cca52c0264a9662d0c0fb7f0bec877c706e..5e145a95c1259e084aeed08a3b1d773843939e3f 100644
+index ca6f3a18ca8902b99c1c8c21b6da5def7fdb2aa8..b2acdd8bf213b779ac3afaac7026bc22eb5cdb8d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1696,7 +1696,7 @@ public final class Bukkit {
+@@ -1699,7 +1699,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -21,7 +21,7 @@ index 29e62cca52c0264a9662d0c0fb7f0bec877c706e..5e145a95c1259e084aeed08a3b1d7738
      public static ScoreboardManager getScoreboardManager() {
          return server.getScoreboardManager();
      }
-@@ -1993,7 +1993,7 @@ public final class Bukkit {
+@@ -1996,7 +1996,7 @@ public final class Bukkit {
       * @param clazz the class of the tag entries
       * @return the tag or null
       */
@@ -101,10 +101,10 @@ index 01bcb3a1bdb5accdf844d0178cec3d25746b3eaa..236c9aea9ffc36269e5c32eacc9f1fd6
          Preconditions.checkArgument(namespace != null && VALID_NAMESPACE.matcher(namespace).matches(), "Invalid namespace. Must be [a-z0-9._-]: %s", namespace);
          Preconditions.checkArgument(key != null && VALID_KEY.matcher(key).matches(), "Invalid key. Must be [a-z0-9/._-]: %s", key);
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ec6a47d46cba718e8f5a947ce11f5a6919dbe343..e32e6b87fefa95c07a0aef58cac33c99efea2631 100644
+index 28be40d6844f801c26e8359e509afc5e3dedd71f..cd2cfaf24c794bb0c64cd613d933b6fba92ed723 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1442,7 +1442,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1445,7 +1445,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */

--- a/patches/api/0183-Expose-the-internal-current-tick.patch
+++ b/patches/api/0183-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5e145a95c1259e084aeed08a3b1d773843939e3f..070a06b1f19c663063f8803bd3698569f67549b4 100644
+index b2acdd8bf213b779ac3afaac7026bc22eb5cdb8d..8ee24af67145bbdeb9ebae4da17e45bfbb25ebef 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2195,6 +2195,10 @@ public final class Bukkit {
+@@ -2198,6 +2198,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfileExact(uuid, name);
      }
@@ -20,10 +20,10 @@ index 5e145a95c1259e084aeed08a3b1d773843939e3f..070a06b1f19c663063f8803bd3698569
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e32e6b87fefa95c07a0aef58cac33c99efea2631..38312ba54a4afd61b002091a742a8c91ecda1b1c 100644
+index cd2cfaf24c794bb0c64cd613d933b6fba92ed723..10056ae3caf9f3b144237e815f784d461b172f03 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1929,5 +1929,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1932,5 +1932,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0189-Add-tick-times-API.patch
+++ b/patches/api/0189-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index af91f6cf87ad0f01370db31720fe318d84786ebd..a6808ead643db1833e1bb2a5f758f1e1d73059c1 100644
+index 8ee24af67145bbdeb9ebae4da17e45bfbb25ebef..705a3d86a97508567659706f34f2c7df1e9267cd 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1897,6 +1897,25 @@ public final class Bukkit {
+@@ -1900,6 +1900,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index af91f6cf87ad0f01370db31720fe318d84786ebd..a6808ead643db1833e1bb2a5f758f1e1
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index dc119a58c02a6b4177d560b70f026db6d9e08c55..02139695e15ec52b09ccbdf6105fa2bc786cf9be 100644
+index 10056ae3caf9f3b144237e815f784d461b172f03..f8c4d257a823e478d0cc0992aedc8d778b0f18bc 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1616,6 +1616,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1619,6 +1619,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0190-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0190-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index d93c189807ca1d22b86ed60e3eb1c1fe0a863495..ffd1c908e56fe4e09def7d7658b59e5827d8ad55 100644
+index 705a3d86a97508567659706f34f2c7df1e9267cd..e4f915939f222784cf29df91fdce1ae210e3979d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2218,6 +2218,15 @@ public final class Bukkit {
+@@ -2221,6 +2221,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index d93c189807ca1d22b86ed60e3eb1c1fe0a863495..ffd1c908e56fe4e09def7d7658b59e58
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 81761ca547e6d2283edc5516a115c84cc48016c0..8a71aaf28eb4c38396c330e0d6eac0ed31182c94 100644
+index f8c4d257a823e478d0cc0992aedc8d778b0f18bc..5c27525096b6e4ea1d6a50377f177b6b0454c4da 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1951,5 +1951,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1954,5 +1954,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0200-Add-Mob-Goal-API.patch
+++ b/patches/api/0200-Add-Mob-Goal-API.patch
@@ -523,10 +523,10 @@ index 0000000000000000000000000000000000000000..8fd399f791b45eb7fc62693ca954eea0
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f020e0d840ffb2d4618f226cc698f2d7c1c3858a..a300b85a475364ca5f32a01ae02a77306ea9a1c8 100644
+index 61060bf1cf43fdaea941129bb408123912700d5b..46331d6c7eef313128437fd032290f4aaadfee1b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2239,6 +2239,16 @@ public final class Bukkit {
+@@ -2242,6 +2242,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -544,10 +544,10 @@ index f020e0d840ffb2d4618f226cc698f2d7c1c3858a..a300b85a475364ca5f32a01ae02a7730
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 52cb28b85e4ce6f69fea7b8f543aea00c3c7be3b..1360973d22ef5da6388863e8558ef7fe08ae7ec8 100644
+index bba460283ce37fee5b13913d8e78dcb4efdde2c9..072e5b35cfa483dc23be6cff2dd9ac1aaa7e9da7 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1968,5 +1968,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1971,5 +1971,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0295-Add-basic-Datapack-API.patch
+++ b/patches/api/0295-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index a4c09666c3bbb9037303a6eb85d95a2555963aad..90bf75ebd1f6105c5b943c56409d60e3ee35b6b9 100644
+index e55e127a0821132a9b080846bffc6305085fff95..cdc7222a8c0d2f95218b69177eb0fce1c219964c 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2293,6 +2293,14 @@ public final class Bukkit {
+@@ -2296,6 +2296,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index a4c09666c3bbb9037303a6eb85d95a2555963aad..90bf75ebd1f6105c5b943c56409d60e3
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index afc77648a8863f9d07f89fa1d3b14e88ce4183f6..bcfa12850ace6f3deee546a573f89887cb179892 100644
+index 77d352a042e77e76303e6c5f85924f2d5788f487..3e7994e0fc3d0b31540f8a8cd937861163a77a9f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2015,5 +2015,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2018,5 +2018,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 09e91f823f01067150546cda2df50eb1b53618d5..b5e545f2122d1fc8f69e11b3d5e4da382382de94 100644
+index d250442678d061844db093a177ad1f09a4ebaabe..4004e4b5150cd9a9b8a31880c4372ca53e21f1dd 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1860,6 +1860,24 @@ public final class Bukkit {
+@@ -1863,6 +1863,24 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -34,10 +34,10 @@ index 09e91f823f01067150546cda2df50eb1b53618d5..b5e545f2122d1fc8f69e11b3d5e4da38
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index da886acceb4cf7129cdc6fe1b4bea2f428597cb7..ca9b5bcfbde3e8709a535134e5de0867d3d51b29 100644
+index 3e7994e0fc3d0b31540f8a8cd937861163a77a9f..62c53273ffc5463c19b8b018493aeabcc72e24d0 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1566,6 +1566,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1569,6 +1569,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  

--- a/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for creating command sender which forwards feedback
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b5e545f2122d1fc8f69e11b3d5e4da382382de94..6a5b155b4fec18d9aa906cd6cea6394a98cfe1b5 100644
+index 4004e4b5150cd9a9b8a31880c4372ca53e21f1dd..a14a032c338bb837b3000232f6a32dc5bfe3f01d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1391,6 +1391,20 @@ public final class Bukkit {
+@@ -1394,6 +1394,20 @@ public final class Bukkit {
          return server.getConsoleSender();
      }
  
@@ -30,10 +30,10 @@ index b5e545f2122d1fc8f69e11b3d5e4da382382de94..6a5b155b4fec18d9aa906cd6cea6394a
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ca9b5bcfbde3e8709a535134e5de0867d3d51b29..24c3abf0fbc05c1aa22453543be94a2360c59f01 100644
+index 62c53273ffc5463c19b8b018493aeabcc72e24d0..e29b11ce9e6b7eb5c7a341f1c92060790ddb1716 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1164,6 +1164,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1167,6 +1167,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/api/0371-Custom-Potion-Mixes.patch
+++ b/patches/api/0371-Custom-Potion-Mixes.patch
@@ -102,10 +102,10 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 75bc84ff3280fe7ecfe684014a8865e066b699ab..5979f00d7c85b8807659f1cb40a69f2e2449ef70 100644
+index a14a032c338bb837b3000232f6a32dc5bfe3f01d..5dc245bfbc1d466ab96294bbc10ead1fcec4f841 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2352,6 +2352,15 @@ public final class Bukkit {
+@@ -2355,6 +2355,15 @@ public final class Bukkit {
      public static io.papermc.paper.datapack.DatapackManager getDatapackManager() {
          return server.getDatapackManager();
      }
@@ -122,10 +122,10 @@ index 75bc84ff3280fe7ecfe684014a8865e066b699ab..5979f00d7c85b8807659f1cb40a69f2e
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f5ea978dade76db193989f4f92a90578e1c4f67a..b26ff5864d97810202257bed466ea16d9e0a988b 100644
+index e29b11ce9e6b7eb5c7a341f1c92060790ddb1716..0eda17c8642aa49c2f57c409c3bd3234948feae9 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2049,5 +2049,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2052,5 +2052,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();


### PR DESCRIPTION
When upstream's profile creation methods were deprecated, javadoc msgs weren't added pointing to the alternative.