### PR TITLE
ItemStack damage API

### DIFF
--- a/patches/api/0410-ItemStack-damage-API.patch
+++ b/patches/api/0410-ItemStack-damage-API.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 8 May 2022 13:35:58 -0700
+Subject: [PATCH] ItemStack damage API
+
+Adds methods notify clients about item breaks and
+to simulate damage done to an itemstack and all
+the logic associated with damaging them
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 3bd1d100d0c481ae7edaa251869640ab370aeb42..f6cbada38ca48638e5ad0bd99d0b6ea65f6b02de 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -1015,5 +1015,48 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+      * @param directionZ The relative z position of the knockback source direction
+      */
+     void knockback(double strength, double directionX, double directionZ);
++
++    /**
++     * Notifies all clients tracking this entity that the item in
++     * the slot of this entity broke.
++     * <p>
++     * NOTE: this does not mutate any entity state
++     *
++     * @param slot the slot
++     */
++    void broadcastSlotBreak(org.bukkit.inventory.@NotNull EquipmentSlot slot);
++
++    /**
++     * Notifies specified players that the item in the slot
++     * of this entity broke.
++     * <p>
++     * NOTE: this does not mutate any entity state
++     *
++     * @param slot the slot
++     * @param players the players to notify
++     */
++    void broadcastSlotBreak(org.bukkit.inventory.@NotNull EquipmentSlot slot, @NotNull Collection<Player> players);
++
++    /**
++     * Damages this itemstack by the specified amount. This
++     * runs all logic associated with damaging an itemstack like
++     * events and stat changes.
++     *
++     * @param stack the itemstack to damage
++     * @param amount the amount of damage to do
++     * @return the damaged itemstack, or an empty stack if it broke. It may be the same instance as the stack passed it, but it may not.
++     */
++    @NotNull ItemStack damageItemStack(@NotNull ItemStack stack, int amount);
++
++    /**
++     * Damages the itemstack in this slot by the specified amount.
++     * This runs all logic associated with damaging an itemstack like
++     * events, stat changes, and notifying clients to play
++     * break animations.
++     *
++     * @param slot the slot of the stack to damage
++     * @param amount the amount of damage to do
++     */
++    void damageItemStack(org.bukkit.inventory.@NotNull EquipmentSlot slot, int amount);
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index b8a344fd900dcbd4b28085a54b85b16c742e9c6f..870c0ddd101094a3bce1ebf5ec4d42c51053db84 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -977,5 +977,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+     public boolean canRepair(@NotNull ItemStack toBeRepaired) {
+         return Bukkit.getUnsafe().isValidRepairItemStack(toBeRepaired, this);
+     }
++
++    /**
++     * Damages this itemstack by the specified amount. This
++     * runs all logic associated with damaging an itemstack like
++     * events and stat changes.
++     *
++     * @param amount the amount of damage to do
++     * @param livingEntity the entity related to the damage
++     * @return the damaged itemstack or an empty one if it broke. May return the same instance of ItemStack
++     * @see org.bukkit.entity.LivingEntity#damageItemStack(EquipmentSlot, int) to damage itemstacks in equipment slots
++     */
++    public @NotNull ItemStack damage(int amount, @NotNull org.bukkit.entity.LivingEntity livingEntity) {
++        return livingEntity.damageItemStack(this, amount);
++    }
+     // Paper end
+ }

--- a/patches/server/0946-ItemStack-damage-API.patch
+++ b/patches/server/0946-ItemStack-damage-API.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 8 May 2022 13:35:45 -0700
+Subject: [PATCH] ItemStack damage API
+
+Adds methods notify clients about item breaks and
+to simulate damage done to an itemstack and all
+the logic associated with damaging them
+
+== AT ==
+public net.minecraft.world.entity.LivingEntity entityEventForEquipmentBreak(Lnet/minecraft/world/entity/EquipmentSlot;)B
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index 76ee8adfb6cccc15dde748b0796d1de7fc5507f8..fa2e865324c11b724c351cdf8c03bfc4c8a274f6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -978,6 +978,53 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         throw new IllegalArgumentException(entityCategory + " is an unrecognized entity category");
+     }
+ 
++    @Override
++    public void broadcastSlotBreak(org.bukkit.inventory.EquipmentSlot slot) {
++        this.getHandle().broadcastBreakEvent(org.bukkit.craftbukkit.CraftEquipmentSlot.getNMS(slot));
++    }
++
++    @Override
++    public void broadcastSlotBreak(org.bukkit.inventory.EquipmentSlot slot, Collection<org.bukkit.entity.Player> players) {
++        if (players.isEmpty()) {
++            return;
++        }
++        final net.minecraft.network.protocol.game.ClientboundEntityEventPacket packet = new net.minecraft.network.protocol.game.ClientboundEntityEventPacket(
++            this.getHandle(),
++            net.minecraft.world.entity.LivingEntity.entityEventForEquipmentBreak(org.bukkit.craftbukkit.CraftEquipmentSlot.getNMS(slot))
++        );
++        players.forEach(player -> ((CraftPlayer) player).getHandle().connection.send(packet));
++    }
++
++    @Override
++    public ItemStack damageItemStack(ItemStack stack, int amount) {
++        final net.minecraft.world.item.ItemStack nmsStack;
++        if (stack instanceof CraftItemStack craftItemStack) {
++            if (craftItemStack.handle == null || craftItemStack.handle.isEmpty()) {
++                return stack;
++            }
++            nmsStack = craftItemStack.handle;
++        } else {
++            nmsStack = CraftItemStack.asNMSCopy(stack);
++            stack = CraftItemStack.asCraftMirror(nmsStack); // mirror to capture changes in hurt logic & events
++        }
++        this.damageItemStack0(nmsStack, amount, null);
++        return stack;
++    }
++
++    @Override
++    public void damageItemStack(org.bukkit.inventory.EquipmentSlot slot, int amount) {
++        final net.minecraft.world.entity.EquipmentSlot nmsSlot = org.bukkit.craftbukkit.CraftEquipmentSlot.getNMS(slot);
++        this.damageItemStack0(this.getHandle().getItemBySlot(nmsSlot), amount, nmsSlot);
++    }
++
++    private void damageItemStack0(net.minecraft.world.item.ItemStack nmsStack, int amount, net.minecraft.world.entity.EquipmentSlot slot) {
++        nmsStack.hurtAndBreak(amount, this.getHandle(), livingEntity -> {
++            if (slot != null) {
++                livingEntity.broadcastBreakEvent(slot);
++            }
++        });
++    }
++
+     @Override
+     public void knockback(double strength, double directionX, double directionZ) {
+         Preconditions.checkArgument(strength > 0, "Knockback strength must be > 0");


### PR DESCRIPTION
Adds methods notify clients about item breaks and to simulate damage done to an itemstack and all the logic associated with damaging them

Resolves https://github.com/PaperMC/Paper/issues/7755