### PR TITLE
Team color parameter may be null, causing NPE

### DIFF
--- a/patches/server/0905-color-parameter-may-be-null.patch
+++ b/patches/server/0905-color-parameter-may-be-null.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: rgnter <maros.prejsa1@gmail.com>
+Date: Sat, 21 May 2022 11:25:35 +0200
+Subject: [PATCH] color parameter may be null
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
+index d3d9641862f4746469bca946ef6d89a88f15698b..29c49cf0e6e7f523e362730f0aa17fc4b18aceb9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
++++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
+@@ -80,8 +80,9 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
+         CraftScoreboard scoreboard = checkState();
+         if (color == null) {
+             this.team.setColor(net.minecraft.ChatFormatting.RESET);
++        } else {
++            team.setColor(io.papermc.paper.adventure.PaperAdventure.asVanilla(color)); // Paper - color parameter may be null
+         }
+-        team.setColor(io.papermc.paper.adventure.PaperAdventure.asVanilla(color));
+     }
+     // Paper end
+ 


### PR DESCRIPTION
Implementation must conform to declaration of method.
```java
void color(@Nullable net.kyori.adventure.text.format.NamedTextColor color);
```
When null is passed as method argument, it must be handled by implementation not to cause NPE. 
In this case, when this class was upgraded from 1.18.R1 to R2, this check was removed.