### PR TITLE
[ci skip] Update repository and API urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ How To (Plugin Developers)
 ```xml
 <repository>
     <id>papermc</id>
-    <url>https://papermc.io/repo/repository/maven-public/</url>
+    <url>https://repo.papermc.io/repository/maven-public/</url>
 </repository>
 ```
  * Artifact Information:
@@ -49,7 +49,7 @@ How To (Plugin Developers)
 ```kotlin
 repositories {
     maven {
-        url = uri("https://papermc.io/repo/repository/maven-public/")
+        url = uri("https://repo.papermc.io/repository/maven-public/")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ allprojects {
     }
 }
 
-val paperMavenPublicUrl = "https://papermc.io/repo/repository/maven-public/"
+val paperMavenPublicUrl = "https://repo.papermc.io/repository/maven-public/"
 
 subprojects {
     tasks.withType<JavaCompile> {
@@ -123,7 +123,7 @@ publishing {
 allprojects {
     publishing {
         repositories {
-            maven("https://papermc.io/repo/repository/maven-snapshots/") {
+            maven("https://repo.papermc.io/repository/maven-snapshots/") {
                 name = "paperSnapshots"
                 credentials(PasswordCredentials::class)
             }

--- a/patches/server/0021-Implement-Paper-VersionChecker.patch
+++ b/patches/server/0021-Implement-Paper-VersionChecker.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement Paper VersionChecker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..91d7afc710a2d52b4f429e0381cf64176ecb6415
+index 0000000000000000000000000000000000000000..351159bbdb0c8045f4983f54dee34430dbcc423e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 @@ -0,0 +1,129 @@
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..91d7afc710a2d52b4f429e0381cf6417
 +        if (siteApiVersion == null) { return -1; }
 +        try {
 +            try (BufferedReader reader = Resources.asCharSource(
-+                new URL("https://papermc.io/api/v2/projects/paper/versions/" + siteApiVersion),
++                new URL("https://api.papermc.io/v2/projects/paper/versions/" + siteApiVersion),
 +                Charsets.UTF_8
 +            ).openBufferedStream()) {
 +                JsonObject json = new Gson().fromJson(reader, JsonObject.class);

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@ import java.util.Locale
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven("https://papermc.io/repo/repository/maven-public/")
+        maven("https://repo.papermc.io/repository/maven-public/")
     }
 }
 


### PR DESCRIPTION
Same as [9936e2b](https://github.com/PaperMC/papermc.io/commit/9936e2b85c65edb5a7ecb06c960988ec0097793d) and [0f41894](https://github.com/PaperMC/docs/commit/0f41894b9b2d41568f0ab0e4670117a4996a84bb) but for paper itself.