### PR TITLE
Fix tick function tag running before load

### DIFF
--- a/patches/server/0891-Fix-tick-function-tag-running-before-load.patch
+++ b/patches/server/0891-Fix-tick-function-tag-running-before-load.patch
@@ -4,7 +4,7 @@ Date: Fri, 8 Apr 2022 21:28:40 +0200
 Subject: [PATCH] Fix tick function tag running before load
 
 When enabling or reloading a datapack that has functions for both
-#tick and #load, the former runs before the latter, which causes
+tick and load, the former runs before the latter, which causes
 problems in some cases such as initializing scoreboard values before
 increasing them per tick.
 See https://bugs.mojang.com/browse/MC-187539

--- a/patches/server/0891-Fix-tick-function-tag-running-before-load.patch
+++ b/patches/server/0891-Fix-tick-function-tag-running-before-load.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: etil2jz <blanchot.arthur@protonmail.ch>
+Date: Fri, 8 Apr 2022 21:28:40 +0200
+Subject: [PATCH] Fix tick function tag running before load
+
+When enabling or reloading a datapack that has functions for both
+#tick and #load, the former runs before the latter, which causes
+problems in some cases such as initializing scoreboard values before
+increasing them per tick.
+See https://bugs.mojang.com/browse/MC-187539
+
+diff --git a/src/main/java/net/minecraft/server/ServerFunctionManager.java b/src/main/java/net/minecraft/server/ServerFunctionManager.java
+index 48205eb72c63fc22042ba4eef8bd1cf85ef61f8a..6bce8d0034d848c81aa32dd4787d6c72a7d9fac4 100644
+--- a/src/main/java/net/minecraft/server/ServerFunctionManager.java
++++ b/src/main/java/net/minecraft/server/ServerFunctionManager.java
+@@ -48,13 +48,14 @@ public class ServerFunctionManager {
+     }
+ 
+     public void tick() {
+-        this.executeTagFunctions(this.ticking, ServerFunctionManager.TICK_FUNCTION_TAG);
++        //this.executeTagFunctions(this.ticking, ServerFunctionManager.TICK_FUNCTION_TAG); // Paper - moved down
+         if (this.postReload) {
+             this.postReload = false;
+             Collection<CommandFunction> collection = this.library.getTag(ServerFunctionManager.LOAD_FUNCTION_TAG).getValues();
+ 
+             this.executeTagFunctions(collection, ServerFunctionManager.LOAD_FUNCTION_TAG);
+         }
++        this.executeTagFunctions(this.ticking, ServerFunctionManager.TICK_FUNCTION_TAG); // Paper - fix tick function tag running before load
+ 
+     }
+ 


### PR DESCRIPTION
When enabling or reloading a datapack that has functions for both tick and load, the former runs before the latter, which causes problems in some cases such as initializing scoreboard values before increasing them per tick.
See https://bugs.mojang.com/browse/MC-187539