### PR TITLE
Add EntityBrainMemoryRemoveEvent

### DIFF
--- a/patches/api/0384-Add-EntityBrainMemoryRemoveEvent.patch
+++ b/patches/api/0384-Add-EntityBrainMemoryRemoveEvent.patch
@@ -6,14 +6,13 @@ Subject: [PATCH] Add EntityBrainMemoryRemoveEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityBrainMemoryRemoveEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityBrainMemoryRemoveEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..18d6c9c70e849c984dbe3c657df0e5b3bc384a0a
+index 0000000000000000000000000000000000000000..e9738dd17ff894fa1bdfb82eeae9591db9e3a402
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityBrainMemoryRemoveEvent.java
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,46 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.Entity;
-+import org.bukkit.entity.LivingEntity;
 +import org.bukkit.entity.memory.MemoryKey;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
@@ -22,7 +21,7 @@ index 0000000000000000000000000000000000000000..18d6c9c70e849c984dbe3c657df0e5b3
 +
 +public class EntityBrainMemoryRemoveEvent extends EntityEvent implements Cancellable {
 +
-+    private static final HandlerList HANDLER_LIST = new HandlerList();
++    private static final HandlerList handlers = new HandlerList();
 +
 +    private boolean cancelled;
 +    private final MemoryKey<?> memoryToBeRemoved;
@@ -44,11 +43,16 @@ index 0000000000000000000000000000000000000000..18d6c9c70e849c984dbe3c657df0e5b3
 +
 +    @Override
 +    public @NotNull HandlerList getHandlers() {
-+        return HANDLER_LIST;
++        return handlers;
 +    }
 +
 +    public MemoryKey<?> getMemoryToBeRemoved() {
 +        return memoryToBeRemoved;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
 +    }
 +
 +}

--- a/patches/api/0384-Add-EntityBrainMemoryRemoveEvent.patch
+++ b/patches/api/0384-Add-EntityBrainMemoryRemoveEvent.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Togira <70365614+Togira123@users.noreply.github.com>
+Date: Sun, 15 May 2022 18:10:11 +0200
+Subject: [PATCH] Add EntityBrainMemoryRemoveEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityBrainMemoryRemoveEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityBrainMemoryRemoveEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..18d6c9c70e849c984dbe3c657df0e5b3bc384a0a
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityBrainMemoryRemoveEvent.java
+@@ -0,0 +1,42 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.memory.MemoryKey;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.NotNull;
++
++public class EntityBrainMemoryRemoveEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private boolean cancelled;
++    private final MemoryKey<?> memoryToBeRemoved;
++
++    public EntityBrainMemoryRemoveEvent(@NotNull Entity what, MemoryKey<?> memoryToBeRemoved) {
++        super(what);
++        this.memoryToBeRemoved = memoryToBeRemoved;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public MemoryKey<?> getMemoryToBeRemoved() {
++        return memoryToBeRemoved;
++    }
++
++}

--- a/patches/api/0385-Add-missing-annotations.patch
+++ b/patches/api/0385-Add-missing-annotations.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Togira <70365614+Togira123@users.noreply.github.com>
+Date: Tue, 17 May 2022 13:21:44 +0200
+Subject: [PATCH] Add missing annotations
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityBrainMemoryRemoveEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityBrainMemoryRemoveEvent.java
+index e9738dd17ff894fa1bdfb82eeae9591db9e3a402..818229c67fd5b3c3534f670492ba4a4d674468d4 100644
+--- a/src/main/java/io/papermc/paper/event/entity/EntityBrainMemoryRemoveEvent.java
++++ b/src/main/java/io/papermc/paper/event/entity/EntityBrainMemoryRemoveEvent.java
+@@ -14,7 +14,7 @@ public class EntityBrainMemoryRemoveEvent extends EntityEvent implements Cancell
+     private boolean cancelled;
+     private final MemoryKey<?> memoryToBeRemoved;
+ 
+-    public EntityBrainMemoryRemoveEvent(@NotNull Entity what, MemoryKey<?> memoryToBeRemoved) {
++    public EntityBrainMemoryRemoveEvent(@NotNull Entity what, @NotNull MemoryKey<?> memoryToBeRemoved) {
+         super(what);
+         this.memoryToBeRemoved = memoryToBeRemoved;
+     }
+@@ -29,11 +29,13 @@ public class EntityBrainMemoryRemoveEvent extends EntityEvent implements Cancell
+         cancelled = cancel;
+     }
+ 
++    @NotNull
+     @Override
+-    public @NotNull HandlerList getHandlers() {
++    public HandlerList getHandlers() {
+         return handlers;
+     }
+ 
++    @NotNull
+     public MemoryKey<?> getMemoryToBeRemoved() {
+         return memoryToBeRemoved;
+     }

--- a/patches/server/0905-Add-LivingEntity-field-to-Brain-add-EntityBrainMemor.patch
+++ b/patches/server/0905-Add-LivingEntity-field-to-Brain-add-EntityBrainMemor.patch
@@ -1,0 +1,141 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Togira <70365614+Togira123@users.noreply.github.com>
+Date: Sun, 15 May 2022 18:31:03 +0200
+Subject: [PATCH] Add LivingEntity field to Brain & add
+ EntityBrainMemoryRemoveEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index bd5825c5b5c81e0694a3635b981588f0d2ba83cb..e368d9b7376ae5b961259d429627ebde09c3a429 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -311,7 +311,7 @@ public abstract class LivingEntity extends Entity {
+     }
+ 
+     protected Brain<?> makeBrain(Dynamic<?> dynamic) {
+-        return this.brainProvider().makeBrain(dynamic);
++        return this.brainProvider().makeBrain(dynamic, this); // Paper - add an entity reference to the brain
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/world/entity/ai/Brain.java b/src/main/java/net/minecraft/world/entity/ai/Brain.java
+index 32456644dfd2e45dfc02cd1fa77d7afd9e1db1e9..0c7052588cd87d4138b408e44151611255ef5bc9 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/Brain.java
++++ b/src/main/java/net/minecraft/world/entity/ai/Brain.java
+@@ -38,6 +38,7 @@ import net.minecraft.world.entity.ai.sensing.SensorType;
+ import net.minecraft.world.entity.schedule.Activity;
+ import net.minecraft.world.entity.schedule.Schedule;
+ import org.apache.commons.lang3.mutable.MutableObject;
++import org.bukkit.craftbukkit.entity.memory.CraftMemoryKey; // Paper
+ import org.slf4j.Logger;
+ 
+ public class Brain<E extends LivingEntity> {
+@@ -54,6 +55,7 @@ public class Brain<E extends LivingEntity> {
+     private final Set<Activity> activeActivities = Sets.newHashSet();
+     private Activity defaultActivity = Activity.IDLE;
+     private long lastScheduleUpdate = -9999L;
++    private LivingEntity owner; // Paper - the entity that belongs to this brain
+ 
+     public static <E extends LivingEntity> Brain.Provider<E> provider(Collection<? extends MemoryModuleType<?>> memoryModules, Collection<? extends SensorType<? extends Sensor<? super E>>> sensors) {
+         return new Brain.Provider<>(memoryModules, sensors);
+@@ -105,8 +107,9 @@ public class Brain<E extends LivingEntity> {
+         return mutableObject.getValue();
+     }
+ 
+-    public Brain(Collection<? extends MemoryModuleType<?>> memories, Collection<? extends SensorType<? extends Sensor<? super E>>> sensors, ImmutableList<Brain.MemoryValue<?>> memoryEntries, Supplier<Codec<Brain<E>>> codecSupplier) {
++    public Brain(Collection<? extends MemoryModuleType<?>> memories, Collection<? extends SensorType<? extends Sensor<? super E>>> sensors, ImmutableList<Brain.MemoryValue<?>> memoryEntries, Supplier<Codec<Brain<E>>> codecSupplier, LivingEntity owner) { // Paper
+         this.codec = codecSupplier;
++        this.owner = owner; // Paper - add the entity reference to the brain
+ 
+         for(MemoryModuleType<?> memoryModuleType : memories) {
+             this.memories.put(memoryModuleType, Optional.empty());
+@@ -143,7 +146,9 @@ public class Brain<E extends LivingEntity> {
+     }
+ 
+     public <U> void eraseMemory(MemoryModuleType<U> type) {
+-        this.setMemory(type, Optional.empty());
++        if (new io.papermc.paper.event.entity.EntityBrainMemoryRemoveEvent(owner.getBukkitLivingEntity(), CraftMemoryKey.toMemoryKey(type)).callEvent()) { // Paper - Add EntityBrainMemoryRemoveEvent
++            this.setMemory(type, Optional.empty());
++        }
+     }
+ 
+     public <U> void setMemory(MemoryModuleType<U> type, @Nullable U value) {
+@@ -496,11 +501,11 @@ public class Brain<E extends LivingEntity> {
+             this.codec = Brain.codec(memoryModules, sensors);
+         }
+ 
+-        public Brain<E> makeBrain(Dynamic<?> data) {
++        public Brain<E> makeBrain(Dynamic<?> data, LivingEntity entity) { // Paper - add an entity reference to the brain
+             return this.codec.parse(data).resultOrPartial(Brain.LOGGER::error).orElseGet(() -> {
+                 return new Brain<>(this.memoryTypes, this.sensorTypes, ImmutableList.of(), () -> {
+                     return this.codec;
+-                });
++                }, entity);
+             });
+         }
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java b/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java
+index e5617c013f1bd6f89dfbb2ccd404489180cd0573..18200292df299f0fbaafe8b870026c34b88fd3da 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java
++++ b/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java
+@@ -480,7 +480,7 @@ public class Axolotl extends Animal implements LerpingModel, Bucketable {
+ 
+     @Override
+     protected Brain<?> makeBrain(Dynamic<?> dynamic) {
+-        return AxolotlAi.makeBrain(this.brainProvider().makeBrain(dynamic));
++        return AxolotlAi.makeBrain(this.brainProvider().makeBrain(dynamic, this)); // Paper - add an entity reference to the brain
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
+index 78f1082b0a3bad923c1e142d15bc7dad2ae5ff15..eab0afe63ae09d3d38d867673bc9f7519b20c9c8 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
++++ b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
+@@ -76,7 +76,7 @@ public class Goat extends Animal {
+ 
+     @Override
+     protected Brain<?> makeBrain(Dynamic<?> dynamic) {
+-        return GoatAi.makeBrain(this.brainProvider().makeBrain(dynamic));
++        return GoatAi.makeBrain(this.brainProvider().makeBrain(dynamic, this)); // Paper - add an entity reference to the brain
+     }
+ 
+     public static AttributeSupplier.Builder createAttributes() {
+diff --git a/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java b/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java
+index 49ca4f6a9e33fdb5295dae2b059d071551353c24..4779515654b666b0346b2ed10e4dc01afcf7346a 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java
++++ b/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java
+@@ -118,7 +118,7 @@ public class Hoglin extends Animal implements Enemy, HoglinBase {
+ 
+     @Override
+     protected Brain<?> makeBrain(Dynamic<?> dynamic) {
+-        return HoglinAi.makeBrain(this.brainProvider().makeBrain(dynamic));
++        return HoglinAi.makeBrain(this.brainProvider().makeBrain(dynamic, this)); // Paper - add an entity reference to the brain
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/world/entity/monster/piglin/Piglin.java b/src/main/java/net/minecraft/world/entity/monster/piglin/Piglin.java
+index 63cfda124b5bad20af3050a0b62d73883b6abf7d..e02f8534828858dc5f99948caa90780fb725fc59 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/piglin/Piglin.java
++++ b/src/main/java/net/minecraft/world/entity/monster/piglin/Piglin.java
+@@ -227,7 +227,7 @@ public class Piglin extends AbstractPiglin implements CrossbowAttackMob, Invento
+ 
+     @Override
+     protected Brain<?> makeBrain(Dynamic<?> dynamic) {
+-        return PiglinAi.makeBrain(this, this.brainProvider().makeBrain(dynamic));
++        return PiglinAi.makeBrain(this, this.brainProvider().makeBrain(dynamic, this)); // Paper - add an entity reference to the brain
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
+index 268524e256a034520438d5c825e5e419d72d29ce..01211c1d6925d62765cfaef7e758dd85b50182d1 100644
+--- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
++++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
+@@ -165,7 +165,7 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+ 
+     @Override
+     protected Brain<?> makeBrain(Dynamic<?> dynamic) {
+-        Brain<Villager> behaviorcontroller = this.brainProvider().makeBrain(dynamic);
++        Brain<Villager> behaviorcontroller = this.brainProvider().makeBrain(dynamic, this); // Paper - add an entity reference to the brain
+ 
+         this.registerBrainGoals(behaviorcontroller);
+         return behaviorcontroller;


### PR DESCRIPTION
This adds an event named EntityBrainMemoryRemoveEvent which fires when an entity's memory is removed from its Brain. It can be cancelled, which causes this memory not to be deleted.