### PR TITLE
Add metrics for datapack usage 

### DIFF
--- a/patches/server/0010-Paper-Metrics.patch
+++ b/patches/server/0010-Paper-Metrics.patch
@@ -15,10 +15,10 @@ decisions on behalf of the project.
 
 diff --git a/src/main/java/com/destroystokyo/paper/Metrics.java b/src/main/java/com/destroystokyo/paper/Metrics.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e3b74dbdf8e14219a56fab939f3174e0c2f66de6
+index 0000000000000000000000000000000000000000..a15b3501cc2eae80ebfc96299854408352d849fd
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/Metrics.java
-@@ -0,0 +1,670 @@
+@@ -0,0 +1,692 @@
 +package com.destroystokyo.paper;
 +
 +import net.minecraft.server.MinecraftServer;
@@ -684,13 +684,35 @@ index 0000000000000000000000000000000000000000..e3b74dbdf8e14219a56fab939f3174e0
 +
 +                    return map;
 +                }));
-+            }
 +
++                metrics.addCustomChart(new Metrics.DrilldownPie("datapacks", () -> {
++                    Map<String, Map<String, Integer>> map = new HashMap<>();
++                    int datapacks = Bukkit.getServer().getDatapackManager().getEnabledPacks().size();
++
++                    // Same as above
++                    Map<String, Integer> entry = new HashMap<>();
++                    entry.put(String.valueOf(datapacks), 1);
++
++                    if (datapacks == 0) {
++                        map.put("0", entry);
++                    } else if (datapacks <= 5) {
++                        map.put("1-5", entry);
++                    } else if (datapacks <= 10) {
++                        map.put("6-10", entry);
++                    } else if (datapacks <= 20) {
++                        map.put("11-20", entry);
++                    } else {
++                        map.put("20+", entry);
++                    }
++
++                    return map;
++                }));
++            }
 +        }
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 15927e8b747e536a5136d9b59edc8d6f50354c42..64511d966043ca5a3c2b8588ef387ea37bf2de93 100644
+index c1eb4201ecb0541c606ef0d05b828ae9c87c8a2c..52e9dca37dab4cacdded3b084c40d4dd75182bb5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -42,6 +42,7 @@ public class PaperConfig {


### PR DESCRIPTION
This PR adds a bstats metrics chart for the amount of enabled datapacks, very similar to the [already existing chart](https://bstats.org/plugin/server-implementation/Paper/580#legacy_plugins) for legacy plugins.

This can be used to make data-based decisions on changes like the dimension storage rework (https://github.com/PaperMC/Paper/pull/7594).

Of course the `datapacks` chart needs to be added to bstats as well for this to work. 
Also data about the type of datapack (e.g. worldgen, loot or dimensions) would be very useful as well, but I have not found a way to get it other than looking at the files directly, and that seems a bit messy. 

cat talked about _maybe_ doing this on Discord so I thought I just make a quick PR. I added the changes to the existing metrics patch, that seemed to be the right place