### PR TITLE
Remove incorrect parent perm from debugstick.always

### DIFF
--- a/patches/server/0006-CB-fixes.patch
+++ b/patches/server/0006-CB-fixes.patch
@@ -6,8 +6,10 @@ Subject: [PATCH] CB fixes
 * Missing Level -> LevelStem generic in StructureCheck
   Need to use the right for injectDatafixingContext
 
+* Removed incorrect parent perm for `minecraft.debugstick.always`
+
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 1e9805b029abd8a59452b185af2eae8d1c9e7267..4c775aca50d8ff75c2c885bbf9fbbc6c8829d66f 100644
+index a480e20ac456a3169c67d2d43c191b7807a8ef10..1427b76110a02cee15865173e06e7b7bb4231ae7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -273,7 +273,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -41,3 +43,16 @@ index 5862fd38fb2a5aeec0a63d001cc043aac62188bb..22e3ac8c5df5592e31ef3f00f102aa3a
          this.storageAccess = chunkIoWorker;
          this.registryAccess = registryManager;
          this.structureManager = structureManager;
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java b/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
+index c93eec7a81ed83dc9190417dd51acb2780d3b60d..70d3949616c63038ad3e9bd1069db5ea2fb3f3b8 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
+@@ -15,7 +15,7 @@ public final class CraftDefaultPermissions {
+         DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".nbt.place", "Gives the user the ability to place restricted blocks with NBT in creative", org.bukkit.permissions.PermissionDefault.OP, parent);
+         DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".nbt.copy", "Gives the user the ability to copy NBT in creative", org.bukkit.permissions.PermissionDefault.TRUE, parent);
+         DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".debugstick", "Gives the user the ability to use the debug stick in creative", org.bukkit.permissions.PermissionDefault.OP, parent);
+-        DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".debugstick.always", "Gives the user the ability to use the debug stick in all game modes", org.bukkit.permissions.PermissionDefault.FALSE, parent);
++        DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".debugstick.always", "Gives the user the ability to use the debug stick in all game modes", org.bukkit.permissions.PermissionDefault.FALSE/* , parent */); // Paper - should not have this parent, as it's not a "vanilla" utility
+         // Spigot end
+         parent.recalculatePermissibles();
+     }

--- a/patches/server/0443-Add-permission-for-command-blocks.patch
+++ b/patches/server/0443-Add-permission-for-command-blocks.patch
@@ -18,7 +18,7 @@ index d4f57fde2f02071dfde08cb2a5c8359984056aef..176e5bbac94cf39805dcacfcae3a3daa
                  return false;
              } else if (this.player.blockActionRestricted(this.level, pos, this.gameModeForPlayer)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 7c97e6eda860b0145d8d5700fcecdcea5e258a03..e2446434e0db09d303c4a831c8f60819ade18f9a 100644
+index d55afdb09af8bc07361c06453a028da36ef934eb..ddcc780a27a60bd9dcc1695d03bf42e42e87b192 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -796,7 +796,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -66,13 +66,13 @@ index 25a297968388f85108d7b9de96fdc7d368034e4d..1a48c5ea1f2f755abfa85469e26f37ea
              return InteractionResult.sidedSuccess(world.isClientSide);
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java b/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
-index c93eec7a81ed83dc9190417dd51acb2780d3b60d..cb75827316fe6c22ec900efea800d35d40573380 100644
+index 70d3949616c63038ad3e9bd1069db5ea2fb3f3b8..8e06bc11fb28baee3407bbfe9d7b3689d6f85ff2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
 @@ -16,6 +16,7 @@ public final class CraftDefaultPermissions {
          DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".nbt.copy", "Gives the user the ability to copy NBT in creative", org.bukkit.permissions.PermissionDefault.TRUE, parent);
          DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".debugstick", "Gives the user the ability to use the debug stick in creative", org.bukkit.permissions.PermissionDefault.OP, parent);
-         DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".debugstick.always", "Gives the user the ability to use the debug stick in all game modes", org.bukkit.permissions.PermissionDefault.FALSE, parent);
+         DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".debugstick.always", "Gives the user the ability to use the debug stick in all game modes", org.bukkit.permissions.PermissionDefault.FALSE/* , parent */); // Paper - should not have this parent, as it's not a "vanilla" utility
 +        DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".commandblock", "Gives the user the ability to use command blocks.", org.bukkit.permissions.PermissionDefault.OP, parent); // Paper
          // Spigot end
          parent.recalculatePermissibles();


### PR DESCRIPTION
The `minecraft.debugstick.always` perm's default was `FALSE` but since it was a child perm of `minecraft` whose default is `OP`, op's all had that permission by default. This is a behavioral change from vanilla as ops can only use them while in creative (the instabuild ability). This removes the parent from the always perm.

Fixes https://github.com/PaperMC/Paper/issues/7844