### PR TITLE
Set send-namespaced to false by default

### DIFF
--- a/patches/server/0899-Set-send-namespaced-to-false-by-default.patch
+++ b/patches/server/0899-Set-send-namespaced-to-false-by-default.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HexedHero <6012891+HexedHero@users.noreply.github.com>
+Date: Sat, 23 Apr 2022 06:09:31 +0100
+Subject: [PATCH] Set send-namespaced to false by default
+
+
+diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
+index d509187ca63963fdd7f1a44d89d2aa1a1b1ce3bd..9e5ef38fa387430c84482ed2d6080580506532f4 100644
+--- a/src/main/java/org/spigotmc/SpigotConfig.java
++++ b/src/main/java/org/spigotmc/SpigotConfig.java
+@@ -191,7 +191,7 @@ public class SpigotConfig
+             }
+         }
+         SpigotConfig.tabComplete = SpigotConfig.getInt( "commands.tab-complete", 0 );
+-        SpigotConfig.sendNamespaced = SpigotConfig.getBoolean( "commands.send-namespaced", true );
++        SpigotConfig.sendNamespaced = SpigotConfig.getBoolean( "commands.send-namespaced", false ); // Paper
+     }
+ 
+     public static String whitelistMessage;


### PR DESCRIPTION
Who uses this? I feel like 95% of servers have this disabled. You're way more likely to go turn it off vs going to turn it on.