### PR TITLE
Explosion Resistance API

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -336,3 +336,5 @@ public net.minecraft.world.entity.projectile.FishingHook timeUntilLured
 # Teleport API
 public net.minecraft.server.network.ServerGamePacketListenerImpl internalTeleport(DDDFFLjava/util/Set;Z)V
 
+# Explosion Resistance API
+public-f net.minecraft.world.level.block.state.BlockBehaviour explosionResistance

--- a/patches/api/0392-Explosion-Resistance-API.patch
+++ b/patches/api/0392-Explosion-Resistance-API.patch
@@ -1,0 +1,161 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Peter Crawley <peterzcrawley@gmail.com>
+Date: Mon, 16 May 2022 13:56:53 +0100
+Subject: [PATCH] Explosion Resistance API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 840aaf9e8fc828b5a7ea02252038c6524680f2e0..b2a59bc124041ee40a4b8af4d6b008054d8d12f5 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -2436,6 +2436,45 @@ public final class Bukkit {
+     public static @NotNull org.bukkit.potion.PotionBrewer getPotionBrewer() {
+         return server.getPotionBrewer();
+     }
++
++    /**
++     * Gets the explosion resistance of the material
++     * @param material Material to get the explosion resistance of
++     * @return The explosion resistance
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    public static float getExplosionResistance(@NotNull Material material) throws IllegalArgumentException {
++        return server.getExplosionResistance(material);
++    }
++
++    /**
++     * Sets the explosion resistance of the material
++     * @param material Material to set the explosion resistance of
++     * @param value Value to set the explosion resistance to
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    public static void setExplosionResistance(@NotNull Material material, float value) throws IllegalArgumentException {
++        server.setExplosionResistance(material, value);
++    }
++
++    /**
++     * Gets the vanilla explosion resistance of the material
++     * @param material Material to get the vanilla explosion resistance of
++     * @return The vanilla explosion resistance
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    public static float getDefaultExplosionResistance(@NotNull Material material) throws IllegalArgumentException {
++        return server.getDefaultExplosionResistance(material);
++    }
++
++    /**
++     * Resets the explosion resistance of the material to the vanilla value
++     * @param material Material to reset the explosion resistance of
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    public static void resetExplosionResistance(@NotNull Material material) throws IllegalArgumentException {
++        server.resetExplosionResistance(material);
++    }
+     // Paper end
+ 
+     @NotNull
+diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
+index 1d6baee05643607baa40a07022576906ea61a92f..33250e62cf41c824a11ca643beca492de6599123 100644
+--- a/src/main/java/org/bukkit/Material.java
++++ b/src/main/java/org/bukkit/Material.java
+@@ -9256,8 +9256,12 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+      * Only available when {@link #isBlock()} is true.
+      *
+      * @return the blast resistance of that material.
++     * @deprecated Renamed to getExplosionResistance
+      */
++    @Deprecated // Paper - Explosion Resistance API
+     public float getBlastResistance() {
++        return getExplosionResistance(); // Paper - Explosion Resistance API
++        /*
+         Preconditions.checkArgument(isBlock(), "The Material is not a block!");
+         switch (this) {
+             // <editor-fold defaultstate="collapsed" desc="getBlastResistance">
+@@ -10076,8 +10080,46 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+                 return 0;
+             // </editor-fold>
+         }
++        */
+     }
+ 
++    // Paper start - Explosion Resistance API
++    /**
++     * Gets the explosion resistance of the material
++     * @return The explosion resistance
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    public float getExplosionResistance() throws IllegalArgumentException {
++        return Bukkit.getExplosionResistance(this);
++    }
++
++    /**
++     * Sets the explosion resistance of the material
++     * @param value Value to set the explosion resistance to
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    public void setExplosionResistance(float value) throws IllegalArgumentException {
++        Bukkit.setExplosionResistance(this, value);
++    }
++
++    /**
++     * Gets the vanilla explosion resistance of the material
++     * @return The vanilla explosion resistance
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    public float getDefaultExplosionResistance() throws IllegalArgumentException {
++        return Bukkit.getDefaultExplosionResistance(this);
++    }
++
++    /**
++     * Resets the explosion resistance of the material to the vanilla value
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    public void resetExplosionResistance() throws IllegalArgumentException {
++        Bukkit.resetExplosionResistance(this);
++    }
++    // Paper end - Explosion Resistance API
++
+     /**
+      * Returns a value that represents how 'slippery' the block is.
+      *
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index da5cab4246bd253fcc4e4d9574bdae1867ebb5ab..400b6995003086027aa221cbf47db758125da610 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -2115,5 +2115,36 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @return the potion brewer
+      */
+     @NotNull org.bukkit.potion.PotionBrewer getPotionBrewer();
++
++    /**
++     * Gets the explosion resistance of the material
++     * @param material Material to get the explosion resistance of
++     * @return The explosion resistance
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    float getExplosionResistance(@NotNull Material material) throws IllegalArgumentException;
++
++    /**
++     * Sets the explosion resistance of the material
++     * @param material Material to set the explosion resistance of
++     * @param value Value to set the explosion resistance to
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    void setExplosionResistance(@NotNull Material material, float value) throws IllegalArgumentException;
++
++    /**
++     * Gets the vanilla explosion resistance of the material
++     * @param material Material to get the vanilla explosion resistance of
++     * @return The vanilla explosion resistance
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    float getDefaultExplosionResistance(@NotNull Material material) throws IllegalArgumentException;
++
++    /**
++     * Resets the explosion resistance of the material to the vanilla value
++     * @param material Material to reset the explosion resistance of
++     * @throws IllegalArgumentException if Material is not a block
++     */
++    void resetExplosionResistance(@NotNull Material material) throws IllegalArgumentException;
+     // Paper end
+ }

--- a/patches/server/0936-Explosion-Resistance-API.patch
+++ b/patches/server/0936-Explosion-Resistance-API.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Peter Crawley <peterzcrawley@gmail.com>
+Date: Mon, 16 May 2022 13:55:32 +0100
+Subject: [PATCH] Explosion Resistance API
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
+index 35c44833ea75f663801cb488171cf5df59b1e366..440a4fa148ba591e3785b9fe3f363c97395f97f3 100644
+--- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
++++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
+@@ -76,6 +76,7 @@ public abstract class BlockBehaviour {
+     protected final Material material;
+     public final boolean hasCollision;
+     public float explosionResistance;
++    public final float defaultExplosionResistance; // Paper - Explosion Resistance API
+     protected final boolean isRandomlyTicking;
+     protected final SoundType soundType;
+     protected final float friction;
+@@ -91,6 +92,7 @@ public abstract class BlockBehaviour {
+         this.hasCollision = settings.hasCollision;
+         this.drops = settings.drops;
+         this.explosionResistance = settings.explosionResistance;
++        this.defaultExplosionResistance = settings.explosionResistance; // Paper - Explosion Resistance API
+         this.isRandomlyTicking = settings.isRandomlyTicking;
+         this.soundType = settings.soundType;
+         this.friction = settings.friction;
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index b443aba38258f501f8f00be6b055f07b709277c4..6b2ec673b11c0b59d1ff0b7e3b5f7627247f936e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -2905,5 +2905,27 @@ public final class CraftServer implements Server {
+         return this.potionBrewer;
+     }
+ 
++    @Override
++    public float getExplosionResistance(org.bukkit.Material material) {
++        if (!material.isBlock()) throw new IllegalArgumentException("Material is not Block");
++        return CraftMagicNumbers.getBlock(material).explosionResistance;
++    }
++
++    @Override
++    public void setExplosionResistance(org.bukkit.Material material, float value) {
++        if (!material.isBlock()) throw new IllegalArgumentException("Material is not Block");
++        CraftMagicNumbers.getBlock(material).explosionResistance = value;
++    }
++
++    @Override
++    public float getDefaultExplosionResistance(org.bukkit.Material material) {
++        if (!material.isBlock()) throw new IllegalArgumentException("Material is not Block");
++        return CraftMagicNumbers.getBlock(material).defaultExplosionResistance;
++    }
++
++    @Override
++    public void resetExplosionResistance(org.bukkit.Material material) {
++        setExplosionResistance(material, getDefaultExplosionResistance(material));
++    }
+     // Paper end
+ }
+diff --git a/src/test/java/org/bukkit/support/DummyServer.java b/src/test/java/org/bukkit/support/DummyServer.java
+index 2ddceb709291d3bd713621ffa4020c02ec26bb21..0e3c4bb26e9b41b3d2d9e4cfa59ad77d3a16907f 100644
+--- a/src/test/java/org/bukkit/support/DummyServer.java
++++ b/src/test/java/org/bukkit/support/DummyServer.java
+@@ -116,6 +116,9 @@ public final class DummyServer implements InvocationHandler {
+                     }
+                 }
+             );
++            methods.put(Server.class.getMethod("getExplosionResistance", Material.class),
++                (server, args) -> CraftMagicNumbers.getBlock(((Material) args[0])).explosionResistance
++            );
+             DummyServer server = new DummyServer();
+             Server instance = Proxy.getProxyClass(Server.class.getClassLoader(), Server.class).asSubclass(Server.class).getConstructor(InvocationHandler.class).newInstance(server);
+             Bukkit.setServer(instance);


### PR DESCRIPTION
Adds API functions to `Bukkit`, `Server`, and `Material` to allow changing the explosion resistance of blocks without using NMS or Reflection which is the current method used to acomplish this.

As `Material` does not have a CraftBukkit implementation the functions to alter the resistance is part of `Server`, these functions are aliased in `Bukkit` and `Material` for easy access.

The existing `getBlastResistance` function has been deprecated as the name "explosion resistance" is used by Mojang Mappings. The function also previously used a switch statement to define the explosion resistance which has been commented out in favor of using the actually values.

A `defaultExplosionResistance` has been added to BlockBehaviour which stores the initial value, allowing a plugin to reset the explosion resistance to the value specified by vanilla minecraft.