### PR TITLE
Fix more upstream javadocs

### DIFF
--- a/patches/api/0054-Fix-upstream-javadocs.patch
+++ b/patches/api/0054-Fix-upstream-javadocs.patch
@@ -19,10 +19,25 @@ index a5868c0bdee345195e279467b526d5d9ff7f64d2..ece84330d2700db8708d2ae2ab7badf4
       * @return an array containing all previous players
       */
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index acd69a5d946974e0b50439a98712750698768ce5..3c987b2fb0f748ce92a87c4ee54a4e9722e1910e 100644
+index acd69a5d946974e0b50439a98712750698768ce5..0053327f3df85a568befc280b53a0eb34e0510d8 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1110,6 +1110,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -509,13 +509,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * </ul>
+      * <p>
+      * <b>Note:</b> If set to 0, {@link SpawnCategory} mobs spawning will be disabled.
+-     * <p>
+-     * Minecraft default: 1.
+-     * <br>
+-     * <b>Note: </b> the {@link SpawnCategory#MISC} are not consider.
+      *
+      * @param spawnCategory the category of spawn
+      * @return the default ticks per {@link SpawnCategory} mobs spawn value
++     * @throws IllegalArgumentException if the category is {@link SpawnCategory#MISC}
+      */
+     public int getTicksPerSpawns(@NotNull SpawnCategory spawnCategory);
+ 
+@@ -1110,6 +1107,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
  
      /**
       * Gets every player that has ever played on this server.

--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -377,10 +377,10 @@ index ece84330d2700db8708d2ae2ab7badf4acb428a8..90c875ad60e473c3ec25f209933d4861
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 3c987b2fb0f748ce92a87c4ee54a4e9722e1910e..9796ae6fcf605af88c1e5c1d29d77ea6857632cc 100644
+index 0053327f3df85a568befc280b53a0eb34e0510d8..451eefff2e6350072d47f59c0e33cca499c5427b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1838,5 +1838,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1835,5 +1835,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 621420d35378e0038c33892c185216894912f023..82387e0c8477f5baa6bd473505b0e0aad6e78268 100644
+index 90c875ad60e473c3ec25f209933d48615d0fd6c0..39f97dac6af70b45101a7de776009c4fa3874868 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1176,8 +1176,10 @@ public final class Bukkit {
@@ -43,10 +43,10 @@ index 621420d35378e0038c33892c185216894912f023..82387e0c8477f5baa6bd473505b0e0aa
          return server.createPlayerProfile(name);
      }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 58c8e74b61dd4d952919a854a374ae7b4c3e02c0..e196903e2e4d619603f445713cee36ea402fc55e 100644
+index 451eefff2e6350072d47f59c0e33cca499c5427b..4597c9b2e4691495b54333711141b83926af193d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1001,8 +1001,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -998,8 +998,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if both the unique id is
       * <code>null</code> and the name is <code>null</code> or blank
@@ -57,7 +57,7 @@ index 58c8e74b61dd4d952919a854a374ae7b4c3e02c0..e196903e2e4d619603f445713cee36ea
      PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name);
  
      /**
-@@ -1011,8 +1013,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1008,8 +1010,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param uniqueId the unique id
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the unique id is <code>null</code>
@@ -68,7 +68,7 @@ index 58c8e74b61dd4d952919a854a374ae7b4c3e02c0..e196903e2e4d619603f445713cee36ea
      PlayerProfile createPlayerProfile(@NotNull UUID uniqueId);
  
      /**
-@@ -1022,8 +1026,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1019,8 +1023,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the name is <code>null</code> or
       * blank

--- a/patches/api/0092-getPlayerUniqueId-API.patch
+++ b/patches/api/0092-getPlayerUniqueId-API.patch
@@ -9,7 +9,7 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index aae3eec8d28a0047bc590ecc55d87d11ee6d08f0..8875c963e358d1db37ecef7312e7608c89040013 100644
+index 39f97dac6af70b45101a7de776009c4fa3874868..098a09baa481f76e63991268d3dfabc413626fcf 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -656,6 +656,20 @@ public final class Bukkit {
@@ -34,10 +34,10 @@ index aae3eec8d28a0047bc590ecc55d87d11ee6d08f0..8875c963e358d1db37ecef7312e7608c
       * Gets the plugin manager for interfacing with plugins.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 51c96a0b6645cf31f4ca051f6a8c75b5f188484c..30d905685b336c7127445ac1d1946334ee954416 100644
+index 4597c9b2e4691495b54333711141b83926af193d..2042f4963c53d5a903f0de1fec6a9af3a7b2bba4 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -561,6 +561,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -558,6 +558,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      public Player getPlayer(@NotNull UUID id);
  

--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -25,10 +25,10 @@ index 098a09baa481f76e63991268d3dfabc413626fcf..ca6f3a18ca8902b99c1c8c21b6da5def
       * Creates a PlayerProfile for the specified uuid, with name as null.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 2642be263b4201ce572386bbaf3434b5af836e8d..28be40d6844f801c26e8359e509afc5e3dedd71f 100644
+index 2042f4963c53d5a903f0de1fec6a9af3a7b2bba4..b8ed8d5d48cb4f1b2f598e2c48e4423ab2d899f4 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1857,6 +1857,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1854,6 +1854,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  

--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -168,10 +168,10 @@ index 6277451c3c6c551078c237cd767b6d70c4f585ea..10f5cfb1885833a1d2c1027c03974da4
      CRACKED(0x0),
      GLYPHED(0x1),
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 28be40d6844f801c26e8359e509afc5e3dedd71f..e0ad194697b0333e760ee5d66dac406921018479 100644
+index b8ed8d5d48cb4f1b2f598e2c48e4423ab2d899f4..102ce4e488d5b6fd4a19766e9fa02d29075b2c33 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -985,10 +985,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -982,10 +982,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param name the name the player to retrieve
       * @return an offline player
       * @see #getOfflinePlayer(java.util.UUID)
@@ -183,7 +183,7 @@ index 28be40d6844f801c26e8359e509afc5e3dedd71f..e0ad194697b0333e760ee5d66dac4069
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  
-@@ -1445,7 +1443,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1442,7 +1440,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */

--- a/patches/api/0183-Expose-the-internal-current-tick.patch
+++ b/patches/api/0183-Expose-the-internal-current-tick.patch
@@ -20,10 +20,10 @@ index b4256e2c66e3f578a4499dc1fff50f213898b96b..6a2cf46d54ae6c93e95e78c5fa98e6ae
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e0ad194697b0333e760ee5d66dac406921018479..f635c7b16b382309eac8bb8ce659d5d862365e94 100644
+index 102ce4e488d5b6fd4a19766e9fa02d29075b2c33..ad1d73940908f4f20a4944e81b186739fded20ab 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1930,5 +1930,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1927,5 +1927,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0189-Add-tick-times-API.patch
+++ b/patches/api/0189-Add-tick-times-API.patch
@@ -35,10 +35,10 @@ index 6a2cf46d54ae6c93e95e78c5fa98e6aef48c168f..c1e1a311ea5fb4826f6b400b098262e1
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f635c7b16b382309eac8bb8ce659d5d862365e94..c437c7f95d642e2816c30ed43492a70c1735f80a 100644
+index ad1d73940908f4f20a4944e81b186739fded20ab..6fe653a2a0fd4f07d39ed584bc11688d4926d54e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1617,6 +1617,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1614,6 +1614,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0190-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0190-Expose-MinecraftServer-isRunning.patch
@@ -26,10 +26,10 @@ index c1e1a311ea5fb4826f6b400b098262e177e22318..96f1619a188d569398bbc2bb8ff0b4bd
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index c437c7f95d642e2816c30ed43492a70c1735f80a..86556846d4daa60ada23043993ab76d7b3a8fa47 100644
+index 6fe653a2a0fd4f07d39ed584bc11688d4926d54e..d59a7e0c9ec50040fb0b2cc3239cae46760aba04 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1952,5 +1952,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1949,5 +1949,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0200-Add-Mob-Goal-API.patch
+++ b/patches/api/0200-Add-Mob-Goal-API.patch
@@ -544,10 +544,10 @@ index 08ac59d4f0935a79323ff34eb585b8a5b5a072b4..21b026aa0f53cf2608b64f9603185562
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d318ba9b21ca9f561f6e485c58af379e8e5210af..01d6d0a9ea3dec63d735a0e4f08777ddc8bb7199 100644
+index 9b2c1eb7e215a9227c60bc85906fed33ec1dd60a..c11d802408c793c6410118bd281a21e59394066f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1969,5 +1969,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1966,5 +1966,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0228-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0228-Add-getOfflinePlayerIfCached-String.patch
@@ -37,10 +37,10 @@ index f9fdb1882a283e47604136a27d1c95266b988a37..8072924c977e0a23ee743ca8d613b9ea
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 4f91e4e73b98d279fe395ba32da8a784392c5208..6deaae052cfee5b2233993f8fbc04f11f11214b7 100644
+index a7ba813396fab77bed292422f881b5a0952972fb..afed6bcf923166065ac9f63dd96191cd42eefcb9 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1009,6 +1009,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1006,6 +1006,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  

--- a/patches/api/0276-Add-methods-to-get-world-by-key.patch
+++ b/patches/api/0276-Add-methods-to-get-world-by-key.patch
@@ -28,10 +28,10 @@ index 8072924c977e0a23ee743ca8d613b9ea5de885fa..c7fe6865e1a14116b61ae69c26d4af2d
      /**
       * Create a new virtual {@link WorldBorder}.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 6deaae052cfee5b2233993f8fbc04f11f11214b7..fcab13ed2e0e1176c969c1a5e7a4e9907218baa6 100644
+index afed6bcf923166065ac9f63dd96191cd42eefcb9..181493def187f72b6ff89c3849598428f35d31f3 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -673,6 +673,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -670,6 +670,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      public World getWorld(@NotNull UUID uid);
  

--- a/patches/api/0295-Add-basic-Datapack-API.patch
+++ b/patches/api/0295-Add-basic-Datapack-API.patch
@@ -89,10 +89,10 @@ index c7fe6865e1a14116b61ae69c26d4af2d8af11955..64fc7215eb93b50173ed716c1dde1a15
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index fcab13ed2e0e1176c969c1a5e7a4e9907218baa6..b9cc6756cb822592104b10db1646721331086656 100644
+index 181493def187f72b6ff89c3849598428f35d31f3..2409c0023f90689399c8ceba179b800156d16eea 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2016,5 +2016,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2013,5 +2013,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -34,10 +34,10 @@ index 746e988f67e1d3218556e52ad70a4f5133d1bc1e..6f9ffbb907b7f14ae2cfc3cae45ea277
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index b9cc6756cb822592104b10db1646721331086656..43f4da8c13ad04e77958af98fa59628b57346338 100644
+index 2409c0023f90689399c8ceba179b800156d16eea..64e4667efbf60204076ef32d64aa3a76c399df05 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1567,6 +1567,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1564,6 +1564,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  
@@ -61,7 +61,7 @@ index b9cc6756cb822592104b10db1646721331086656..43f4da8c13ad04e77958af98fa59628b
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
-index d14d3851a7b0340668f44f5213f0e18072d7481b..04be4214bc1c4b476c70aea457118e786fa67eff 100644
+index eff4c1cb410e032ee287084cb51b59fd9f84df8d..7c24e9d207bad6eff6793e2348fd34a462a49e5d 100644
 --- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
 +++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
 @@ -454,6 +454,22 @@ public abstract class ChunkGenerator {

--- a/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -30,10 +30,10 @@ index 6f9ffbb907b7f14ae2cfc3cae45ea277c00d461c..9a7a2ad3d245b5215b914ef1a00fb65a
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 43f4da8c13ad04e77958af98fa59628b57346338..9276074c42aed435d4bd02145ac1a0943538c945 100644
+index 64e4667efbf60204076ef32d64aa3a76c399df05..5aa14f6c2f5be4d72689d764ad4d0ce5a3d704a8 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1165,6 +1165,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1162,6 +1162,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/api/0371-Custom-Potion-Mixes.patch
+++ b/patches/api/0371-Custom-Potion-Mixes.patch
@@ -122,10 +122,10 @@ index 9a7a2ad3d245b5215b914ef1a00fb65a83639871..d8666481f9a407403d0114ff02024fd3
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 9276074c42aed435d4bd02145ac1a0943538c945..743a4091e06015b303d1eebc3b6bd393f98e4b9f 100644
+index 5aa14f6c2f5be4d72689d764ad4d0ce5a3d704a8..79b26045a68ebb9b01e5bd06abbccaaef5489777 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2050,5 +2050,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2047,5 +2047,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();


### PR DESCRIPTION
Weird grammar around not allowing MISC as a argument here and also, that `Minecraft default:` section isn't true because its not the same for each category.