### PR TITLE
Fix CCE for SplashPotion and LingeringPotion spawning

### DIFF
--- a/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
@@ -290,14 +290,18 @@ index 821c690f8a32918bdb284ffec4af98f411f76ccc..94f3a8c4bf8cf14263d34d866db66728
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/LingeringPotion.java b/src/main/java/org/bukkit/entity/LingeringPotion.java
-index f124b35ec76e6cb6a1a0dc464005087043c3efd0..94a2fef0dc9e13c754cd31d5eabc1bde2dbbe6a5 100644
+index f124b35ec76e6cb6a1a0dc464005087043c3efd0..f50aaddf8582be55fd4860ad374d8f2206991897 100644
 --- a/src/main/java/org/bukkit/entity/LingeringPotion.java
 +++ b/src/main/java/org/bukkit/entity/LingeringPotion.java
-@@ -5,4 +5,5 @@ package org.bukkit.entity;
+@@ -3,6 +3,8 @@ package org.bukkit.entity;
+ /**
+  * Represents a thrown lingering potion bottle
   *
-  * @deprecated lingering status depends on only on the potion item.
+- * @deprecated lingering status depends on only on the potion item.
++ * @deprecated should not be used for anything, use {@link ThrownPotion} and
++ * set the potion via the methods there.
   */
-+@Deprecated // Paper
++@Deprecated(forRemoval = true) // Paper
  public interface LingeringPotion extends ThrownPotion { }
 diff --git a/src/main/java/org/bukkit/entity/Minecart.java b/src/main/java/org/bukkit/entity/Minecart.java
 index 95c79c5fa0c4e30201f887da6467ce5f81c8a255..7f9c4d4b430a3f0276461346ff2621bacf864075 100644
@@ -325,7 +329,7 @@ index 95c79c5fa0c4e30201f887da6467ce5f81c8a255..7f9c4d4b430a3f0276461346ff2621ba
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5c0d9412f9691001d737cb8ffe0f5f0ada7c24d6..6b29889f59c127529a4807c815abf01655f7759f 100644
+index 97a8074e26e934e29a301712a7fc1a0ea057d37d..828963a5d0661dafc07a8e094dfc6000cc5102eb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1361,9 +1361,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -384,6 +388,21 @@ index c854860c13912f9a8707eb825cca23763d1323a6..a523fca4baab447181ef91df67fa69b2
 +    @Deprecated(forRemoval = true) // Paper
      public void setBounce(boolean doesBounce);
  }
+diff --git a/src/main/java/org/bukkit/entity/SplashPotion.java b/src/main/java/org/bukkit/entity/SplashPotion.java
+index 9cb08fe7201a9f91e88c7b1ee22c17889a7bf1c3..c0fcfccdf476106b48e626a099658c04244ebff8 100644
+--- a/src/main/java/org/bukkit/entity/SplashPotion.java
++++ b/src/main/java/org/bukkit/entity/SplashPotion.java
+@@ -3,7 +3,8 @@ package org.bukkit.entity;
+ /**
+  * Represents a thrown splash potion bottle
+  *
+- * @deprecated splash status depends on only on the potion item.
++ * @deprecated should not be used for anything, use {@link ThrownPotion} and
++ * set the potion via the methods there.
+  */
+-@Deprecated
++@Deprecated(forRemoval = true) // Paper
+ public interface SplashPotion extends ThrownPotion { }
 diff --git a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
 index 2ff1b1308571d8f8056d3359e8a8ba4a589c3726..8eb6f4090578d9e1b12aff813840108fdeece730 100644
 --- a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
@@ -748,7 +767,7 @@ index ff5a0e378a7c1e0f89d81144629251dc61af6355..c6dba5bbca302237bb4abd2b7ef17c12
          return removeIngredient(count, ingredient.getItemType(), ingredient.getData());
      }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 71c7780424a986a95852b1ca15116096896500df..5428aeb018c415f8e9bb46c84a627adf70829259 100644
+index 35009498aafd1bd36c493085127135fc8a5c36ec..1beedb446a9dd554d05d1d94dba8598e4b69eba6 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -74,8 +74,10 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste

--- a/patches/server/0918-Fix-CCE-for-SplashPotion-and-LingeringPotion-spawnin.patch
+++ b/patches/server/0918-Fix-CCE-for-SplashPotion-and-LingeringPotion-spawnin.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 21 Apr 2022 18:18:02 -0700
+Subject: [PATCH] Fix CCE for SplashPotion and LingeringPotion spawning
+
+Remove in 1.19 along with the SplashPotion and
+LingeringPotion interfaces
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownPotion.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownPotion.java
+index c1594f62c06a49ba2d0c2c6e6befcda7d1fe6e1b..793d12cd7f2782cb412535fa7ec8ae9f57c082b0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownPotion.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftThrownPotion.java
+@@ -14,7 +14,7 @@ import org.bukkit.entity.ThrownPotion;
+ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.potion.PotionEffect;
+ 
+-public class CraftThrownPotion extends CraftProjectile implements ThrownPotion {
++public class CraftThrownPotion extends CraftProjectile implements ThrownPotion, org.bukkit.entity.SplashPotion, org.bukkit.entity.LingeringPotion { // Paper - implement other classes to avoid violating spawn method generic contracts
+     public CraftThrownPotion(CraftServer server, net.minecraft.world.entity.projectile.ThrownPotion entity) {
+         super(server, entity);
+     }


### PR DESCRIPTION
Remove in 1.19 along with the SplashPotion and
LingeringPotion interfaces