### PR TITLE
Fix setting invalid direction state prop in UpgradeData

### DIFF
--- a/patches/server/0920-Fix-setting-invalid-direction-state-prop-in-UpgradeD.patch
+++ b/patches/server/0920-Fix-setting-invalid-direction-state-prop-in-UpgradeD.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 24 Apr 2022 11:07:21 -0700
+Subject: [PATCH] Fix setting invalid direction state prop in UpgradeData
+
+
+diff --git a/src/main/java/net/minecraft/world/level/chunk/UpgradeData.java b/src/main/java/net/minecraft/world/level/chunk/UpgradeData.java
+index 8c68f95d78909e6fe7dd4b6025af5d958b122f28..20b11d62976c79829d8cbb9a988a543b15260e21 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/UpgradeData.java
++++ b/src/main/java/net/minecraft/world/level/chunk/UpgradeData.java
+@@ -357,7 +357,7 @@ public class UpgradeData {
+         STEM_BLOCK(Blocks.MELON_STEM, Blocks.PUMPKIN_STEM) {
+             @Override
+             public BlockState updateShape(BlockState oldState, Direction direction, BlockState otherState, LevelAccessor world, BlockPos currentPos, BlockPos otherPos) {
+-                if (oldState.getValue(StemBlock.AGE) == 7) {
++                if (direction.getAxis().isHorizontal() && oldState.getValue(StemBlock.AGE) == 7) { // Paper
+                     StemGrownBlock stemGrownBlock = ((StemBlock)oldState.getBlock()).getFruit();
+                     if (otherState.is(stemGrownBlock)) {
+                         return stemGrownBlock.getAttachedStem().defaultBlockState().setValue(HorizontalDirectionalBlock.FACING, direction);


### PR DESCRIPTION
Should fix https://github.com/PaperMC/Paper/issues/7764 although I don't know how to test it exactly. Not 100% on the logic that makes these run in the first place. Other fixers there have a isHorizontal check which supports this one having one too.