### PR TITLE
Fix villager cure exploit patch

### DIFF
--- a/patches/server/0538-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/patches/server/0538-Fix-curing-zombie-villager-discount-exploit.patch
@@ -24,10 +24,10 @@ index 7a61a46fdfbd597ed6d76f8142c8159e05eba1d3..99730237e0e447159282b70a179bc9cb
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-index 089fb4640cb4e74d7cc90088a8772743d5cbe0c4..268524e256a034520438d5c825e5e419d72d29ce 100644
+index 089fb4640cb4e74d7cc90088a8772743d5cbe0c4..00301b64578758f4b21aa9529aa6d2a422cd0c9f 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-@@ -1066,6 +1066,15 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+@@ -1066,8 +1066,18 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
      @Override
      public void onReputationEventFrom(ReputationEventType interaction, Entity entity) {
          if (interaction == ReputationEventType.ZOMBIE_VILLAGER_CURED) {
@@ -38,8 +38,11 @@ index 089fb4640cb4e74d7cc90088a8772743d5cbe0c4..268524e256a034520438d5c825e5e419
 +                    playerReputation.remove(GossipType.MAJOR_POSITIVE);
 +                    playerReputation.remove(GossipType.MINOR_POSITIVE);
 +                }
-+            }
-+            // Paper end
++            } else {
              this.gossips.add(entity.getUUID(), GossipType.MAJOR_POSITIVE, 20);
              this.gossips.add(entity.getUUID(), GossipType.MINOR_POSITIVE, 25);
++            }
++            // Paper end
          } else if (interaction == ReputationEventType.TRADE) {
+             this.gossips.add(entity.getUUID(), GossipType.TRADING, 2);
+         } else if (interaction == ReputationEventType.VILLAGER_HURT) {


### PR DESCRIPTION
Fixes the villager cure exploit not working by wrapping the part that awards positive gossip in an else, instead of only removing any previous gossip for the player that cured the villager.