### PR TITLE
cleanup filtered sign text

### DIFF
--- a/patches/server/0902-Sign-cleanup-filtering.patch
+++ b/patches/server/0902-Sign-cleanup-filtering.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Sat, 30 Apr 2022 00:38:57 +0100
+Subject: [PATCH] Sign cleanup filtering
+
+TODO: This logic here should be moved into a DataFixer in the next MC release
+noting to ensure to apply the cleanup logic here, and clean up the added
+tags
+
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
+index 6371176fba41218a209ea59b4cafe5b2d4a685fd..d5bcc81a809e3c733c6fc11309bcf0913860edf6 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
+@@ -72,6 +72,7 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+         }
+         // CraftBukkit end
+ 
++        nbt.putBoolean("Paper.cleanedFiltered", true); // Paper
+         nbt.putString("Color", this.color.getName());
+         nbt.putBoolean("GlowingText", this.hasGlowingText);
+     }
+@@ -88,6 +89,7 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+         boolean oldSign = Boolean.getBoolean("convertLegacySigns") && !nbt.getBoolean("Bukkit.isConverted");
+         // CraftBukkit end
+ 
++        boolean cleanedFiltered = nbt.getBoolean("Paper.cleanedFiltered"); // Paper
+         for (int i = 0; i < 4; ++i) {
+             String s = nbt.getString(SignBlockEntity.RAW_TEXT_FIELD_NAMES[i]);
+             // CraftBukkit start
+@@ -105,7 +107,7 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+             this.messages[i] = ichatbasecomponent;
+             String s1 = SignBlockEntity.FILTERED_TEXT_FIELD_NAMES[i];
+ 
+-            if (nbt.contains(s1, 8)) {
++            if (cleanedFiltered && nbt.contains(s1, 8)) { // Paper
+                 this.filteredMessages[i] = this.loadLine(nbt.getString(s1));
+             } else {
+                 this.filteredMessages[i] = ichatbasecomponent;


### PR DESCRIPTION
Paper was at some point writing data inside of the filtered text,
which in the past was not an issue, however, it appears that mojang
has flipped something which is now causing this information to be
relevant and thus causing interesting effects on the client.

This patch will clean up said data for existing signs, given that
there is realistically 0 chance that nobody was even using this data,
this should be a none issue for old signs
