### PR TITLE
Fix door breaking difficulty defaults for vindicator

### DIFF
--- a/patches/server/0567-Configurable-door-breaking-difficulty.patch
+++ b/patches/server/0567-Configurable-door-breaking-difficulty.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Configurable door breaking difficulty
 Co-authored-by: Doc <nachito94@msn.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bd28bbab098441bdede682c6b269c1d19a2dd062..082a7d3c7ebaa66e89dbab3ebf7c9b5451e7180b 100644
+index bd28bbab098441bdede682c6b269c1d19a2dd062..13fc7c21283f09fd135a12649776bb1355da4154 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -137,6 +137,27 @@ public class PaperWorldConfig {
@@ -19,7 +19,7 @@ index bd28bbab098441bdede682c6b269c1d19a2dd062..082a7d3c7ebaa66e89dbab3ebf7c9b54
 +    private void setupEntityBreakingDoors() {
 +        for (net.minecraft.world.entity.EntityType<?> entityType : entitiesValidForBreakDoors) {
 +            java.util.function.Predicate<net.minecraft.world.Difficulty> difficultyPredicate = net.minecraft.world.entity.monster.Zombie.DOOR_BREAKING_PREDICATE;
-+            if (entityType.getBaseClass() == net.minecraft.world.entity.monster.Vindicator.class) {
++            if (entityType == net.minecraft.world.entity.EntityType.VINDICATOR) {
 +                difficultyPredicate = net.minecraft.world.entity.monster.Vindicator.DOOR_BREAKING_PREDICATE;
 +            }
 +            entitiesDifficultyBreakDoors.put(


### PR DESCRIPTION
https://github.com/PaperMC/Paper/commit/2515bc4751c5243c298f582920be89043c187d34 broke the default door breaking difficulty config option for Vindicators. `EntityType#getBaseClass()` just returns `Entity.class` for all entity types.