### PR TITLE
List world on tile entity placement exception

### DIFF
--- a/patches/server/0055-Add-exception-reporting-event.patch
+++ b/patches/server/0055-Add-exception-reporting-event.patch
@@ -143,7 +143,7 @@ index 2d290d2e17517bc39828e05369ca5bc5ce892c27..fee21a585b95448a5edab70002e9c4ea
                                  }
  
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index ed6203119fe2e4ee47a2d51c84df5b7c236f32da..108c7ec010f826f9b9bb2db0987d2bcc18266482 100644
+index ed6203119fe2e4ee47a2d51c84df5b7c236f32da..7a63c26e360fd054bf237df3eeffc466d73d5dfb 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -1,6 +1,7 @@
@@ -154,7 +154,7 @@ index ed6203119fe2e4ee47a2d51c84df5b7c236f32da..108c7ec010f826f9b9bb2db0987d2bcc
  import com.google.common.collect.Maps;
  import com.google.common.collect.UnmodifiableIterator;
  import com.mojang.logging.LogUtils;
-@@ -544,10 +545,15 @@ public class LevelChunk extends ChunkAccess {
+@@ -544,10 +545,16 @@ public class LevelChunk extends ChunkAccess {
  
              // CraftBukkit start
          } else {
@@ -167,14 +167,15 @@ index ed6203119fe2e4ee47a2d51c84df5b7c236f32da..108c7ec010f826f9b9bb2db0987d2bcc
 +                "Attempted to place a tile entity (" + blockEntity + ") at " + blockEntity.getBlockPos().getX() + ","
 +                    + blockEntity.getBlockPos().getY() + "," + blockEntity.getBlockPos().getZ()
 +                    + " (" + getBlockState(blockposition) + ") where there was no entity tile!\n" +
-+                    "Chunk coordinates: " + (this.chunkPos.x * 16) + "," + (this.chunkPos.z * 16));
++                    "Chunk coordinates: " + (this.chunkPos.x * 16) + "," + (this.chunkPos.z * 16) +
++                    "\nWorld: " + level.getLevel().dimension().location());
 +            e.printStackTrace();
 +            ServerInternalException.reportInternalException(e);
 +            // Paper end
              // CraftBukkit end
          }
      }
-@@ -1027,6 +1033,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -1027,6 +1034,7 @@ public class LevelChunk extends ChunkAccess {
                          // Paper start - Prevent tile entity and entity crashes
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);

--- a/patches/server/0387-Improved-Watchdog-Support.patch
+++ b/patches/server/0387-Improved-Watchdog-Support.patch
@@ -311,10 +311,10 @@ index 334fd625829c8e5e9c434b184f6d0084b2d6ccc8..e4c2bd0131a54495fbd1930ad0462251
              final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level.getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
              MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 6129ea877c95445d358baf5036be8c4eee1f2770..9d667be3fe04b7d86986bd1ecaf4fce8b63198ae 100644
+index e48549ceb50b102495d17a7f05e879fe04e8bc30..9516d5cabbdc2d587bea54cbc02548d02a434893 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-@@ -1057,6 +1057,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -1058,6 +1058,7 @@ public class LevelChunk extends ChunkAccess {
  
                          gameprofilerfiller.pop();
                      } catch (Throwable throwable) {

--- a/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1148,7 +1148,7 @@ index ba0f9d729a4d4bd35050ab41d6d70ee3ea46beeb..3c3960abd63297bf6c247bc48de3b77a
      public float yRotO;
      public float xRotO;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index dc95aaa62220f2042e287c7d0d69753b8e891fba..06577d9cd276e65f2fdf5082b9ee4dc2d5211611 100644
+index 47257e22c75acf7f8eb582d7bbee5e8a6af9b4a6..b3752e1f1ed310cb104c8f955a94baf787a9e9ac 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -141,7 +141,7 @@ public class LevelChunk extends ChunkAccess {
@@ -1160,7 +1160,7 @@ index dc95aaa62220f2042e287c7d0d69753b8e891fba..06577d9cd276e65f2fdf5082b9ee4dc2
      private long neighbourChunksLoadedBitset;
      private final LevelChunk[] loadedNeighbourChunks = new LevelChunk[(NEIGHBOUR_CACHE_RADIUS * 2 + 1) * (NEIGHBOUR_CACHE_RADIUS * 2 + 1)];
  
-@@ -672,6 +672,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -673,6 +673,7 @@ public class LevelChunk extends ChunkAccess {
  
      // CraftBukkit start
      public void loadCallback() {
@@ -1168,7 +1168,7 @@ index dc95aaa62220f2042e287c7d0d69753b8e891fba..06577d9cd276e65f2fdf5082b9ee4dc2
          // Paper start - neighbour cache
          int chunkX = this.chunkPos.x;
          int chunkZ = this.chunkPos.z;
-@@ -726,6 +727,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -727,6 +728,7 @@ public class LevelChunk extends ChunkAccess {
      }
  
      public void unloadCallback() {

--- a/patches/server/0853-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0853-Replace-player-chunk-loader-system.patch
@@ -2041,7 +2041,7 @@ index 03824f73ecbac8ef6da586feb82f851557f82b6a..160c0f37aa3aaf7598f852acf9bd444f
  
              if ((i & 1) != 0) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index b46648301396930478391967b371bf8d201901e1..c8fb4b2bc86c9aa2e7c2e9ee10208cf9598b39ef 100644
+index 5566dceb6b0434dbcc68ba443cb357463fe6e2d3..cd2640855485960bef12f8d3e04734058b0dc525 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -191,6 +191,43 @@ public class LevelChunk extends ChunkAccess {
@@ -2088,7 +2088,7 @@ index b46648301396930478391967b371bf8d201901e1..c8fb4b2bc86c9aa2e7c2e9ee10208cf9
      }
  
      public final boolean isAnyNeighborsLoaded() {
-@@ -794,6 +831,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -795,6 +832,7 @@ public class LevelChunk extends ChunkAccess {
          // Paper end - neighbour cache
          org.bukkit.Server server = this.level.getCraftServer();
          this.level.getChunkSource().addLoadedChunk(this); // Paper
@@ -2096,7 +2096,7 @@ index b46648301396930478391967b371bf8d201901e1..c8fb4b2bc86c9aa2e7c2e9ee10208cf9
          if (server != null) {
              /*
               * If it's a new world, the first few chunks are generated inside
-@@ -918,7 +956,10 @@ public class LevelChunk extends ChunkAccess {
+@@ -919,7 +957,10 @@ public class LevelChunk extends ChunkAccess {
          });
      }
  
@@ -2107,7 +2107,7 @@ index b46648301396930478391967b371bf8d201901e1..c8fb4b2bc86c9aa2e7c2e9ee10208cf9
          ChunkPos chunkcoordintpair = this.getPos();
  
          for (int i = 0; i < this.postProcessing.length; ++i) {
-@@ -956,6 +997,11 @@ public class LevelChunk extends ChunkAccess {
+@@ -957,6 +998,11 @@ public class LevelChunk extends ChunkAccess {
  
          this.pendingBlockEntities.clear();
          this.upgradeData.upgrade(this);


### PR DESCRIPTION
An exception is called whenever there is an attempt to place a tile entity where there is something else there, such as this:
```
[03:29:22 WARN]: com.destroystokyo.paper.exception.ServerInternalException: Attempted to place a tile entity (net.minecraft.world.level.block.entity.TileEntityCampfire@135dea23) at 6876,131,5939 (Block{minecraft:red_sand}) where there was no entity tile!
[03:29:22 WARN]: Chunk coordinates: 6864,5936
```
This minor change will cause the world to be listed when that exception occurs, this is helpful for people who have dozens of worlds on one server, and want to know where the issue occurred without checking every single one.