### PR TITLE
Add onReload() to Plugin to make /reload safe to use

### DIFF
--- a/patches/api/0381-Add-onReload-to-make-reload-safe.patch
+++ b/patches/api/0381-Add-onReload-to-make-reload-safe.patch
@@ -1,0 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Turtley12 <76929530+Turtley12@users.noreply.github.com>
+Date: Sat, 23 Apr 2022 17:09:28 -0700
+Subject: [PATCH] Add onReload() to make /reload safe
+
+
+diff --git a/src/main/java/org/bukkit/command/defaults/ReloadCommand.java b/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
+index 0c7ba0718de2b93d013968ca0fec34ffd423990f..aef971d0fe565fd57089f318aed0f3503c9cb8fa 100644
+--- a/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
++++ b/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
+@@ -13,7 +13,7 @@ public class ReloadCommand extends BukkitCommand {
+     public ReloadCommand(@NotNull String name) {
+         super(name);
+         this.description = "Reloads the server configuration and plugins";
+-        this.usageMessage = "/reload [permissions|commands|confirm]"; // Paper
++        this.usageMessage = "/reload [permissions|commands]"; // Paper
+         this.setPermission("bukkit.command.reload");
+         this.setAliases(Arrays.asList("rl"));
+     }
+@@ -22,8 +22,7 @@ public class ReloadCommand extends BukkitCommand {
+     public boolean execute(@NotNull CommandSender sender, @NotNull String currentAlias, @NotNull String[] args) { // Paper
+         if (!testPermission(sender)) return true;
+ 
+-        // Paper start - Reload permissions.yml & require confirm
+-        boolean confirmed = System.getProperty("LetMeReload") != null;
++        // Paper start - Reload permissions.yml
+         if (args.length == 1) {
+             if (args[0].equalsIgnoreCase("permissions")) {
+                 Bukkit.getServer().reloadPermissions();
+@@ -36,20 +35,14 @@ public class ReloadCommand extends BukkitCommand {
+                     Command.broadcastCommandMessage(sender, ChatColor.RED + "An error occurred while trying to reload command aliases.");
+                 }
+                 return true;
+-            } else if ("confirm".equalsIgnoreCase(args[0])) {
+-                confirmed = true;
+             } else {
+                 Command.broadcastCommandMessage(sender, ChatColor.RED + "Usage: " + usageMessage);
+                 return true;
+             }
+         }
+-        if (!confirmed) {
+-            Command.broadcastCommandMessage(sender, ChatColor.RED + "Are you sure you wish to reload your server? Doing so may cause bugs and memory leaks. It is recommended to restart instead of using /reload. To confirm, please type " + ChatColor.YELLOW + "/reload confirm");
+-            return true;
+-        }
+         // Paper end
+ 
+-        Command.broadcastCommandMessage(sender, ChatColor.RED + "Please note that this command is not supported and may cause issues when using some plugins.");
++        Command.broadcastCommandMessage(sender, ChatColor.RED + "Please note that while this command is no longer unsafe, it may not be supported by some plugins"); // Paper - Update unsupported command messages
+         Command.broadcastCommandMessage(sender, ChatColor.RED + "If you encounter any issues please use the /stop command to restart your server.");
+         Bukkit.reload();
+         Command.broadcastCommandMessage(sender, ChatColor.GREEN + "Reload complete.");
+diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
+index 34438b5362b0ba0949625d81e8371fe0d1f76fdf..7657352a87040f125926e775c95f21b770dd112f 100644
+--- a/src/main/java/org/bukkit/plugin/Plugin.java
++++ b/src/main/java/org/bukkit/plugin/Plugin.java
+@@ -130,6 +130,13 @@ public interface Plugin extends TabExecutor {
+      * Called when this plugin is enabled
+      */
+     public void onEnable();
++    // Paper start
++
++    /**
++     * Called when /reload is run.
++     */
++    public void onReload();
++    // Paper end
+ 
+     /**
+      * Simple boolean if we can still nag to the logs about things
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+index c943bd801b54519ba6cf5d45aec593d7b7438f99..d3821327b5711472b1a41095e38a1c70a93f2e78 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+@@ -333,6 +333,10 @@ public abstract class JavaPlugin extends PluginBase {
+ 
+     @Override
+     public void onEnable() {}
++    // Paper start
++    @Override
++    public void onReload() {}
++    // Paper end
+ 
+     @Nullable
+     @Override

--- a/patches/server/0899-Add-onReload-to-make-reload-safe.patch
+++ b/patches/server/0899-Add-onReload-to-make-reload-safe.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Turtley12 <76929530+Turtley12@users.noreply.github.com>
+Date: Sat, 23 Apr 2022 17:10:50 -0700
+Subject: [PATCH] Add onReload() to make /reload safe
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 15278bb897e6169bc5d02bf47b455634baec7be1..a4caa48cd7cdd5f87d7f5b2b4656ebfd002eb4d6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -924,7 +924,6 @@ public final class CraftServer implements Server {
+ 
+     @Override
+     public void reload() {
+-        org.spigotmc.WatchdogThread.hasStarted = false; // Paper - Disable watchdog early timeout on reload
+         this.reloadCount++;
+         this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
+         this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
+@@ -974,49 +973,22 @@ public final class CraftServer implements Server {
+             world.paperConfig.init(); // Paper
+         }
+ 
+-        Plugin[] pluginClone = pluginManager.getPlugins().clone(); // Paper
+-        this.pluginManager.clearPlugins();
+-        this.commandMap.clearCommands();
+-        // Paper start
+-        for (Plugin plugin : pluginClone) {
+-            entityMetadata.removeAll(plugin);
+-            worldMetadata.removeAll(plugin);
+-            playerMetadata.removeAll(plugin);
+-        }
+-        // Paper end
++        // Paper - Removed plugin related method calls
++
+         this.reloadData();
+         org.spigotmc.SpigotConfig.registerCommands(); // Spigot
+         com.destroystokyo.paper.PaperConfig.registerCommands(); // Paper
+         this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
+         this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
+ 
+-        int pollCount = 0;
++        // Paper start - Add onReload() to Plugin
++        Plugin[] plugins = this.pluginManager.getPlugins();
+ 
+-        // Wait for at most 2.5 seconds for plugins to close their threads
+-        while (pollCount < 50 && this.getScheduler().getActiveWorkers().size() > 0) {
+-            try {
+-                Thread.sleep(50);
+-            } catch (InterruptedException e) {}
+-            pollCount++;
++        for (Plugin plugin : plugins) {
++            plugin.onReload();
+         }
+-
+-        List<BukkitWorker> overdueWorkers = this.getScheduler().getActiveWorkers();
+-        for (BukkitWorker worker : overdueWorkers) {
+-            Plugin plugin = worker.getOwner();
+-            this.getLogger().log(Level.SEVERE, String.format(
+-                "Nag author(s): '%s' of '%s' about the following: %s",
+-                plugin.getDescription().getAuthors(),
+-                plugin.getDescription().getFullName(),
+-                "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
+-            ));
+-            if (console.isDebugging()) io.papermc.paper.util.TraceUtil.dumpTraceForThread(worker.getThread(), "still running"); // Paper
++        // Paper end
+         }
+-        this.loadPlugins();
+-        this.enablePlugins(PluginLoadOrder.STARTUP);
+-        this.enablePlugins(PluginLoadOrder.POSTWORLD);
+-        this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));
+-        org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
+-    }
+ 
+     // Paper start
+     public void waitForAsyncTasksShutdown() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java b/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java
+index 909b2c98e7a9117d2f737245e4661792ffafb744..91bb2f2a9b9ecfb8e733c0363c2ba6811124d2aa 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java
++++ b/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java
+@@ -107,6 +107,11 @@ public class MinecraftInternalPlugin extends PluginBase {
+     public void onEnable() {
+         throw new UnsupportedOperationException("Not supported.");
+     }
++    // Paper start
++
++    @Override
++    public void onReload() {throw new UnsupportedOperationException("Not supported.");}
++    // Paper end
+ 
+     @Override
+     public boolean isNaggable() {


### PR DESCRIPTION
The reload command has been unsafe in several ways since it was introduced. This PR modifies the command so it can safely be used for it's intended purpose

This PR changes the functionality of reload so that instead of disabling and re-enabling plugins, the reload command will call `Plugin#onReload()`. All other functionality such as reloading server configuration has been kept.

`onReload()` is used the same was as `onEnable()` and the other similar methods in `Plugin`.

Running the Reload command now displays a modified warning message. Instead of informing the user that the command is no longer supported, it says "Please note that while this command is no longer unsafe, it may not be supported by some plugins". 

For plugins that have overrided `onReload()`, It will run their `onReload()` methods. This can be used instead or with plugin specific reload commands. Using WorldEdit as an example, WorldEdit has a `/worldedit reload` command that will reload the worldedit configuration. with this PR, the same configuration reload code could be called in `onReload()`. This will enable users to have a easy way to reload all configurations and/or other things, without any issues with things breaking like the old reload command had.

This was implemented as a method in `Plugin` instead of an event because I felt that it was similar to `onLoad()`. `onLoad()` might be able to be implemented as an event, but because it was implemented as a method in `Plugin`, I went the same way and put `onReload()` as a method in `Plugin`.