### PR TITLE
Revert to old createProfile(UUID, String) logic

### DIFF
--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -289,10 +289,10 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ece84330d2700db8708d2ae2ab7badf4acb428a8..621420d35378e0038c33892c185216894912f023 100644
+index ece84330d2700db8708d2ae2ab7badf4acb428a8..90c875ad60e473c3ec25f209933d48615d0fd6c0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2092,6 +2092,50 @@ public final class Bukkit {
+@@ -2092,6 +2092,83 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
@@ -301,7 +301,7 @@ index ece84330d2700db8708d2ae2ab7badf4acb428a8..621420d35378e0038c33892c18521689
 +     * Creates a PlayerProfile for the specified uuid, with name as null.
 +     *
 +     * If a player with the passed uuid exists on the server at the time of creation, the returned player profile will
-+     * be populated with the properties of said player.
++     * be populated with the properties of said player (including their uuid and name).
 +     *
 +     * @param uuid UUID to create profile for
 +     * @return A PlayerProfile object
@@ -315,7 +315,12 @@ index ece84330d2700db8708d2ae2ab7badf4acb428a8..621420d35378e0038c33892c18521689
 +     * Creates a PlayerProfile for the specified name, with UUID as null.
 +     *
 +     * If a player with the passed name exists on the server at the time of creation, the returned player profile will
-+     * be populated with the properties of said player.
++     * be populated with the properties of said player (including their uuid and name).
++     * <p>
++     * E.g. if the player 'jeb_' is currently playing on the server, calling {@code createProfile("JEB_")} will
++     * yield a profile with the name 'jeb_', their uuid and their textures.
++     * To bypass this pre-population on a case-insensitive name match, see {@link #createProfileExact(UUID, String)}.
++     * <p>
 +     *
 +     * @param name Name to create profile for
 +     * @return A PlayerProfile object
@@ -330,7 +335,15 @@ index ece84330d2700db8708d2ae2ab7badf4acb428a8..621420d35378e0038c33892c18521689
 +     *
 +     * Both UUID and Name can not be null at same time. One must be supplied.
 +     * If a player with the passed uuid or name exists on the server at the time of creation, the returned player
-+     * profile will be populated with the properties of said player.
++     * profile will be populated with the properties of said player (including their uuid and name).
++     * <p>
++     * E.g. if the player 'jeb_' is currently playing on the server, calling {@code createProfile(null, "JEB_")} will
++     * yield a profile with the name 'jeb_', their uuid and their textures.
++     * To bypass this pre-population on an case-insensitive name match, see {@link #createProfileExact(UUID, String)}.
++     * <p>
++     *
++     * The name comparison will compare the {@link String#toLowerCase()} version of both the passed name parameter and
++     * a players name to honour the case-insensitive nature of a mojang profile lookup.
 +     *
 +     * @param uuid UUID to create profile for
 +     * @param name Name to create profile for
@@ -340,14 +353,34 @@ index ece84330d2700db8708d2ae2ab7badf4acb428a8..621420d35378e0038c33892c18521689
 +    public static com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
 +        return server.createProfile(uuid, name);
 +    }
++
++    /**
++     * Creates an exact PlayerProfile for the specified name/uuid
++     *
++     * Both UUID and Name can not be null at same time. One must be supplied.
++     * If a player with the passed uuid or name exists on the server at the time of creation, the returned player
++     * profile will be populated with the properties of said player.
++     * <p>
++     * Compared to {@link #createProfile(UUID, String)}, this method will never mutate the passed uuid or name.
++     * If a player with either the same uuid or a matching name (case-insensitive) is found on the server, their
++     * properties, such as textures, will be pre-populated in the profile, however the passed uuid and name stay intact.
++     *
++     * @param uuid UUID to create profile for
++     * @param name Name to create profile for
++     * @return A PlayerProfile object
++     */
++    @NotNull
++    public static com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name) {
++        return server.createProfileExact(uuid, name);
++    }
      // Paper end
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 3c987b2fb0f748ce92a87c4ee54a4e9722e1910e..58c8e74b61dd4d952919a854a374ae7b4c3e02c0 100644
+index 3c987b2fb0f748ce92a87c4ee54a4e9722e1910e..9796ae6fcf605af88c1e5c1d29d77ea6857632cc 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1838,5 +1838,43 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1838,5 +1838,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
@@ -356,7 +389,7 @@ index 3c987b2fb0f748ce92a87c4ee54a4e9722e1910e..58c8e74b61dd4d952919a854a374ae7b
 +     * Creates a PlayerProfile for the specified uuid, with name as null.
 +     *
 +     * If a player with the passed uuid exists on the server at the time of creation, the returned player profile will
-+     * be populated with the properties of said player.
++     * be populated with the properties of said player (including their uuid and name).
 +     *
 +     * @param uuid UUID to create profile for
 +     * @return A PlayerProfile object
@@ -368,7 +401,12 @@ index 3c987b2fb0f748ce92a87c4ee54a4e9722e1910e..58c8e74b61dd4d952919a854a374ae7b
 +     * Creates a PlayerProfile for the specified name, with UUID as null.
 +     *
 +     * If a player with the passed name exists on the server at the time of creation, the returned player profile will
-+     * be populated with the properties of said player.
++     * be populated with the properties of said player (including their uuid and name).
++     * <p>
++     * E.g. if the player 'jeb_' is currently playing on the server, calling {@code createProfile("JEB_")} will
++     * yield a profile with the name 'jeb_', their uuid and their textures.
++     * To bypass this pre-population on a case-insensitive name match, see {@link #createProfileExact(UUID, String)}.
++     * <p>
 +     *
 +     * @param name Name to create profile for
 +     * @return A PlayerProfile object
@@ -381,7 +419,15 @@ index 3c987b2fb0f748ce92a87c4ee54a4e9722e1910e..58c8e74b61dd4d952919a854a374ae7b
 +     *
 +     * Both UUID and Name can not be null at same time. One must be supplied.
 +     * If a player with the passed uuid or name exists on the server at the time of creation, the returned player
-+     * profile will be populated with the properties of said player.
++     * profile will be populated with the properties of said player (including their uuid and name).
++     * <p>
++     * E.g. if the player 'jeb_' is currently playing on the server, calling {@code createProfile(null, "JEB_")} will
++     * yield a profile with the name 'jeb_', their uuid and their textures.
++     * To bypass this pre-population on an case-insensitive name match, see {@link #createProfileExact(UUID, String)}.
++     * <p>
++     *
++     * The name comparison will compare the {@link String#toLowerCase()} version of both the passed name parameter and
++     * a players name to honour the case-insensitive nature of a mojang profile lookup.
 +     *
 +     * @param uuid UUID to create profile for
 +     * @param name Name to create profile for
@@ -389,5 +435,23 @@ index 3c987b2fb0f748ce92a87c4ee54a4e9722e1910e..58c8e74b61dd4d952919a854a374ae7b
 +     */
 +    @NotNull
 +    com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name);
++
++    /**
++     * Creates an exact PlayerProfile for the specified name/uuid
++     *
++     * Both UUID and Name can not be null at same time. One must be supplied.
++     * If a player with the passed uuid or name exists on the server at the time of creation, the returned player
++     * profile will be populated with the properties of said player.
++     * <p>
++     * Compared to {@link #createProfile(UUID, String)}, this method will never mutate the passed uuid or name.
++     * If a player with either the same uuid or a matching name (case-insensitive) is found on the server, their
++     * properties, such as textures, will be pre-populated in the profile, however the passed uuid and name stay intact.
++     *
++     * @param uuid UUID to create profile for
++     * @param name Name to create profile for
++     * @return A PlayerProfile object
++     */
++    @NotNull
++    com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);
      // Paper end
  }

--- a/patches/api/0183-Expose-the-internal-current-tick.patch
+++ b/patches/api/0183-Expose-the-internal-current-tick.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c8580174d88674a8ab115976e93f225bb20b5854..af91f6cf87ad0f01370db31720fe318d84786ebd 100644
+index 5e145a95c1259e084aeed08a3b1d773843939e3f..070a06b1f19c663063f8803bd3698569f67549b4 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2162,6 +2162,10 @@ public final class Bukkit {
-     public static com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
-         return server.createProfile(uuid, name);
+@@ -2195,6 +2195,10 @@ public final class Bukkit {
+     public static com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name) {
+         return server.createProfileExact(uuid, name);
      }
 +
 +    public static int getCurrentTick() {
@@ -20,13 +20,13 @@ index c8580174d88674a8ab115976e93f225bb20b5854..af91f6cf87ad0f01370db31720fe318d
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f673927df360702b07f1fd197a3de07bc47b60cd..dc119a58c02a6b4177d560b70f026db6d9e08c55 100644
+index e32e6b87fefa95c07a0aef58cac33c99efea2631..38312ba54a4afd61b002091a742a8c91ecda1b1c 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1898,5 +1898,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1929,5 +1929,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
-     com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name);
+     com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);
 +
 +    /**
 +     * Get the current internal server tick

--- a/patches/api/0190-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0190-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index a6808ead643db1833e1bb2a5f758f1e1d73059c1..61a60d02557ec83392dc9ce53ac83d8e4060d23b 100644
+index d93c189807ca1d22b86ed60e3eb1c1fe0a863495..ffd1c908e56fe4e09def7d7658b59e5827d8ad55 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2185,6 +2185,15 @@ public final class Bukkit {
+@@ -2218,6 +2218,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index a6808ead643db1833e1bb2a5f758f1e1d73059c1..61a60d02557ec83392dc9ce53ac83d8e
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 02139695e15ec52b09ccbdf6105fa2bc786cf9be..fdf88c204505efdb8bd2a51e0f7e0ad1ca803e75 100644
+index 81761ca547e6d2283edc5516a115c84cc48016c0..8a71aaf28eb4c38396c330e0d6eac0ed31182c94 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1920,5 +1920,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1951,5 +1951,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0200-Add-Mob-Goal-API.patch
+++ b/patches/api/0200-Add-Mob-Goal-API.patch
@@ -523,10 +523,10 @@ index 0000000000000000000000000000000000000000..8fd399f791b45eb7fc62693ca954eea0
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index e86d3a012f62e87af1894bf697d496bb82cc6c02..cd175830d73b6db5388d5fcf9c37399f4ccb72e0 100644
+index f020e0d840ffb2d4618f226cc698f2d7c1c3858a..a300b85a475364ca5f32a01ae02a77306ea9a1c8 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2206,6 +2206,16 @@ public final class Bukkit {
+@@ -2239,6 +2239,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -544,10 +544,10 @@ index e86d3a012f62e87af1894bf697d496bb82cc6c02..cd175830d73b6db5388d5fcf9c37399f
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index dda3eb79a9687f8a6fdc9e6bdce3ecdcdfddb5f4..0e7bb5c572aa46120f85e9202dd0fe5cc7943ff5 100644
+index 52cb28b85e4ce6f69fea7b8f543aea00c3c7be3b..1360973d22ef5da6388863e8558ef7fe08ae7ec8 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1937,5 +1937,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1968,5 +1968,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0295-Add-basic-Datapack-API.patch
+++ b/patches/api/0295-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9f77415577a6ea3f6fda6c3077cdbf123ce47674..fd1ec52f2135914e50dcb9d61635ddab67e46f5a 100644
+index a4c09666c3bbb9037303a6eb85d95a2555963aad..90bf75ebd1f6105c5b943c56409d60e3ee35b6b9 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2260,6 +2260,14 @@ public final class Bukkit {
+@@ -2293,6 +2293,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index 9f77415577a6ea3f6fda6c3077cdbf123ce47674..fd1ec52f2135914e50dcb9d61635ddab
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index b0cfe2e72d404aca204a0a1a43e4ba4e0c44ac98..da886acceb4cf7129cdc6fe1b4bea2f428597cb7 100644
+index afc77648a8863f9d07f89fa1d3b14e88ce4183f6..bcfa12850ace6f3deee546a573f89887cb179892 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1984,5 +1984,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2015,5 +2015,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0371-Custom-Potion-Mixes.patch
+++ b/patches/api/0371-Custom-Potion-Mixes.patch
@@ -102,10 +102,10 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 6a5b155b4fec18d9aa906cd6cea6394a98cfe1b5..dcfd22862c79ae01ca7707d9abf0a71cc0d4ad9d 100644
+index 75bc84ff3280fe7ecfe684014a8865e066b699ab..5979f00d7c85b8807659f1cb40a69f2e2449ef70 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2319,6 +2319,15 @@ public final class Bukkit {
+@@ -2352,6 +2352,15 @@ public final class Bukkit {
      public static io.papermc.paper.datapack.DatapackManager getDatapackManager() {
          return server.getDatapackManager();
      }
@@ -122,10 +122,10 @@ index 6a5b155b4fec18d9aa906cd6cea6394a98cfe1b5..dcfd22862c79ae01ca7707d9abf0a71c
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 24c3abf0fbc05c1aa22453543be94a2360c59f01..7a3a2ff605e06e42ba2a0263e2c50eed5c24f8e9 100644
+index f5ea978dade76db193989f4f92a90578e1c4f67a..b26ff5864d97810202257bed466ea16d9e0a988b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2018,5 +2018,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2049,5 +2049,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();

--- a/patches/server/0138-Basic-PlayerProfile-API.patch
+++ b/patches/server/0138-Basic-PlayerProfile-API.patch
@@ -621,7 +621,7 @@ index c4142568c3188c89142799cc4911dd7eae32a45f..f379e108ec3c762940bddea878a0a711
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6f1b1191426d864719e1b5cbd42bf5699e6193e3..59f3167c276d93c36b0b36ff0e36918cf498424b 100644
+index 6f1b1191426d864719e1b5cbd42bf5699e6193e3..4dad4b95f263bd7cd086d87848ee8c8a862e1577 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -244,6 +244,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -642,7 +642,7 @@ index 6f1b1191426d864719e1b5cbd42bf5699e6193e3..59f3167c276d93c36b0b36ff0e36918c
          CraftItemFactory.instance();
      }
  
-@@ -2574,5 +2578,29 @@ public final class CraftServer implements Server {
+@@ -2574,5 +2578,37 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
@@ -659,6 +659,14 @@ index 6f1b1191426d864719e1b5cbd42bf5699e6193e3..59f3167c276d93c36b0b36ff0e36918c
 +
 +    @Override
 +    public com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
++        Player player = uuid != null ? Bukkit.getPlayer(uuid) : (name != null ? Bukkit.getPlayerExact(name) : null);
++        if (player != null) return new com.destroystokyo.paper.profile.CraftPlayerProfile((CraftPlayer) player);
++
++        return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
++    }
++
++    @Override
++    public com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name) {
 +        Player player = uuid != null ? Bukkit.getPlayer(uuid) : (name != null ? Bukkit.getPlayerExact(name) : null);
 +        if (player == null) return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
 +

--- a/patches/server/0326-Expose-the-internal-current-tick.patch
+++ b/patches/server/0326-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a98a9a2eb9f19d37bfff412c1dcebecb07b60014..ad8392124f12f54f4ed03887c805367403e51bb6 100644
+index 56adf4f5a478a7f4ae1d29a18572be0fcf011fca..e9c8eb1ca3e39840b3791d814b66ad5b5919112f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2628,5 +2628,10 @@ public final class CraftServer implements Server {
+@@ -2636,5 +2636,10 @@ public final class CraftServer implements Server {
          profile.getProperties().putAll(((CraftPlayer)player).getHandle().getGameProfile().getProperties());
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }

--- a/patches/server/0376-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0376-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2d136e8cb25598f610ba114a4e7e1a9f80c08b58..b74e74d511849c1d94564cc508e832868c304ee9 100644
+index 8452e72f669b82acb46ef00a7cdbb4177926ebc9..1f106b4a622c14d5a9bee9eeefd5e16b2592d3b5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2643,5 +2643,10 @@ public final class CraftServer implements Server {
+@@ -2651,5 +2651,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0413-Implement-Mob-Goal-API.patch
+++ b/patches/server/0413-Implement-Mob-Goal-API.patch
@@ -785,10 +785,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c7f43771616310e8404b033b3cd99fb0a0024d69..a16cdce0d185d0b42cb266614729c7d6cf7a875d 100644
+index 785389d11ead646d7f11c883f9784c3950a547aa..7353cfd8316f2c7725bba7d4aee41de135985daa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2656,5 +2656,11 @@ public final class CraftServer implements Server {
+@@ -2664,5 +2664,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0646-Add-basic-Datapack-API.patch
+++ b/patches/server/0646-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d7f45b1fb5e2ce55ceaf6f844286a177533374a3..48f991bd9b6ec689b462f6a546ec1379d2e30002 100644
+index 3e26f9a4c93f616f4f02edbbd851cf0b9ab0cdb1..8cf01762342c848ce7610d32e033f9a36953077b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -281,6 +281,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index d7f45b1fb5e2ce55ceaf6f844286a177533374a3..48f991bd9b6ec689b462f6a546ec1379
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2729,5 +2731,11 @@ public final class CraftServer implements Server {
+@@ -2737,5 +2739,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0865-Custom-Potion-Mixes.patch
+++ b/patches/server/0865-Custom-Potion-Mixes.patch
@@ -164,7 +164,7 @@ index 287205bce7f655f9a6b815f40d349c3db4c1e788..5c0f1488c8a8100cd39a03adeccded99
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 65a173c0d99c44679f7db1976fe310c8200bd80e..cea238696ef83ca8e26812072dfbb45b1915dab9 100644
+index 7775041c067e17da3d442fb8127f1ed2bba4f78c..cafef315ccc714afd9c3554cbfb19ca26085b597 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -285,6 +285,7 @@ public final class CraftServer implements Server {
@@ -184,7 +184,7 @@ index 65a173c0d99c44679f7db1976fe310c8200bd80e..cea238696ef83ca8e26812072dfbb45b
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2857,5 +2858,10 @@ public final class CraftServer implements Server {
+@@ -2865,5 +2866,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  


### PR DESCRIPTION
The recent change to the createProfile method set, which allowed plugins
to properly create profiles with differing names/uuids for players
currently on the server broke an implicit method contract for plugins
providing the lowercased version of a player name to the method.

Previously, the returned profile would simply be pulled from an online
player with the same name (when compared case-insensitively), however
the previously mentioned fix to the creation logic currently returns
a profile with the lowercased name instead.

To not break plugins that relied on this specific internal logic, the
ability to create pre-filled profiles with different names or uuids for
players that are currently online is moved by this commit to a new
method called createProfileExact, which simply mirrors the current
createProfile logic.

The createProfile logic is hence returned to its old functionality, once
again allowing plugins to grab an online players profile from their
lowercased name.

See: #7558
Resolves: #7700

-------------------------------------------------------------------------

Potential points of discussions:

This PR actively brings back (in my opinion) unwanted behaviour to the `createProfile` method. While I see the use of the logic in said method, I am uncertain whether moving the (in my opinion) correct logic to a new method like `createProfileExact` is the way to go here or if we should move the old logic into a new method. Both sides have their benefits, however the patch currently introduces a new method as not break plugins that relied on the lowercase hack.