### PR TITLE
Fix slime spawners not spawning outside slime chunks

### DIFF
--- a/patches/server/0893-Fix-slime-spawners-not-spawning-outside-slime-chunks.patch
+++ b/patches/server/0893-Fix-slime-spawners-not-spawning-outside-slime-chunks.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 15 Apr 2022 17:09:28 -0700
+Subject: [PATCH] Fix slime spawners not spawning outside slime chunks
+
+Fixes MC-50647 by just checking if the spawn type is a SPAWNER
+and then bypassing the spawn check logic if on slimes if it is.
+
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Slime.java b/src/main/java/net/minecraft/world/entity/monster/Slime.java
+index b6e78e8145ea78d532f22707c7525829c5778076..2e819d32915941bd77034ce599eb787610a6d666 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Slime.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Slime.java
+@@ -325,6 +325,11 @@ public class Slime extends Mob implements Enemy {
+ 
+     public static boolean checkSlimeSpawnRules(EntityType<Slime> type, LevelAccessor world, MobSpawnType spawnReason, BlockPos pos, Random random) {
+         if (world.getDifficulty() != Difficulty.PEACEFUL) {
++            // Paper start - fix slime spawners; Fixes MC-50647
++            if (spawnReason == MobSpawnType.SPAWNER) {
++                return random.nextInt(10) == 0;
++            }
++            // Paper end
+             // Paper start - Replace rules for Height in Swamp Biome
+             final double maxHeightSwamp = world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSwamp;
+             final double minHeightSwamp = world.getMinecraftWorld().paperConfig.slimeMinSpawnHeightInSwamp;


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/7737
Fixes [MC-50647](https://bugs.mojang.com/browse/MC-50647)

Just adds a check on the spawn type; if its SPAWNER, bypass the logic and allow the spawn. This bypasses both the swamp biome check and the slime chunk check.