### PR TITLE
Add Alternate Current's redstone implementation as an alternative to vanilla and Eigencraft's.

### DIFF
--- a/patches/server/0889-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/0889-Add-Alternate-Current-redstone-implementation.patch
@@ -16,10 +16,10 @@ cannot comment on how the two compare in that aspect.
 
 Alternate Current is more invasive than Eigencraft, though some of the modifications can be removed with only a minor
 performance penalty in a small number of cases. Alternate Current needs the following modifications:
-- Level/ServerLevel: Each level has its own 'wire handler' that handles redstone dust power changes. 
-- RedStoneWireBlock: Replace calls to vanilla's or Eigencraft's methods for handling power changes with calls to
+* Level/ServerLevel: Each level has its own 'wire handler' that handles redstone dust power changes. 
+* RedStoneWireBlock: Replace calls to vanilla's or Eigencraft's methods for handling power changes with calls to
 Alternate Current's wire handler.
-- (optional) Every power emitter's block class: new methods added to these classes make it easier for Alternate Current
+* (optional) Every power emitter's block class: new methods added to these classes make it easier for Alternate Current
 to check if any block is a potential power source.
 
 The useEigencraftRedstone config has been replaced with the redstoneImplementation config, which can be used to switch

--- a/patches/server/0889-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/0889-Add-Alternate-Current-redstone-implementation.patch
@@ -1,0 +1,2753 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Space Walker <spacedoesrs@gmail.com>
+Date: Sun, 3 Apr 2022 00:09:40 +0200
+Subject: [PATCH] Add Alternate Current's redstone implementation as an alternative to vanilla and Eigencraft's
+
+Author: Space Walker <spacedoesrs@gmail.com>
+
+Original license: MIT
+
+This patch adds Alternate Current's redstone implementation as an alternative to vanilla and Eigencraft's.
+Performance of (de)powering redstone dust is many times faster than vanilla, and even exceeds Eigencraft.
+Similar to Eigencraft, Alternate Current heavily changes the update order of redstone dust. This means any contraption that
+is location dependent in vanilla will either work everywhere or nowhere when using Alternate Current/Eigencraft. Beyond that
+parity issues should be rare for both implementations, though Alternate Current has not been tested as thoroughly, so I
+cannot comment on how the two compare in that aspect.
+
+Alternate Current is more invasive than Eigencraft, though some of the modifications can be removed with only a minor
+performance penalty in a small number of cases. Alternate Current needs the following modifications:
+- Level/ServerLevel: Each level has its own 'wire handler' that handles redstone dust power changes. 
+- RedStoneWireBlock: Replace calls to vanilla's or Eigencraft's methods for handling power changes with calls to
+Alternate Current's wire handler.
+- (optional) Every power emitter's block class: new methods added to these classes make it easier for Alternate Current
+to check if any block is a potential power source.
+
+The useEigencraftRedstone config has been replaced with the redstoneImplementation config, which can be used to switch
+between the vanilla, Eigencraft, and Alternate Current implementations.
+
+diff --git a/src/main/java/alternate/current/util/BlockUtil.java b/src/main/java/alternate/current/util/BlockUtil.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..04b355e2eba47439efd81471a19ac04663f57fea
+--- /dev/null
++++ b/src/main/java/alternate/current/util/BlockUtil.java
+@@ -0,0 +1,14 @@
++package alternate.current.util;
++
++import net.minecraft.core.Direction;
++import net.minecraft.world.level.block.state.BlockBehaviour;
++
++public abstract class BlockUtil extends BlockBehaviour {
++
++	/** Directions in the order in which they are used for emitting shape updates. */
++	public static final Direction[] SHAPE_UPDATE_ORDER = UPDATE_SHAPE_ORDER;
++
++	private BlockUtil(Properties properties) {
++		super(properties);
++	}
++}
+diff --git a/src/main/java/alternate/current/wire/LevelAccess.java b/src/main/java/alternate/current/wire/LevelAccess.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..7fd1b76b048ca68ec4d53490c22a0d5ad1601fda
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/LevelAccess.java
+@@ -0,0 +1,133 @@
++package alternate.current.wire;
++
++import net.minecraft.core.BlockPos;
++import net.minecraft.core.Direction;
++import net.minecraft.server.level.ServerLevel;
++import net.minecraft.world.level.block.Block;
++import net.minecraft.world.level.block.Blocks;
++import net.minecraft.world.level.block.entity.BlockEntity;
++import net.minecraft.world.level.block.state.BlockState;
++import net.minecraft.world.level.chunk.ChunkAccess;
++import net.minecraft.world.level.chunk.ChunkStatus;
++import net.minecraft.world.level.chunk.LevelChunkSection;
++
++public class LevelAccess {
++
++	private final ServerLevel level;
++
++	LevelAccess(ServerLevel level) {
++		this.level = level;
++	}
++
++	/**
++	 * A slightly optimized version of Level.getBlockState.
++	 */
++	BlockState getBlockState(BlockPos pos) {
++		int y = pos.getY();
++
++		if (y < level.getMinBuildHeight() || y >= level.getMaxBuildHeight()) {
++			return Blocks.VOID_AIR.defaultBlockState();
++		}
++
++		int x = pos.getX();
++		int z = pos.getZ();
++		int index = level.getSectionIndex(y);
++
++		ChunkAccess chunk = level.getChunk(x >> 4, z >> 4, ChunkStatus.FULL, true);
++		LevelChunkSection section = chunk.getSections()[index];
++
++		if (section == null) {
++			return Blocks.AIR.defaultBlockState();
++		}
++
++		return section.getBlockState(x & 15, y & 15, z & 15);
++	}
++
++	/**
++	 * An optimized version of Level.setBlock. Since this method is only used to
++	 * update redstone wire block states, lighting checks, height map updates, and
++	 * block entity updates are omitted.
++	 */
++	boolean setWireState(BlockPos pos, BlockState state) {
++		if (!(state.getBlock() instanceof WireBlock)) {
++			return false;
++		}
++
++		int y = pos.getY();
++
++		if (y < level.getMinBuildHeight() || y >= level.getMaxBuildHeight()) {
++			return false;
++		}
++
++		int x = pos.getX();
++		int z = pos.getZ();
++		int index = level.getSectionIndex(y);
++
++		ChunkAccess chunk = level.getChunk(x >> 4, z >> 4, ChunkStatus.FULL, true);
++		LevelChunkSection section = chunk.getSections()[index];
++
++		if (section == null) {
++			return false; // we should never get here
++		}
++
++		BlockState prevState = section.setBlockState(x & 15, y & 15, z & 15, state);
++
++		if (state == prevState) {
++			return false;
++		}
++
++		// notify clients of the BlockState change
++		level.getChunkSource().blockChanged(pos);
++		// mark the chunk for saving
++		chunk.setUnsaved(true);
++
++		return true;
++	}
++
++	boolean breakWire(BlockPos pos, BlockState state) {
++		BlockEntity blockEntity = state.hasBlockEntity() ? level.getBlockEntity(pos) : null;
++		Block.dropResources(state, level, pos, blockEntity);
++		return level.setBlock(pos, Blocks.AIR.defaultBlockState(), Block.UPDATE_CLIENTS);
++	}
++
++	void updateNeighborShape(BlockPos pos, BlockState state, Direction fromDir, BlockPos fromPos, BlockState fromState) {
++		BlockState newState = state.updateShape(fromDir, fromState, level, pos, fromPos);
++		Block.updateOrDestroy(state, newState, level, pos, Block.UPDATE_CLIENTS);
++	}
++
++	void updateNeighborBlock(BlockPos pos, BlockPos fromPos, Block fromBlock) {
++		getBlockState(pos).neighborChanged(level, pos, fromBlock, fromPos, false);
++	}
++
++	void updateNeighborBlock(BlockPos pos, BlockState state, BlockPos fromPos, Block fromBlock) {
++		state.neighborChanged(level, pos, fromBlock, fromPos, false);
++	}
++
++	public boolean isConductor(BlockPos pos) {
++		return getBlockState(pos).isRedstoneConductor(level, pos);
++	}
++
++	public boolean isConductor(BlockPos pos, BlockState state) {
++		return state.isRedstoneConductor(level, pos);
++	}
++
++	public boolean isSignalSourceTo(BlockPos pos, BlockState state, Direction dir) {
++		return state.isSignalSourceTo(level, pos, dir);
++	}
++
++	public boolean isDirectSignalSourceTo(BlockPos pos, BlockState state, Direction dir) {
++		return state.isDirectSignalSourceTo(level, pos, dir);
++	}
++
++	public int getSignalFrom(BlockPos pos, BlockState state, Direction dir) {
++		return state.getSignal(level, pos, dir);
++	}
++
++	public int getDirectSignalFrom(BlockPos pos, BlockState state, Direction dir) {
++		return state.getDirectSignal(level, pos, dir);
++	}
++
++	public boolean shouldBreak(BlockPos pos, BlockState state) {
++		return !state.canSurvive(level, pos);
++	}
++}
+diff --git a/src/main/java/alternate/current/wire/Node.java b/src/main/java/alternate/current/wire/Node.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..191ef2fdcbfa4a4bd4707905c9abaf4d2e22ec63
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/Node.java
+@@ -0,0 +1,101 @@
++package alternate.current.wire;
++
++import java.util.Arrays;
++
++import alternate.current.wire.WireHandler.Directions;
++
++import net.minecraft.core.BlockPos;
++import net.minecraft.world.level.block.state.BlockState;
++
++/**
++ * A Node represents a block in the world. It is tied to a specific wire block
++ * type so it can be identified as part of a wire network or as a neighbor of a
++ * wire network. It also holds a few other pieces of information that speed up
++ * the calculations in the WireHandler class.
++ * 
++ * @author Space Walker
++ */
++public class Node {
++
++	// flags that encode the Node type
++	private static final int CONDUCTOR = 0b01;
++	private static final int SOURCE    = 0b10;
++
++	final LevelAccess level;
++	final Node[] neighbors;
++
++	BlockPos pos;
++	BlockState state;
++	boolean invalid;
++
++	private int flags;
++
++	Node(LevelAccess level) {
++		this.level = level;
++		this.neighbors = new Node[Directions.ALL.length];
++	}
++
++	@Override
++	public boolean equals(Object obj) {
++		if (this == obj) {
++			return true;
++		}
++		if (!(obj instanceof Node)) {
++			return false;
++		}
++
++		Node node = (Node)obj;
++
++		return level == node.level && pos.equals(node.pos);
++	}
++
++	@Override
++	public int hashCode() {
++		return pos.hashCode();
++	}
++
++	Node update(BlockPos pos, BlockState state, boolean clearNeighbors) {
++		if (state.getBlock() instanceof WireBlock) {
++			throw new IllegalStateException("Cannot update a regular Node to a WireNode!");
++		}
++
++		if (clearNeighbors) {
++			Arrays.fill(neighbors, null);
++		}
++
++		this.pos = pos.immutable();
++		this.state = state;
++		this.invalid = false;
++
++		this.flags = 0;
++
++		if (this.level.isConductor(this.pos, this.state)) {
++			this.flags |= CONDUCTOR;
++		}
++		if (this.state.isSignalSource()) {
++			this.flags |= SOURCE;
++		}
++
++		return this;
++	}
++
++	public boolean isWire() {
++		return false;
++	}
++
++	public boolean isWire(WireType type) {
++		return false;
++	}
++
++	public boolean isConductor() {
++		return (flags & CONDUCTOR) != 0;
++	}
++
++	public boolean isSignalSource() {
++		return (flags & SOURCE) != 0;
++	}
++
++	public WireNode asWire() {
++		throw new UnsupportedOperationException("Not a WireNode!");
++	}
++}
+diff --git a/src/main/java/alternate/current/wire/PowerQueue.java b/src/main/java/alternate/current/wire/PowerQueue.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..943a529ad88964b902a8f5080da1f37084bbf2d9
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/PowerQueue.java
+@@ -0,0 +1,227 @@
++package alternate.current.wire;
++
++import java.util.AbstractQueue;
++import java.util.Iterator;
++
++public class PowerQueue extends AbstractQueue<WireNode> {
++
++	private WireNode head;
++	private WireNode tail;
++
++	/** The last wire for each power level. */
++	private WireNode[] tails;
++
++	private int offset;
++	private int size;
++
++	public PowerQueue() {
++		clear();
++	}
++
++	@Override
++	public boolean offer(WireNode wire) {
++		if (wire == null) {
++			throw new NullPointerException();
++		}
++
++		int power = wire.nextPower();
++
++		if (contains(wire)) {
++			if (power != wire.power) {
++				move(wire, power);
++			} else {
++				return false;
++			}
++		} else {
++			insert(wire, power);
++		}
++
++		return true;
++	}
++
++	@Override
++	public WireNode poll() {
++		if (head == null) {
++			return null;
++		}
++
++		WireNode wire = head;
++		head = head.next;
++
++		if (head == null) {
++			clear();
++		} else {
++			head.prev = null;
++
++			if (wire.power != head.power) {
++				tails[wire.power + offset] = null;
++			}
++
++			size--;
++		}
++
++		return wire;
++	}
++
++	@Override
++	public WireNode peek() {
++		return head;
++	}
++
++	@Override
++	public void clear() {
++		for (WireNode wire = head; wire != null; ) {
++			WireNode w = wire;
++			wire = wire.next;
++
++			w.prev = null;
++			w.next = null;
++		}
++
++		head = null;
++		tail = null;
++
++		tails = new WireNode[0];
++
++		offset = 0;
++		size = 0;
++	}
++
++	@Override
++	public Iterator<WireNode> iterator() {
++		throw new UnsupportedOperationException();
++	}
++
++	@Override
++	public int size() {
++		return size;
++	}
++
++	public boolean contains(WireNode wire) {
++		return wire.next != null || wire == tail;
++	}
++
++	private void move(WireNode wire, int power) {
++		if (wire == tail || wire.power != wire.next.power) {
++			if (wire == head || wire.prev.power != wire.power) {
++				tails[wire.power + offset] = null;
++			} else {
++				tails[wire.power + offset] = wire.prev;
++			}
++		}
++
++		size--;
++
++		unlink(wire);
++		insert(wire, power);
++	}
++
++	private void unlink(WireNode wire) {
++		if (wire == head) {
++			head = head.next;
++		} else {
++			wire.prev.next = wire.next;
++		}
++		if (wire == tail) {
++			tail = tail.prev;
++		} else {
++			wire.next.prev = wire.prev;
++		}
++
++		wire.prev = null;
++		wire.next = null;
++	}
++
++	private void insert(WireNode wire, int power) {
++		wire.power = power;
++
++		index(wire);
++		link(wire);
++
++		size++;
++
++		int index = wire.power + offset;
++		tails[index] = wire;
++	}
++
++	private void index(WireNode wire) {
++		int size = wire.power + offset + 1;
++		int move = -wire.type.minPower - offset;
++
++		if (size < tails.length) {
++			size = tails.length;
++		}
++		if (move < 0) {
++			move = 0;
++		}
++
++		size += move;
++
++		if (size > tails.length) {
++			resize(size, move);
++		}
++	}
++
++	private void resize(int size, int move) {
++		WireNode[] array = tails;
++		tails = new WireNode[size];
++
++		for (int i = 0; i < array.length; i++) {
++			tails[i + move] = array[i];
++		}
++
++		offset += move;
++	}
++
++	private void link(WireNode wire) {
++		if (head == null) {
++			linkFirst(wire);
++		} else if (wire.power > head.power) {
++			linkHead(wire);
++		} else if (wire.power <= tail.power) {
++			linkTail(wire);
++		} else {
++			linkAfter(findPrev(wire), wire);
++		}
++	}
++
++	private void linkFirst(WireNode wire) {
++		head = tail = wire;
++	}
++
++	private void linkHead(WireNode wire) {
++		wire.next = head;
++		head.prev = wire;
++		head = wire;
++	}
++
++	private void linkTail(WireNode wire) {
++		tail.next = wire;
++		wire.prev = tail;
++		tail = wire;
++	}
++
++	private void linkAfter(WireNode prev, WireNode wire) {
++		prev.next = wire;
++		wire.prev = prev;
++
++		if (prev != tail) {
++			wire.next = prev.next;
++			prev.next.prev = wire;
++		}
++	}
++
++	private WireNode findPrev(WireNode wire) {
++		WireNode prev = null;
++
++		for (int i = wire.power + offset; i < tails.length; i++) {
++			prev = tails[i];
++
++			if (prev != null) {
++				break;
++			}
++		}
++
++		return prev;
++	}
++}
+diff --git a/src/main/java/alternate/current/wire/WireBlock.java b/src/main/java/alternate/current/wire/WireBlock.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..844cff9d85f6d98e7c2bd7fe1020ff67cd077b7d
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/WireBlock.java
+@@ -0,0 +1,16 @@
++package alternate.current.wire;
++
++/**
++ * This interface should be implemented by each wire block type. While Vanilla
++ * only has one wire block type, they could add more in the future, and any mods
++ * that add more wire block types that wish to take advantage of Alternate
++ * Current's performance improvements should have those wire blocks implement
++ * this interface.
++ * 
++ * @author Space Walker
++ */
++public interface WireBlock {
++
++	public WireType getWireType();
++
++}
+diff --git a/src/main/java/alternate/current/wire/WireConnection.java b/src/main/java/alternate/current/wire/WireConnection.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..d6784bb00211a41702b60eb3d52db8f208492265
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/WireConnection.java
+@@ -0,0 +1,30 @@
++package alternate.current.wire;
++
++/**
++ * This class represents a connection between some WireNode (the 'owner') and a
++ * neighboring WireNode. Two wires are considered to be connected if power can
++ * flow from one wire to the other (and/or vice versa).
++ * 
++ * @author Space Walker
++ */
++public class WireConnection {
++
++	/** The connected wire. */
++	final WireNode wire;
++	/** Cardinal direction to the connected wire. */
++	final int iDir;
++	/** True if the owner of the connection can provide power to the connected wire. */
++	final boolean offer;
++	/** True if the connected wire can provide power to the owner of the connection. */
++	final boolean accept;
++
++	/** The next connection in the sequence. */
++	WireConnection next;
++
++	WireConnection(WireNode wire, int iDir, boolean offer, boolean accept) {
++		this.wire = wire;
++		this.iDir = iDir;
++		this.offer = offer;
++		this.accept = accept;
++	}
++}
+diff --git a/src/main/java/alternate/current/wire/WireConnectionManager.java b/src/main/java/alternate/current/wire/WireConnectionManager.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..497c8c730bb6279141335bbd1ab2fe4f0489a905
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/WireConnectionManager.java
+@@ -0,0 +1,150 @@
++package alternate.current.wire;
++
++import java.util.Arrays;
++import java.util.function.Consumer;
++
++import alternate.current.wire.WireHandler.Directions;
++import alternate.current.wire.WireHandler.NodeProvider;
++
++public class WireConnectionManager {
++
++	/** The owner of these connections. */
++	final WireNode owner;
++
++	/** The first connection for each cardinal direction. */
++	private final WireConnection[] heads;
++
++	private WireConnection head;
++	private WireConnection tail;
++
++	/** The total number of connections. */
++	int total;
++
++	/**
++	 * A 4 bit number that encodes which in direction(s) the owner has connections
++	 * to other wires.
++	 */
++	private int flowTotal;
++	/** The direction of flow based connections to other wires. */
++	int iFlowDir;
++
++	WireConnectionManager(WireNode owner) {
++		this.owner = owner;
++
++		this.heads = new WireConnection[Directions.HORIZONTAL.length];
++
++		this.total = 0;
++
++		this.flowTotal = 0;
++		this.iFlowDir = -1;
++	}
++
++	void set(NodeProvider nodes) {
++		if (total > 0) {
++			clear();
++		}
++
++		boolean belowIsConductor = nodes.getNeighbor(owner, Directions.DOWN).isConductor();
++		boolean aboveIsConductor = nodes.getNeighbor(owner, Directions.UP).isConductor();
++
++		for (int iDir = 0; iDir < Directions.HORIZONTAL.length; iDir++) {
++			Node neighbor = nodes.getNeighbor(owner, iDir);
++
++			if (neighbor.isWire()) {
++				add(neighbor.asWire(), iDir, true, true);
++
++				continue;
++			}
++
++			boolean sideIsConductor = neighbor.isConductor();
++
++			if (!sideIsConductor) {
++				Node node = nodes.getNeighbor(neighbor, Directions.DOWN);
++
++				if (node.isWire()) {
++					add(node.asWire(), iDir, belowIsConductor, true);
++				}
++			}
++			if (!aboveIsConductor) {
++				Node node = nodes.getNeighbor(neighbor, Directions.UP);
++
++				if (node.isWire()) {
++					add(node.asWire(), iDir, true, sideIsConductor);
++				}
++			}
++		}
++
++		if (total > 0) {
++			iFlowDir = WireHandler.FLOW_IN_TO_FLOW_OUT[flowTotal];
++		}
++	}
++
++	private void clear() {
++		Arrays.fill(heads, null);
++
++		head = null;
++		tail = null;
++
++		total = 0;
++
++		flowTotal = 0;
++		iFlowDir = -1;
++	}
++
++	private void add(WireNode wire, int iDir, boolean offer, boolean accept) {
++		if (owner.type != wire.type) {
++			if (offer) {
++				offer = owner.type.offer && wire.type.accept;
++			}
++			if (accept) {
++				accept = owner.type.accept && wire.type.offer;
++			}
++		}
++
++		if (offer || accept) {
++			add(new WireConnection(wire, iDir, offer, accept));
++		}
++	}
++
++	private void add(WireConnection connection) {
++		if (head == null) {
++			head = connection;
++			tail = connection;
++		} else {
++			tail.next = connection;
++			tail = connection;
++		}
++
++		if (heads[connection.iDir] == null) {
++			heads[connection.iDir] = connection;
++
++			flowTotal |= (1 << connection.iDir);
++		}
++
++		total++;
++	}
++
++	/** 
++	 * Iterate over all connections, without any specific
++	 * update order in mind. Use this method if the iteration
++	 * order is not important.
++	 */
++	void forEach(Consumer<WireConnection> consumer) {
++		for (WireConnection c = head; c != null; c = c.next) {
++			consumer.accept(c);
++		}
++	}
++
++	/**
++	 * Iterate over all connections in an order determined by
++	 * the given flow direction. Use this method if the iteration
++	 * order is important.
++	 */
++	void forEach(Consumer<WireConnection> consumer, int iFlowDir) {
++		for (int iDir : WireHandler.CARDINAL_UPDATE_ORDERS[iFlowDir]) {
++			for (WireConnection c = heads[iDir]; c != null && c.iDir == iDir; c = c.next) {
++				consumer.accept(c);
++			}
++		}
++	}
++}
+diff --git a/src/main/java/alternate/current/wire/WireHandler.java b/src/main/java/alternate/current/wire/WireHandler.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..2b8d309141b49c00a0bd43c363eb195909524543
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/WireHandler.java
+@@ -0,0 +1,1128 @@
++package alternate.current.wire;
++
++import java.util.ArrayList;
++import java.util.Iterator;
++import java.util.List;
++import java.util.Queue;
++
++//import alternate.current.AlternateCurrentMod;
++import alternate.current.util.BlockUtil;
++//import alternate.current.util.profiler.Profiler;
++
++import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
++import it.unimi.dsi.fastutil.longs.Long2ObjectMap.Entry;
++import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
++import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
++
++import net.minecraft.core.BlockPos;
++import net.minecraft.core.Direction;
++import net.minecraft.server.level.ServerLevel;
++import net.minecraft.world.level.block.Block;
++import net.minecraft.world.level.block.state.BlockState;
++
++/**
++ * This class handles power changes for redstone wire. The algorithm was
++ * designed with the following goals in mind:
++ * <br>
++ * 1. Minimize the number of times a wire checks its surroundings to determine
++ * its power level.
++ * <br>
++ * 2. Minimize the number of block and shape updates emitted.
++ * <br>
++ * 3. Emit block and shape updates in a deterministic, non-locational order,
++ * fixing bug MC-11193.
++ * 
++ * <p>
++ * In Vanilla redstone wire is laggy because it fails on points 1 and 2.
++ * 
++ * <p>
++ * Redstone wire updates recursively and each wire calculates its power level in
++ * isolation rather than in the context of the network it is a part of. This
++ * means a wire in a grid can change its power level over half a dozen times
++ * before settling on its final value. This problem used to be worse in 1.13 and
++ * below, where a wire would only decrease its power level by 1 at a time.
++ * 
++ * <p>
++ * In addition to this, a wire emits 42 block updates and up to 22 shape updates
++ * each time it changes its power level.
++ * 
++ * <p>
++ * Of those 42 block updates, 6 are to itself, which are thus not only
++ * redundant, but a big source of lag, since those cause the wire to
++ * unnecessarily re-calculate its power level. A block only has 24 neighbors
++ * within a Manhattan distance of 2, meaning 12 of the remaining 36 block
++ * updates are duplicates and thus also redundant.
++ * 
++ * <p>
++ * Of the 22 shape updates, only 6 are strictly necessary. The other 16 are sent
++ * to blocks diagonally above and below. These are necessary if a wire changes
++ * its connections, but not when it changes its power level.
++ * 
++ * <p>
++ * Redstone wire in Vanilla also fails on point 3, though this is more of a
++ * quality-of-life issue than a lag issue. The recursive nature in which it
++ * updates, combined with the location-dependent order in which each wire
++ * updates its neighbors, makes the order in which neighbors of a wire network
++ * are updated incredibly inconsistent and seemingly random.
++ * 
++ * <p>
++ * Alternate Current fixes each of these problems as follows.
++ * 
++ * <p>
++ * 1. To make sure a wire calculates its power level as little as possible, we
++ * remove the recursive nature in which redstone wire updates in Vanilla.
++ * Instead, we build a network of connected wires, find those wires that receive
++ * redstone power from "outside" the network, and spread the power from there.
++ * This has a few advantages:
++ * <br>
++ * - Each wire checks for power from non-wire components just once, and from
++ * nearby wires just twice.
++ * <br>
++ * - Each wire only sets its power level in the world once. This is important,
++ * because calls to Level.setBlock are even more expensive than calls to
++ * Level.getBlockState.
++ * 
++ * <p>
++ * 2. There are 2 obvious ways in which we can reduce the number of block and
++ * shape updates.
++ * <br>
++ * - Get rid of the 18 redundant block updates and 16 redundant shape updates,
++ * so each wire only emits 24 block updates and 6 shape updates whenever it
++ * changes its power level.
++ * <br>
++ * - Only emit block updates and shape updates once a wire reaches its final
++ * power level, rather than at each intermediary stage.
++ * <br>
++ * For an individual wire, these two optimizations are the best you can do, but
++ * for an entire grid, you can do better!
++ * 
++ * <p>
++ * Since we calculate the power of the entire network, sending block and shape
++ * updates to the wires in it is redundant. Removing those updates can reduce
++ * the number of block and shape updates by up to 20%.
++ * 
++ * <p>
++ * 3. To make the order of block updates to neighbors of a network
++ * deterministic, the first thing we must do is to replace the location-
++ * dependent order in which a wire updates its neighbors. Instead, we base it on
++ * the direction of power flow. This part of the algorithm was heavily inspired
++ * by theosib's 'RedstoneWireTurbo', which you can read more about in theosib's
++ * comment on Mojira <a href="https://bugs.mojang.com/browse/MC-81098?focusedCommentId=420777&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-420777">here</a>
++ * or by checking out its implementation in carpet mod <a href="https://github.com/gnembon/fabric-carpet/blob/master/src/main/java/carpet/helpers/RedstoneWireTurbo.java">here</a>.
++ * 
++ * <p>
++ * The idea is to determine the direction of power flow through a wire based on
++ * the power it receives from neighboring wires. For example, if the only power
++ * a wire receives is from a neighboring wire to its west, it can be said that
++ * the direction of power flow through the wire is east.
++ * 
++ * <p>
++ * We make the order of block updates to neighbors of a wire depend on what is
++ * determined to be the direction of power flow. This not only removes
++ * locationality entirely, it even removes directionality in a large number of
++ * cases. Unlike in 'RedstoneWireTurbo', however, I have decided to keep a
++ * directional element in ambiguous cases, rather than to introduce randomness,
++ * though this is trivial to change.
++ * 
++ * <p>
++ * While this change fixes the block update order of individual wires, we must
++ * still address the overall block update order of a network. This turns out to
++ * be a simple fix, because of a change we made earlier: we search through the
++ * network for wires that receive power from outside it, and spread the power
++ * from there. If we make each wire transmit its power to neighboring wires in
++ * an order dependent on the direction of power flow, we end up with a
++ * non-locational and largely non-directional wire update order.
++ * 
++ * @author Space Walker
++ */
++public class WireHandler {
++
++	public static class Directions {
++
++		public static final Direction[] ALL        = { Direction.WEST, Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.DOWN, Direction.UP };
++		public static final Direction[] HORIZONTAL = { Direction.WEST, Direction.NORTH, Direction.EAST, Direction.SOUTH };
++
++		// Indices for the arrays above.
++		// The cardinal directions are ordered clockwise. This allows
++		// for conversion between relative and absolute directions
++		// ('left' 'right' vs 'east' 'west') with simple arithmetic:
++		// If some Direction index 'iDir' is considered 'forward', then
++		// '(iDir + 1) & 0b11' is 'right', '(iDir + 2) & 0b11' is 'backward', etc.
++		public static final int WEST  = 0b000; // 0
++		public static final int NORTH = 0b001; // 1
++		public static final int EAST  = 0b010; // 2
++		public static final int SOUTH = 0b011; // 3
++		public static final int DOWN  = 0b100; // 4
++		public static final int UP    = 0b101; // 5
++
++		public static int iOpposite(int iDir) {
++			return iDir ^ (0b10 >>> (iDir >>> 2));
++		}
++
++		/**
++		 * Each array is placed at the index that encodes the direction that is missing
++		 * from the array.
++		 */
++		private static final int[][] I_EXCEPT = {
++			{       NORTH, EAST, SOUTH, DOWN, UP },
++			{ WEST,        EAST, SOUTH, DOWN, UP },
++			{ WEST, NORTH,       SOUTH, DOWN, UP },
++			{ WEST, NORTH, EAST,        DOWN, UP },
++			{ WEST, NORTH, EAST, SOUTH,       UP },
++			{ WEST, NORTH, EAST, SOUTH, DOWN     }
++		};
++	}
++
++	/**
++	 * This conversion table takes in information about incoming flow, and outputs
++	 * the determined outgoing flow.
++	 * 
++	 * <p>
++	 * The input is a 4 bit number that encodes the incoming flow. Each bit
++	 * represents a cardinal direction, and when it is 'on', there is flow in that
++	 * direction.
++	 * 
++	 * <p>
++	 * The output is a single Direction index, or -1 for ambiguous cases.
++	 * 
++	 * <p>
++	 * The outgoing flow is determined as follows:
++	 * 
++	 * <p>
++	 * If there is just 1 direction of incoming flow, that direction will be the
++	 * direction of outgoing flow.
++	 * 
++	 * <p>
++	 * If there are 2 directions of incoming flow, and these directions are not each
++	 * other's opposites, the direction that is 'more clockwise' will be the
++	 * direction of outgoing flow. More precisely, the direction that is 1 clockwise
++	 * turn from the other is picked.
++	 * 
++	 * <p>
++	 * If there are 3 directions of incoming flow, the two opposing directions
++	 * cancel each other out, and the remaining direction will be the direction of
++	 * outgoing flow.
++	 * 
++	 * <p>
++	 * In all other cases, the flow is completely ambiguous.
++	 */
++	static final int[] FLOW_IN_TO_FLOW_OUT = {
++		-1,               // 0b0000: -                     -> x
++		Directions.WEST,  // 0b0001: west                  -> west
++		Directions.NORTH, // 0b0010: north                 -> north
++		Directions.NORTH, // 0b0011: west/north            -> north
++		Directions.EAST,  // 0b0100: east                  -> east
++		-1,               // 0b0101: west/east             -> x
++		Directions.EAST,  // 0b0110: north/east            -> east
++		Directions.NORTH, // 0b0111: west/north/east       -> north
++		Directions.SOUTH, // 0b1000: south                 -> south
++		Directions.WEST,  // 0b1001: west/south            -> west
++		-1,               // 0b1010: north/south           -> x
++		Directions.WEST,  // 0b1011: west/north/south      -> west
++		Directions.SOUTH, // 0b1100: east/south            -> south
++		Directions.SOUTH, // 0b1101: west/east/south       -> south
++		Directions.EAST,  // 0b1110: north/east/south      -> east
++		-1,               // 0b1111: west/north/east/south -> x
++	};
++	/**
++	 * Update order of cardinal directions. Given that the index encodes the
++	 * direction that is to be considered 'forward', the resulting update order is {
++	 * front, back, right, left }.
++	 */
++	static final int[][] CARDINAL_UPDATE_ORDERS = {
++		{ Directions.WEST , Directions.EAST , Directions.NORTH, Directions.SOUTH },
++		{ Directions.NORTH, Directions.SOUTH, Directions.EAST , Directions.WEST  },
++		{ Directions.EAST , Directions.WEST , Directions.SOUTH, Directions.NORTH },
++		{ Directions.SOUTH, Directions.NORTH, Directions.WEST , Directions.EAST  }
++	};
++	/**
++	 * The default update order of all cardinal directions.
++	 */
++	static final int[] DEFAULT_CARDINAL_UPDATE_ORDER = CARDINAL_UPDATE_ORDERS[0];
++	/**
++	 * The default update order of all directions. It is equivalent to the order of
++	 * shape updates in vanilla Minecraft.
++	 */
++	static final int[] DEFAULT_FULL_UPDATE_ORDER = {
++		Directions.WEST,
++		Directions.EAST,
++		Directions.NORTH,
++		Directions.SOUTH,
++		Directions.DOWN,
++		Directions.UP
++	};
++
++	// If Vanilla will ever multi-thread the ticking of levels, there should
++	// be only one WireHandler per level, in case redstone updates in multiple
++	// levels at the same time. There are already mods that add multi-threading
++	// as well.
++	private final LevelAccess level;
++
++	/** All the wires in the network. */
++	private final List<WireNode> network;
++	/** Map of wires and neighboring blocks. */
++	private final Long2ObjectMap<Node> nodes;
++	/** All the power changes that need to happen. */
++	private final Queue<WireNode> powerChanges;
++
++	private int rootCount;
++	// Rather than creating new nodes every time a network is updated we keep
++	// a cache of nodes that can be re-used.
++	private Node[] nodeCache;
++	private int nodeCount;
++
++	private boolean updatingPower;
++
++	public WireHandler(ServerLevel level) {
++		this.level = new LevelAccess(level);
++
++		this.network = new ArrayList<>();
++		this.nodes = new Long2ObjectOpenHashMap<>();
++		this.powerChanges = new PowerQueue();
++
++		this.nodeCache = new Node[16];
++		this.fillNodeCache(0, 16);
++	}
++
++	private Node getOrAddNode(BlockPos pos) {
++		return nodes.compute(pos.asLong(), (key, node) -> {
++			if (node == null) {
++				// If there is not yet a node at this position, retrieve and
++				// update one from the cache.
++				return getNextNode(pos);
++			}
++			if (node.invalid) {
++				return revalidateNode(node);
++			}
++
++			return node;
++		});
++	}
++
++	/**
++	 * Retrieve the neighbor of a node in the given direction and create a link
++	 * between the two nodes.
++	 */
++	private Node getNeighbor(Node node, int iDir) {
++		Node neighbor = node.neighbors[iDir];
++
++		if (neighbor == null || neighbor.invalid) {
++			Direction dir = Directions.ALL[iDir];
++			BlockPos pos = node.pos.relative(dir);
++
++			Node oldNeighbor = neighbor;
++			neighbor = getOrAddNode(pos);
++
++			if (neighbor != oldNeighbor) {
++				int iOpp = Directions.iOpposite(iDir);
++
++				node.neighbors[iDir] = neighbor;
++				neighbor.neighbors[iOpp] = node;
++			}
++		}
++
++		return neighbor;
++	}
++
++	private Node removeNode(BlockPos pos) {
++		return nodes.remove(pos.asLong());
++	}
++
++	private Node revalidateNode(Node node) {
++		node.invalid = false;
++
++		if (node.isWire()) {
++			WireNode wire = node.asWire();
++
++			wire.prepared = false;
++			wire.inNetwork = false;
++		} else {
++			BlockPos pos = node.pos;
++			BlockState state = level.getBlockState(pos);
++
++			node.update(pos, state, false);
++		}
++
++		return node;
++	}
++
++	/**
++	 * Check the BlockState that occupies the given position. If it is a wire, then
++	 * create a new WireNode. Otherwise, grab the next Node from the cache and
++	 * update it.
++	 */
++	private Node getNextNode(BlockPos pos) {
++		BlockState state = level.getBlockState(pos);
++		Block block = state.getBlock();
++
++		if (block instanceof WireBlock) {
++			return new WireNode((WireBlock)block, level, pos, state);
++		}
++
++		return getNextNode().update(pos, state, true);
++	}
++
++	/**
++	 * Grab the first unused Node from the cache. If all of the cache is already in
++	 * use, increase it in size first.
++	 */
++	private Node getNextNode() {
++		if (nodeCount == nodeCache.length) {
++			increaseNodeCache();
++		}
++
++		return nodeCache[nodeCount++];
++	}
++
++	private void increaseNodeCache() {
++		Node[] oldCache = nodeCache;
++		nodeCache = new Node[oldCache.length << 1];
++
++		for (int index = 0; index < oldCache.length; index++) {
++			nodeCache[index] = oldCache[index];
++		}
++
++		fillNodeCache(oldCache.length, nodeCache.length);
++	}
++
++	private void fillNodeCache(int start, int end) {
++		for (int index = start; index < end; index++) {
++			nodeCache[index] = new Node(level);
++		}
++	}
++
++	/**
++	 * This method should be called whenever a wire receives a block update.
++	 */
++	public void onWireUpdated(BlockPos pos, WireType type) {
++		invalidateNodes();
++		findRoots(pos, type, true);
++		tryUpdatePower();
++	}
++
++	/**
++	 * This method should be called whenever a wire is placed.
++	 */
++	public void onWireAdded(BlockPos pos, WireType type) {
++		invalidateNodes();
++		findRoots(pos, type, false);
++		tryUpdatePower();
++	}
++
++	/**
++	 * This method should be called whenever a wire is removed.
++	 */
++	public void onWireRemoved(BlockPos pos, WireType type) {
++		Node node = removeNode(pos);
++		WireNode wire;
++
++		if (node == null || !node.isWire(type)) {
++			wire = new WireNode(type, level, pos);
++		} else {
++			wire = node.asWire();
++		}
++
++		wire.invalid = true;
++		wire.removed = true;
++
++		// If these fields are set to 'true', the removal of this wire was part of
++		// already ongoing power changes, so we can exit early here.
++		if (updatingPower && wire.shouldBreak) {
++			return;
++		}
++
++		invalidateNodes();
++		tryAddRoot(wire);
++		tryUpdatePower();
++	}
++
++	/**
++	 * The nodes map is a snapshot of the state of the world. It becomes invalid
++	 * when power changes are carried out, since the block and shape updates can
++	 * lead to block changes. If these block changes cause the network to be updated
++	 * again every node must be invalidated, and revalidated before it is used
++	 * again. This ensures the power calculations of the network are accurate.
++	 */
++	private void invalidateNodes() {
++		if (updatingPower && !nodes.isEmpty()) {
++			Iterator<Entry<Node>> it = Long2ObjectMaps.fastIterator(nodes);
++
++			while (it.hasNext()) {
++				Entry<Node> entry = it.next();
++				Node node = entry.getValue();
++
++				node.invalid = true;
++			}
++		}
++	}
++
++	/**
++	 * Look for wires at and around the given position that are in an invalid state
++	 * and require power changes. These wires are called 'roots' because it is only
++	 * when these wires change power level that neighboring wires must adjust as
++	 * well.
++	 * 
++	 * <p>
++	 * While it is strictly only necessary to check the wire at the given position,
++	 * if that wire is part of a network, it is beneficial to check its surroundings
++	 * for other wires that require power changes. This is because a network can
++	 * receive power at multiple points. Consider the following setup:
++	 * 
++	 * <p>
++	 * (top-down view, W = wire, L = lever, _ = air/other)
++	 * <br> {@code _ _ W _ _ }
++	 * <br> {@code _ W W W _ }
++	 * <br> {@code W W L W W }
++	 * <br> {@code _ W W W _ }
++	 * <br> {@code _ _ W _ _ }
++	 * 
++	 * <p>
++	 * The lever powers four wires in the network at once. If this is identified
++	 * correctly, the entire network can (un)power at once. While it is not
++	 * practical to cover every possible situation where a network is (un)powered
++	 * from multiple points at once, checking for common cases like the one
++	 * described above is relatively straight-forward.
++	 * 
++	 * <p>
++	 * While these extra checks can provide significant performance gains in some
++	 * cases, in the majority of cases they will have little to no effect, but do
++	 * require extra code modifications to all redstone power emitters. Removing
++	 * these optimizations would limit code modifications to the RedStoneWireBlock
++	 * and ServerLevel classes while leaving the performance mostly intact.
++	 */
++	private void findRoots(BlockPos pos, WireType type, boolean checkNeighbors) {
++		Node node = getOrAddNode(pos);
++
++		if (!node.isWire(type)) {
++			return; // we should never get here
++		}
++
++		WireNode wire = node.asWire();
++		tryAddRoot(wire);
++
++		// If the wire at the given position is not in an invalid state or is not
++		// part of a larger network, we can exit early.
++		if (!checkNeighbors || !wire.inNetwork || wire.connections.total == 0) {
++			return;
++		}
++
++		for (int iDir : DEFAULT_FULL_UPDATE_ORDER) {
++			Node neighbor = getNeighbor(wire, iDir);
++
++			if (neighbor.isConductor()) {
++				// Redstone components can power multiple wires through solid
++				// blocks.
++				findSignalSourcesAround(neighbor, Directions.iOpposite(iDir));
++			} else if (level.isSignalSourceTo(neighbor.pos, neighbor.state, Directions.ALL[iDir])) {
++				// Redstone components can also power multiple wires directly.
++				findRootsAroundSignalSource(neighbor, Directions.iOpposite(iDir));
++			}
++		}
++	}
++
++	/**
++	 * Find signal sources around the given node that can provide direct signals
++	 * to that node, and then search for wires that require power changes around
++	 * those signal sources.
++	 */
++	private void findSignalSourcesAround(Node node, int except) {
++		for (int iDir : Directions.I_EXCEPT[except]) {
++			Node neighbor = getNeighbor(node, iDir);
++
++			if (level.isDirectSignalSourceTo(neighbor.pos, neighbor.state, Directions.ALL[iDir])) {
++				findRootsAroundSignalSource(neighbor, iDir);
++			}
++		}
++	}
++
++	/**
++	 * Find wires around the given signal source that require power changes.
++	 */
++	private void findRootsAroundSignalSource(Node node, int except) {
++		for (int iDir : Directions.I_EXCEPT[except]) {
++			// Directions are backwards for redstone related methods, so we must
++			// check for power emitted in the opposite direction that we are
++			// interested in.
++			int iOpp = Directions.iOpposite(iDir);
++			Direction opp = Directions.ALL[iOpp];
++
++			boolean signal = level.isSignalSourceTo(node.pos, node.state, opp);
++			boolean directSignal = level.isDirectSignalSourceTo(node.pos, node.state, opp);
++
++			// If the signal source does not emit any power in this direction,
++			// move on to the next direction.
++			if (!signal && !directSignal) {
++				continue;
++			}
++
++			Node neighbor = getNeighbor(node, iDir);
++
++			if (signal && neighbor.isWire()) {
++				tryAddRoot(neighbor.asWire());
++			} else if (directSignal && neighbor.isConductor()) {
++				findRootsAround(neighbor, iOpp);
++			}
++		}
++	}
++
++	/**
++	 * Look for wires around the given node that require power changes.
++	 */
++	private void findRootsAround(Node node, int except) {
++		for (int iDir : Directions.I_EXCEPT[except]) {
++			Node neighbor = getNeighbor(node, iDir);
++
++			if (neighbor.isWire()) {
++				tryAddRoot(neighbor.asWire());
++			}
++		}
++	}
++
++	/**
++	 * Check if the given wire is in an illegal state and needs power changes.
++	 */
++	private void tryAddRoot(WireNode wire) {
++		// Each potential root needs to be checked only once.
++		if (wire.prepared) {
++			return;
++		}
++
++		prepare(wire);
++
++		// To stop wires with power step 0 from perpetually powering themselves,
++		// those wires initially ignore power from neighboring wires. Only if
++		// power from non-wires matches their current power, is power from
++		// neighboring wires considered. This makes sure the wires still update
++		// their power correctly if they are in an invalid state within their
++		// network, e.g. when placed in an already powered network.
++		if (wire.type.powerStep != 0 || !needsPowerChange(wire)) {
++			findPower(wire, false);
++		}
++
++		if (needsPowerChange(wire)) {
++			addRoot(wire);
++		}
++	}
++
++	/**
++	 * Add the given wire to the network as a root.
++	 */
++	private void addRoot(WireNode wire) {
++		network.add(wire);
++		rootCount++;
++
++		wire.inNetwork = true;
++
++		if (wire.connections.iFlowDir >= 0) {
++			wire.iFlowDir = wire.connections.iFlowDir;
++		}
++	}
++
++	/**
++	 * Before a wire can be added to the network, it must be properly prepared.
++	 * This method
++	 * <br>
++	 * - checks if this wire should break. Rather than break the wire right away,
++	 * its effects are integrated into the power calculations.
++	 * <br>
++	 * - determines the 'external power' this wire receives (power from non-wire
++	 * components).
++	 * <br>
++	 * - finds connections this wire has to neighboring wires.
++	 */
++	private void prepare(WireNode wire) {
++		// Each wire only needs to be prepared once.
++		if (wire.prepared) {
++			return;
++		}
++
++		wire.prepared = true;
++		wire.inNetwork = false;
++
++		if (!wire.removed && !wire.shouldBreak && level.shouldBreak(wire.pos, wire.state)) {
++			wire.shouldBreak = true;
++		}
++
++		wire.virtualPower = wire.externalPower = getInitialPower(wire);
++		wire.connections.set(this::getNeighbor);
++	}
++
++	private int getInitialPower(WireNode wire) {
++		return (wire.removed || wire.shouldBreak) ? wire.type.minPower : getExternalPower(wire);
++	}
++
++	private int getExternalPower(WireNode wire) {
++		int power = wire.type.minPower;
++
++		for (int iDir = 0; iDir < Directions.ALL.length; iDir++) {
++			Node neighbor = getNeighbor(wire, iDir);
++
++			// Power from wires is handled separately.
++			if (neighbor.isWire()) {
++				continue;
++			}
++
++			// Since 1.16 there is a block that is both a conductor and a signal
++			// source: the target block!
++			if (neighbor.isConductor()) {
++				power = Math.max(power, getDirectSignalTo(wire, neighbor, Directions.iOpposite(iDir)));
++			}
++			if (neighbor.isSignalSource()) {
++				power = Math.max(power, level.getSignalFrom(neighbor.pos, neighbor.state, Directions.ALL[iDir]));
++			}
++
++			if (power >= wire.type.maxPower) {
++				return wire.type.maxPower;
++			}
++		}
++
++		return power;
++	}
++
++	/**
++	 * Determine the direct signal the given wire receives from neighboring blocks
++	 * through the given conductor node.
++	 */
++	private int getDirectSignalTo(WireNode wire, Node node, int except) {
++		int power = wire.type.minPower;
++
++		for (int iDir : Directions.I_EXCEPT[except]) {
++			Node neighbor = getNeighbor(node, iDir);
++
++			if (neighbor.isSignalSource()) {
++				power = Math.max(power, level.getDirectSignalFrom(neighbor.pos, neighbor.state, Directions.ALL[iDir]));
++
++				if (power >= wire.type.maxPower) {
++					return wire.type.maxPower;
++				}
++			}
++		}
++
++		return power;
++	}
++
++	/**
++	 * Determine the power level the given wire receives from the blocks around it.
++	 * Power from non-wire components has already been determined, so only power
++	 * received from other wires needs to be checked. There are a few exceptions:
++	 * <br>
++	 * - If the wire is removed or going to break, its power level should always be
++	 * the minimum value. This is because it (effectively) no longer exists, so
++	 * cannot provide any power to neighboring wires.
++	 * <br>
++	 * - Power received from neighboring wires will never exceed {@code maxPower},
++	 * so if the external power is already larger than or equal to that, there is no
++	 * need to check for power from neighboring wires.
++	 */
++	private void findPower(WireNode wire, boolean ignoreNetwork) {
++		if (wire.removed || wire.shouldBreak || wire.externalPower >= wire.type.maxPower) {
++			return;
++		}
++
++		// The virtual power is reset to the external power, so the flow information
++		// must be reset as well.
++		wire.virtualPower = wire.externalPower;
++		wire.flowIn = 0;
++
++		findWirePower(wire, ignoreNetwork);
++	}
++
++	/**
++	 * Determine the power level the given wire receives from connected wires.
++	 */
++	private void findWirePower(WireNode wire, boolean ignoreNetwork) {
++		wire.connections.forEach(connection -> {
++			if (!connection.accept) {
++				return;
++			}
++
++			WireNode neighbor = connection.wire;
++
++			if (!ignoreNetwork || !neighbor.inNetwork) {
++				int step = Math.max(wire.type.powerStep, neighbor.type.powerStep);
++				int power = Math.max(wire.type.minPower, neighbor.virtualPower - step);
++				int iOpp = Directions.iOpposite(connection.iDir);
++
++				wire.offerPower(power, iOpp);
++			}
++		});
++	}
++
++	private boolean needsPowerChange(WireNode wire) {
++		return wire.removed || wire.shouldBreak || wire.virtualPower != wire.currentPower;
++	}
++
++	private void tryUpdatePower() {
++		if (rootCount > 0) {
++			updatePower();
++		}
++		if (!updatingPower) {
++			nodes.clear();
++			nodeCount = 0;
++		}
++	}
++
++	/**
++	 * Propagate power changes through the network and notify neighboring blocks of
++	 * these changes.
++	 * 
++	 * <p>
++	 * Power changes are done in the following 3 steps.
++	 * 
++	 * <p>
++	 * <b>1. Build up the network</b>
++	 * <br>
++	 * Collect all the wires around the roots that need to change their power
++	 * levels.
++	 * 
++	 * <p>
++	 * <b>2. Find powered wires</b>
++	 * <br>
++	 * Find those wires in the network that receive power from outside the network.
++	 * This can come in 2 forms:
++	 * <br>
++	 * - Power from non-wire components (repeaters, torches, etc.).
++	 * <br>
++	 * - Power from wires that are not in the network.
++	 * <br>
++	 * These powered wires will then queue their power changes.
++	 * 
++	 * <p>
++	 * <b>3. Let power flow</b>
++	 * <br>
++	 * Work through the queue of power changes. After each wire's power change, emit
++	 * shape and block updates to neighboring blocks, then queue power changes for
++	 * connected wires.
++	 */
++	private void updatePower() {
++		// The profiler keeps track of how long various parts of the algorithm take.
++		// It is only here for debugging purposes, and is commented out in production.
++//		Profiler profiler = AlternateCurrentMod.createProfiler();
++//		profiler.start();
++
++		// Build a network of wires that need power changes. This includes the roots
++		// as well as any wires that will be affected by power changes to those roots.
++//		profiler.push("build network");
++		buildNetwork();
++
++		// Find those wires in the network that receive power from outside it.
++		// Remember that the power changes for those wires are already queued here!
++//		profiler.swap("find powered wires");
++		findPoweredWires();
++
++		// Once the powered wires have been found, the network is no longer needed. In
++		// fact, it should be cleared before block and shape updates are emitted, in
++		// case a different network is updated that needs power changes.
++//		profiler.swap("clear " + rootCount + " roots and network of " + network.size());
++		network.clear();
++		rootCount = 0;
++
++		// Carry out the power changes and emit shape and block updates.
++//		profiler.swap("let power flow");
++		try {
++			letPowerFlow();
++		} catch (Throwable t) {
++			// If anything goes wrong while carrying out power changes, this field must
++			// be reset to 'false', or the wire handler will be locked out of carrying
++			// out power changes until the world is reloaded.
++			updatingPower = false;
++
++			throw t;
++		} finally {
++//			profiler.pop();
++//			profiler.end();
++		}
++	}
++
++	/**
++	 * Build up a network of wires that need power changes. This includes the roots
++	 * that were already added and any wires powered by those roots that will need
++	 * power changes as a result of power changes to the roots.
++	 */
++	private void buildNetwork() {
++		for (int index = 0; index < network.size(); index++) {
++			WireNode wire = network.get(index);
++
++			// The order in which wires are added to the network can influence the
++			// order in which they update their power levels.
++			wire.connections.forEach(connection -> {
++				if (!connection.offer) {
++					return;
++				}
++
++				WireNode neighbor = connection.wire;
++
++				if (neighbor.inNetwork) {
++					return;
++				}
++
++				prepare(neighbor);
++
++				// These checks stop wires with power step 0 from perpetually
++				// powering themselves. See the comment in the tryAddRoot method
++				// for more information.
++				if (neighbor.type.powerStep != 0 || !needsPowerChange(neighbor)) {
++					findPower(neighbor, false);
++				}
++
++				if (needsPowerChange(neighbor)) {
++					addToNetwork(neighbor, connection.iDir);
++				}
++			}, wire.iFlowDir);
++		}
++	}
++
++	/**
++	 * Add the given wire to the network and set its outgoing flow to some backup
++	 * value. This avoids directionality in redstone grids.
++	 */
++	private void addToNetwork(WireNode wire, int iBackupFlowDir) {
++		network.add(wire);
++
++		wire.inNetwork = true;
++		// Normally the flow is not set until the power level is updated. However,
++		// in networks with multiple power sources the update order between them
++		// depends on which was discovered first. To make this less prone to
++		// directionality, each wire node is given a 'backup' flow. For roots, this
++		// is the determined flow of their connections. For non-roots this is the
++		// direction from which they were discovered.
++		wire.iFlowDir = iBackupFlowDir;
++	}
++
++	/**
++	 * Find those wires in the network that receive power from outside it, either
++	 * from non-wire components or from wires that are not in the network, and queue
++	 * the power changes for those wires.
++	 */
++	private void findPoweredWires() {
++		for (int index = 0; index < network.size(); index++) {
++			WireNode wire = network.get(index);
++			findPower(wire, true);
++
++			if (index < rootCount || wire.removed || wire.shouldBreak || wire.virtualPower > wire.type.minPower) {
++				queuePowerChange(wire);
++			} else {
++				// Wires that do not receive any power do not queue power changes
++				// until they are offered power from a neighboring wire. To ensure
++				// that they accept any power from neighboring wires and thus queue
++				// their power changes, their virtual power is set to below the
++				// minimum.
++				wire.virtualPower--;
++			}
++		}
++	}
++
++	/**
++	 * Queue the power change for the given wire. If the wire does not need a power
++	 * change (perhaps because its power has already changed), transmit power to
++	 * neighboring wires.
++	 */
++	private void queuePowerChange(WireNode wire) {
++		if (needsPowerChange(wire)) {
++			powerChanges.offer(wire);
++		} else {
++			findPowerFlow(wire);
++			transmitPower(wire);
++		}
++	}
++
++	/**
++	 * Use the information of incoming power flow to determine the direction of
++	 * power flow through this wire. If that flow is ambiguous, try to use a flow
++	 * direction based on connections to neighboring wires. If that is also
++	 * ambiguous, use the backup value that was set when the wire was first added
++	 * to the network.
++	 */
++	private void findPowerFlow(WireNode wire) {
++		int flow = FLOW_IN_TO_FLOW_OUT[wire.flowIn];
++
++		if (flow >= 0) {
++			wire.iFlowDir = flow;
++		} else if (wire.connections.iFlowDir >= 0) {
++			wire.iFlowDir = wire.connections.iFlowDir;
++		}
++	}
++
++	/**
++	 * Transmit power from the given wire to neighboring wires.
++	 */
++	private void transmitPower(WireNode wire) {
++		wire.connections.forEach(connection -> {
++			if (!connection.offer) {
++				return;
++			}
++
++			WireNode neighbor = connection.wire;
++
++			int step = Math.max(wire.type.powerStep, neighbor.type.powerStep);
++			int power = Math.max(neighbor.type.minPower, wire.virtualPower - step);
++			int iDir = connection.iDir;
++
++			if (neighbor.offerPower(power, iDir)) {
++				queuePowerChange(neighbor);
++			}
++		}, wire.iFlowDir);
++	}
++
++	/**
++	 * Carry out power changes, setting the new power of each wire in the world,
++	 * notifying neighbors of the power change, then queueing power changes of
++	 * connected wires.
++	 */
++	private void letPowerFlow() {
++		// If an instantaneous update chain causes updates to another network
++		// (or the same network in another place), new power changes will be
++		// integrated into the already ongoing power queue, so we can exit early
++		// here.
++		if (updatingPower) {
++			return;
++		}
++
++		updatingPower = true;
++
++		while (!powerChanges.isEmpty()) {
++			WireNode wire = powerChanges.poll();
++
++			if (!needsPowerChange(wire)) {
++				continue;
++			}
++
++			findPowerFlow(wire);
++
++			if (wire.setPower()) {
++				// If the wire was removed, shape updates have already been emitted.
++				if (!wire.shouldBreak) {
++					updateNeighborShapes(wire);
++				}
++
++				updateNeighborBlocks(wire);
++			}
++
++			transmitPower(wire);
++		}
++
++		updatingPower = false;
++	}
++
++	/**
++	 * Emit shape updates around the given wire.
++	 */
++	private void updateNeighborShapes(WireNode wire) {
++		BlockPos wirePos = wire.pos;
++		BlockState wireState = wire.state;
++
++		for (Direction dir : BlockUtil.SHAPE_UPDATE_ORDER) {
++			updateNeighborShape(wirePos.relative(dir), dir.getOpposite(), wirePos, wireState);
++		}
++	}
++
++	private void updateNeighborShape(BlockPos pos, Direction fromDir, BlockPos fromPos, BlockState fromState) {
++		BlockState state = level.getBlockState(pos);
++
++		// Shape updates to redstone wire are very expensive, and should never happen
++		// as a result of power changes anyway.
++		if (!state.isAir() && !(state.getBlock() instanceof WireBlock)) {
++			level.updateNeighborShape(pos, state, fromDir, fromPos, fromState);
++		}
++	}
++
++	/**
++	 * Emit block updates around the given wire. The order in which neighbors are
++	 * updated is determined as follows:
++	 * <br>
++	 * 1. The direction of power flow through the wire is to be considered'forward'.
++	 * The order in which neighbors are updated depends on their relative positions
++	 * to the wire.
++	 * <br>
++	 * 2. Each neighbor is identified by the step(s) you must take, starting at the
++	 * wire, to reach it. Each step is 1 block, thus the position of a neighbor is
++	 * encoded by the direction(s) of the step(s), e.g. (right), (down), (up, left),
++	 * etc.
++	 * <br>
++	 * 3. Neighbors are updated in pairs that lie on opposite sides of the wire.
++	 * <br>
++	 * 4. Neighbors are updated in order of their distance from the wire. This means
++	 * they are updated in 3 groups: direct neighbors are updated first, then
++	 * diagonal neighbors, and last are the far neighbors that are 2 blocks directly
++	 * out.
++	 * <br>
++	 * 5. The order within each group is determined using the following basic order:
++	 * { front, back, right, left, down, up }. This order was chosen because it
++	 * converts to the following order of absolute directions when west is said to
++	 * be 'forward': { west, east, north, south, down, up } - this is the order of
++	 * shape updates.
++	 */
++	private void updateNeighborBlocks(WireNode wire) {
++		int iDir = wire.iFlowDir;
++
++		Direction forward   = Directions.HORIZONTAL[ iDir            ];
++		Direction rightward = Directions.HORIZONTAL[(iDir + 1) & 0b11];
++		Direction backward  = Directions.HORIZONTAL[(iDir + 2) & 0b11];
++		Direction leftward  = Directions.HORIZONTAL[(iDir + 3) & 0b11];
++		Direction downward  = Direction.DOWN;
++		Direction upward    = Direction.UP;
++
++		BlockPos self  = wire.pos;
++		BlockPos front = self.relative(forward);
++		BlockPos right = self.relative(rightward);
++		BlockPos back  = self.relative(backward);
++		BlockPos left  = self.relative(leftward);
++		BlockPos below = self.relative(downward);
++		BlockPos above = self.relative(upward);
++
++		// direct neighbors (6)
++		updateNeighbor(front, self);
++		updateNeighbor(back, self);
++		updateNeighbor(right, self);
++		updateNeighbor(left, self);
++		updateNeighbor(below, self);
++		updateNeighbor(above, self);
++
++		// diagonal neighbors (12)
++		updateNeighbor(front.relative(rightward), self);
++		updateNeighbor(back.relative(leftward), self);
++		updateNeighbor(front.relative(leftward), self);
++		updateNeighbor(back.relative(rightward), self);
++		updateNeighbor(front.relative(downward), self);
++		updateNeighbor(back.relative(upward), self);
++		updateNeighbor(front.relative(upward), self);
++		updateNeighbor(back.relative(downward), self);
++		updateNeighbor(right.relative(downward), self);
++		updateNeighbor(left.relative(upward), self);
++		updateNeighbor(right.relative(upward), self);
++		updateNeighbor(left.relative(downward), self);
++
++		// far neighbors (6)
++		updateNeighbor(front.relative(forward), self);
++		updateNeighbor(back.relative(backward), self);
++		updateNeighbor(right.relative(rightward), self);
++		updateNeighbor(left.relative(leftward), self);
++		updateNeighbor(below.relative(downward), self);
++		updateNeighbor(above.relative(upward), self);
++	}
++
++	private void updateNeighbor(BlockPos pos, BlockPos fromPos) {
++		BlockState state = level.getBlockState(pos);
++		Block block = state.getBlock();
++
++		// While this check makes sure wires in the network are not given block
++		// updates, it also prevents block updates to wires in neighboring networks.
++		// While this should not make a difference in theory, in practice, it is
++		// possible to force a network into an invalid state without updating it, even
++		// if it is relatively obscure.
++		// While I was willing to make this compromise in return for some significant
++		// performance gains in certain setups, if you are not, you can add all the
++		// positions of the network to a set and filter out block updates to wires in
++		// the network that way.
++		if (!state.isAir() && !(block instanceof WireBlock)) {
++			level.updateNeighborBlock(pos, state, fromPos, block);
++		}
++	}
++
++	@FunctionalInterface
++	public interface NodeProvider {
++
++		public Node getNeighbor(Node node, int iDir);
++
++	}
++}
+diff --git a/src/main/java/alternate/current/wire/WireNode.java b/src/main/java/alternate/current/wire/WireNode.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..00ea89b6e4684904771f0743a980a4d41d073714
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/WireNode.java
+@@ -0,0 +1,125 @@
++package alternate.current.wire;
++
++import net.minecraft.core.BlockPos;
++import net.minecraft.world.level.block.state.BlockState;
++
++/**
++ * A WireNode is a Node that represents a wire in the world. It stores
++ * all the information about the wire that the WireHandler needs to
++ * calculate power changes.
++ * 
++ * @author Space Walker
++ */
++public class WireNode extends Node {
++
++	final WireType type;
++	final WireConnectionManager connections;
++
++	/** The power level this wire currently holds in the world. */
++	int currentPower;
++	/**
++	 * While calculating power changes for a network, this field is used to keep
++	 * track of the power level this wire should have.
++	 */
++	int virtualPower;
++	/** The power level received from non-wire components. */
++	int externalPower;
++	/**
++	 * A 4-bit number that keeps track of the power flow of the wires that give this
++	 * wire its power level.
++	 */
++	int flowIn;
++	/** The direction of power flow, based on the incoming flow. */
++	int iFlowDir;
++	boolean removed;
++	boolean shouldBreak;
++	boolean prepared;
++	boolean inNetwork;
++
++	/** The power for which this wire was queued. */
++	int power;
++	/** The previous wire in the power queue. */
++	WireNode prev;
++	/** The next wire in the power queue. */
++	WireNode next;
++
++	WireNode(WireBlock wireBlock, LevelAccess level, BlockPos pos, BlockState state) {
++		this(wireBlock.getWireType(), level, pos, state);
++	}
++
++	WireNode(WireType type, LevelAccess level, BlockPos pos, BlockState state) {
++		this(type, level, pos);
++
++		this.state = state;
++
++		this.virtualPower = this.currentPower = this.type.getPower(this.level, this.pos, this.state);
++	}
++
++	WireNode(WireType type, LevelAccess level, BlockPos pos) {
++		super(level);
++
++		this.pos = pos.immutable();
++
++		this.type = type;
++		this.connections = new WireConnectionManager(this);
++	}
++
++	@Override
++	public Node update(BlockPos pos, BlockState state, boolean clearNeighbors) {
++		throw new UnsupportedOperationException("Cannot update a WireNode!");
++	}
++
++	@Override
++	public boolean isWire() {
++		return true;
++	}
++
++	@Override
++	public boolean isWire(WireType type) {
++		return this.type == type;
++	}
++
++	@Override
++	public WireNode asWire() {
++		return this;
++	}
++
++	int nextPower() {
++		return type.clamp(virtualPower);
++	}
++
++	boolean offerPower(int power, int iDir) {
++		if (removed || shouldBreak) {
++			return false;
++		}
++		if (power == virtualPower) {
++			flowIn |= (1 << iDir);
++			return false;
++		}
++		if (power > virtualPower) {
++			virtualPower = power;
++			flowIn = (1 << iDir);
++
++			return true;
++		}
++
++		return false;
++	}
++
++	boolean setPower() {
++		if (removed) {
++			return true;
++		}
++
++		state = level.getBlockState(pos);
++
++		if (shouldBreak) {
++			return level.breakWire(pos, state);
++		}
++
++		currentPower = power;
++		state = type.setPower(level, pos, state, currentPower);
++
++		return level.setWireState(pos, state);
++	}
++}
+diff --git a/src/main/java/alternate/current/wire/WireType.java b/src/main/java/alternate/current/wire/WireType.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..e6c67a66fbf394417638b0b6085bd5eadb77dd3a
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/WireType.java
+@@ -0,0 +1,46 @@
++package alternate.current.wire;
++
++import net.minecraft.core.BlockPos;
++import net.minecraft.util.Mth;
++import net.minecraft.world.level.block.state.BlockState;
++
++/**
++ * This class holds all information that specifies how a wire of this type
++ * should interact with other wires.
++ * 
++ * @author Space Walker
++ */
++public abstract class WireType {
++
++	public final String name;
++	public final int minPower;
++	public final int maxPower;
++	public final int powerStep;
++
++	// default behavior when interacting with other wire types
++	public final boolean offer;
++	public final boolean accept;
++
++	protected WireType(String name, int minPower, int maxPower, int powerStep, boolean offer, boolean accept) {
++		if (powerStep < 0) {
++			throw new IllegalArgumentException("powerStep must be at least 0!");
++		}
++
++		this.name = name;
++		this.minPower = minPower;
++		this.maxPower = maxPower;
++		this.powerStep = powerStep;
++
++		this.offer = offer;
++		this.accept = accept;
++	}
++
++	public final int clamp(int power) {
++		return Mth.clamp(power, minPower, maxPower);
++	}
++
++	public abstract int getPower(LevelAccess level, BlockPos pos, BlockState state);
++
++	public abstract BlockState setPower(LevelAccess level, BlockPos pos, BlockState state, int power);
++
++}
+diff --git a/src/main/java/alternate/current/wire/WireTypes.java b/src/main/java/alternate/current/wire/WireTypes.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..a2bab9219ef141571e00a3080996776d7d357d86
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/WireTypes.java
+@@ -0,0 +1,14 @@
++package alternate.current.wire;
++
++import alternate.current.wire.redstone.RedstoneWireType;
++
++public class WireTypes {
++
++	public static final WireType REDSTONE;
++
++	static {
++
++		REDSTONE = new RedstoneWireType("Redstone Wire", 1, true, true);
++
++	}
++}
+diff --git a/src/main/java/alternate/current/wire/redstone/RedstoneWireType.java b/src/main/java/alternate/current/wire/redstone/RedstoneWireType.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..95aeb35cd884f5cab194c716d317173458b5514d
+--- /dev/null
++++ b/src/main/java/alternate/current/wire/redstone/RedstoneWireType.java
+@@ -0,0 +1,26 @@
++package alternate.current.wire.redstone;
++
++import alternate.current.wire.LevelAccess;
++import alternate.current.wire.WireType;
++
++import net.minecraft.core.BlockPos;
++import net.minecraft.world.level.block.state.BlockState;
++import net.minecraft.world.level.block.state.properties.BlockStateProperties;
++import net.minecraft.world.level.redstone.Redstone;
++
++public class RedstoneWireType extends WireType {
++
++	public RedstoneWireType(String name, int powerStep, boolean offer, boolean accept) {
++		super(name, Redstone.SIGNAL_MIN, Redstone.SIGNAL_MAX, powerStep, offer, accept);
++	}
++
++	@Override
++	public int getPower(LevelAccess level, BlockPos pos, BlockState state) {
++		return state.getValue(BlockStateProperties.POWER);
++	}
++
++	@Override
++	public BlockState setPower(LevelAccess level, BlockPos pos, BlockState state, int power) {
++		return state.setValue(BlockStateProperties.POWER, power);
++	}
++}
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index c9c08e20f729b40b1d90f3ac144f5245f4f35230..33adaac9449862879724da25f0c138709a536dbe 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -71,8 +71,8 @@ public class PaperConfig {
+         commands.put("paper", new PaperCommand("paper"));
+         commands.put("mspt", new MSPTCommand("mspt"));
+ 
+-        version = getInt("config-version", 25);
+-        set("config-version", 25);
++        version = getInt("config-version", 26);
++        set("config-version", 26);
+         readConfig(PaperConfig.class, null);
+     }
+ 
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index ad3f0ff353a0448babde334641d1b1ac94779b07..0cf9c1157b2851b1fe7bbccce31ca1986b5000fd 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -77,13 +77,37 @@ public class PaperWorldConfig {
+         piglinsGuardChests = getBoolean("piglins-guard-chests", piglinsGuardChests);
+     }
+ 
+-    public boolean useEigencraftRedstone = false;
+-    private void useEigencraftRedstone() {
+-        useEigencraftRedstone = this.getBoolean("use-faster-eigencraft-redstone", false);
+-        if (useEigencraftRedstone) {
+-            log("Using Eigencraft redstone algorithm by theosib.");
++    public enum RedstoneImplementation {
++        VANILLA, EIGENCRAFT, ALTERNATE_CURRENT
++    }
++    public RedstoneImplementation redstoneImplementation = RedstoneImplementation.VANILLA;
++    private void redstoneImplementation() {
++        String implementation;
++        if (PaperConfig.version < 26) {
++            boolean useEigencraft = this.getBoolean("use-faster-eigencraft-redstone", false);
++            if (useEigencraft) {
++                implementation = "eigencraft";
++            } else {
++                implementation = "vanilla";
++            }
+         } else {
+-            log("Using vanilla redstone algorithm.");
++            implementation = this.getString("redstone-implementation", "vanilla").toLowerCase().trim();
++        }
++        switch (implementation) {
++            default:
++                logError("Warning: Invalid redstone-implementation config " + implementation + " - must be one of: vanilla, eigencraft, alternate-current");
++            case "vanilla":
++                redstoneImplementation = RedstoneImplementation.VANILLA;
++                log("Using the vanilla redstone implementation.");
++                break;
++            case "eigencraft":
++                redstoneImplementation = RedstoneImplementation.EIGENCRAFT;
++                log("Using Eigencraft's redstone implementation by theosib.");
++                break;
++            case "alternate-current":
++                redstoneImplementation = RedstoneImplementation.ALTERNATE_CURRENT;
++                log("Using Alternate Current's redstone implementation by Space Walker.");
++                break;
+         }
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 3b1a34b34979ab436ccd33f0a85bfae537cbecb4..dc114848e72c186c1ac07555913be5cb6ebc3ed0 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -6,6 +6,9 @@ import com.google.common.collect.Lists;
+ import com.mojang.datafixers.DataFixer;
+ import com.mojang.datafixers.util.Pair;
+ import com.mojang.logging.LogUtils;
++
++import alternate.current.wire.WireHandler; // Paper - optimize redstone (Alternate Current)
++
+ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+ import it.unimi.dsi.fastutil.longs.LongSet;
+@@ -212,6 +215,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+     public final UUID uuid;
+     public boolean hasPhysicsEvent = true; // Paper
+     public boolean hasEntityMoveEvent = false; // Paper
++    private final WireHandler wireHandler = new WireHandler(this); // Paper - optimize redstone (Alternate Current)
+     public static Throwable getAddToWorldStackTrace(Entity entity) {
+         return new Throwable(entity + " Added to world at " + new java.util.Date());
+     }
+@@ -2407,6 +2411,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
+         return this.entityManager.canPositionTick(pos.toLong()); // Paper
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public WireHandler getWireHandler() {
++        return wireHandler;
++    }
++    // Paper end
++
+     private final class EntityCallbacks implements LevelCallback<Entity> {
+ 
+         EntityCallbacks() {}
+diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
+index 160c0f37aa3aaf7598f852acf9bd444f79444c97..5f4943ce88cfdaa6de99325124cdeb26bdd0587a 100644
+--- a/src/main/java/net/minecraft/world/level/Level.java
++++ b/src/main/java/net/minecraft/world/level/Level.java
+@@ -7,6 +7,9 @@ import com.destroystokyo.paper.exception.ServerInternalException;
+ import com.google.common.base.MoreObjects;
+ import com.google.common.collect.Lists;
+ import com.mojang.serialization.Codec;
++
++import alternate.current.wire.WireHandler; // Paper - optimize redstone (Alternate Current)
++
+ import java.io.IOException;
+ import java.util.Iterator;
+ import java.util.List;
+@@ -1499,4 +1502,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+         return ret;
+     }
+     // Paper end
++
++    // Paper start - optimize redstone (Alternate Current)
++    public WireHandler getWireHandler() {
++        // This method is overridden in ServerLevel.
++        // Since Paper is a server platform there is no risk
++        // of this implementation being called. It is here 
++        // only so this method can be called without casting
++        // an instance of Level to ServerLevel.
++        return null;
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/net/minecraft/world/level/block/BasePressurePlateBlock.java b/src/main/java/net/minecraft/world/level/block/BasePressurePlateBlock.java
+index 2036006b934ba1f27da606320b4c456af019a361..9d1d59fe26eff0640906037aba93e73dda433d0d 100644
+--- a/src/main/java/net/minecraft/world/level/block/BasePressurePlateBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/BasePressurePlateBlock.java
+@@ -153,6 +153,18 @@ public abstract class BasePressurePlateBlock extends Block {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++
++    @Override
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return dir == Direction.UP;
++    }
++    // Paper end
++
+     @Override
+     public PushReaction getPistonPushReaction(BlockState state) {
+         return PushReaction.DESTROY;
+diff --git a/src/main/java/net/minecraft/world/level/block/ButtonBlock.java b/src/main/java/net/minecraft/world/level/block/ButtonBlock.java
+index b7f37475192bf79252482314080c9ba08e9aefdb..8b6eeb1ccad3a2e3858b70e59819c79485a2e538 100644
+--- a/src/main/java/net/minecraft/world/level/block/ButtonBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/ButtonBlock.java
+@@ -159,6 +159,18 @@ public abstract class ButtonBlock extends FaceAttachedHorizontalDirectionalBlock
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++
++    @Override
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return getConnectedDirection(state) == dir;
++    }
++    // Paper end
++
+     @Override
+     public void tick(BlockState state, ServerLevel world, BlockPos pos, Random random) {
+         if ((Boolean) state.getValue(ButtonBlock.POWERED)) {
+diff --git a/src/main/java/net/minecraft/world/level/block/DaylightDetectorBlock.java b/src/main/java/net/minecraft/world/level/block/DaylightDetectorBlock.java
+index 40b0380aa6fd052bf6376a15939c08e603f2f60c..e57c5242866165e589277bd0184098c7806538ba 100644
+--- a/src/main/java/net/minecraft/world/level/block/DaylightDetectorBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/DaylightDetectorBlock.java
+@@ -99,6 +99,13 @@ public class DaylightDetectorBlock extends BaseEntityBlock {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++    // Paper end
++
+     @Override
+     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+         return new DaylightDetectorBlockEntity(pos, state);
+diff --git a/src/main/java/net/minecraft/world/level/block/DiodeBlock.java b/src/main/java/net/minecraft/world/level/block/DiodeBlock.java
+index 9c764d2273d70b8dffcaa7f324544cb48f12acc3..7f0aa1e8b53a749459fb8cb99c73c6c2c60ea4e9 100644
+--- a/src/main/java/net/minecraft/world/level/block/DiodeBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/DiodeBlock.java
+@@ -159,6 +159,18 @@ public abstract class DiodeBlock extends HorizontalDirectionalBlock {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return state.getValue(FACING) == dir;
++    }
++
++    @Override
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return state.getValue(FACING) == dir;
++    }
++    // Paper end
++
+     @Override
+     public BlockState getStateForPlacement(BlockPlaceContext ctx) {
+         return (BlockState) this.defaultBlockState().setValue(DiodeBlock.FACING, ctx.getHorizontalDirection().getOpposite());
+diff --git a/src/main/java/net/minecraft/world/level/block/LecternBlock.java b/src/main/java/net/minecraft/world/level/block/LecternBlock.java
+index 25ed6dfef2887612a02fcf8884dc8dac4fbd64ff..7f6f14e7858c2577e44ace8370621114dce29ea8 100644
+--- a/src/main/java/net/minecraft/world/level/block/LecternBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/LecternBlock.java
+@@ -220,6 +220,18 @@ public class LecternBlock extends BaseEntityBlock {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++
++    @Override
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return dir == Direction.UP;
++    }
++    // Paper end;
++
+     @Override
+     public int getSignal(BlockState state, BlockGetter world, BlockPos pos, Direction direction) {
+         return (Boolean) state.getValue(LecternBlock.POWERED) ? 15 : 0;
+diff --git a/src/main/java/net/minecraft/world/level/block/LeverBlock.java b/src/main/java/net/minecraft/world/level/block/LeverBlock.java
+index 1093dc8595e42a90e74e19f74965f5be07a1d6cf..6e7320f5b8e2cf030b96f2ab80c8fb885b0fe1e3 100644
+--- a/src/main/java/net/minecraft/world/level/block/LeverBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/LeverBlock.java
+@@ -165,6 +165,18 @@ public class LeverBlock extends FaceAttachedHorizontalDirectionalBlock {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++
++    @Override
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return getConnectedDirection(state) == dir;
++    }
++    // Paper end
++
+     private void updateNeighbours(BlockState state, Level world, BlockPos pos) {
+         world.updateNeighborsAt(pos, this);
+         world.updateNeighborsAt(pos.relative(getConnectedDirection(state).getOpposite()), this);
+diff --git a/src/main/java/net/minecraft/world/level/block/LightningRodBlock.java b/src/main/java/net/minecraft/world/level/block/LightningRodBlock.java
+index b7605dda79c4d907f5822a0ded694b080e08dae5..ff24cbf03e937572a0c21fe298557d4eab8760b9 100644
+--- a/src/main/java/net/minecraft/world/level/block/LightningRodBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/LightningRodBlock.java
+@@ -166,4 +166,16 @@ public class LightningRodBlock extends RodBlock implements SimpleWaterloggedBloc
+     public boolean isSignalSource(BlockState state) {
+         return true;
+     }
++
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++
++    @Override
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return state.getValue(FACING) == dir;
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/net/minecraft/world/level/block/ObserverBlock.java b/src/main/java/net/minecraft/world/level/block/ObserverBlock.java
+index 4a34a08a1d46e4d3020644a51d9e30a36a18791a..358a40eb9b4be4d2b5446270f90b51138a19b051 100644
+--- a/src/main/java/net/minecraft/world/level/block/ObserverBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/ObserverBlock.java
+@@ -90,6 +90,18 @@ public class ObserverBlock extends DirectionalBlock {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return state.getValue(FACING) == dir;
++    }
++
++    @Override
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return state.getValue(FACING) == dir;
++    }
++    // Paper end
++
+     @Override
+     public int getDirectSignal(BlockState state, BlockGetter world, BlockPos pos, Direction direction) {
+         return state.getSignal(world, pos, direction);
+diff --git a/src/main/java/net/minecraft/world/level/block/PoweredBlock.java b/src/main/java/net/minecraft/world/level/block/PoweredBlock.java
+index 0afffc33f3be221a28c62115f493808aeffb1bd8..def39cd02da68b9be1ecfa5ae70119ef862cd079 100644
+--- a/src/main/java/net/minecraft/world/level/block/PoweredBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/PoweredBlock.java
+@@ -3,6 +3,7 @@ package net.minecraft.world.level.block;
+ import net.minecraft.core.BlockPos;
+ import net.minecraft.core.Direction;
+ import net.minecraft.world.level.BlockGetter;
++import net.minecraft.world.level.Level;
+ import net.minecraft.world.level.block.state.BlockBehaviour;
+ import net.minecraft.world.level.block.state.BlockState;
+ 
+@@ -16,6 +17,13 @@ public class PoweredBlock extends Block {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++    // Paper end
++
+     @Override
+     public int getSignal(BlockState state, BlockGetter world, BlockPos pos, Direction direction) {
+         return 15;
+diff --git a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
+index 037330bcb10039c013b2ed5fd68dee16ede20fbe..af42721f2097749c772cb9b7202e355303c11562 100644
+--- a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
+@@ -1,12 +1,20 @@
+ package net.minecraft.world.level.block;
+ 
+ import com.destroystokyo.paper.PaperConfig;
++import com.destroystokyo.paper.PaperWorldConfig.RedstoneImplementation;
+ import com.destroystokyo.paper.util.RedstoneWireTurbo;
+ import com.google.common.collect.ImmutableMap;
+ import com.google.common.collect.Maps;
+ import com.google.common.collect.Sets;
+ import com.google.common.collect.UnmodifiableIterator;
+ import com.mojang.math.Vector3f;
++
++// Paper start - optimize redstone (Alternate Current)
++import alternate.current.wire.WireBlock;
++import alternate.current.wire.WireType;
++import alternate.current.wire.WireTypes;
++// Paper end
++
+ import java.util.Iterator;
+ import java.util.Map;
+ import java.util.Random;
+@@ -40,7 +48,7 @@ import net.minecraft.world.phys.shapes.Shapes;
+ import net.minecraft.world.phys.shapes.VoxelShape;
+ import org.bukkit.event.block.BlockRedstoneEvent; // CraftBukkit
+ 
+-public class RedStoneWireBlock extends Block {
++public class RedStoneWireBlock extends Block implements WireBlock {
+ 
+     public static final EnumProperty<RedstoneSide> NORTH = BlockStateProperties.NORTH_REDSTONE;
+     public static final EnumProperty<RedstoneSide> EAST = BlockStateProperties.EAST_REDSTONE;
+@@ -69,6 +77,7 @@ public class RedStoneWireBlock extends Block {
+ 
+     });
+     private static final float PARTICLE_DENSITY = 0.2F;
++    private static final WireType TYPE = WireTypes.REDSTONE; // Paper - optimize redstone (Alternate Current)
+     private final BlockState crossState;
+     public boolean shouldSignal = true;
+ 
+@@ -257,7 +266,7 @@ public class RedStoneWireBlock extends Block {
+         return floor.isFaceSturdy(world, pos, Direction.UP) || floor.is(Blocks.HOPPER);
+     }
+ 
+-    // Paper start - Optimize redstone
++    // Paper start - Optimize redstone (Eigencraft)
+     // The bulk of the new functionality is found in RedstoneWireTurbo.java
+     RedstoneWireTurbo turbo = new RedstoneWireTurbo(this);
+ 
+@@ -267,7 +276,7 @@ public class RedStoneWireBlock extends Block {
+      * Note: Added 'source' argument so as to help determine direction of information flow
+      */
+     private void updateSurroundingRedstone(Level worldIn, BlockPos pos, BlockState state, BlockPos source) {
+-        if (worldIn.paperConfig.useEigencraftRedstone) {
++        if (worldIn.paperConfig.redstoneImplementation == RedstoneImplementation.EIGENCRAFT) {
+             turbo.updateSurroundingRedstone(worldIn, pos, state, source);
+             return;
+         }
+@@ -291,7 +300,7 @@ public class RedStoneWireBlock extends Block {
+         int k = worldIn.getBestNeighborSignal(pos1);
+         this.shouldSignal = true;
+ 
+-        if (!worldIn.paperConfig.useEigencraftRedstone) {
++        if (worldIn.paperConfig.redstoneImplementation == RedstoneImplementation.VANILLA) {
+             // This code is totally redundant to if statements just below the loop.
+             if (k > 0 && k > j - 1) {
+                 j = k;
+@@ -305,7 +314,7 @@ public class RedStoneWireBlock extends Block {
+         // redstone wire will be set to 'k'.  If 'k' is already 15, then nothing inside the
+         // following loop can affect the power level of the wire.  Therefore, the loop is
+         // skipped if k is already 15.
+-        if (!worldIn.paperConfig.useEigencraftRedstone || k < 15) {
++        if (worldIn.paperConfig.redstoneImplementation == RedstoneImplementation.VANILLA && k < 15) {
+             for (Direction enumfacing : Direction.Plane.HORIZONTAL) {
+                 BlockPos blockpos = pos1.relative(enumfacing);
+                 boolean flag = blockpos.getX() != pos2.getX() || blockpos.getZ() != pos2.getZ();
+@@ -324,7 +333,7 @@ public class RedStoneWireBlock extends Block {
+             }
+         }
+ 
+-        if (!worldIn.paperConfig.useEigencraftRedstone) {
++        if (worldIn.paperConfig.redstoneImplementation == RedstoneImplementation.VANILLA) {
+             // The old code would decrement the wire value only by 1 at a time.
+             if (l > j) {
+                 j = l - 1;
+@@ -464,7 +473,13 @@ public class RedStoneWireBlock extends Block {
+     @Override
+     public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify) {
+         if (!oldState.is(state.getBlock()) && !world.isClientSide) {
+-            this.updateSurroundingRedstone(world, pos, state, null); // Paper - Optimize redstone
++            // Paper start - optimize redstone - replace call to updatePowerStrength
++            if (world.paperConfig.redstoneImplementation == RedstoneImplementation.ALTERNATE_CURRENT) {
++                world.getWireHandler().onWireAdded(pos, TYPE); // Alternate Current
++            } else {
++                this.updateSurroundingRedstone(world, pos, state, null); // vanilla/Eigencraft
++            }
++            // Paper end
+             Iterator iterator = Direction.Plane.VERTICAL.iterator();
+ 
+             while (iterator.hasNext()) {
+@@ -491,7 +506,13 @@ public class RedStoneWireBlock extends Block {
+                     world.updateNeighborsAt(pos.relative(enumdirection), this);
+                 }
+ 
+-                this.updateSurroundingRedstone(world, pos, state, null); // Paper - Optimize redstone
++                // Paper start - optimize redstone - replace call to updatePowerStrength
++                if (world.paperConfig.redstoneImplementation == RedstoneImplementation.ALTERNATE_CURRENT) {
++                    world.getWireHandler().onWireRemoved(pos, TYPE); // Alternate Current
++                } else {
++                    this.updateSurroundingRedstone(world, pos, state, null); // vanilla/Eigencraft
++                }
++                // Paper end
+                 this.updateNeighborsOfNeighboringWires(world, pos);
+             }
+         }
+@@ -525,8 +546,13 @@ public class RedStoneWireBlock extends Block {
+     @Override
+     public void neighborChanged(BlockState state, Level world, BlockPos pos, Block block, BlockPos fromPos, boolean notify) {
+         if (!world.isClientSide) {
++            // Paper start - optimize redstone (Alternate Current)
++            if (world.paperConfig.redstoneImplementation == RedstoneImplementation.ALTERNATE_CURRENT) {
++                world.getWireHandler().onWireAdded(pos, TYPE);
++            } else
++            // Paper end
+             if (state.canSurvive(world, pos)) {
+-                this.updateSurroundingRedstone(world, pos, state, fromPos); // Paper - Optimize redstone
++                this.updateSurroundingRedstone(world, pos, state, fromPos); // Paper - optimize redstone (Eigencraft)
+             } else {
+                 dropResources(state, world, pos);
+                 world.removeBlock(pos, false);
+@@ -683,4 +709,10 @@ public class RedStoneWireBlock extends Block {
+         }
+ 
+     }
++
++    // Paper start - optimize redstone (Alternate Current)
++    public WireType getWireType() {
++        return TYPE;
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java b/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java
+index 954b86bea345a8e0e3a8dd425f356db6f5cd496f..3731749436c86210954e4213f893a51eea06230a 100644
+--- a/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java
+@@ -139,6 +139,18 @@ public class RedstoneTorchBlock extends TorchBlock {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return dir != Direction.UP;
++    }
++
++    @Override
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return dir == Direction.DOWN;
++    }
++    // Paper end
++
+     @Override
+     public void animateTick(BlockState state, Level world, BlockPos pos, Random random) {
+         if ((Boolean) state.getValue(RedstoneTorchBlock.LIT)) {
+diff --git a/src/main/java/net/minecraft/world/level/block/RedstoneWallTorchBlock.java b/src/main/java/net/minecraft/world/level/block/RedstoneWallTorchBlock.java
+index 5cf0ae04059533385a19f7b07909a67b57350c09..ec5c201ebac0e1b44b90319884ce968a9212f3b2 100644
+--- a/src/main/java/net/minecraft/world/level/block/RedstoneWallTorchBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/RedstoneWallTorchBlock.java
+@@ -76,6 +76,13 @@ public class RedstoneWallTorchBlock extends RedstoneTorchBlock {
+         return state.getValue(LIT) && state.getValue(FACING) != direction ? 15 : 0;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return state.getValue(FACING) != dir;
++    }
++    // Paper end
++
+     @Override
+     public BlockState rotate(BlockState state, Rotation rotation) {
+         return Blocks.WALL_TORCH.rotate(state, rotation);
+diff --git a/src/main/java/net/minecraft/world/level/block/SculkSensorBlock.java b/src/main/java/net/minecraft/world/level/block/SculkSensorBlock.java
+index 33bca696c1ae0a63055eea5d2e05551458da50b4..4a0e4b9c49f04d63ca0b7d0a6ce71680f911ff29 100644
+--- a/src/main/java/net/minecraft/world/level/block/SculkSensorBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/SculkSensorBlock.java
+@@ -206,6 +206,13 @@ public class SculkSensorBlock extends BaseEntityBlock implements SimpleWaterlogg
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++    // Paper end
++
+     @Override
+     public int getSignal(BlockState state, BlockGetter world, BlockPos pos, Direction direction) {
+         return (Integer) state.getValue(SculkSensorBlock.POWER);
+diff --git a/src/main/java/net/minecraft/world/level/block/TargetBlock.java b/src/main/java/net/minecraft/world/level/block/TargetBlock.java
+index d609c60c1650a5b7f860154e0a4f4c6d84fa63fc..391d64b698871aa420f736a97b7b4b28c9d11da0 100644
+--- a/src/main/java/net/minecraft/world/level/block/TargetBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/TargetBlock.java
+@@ -113,6 +113,13 @@ public class TargetBlock extends Block {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++    // Paper end
++
+     @Override
+     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+         builder.add(OUTPUT_POWER);
+diff --git a/src/main/java/net/minecraft/world/level/block/TrappedChestBlock.java b/src/main/java/net/minecraft/world/level/block/TrappedChestBlock.java
+index 184c70cd2954f4904518c3fee2a377d9c4e81cc3..78a3d810cbb4c0da8c59a9b225e9241945520586 100644
+--- a/src/main/java/net/minecraft/world/level/block/TrappedChestBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/TrappedChestBlock.java
+@@ -7,6 +7,7 @@ import net.minecraft.stats.Stat;
+ import net.minecraft.stats.Stats;
+ import net.minecraft.util.Mth;
+ import net.minecraft.world.level.BlockGetter;
++import net.minecraft.world.level.Level;
+ import net.minecraft.world.level.block.entity.BlockEntity;
+ import net.minecraft.world.level.block.entity.BlockEntityType;
+ import net.minecraft.world.level.block.entity.ChestBlockEntity;
+@@ -36,6 +37,18 @@ public class TrappedChestBlock extends ChestBlock {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++
++    @Override
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return dir == Direction.UP;
++    }
++    // Paper end
++
+     @Override
+     public int getSignal(BlockState state, BlockGetter world, BlockPos pos, Direction direction) {
+         return Mth.clamp(ChestBlockEntity.getOpenCount(world, pos), 0, 15);
+diff --git a/src/main/java/net/minecraft/world/level/block/TripWireHookBlock.java b/src/main/java/net/minecraft/world/level/block/TripWireHookBlock.java
+index a4344bf2267112e3c1e31c07c9f6b8eae9666947..5e973eb53b240615e70b7d46ef4dc17b907ecaf9 100644
+--- a/src/main/java/net/minecraft/world/level/block/TripWireHookBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/TripWireHookBlock.java
+@@ -265,6 +265,18 @@ public class TripWireHookBlock extends Block {
+         return true;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    @Override
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return true;
++    }
++
++    @Override
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return state.getValue(FACING) == dir;
++    }
++    // Paper end
++
+     @Override
+     public BlockState rotate(BlockState state, Rotation rotation) {
+         return (BlockState) state.setValue(TripWireHookBlock.FACING, rotation.rotate((Direction) state.getValue(TripWireHookBlock.FACING)));
+diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
+index 61590f2f04a797235299f1bd6b78a08f5bfe4a33..da7b4783da35bc08f48f2fe31c4d06f9fb5e160f 100644
+--- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
++++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
+@@ -187,6 +187,16 @@ public abstract class BlockBehaviour {
+         return false;
+     }
+ 
++    // Paper start - optimize redstone (Alternate Current)
++    public boolean isSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return false;
++    }
++
++    public boolean isDirectSignalSourceTo(Level level, BlockPos pos, BlockState state, Direction dir) {
++        return false;
++    }
++    // Paper end
++
+     /** @deprecated */
+     @Deprecated
+     public PushReaction getPistonPushReaction(BlockState state) {
+@@ -846,6 +856,16 @@ public abstract class BlockBehaviour {
+             return this.getBlock().isSignalSource(this.asState());
+         }
+ 
++        // Paper start - optimize redstone (Alternate Current)
++        public boolean isSignalSourceTo(Level level, BlockPos pos, Direction dir) {
++            return this.getBlock().isSignalSourceTo(level, pos, this.asState(), dir);
++        }
++
++        public boolean isDirectSignalSourceTo(Level level, BlockPos pos, Direction dir) {
++            return this.getBlock().isDirectSignalSourceTo(level, pos, this.asState(), dir);
++        }
++        // Paper end
++
+         public int getSignal(BlockGetter world, BlockPos pos, Direction direction) {
+             return this.getBlock().getSignal(this.asState(), world, pos, direction);
+         }

--- a/patches/server/0890-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/0890-Add-Alternate-Current-redstone-implementation.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Space Walker <spacedoesrs@gmail.com>
 Date: Sun, 3 Apr 2022 00:09:40 +0200
-Subject: [PATCH] Add Alternate Current's redstone implementation as an alternative to vanilla and Eigencraft's
+Subject: [PATCH] Add Alternate Current redstone implementation
 
 Author: Space Walker <spacedoesrs@gmail.com>
 
@@ -16,7 +16,7 @@ cannot comment on how the two compare in that aspect.
 
 Alternate Current is more invasive than Eigencraft, though some of the modifications can be removed with only a minor
 performance penalty in a small number of cases. Alternate Current needs the following modifications:
-* Level/ServerLevel: Each level has its own 'wire handler' that handles redstone dust power changes. 
+* Level/ServerLevel: Each level has its own 'wire handler' that handles redstone dust power changes.
 * RedStoneWireBlock: Replace calls to vanilla's or Eigencraft's methods for handling power changes with calls to
 Alternate Current's wire handler.
 * (optional) Every power emitter's block class: new methods added to these classes make it easier for Alternate Current
@@ -293,10 +293,10 @@ index 0000000000000000000000000000000000000000..191ef2fdcbfa4a4bd4707905c9abaf4d
 +}
 diff --git a/src/main/java/alternate/current/wire/PowerQueue.java b/src/main/java/alternate/current/wire/PowerQueue.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..943a529ad88964b902a8f5080da1f37084bbf2d9
+index 0000000000000000000000000000000000000000..4b89ef08947b0adb6cb97afcb7ecd9d06518d05b
 --- /dev/null
 +++ b/src/main/java/alternate/current/wire/PowerQueue.java
-@@ -0,0 +1,227 @@
+@@ -0,0 +1,229 @@
 +package alternate.current.wire;
 +
 +import java.util.AbstractQueue;
@@ -501,13 +501,15 @@ index 0000000000000000000000000000000000000000..943a529ad88964b902a8f5080da1f370
 +	}
 +
 +	private void linkAfter(WireNode prev, WireNode wire) {
-+		prev.next = wire;
-+		wire.prev = prev;
++		linkBetween(prev, wire, prev.next);
++	}
 +
-+		if (prev != tail) {
-+			wire.next = prev.next;
-+			prev.next.prev = wire;
-+		}
++	private void linkBetween(WireNode prev, WireNode wire, WireNode next) {
++		prev.next = wire;
++		wire.next = next;
++
++		wire.prev = prev;
++		next.prev = wire;
 +	}
 +
 +	private WireNode findPrev(WireNode wire) {
@@ -740,10 +742,10 @@ index 0000000000000000000000000000000000000000..497c8c730bb6279141335bbd1ab2fe4f
 +}
 diff --git a/src/main/java/alternate/current/wire/WireHandler.java b/src/main/java/alternate/current/wire/WireHandler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2b8d309141b49c00a0bd43c363eb195909524543
+index 0000000000000000000000000000000000000000..8bf304465071079c261913a0e7d5128637ef91e6
 --- /dev/null
 +++ b/src/main/java/alternate/current/wire/WireHandler.java
-@@ -0,0 +1,1128 @@
+@@ -0,0 +1,1114 @@
 +package alternate.current.wire;
 +
 +import java.util.ArrayList;
@@ -751,9 +753,7 @@ index 0000000000000000000000000000000000000000..2b8d309141b49c00a0bd43c363eb1959
 +import java.util.List;
 +import java.util.Queue;
 +
-+//import alternate.current.AlternateCurrentMod;
 +import alternate.current.util.BlockUtil;
-+//import alternate.current.util.profiler.Profiler;
 +
 +import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 +import it.unimi.dsi.fastutil.longs.Long2ObjectMap.Entry;
@@ -1541,30 +1541,21 @@ index 0000000000000000000000000000000000000000..2b8d309141b49c00a0bd43c363eb1959
 +	 * connected wires.
 +	 */
 +	private void updatePower() {
-+		// The profiler keeps track of how long various parts of the algorithm take.
-+		// It is only here for debugging purposes, and is commented out in production.
-+//		Profiler profiler = AlternateCurrentMod.createProfiler();
-+//		profiler.start();
-+
 +		// Build a network of wires that need power changes. This includes the roots
 +		// as well as any wires that will be affected by power changes to those roots.
-+//		profiler.push("build network");
 +		buildNetwork();
 +
 +		// Find those wires in the network that receive power from outside it.
 +		// Remember that the power changes for those wires are already queued here!
-+//		profiler.swap("find powered wires");
 +		findPoweredWires();
 +
 +		// Once the powered wires have been found, the network is no longer needed. In
 +		// fact, it should be cleared before block and shape updates are emitted, in
 +		// case a different network is updated that needs power changes.
-+//		profiler.swap("clear " + rootCount + " roots and network of " + network.size());
 +		network.clear();
 +		rootCount = 0;
 +
 +		// Carry out the power changes and emit shape and block updates.
-+//		profiler.swap("let power flow");
 +		try {
 +			letPowerFlow();
 +		} catch (Throwable t) {
@@ -1574,9 +1565,6 @@ index 0000000000000000000000000000000000000000..2b8d309141b49c00a0bd43c363eb1959
 +			updatingPower = false;
 +
 +			throw t;
-+		} finally {
-+//			profiler.pop();
-+//			profiler.end();
 +		}
 +	}
 +
@@ -2440,7 +2428,7 @@ index 0afffc33f3be221a28c62115f493808aeffb1bd8..def39cd02da68b9be1ecfa5ae70119ef
      public int getSignal(BlockState state, BlockGetter world, BlockPos pos, Direction direction) {
          return 15;
 diff --git a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
-index 037330bcb10039c013b2ed5fd68dee16ede20fbe..af42721f2097749c772cb9b7202e355303c11562 100644
+index 037330bcb10039c013b2ed5fd68dee16ede20fbe..9f5cd65808c9ec8f03f45bb14b95c0f85b58f70c 100644
 --- a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 @@ -1,12 +1,20 @@
@@ -2562,7 +2550,7 @@ index 037330bcb10039c013b2ed5fd68dee16ede20fbe..af42721f2097749c772cb9b7202e3553
          if (!world.isClientSide) {
 +            // Paper start - optimize redstone (Alternate Current)
 +            if (world.paperConfig.redstoneImplementation == RedstoneImplementation.ALTERNATE_CURRENT) {
-+                world.getWireHandler().onWireAdded(pos, TYPE);
++                world.getWireHandler().onWireUpdated(pos, TYPE);
 +            } else
 +            // Paper end
              if (state.canSurvive(world, pos)) {


### PR DESCRIPTION
This PR adds [Alternate Current](https://github.com/SpaceWalkerRS/alternate-current)'s redstone implementation as an alternative to vanilla and Eigencraft's. A previous attempt at this was made by [Titaniumtown](https://github.com/Titaniumtown) (#7291), but as they moved on, I decided to have a crack at it.

Alternate Current is many times faster than vanilla, and even exceeds Eigencraft. I will do some testing in the coming days and update this post with some numbers.

Just like Eigencraft, Alternate Current changes redstone dust's update order. This means any redstone contraption that is location dependent in vanilla has a significant chance of breaking with either of the faster implementations. Beyond that, parity issues should be rare, though Alternate Current has not been as thoroughly tested as Eigencraft, so I cannot compare the two in that aspect.

### Performance

[Grids](https://imgur.com/DvIH6fm)
- Vanilla: 295 mspt
- Eigencraft: 54 mspt
- Alternate Current: 17

[Lines](https://imgur.com/Uf5FiIH)
- Vanilla: 202 mspt
- Eigencraft: 65 mspt
- Alternate Current: 21 mspt

The second test is probably closest of the two to a 'real-world' scenario. 