### PR TITLE
Allow customizing hopper minecart cooldowns

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -1444,10 +1444,10 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7e995bb83a06e302fd70a8e6f079e3ac55c60473
+index 0000000000000000000000000000000000000000..891d63a8d722bd3e84d6f18690bf952bed49f46f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,468 @@
+@@ -0,0 +1,470 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1833,6 +1833,8 @@ index 0000000000000000000000000000000000000000..7e995bb83a06e302fd70a8e6f079e3ac
 +        public boolean cooldownWhenFull = true;
 +        public boolean disableMoveEvent = false;
 +        public boolean ignoreOccludingBlocks = false;
++        public int hopperMinecartTransferCooldown = 0;
++        public boolean resetHopperMinecartCooldownOnMove = true;
 +    }
 +
 +    public Collisions collisions;

--- a/patches/server/0333-Optimize-Hoppers.patch
+++ b/patches/server/0333-Optimize-Hoppers.patch
@@ -24,6 +24,37 @@ index 1a21f7e590aaeca131256dd7079b9546710ca9ad..eeb794d96ac8cbe36b788d390e638192
  
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
+diff --git a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
+index 3f8990d15bd6815db0ccb924e621dfcc3220e0e0..4ce983f131ff190c4c9b35ae0a6be46f6655b971 100644
+--- a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
++++ b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
+@@ -21,7 +21,7 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+     public static final int MOVE_ITEM_SPEED = 4;
+     private boolean enabled = true;
+     public int cooldownTime = -1;
+-    private final BlockPos lastPosition = BlockPos.ZERO;
++    private BlockPos lastPosition = BlockPos.ZERO; // Paper
+ 
+     public MinecartHopper(EntityType<? extends MinecartHopper> type, Level world) {
+         super(type, world);
+@@ -90,14 +90,15 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+             BlockPos blockPos = this.blockPosition();
+             if (blockPos.equals(this.lastPosition)) {
+                 --this.cooldownTime;
+-            } else {
++            } else if (this.level.paperConfig().hopper.resetHopperMinecartCooldownOnMove) { // Paper
++                this.lastPosition = blockPos; // Paper
+                 this.setCooldown(0);
+             }
+ 
+             if (!this.isOnCooldown()) {
+                 this.setCooldown(0);
+                 if (this.suckInItems()) {
+-                    this.setCooldown(4);
++                    this.setCooldown(this.level.paperConfig().hopper.hopperMinecartTransferCooldown); // Paper
+                     this.setChanged();
+                 }
+             }
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
 index 4b41d2dd00c1b206c1419ba767a3474947664e53..5e0852c4656813272a7ee6cb9c2331410c1b7739 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
@@ -78,7 +109,7 @@ index a05acf709735b40ca86f978508c63a86065fd405..6a1405a8630e90db3b5a3c9152259ba6
  
      double getLevelY();
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index a507d7f65a94e49ecd18cd18797b156474558390..a7ac6b528aecae528a17af157f8ec29371e4484c 100644
+index a507d7f65a94e49ecd18cd18797b156474558390..00e35fb79ca4aa35482631b266d52d4e7052c95b 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 @@ -3,7 +3,6 @@ package net.minecraft.world.level.block.entity;
@@ -248,8 +279,8 @@ index a507d7f65a94e49ecd18cd18797b156474558390..a7ac6b528aecae528a17af157f8ec293
 +    private static void cooldownHopper(Hopper hopper) {
 +        if (hopper instanceof HopperBlockEntity blockEntity) {
 +            blockEntity.setCooldown(blockEntity.getLevel().spigotConfig.hopperTransfer);
-+        } else if (hopper instanceof MinecartHopper blockEntity) {
-+            blockEntity.setCooldown(blockEntity.getLevel().spigotConfig.hopperTransfer / 2);
++        } else if (hopper instanceof MinecartHopper minecart) {
++            minecart.setCooldown(minecart.getLevel().paperConfig().hopper.hopperMinecartTransferCooldown);
 +        }
 +    }
 +    // Paper end

--- a/patches/server/0333-Optimize-Hoppers.patch
+++ b/patches/server/0333-Optimize-Hoppers.patch
@@ -12,6 +12,9 @@ Subject: [PATCH] Optimize Hoppers
 * Don't check for Entities with Inventories if the block above us is also occluding (not just Inventoried)
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
+== AT ==
+private-f net.minecraft.world.entity.vehicle.MinecartHopper lastPosition
+
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index 1a21f7e590aaeca131256dd7079b9546710ca9ad..eeb794d96ac8cbe36b788d390e638192182a21c8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -25,26 +28,20 @@ index 1a21f7e590aaeca131256dd7079b9546710ca9ad..eeb794d96ac8cbe36b788d390e638192
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
-index 3f8990d15bd6815db0ccb924e621dfcc3220e0e0..4ce983f131ff190c4c9b35ae0a6be46f6655b971 100644
+index 3b85a2e1cc22ea2a8d2e0e346f3d400b5237b0ca..c0b5f10d053654ba0e592289df0b9b4aff9a748f 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
-@@ -21,7 +21,7 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
-     public static final int MOVE_ITEM_SPEED = 4;
-     private boolean enabled = true;
-     public int cooldownTime = -1;
--    private final BlockPos lastPosition = BlockPos.ZERO;
-+    private BlockPos lastPosition = BlockPos.ZERO; // Paper
- 
-     public MinecartHopper(EntityType<? extends MinecartHopper> type, Level world) {
-         super(type, world);
-@@ -90,14 +90,15 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
-             BlockPos blockPos = this.blockPosition();
+@@ -91,13 +91,19 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
              if (blockPos.equals(this.lastPosition)) {
                  --this.cooldownTime;
--            } else {
-+            } else if (this.level.paperConfig().hopper.resetHopperMinecartCooldownOnMove) { // Paper
-+                this.lastPosition = blockPos; // Paper
+             } else {
++                // Paper start
++                --this.cooldownTime;
++                this.lastPosition = blockPos;
++                if (this.level.paperConfig().hopper.resetHopperMinecartCooldownOnMove) {
++                // Paper end
                  this.setCooldown(0);
++                } // Paper
              }
  
              if (!this.isOnCooldown()) {
@@ -56,7 +53,7 @@ index 3f8990d15bd6815db0ccb924e621dfcc3220e0e0..4ce983f131ff190c4c9b35ae0a6be46f
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 4b41d2dd00c1b206c1419ba767a3474947664e53..5e0852c4656813272a7ee6cb9c2331410c1b7739 100644
+index b4fbe1f393e2c348bc0120bf6c55d57d61011787..2650deb381bae30593128fc003c042f42110802c 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -625,11 +625,12 @@ public final class ItemStack {

--- a/patches/server/0333-Optimize-Hoppers.patch
+++ b/patches/server/0333-Optimize-Hoppers.patch
@@ -11,6 +11,8 @@ Subject: [PATCH] Optimize Hoppers
 * Skip subsequent InventoryMoveItemEvents if a plugin does not use the item after first event fire for an iteration
 * Don't check for Entities with Inventories if the block above us is also occluding (not just Inventoried)
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
+* Hopper minecart cooldowns have been reimplemented, and will trigger when a minecart picks up items or goes over a 
+container. This is all under configuration as this behavior is currently not functional on vanilla.
 
 == AT ==
 private-f net.minecraft.world.entity.vehicle.MinecartHopper lastPosition
@@ -28,7 +30,7 @@ index 1a21f7e590aaeca131256dd7079b9546710ca9ad..eeb794d96ac8cbe36b788d390e638192
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
-index 3b85a2e1cc22ea2a8d2e0e346f3d400b5237b0ca..c0b5f10d053654ba0e592289df0b9b4aff9a748f 100644
+index 3b85a2e1cc22ea2a8d2e0e346f3d400b5237b0ca..45f99857204329b90a1ace7e27e1fd9a8e4ac779 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
 @@ -91,13 +91,19 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
@@ -52,6 +54,15 @@ index 3b85a2e1cc22ea2a8d2e0e346f3d400b5237b0ca..c0b5f10d053654ba0e592289df0b9b4a
                      this.setChanged();
                  }
              }
+@@ -111,7 +117,7 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+         } else {
+             List<ItemEntity> list = this.level.getEntitiesOfClass(ItemEntity.class, this.getBoundingBox().inflate(0.25D, 0.0D, 0.25D), EntitySelector.ENTITY_STILL_ALIVE);
+             if (!list.isEmpty()) {
+-                HopperBlockEntity.addItem(this, list.get(0));
++                return HopperBlockEntity.addItem(this, list.get(0)); // Paper - Return result for picked up items
+             }
+ 
+             return false;
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
 index b4fbe1f393e2c348bc0120bf6c55d57d61011787..2650deb381bae30593128fc003c042f42110802c 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java

--- a/patches/server/0344-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0344-Entity-Activation-Range-2.0.patch
@@ -307,7 +307,7 @@ index f957c0aca36b7228ac3a33ca04c948b1d10642d1..39fc94b1e1555fd6706391223dd27831
          super.customServerAiStep();
      }
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
-index 4ce983f131ff190c4c9b35ae0a6be46f6655b971..4f650f6e750feb0e703d3a41258b69252e3eb3d3 100644
+index c0b5f10d053654ba0e592289df0b9b4aff9a748f..a611385e638b963bce3c06bb685d3655dc09d0ba 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
 @@ -57,6 +57,7 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
@@ -318,7 +318,7 @@ index 4ce983f131ff190c4c9b35ae0a6be46f6655b971..4f650f6e750feb0e703d3a41258b6925
  
      }
  
-@@ -108,11 +109,13 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+@@ -113,11 +114,13 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
  
      public boolean suckInItems() {
          if (HopperBlockEntity.suckInItems(this.level, this)) {
@@ -332,7 +332,7 @@ index 4ce983f131ff190c4c9b35ae0a6be46f6655b971..4f650f6e750feb0e703d3a41258b6925
              }
  
              return false;
-@@ -150,4 +153,11 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+@@ -155,4 +158,11 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
      public AbstractContainerMenu createMenu(int syncId, Inventory playerInventory) {
          return new HopperMenu(syncId, playerInventory, this);
      }

--- a/patches/server/0344-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0344-Entity-Activation-Range-2.0.patch
@@ -307,7 +307,7 @@ index f957c0aca36b7228ac3a33ca04c948b1d10642d1..39fc94b1e1555fd6706391223dd27831
          super.customServerAiStep();
      }
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
-index c0b5f10d053654ba0e592289df0b9b4aff9a748f..a611385e638b963bce3c06bb685d3655dc09d0ba 100644
+index 45f99857204329b90a1ace7e27e1fd9a8e4ac779..11fd31cee3478c0094e953d9a089ef947c425983 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
 @@ -57,6 +57,7 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
@@ -318,7 +318,7 @@ index c0b5f10d053654ba0e592289df0b9b4aff9a748f..a611385e638b963bce3c06bb685d3655
  
      }
  
-@@ -113,11 +114,13 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+@@ -113,10 +114,12 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
  
      public boolean suckInItems() {
          if (HopperBlockEntity.suckInItems(this.level, this)) {
@@ -327,11 +327,10 @@ index c0b5f10d053654ba0e592289df0b9b4aff9a748f..a611385e638b963bce3c06bb685d3655
          } else {
              List<ItemEntity> list = this.level.getEntitiesOfClass(ItemEntity.class, this.getBoundingBox().inflate(0.25D, 0.0D, 0.25D), EntitySelector.ENTITY_STILL_ALIVE);
              if (!list.isEmpty()) {
-                 HopperBlockEntity.addItem(this, list.get(0));
-+                this.immunize();  // Paper
++                this.immunize(); // Paper
+                 return HopperBlockEntity.addItem(this, list.get(0)); // Paper - Return result for picked up items
              }
  
-             return false;
 @@ -155,4 +158,11 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
      public AbstractContainerMenu createMenu(int syncId, Inventory playerInventory) {
          return new HopperMenu(syncId, playerInventory, this);

--- a/patches/server/0344-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0344-Entity-Activation-Range-2.0.patch
@@ -307,7 +307,7 @@ index f957c0aca36b7228ac3a33ca04c948b1d10642d1..39fc94b1e1555fd6706391223dd27831
          super.customServerAiStep();
      }
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
-index 3f8990d15bd6815db0ccb924e621dfcc3220e0e0..70f1916185b79bbb9f033f4ef8119d7b17a13ef8 100644
+index 4ce983f131ff190c4c9b35ae0a6be46f6655b971..4f650f6e750feb0e703d3a41258b69252e3eb3d3 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/MinecartHopper.java
 @@ -57,6 +57,7 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
@@ -318,7 +318,7 @@ index 3f8990d15bd6815db0ccb924e621dfcc3220e0e0..70f1916185b79bbb9f033f4ef8119d7b
  
      }
  
-@@ -107,11 +108,13 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+@@ -108,11 +109,13 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
  
      public boolean suckInItems() {
          if (HopperBlockEntity.suckInItems(this.level, this)) {
@@ -332,7 +332,7 @@ index 3f8990d15bd6815db0ccb924e621dfcc3220e0e0..70f1916185b79bbb9f033f4ef8119d7b
              }
  
              return false;
-@@ -149,4 +152,11 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
+@@ -150,4 +153,11 @@ public class MinecartHopper extends AbstractMinecartContainer implements Hopper
      public AbstractContainerMenu createMenu(int syncId, Inventory playerInventory) {
          return new HopperMenu(syncId, playerInventory, this);
      }


### PR DESCRIPTION
Currently, hopper minecarts ignore the cooldown completely, as they never update the last position variable. (It only follows the cooldown if the hopper minecart is at 0,0,0) Mojang has this issue marked as [Works as Intended](https://bugs.mojang.com/browse/MC-65029?jql=text%20~%20%22TransferCooldown%22).

Therefore, I decided to fix this by not using this system and instead just correctly respecting when the cooldown is set. This is because paper sets the cooldown in some places, and I feel it's appropriate to have those applied to these hoppers as well.
This should ensure that the optimizations to hoppers properly have cooldowns applied to hopper minecarts (for example, if the hopper is full).

Another fix is to possibly just update the lastPosition, however, this will cause the optimization to perhaps skip the cooldown in some cases if the hopper minecart moves, which seems a bit silly, especially since this system isn't even used.

Feedback is needed on this if this should be the correct fix, a separate config to change the cooldown on minecart hoppers (currently the normal cooldown of hoppers / 2), or if we just fix the vanilla system.

Also, should this go in a separate patch? Or the optimized hopper patch?