### PR TITLE
Don't send itemmeta for books when hide-itemmeta is enabled

### DIFF
--- a/patches/server/0803-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0803-Hide-unnecessary-itemmeta-from-clients.patch
@@ -36,7 +36,7 @@ index 7464336f0c7ee59e59552afbad7bed0afcecef87..fe29bf349b987d633b185b9d44d22105
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 626e53564d4130b98440982e174fd7c23b7df863..a1c43c61ab3a618f864bfefb9e481386d82621e8 100644
+index 626e53564d4130b98440982e174fd7c23b7df863..f21f69977ff92ac967aac2e72b679f17e2c42501 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3079,7 +3079,7 @@ public abstract class LivingEntity extends Entity {
@@ -48,7 +48,7 @@ index 626e53564d4130b98440982e174fd7c23b7df863..a1c43c61ab3a618f864bfefb9e481386
              // Paper end
              switch (enumitemslot.getType()) {
                  case HAND:
-@@ -3093,6 +3093,51 @@ public abstract class LivingEntity extends Entity {
+@@ -3093,6 +3093,59 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  
@@ -91,6 +91,14 @@ index 626e53564d4130b98440982e174fd7c23b7df863..a1c43c61ab3a618f864bfefb9e481386
 +                    tag.put("Enchantments", enchantments);
 +                }
 +                tag.remove("AttributeModifiers");
++
++                // Books
++                tag.remove("author");
++                tag.remove("filtered_title");
++                tag.remove("pages");
++                tag.remove("filtered_pages");
++                tag.remove("title");
++                tag.remove("generation");
 +            }
 +        }
 +        return copy;

--- a/patches/server/0845-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0845-Freeze-Tick-Lock-API.patch
@@ -46,10 +46,10 @@ index ed13725945d8f090b279ae8cabc584857ba8a852..8b57a24d4e8469dfbfb4eb2d11ca616e
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a1c43c61ab3a618f864bfefb9e481386d82621e8..fdd76d1a1636f30f519c434b41061d826c4a8261 100644
+index f21f69977ff92ac967aac2e72b679f17e2c42501..1521f53ee1bd85ca44a68b2c9d969eaf63fa342e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3311,7 +3311,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3319,7 +3319,7 @@ public abstract class LivingEntity extends Entity {
          boolean flag1 = this.getType().is(EntityTypeTags.FREEZE_HURTS_EXTRA_TYPES);
          int i;
  

--- a/test-plugin/src/main/java/io/papermc/paper/testplugin/TestPlugin.java
+++ b/test-plugin/src/main/java/io/papermc/paper/testplugin/TestPlugin.java
@@ -1,18 +1,11 @@
 package io.papermc.paper.testplugin;
 
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class TestPlugin extends JavaPlugin implements Listener {
     @Override
     public void onEnable() {
         this.getServer().getPluginManager().registerEvents(this, this);
-    }
-
-    @EventHandler
-    public void a(PlayerItemDamageEvent event) {
-        System.out.println(event.getOriginalDamage() + " to " + event.getDamage());
     }
 }


### PR DESCRIPTION
Expands `hide-itemmeta` to include unneeded information from [Written Books](https://minecraft.fandom.com/wiki/Written_Book#Item_data).