### PR TITLE
Add Wither AlternativeTargets

### DIFF
--- a/patches/api/0384-Wither-AlternativeTargets-and-related-behaviour.patch
+++ b/patches/api/0384-Wither-AlternativeTargets-and-related-behaviour.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Wither AlternativeTargets and related behaviour
 
 
 diff --git a/src/main/java/org/bukkit/entity/Wither.java b/src/main/java/org/bukkit/entity/Wither.java
-index 8c95cd6933f11076de936854f379e6fc8600b525..2630d6d8f67dd5900b246002f245f9f7df7c0616 100644
+index 8c95cd6933f11076de936854f379e6fc8600b525..0b19063fd1f4d5531041d09d99dec9655e39d2db 100644
 --- a/src/main/java/org/bukkit/entity/Wither.java
 +++ b/src/main/java/org/bukkit/entity/Wither.java
-@@ -35,5 +35,27 @@ public interface Wither extends Monster, Boss, RangedEntity { // Paper
+@@ -35,5 +35,29 @@ public interface Wither extends Monster, Boss, RangedEntity { // Paper
       * @param value whether the wither can travel through portals
       */
      void setCanTravelThroughPortals(boolean value);
@@ -17,6 +17,8 @@ index 8c95cd6933f11076de936854f379e6fc8600b525..2630d6d8f67dd5900b246002f245f9f7
 +     * Get the target for a {@link Wither.HEAD}
 +     *
 +     * @param head the {@link Wither.HEAD}
++     *
++     * @return the {@link Entity} target or null
 +     */
 +    @org.jetbrains.annotations.Nullable
 +    Entity getAlternativeTarget(@org.jetbrains.annotations.NotNull Wither.HEAD head);

--- a/patches/api/0384-Wither-AlternativeTargets-and-related-behaviour.patch
+++ b/patches/api/0384-Wither-AlternativeTargets-and-related-behaviour.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Fri, 13 May 2022 17:10:47 -0400
+Subject: [PATCH] Wither AlternativeTargets and related behaviour
+
+
+diff --git a/src/main/java/org/bukkit/entity/Wither.java b/src/main/java/org/bukkit/entity/Wither.java
+index 8c95cd6933f11076de936854f379e6fc8600b525..2630d6d8f67dd5900b246002f245f9f7df7c0616 100644
+--- a/src/main/java/org/bukkit/entity/Wither.java
++++ b/src/main/java/org/bukkit/entity/Wither.java
+@@ -35,5 +35,27 @@ public interface Wither extends Monster, Boss, RangedEntity { // Paper
+      * @param value whether the wither can travel through portals
+      */
+     void setCanTravelThroughPortals(boolean value);
++
++    /**
++     * Get the target for a {@link Wither.HEAD}
++     *
++     * @param head the {@link Wither.HEAD}
++     */
++    @org.jetbrains.annotations.Nullable
++    Entity getAlternativeTarget(@org.jetbrains.annotations.NotNull Wither.HEAD head);
++
++    /**
++     * Set the target for a {@link Wither.HEAD}
++     *
++     * @param head the {@link Wither.HEAD}
++     * @param target the {@link Entity} to be the target or null for clear
++     */
++    void setAlternativeTarget(@org.jetbrains.annotations.NotNull Wither.HEAD head, @org.jetbrains.annotations.Nullable Entity target);
++
++    public enum HEAD {
++        CENTER,
++        RIGHT,
++        LEFT;
++    }
+     // Paper end
+ }

--- a/patches/server/0905-Wither-AlternativeTargets-and-related-behaviour.patch
+++ b/patches/server/0905-Wither-AlternativeTargets-and-related-behaviour.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Fri, 13 May 2022 17:12:23 -0400
+Subject: [PATCH] Wither AlternativeTargets and related behaviour
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
+index 299d5e47489cfe489ac130a33a08cdb29ba76d72..aded09dfbbcd085a6517864675de18f3178c7bcd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
+@@ -64,5 +64,31 @@ public class CraftWither extends CraftMonster implements Wither, com.destroystok
+     public void setCanTravelThroughPortals(boolean value) {
+         getHandle().setCanTravelThroughPortals(value);
+     }
++
++    @Override
++    public void setTarget(org.bukkit.entity.LivingEntity entity) {
++        super.setTarget(entity);
++        for (Wither.HEAD head : Wither.HEAD.values()) {
++            setAlternativeTarget(head, entity);
++        }
++    }
++
++    @Override
++    public org.bukkit.entity.Entity getAlternativeTarget(Wither.HEAD head) {
++        com.google.common.base.Preconditions.checkNotNull(head, "head cannot be null");
++        int entityId = getHandle().getAlternativeTarget(head.ordinal());
++        net.minecraft.world.entity.Entity entityNms = getHandle().getLevel().getEntity(entityId);
++        return (entityNms != null) ? entityNms.getBukkitEntity() : null;
++    }
++
++    @Override
++    public void setAlternativeTarget(Wither.HEAD head, org.bukkit.entity.Entity target) {
++        com.google.common.base.Preconditions.checkNotNull(head, "head cannot be null");
++        if (target != null) {
++            getHandle().setAlternativeTarget(head.ordinal(), ((CraftEntity) target).getHandle().getId());
++        } else {
++            getHandle().setAlternativeTarget(head.ordinal(), 0);
++        }
++    }
+     // Paper end
+ }


### PR DESCRIPTION
This PR close #7812 adding methods for get the targets for the "heads" of the Wither, this values are a temp value used for withers in attacks, this PR too change the logic for Wither#setTarget making the change affect all the heads.