### PR TITLE
Fix addPassenger for Marker

### DIFF
--- a/patches/server/0006-CB-fixes.patch
+++ b/patches/server/0006-CB-fixes.patch
@@ -8,6 +8,8 @@ Subject: [PATCH] CB fixes
 
 * Removed incorrect parent perm for `minecraft.debugstick.always`
 
+* Fixed method signature of Marker#addPassenger
+
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
 index a480e20ac456a3169c67d2d43c191b7807a8ef10..1427b76110a02cee15865173e06e7b7bb4231ae7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
@@ -21,6 +23,21 @@ index a480e20ac456a3169c67d2d43c191b7807a8ef10..1427b76110a02cee15865173e06e7b7b
          this.structureFeatureManager = new StructureFeatureManager(this, this.serverLevelData.worldGenSettings(), this.structureCheck); // CraftBukkit
          if (this.dimensionType().createDragonFight()) {
              this.dragonFight = new EndDragonFight(this, this.serverLevelData.worldGenSettings().seed(), this.serverLevelData.endDragonFightData()); // CraftBukkit
+diff --git a/src/main/java/net/minecraft/world/entity/Marker.java b/src/main/java/net/minecraft/world/entity/Marker.java
+index aef33a96cf8df9400cc60285ef1f7c5ded03b495..059c4c3b59f66ea2b2b23fe1eb106bf9447b607c 100644
+--- a/src/main/java/net/minecraft/world/entity/Marker.java
++++ b/src/main/java/net/minecraft/world/entity/Marker.java
+@@ -38,8 +38,9 @@ public class Marker extends Entity {
+     }
+ 
+     @Override
+-    protected void addPassenger(Entity passenger) {
++    protected boolean addPassenger(Entity passenger) { // Paper - fix upstream
+         passenger.stopRiding();
++        return false; // Paper - fix upstream
+     }
+ 
+     @Override
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/structure/StructureCheck.java b/src/main/java/net/minecraft/world/level/levelgen/structure/StructureCheck.java
 index 5862fd38fb2a5aeec0a63d001cc043aac62188bb..22e3ac8c5df5592e31ef3f00f102aa3a25e794b4 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/structure/StructureCheck.java


### PR DESCRIPTION
You can't add passengers to marker but since upstream failed to
account for the overriden addPassenger method in Marker, you
were able to add passengers which might lead to unexpected weirdness