### PR TITLE
Use username instead of display name in PlayerList#getPlayerStats

### DIFF
--- a/patches/server/0893-Use-username-instead-of-display-name-in-PlayerList-g.patch
+++ b/patches/server/0893-Use-username-instead-of-display-name-in-PlayerList-g.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Fri, 15 Apr 2022 17:40:30 -0400
+Subject: [PATCH] Use username instead of display name in
+ PlayerList#getPlayerStats
+
+
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index 02dc93c394d37c9a84aa4a58d80615c403c54fb9..b183732a9cf63e246579ba18609201c27cd4ea25 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -1414,7 +1414,7 @@ public abstract class PlayerList {
+     // CraftBukkit start
+     public ServerStatsCounter getPlayerStats(ServerPlayer entityhuman) {
+         ServerStatsCounter serverstatisticmanager = entityhuman.getStats();
+-        return serverstatisticmanager == null ? this.getPlayerStats(entityhuman.getUUID(), entityhuman.getDisplayName().getString()) : serverstatisticmanager;
++        return serverstatisticmanager == null ? this.getPlayerStats(entityhuman.getUUID(), entityhuman.getGameProfile().getName()) : serverstatisticmanager; // Paper - use username and not display name
+     }
+ 
+     public ServerStatsCounter getPlayerStats(UUID uuid, String displayName) {


### PR DESCRIPTION
This fixs #7739 making the PlayerStats method use the GameProfile for the name.