### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0121-Allow-setting-the-vex-s-summoner.patch
+++ b/patches/api/0121-Allow-setting-the-vex-s-summoner.patch
@@ -5,23 +5,15 @@ Subject: [PATCH] Allow setting the vex's summoner
 
 
 diff --git a/src/main/java/org/bukkit/entity/Vex.java b/src/main/java/org/bukkit/entity/Vex.java
-index 6b61c4ab773c731fe5ae9577fd13e44707be9787..c34a3ea7b4d16817b4bee25d5c69787e22ec44d8 100644
+index dc21f3ba648ab02a2b75ec429501143398c356f6..627e3c1a96ae3331f5aa2dd7803dd2a31c7204be 100644
 --- a/src/main/java/org/bukkit/entity/Vex.java
 +++ b/src/main/java/org/bukkit/entity/Vex.java
-@@ -1,5 +1,7 @@
- package org.bukkit.entity;
- 
-+import org.jetbrains.annotations.Nullable;
-+
- /**
-  * Represents a Vex.
-  */
-@@ -22,4 +24,21 @@ public interface Vex extends Monster {
-      * @param charging new state
+@@ -73,4 +73,21 @@ public interface Vex extends Monster {
+      * @return true if the entity has limited life
       */
-     void setCharging(boolean charging);
-+
+     boolean hasLimitedLife();
 +    // Paper start
++
 +    /**
 +     * Get the Mob that summoned this vex
 +     *

--- a/patches/api/0312-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0312-Missing-Entity-Behavior-API.patch
@@ -562,10 +562,10 @@ index 28cdb3b544572ba7aeb9061e3163e3895ac7d4e6..c8015ff610e3c1222cb368ea1d8a0c2f
 +}
 +// Paper end
 diff --git a/src/main/java/org/bukkit/entity/Vex.java b/src/main/java/org/bukkit/entity/Vex.java
-index c34a3ea7b4d16817b4bee25d5c69787e22ec44d8..6a39042f1ea18b4849c4b6d2343938e0f430aefb 100644
+index 627e3c1a96ae3331f5aa2dd7803dd2a31c7204be..a1427e02ef19db252b39aba05d3c3e07887c8fb6 100644
 --- a/src/main/java/org/bukkit/entity/Vex.java
 +++ b/src/main/java/org/bukkit/entity/Vex.java
-@@ -40,5 +40,37 @@ public interface Vex extends Monster {
+@@ -89,5 +89,37 @@ public interface Vex extends Monster {
       * @param summoner New summoner
       */
      void setSummoner(@Nullable Mob summoner);

--- a/patches/api/0312-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0312-Missing-Entity-Behavior-API.patch
@@ -562,10 +562,41 @@ index 28cdb3b544572ba7aeb9061e3163e3895ac7d4e6..c8015ff610e3c1222cb368ea1d8a0c2f
 +}
 +// Paper end
 diff --git a/src/main/java/org/bukkit/entity/Vex.java b/src/main/java/org/bukkit/entity/Vex.java
-index 627e3c1a96ae3331f5aa2dd7803dd2a31c7204be..a1427e02ef19db252b39aba05d3c3e07887c8fb6 100644
+index 627e3c1a96ae3331f5aa2dd7803dd2a31c7204be..3c447d2300c866ae605eeca97bd869f400d6be6f 100644
 --- a/src/main/java/org/bukkit/entity/Vex.java
 +++ b/src/main/java/org/bukkit/entity/Vex.java
-@@ -89,5 +89,37 @@ public interface Vex extends Monster {
+@@ -57,21 +57,30 @@ public interface Vex extends Monster {
+      * Gets the remaining lifespan of this entity.
+      *
+      * @return life in ticks
++     * @deprecated This API duplicates existing API which uses the more
++     * preferable name due to mirroring internals better
+      */
++    @Deprecated
+     int getLifeTicks();
+ 
+     /**
+      * Sets the remaining lifespan of this entity.
+      *
+      * @param lifeTicks life in ticks, or negative for unlimited lifepan
++     * @deprecated This API duplicates existing API which uses the more
++     * preferable name due to mirroring internals better
+      */
++    @Deprecated
+     void setLifeTicks(int lifeTicks);
+ 
+     /**
+      * Gets if the entity has a limited life.
+      *
+      * @return true if the entity has limited life
++     * @deprecated This API duplicates existing API which uses the more
++     * preferable name due to mirroring internals better
+      */
++    @Deprecated
+     boolean hasLimitedLife();
+     // Paper start
+ 
+@@ -89,5 +98,37 @@ public interface Vex extends Monster {
       * @param summoner New summoner
       */
      void setSummoner(@Nullable Mob summoner);

--- a/patches/api/0351-System-prop-for-default-config-comment-parsing.patch
+++ b/patches/api/0351-System-prop-for-default-config-comment-parsing.patch
@@ -22,30 +22,3 @@ index c71f8a7b96fc5abc499802a79fcb3b0771de021c..121dbbf163588690d0678ae73a6ab8ed
  
      protected FileConfigurationOptions(@NotNull MemoryConfiguration configuration) {
          super(configuration);
-diff --git a/src/main/java/org/bukkit/configuration/file/YamlRepresenter.java b/src/main/java/org/bukkit/configuration/file/YamlRepresenter.java
-index 20e968764725ddb324be28d81c50be57abd00e05..1514d3ec63a6c43fbdb4933ef75f9617ce1a1a4d 100644
---- a/src/main/java/org/bukkit/configuration/file/YamlRepresenter.java
-+++ b/src/main/java/org/bukkit/configuration/file/YamlRepresenter.java
-@@ -11,11 +11,22 @@ import org.yaml.snakeyaml.representer.Representer;
- public class YamlRepresenter extends Representer {
- 
-     public YamlRepresenter() {
-+        this.multiRepresenters.put(org.bukkit.configuration.ConfigurationSection.class, new RepresentConfigurationSection()); // Paper - restore old yaml config section representer
-         this.multiRepresenters.put(ConfigurationSerializable.class, new RepresentConfigurationSerializable());
-         // SPIGOT-6234: We could just switch YamlConstructor to extend Constructor rather than SafeConstructor, however there is a very small risk of issues with plugins treating config as untrusted input
-         // So instead we will just allow future plugins to have their enums extend ConfigurationSerializable
-         this.multiRepresenters.remove(Enum.class);
-     }
-+    // Paper start - restore old yaml config section representer
-+    private class RepresentConfigurationSection extends RepresentMap {
-+
-+        @NotNull
-+        @Override
-+        public Node representData(@NotNull Object data) {
-+            return super.representData(((org.bukkit.configuration.ConfigurationSection) data).getValues(false));
-+        }
-+    }
-+    // Paper end
- 
-     private class RepresentConfigurationSerializable extends RepresentMap {
- 

--- a/patches/api/0353-Remove-upstream-snakeyaml-fix.patch
+++ b/patches/api/0353-Remove-upstream-snakeyaml-fix.patch
@@ -19,10 +19,10 @@ index f9abe6991dadc7c652dcf6682bdb1b43240af438..9ba2e956be80952c146bac9a03bdb837
  
      @NotNull
 diff --git a/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java b/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
-index 3522baa0a234999114db69dea5743de2c8f059a0..cbdf7aa91e8399d3b936690b34a29bd6d0f2d518 100644
+index 194949d74a3f1c69f7869a826ee3a011a6c26786..9f83d16341b4efd5c7150d2ab9abd579f373fa95 100644
 --- a/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
 +++ b/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
-@@ -146,6 +146,7 @@ public class YamlConfigurationTest extends FileConfigurationTest {
+@@ -152,6 +152,7 @@ public class YamlConfigurationTest extends FileConfigurationTest {
      }
  
      @Test

--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -1777,7 +1777,7 @@ index d29c6d0536619fab5a48fbb52115dac09e7d7ca3..75871f74a25ee34db89a431de584b998
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0bc0bd2e6861772f32e24694ad733fa4813f3033..305d5cb3581764b4d89c1f2220acb5786eb8faef 100644
+index 7b16529c9b11f6a0ba4f35746f9990e8b9a498b7..886a292dfd45a87be3a0069b7c2eb85437c6e6a4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -142,6 +142,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -1788,7 +1788,7 @@ index 0bc0bd2e6861772f32e24694ad733fa4813f3033..305d5cb3581764b4d89c1f2220acb578
  
      private static final Random rand = new Random();
  
-@@ -1862,4 +1863,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1856,4 +1857,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0019-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/patches/server/0019-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -25,10 +25,10 @@ index 9b908c5c66dc454faa479430a908dda0745638c8..6dec1bb96d695f28aae6517e4d782491
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 690a2a97e10bf1003b49f7e4806aab0bca206d99..6dc1500866e634364ac258956b07a880ecbf6c76 100644
+index 7e1594e8df4fd09cd1aecbc5f3784797b04a8337..26ab6d0c98560e4dfebbad3482fd308861818e30 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-@@ -131,6 +131,17 @@ public class FallingBlockEntity extends Entity {
+@@ -137,6 +137,17 @@ public class FallingBlockEntity extends Entity {
              }
  
              this.move(MoverType.SELF, this.getDeltaMovement());

--- a/patches/server/0026-Entity-Origin-API.patch
+++ b/patches/server/0026-Entity-Origin-API.patch
@@ -94,10 +94,10 @@ index 89a0fe6695f70c726b5a39b8990ed7e7ce451a92..ac540cacc1858697b54950e86e84efbf
              CrashReport crashreport = CrashReport.forThrowable(throwable, "Loading entity NBT");
              CrashReportCategory crashreportsystemdetails = crashreport.addCategory("Entity being loaded");
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 6dc1500866e634364ac258956b07a880ecbf6c76..b8155fb12ab7bb83290502e8313cbfa773ac15a7 100644
+index 26ab6d0c98560e4dfebbad3482fd308861818e30..242e02646b8584a8d2a512374ad03729661d584f 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-@@ -331,6 +331,14 @@ public class FallingBlockEntity extends Entity {
+@@ -337,6 +337,14 @@ public class FallingBlockEntity extends Entity {
              this.blockState = Blocks.SAND.defaultBlockState();
          }
  

--- a/patches/server/0039-Per-Player-View-Distance-API-placeholders.patch
+++ b/patches/server/0039-Per-Player-View-Distance-API-placeholders.patch
@@ -18,10 +18,10 @@ index 1705a2bb3497546635a1b82dcd8d23cb87c21084..a2227d2b29f2f78d0b7fc8f0650f107b
 +    public final int getViewDistance() { return this.getLevel().getChunkSource().chunkMap.viewDistance - 1; } // Paper - placeholder
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 305d5cb3581764b4d89c1f2220acb5786eb8faef..1b16d5d4823086d41f00bf0ccba4e21265f51886 100644
+index 886a292dfd45a87be3a0069b7c2eb85437c6e6a4..99ffec8eaa97f3299d81d9fd5711f1b7db96e5c7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1832,6 +1832,37 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1826,6 +1826,37 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return world.spigotConfig.simulationDistance;
      }
      // Spigot end
@@ -60,7 +60,7 @@ index 305d5cb3581764b4d89c1f2220acb5786eb8faef..1b16d5d4823086d41f00bf0ccba4e212
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 68e61e9509565474a800cce4e36112ea3a322591..c5630c292dbcdd8b1c0fcf149df888707a550846 100644
+index b6abe5d82843a60498bdb1ffc91777134662ea65..ead311bfb744a673179484ed2ba6169d3b07ba15 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -399,6 +399,46 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0106-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/patches/server/0106-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -22,10 +22,10 @@ index d7734fbc6b684b14bc32c94e65947fb41aae126a..7320f07beffee60fe3c49016daf7a986
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index b8155fb12ab7bb83290502e8313cbfa773ac15a7..f12eafb49c2536f91f4716188c931ad97264c113 100644
+index 242e02646b8584a8d2a512374ad03729661d584f..08defb76e73a5f9121bf405c86a3c4c750ab1933 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-@@ -310,6 +310,18 @@ public class FallingBlockEntity extends Entity {
+@@ -316,6 +316,18 @@ public class FallingBlockEntity extends Entity {
      @Override
      protected void readAdditionalSaveData(CompoundTag nbt) {
          this.blockState = NbtUtils.readBlockState(nbt.getCompound("BlockState"));

--- a/patches/server/0192-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0192-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,7 +10,7 @@ Adds an option to control the force mode of the particle.
 This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 9769977c9db77aa52b99b793ca4f5d0c7b54528f..d8b0f6ae1604a158ef1be02701c8c605192e7fe1 100644
+index eb6981ca27d27946c748047660ced880c4dea01a..3cb4a84a08cbf76e39da5f25fea490c26c77a289 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1390,12 +1390,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -34,10 +34,10 @@ index 9769977c9db77aa52b99b793ca4f5d0c7b54528f..d8b0f6ae1604a158ef1be02701c8c605
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fbb159f1300f4bcd0f85ec348f16de3e80af686f..6be238a6df674cd46e417459e610afd3f4d672d2 100644
+index 2788f7ac36f739629ff3f9252eaf5639079d5f84..5dec3c30b13041c72e8d05ffb5eea8ca17aebc5b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1812,11 +1812,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1806,11 +1806,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0215-Vex-get-setSummoner-API.patch
+++ b/patches/server/0215-Vex-get-setSummoner-API.patch
@@ -9,10 +9,10 @@ Allow setting the vex's summoner
 Co-authored-by: BillyGalbreath <Blake.Galbreath@GMail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
-index d07d956e727483bb0b85dce618acb2adc8d89872..0f5c81c0d599d3b58f7864d1527391ad50983c4e 100644
+index fecb1e6b84fed241d1028ef24660804e5518ea3b..2ba16e33dd21c3c72cb12244aa78c59bf53e76d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
-@@ -15,6 +15,19 @@ public class CraftVex extends CraftMonster implements Vex {
+@@ -18,6 +18,19 @@ public class CraftVex extends CraftMonster implements Vex {
          return (net.minecraft.world.entity.monster.Vex) super.getHandle();
      }
  

--- a/patches/server/0252-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0252-Asynchronous-chunk-IO-and-loading.patch
@@ -2762,7 +2762,7 @@ index f2d92cd125cbc1bd6fdab774e7002d6b7eda29fc..98f3b91605ecf81538659220354f78d4
          } finally {
              chunkMap.callbackExecutor.run();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 5f58aa648a5f0c3e61f6d9d5853583ca003e3620..98094546bb2867b20f89a1bc0efe911cdb6c9b79 100644
+index e09638b0ac68a685bf71ae3a84475bde19669b1e..b57b6f411442827ec1222fbf5bf87947e325d470 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -310,6 +310,78 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -3562,10 +3562,10 @@ index 4160a35ecfa1c28b88d6ebbfd14a0be1933e3b6d..3e08ff74979c78b27537403bbcaf1345
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 11c9c33e560304c868991e9f6e4dc0040fbe06e9..68d6f6b9edab370aaaf6a0113aaf7563770db229 100644
+index 2bae0df4bcde7e278b44c0adf38c7ef80339e92a..0517edc8f42a3c6668f5fd24ac0755332a873571 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1875,6 +1875,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1869,6 +1869,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public DragonBattle getEnderDragonBattle() {
          return (this.getHandle().dragonFight() == null) ? null : new CraftDragonBattle(this.getHandle().dragonFight());
      }

--- a/patches/server/0322-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0322-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -81,7 +81,7 @@ index 5ce1fab4d1e68ad83bd46ae6269446b6f913fa07..25fb2789bcec7cf864b3a401610e765d
          // CraftBukkit start
          // this.updateMobSpawningFlags();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 46e16685dfe3b7721692f96d7d7e0af0a1fb9c22..3c89e7ec876cc11437e1e035d1f43ea32426eec7 100644
+index 19dc74ab02744c70a3b2c75c0a62edb1cfca1be3..13966539626742b6914b940c6dd74c83485e588e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -63,6 +63,7 @@ import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
@@ -217,10 +217,10 @@ index 1fdb4242784e55d5bb6102deb150a57a156aacd3..419e1c4db73631de3d65d8a0e7d5eb08
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 62a3de8f5a7a8a6da0431918f016ebc1a1735f70..5aa50b1165d17626bdf2b0ccc654952767f9c539 100644
+index 1e8ec9587560cd22991aeb586224d70c7229bc4f..a87b6fbd3e3da1983003447c9a3f9d3450806ea7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1349,15 +1349,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1343,15 +1343,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/patches/server/0405-Villager-Restocks-API.patch
+++ b/patches/server/0405-Villager-Restocks-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Villager Restocks API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index c5fdb1b956ffbd90b119c821a8a11e4dfff33058..0cd83a20ab565c9a5a38f19eed016289237e72ab 100644
+index 1400f8c0cac3d653465b3750078de4d2691ac2a1..1a8a49bd269ed52879866ff3853e131d04aa8bba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-@@ -90,6 +90,18 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+@@ -91,6 +91,18 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
          this.getHandle().setVillagerXp(experience);
      }
  

--- a/patches/server/0414-Add-villager-reputation-API.patch
+++ b/patches/server/0414-Add-villager-reputation-API.patch
@@ -62,12 +62,12 @@ index 22aa000ad7d44a86231fd8ad93083c972f14caa6..125d08fc4536f15604ef13636056c94f
  
      static class GossipEntry {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index 420b3410fd9ba7930ac9156d52571844964b5403..6de6553e79c9729ef49e2a544730b1ac1020dff2 100644
+index 1a8a49bd269ed52879866ff3853e131d04aa8bba..f0b910df1ee471b4d72d97c6197ab14f2854976e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-@@ -16,6 +16,13 @@ import org.bukkit.entity.EntityType;
- import org.bukkit.entity.Villager;
+@@ -17,6 +17,13 @@ import org.bukkit.entity.Villager;
  import org.bukkit.entity.ZombieVillager;
+ import org.bukkit.event.entity.CreatureSpawnEvent;
  
 +// Paper start
 +import com.destroystokyo.paper.entity.villager.Reputation;
@@ -79,7 +79,7 @@ index 420b3410fd9ba7930ac9156d52571844964b5403..6de6553e79c9729ef49e2a544730b1ac
  public class CraftVillager extends CraftAbstractVillager implements Villager {
  
      public CraftVillager(CraftServer server, net.minecraft.world.entity.npc.Villager entity) {
-@@ -145,4 +152,45 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+@@ -146,4 +153,45 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
      public static VillagerProfession bukkitToNmsProfession(Profession bukkit) {
          return Registry.VILLAGER_PROFESSION.get(CraftNamespacedKey.toMinecraft(bukkit.getKey()));
      }

--- a/patches/server/0418-Optimize-brigadier-child-sorting-performance.patch
+++ b/patches/server/0418-Optimize-brigadier-child-sorting-performance.patch
@@ -5,23 +5,23 @@ Subject: [PATCH] Optimize brigadier child sorting performance
 
 
 diff --git a/src/main/java/com/mojang/brigadier/tree/CommandNode.java b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
-index 2dd09c97e00d877f5f3beed9583d3fdabc88e181..2b87c6eb28d4db634dd6d8ee42ff3aa78ed7cb68 100644
+index da6250df1c5f3385b683cffde47754bca4606f5e..a4f97c1df86c574af9b9824a38034a3d76d6e357 100644
 --- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
 +++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
-@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
+@@ -26,7 +26,7 @@ import java.util.function.Predicate;
  import net.minecraft.commands.CommandSourceStack;
  
  public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
--    private Map<String, CommandNode<S>> children = Maps.newLinkedHashMap();
-+    private Map<String, CommandNode<S>> children = Maps.newTreeMap(); // Paper - Switch to tree map for automatic sorting
-     private Map<String, LiteralCommandNode<S>> literals = Maps.newLinkedHashMap();
-     private Map<String, ArgumentCommandNode<S, ?>> arguments = Maps.newLinkedHashMap();
+-    private final Map<String, CommandNode<S>> children = new LinkedHashMap<>();
++    private Map<String, CommandNode<S>> children = com.google.common.collect.Maps.newTreeMap(); // Paper - Switch to tree map for automatic sorting
+     private final Map<String, LiteralCommandNode<S>> literals = new LinkedHashMap<>();
+     private final Map<String, ArgumentCommandNode<S, ?>> arguments = new LinkedHashMap<>();
      public Predicate<S> requirement;
-@@ -107,7 +107,7 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
+@@ -106,6 +106,8 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
+                 this.arguments.put(node.getName(), (ArgumentCommandNode<S, ?>) node);
              }
          }
- 
--        this.children = this.children.entrySet().stream().sorted(Map.Entry.comparingByValue()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
++
 +        // Paper - Remove manual sorting, it is no longer needed
      }
  

--- a/patches/server/0437-Fix-sand-duping.patch
+++ b/patches/server/0437-Fix-sand-duping.patch
@@ -7,10 +7,10 @@ If the falling block dies during teleportation (entity#move), then we need
 to detect that by placing a check after the move.
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index f12eafb49c2536f91f4716188c931ad97264c113..e234373432f34f237f884f7054c0d80829228522 100644
+index 08defb76e73a5f9121bf405c86a3c4c750ab1933..46102c28d10b11ecbafd3dda2de66982eaed8a00 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-@@ -120,6 +120,11 @@ public class FallingBlockEntity extends Entity {
+@@ -126,6 +126,11 @@ public class FallingBlockEntity extends Entity {
  
      @Override
      public void tick() {
@@ -22,7 +22,7 @@ index f12eafb49c2536f91f4716188c931ad97264c113..e234373432f34f237f884f7054c0d808
          if (this.blockState.isAir()) {
              this.discard();
          } else {
-@@ -132,6 +137,12 @@ public class FallingBlockEntity extends Entity {
+@@ -138,6 +143,12 @@ public class FallingBlockEntity extends Entity {
  
              this.move(MoverType.SELF, this.getDeltaMovement());
  

--- a/patches/server/0450-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0450-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4756ae3b7e217e3849c6fedfcb6f5b601719735d..8699b1c7d9085a07919cdb51391a189cf59e6623 100644
+index d4d8eee914f71d9a33feda82ef54cb0c40b0e60c..28a04d21801a9bb1e4311e6da28eae26283a2e36 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -359,7 +359,7 @@ public final class CraftServer implements Server {
@@ -44,7 +44,7 @@ index 4756ae3b7e217e3849c6fedfcb6f5b601719735d..8699b1c7d9085a07919cdb51391a189c
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 98ce85ee3d717e921dcbf7e4c4b3a4c5db61b77b..68f6ccacacad0e06f27d56b19b9f68b0691e747e 100644
+index 249befd851798012e390017b90cd234a17d71718..62078ee1996c671639d00ddce4dabb7238a672b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -275,8 +275,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -111,7 +111,7 @@ index 98ce85ee3d717e921dcbf7e4c4b3a4c5db61b77b..68f6ccacacad0e06f27d56b19b9f68b0
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -1978,6 +1994,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1972,6 +1988,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);

--- a/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1177,10 +1177,10 @@ index dc95aaa62220f2042e287c7d0d69753b8e891fba..06577d9cd276e65f2fdf5082b9ee4dc2
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 68f6ccacacad0e06f27d56b19b9f68b0691e747e..b61a53af941946a07f8bbd34f53191f3de23f927 100644
+index 62078ee1996c671639d00ddce4dabb7238a672b7..1223cf6a8d540ad06e4a2b7cba120c8036903930 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1992,6 +1992,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1986,6 +1986,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return future;
          }
  

--- a/patches/server/0475-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/patches/server/0475-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b61a53af941946a07f8bbd34f53191f3de23f927..4d0eb42a3f9ba213f70d856640beaa9aa42149db 100644
+index 1223cf6a8d540ad06e4a2b7cba120c8036903930..7188930d5b36e8a51b8036262745e48baeb24761 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2087,6 +2087,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2081,6 +2081,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
              lightning.visualOnly = true;
              lightning.isSilent = isSilent;

--- a/patches/server/0482-Don-t-require-FACING-data.patch
+++ b/patches/server/0482-Don-t-require-FACING-data.patch
@@ -5,16 +5,18 @@ Subject: [PATCH] Don't require FACING data
 
 
 diff --git a/src/main/java/net/minecraft/core/dispenser/DefaultDispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DefaultDispenseItemBehavior.java
-index 6939a6a9df7b8aa7103788285ecb5a1d4b734b55..ba6d3de82e409397a69fa95131b3a27486e3a774 100644
+index b49ecca9cc3fe8a3e2c8643c7714346b02212b7e..a59b20c847344e967862c7519896263b41071064 100644
 --- a/src/main/java/net/minecraft/core/dispenser/DefaultDispenseItemBehavior.java
 +++ b/src/main/java/net/minecraft/core/dispenser/DefaultDispenseItemBehavior.java
-@@ -14,20 +14,22 @@ import org.bukkit.event.block.BlockDispenseEvent;
+@@ -14,6 +14,7 @@ import org.bukkit.event.block.BlockDispenseEvent;
  // CraftBukkit end
  
  public class DefaultDispenseItemBehavior implements DispenseItemBehavior {
 +    private Direction enumdirection; // Paper
  
-     public DefaultDispenseItemBehavior() {}
+     // CraftBukkit start
+     private boolean dropper;
+@@ -27,15 +28,16 @@ public class DefaultDispenseItemBehavior implements DispenseItemBehavior {
  
      @Override
      public final ItemStack dispense(BlockSource pointer, ItemStack stack) {

--- a/patches/server/0561-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0561-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 74e10d581f8c1b0b026d8f940194971efbdef434..798afc145c54306fcf0838d8daef2bdf
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d26fd3ff134fcda2cae0e564443039d47cd50856..7711591bf57987ea6d787859eba7953285d01da8 100644
+index f1b7215c4bcd68c5497c12736dc43c20d91f7e34..bc15e58ae371b4597914cfc9960ba780358435ec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1797,8 +1797,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1791,8 +1791,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index d26fd3ff134fcda2cae0e564443039d47cd50856..7711591bf57987ea6d787859eba79532
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1833,8 +1838,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1827,8 +1832,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0608-Implement-Keyed-on-World.patch
+++ b/patches/server/0608-Implement-Keyed-on-World.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 67579748521194f49d371be6dacc2005d7f752ed..d7f45b1fb5e2ce55ceaf6f844286a177533374a3 100644
+index f904ce285548a81835b1d3af9c05f00f84d5d3da..3e26f9a4c93f616f4f02edbbd851cf0b9ab0cdb1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1232,7 +1232,7 @@ public final class CraftServer implements Server {
@@ -34,10 +34,10 @@ index 67579748521194f49d371be6dacc2005d7f752ed..d7f45b1fb5e2ce55ceaf6f844286a177
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7711591bf57987ea6d787859eba7953285d01da8..3f8d38a5a0920038b116f36a345a9a5af89a5cb2 100644
+index bc15e58ae371b4597914cfc9960ba780358435ec..344972b485cfd1430a7b8ee6e29c2f116bd5c42b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2020,6 +2020,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2014,6 +2014,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return java.util.concurrent.CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
          }, net.minecraft.server.MinecraftServer.getServer());
      }

--- a/patches/server/0630-More-World-API.patch
+++ b/patches/server/0630-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3f8d38a5a0920038b116f36a345a9a5af89a5cb2..232a5582032108402d4371d95f68f98b2685c8fd 100644
+index 344972b485cfd1430a7b8ee6e29c2f116bd5c42b..42200d93d52e67f64ccfaac3716cb25481bfc672 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1966,6 +1966,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1960,6 +1960,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0675-Missing-Entity-Behavior-API.patch
+++ b/patches/server/0675-Missing-Entity-Behavior-API.patch
@@ -533,10 +533,10 @@ index bf5b2fd6676c4430578db4cc6c603c501cc5e349..832981b07ef5c633ef00a382f56798ee
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
-index 0f5c81c0d599d3b58f7864d1527391ad50983c4e..606d8485a5fc67b59f8fed38a739d6bc5888d99d 100644
+index 2ba16e33dd21c3c72cb12244aa78c59bf53e76d1..634a5099fb6faea03615783f57e643ad0083fa30 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVex.java
-@@ -26,6 +26,26 @@ public class CraftVex extends CraftMonster implements Vex {
+@@ -29,6 +29,26 @@ public class CraftVex extends CraftMonster implements Vex {
      public void setSummoner(org.bukkit.entity.Mob summoner) {
          getHandle().setOwner(summoner == null ? null : ((CraftMob) summoner).getHandle());
      }

--- a/patches/server/0734-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0734-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -293,7 +293,7 @@ index 1622450b53e0f0f48c3ca107e4d705b4ad29dadf..f6a225eed29eed364b7e2ea6bc85d55d
      public static void spawnCategoryForChunk(MobCategory group, ServerLevel world, LevelChunk chunk, NaturalSpawner.SpawnPredicate checker, NaturalSpawner.AfterSpawnCallback runner) {
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 75c153b739e1c22877102791adb90e955906a31c..030bb69543f077d5fb80e478efa786c123ff1487 100644
+index 4fb0ad44672e0fed8c5d523d03801df725cc136f..7b1bccfbf44c5b431f52f4ed974f9143c12a8300 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2143,6 +2143,11 @@ public final class CraftServer implements Server {
@@ -309,10 +309,10 @@ index 75c153b739e1c22877102791adb90e955906a31c..030bb69543f077d5fb80e478efa786c1
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f0e84b0a37a7fc374fb3f11e77a76a627c39b3e8..df986f97b86ba1fa4da15d969c635333abfdba91 100644
+index eb4c79a902166dd8e89f4de71dcb75c493852af5..6c791db6d010877dcc77acac449720727dda1b57 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1717,9 +1717,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1711,9 +1711,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(spawnCategory, "SpawnCategory cannot be null");
          Validate.isTrue(CraftSpawnCategory.isValidForLimits(spawnCategory), "SpawnCategory." + spawnCategory + " are not supported.");
  

--- a/patches/server/0775-Check-requirement-before-suggesting-root-nodes.patch
+++ b/patches/server/0775-Check-requirement-before-suggesting-root-nodes.patch
@@ -11,17 +11,17 @@ encountering a command node with ASK_SERVER suggestions, however a
 modified client can send this packet whenever it wants.
 
 diff --git a/src/main/java/com/mojang/brigadier/CommandDispatcher.java b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
-index ca24830bac1a04b798229d1946863429c7849495..5584040fe48c18aa809f5a1510157e735851df79 100644
+index e733a5657032d29e5a0d64375c9e36639360a7e0..fa8e891db9f7b6d43457fea255e03f4903cad50e 100644
 --- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
 +++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
-@@ -594,10 +594,14 @@ public class CommandDispatcher<S> {
+@@ -595,10 +595,14 @@ public class CommandDispatcher<S> {
          int i = 0;
          for (final CommandNode<S> node : parent.getChildren()) {
              CompletableFuture<Suggestions> future = Suggestions.empty();
 +            // Paper start - Don't suggest if the requirement isn't met
 +            if (parent != this.root || node.canUse(context.getSource())) {
              try {
-                 future = node.listSuggestions(context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, truncatedInputLowerCase, start));
+                 if (node.canUse(parse.getContext().getSource())) future = node.listSuggestions(context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, truncatedInputLowerCase, start)); // CraftBukkit
              } catch (final CommandSyntaxException ignored) {
              }
 +            }

--- a/patches/server/0775-Check-requirement-before-suggesting-root-nodes.patch
+++ b/patches/server/0775-Check-requirement-before-suggesting-root-nodes.patch
@@ -11,7 +11,7 @@ encountering a command node with ASK_SERVER suggestions, however a
 modified client can send this packet whenever it wants.
 
 diff --git a/src/main/java/com/mojang/brigadier/CommandDispatcher.java b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
-index e733a5657032d29e5a0d64375c9e36639360a7e0..fa8e891db9f7b6d43457fea255e03f4903cad50e 100644
+index e733a5657032d29e5a0d64375c9e36639360a7e0..b64c98c173e25055f4ff9d7124d0a3cb7ff6ab1d 100644
 --- a/src/main/java/com/mojang/brigadier/CommandDispatcher.java
 +++ b/src/main/java/com/mojang/brigadier/CommandDispatcher.java
 @@ -595,10 +595,14 @@ public class CommandDispatcher<S> {
@@ -21,7 +21,8 @@ index e733a5657032d29e5a0d64375c9e36639360a7e0..fa8e891db9f7b6d43457fea255e03f49
 +            // Paper start - Don't suggest if the requirement isn't met
 +            if (parent != this.root || node.canUse(context.getSource())) {
              try {
-                 if (node.canUse(parse.getContext().getSource())) future = node.listSuggestions(context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, truncatedInputLowerCase, start)); // CraftBukkit
+-                if (node.canUse(parse.getContext().getSource())) future = node.listSuggestions(context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, truncatedInputLowerCase, start)); // CraftBukkit
++                future = node.listSuggestions(context.build(truncatedInput), new SuggestionsBuilder(truncatedInput, truncatedInputLowerCase, start)); // CraftBukkit
              } catch (final CommandSyntaxException ignored) {
              }
 +            }

--- a/patches/server/0856-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0856-Replace-player-chunk-loader-system.patch
@@ -2120,10 +2120,10 @@ index b46648301396930478391967b371bf8d201901e1..c8fb4b2bc86c9aa2e7c2e9ee10208cf9
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b3dff7979aeec8ff4eff1233b551023309f580ae..f807ee757488f05be626643e009eac95245b3af1 100644
+index eac1891c8eb073522ea9fb5608a7ef0b809d6a80..e663ebbfd687fc94bca6c489506ce85c73ea60e6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2218,43 +2218,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2212,43 +2212,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {
@@ -2189,7 +2189,7 @@ index b3dff7979aeec8ff4eff1233b551023309f580ae..f807ee757488f05be626643e009eac95
      // Paper end - view distance api
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1f53981fb59ab93566d632b3c950a2a629a0b4fd..1a1fa6595c5adf074ac6caed831bf885a5345937 100644
+index 4a372ab984a02b1f54232e45b5a0d483216d37e5..7e7b3692b5b7168f6122ae10fbb1772369f922fd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -538,45 +538,80 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0867-Fix-World-locateNearestStructure.patch
+++ b/patches/server/0867-Fix-World-locateNearestStructure.patch
@@ -45,10 +45,10 @@ index 344c5bafe291a2542c4940e4d80232644de7b877..00e6f60e13f50c727530de37ab9692ad
                  return pair != null ? (BlockPos) pair.getFirst() : null;
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f807ee757488f05be626643e009eac95245b3af1..4d0c2b29d43c420bb603298adc6c35941724ff53 100644
+index e663ebbfd687fc94bca6c489506ce85c73ea60e6..d5c17607e74db46c28cec4b34dc04cdaea00688a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2071,10 +2071,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2065,10 +2065,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      }
  

--- a/patches/server/0869-Fix-falling-block-spawn-methods.patch
+++ b/patches/server/0869-Fix-falling-block-spawn-methods.patch
@@ -3,6 +3,9 @@ From: Nassim Jahnke <jahnke.nassim@gmail.com>
 Date: Fri, 4 Mar 2022 20:35:19 +0100
 Subject: [PATCH] Fix falling block spawn methods
 
+Restores the API behavior from previous versions of the server
+- Do not call API events
+- Do not replace the existing block in the world
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 index 850131e601047ab1c585a6f8883ac3c0d0e97ba1..99cb7625d50d5da4ce0999e10fb84403958a7ffe 100644
@@ -18,24 +21,34 @@ index 850131e601047ab1c585a6f8883ac3c0d0e97ba1..99cb7625d50d5da4ce0999e10fb84403
              if (Snowball.class.isAssignableFrom(clazz)) {
                  entity = new net.minecraft.world.entity.projectile.Snowball(world, x, y, z);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4d0c2b29d43c420bb603298adc6c35941724ff53..21db68e58d053b83d8688b3fc71984ff36dda048 100644
+index d5c17607e74db46c28cec4b34dc04cdaea00688a..92c9f57d6ed632dd8bf45a31164533cf09135694 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1416,7 +1416,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1416,7 +1416,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(material, "Material cannot be null");
          Validate.isTrue(material.isBlock(), "Material must be a block");
  
--        FallingBlockEntity entity = FallingBlockEntity.fall(world, new BlockPos(location.getX(), location.getY(), location.getZ()), CraftMagicNumbers.getBlock(material).defaultBlockState());
+-        FallingBlockEntity entity = FallingBlockEntity.fall(world, new BlockPos(location.getX(), location.getY(), location.getZ()), CraftMagicNumbers.getBlock(material).defaultBlockState(), SpawnReason.CUSTOM);
++        // Paper start - restore API behavior for spawning falling blocks
 +        FallingBlockEntity entity = new FallingBlockEntity(this.world, location.getX(), location.getY(), location.getZ(), CraftMagicNumbers.getBlock(material).defaultBlockState()); // Paper
-         entity.time = 1;
++        entity.time = 1;
++
++        this.world.addFreshEntity(entity, SpawnReason.CUSTOM);
++        // Paper end
+         return (FallingBlock) entity.getBukkitEntity();
+     }
  
-         this.world.addFreshEntity(entity, SpawnReason.CUSTOM);
-@@ -1428,7 +1428,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1425,7 +1430,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(location, "Location cannot be null");
-         Validate.notNull(data, "Material cannot be null");
+         Validate.notNull(data, "BlockData cannot be null");
  
--        FallingBlockEntity entity = FallingBlockEntity.fall(world, new BlockPos(location.getX(), location.getY(), location.getZ()), ((CraftBlockData) data).getState());
-+        FallingBlockEntity entity = new FallingBlockEntity(this.world, location.getX(), location.getY(), location.getZ(), ((CraftBlockData) data).getState()); // Paper
-         entity.time = 1;
+-        FallingBlockEntity entity = FallingBlockEntity.fall(world, new BlockPos(location.getX(), location.getY(), location.getZ()), ((CraftBlockData) data).getState(), SpawnReason.CUSTOM);
++        // Paper start - restore API behavior for spawning falling blocks
++        FallingBlockEntity entity = new FallingBlockEntity(this.world, location.getX(), location.getY(), location.getZ(), ((CraftBlockData) data).getState());
++        entity.time = 1;
++
++        this.world.addFreshEntity(entity, SpawnReason.CUSTOM);
++        // Paper end
+         return (FallingBlock) entity.getBukkitEntity();
+     }
  
-         this.world.addFreshEntity(entity, SpawnReason.CUSTOM);

--- a/patches/server/0894-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0894-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -18,7 +18,7 @@ index e28e09aae1d95d9bed50a137e999e6d457e62478..257c94f7c1cb00c9a91ab82e311dfd8e
  
              if (dedicatedserverproperties.enableQuery) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ca876d0916b7b888e8df58fb6b115fa0ab5b79d3..9df5b678ce4343d0bb54133393f6bbe40fe5366b 100644
+index c087d7a1f5e560193f87a681101da8be1b60c8b3..1a87f61d534ed531132fb43a9d2a45a4b604a6fc 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2603,7 +2603,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -158,10 +158,10 @@ index 798afc145c54306fcf0838d8daef2bdf17763da9..22feab6477bad023c2d6cc9ac99d392d
              this.onChanged(server);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 21db68e58d053b83d8688b3fc71984ff36dda048..de4f750cbad3baa8ca22f485567751ed2da8df29 100644
+index 92c9f57d6ed632dd8bf45a31164533cf09135694..d637bb8d52ee8e6ba8c7e48f1155e845841a5e97 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1916,7 +1916,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1920,7 +1920,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule));
          handle.deserialize(event.getValue()); // Paper
@@ -170,7 +170,7 @@ index 21db68e58d053b83d8688b3fc71984ff36dda048..de4f750cbad3baa8ca22f485567751ed
          return true;
      }
  
-@@ -1956,7 +1956,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1960,7 +1960,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule.getName()));
          handle.deserialize(event.getValue()); // Paper


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
31514774 SPIGOT-6949: Configuration sections that are nested within Maps or Lists are not properly serialized.
1bebebfb SPIGOT-6992: Add LimitedLife/LifeTicks/Bound APIs to Vex

CraftBukkit Changes:
9cc7d766d SPIGOT-7010: Changing dropper item results in using dispensing behaviour
e87f2e3ed SPIGOT-6992: Add LimitedLife/LifeTicks/Bound APIs to Vex
cf391b51c Pass in SpawnReason rather than boolean
098aecb04 SPIGOT-7001: Fix entity already exists in CraftWorld#spawnFallingBlock
911bde181 SPIGOT-6972: Root command nodes can leak to client
