### PR TITLE
Use Mojang code to validate usernames

### DIFF
--- a/patches/server/0832-Validate-usernames.patch
+++ b/patches/server/0832-Validate-usernames.patch
@@ -22,7 +22,7 @@ index 24ddf8cfdbe6ed2fb148f57f0d7dd98446b07bbc..da6346cacf08e12f7f1fabe2d5b1c66c
      public static int maxPlayerAutoSavePerTick = 10;
      private static void playerAutoSaveRate() {
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index f5c1dff1d571e89f960f11400edbcbbea0620575..7065aa4522431d08018fec8e591ba7c255398140 100644
+index f5c1dff1d571e89f960f11400edbcbbea0620575..b5cf181bd3cd970ca9b20a2fd468f7e9bebb24df 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -61,6 +61,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
@@ -33,40 +33,16 @@ index f5c1dff1d571e89f960f11400edbcbbea0620575..7065aa4522431d08018fec8e591ba7c2
  
      public ServerLoginPacketListenerImpl(MinecraftServer server, Connection connection) {
          this.state = ServerLoginPacketListenerImpl.State.HELLO;
-@@ -226,11 +227,39 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
-         // Paper end
-     }
- 
-+    // Paper start - validate usernames
-+    public static boolean validateUsername(String in) {
-+        if (in == null || in.isEmpty() || in.length() > 16) {
-+            return false;
-+        }
-+
-+        for (int i = 0, len = in.length(); i < len; ++i) {
-+            char c = in.charAt(i);
-+
-+            if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c == '_' || c == '.')) {
-+                continue;
-+            }
-+
-+            return false;
-+        }
-+
-+        return true;
-+    }
-+    // Paper end - validate usernames
-+
-     @Override
+@@ -230,7 +231,14 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
      public void handleHello(ServerboundHelloPacket packet) {
          Validate.validState(this.state == ServerLoginPacketListenerImpl.State.HELLO, "Unexpected hello packet", new Object[0]);
          this.gameProfile = packet.getGameProfile();
-         Validate.validState(ServerLoginPacketListenerImpl.isValidUsername(this.gameProfile.getName()), "Invalid characters in username", new Object[0]);
+-        Validate.validState(ServerLoginPacketListenerImpl.isValidUsername(this.gameProfile.getName()), "Invalid characters in username", new Object[0]);
++//        Validate.validState(ServerLoginPacketListenerImpl.isValidUsername(this.gameProfile.getName()), "Invalid characters in username", new Object[0]);
 +        // Paper start - validate usernames
 +        if (com.destroystokyo.paper.PaperConfig.isProxyOnlineMode() && com.destroystokyo.paper.PaperConfig.performUsernameValidation) {
-+            if (!this.iKnowThisMayNotBeTheBestIdeaButPleaseDisableUsernameValidation && !validateUsername(this.gameProfile.getName())) {
-+                ServerLoginPacketListenerImpl.this.disconnect("Failed to verify username!");
-+                return;
++            if (!this.iKnowThisMayNotBeTheBestIdeaButPleaseDisableUsernameValidation) {
++                Validate.validState(ServerLoginPacketListenerImpl.isValidUsername(this.gameProfile.getName()), "Invalid characters in username", new Object[0]); // Paper - use Mojang code to validate usernames
 +            }
 +        }
 +        // Paper end - validate usernames

--- a/patches/server/0841-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/server/0841-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added getHostname to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 7065aa4522431d08018fec8e591ba7c255398140..befcb501b4b1b6330bf3cd53e00e30b01efade6f 100644
+index b5cf181bd3cd970ca9b20a2fd468f7e9bebb24df..4a7e683d4560584d4bc312ec84efc8f760f82256 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -395,7 +395,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+@@ -374,7 +374,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
  
                          // Paper start
                          com.destroystokyo.paper.profile.PlayerProfile profile = com.destroystokyo.paper.profile.CraftPlayerProfile.asBukkitMirror(ServerLoginPacketListenerImpl.this.gameProfile);


### PR DESCRIPTION
Paper will validate the characters of usernames when players join the server but offer a configuration to disable the feature. However, Mojang will do the validation for usernames no matter whether the server is in the online mode since 1.18.2.

For this reason, there is no need for Paper to do the same thing again. Considering many Paper servers, especially in China or Japan, have used non-ASCII characters as usernames by disabling the validation Paper offers, it is better to keep the configuration that can disable the validation of usernames.

This commit replaces the Paper's validating usernames logic as Mojang's, and it will work only when the server is in the online mode (Just like how it worked before 1.18.2).