### PR TITLE
Use setMessage instead of arraycopy

### DIFF
--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -2285,7 +2285,7 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2577a135bb88adc9000ab67477846c6466d973e7..09f43730e40b4ab9f0a6c8d175cbcf7c9e069fac 100644
+index 2577a135bb88adc9000ab67477846c6466d973e7..7ff1fcfdc87bcd299da46fe8a7e090c118a42cfa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -272,14 +272,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2398,7 +2398,7 @@ index 2577a135bb88adc9000ab67477846c6466d973e7..09f43730e40b4ab9f0a6c8d175cbcf7c
      @Override
      public void setCompassTarget(Location loc) {
          if (this.getHandle().connection == null) return;
-@@ -620,6 +656,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -620,6 +656,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
@@ -2424,7 +2424,9 @@ index 2577a135bb88adc9000ab67477846c6466d973e7..09f43730e40b4ab9f0a6c8d175cbcf7c
 +        SignBlockEntity sign = new SignBlockEntity(new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()), Blocks.OAK_SIGN.defaultBlockState());
 +        sign.setColor(net.minecraft.world.item.DyeColor.byId(dyeColor.getWoolData()));
 +        sign.setHasGlowingText(hasGlowingText);
-+        System.arraycopy(components, 0, sign.messages, 0, sign.messages.length);
++        for (int i = 0; i < components.length; i++) {
++            sign.setMessage(i, components[i]);
++        }
 +
 +        getHandle().connection.send(sign.getUpdatePacket());
 +    }
@@ -2432,7 +2434,7 @@ index 2577a135bb88adc9000ab67477846c6466d973e7..09f43730e40b4ab9f0a6c8d175cbcf7c
      @Override
      public void sendSignChange(Location loc, String[] lines) {
          this.sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -647,14 +710,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -647,14 +712,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          Component[] components = CraftSign.sanitizeLines(lines);
@@ -2450,7 +2452,7 @@ index 2577a135bb88adc9000ab67477846c6466d973e7..09f43730e40b4ab9f0a6c8d175cbcf7c
      }
  
      @Override
-@@ -1425,7 +1489,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1425,7 +1491,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url) {
@@ -2459,7 +2461,7 @@ index 2577a135bb88adc9000ab67477846c6466d973e7..09f43730e40b4ab9f0a6c8d175cbcf7c
      }
  
      @Override
-@@ -1440,7 +1504,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1440,7 +1506,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url, byte[] hash, boolean force) {
@@ -2468,7 +2470,7 @@ index 2577a135bb88adc9000ab67477846c6466d973e7..09f43730e40b4ab9f0a6c8d175cbcf7c
      }
  
      @Override
-@@ -1456,6 +1520,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1456,6 +1522,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2490,7 +2492,7 @@ index 2577a135bb88adc9000ab67477846c6466d973e7..09f43730e40b4ab9f0a6c8d175cbcf7c
      public void addChannel(String channel) {
          Preconditions.checkState(this.channels.size() < 128, "Cannot register channel '%s'. Too many channels registered!", channel);
          channel = StandardMessenger.validateAndCorrectChannel(channel);
-@@ -1860,6 +1939,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1860,6 +1941,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -2503,7 +2505,7 @@ index 2577a135bb88adc9000ab67477846c6466d973e7..09f43730e40b4ab9f0a6c8d175cbcf7c
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -1905,6 +1990,194 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1905,6 +1992,194 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  

--- a/patches/server/0011-Timings-v2.patch
+++ b/patches/server/0011-Timings-v2.patch
@@ -1911,10 +1911,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 09f43730e40b4ab9f0a6c8d175cbcf7c9e069fac..6736fe98ddd475ab30d7c97ad334097671b25b92 100644
+index 7ff1fcfdc87bcd299da46fe8a7e090c118a42cfa..274e4d983015a5c8a8fbfcf269e7cb2cac34333f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2274,6 +2274,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2276,6 +2276,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              packet.components = components;
              CraftPlayer.this.getHandle().connection.send(packet);
          }

--- a/patches/server/0023-Player-affects-spawning-API.patch
+++ b/patches/server/0023-Player-affects-spawning-API.patch
@@ -117,10 +117,10 @@ index 1e420c4230a326da345b2e28442ece26b44f8259..41d20c16ea165cf166c6f3b228bc8261
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6736fe98ddd475ab30d7c97ad334097671b25b92..6b8e0bdc49b240cc038e01154ba1cd563c795b90 100644
+index 274e4d983015a5c8a8fbfcf269e7cb2cac34333f..087c251cbf0551b6e80b7a4a296720ebabc83c62 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1953,8 +1953,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1955,8 +1955,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0025-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0025-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6b8e0bdc49b240cc038e01154ba1cd563c795b90..06cdb4b572a456c1daabdd34d4ca1a2670bfd5fe 100644
+index 087c251cbf0551b6e80b7a4a296720ebabc83c62..aa9d70d0153279794193f111ea43acb9a6235c36 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1622,12 +1622,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1624,12 +1624,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0038-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0038-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index 58943b2c2cb416753c60ca5cd4445911ab98eeb6..1705a2bb3497546635a1b82dcd8d23cb
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 06cdb4b572a456c1daabdd34d4ca1a2670bfd5fe..68e61e9509565474a800cce4e36112ea3a322591 100644
+index aa9d70d0153279794193f111ea43acb9a6235c36..b6abe5d82843a60498bdb1ffc91777134662ea65 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1953,8 +1953,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1955,8 +1955,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0054-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0054-Configurable-inter-world-teleportation-safety.patch
@@ -30,10 +30,10 @@ index c248b66486044150c64eaddbef85fa6644494212..ada624b5f58381122e59568c2087cf38
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 69182e10af84315cae3cc842c26ca3ff0feb8794..e91f20720d0f9ee4451164eb4a3d044507f7aec6 100644
+index 5d4b65fe20d60eecc599b922785ef95c1de2d349..d106c92fa2f959e844f3c4ca35bb7dd989e27a70 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1026,7 +1026,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1028,7 +1028,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (fromWorld == toWorld) {
              entity.connection.teleport(to);
          } else {

--- a/patches/server/0060-Complete-resource-pack-API.patch
+++ b/patches/server/0060-Complete-resource-pack-API.patch
@@ -23,7 +23,7 @@ index 44039e85bbb53e7bf89f9572c29c21fb4b147cc7..1ff86d507700ac39752efcbfbbc9b29d
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e91f20720d0f9ee4451164eb4a3d044507f7aec6..f9e1850d00bcb3b5b5367278e5786ddbf41b7609 100644
+index d106c92fa2f959e844f3c4ca35bb7dd989e27a70..bf6b70e7de71bd4aa9ba8fe2a3a97e3a895a764f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -147,6 +147,7 @@ import org.bukkit.plugin.Plugin;
@@ -45,7 +45,7 @@ index e91f20720d0f9ee4451164eb4a3d044507f7aec6..f9e1850d00bcb3b5b5367278e5786ddb
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -2103,6 +2108,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2105,6 +2110,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0068-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0068-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -44,10 +44,10 @@ index f364978ff256aecb078cca2b6c3fd433d9a4820b..5f7a16651a0ca5497b20d8723e9c1705
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f9e1850d00bcb3b5b5367278e5786ddbf41b7609..5bfa459e4182d27aa1424d93c872511897c8706d 100644
+index bf6b70e7de71bd4aa9ba8fe2a3a97e3a895a764f..4c21eca7fbb01b5e58d82a7542adb2af0c321dc5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1908,6 +1908,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1910,6 +1910,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0166-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0166-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9f0f4d48b0b856379a90a49a58c912f29a47b883..5929ee9dc7ccfbaf51c49917dedfbaecb10d4091 100644
+index 6ae718ac0c426fed2dc8890a03d8c8271978296e..698a290a50a51d4e4c5b0282a300f130a9fe87e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1341,7 +1341,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1343,7 +1343,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override

--- a/patches/server/0179-Player.setPlayerProfile-API.patch
+++ b/patches/server/0179-Player.setPlayerProfile-API.patch
@@ -24,7 +24,7 @@ index d3462cdc5eee37cedbff80f35d5b9c51e8dcd1da..5ebc450432805d52457b9f8ff1e2b198
                          playerName = gameProfile.getName();
                          uniqueId = gameProfile.getId();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5929ee9dc7ccfbaf51c49917dedfbaecb10d4091..04d40c53ddce5fec704f3c1cc3e965276a0cec72 100644
+index 698a290a50a51d4e4c5b0282a300f130a9fe87e1..18e1907551978b541c82a07cdc30fd254484812f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -77,6 +77,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -47,7 +47,7 @@ index 5929ee9dc7ccfbaf51c49917dedfbaecb10d4091..04d40c53ddce5fec704f3c1cc3e96527
      @Override
      public InetSocketAddress getAddress() {
          if (this.getHandle().connection == null) return null;
-@@ -1474,8 +1470,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1476,8 +1472,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.hiddenEntities.put(entity.getUniqueId(), hidingPlugins);
  
          // Remove this entity from the hidden player's EntityTrackerEntry
@@ -64,7 +64,7 @@ index 5929ee9dc7ccfbaf51c49917dedfbaecb10d4091..04d40c53ddce5fec704f3c1cc3e96527
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1488,8 +1491,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1490,8 +1493,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  this.getHandle().connection.send(new ClientboundPlayerInfoPacket(ClientboundPlayerInfoPacket.Action.REMOVE_PLAYER, otherPlayer));
              }
          }
@@ -73,7 +73,7 @@ index 5929ee9dc7ccfbaf51c49917dedfbaecb10d4091..04d40c53ddce5fec704f3c1cc3e96527
      }
  
      @Override
-@@ -1526,8 +1527,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1528,8 +1529,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          this.hiddenEntities.remove(entity.getUniqueId());
  
@@ -90,7 +90,7 @@ index 5929ee9dc7ccfbaf51c49917dedfbaecb10d4091..04d40c53ddce5fec704f3c1cc3e96527
  
          if (other instanceof ServerPlayer) {
              ServerPlayer otherPlayer = (ServerPlayer) other;
-@@ -1538,9 +1546,51 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1540,9 +1548,51 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (entry != null && !entry.seenBy.contains(this.getHandle().connection)) {
              entry.updatePlayer(this.getHandle());
          }

--- a/patches/server/0185-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0185-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 04d40c53ddce5fec704f3c1cc3e965276a0cec72..3a80cec3ce56dc55eb85c37efe0898c4de0b0a16 100644
+index 18e1907551978b541c82a07cdc30fd254484812f..0006c86b4d464832558b52555b50e7833b88a486 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -170,6 +170,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index 04d40c53ddce5fec704f3c1cc3e965276a0cec72..3a80cec3ce56dc55eb85c37efe0898c4
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1790,7 +1791,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1792,7 +1793,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0214-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0214-InventoryCloseEvent-Reason-API.patch
@@ -174,10 +174,10 @@ index c0ed3dd9ebcaf710d202ae8b38007e6a1f20b57e..adfbc156b4c4a8591609f385adaa6b04
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3a80cec3ce56dc55eb85c37efe0898c4de0b0a16..8671a21a6a87de296e3dffb174e099f0cd29a40f 100644
+index 0006c86b4d464832558b52555b50e7833b88a486..cae4169b74b244af27763b3ac2740674c9c55116 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1055,7 +1055,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1057,7 +1057,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {

--- a/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8671a21a6a87de296e3dffb174e099f0cd29a40f..8299a0a81e371d469ac8ff8fb5f23cc54705313a 100644
+index cae4169b74b244af27763b3ac2740674c9c55116..59691ec967f69d0c4dff8894ab8adc9ab23d0652 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2487,6 +2487,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2489,6 +2489,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0255-Improve-death-events.patch
+++ b/patches/server/0255-Improve-death-events.patch
@@ -308,10 +308,10 @@ index 91cf7728aee475cb36f2c02bbfb7e3d2e0d00576..a3a900d10440ed5ebe24370a77ccb6ca
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8299a0a81e371d469ac8ff8fb5f23cc54705313a..84fc7688e5d9a86499a88484530f5b9623e8dc22 100644
+index 59691ec967f69d0c4dff8894ab8adc9ab23d0652..abc036af7963f63e4614c4fc8315efdf532b74d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2050,7 +2050,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2052,7 +2052,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/patches/server/0293-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0293-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -106,7 +106,7 @@ index f6665825e62a0cd912e6b06df6d68795596486f0..1f2bc88d4570c6ef00e67a772b745e0b
      public Location getBedSpawnLocation() {
          CompoundTag data = this.getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 84fc7688e5d9a86499a88484530f5b9623e8dc22..b15876756bf677611f29acefd18b490d333c6291 100644
+index abc036af7963f63e4614c4fc8315efdf532b74d6..716b1cae32bf944c23559848c628fa8b64b693f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -171,6 +171,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index 84fc7688e5d9a86499a88484530f5b9623e8dc22..b15876756bf677611f29acefd18b490d
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1662,6 +1663,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1664,6 +1665,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 84fc7688e5d9a86499a88484530f5b9623e8dc22..b15876756bf677611f29acefd18b490d
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1684,6 +1697,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1686,6 +1699,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index 84fc7688e5d9a86499a88484530f5b9623e8dc22..b15876756bf677611f29acefd18b490d
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1698,6 +1713,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1700,6 +1715,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0295-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0295-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b15876756bf677611f29acefd18b490d333c6291..4bfb6f50f5cdc8fa46a9062e09887baaa5c79701 100644
+index 716b1cae32bf944c23559848c628fa8b64b693f4..13096dc6ae67bc41367d0c3db95d403338a79ec2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2534,6 +2534,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2536,6 +2536,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1194,10 +1194,10 @@ index 68f6ccacacad0e06f27d56b19b9f68b0691e747e..b61a53af941946a07f8bbd34f53191f3
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1fc88fb5ef5fb0baadc80552de468d0cd6bc2c91..581e882cc49a9a1f6cc324fea2646c17d72cdfb4 100644
+index 1e2710da48ac9ef855bb57784ab87bfdfd26f7e6..0222d47c97ac34a8ea58208908aae06aef6a47f5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1023,6 +1023,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1025,6 +1025,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
      }
  

--- a/patches/server/0479-Brand-support.patch
+++ b/patches/server/0479-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 48e4ed91def1cfda0d7f10d00e13c415f74dbca2..82ef4b4f99216eee00c867565d55e133bf7d8bcb 100644
+index ee0aa6de6528ac281efc7aa255721701561bb3f7..85b1ef1305efb86e307313490a4176503e34ea81 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -38,6 +38,7 @@ import net.minecraft.nbt.CompoundTag;
@@ -64,10 +64,10 @@ index 48e4ed91def1cfda0d7f10d00e13c415f74dbca2..82ef4b4f99216eee00c867565d55e133
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 581e882cc49a9a1f6cc324fea2646c17d72cdfb4..97ae5c8c44efc70634fd939b8082479fd87a5395 100644
+index 0222d47c97ac34a8ea58208908aae06aef6a47f5..210dd220d00edceb8cd3ee19a49c6a7f24619d19 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2678,6 +2678,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2680,6 +2680,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0531-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0531-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8f95dff2148a3e411e2ca0dc3d4f97a4d38f9848..d5902d8a4e324014a0cdd503934f9b049e1f123c 100644
+index eec7f43cb188d5b410cd4d89da7a3934ac1b9d25..e0b8827a0e248f6339ec826dc076e207b8fdc451 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2249,7 +2249,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2251,7 +2251,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0648-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0648-additions-to-PlayerGameModeChangeEvent.patch
@@ -126,7 +126,7 @@ index f97d97426144527cff9ebb91b26fe8541a9c6d9b..b6eef41079120fffd63f06f681378b1b
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 20a1c0e3926e3853c74e0d6484333bca02c76a2f..50797b32b71b2c8a73f34313021457b27fc90660 100644
+index 51d15a8186cc0e8a2d1508277627809c60c952fa..0199686c4c776c7ffc79f647b0339ccc085e89dd 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2510,7 +2510,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -139,10 +139,10 @@ index 20a1c0e3926e3853c74e0d6484333bca02c76a2f..50797b32b71b2c8a73f34313021457b2
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0fff9e1b95eb5a0738cbf3af6974db9febc40697..6c6a5c36cec7ab3e6548554d7463b2912c02deaa 100644
+index f41c58694f8fff77ce5a6bc165967bb49529962f..6c88978dab0911621b889c0e53810bb6e4808c49 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1372,7 +1372,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1374,7 +1374,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0695-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0695-Add-PlayerSetSpawnEvent.patch
@@ -93,10 +93,10 @@ index d620f559cdd1bd0e161a99123ef6c6f64e3302df..07e893f1859abe3c2a765694c21309d6
                      return InteractionResult.SUCCESS;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 878620e37635396d58e48fa1910843c01d11aa5b..8ef2f3053c0fde6a11597eefc127c5735c240014 100644
+index 56884ab0053051fca28c5ff58af55c027e296f39..415bcb2b53e943fefeaa58c49d901b029bfd2049 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1192,9 +1192,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1194,9 +1194,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0807-Add-player-health-update-API.patch
+++ b/patches/server/0807-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8ef2f3053c0fde6a11597eefc127c5735c240014..d44df73c2fd4481861cd94d34d91b62b2d2c5718 100644
+index 415bcb2b53e943fefeaa58c49d901b029bfd2049..1c5be0cb22c568aee4fe6a13be591a123de100f5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2128,9 +2128,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2130,9 +2130,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index 8ef2f3053c0fde6a11597eefc127c5735c240014..d44df73c2fd4481861cd94d34d91b62b
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2138,7 +2140,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2140,7 +2142,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          // Paper end
      }


### PR DESCRIPTION
setMessage affects messages, filteredMessage, and renderMessages, we were only doing an arraycopy for messages

fixes #7774