### PR TITLE
Fix cancelling PlayerItemFrameChangeEvent

### DIFF
--- a/patches/server/0803-Add-PlayerItemFrameChangeEvent.patch
+++ b/patches/server/0803-Add-PlayerItemFrameChangeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerItemFrameChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/decoration/ItemFrame.java b/src/main/java/net/minecraft/world/entity/decoration/ItemFrame.java
-index d02f507ac58bae5d4f669dae52cc01c35651cee5..f134a2e68d50fba021b19fac4c75fb35d0e252c6 100644
+index d02f507ac58bae5d4f669dae52cc01c35651cee5..a6d94e99d18cd569545981014af733ba8fdb4d31 100644
 --- a/src/main/java/net/minecraft/world/entity/decoration/ItemFrame.java
 +++ b/src/main/java/net/minecraft/world/entity/decoration/ItemFrame.java
 @@ -2,6 +2,7 @@ package net.minecraft.world.entity.decoration;
@@ -23,7 +23,7 @@ index d02f507ac58bae5d4f669dae52cc01c35651cee5..f134a2e68d50fba021b19fac4c75fb35
 +                // Paper start - call PlayerItemFrameChangeEvent
 +                if (source.getEntity() instanceof Player player) {
 +                    var event = new PlayerItemFrameChangeEvent((org.bukkit.entity.Player) player.getBukkitEntity(), (org.bukkit.entity.ItemFrame) this.getBukkitEntity(), this.getItem().asBukkitCopy(), PlayerItemFrameChangeEvent.ItemFrameChangeAction.REMOVE);
-+                    if (!event.callEvent()) return false;
++                    if (!event.callEvent()) return true; // return true here because you aren't cancelling the damage, just the change
 +                    this.setItem(ItemStack.fromBukkitCopy(event.getItemStack()), false);
 +                }
 +                // Paper end


### PR DESCRIPTION
The ItemFrame hurt method is called in Entity's skipAttackInteraction method, which if the PlayerItemFrameChangeEvent is cancelled, returns false which then enters the normal entity attack logic which calls hurt again resulting in a double fire. One fix (the one here), is to just return true if the event is cancelled. I think its the simplest and shouldn't really have many if any side effects, you are cancelling the change, not the damage itself.