### PR TITLE
Mark MaterialData related methods in ItemStack as deprecated

### DIFF
--- a/patches/api/0382-Mark-MaterialData-related-methods-in-ItemStack-as-De.patch
+++ b/patches/api/0382-Mark-MaterialData-related-methods-in-ItemStack-as-De.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: leguan <longboard.noah@gmail.com>
+Date: Fri, 13 May 2022 19:22:10 +0200
+Subject: [PATCH] Mark MaterialData related methods in ItemStack as Deprecated
+
+
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index 56897cfb96b53e43fec343568e514ee636ddd5c5..f9035d3235d1d5a3263d178e18e2987084bfed96 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -173,6 +173,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+      * @return MaterialData for this item
+      */
+     @Nullable
++    @Deprecated //paper
+     public MaterialData getData() {
+         Material mat = Bukkit.getUnsafe().toLegacy(getType());
+         if (data == null && mat != null && mat.getData() != null) {
+@@ -187,6 +188,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+      *
+      * @param data New MaterialData for this item
+      */
++    @Deprecated //paper
+     public void setData(@Nullable MaterialData data) {
+         if (data == null) {
+             this.data = data;
+@@ -247,6 +249,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+         return -1;
+     }
+ 
++    @Deprecated //paper
+     private void createData(final byte data) {
+         this.data = type.getNewData(data);
+     }


### PR DESCRIPTION
These methods are for the MaterialData class which is already marked as deprecated. 