### PR TITLE
Deprecate getEntityId as a magic value

### DIFF
--- a/patches/api/0054-Fix-upstream-javadocs.patch
+++ b/patches/api/0054-Fix-upstream-javadocs.patch
@@ -59,6 +59,20 @@ index 91fc11dda99de506be83d40df8929bf7cd8e8d85..7dc631ebd009f5f5c3ac1699c3f3515c
 +    org.bukkit.inventory.@NotNull EntityEquipment getEquipment();
      // Paper end
  }
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index c315d2494969190f8b53236f905ad5c5cf1bfc39..95646ae594535095b6bf548e24e3361c0178997b 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -178,7 +178,9 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+      * Returns a unique id for this entity
+      *
+      * @return Entity id
++     * @deprecated magic value. use {@link #getUniqueId()} for a unique id
+      */
++    @Deprecated // Paper
+     public int getEntityId();
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
 index 50ac6f0374da5697a38ef5ec7625da91d4a4276c..f607c57275958bf1cbf8e77b4d7efa936064c228 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java

--- a/patches/api/0061-Entity-fromMobSpawner.patch
+++ b/patches/api/0061-Entity-fromMobSpawner.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index c315d2494969190f8b53236f905ad5c5cf1bfc39..b9a61d06d72831dc0c591e129553453a537d3785 100644
+index 95646ae594535095b6bf548e24e3361c0178997b..92d61590823efe44f53c8fbc5b994173cfb3e8ac 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -681,5 +681,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -683,5 +683,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      @Nullable
      Location getOrigin();

--- a/patches/api/0122-Entity-getChunk-API.patch
+++ b/patches/api/0122-Entity-getChunk-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Entity#getChunk API
 Get the chunk the entity is currently registered to
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index b9a61d06d72831dc0c591e129553453a537d3785..df07eb07896790a09d1022daef5cffc6a435f739 100644
+index 92d61590823efe44f53c8fbc5b994173cfb3e8ac..e0abe7949e79c412d99be61f6d2e1ab0a0c08cfe 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -3,6 +3,7 @@ package org.bukkit.entity;
@@ -17,7 +17,7 @@ index b9a61d06d72831dc0c591e129553453a537d3785..df07eb07896790a09d1022daef5cffc6
  import org.bukkit.EntityEffect;
  import org.bukkit.Location;
  import org.bukkit.Nameable;
-@@ -688,5 +689,16 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -690,5 +691,16 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return True if entity spawned from a mob spawner
       */
      boolean fromMobSpawner();

--- a/patches/api/0174-Entity-getEntitySpawnReason.patch
+++ b/patches/api/0174-Entity-getEntitySpawnReason.patch
@@ -10,10 +10,10 @@ persistenting Living Entity, SPAWNER for spawners,
 or DEFAULT since data was not stored.
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 7a05615ec7678338801bcae2ec9a029b13d323d2..634f3b5dd22bf439aaec7c3ecfb3477b66e994e8 100644
+index abb8edf50840073229347ffd8ddfd4ba8f14824a..56d299acab6307245abe12620d998455435e1044 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -727,5 +727,11 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -729,5 +729,11 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
          // TODO remove impl here
          return getLocation().getChunk();
      }

--- a/patches/api/0211-Add-entity-liquid-API.patch
+++ b/patches/api/0211-Add-entity-liquid-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 634f3b5dd22bf439aaec7c3ecfb3477b66e994e8..1c9d0e6541d41972f9966b83cbba02f6b230a72c 100644
+index 56d299acab6307245abe12620d998455435e1044..8c367f450c7875489d88d7d7c1220aee511892c7 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -733,5 +733,35 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -735,5 +735,35 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      @NotNull
      org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason();

--- a/patches/api/0224-Entity-isTicking.patch
+++ b/patches/api/0224-Entity-isTicking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 1c9d0e6541d41972f9966b83cbba02f6b230a72c..718af7c49ab8cc232bf72cecdef8a90e2595e835 100644
+index 8c367f450c7875489d88d7d7c1220aee511892c7..4e280d4234ca970bb50a7a6c88c7ca1747f85c77 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -763,5 +763,10 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -765,5 +765,10 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * Check if entity is in lava
       */
      public boolean isInLava();

--- a/patches/api/0225-Clarify-the-Javadocs-for-Entity.getEntitySpawnReason.patch
+++ b/patches/api/0225-Clarify-the-Javadocs-for-Entity.getEntitySpawnReason.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Clarify the Javadocs for Entity.getEntitySpawnReason()
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 718af7c49ab8cc232bf72cecdef8a90e2595e835..e3de56ffa7b3a554755a7401988945eca655d816 100644
+index 4e280d4234ca970bb50a7a6c88c7ca1747f85c77..37184db20836ab668ea506c20155bf2b69a8c54e 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -729,7 +729,7 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -731,7 +731,7 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      }
  
      /**

--- a/patches/api/0270-Expose-Tracked-Players.patch
+++ b/patches/api/0270-Expose-Tracked-Players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index e3de56ffa7b3a554755a7401988945eca655d816..898c005cb715235df8d7ed6a98faa8191af2fd91 100644
+index 37184db20836ab668ea506c20155bf2b69a8c54e..851bd73551edfdc8989990d2c0b78bad8baafa1a 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -768,5 +768,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -770,5 +770,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * Check if entity is inside a ticking chunk
       */
      public boolean isTicking();

--- a/patches/api/0340-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/api/0340-Add-Raw-Byte-Entity-Serialization.patch
@@ -24,10 +24,10 @@ index 54b0fe21d3b6379e6550a3b1dc81c2a44e7699da..b39d1474210da1974d7e95f10daaf496
       * Return the translation key for the Material, so the client can translate it into the active
       * locale when using a {@link net.kyori.adventure.text.TranslatableComponent}.
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 898c005cb715235df8d7ed6a98faa8191af2fd91..9b46e42fcd803c2f0fb46b220ed79d69b1d16fc4 100644
+index 851bd73551edfdc8989990d2c0b78bad8baafa1a..4a2bc22f9c3604c784eeb5cda8f88e6f8d1a40b8 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -775,5 +775,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -777,5 +777,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return players in tracking range
       */
      @NotNull Set<Player> getTrackedPlayers();

--- a/patches/api/0347-Entity-powdered-snow-API.patch
+++ b/patches/api/0347-Entity-powdered-snow-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity powdered snow API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 9b46e42fcd803c2f0fb46b220ed79d69b1d16fc4..9c31424a297b9b727ac4ad13040eb9e5674b716b 100644
+index 4a2bc22f9c3604c784eeb5cda8f88e6f8d1a40b8..423016f6d9770cdb5559bc73110a75cd39a7b079 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -802,5 +802,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -804,5 +804,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return Whether the entity was successfully spawned.
       */
      public boolean spawnAt(@NotNull Location location, @NotNull org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason);

--- a/patches/api/0360-Freeze-Tick-Lock-API.patch
+++ b/patches/api/0360-Freeze-Tick-Lock-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 9c31424a297b9b727ac4ad13040eb9e5674b716b..8bc6876c82935988436597161fa0ec94c032174b 100644
+index 423016f6d9770cdb5559bc73110a75cd39a7b079..556e45a9369b67fa109f472afe9e3a7b6ec39639 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -278,6 +278,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -280,6 +280,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      boolean isFrozen();
  


### PR DESCRIPTION
getEntityId is left over when entities didn't have UUID (I'm guessing) and its only used for network stuff. like the network ids for everything in registries. getUniqueId (which returns a UUID) should be used by plugins.