### PR TITLE
Add BlockLockCheckEvent

### DIFF
--- a/patches/api/0420-Add-BlockLockCheckEvent.patch
+++ b/patches/api/0420-Add-BlockLockCheckEvent.patch
@@ -1,0 +1,242 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 21 May 2022 20:59:56 -0700
+Subject: [PATCH] Add BlockLockCheckEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/block/LockableTileState.java b/src/main/java/io/papermc/paper/block/LockableTileState.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..f309961e0e96b6baacc4fe6d80dabd6c7c5d2e1d
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/block/LockableTileState.java
+@@ -0,0 +1,11 @@
++package io.papermc.paper.block;
++
++import org.bukkit.Nameable;
++import org.bukkit.block.Lockable;
++import org.bukkit.block.TileState;
++
++/**
++ * Interface for tile entities that are lockable.
++ */
++public interface LockableTileState extends TileState, Lockable, Nameable {
++}
+diff --git a/src/main/java/io/papermc/paper/event/block/BlockLockCheckEvent.java b/src/main/java/io/papermc/paper/event/block/BlockLockCheckEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..d298ebecaa6e0a4cdc273e326d1976d27efe0e32
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/block/BlockLockCheckEvent.java
+@@ -0,0 +1,187 @@
++package io.papermc.paper.event.block;
++
++import com.google.common.base.Preconditions;
++import io.papermc.paper.block.LockableTileState;
++import net.kyori.adventure.sound.Sound;
++import net.kyori.adventure.text.Component;
++import org.bukkit.Nameable;
++import org.bukkit.block.Block;
++import org.bukkit.block.BlockState;
++import org.bukkit.block.Lockable;
++import org.bukkit.block.TileState;
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.BlockEvent;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++import java.util.Objects;
++
++/**
++ * Called when the server tries to check the lock on a lockable tile entity.
++ * @see #setResult(Result) to change behavior
++ */
++public class BlockLockCheckEvent extends BlockEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final LockableTileState state;
++    private final Player player;
++    private ItemStack itemStack;
++    private Result result = Result.DEFAULT;
++    private Component lockedMessage;
++    private Sound lockedSound;
++
++    public BlockLockCheckEvent(final @NotNull Block block, final @NotNull LockableTileState state, final @NotNull Player player, final @NotNull Component lockedMessage, final @NotNull Sound lockedSound) {
++        super(block);
++        this.state = state;
++        this.player = player;
++        this.lockedMessage = lockedMessage;
++        this.lockedSound = lockedSound;
++    }
++
++    /**
++     * Gets the snapshot {@link LockableTileState} of the tile entity
++     * whose lock is being checked.
++     *
++     * @return the snapshot block state.
++     */
++    public @NotNull LockableTileState getBlockState() {
++        return this.state;
++    }
++
++    /**
++     * Get the player involved this lock check.
++     *
++     * @return the player
++     */
++    public @NotNull Player getPlayer() {
++        return this.player;
++    }
++
++    /**
++     * Gets the itemstack that will be used as the key itemstack. Initially
++     * this will be the item in the player's main hand but an override can be set
++     * with {@link #setKeyItem(ItemStack)}. Use {@link #isUsingCustomKeyItemStack()}
++     * to check if a custom key stack has been set.
++     *
++     * @return the item being used as the key item
++     * @see #isUsingCustomKeyItemStack()
++     */
++    public @NotNull ItemStack getKeyItem() {
++        return Objects.requireNonNullElseGet(this.itemStack, this.player.getInventory()::getItemInMainHand);
++    }
++
++    /**
++     * Sets the itemstack that will be used as the key item.
++     *
++     * @param stack the stack to use as a key (or null to fall back to the player's main hand item)
++     * @see #resetKeyItem() to clear a custom key item
++     */
++    public void setKeyItem(@NotNull ItemStack stack) {
++        Preconditions.checkNotNull(stack, "stack is null");
++        this.itemStack = stack;
++    }
++
++    /**
++     * Reset the key stack to the default (the player's main hand).
++     */
++    public void resetKeyItem() {
++        this.itemStack = null;
++    }
++
++    /**
++     * Checks if a custom key stack has been set.
++     *
++     * @return true if a custom key itemstack has been set
++     */
++    public boolean isUsingCustomKeyItemStack() {
++        return this.itemStack != null;
++    }
++
++    /**
++     * Gets the result of this event.
++     *
++     * @return the result
++     * @see #setResult(Result)
++     */
++    public @NotNull Result getResult() {
++        return this.result;
++    }
++
++    /**
++     * Gets the result of this event. {@link org.bukkit.event.Event.Result#DEFAULT} is the default
++     * allowing the vanilla logic to check the lock of this block. Set to {@link org.bukkit.event.Event.Result#ALLOW}
++     * or {@link org.bukkit.event.Event.Result#DENY} to override that behavior.
++     * <p>
++     * Setting this to {@link org.bukkit.event.Event.Result#ALLOW} bypasses the spectator check.
++     *
++     * @param result the result of this event
++     */
++    public void setResult(@NotNull Result result) {
++        this.result = result;
++    }
++
++    /**
++     * Shorthand method to set the {@link #getResult()} to {@link org.bukkit.event.Event.Result#DENY},
++     * the locked message and locked sound.
++     *
++     * @param lockedMessage the message to show if locked (or null for none)
++     * @param lockedSound the sound to play if locked (or null for none)
++     */
++    public void denyWithMessageAndSound(@Nullable Component lockedMessage, @Nullable Sound lockedSound) {
++        this.result = Result.DENY;
++        this.lockedMessage = lockedMessage;
++        this.lockedSound = lockedSound;
++    }
++
++    /**
++     * Gets the locked message that will be sent if the
++     * player cannot open the block.
++     *
++     * @return the locked message (or null if none)
++     */
++    public @Nullable Component getLockedMessage() {
++        return this.lockedMessage;
++    }
++
++    /**
++     * Sets the locked message that will be sent if the
++     * player cannot open the block.
++     *
++     * @param lockedMessage the locked message (or null for none)
++     */
++    public void setLockedMessage(@Nullable Component lockedMessage) {
++        this.lockedMessage = lockedMessage;
++    }
++
++    /**
++     * Gets the locked sound that will play if the
++     * player cannot open the block.
++     *
++     * @return the locked sound (or null if none)
++     */
++    public @Nullable Sound getLockedSound() {
++        return this.lockedSound;
++    }
++
++    /**
++     * Sets the locked sound that will play if the
++     * player cannot open the block.
++     *
++     * @param lockedSound the locked sound (or null for none)
++     */
++    public void setLockedSound(@Nullable Sound lockedSound) {
++        this.lockedSound = lockedSound;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}
+diff --git a/src/main/java/org/bukkit/block/Beacon.java b/src/main/java/org/bukkit/block/Beacon.java
+index 78475fc6faff0f295828d7b53792001d51aa2889..c86e18508c3df72bf1d67b226bf02af00d66ce98 100644
+--- a/src/main/java/org/bukkit/block/Beacon.java
++++ b/src/main/java/org/bukkit/block/Beacon.java
+@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
+ /**
+  * Represents a captured state of a beacon.
+  */
+-public interface Beacon extends TileState, Lockable, Nameable {
++public interface Beacon extends io.papermc.paper.block.LockableTileState { // Paper
+ 
+     /**
+      * Returns the list of players within the beacon's range of effect.
+diff --git a/src/main/java/org/bukkit/block/Container.java b/src/main/java/org/bukkit/block/Container.java
+index bc06199f0a1cc43e0bdfd5b11fa170badd46e180..a67ee0cb0cd2cbab8dab375e2fe44168c250bcb7 100644
+--- a/src/main/java/org/bukkit/block/Container.java
++++ b/src/main/java/org/bukkit/block/Container.java
+@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Represents a captured state of a container block.
+  */
+-public interface Container extends TileState, BlockInventoryHolder, Lockable, Nameable {
++public interface Container extends io.papermc.paper.block.LockableTileState, BlockInventoryHolder { // Paper
+ 
+     /**
+      * Gets the inventory of the block represented by this block state.

--- a/patches/server/0948-Add-BlockLockCheckEvent.patch
+++ b/patches/server/0948-Add-BlockLockCheckEvent.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 21 May 2022 20:59:45 -0700
+Subject: [PATCH] Add BlockLockCheckEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java
+index a782994e2e53f2c4212c2d59ce740ebf00a826b0..3444c1a2e7f1dd938e42cdf0668e43be273b9116 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java
+@@ -69,17 +69,44 @@ public abstract class BaseContainerBlockEntity extends BlockEntity implements Co
+     protected abstract Component getDefaultName();
+ 
+     public boolean canOpen(Player player) {
+-        return BaseContainerBlockEntity.canUnlock(player, this.lockKey, this.getDisplayName());
++        return BaseContainerBlockEntity.canUnlock(player, this.lockKey, this.getDisplayName(), this); // Paper
+     }
+ 
++    @Deprecated @io.papermc.paper.annotation.DoNotUse // Paper
+     public static boolean canUnlock(Player player, LockCode lock, Component containerName) {
++        // Paper start
++        return canUnlock(player, lock, containerName, null);
++    }
++    public static boolean canUnlock(Player player, LockCode lock, Component containerName, @Nullable BlockEntity blockEntity) {
++        if (player instanceof net.minecraft.server.level.ServerPlayer serverPlayer && blockEntity != null && blockEntity.getLevel() != null) {
++            final org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(blockEntity.getLevel(), blockEntity.getBlockPos());
++            net.kyori.adventure.text.Component lockedMessage = net.kyori.adventure.text.Component.translatable("container.isLocked", io.papermc.paper.adventure.PaperAdventure.asAdventure(containerName));
++            net.kyori.adventure.sound.Sound lockedSound = net.kyori.adventure.sound.Sound.sound(org.bukkit.Sound.BLOCK_CHEST_LOCKED, net.kyori.adventure.sound.Sound.Source.BLOCK, 1.0F, 1.0F);
++            final io.papermc.paper.event.block.BlockLockCheckEvent event = new io.papermc.paper.event.block.BlockLockCheckEvent(block, (io.papermc.paper.block.LockableTileState) block.getState(), serverPlayer.getBukkitEntity(), lockedMessage, lockedSound);
++            event.callEvent();
++            if (event.getResult() == org.bukkit.event.Event.Result.ALLOW) {
++                return true;
++            } else if (event.getResult() == org.bukkit.event.Event.Result.DENY || (!player.isSpectator() && !lock.unlocksWith(event.isUsingCustomKeyItemStack() ? org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getKeyItem()) : player.getMainHandItem()))) {
++                if (event.getLockedMessage() != null) {
++                    event.getPlayer().sendActionBar(event.getLockedMessage());
++                }
++                if (event.getLockedSound() != null) {
++                    event.getPlayer().playSound(event.getLockedSound());
++                }
++                return false;
++            } else {
++                return true;
++            }
++        } else { // logic below is replaced by logic above
++        // Paper end
+         if (!player.isSpectator() && !lock.unlocksWith(player.getMainHandItem())) {
+-            player.displayClientMessage(Component.translatable("container.isLocked", containerName), true);
++            player.displayClientMessage(Component.translatable("container.isLocked", containerName), true); // Paper - diff on change
+             player.playNotifySound(SoundEvents.CHEST_LOCKED, SoundSource.BLOCKS, 1.0F, 1.0F);
+             return false;
+         } else {
+             return true;
+         }
++        } // Paper
+     }
+ 
+     @Nullable
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
+index 49ca1d45bb4b3ddafc1d5952ff9830ba69b745e2..928625b5ab054ffa412be8a438f58291cc7a3cc0 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
+@@ -444,7 +444,7 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name
+     @Nullable
+     @Override
+     public AbstractContainerMenu createMenu(int syncId, Inventory inv, Player player) {
+-        return BaseContainerBlockEntity.canUnlock(player, this.lockKey, this.getDisplayName()) ? new BeaconMenu(syncId, inv, this.dataAccess, ContainerLevelAccess.create(this.level, this.getBlockPos())) : null;
++        return BaseContainerBlockEntity.canUnlock(player, this.lockKey, this.getDisplayName(), this) ? new BeaconMenu(syncId, inv, this.dataAccess, ContainerLevelAccess.create(this.level, this.getBlockPos())) : null; // Paper
+     }
+ 
+     @Override


### PR DESCRIPTION
Adds an event to further extend vanilla's locked block feature.

Couple things to address. Not a huge fan of the generic hack to combine `TileState`, `Nameable`, and `Lockable`. Could either make `Lockable` extend both `TileState` and `Nameable` or make a new interface `LockableTileState` to combine them.