### PR TITLE
Allow using degrees for ArmorStand rotations

### DIFF
--- a/patches/api/0131-Expand-ArmorStand-API.patch
+++ b/patches/api/0131-Expand-ArmorStand-API.patch
@@ -3,12 +3,15 @@ From: willies952002 <admin@domnian.com>
 Date: Thu, 26 Jul 2018 02:22:44 -0400
 Subject: [PATCH] Expand ArmorStand API
 
-Add the following:
+Adds the following:
 - Add proper methods for getting and setting items in both hands. Deprecates old methods
 - Enable/Disable slot interactions
+- Allow using Vectors for ArmorStand rotations
+
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/entity/ArmorStand.java b/src/main/java/org/bukkit/entity/ArmorStand.java
-index 2ee3814a52945f541e049b621b9552f8ae9e261d..707639096657f995cc812c7b50108eeed48e8181 100644
+index 2ee3814a52945f541e049b621b9552f8ae9e261d..b5ec4b980b5596dca438919bd2e97cbcc6147fef 100644
 --- a/src/main/java/org/bukkit/entity/ArmorStand.java
 +++ b/src/main/java/org/bukkit/entity/ArmorStand.java
 @@ -14,7 +14,7 @@ public interface ArmorStand extends LivingEntity {
@@ -29,7 +32,7 @@ index 2ee3814a52945f541e049b621b9552f8ae9e261d..707639096657f995cc812c7b50108eee
       */
      @Deprecated
      void setItemInHand(@Nullable ItemStack item);
-@@ -379,5 +379,71 @@ public interface ArmorStand extends LivingEntity {
+@@ -379,5 +379,173 @@ public interface ArmorStand extends LivingEntity {
       * @param tick {@code true} if this armour stand can tick, {@code false} otherwise
       */
      void setCanTick(final boolean tick);
@@ -99,5 +102,107 @@ index 2ee3814a52945f541e049b621b9552f8ae9e261d..707639096657f995cc812c7b50108eee
 +     * @return {@code true} if the slot is disabled, else {@code false}.
 +     */
 +    boolean isSlotDisabled(@NotNull org.bukkit.inventory.EquipmentSlot slot);
++
++    /**
++     * Returns the armor stand's body's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @return the current rotation
++     */
++    @NotNull
++    org.bukkit.util.Vector getBodyRotation();
++
++    /**
++     * Sets the armor stand's body's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @param rotation the current rotation
++     */
++    void setBodyRotation(@NotNull org.bukkit.util.Vector rotation);
++
++    /**
++     * Returns the armor stand's left arm's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @return the current rotation
++     */
++    @NotNull
++    org.bukkit.util.Vector getLeftArmRotation();
++
++    /**
++     * Sets the armor stand's left arm's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @param rotation the current rotation
++     */
++    void setLeftArmRotation(@NotNull org.bukkit.util.Vector rotation);
++
++    /**
++     * Returns the armor stand's right arm's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @return the current rotation
++     */
++    @NotNull
++    org.bukkit.util.Vector getRightArmRotation();
++
++    /**
++     * Sets the armor stand's right arm's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @param rotation the current rotation
++     */
++    void setRightArmRotation(@NotNull org.bukkit.util.Vector rotation);
++
++    /**
++     * Returns the armor stand's left leg's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @return the current rotation
++     */
++    @NotNull
++    org.bukkit.util.Vector getLeftLegRotation();
++
++    /**
++     * Sets the armor stand's left leg's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @param rotation the current rotation
++     */
++    void setLeftLegRotation(@NotNull org.bukkit.util.Vector rotation);
++
++    /**
++     * Returns the armor stand's right leg's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @return the current rotation
++     */
++    @NotNull
++    org.bukkit.util.Vector getRightLegRotation();
++
++    /**
++     * Sets the armor stand's right leg's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @param rotation the current rotation
++     */
++    void setRightLegRotation(@NotNull org.bukkit.util.Vector rotation);
++
++    /**
++     * Returns the armor stand's head's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @return the current rotation
++     */
++    @NotNull
++    org.bukkit.util.Vector getHeadRotation();
++
++    /**
++     * Sets the armor stand's head's current rotation as a
++     * {@link org.bukkit.util.Vector}.
++     *
++     * @param rotation the current rotation
++     */
++    void setHeadRotation(@NotNull org.bukkit.util.Vector rotation);
      // Paper end
  }

--- a/patches/api/0131-Expand-ArmorStand-API.patch
+++ b/patches/api/0131-Expand-ArmorStand-API.patch
@@ -12,28 +12,61 @@ Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/math/Rotations.java b/src/main/java/io/papermc/paper/math/Rotations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ef5494fe67409c30bfcc6382f2683cbbe0efb112
+index 0000000000000000000000000000000000000000..5a111f15ebe33b22a17e55bd4ec246f72ed9f6be
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/math/Rotations.java
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,104 @@
 +package io.papermc.paper.math;
 +
-+import org.bukkit.entity.ArmorStand;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Stores rotations for {@link ArmorStand}'s parts
-+ *
-+ * @param x the angle for the X axis in degrees
-+ * @param y the angle for the Y axis in degrees
-+ * @param z the angle for the Z axis in degrees
++ * Rotations is an immutable object that stores rotations
++ * in degrees on each axis (X, Y, Z).
 + */
-+public record Rotations(double x, double y, double z) {
++@ApiStatus.NonExtendable
++public interface Rotations {
 +
 +    /**
-+     * Rotations with every axis set to 0
++     * Returns Rotations instance with every axis set to 0
 +     */
-+    public static final Rotations ZERO = new Rotations(0, 0, 0);
++    static @NotNull Rotations zero() {
++        return RotationsImpl.ZERO;
++    }
++
++    /**
++     * Creates a new Rotations instance holding the provided rotations
++     *
++     * @param x the angle for the X axis in degrees
++     * @param y the angle for the Y axis in degrees
++     * @param z the angle for the Z axis in degrees
++     * @return Rotations instance holding the provided rotations
++     */
++    static @NotNull Rotations ofDegrees(double x, double y, double z) {
++        return new RotationsImpl(x, y, z);
++    }
++
++    /**
++     * Returns the angle on the X axis in degrees
++     *
++     * @return the angle in degrees
++     */
++    double x();
++
++    /**
++     * Returns the angle on the Y axis in degrees
++     *
++     * @return the angle in degrees
++     */
++    double y();
++
++    /**
++     * Returns the angle on the Z axis in degrees
++     *
++     * @return the angle in degrees
++     */
++    double z();
 +
 +    /**
 +     * Returns a new Rotations instance which is the result
@@ -42,10 +75,7 @@ index 0000000000000000000000000000000000000000..ef5494fe67409c30bfcc6382f2683cbb
 +     * @param x the angle in degrees
 +     * @return the resultant Rotations
 +     */
-+    @NotNull
-+    public Rotations withX(double x) {
-+        return new Rotations(x, y, z);
-+    }
++    @NotNull Rotations withX(double x);
 +
 +    /**
 +     * Returns a new Rotations instance which is the result
@@ -54,10 +84,7 @@ index 0000000000000000000000000000000000000000..ef5494fe67409c30bfcc6382f2683cbb
 +     * @param y the angle in degrees
 +     * @return the resultant Rotations
 +     */
-+    @NotNull
-+    public Rotations withY(double y) {
-+        return new Rotations(x, y, z);
-+    }
++    @NotNull Rotations withY(double y);
 +
 +    /**
 +     * Returns a new Rotations instance which is the result
@@ -66,10 +93,7 @@ index 0000000000000000000000000000000000000000..ef5494fe67409c30bfcc6382f2683cbb
 +     * @param z the angle in degrees
 +     * @return the resultant Rotations
 +     */
-+    @NotNull
-+    public Rotations withZ(double z) {
-+        return new Rotations(x, y, z);
-+    }
++    @NotNull Rotations withZ(double z);
 +
 +    /**
 +     * Returns a new Rotations instance which is the result of adding
@@ -80,10 +104,7 @@ index 0000000000000000000000000000000000000000..ef5494fe67409c30bfcc6382f2683cbb
 +     * @param z the angle to add to the Z axis in degrees
 +     * @return the resultant Rotations
 +     */
-+    @NotNull
-+    public Rotations add(double x, double y, double z) {
-+        return new Rotations(this.x + x, this.y + y, this.z + z);
-+    }
++    @NotNull Rotations add(double x, double y, double z);
 +
 +    /**
 +     * Returns a new Rotations instance which is the result of subtracting
@@ -94,9 +115,43 @@ index 0000000000000000000000000000000000000000..ef5494fe67409c30bfcc6382f2683cbb
 +     * @param z the angle to subtract from the Z axis in degrees
 +     * @return the resultant Rotations
 +     */
-+    @NotNull
-+    public Rotations subtract(double x, double y, double z) {
++    default @NotNull Rotations subtract(double x, double y, double z) {
 +        return add(-x, -y, -z);
++    }
++
++}
+diff --git a/src/main/java/io/papermc/paper/math/RotationsImpl.java b/src/main/java/io/papermc/paper/math/RotationsImpl.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..6a11edfce24e512b6be7b7eba2347872029a2afc
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/math/RotationsImpl.java
+@@ -0,0 +1,29 @@
++package io.papermc.paper.math;
++
++import org.jetbrains.annotations.NotNull;
++
++record RotationsImpl(double x, double y, double z) implements Rotations {
++
++    static final Rotations ZERO = new RotationsImpl(0, 0, 0);
++
++    @Override
++    public @NotNull RotationsImpl withX(double x) {
++        return new RotationsImpl(x, y, z);
++    }
++
++    @Override
++    public @NotNull RotationsImpl withY(double y) {
++        return new RotationsImpl(x, y, z);
++    }
++
++    @Override
++    public @NotNull RotationsImpl withZ(double z) {
++        return new RotationsImpl(x, y, z);
++    }
++
++    @Override
++    public @NotNull RotationsImpl add(double x, double y, double z) {
++        return new RotationsImpl(this.x + x, this.y + y, this.z + z);
 +    }
 +
 +}

--- a/patches/api/0131-Expand-ArmorStand-API.patch
+++ b/patches/api/0131-Expand-ArmorStand-API.patch
@@ -12,28 +12,24 @@ Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/math/Rotations.java b/src/main/java/io/papermc/paper/math/Rotations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5a111f15ebe33b22a17e55bd4ec246f72ed9f6be
+index 0000000000000000000000000000000000000000..0ac1618113699ac50b9c35294bf23fb9fb7cfbad
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/math/Rotations.java
-@@ -0,0 +1,104 @@
+@@ -0,0 +1,100 @@
 +package io.papermc.paper.math;
 +
-+import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
 + * Rotations is an immutable object that stores rotations
 + * in degrees on each axis (X, Y, Z).
 + */
-+@ApiStatus.NonExtendable
 +public interface Rotations {
 +
 +    /**
-+     * Returns Rotations instance with every axis set to 0
++     * Rotations instance with every axis set to 0
 +     */
-+    static @NotNull Rotations zero() {
-+        return RotationsImpl.ZERO;
-+    }
++    Rotations ZERO = ofDegrees(0, 0, 0);
 +
 +    /**
 +     * Creates a new Rotations instance holding the provided rotations
@@ -122,17 +118,15 @@ index 0000000000000000000000000000000000000000..5a111f15ebe33b22a17e55bd4ec246f7
 +}
 diff --git a/src/main/java/io/papermc/paper/math/RotationsImpl.java b/src/main/java/io/papermc/paper/math/RotationsImpl.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6a11edfce24e512b6be7b7eba2347872029a2afc
+index 0000000000000000000000000000000000000000..53359ab4a6659bce895deef6a21cde848d3cadcd
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/math/RotationsImpl.java
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,27 @@
 +package io.papermc.paper.math;
 +
 +import org.jetbrains.annotations.NotNull;
 +
 +record RotationsImpl(double x, double y, double z) implements Rotations {
-+
-+    static final Rotations ZERO = new RotationsImpl(0, 0, 0);
 +
 +    @Override
 +    public @NotNull RotationsImpl withX(double x) {

--- a/patches/api/0131-Expand-ArmorStand-API.patch
+++ b/patches/api/0131-Expand-ArmorStand-API.patch
@@ -12,69 +12,28 @@ Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/util/Rotations.java b/src/main/java/io/papermc/paper/util/Rotations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2c18961081e9f5ece9001f92749741e9b465c472
+index 0000000000000000000000000000000000000000..f4fd42296ba470b63224f42e0de1479dc904b3f8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/Rotations.java
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,84 @@
 +package io.papermc.paper.util;
 +
++import org.bukkit.entity.ArmorStand;
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Represents 3 angles, one for each axis (X, Y, Z).
-+ * The angles are in degrees.
++ * Stores rotations for {@link ArmorStand}'s parts
++ *
++ * @param x the angle for the X axis in degrees
++ * @param y the angle for the Y axis in degrees
++ * @param z the angle for the Z axis in degrees
 + */
-+public class Rotations {
++public record Rotations(double x, double y, double z) {
 +
 +    /**
 +     * Rotations with every axis set to 0
 +     */
 +    public static final Rotations ZERO = new Rotations(0, 0, 0);
-+
-+    private final double x;
-+    private final double y;
-+    private final double z;
-+
-+    /**
-+     * Creates Rotations with each axis set to the
-+     * passed angle in degrees
-+     *
-+     * @param x the angle for the X axis in degrees
-+     * @param y the angle for the Y axis in degrees
-+     * @param z the angle for the Z axis in degrees
-+     */
-+    public Rotations(double x, double y, double z) {
-+        this.x = x;
-+        this.y = y;
-+        this.z = z;
-+    }
-+
-+    /**
-+     * Returns the angle on the X axis in degrees
-+     *
-+     * @return the angle in degrees
-+     */
-+    public double getX() {
-+        return x;
-+    }
-+
-+    /**
-+     * Returns the angle on the Y axis in degrees
-+     *
-+     * @return the angle in degrees
-+     */
-+    public double getY() {
-+        return y;
-+    }
-+
-+    /**
-+     * Returns the angle on the Z axis in degrees
-+     *
-+     * @return the angle in degrees
-+     */
-+    public double getZ() {
-+        return z;
-+    }
 +
 +    /**
 +     * Returns a new Rotations instance which is the result
@@ -84,7 +43,7 @@ index 0000000000000000000000000000000000000000..2c18961081e9f5ece9001f92749741e9
 +     * @return the resultant Rotations
 +     */
 +    @NotNull
-+    public Rotations setX(double x) {
++    public Rotations withX(double x) {
 +        return new Rotations(x, y, z);
 +    }
 +
@@ -96,7 +55,7 @@ index 0000000000000000000000000000000000000000..2c18961081e9f5ece9001f92749741e9
 +     * @return the resultant Rotations
 +     */
 +    @NotNull
-+    public Rotations setY(double y) {
++    public Rotations withY(double y) {
 +        return new Rotations(x, y, z);
 +    }
 +
@@ -108,7 +67,7 @@ index 0000000000000000000000000000000000000000..2c18961081e9f5ece9001f92749741e9
 +     * @return the resultant Rotations
 +     */
 +    @NotNull
-+    public Rotations setZ(double z) {
++    public Rotations withZ(double z) {
 +        return new Rotations(x, y, z);
 +    }
 +
@@ -123,40 +82,21 @@ index 0000000000000000000000000000000000000000..2c18961081e9f5ece9001f92749741e9
 +     */
 +    @NotNull
 +    public Rotations add(double x, double y, double z) {
-+        return new Rotations(
-+            this.x + x,
-+            this.y + y,
-+            this.z + z
-+        );
++        return new Rotations(this.x + x, this.y + y, this.z + z);
 +    }
 +
 +    /**
 +     * Returns a new Rotations instance which is the result of subtracting
 +     * the x, y, z components from this Rotations
 +     *
-+     * @param x the angle to subtract to the X axis in degrees
-+     * @param y the angle to subtract to the Y axis in degrees
-+     * @param z the angle to subtract to the Z axis in degrees
++     * @param x the angle to subtract from the X axis in degrees
++     * @param y the angle to subtract from the Y axis in degrees
++     * @param z the angle to subtract from the Z axis in degrees
 +     * @return the resultant Rotations
 +     */
 +    @NotNull
 +    public Rotations subtract(double x, double y, double z) {
 +        return add(-x, -y, -z);
-+    }
-+
-+    @Override
-+    public boolean equals(Object o) {
-+        if (this == o) return true;
-+        if (!(o instanceof Rotations that)) return false;
-+
-+        return Double.compare(this.x, that.x) == 0
-+            && Double.compare(this.y, that.y) == 0
-+            && Double.compare(this.z, that.z) == 0;
-+    }
-+
-+    @Override
-+    public int hashCode() {
-+        return Double.hashCode(x) * Double.hashCode(y) * Double.hashCode(z);
 +    }
 +
 +}

--- a/patches/api/0131-Expand-ArmorStand-API.patch
+++ b/patches/api/0131-Expand-ArmorStand-API.patch
@@ -10,8 +10,158 @@ Adds the following:
 
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
+diff --git a/src/main/java/io/papermc/paper/util/Rotations.java b/src/main/java/io/papermc/paper/util/Rotations.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..2c18961081e9f5ece9001f92749741e9b465c472
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/util/Rotations.java
+@@ -0,0 +1,144 @@
++package io.papermc.paper.util;
++
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Represents 3 angles, one for each axis (X, Y, Z).
++ * The angles are in degrees.
++ */
++public class Rotations {
++
++    /**
++     * Rotations with every axis set to 0
++     */
++    public static final Rotations ZERO = new Rotations(0, 0, 0);
++
++    private final double x;
++    private final double y;
++    private final double z;
++
++    /**
++     * Creates Rotations with each axis set to the
++     * passed angle in degrees
++     *
++     * @param x the angle for the X axis in degrees
++     * @param y the angle for the Y axis in degrees
++     * @param z the angle for the Z axis in degrees
++     */
++    public Rotations(double x, double y, double z) {
++        this.x = x;
++        this.y = y;
++        this.z = z;
++    }
++
++    /**
++     * Returns the angle on the X axis in degrees
++     *
++     * @return the angle in degrees
++     */
++    public double getX() {
++        return x;
++    }
++
++    /**
++     * Returns the angle on the Y axis in degrees
++     *
++     * @return the angle in degrees
++     */
++    public double getY() {
++        return y;
++    }
++
++    /**
++     * Returns the angle on the Z axis in degrees
++     *
++     * @return the angle in degrees
++     */
++    public double getZ() {
++        return z;
++    }
++
++    /**
++     * Returns a new Rotations instance which is the result
++     * of changing the X axis to the passed angle
++     *
++     * @param x the angle in degrees
++     * @return the resultant Rotations
++     */
++    @NotNull
++    public Rotations setX(double x) {
++        return new Rotations(x, y, z);
++    }
++
++    /**
++     * Returns a new Rotations instance which is the result
++     * of changing the Y axis to the passed angle
++     *
++     * @param y the angle in degrees
++     * @return the resultant Rotations
++     */
++    @NotNull
++    public Rotations setY(double y) {
++        return new Rotations(x, y, z);
++    }
++
++    /**
++     * Returns a new Rotations instance which is the result
++     * of changing the Z axis to the passed angle
++     *
++     * @param z the angle in degrees
++     * @return the resultant Rotations
++     */
++    @NotNull
++    public Rotations setZ(double z) {
++        return new Rotations(x, y, z);
++    }
++
++    /**
++     * Returns a new Rotations instance which is the result of adding
++     * the x, y, z components to this Rotations
++     *
++     * @param x the angle to add to the X axis in degrees
++     * @param y the angle to add to the Y axis in degrees
++     * @param z the angle to add to the Z axis in degrees
++     * @return the resultant Rotations
++     */
++    @NotNull
++    public Rotations add(double x, double y, double z) {
++        return new Rotations(
++            this.x + x,
++            this.y + y,
++            this.z + z
++        );
++    }
++
++    /**
++     * Returns a new Rotations instance which is the result of subtracting
++     * the x, y, z components from this Rotations
++     *
++     * @param x the angle to subtract to the X axis in degrees
++     * @param y the angle to subtract to the Y axis in degrees
++     * @param z the angle to subtract to the Z axis in degrees
++     * @return the resultant Rotations
++     */
++    @NotNull
++    public Rotations subtract(double x, double y, double z) {
++        return add(-x, -y, -z);
++    }
++
++    @Override
++    public boolean equals(Object o) {
++        if (this == o) return true;
++        if (!(o instanceof Rotations that)) return false;
++
++        return Double.compare(this.x, that.x) == 0
++            && Double.compare(this.y, that.y) == 0
++            && Double.compare(this.z, that.z) == 0;
++    }
++
++    @Override
++    public int hashCode() {
++        return Double.hashCode(x) * Double.hashCode(y) * Double.hashCode(z);
++    }
++
++}
 diff --git a/src/main/java/org/bukkit/entity/ArmorStand.java b/src/main/java/org/bukkit/entity/ArmorStand.java
-index 2ee3814a52945f541e049b621b9552f8ae9e261d..b5ec4b980b5596dca438919bd2e97cbcc6147fef 100644
+index 2ee3814a52945f541e049b621b9552f8ae9e261d..e54b0fcaa4ca324fd92718150ff4c3ea87122112 100644
 --- a/src/main/java/org/bukkit/entity/ArmorStand.java
 +++ b/src/main/java/org/bukkit/entity/ArmorStand.java
 @@ -14,7 +14,7 @@ public interface ArmorStand extends LivingEntity {
@@ -104,105 +254,105 @@ index 2ee3814a52945f541e049b621b9552f8ae9e261d..b5ec4b980b5596dca438919bd2e97cbc
 +    boolean isSlotDisabled(@NotNull org.bukkit.inventory.EquipmentSlot slot);
 +
 +    /**
-+     * Returns the armor stand's body's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
++     * Returns the ArmorStand's body rotations as
++     * {@link io.papermc.paper.util.Rotations}.
 +     *
-+     * @return the current rotation
++     * @return the current rotations
 +     */
 +    @NotNull
-+    org.bukkit.util.Vector getBodyRotation();
++    io.papermc.paper.util.Rotations getBodyRotations();
 +
 +    /**
-+     * Sets the armor stand's body's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
++     * Sets the ArmorStand's body rotations as
++     * {@link io.papermc.paper.util.Rotations}.
 +     *
-+     * @param rotation the current rotation
++     * @param rotations the current rotations
 +     */
-+    void setBodyRotation(@NotNull org.bukkit.util.Vector rotation);
++    void setBodyRotations(@NotNull io.papermc.paper.util.Rotations rotations);
 +
 +    /**
-+     * Returns the armor stand's left arm's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
++     * Returns the ArmorStand's left arm rotations as
++     * {@link io.papermc.paper.util.Rotations}.
 +     *
-+     * @return the current rotation
-+     */
-+    @NotNull
-+    org.bukkit.util.Vector getLeftArmRotation();
-+
-+    /**
-+     * Sets the armor stand's left arm's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
-+     *
-+     * @param rotation the current rotation
-+     */
-+    void setLeftArmRotation(@NotNull org.bukkit.util.Vector rotation);
-+
-+    /**
-+     * Returns the armor stand's right arm's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
-+     *
-+     * @return the current rotation
++     * @return the current rotations
 +     */
 +    @NotNull
-+    org.bukkit.util.Vector getRightArmRotation();
++    io.papermc.paper.util.Rotations getLeftArmRotations();
 +
 +    /**
-+     * Sets the armor stand's right arm's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
++     * Sets the ArmorStand's left arm rotations as
++     * {@link io.papermc.paper.util.Rotations}.
 +     *
-+     * @param rotation the current rotation
++     * @param rotations the current rotations
 +     */
-+    void setRightArmRotation(@NotNull org.bukkit.util.Vector rotation);
++    void setLeftArmRotations(@NotNull io.papermc.paper.util.Rotations rotations);
 +
 +    /**
-+     * Returns the armor stand's left leg's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
++     * Returns the ArmorStand's right arm rotations as
++     * {@link io.papermc.paper.util.Rotations}.
 +     *
-+     * @return the current rotation
-+     */
-+    @NotNull
-+    org.bukkit.util.Vector getLeftLegRotation();
-+
-+    /**
-+     * Sets the armor stand's left leg's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
-+     *
-+     * @param rotation the current rotation
-+     */
-+    void setLeftLegRotation(@NotNull org.bukkit.util.Vector rotation);
-+
-+    /**
-+     * Returns the armor stand's right leg's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
-+     *
-+     * @return the current rotation
++     * @return the current rotations
 +     */
 +    @NotNull
-+    org.bukkit.util.Vector getRightLegRotation();
++    io.papermc.paper.util.Rotations getRightArmRotations();
 +
 +    /**
-+     * Sets the armor stand's right leg's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
++     * Sets the ArmorStand's right arm rotations as
++     * {@link io.papermc.paper.util.Rotations}.
 +     *
-+     * @param rotation the current rotation
++     * @param rotations the current rotations
 +     */
-+    void setRightLegRotation(@NotNull org.bukkit.util.Vector rotation);
++    void setRightArmRotations(@NotNull io.papermc.paper.util.Rotations rotations);
 +
 +    /**
-+     * Returns the armor stand's head's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
++     * Returns the ArmorStand's left leg rotations as
++     * {@link io.papermc.paper.util.Rotations}.
 +     *
-+     * @return the current rotation
++     * @return the current rotations
 +     */
 +    @NotNull
-+    org.bukkit.util.Vector getHeadRotation();
++    io.papermc.paper.util.Rotations getLeftLegRotations();
 +
 +    /**
-+     * Sets the armor stand's head's current rotation as a
-+     * {@link org.bukkit.util.Vector}.
++     * Sets the ArmorStand's left leg rotations as
++     * {@link io.papermc.paper.util.Rotations}.
 +     *
-+     * @param rotation the current rotation
++     * @param rotations the current rotations
 +     */
-+    void setHeadRotation(@NotNull org.bukkit.util.Vector rotation);
++    void setLeftLegRotations(@NotNull io.papermc.paper.util.Rotations rotations);
++
++    /**
++     * Returns the ArmorStand's right leg rotations as
++     * {@link io.papermc.paper.util.Rotations}.
++     *
++     * @return the current rotations
++     */
++    @NotNull
++    io.papermc.paper.util.Rotations getRightLegRotations();
++
++    /**
++     * Sets the ArmorStand's right leg rotations as
++     * {@link io.papermc.paper.util.Rotations}.
++     *
++     * @param rotations the current rotations
++     */
++    void setRightLegRotations(@NotNull io.papermc.paper.util.Rotations rotations);
++
++    /**
++     * Returns the ArmorStand's head rotations as
++     * {@link io.papermc.paper.util.Rotations}.
++     *
++     * @return the current rotations
++     */
++    @NotNull
++    io.papermc.paper.util.Rotations getHeadRotations();
++
++    /**
++     * Sets the ArmorStand's head rotations as
++     * {@link io.papermc.paper.util.Rotations}.
++     *
++     * @param rotations the current rotations
++     */
++    void setHeadRotations(@NotNull io.papermc.paper.util.Rotations rotations);
      // Paper end
  }

--- a/patches/api/0131-Expand-ArmorStand-API.patch
+++ b/patches/api/0131-Expand-ArmorStand-API.patch
@@ -10,13 +10,13 @@ Adds the following:
 
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
-diff --git a/src/main/java/io/papermc/paper/util/Rotations.java b/src/main/java/io/papermc/paper/util/Rotations.java
+diff --git a/src/main/java/io/papermc/paper/math/Rotations.java b/src/main/java/io/papermc/paper/math/Rotations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f4fd42296ba470b63224f42e0de1479dc904b3f8
+index 0000000000000000000000000000000000000000..ef5494fe67409c30bfcc6382f2683cbbe0efb112
 --- /dev/null
-+++ b/src/main/java/io/papermc/paper/util/Rotations.java
++++ b/src/main/java/io/papermc/paper/math/Rotations.java
 @@ -0,0 +1,84 @@
-+package io.papermc.paper.util;
++package io.papermc.paper.math;
 +
 +import org.bukkit.entity.ArmorStand;
 +import org.jetbrains.annotations.NotNull;
@@ -101,7 +101,7 @@ index 0000000000000000000000000000000000000000..f4fd42296ba470b63224f42e0de1479d
 +
 +}
 diff --git a/src/main/java/org/bukkit/entity/ArmorStand.java b/src/main/java/org/bukkit/entity/ArmorStand.java
-index 2ee3814a52945f541e049b621b9552f8ae9e261d..e54b0fcaa4ca324fd92718150ff4c3ea87122112 100644
+index 2ee3814a52945f541e049b621b9552f8ae9e261d..7530eb5d2a506e13e2bc7e189fd6e957c013cdf5 100644
 --- a/src/main/java/org/bukkit/entity/ArmorStand.java
 +++ b/src/main/java/org/bukkit/entity/ArmorStand.java
 @@ -14,7 +14,7 @@ public interface ArmorStand extends LivingEntity {
@@ -122,7 +122,7 @@ index 2ee3814a52945f541e049b621b9552f8ae9e261d..e54b0fcaa4ca324fd92718150ff4c3ea
       */
      @Deprecated
      void setItemInHand(@Nullable ItemStack item);
-@@ -379,5 +379,173 @@ public interface ArmorStand extends LivingEntity {
+@@ -379,5 +379,167 @@ public interface ArmorStand extends LivingEntity {
       * @param tick {@code true} if this armour stand can tick, {@code false} otherwise
       */
      void setCanTick(final boolean tick);
@@ -195,104 +195,98 @@ index 2ee3814a52945f541e049b621b9552f8ae9e261d..e54b0fcaa4ca324fd92718150ff4c3ea
 +
 +    /**
 +     * Returns the ArmorStand's body rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @return the current rotations
 +     */
-+    @NotNull
-+    io.papermc.paper.util.Rotations getBodyRotations();
++    @NotNull io.papermc.paper.math.Rotations getBodyRotations();
 +
 +    /**
 +     * Sets the ArmorStand's body rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @param rotations the current rotations
 +     */
-+    void setBodyRotations(@NotNull io.papermc.paper.util.Rotations rotations);
++    void setBodyRotations(@NotNull io.papermc.paper.math.Rotations rotations);
 +
 +    /**
 +     * Returns the ArmorStand's left arm rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @return the current rotations
 +     */
-+    @NotNull
-+    io.papermc.paper.util.Rotations getLeftArmRotations();
++    @NotNull io.papermc.paper.math.Rotations getLeftArmRotations();
 +
 +    /**
 +     * Sets the ArmorStand's left arm rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @param rotations the current rotations
 +     */
-+    void setLeftArmRotations(@NotNull io.papermc.paper.util.Rotations rotations);
++    void setLeftArmRotations(@NotNull io.papermc.paper.math.Rotations rotations);
 +
 +    /**
 +     * Returns the ArmorStand's right arm rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @return the current rotations
 +     */
-+    @NotNull
-+    io.papermc.paper.util.Rotations getRightArmRotations();
++    @NotNull io.papermc.paper.math.Rotations getRightArmRotations();
 +
 +    /**
 +     * Sets the ArmorStand's right arm rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @param rotations the current rotations
 +     */
-+    void setRightArmRotations(@NotNull io.papermc.paper.util.Rotations rotations);
++    void setRightArmRotations(@NotNull io.papermc.paper.math.Rotations rotations);
 +
 +    /**
 +     * Returns the ArmorStand's left leg rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @return the current rotations
 +     */
-+    @NotNull
-+    io.papermc.paper.util.Rotations getLeftLegRotations();
++    @NotNull io.papermc.paper.math.Rotations getLeftLegRotations();
 +
 +    /**
 +     * Sets the ArmorStand's left leg rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @param rotations the current rotations
 +     */
-+    void setLeftLegRotations(@NotNull io.papermc.paper.util.Rotations rotations);
++    void setLeftLegRotations(@NotNull io.papermc.paper.math.Rotations rotations);
 +
 +    /**
 +     * Returns the ArmorStand's right leg rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @return the current rotations
 +     */
-+    @NotNull
-+    io.papermc.paper.util.Rotations getRightLegRotations();
++    @NotNull io.papermc.paper.math.Rotations getRightLegRotations();
 +
 +    /**
 +     * Sets the ArmorStand's right leg rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @param rotations the current rotations
 +     */
-+    void setRightLegRotations(@NotNull io.papermc.paper.util.Rotations rotations);
++    void setRightLegRotations(@NotNull io.papermc.paper.math.Rotations rotations);
 +
 +    /**
 +     * Returns the ArmorStand's head rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @return the current rotations
 +     */
-+    @NotNull
-+    io.papermc.paper.util.Rotations getHeadRotations();
++    @NotNull io.papermc.paper.math.Rotations getHeadRotations();
 +
 +    /**
 +     * Sets the ArmorStand's head rotations as
-+     * {@link io.papermc.paper.util.Rotations}.
++     * {@link io.papermc.paper.math.Rotations}.
 +     *
 +     * @param rotations the current rotations
 +     */
-+    void setHeadRotations(@NotNull io.papermc.paper.util.Rotations rotations);
++    void setHeadRotations(@NotNull io.papermc.paper.math.Rotations rotations);
      // Paper end
  }

--- a/patches/api/0131-Expand-ArmorStand-API.patch
+++ b/patches/api/0131-Expand-ArmorStand-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Expand ArmorStand API
 Adds the following:
 - Add proper methods for getting and setting items in both hands. Deprecates old methods
 - Enable/Disable slot interactions
-- Allow using Vectors for ArmorStand rotations
+- Allow using degrees for ArmorStand rotations (via new Rotations class)
 
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 

--- a/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
+++ b/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
@@ -3,18 +3,21 @@ From: willies952002 <admin@domnian.com>
 Date: Thu, 26 Jul 2018 02:25:46 -0400
 Subject: [PATCH] Implement Expanded ArmorStand API
 
-Add the following:
+Adds the following:
 - Add proper methods for getting and setting items in both hands. Deprecates old methods
 - Enable/Disable slot interactions
+- Allow using Vectors for ArmorStand rotations
+
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 == AT ==
 public net.minecraft.world.entity.decoration.ArmorStand isDisabled(Lnet/minecraft/world/entity/EquipmentSlot;)Z
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..f4065938bbfd04519d1363ee8781c316aca468ab 100644
+index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..48ee0a4724efc723aa766384327f04759901afc0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-@@ -239,6 +239,79 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
+@@ -239,6 +239,147 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
          getHandle().canMove = move;
      }
  
@@ -89,6 +92,74 @@ index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..f4065938bbfd04519d1363ee8781c316
 +    @Override
 +    public boolean isSlotDisabled(org.bukkit.inventory.EquipmentSlot slot) {
 +        return getHandle().isDisabled(org.bukkit.craftbukkit.CraftEquipmentSlot.getNMS(slot));
++    }
++
++    @Override
++    public org.bukkit.util.Vector getBodyRotation() {
++        return fromNMSRotation(getHandle().bodyPose);
++    }
++
++    @Override
++    public void setBodyRotation(org.bukkit.util.Vector rotation) {
++        getHandle().setBodyPose(toNMSRotation(rotation));
++    }
++
++    @Override
++    public org.bukkit.util.Vector getLeftArmRotation() {
++        return fromNMSRotation(getHandle().leftArmPose);
++    }
++
++    @Override
++    public void setLeftArmRotation(org.bukkit.util.Vector rotation) {
++        getHandle().setLeftArmPose(toNMSRotation(rotation));
++    }
++
++    @Override
++    public org.bukkit.util.Vector getRightArmRotation() {
++        return fromNMSRotation(getHandle().rightArmPose);
++    }
++
++    @Override
++    public void setRightArmRotation(org.bukkit.util.Vector rotation) {
++        getHandle().setRightArmPose(toNMSRotation(rotation));
++    }
++
++    @Override
++    public org.bukkit.util.Vector getLeftLegRotation() {
++        return fromNMSRotation(getHandle().leftLegPose);
++    }
++
++    @Override
++    public void setLeftLegRotation(org.bukkit.util.Vector rotation) {
++        getHandle().setLeftLegPose(toNMSRotation(rotation));
++    }
++
++    @Override
++    public org.bukkit.util.Vector getRightLegRotation() {
++        return fromNMSRotation(getHandle().rightLegPose);
++    }
++
++    @Override
++    public void setRightLegRotation(org.bukkit.util.Vector rotation) {
++        getHandle().setRightLegPose(toNMSRotation(rotation));
++    }
++
++    @Override
++    public org.bukkit.util.Vector getHeadRotation() {
++        return fromNMSRotation(getHandle().headPose);
++    }
++
++    @Override
++    public void setHeadRotation(org.bukkit.util.Vector rotation) {
++        getHandle().setHeadPose(toNMSRotation(rotation));
++    }
++
++    private static org.bukkit.util.Vector fromNMSRotation(Rotations old) {
++        return new org.bukkit.util.Vector(old.getX(), old.getY(), old.getZ());
++    }
++
++    private static Rotations toNMSRotation(org.bukkit.util.Vector old) {
++        return new Rotations((float) old.getX(), (float) old.getY(), (float) old.getZ());
 +    }
 +
      @Override

--- a/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
+++ b/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
@@ -8,10 +8,10 @@ Adds the following:
 - Enable/Disable slot interactions
 - Allow using degrees for ArmorStand rotations (via new Rotations class)
 
-Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
-
 == AT ==
 public net.minecraft.world.entity.decoration.ArmorStand isDisabled(Lnet/minecraft/world/entity/EquipmentSlot;)Z
+
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..f80cafe3544c7e6c3c29073ba6539783adf6666c 100644

--- a/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
+++ b/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
@@ -14,7 +14,7 @@ Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 public net.minecraft.world.entity.decoration.ArmorStand isDisabled(Lnet/minecraft/world/entity/EquipmentSlot;)Z
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..6fc6dfddb7a9e8a9e4f465daf9e39d6d3a8de1b6 100644
+index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..5dc1b31db2fffb2e327f7cfa7bc4efa784e4f6fa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 @@ -239,6 +239,147 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
@@ -159,7 +159,7 @@ index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..6fc6dfddb7a9e8a9e4f465daf9e39d6d
 +    }
 +
 +    private static Rotations toNMSRotations(io.papermc.paper.util.Rotations old) {
-+        return new Rotations((float) old.getX(), (float) old.getY(), (float) old.getZ());
++        return new Rotations((float) old.x(), (float) old.y(), (float) old.z());
 +    }
 +
      @Override

--- a/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
+++ b/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
@@ -14,7 +14,7 @@ Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 public net.minecraft.world.entity.decoration.ArmorStand isDisabled(Lnet/minecraft/world/entity/EquipmentSlot;)Z
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..48ee0a4724efc723aa766384327f04759901afc0 100644
+index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..6fc6dfddb7a9e8a9e4f465daf9e39d6d3a8de1b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 @@ -239,6 +239,147 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
@@ -95,70 +95,70 @@ index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..48ee0a4724efc723aa766384327f0475
 +    }
 +
 +    @Override
-+    public org.bukkit.util.Vector getBodyRotation() {
-+        return fromNMSRotation(getHandle().bodyPose);
++    public io.papermc.paper.util.Rotations getBodyRotations() {
++        return fromNMSRotations(getHandle().bodyPose);
 +    }
 +
 +    @Override
-+    public void setBodyRotation(org.bukkit.util.Vector rotation) {
-+        getHandle().setBodyPose(toNMSRotation(rotation));
++    public void setBodyRotations(io.papermc.paper.util.Rotations rotations) {
++        getHandle().setBodyPose(toNMSRotations(rotations));
 +    }
 +
 +    @Override
-+    public org.bukkit.util.Vector getLeftArmRotation() {
-+        return fromNMSRotation(getHandle().leftArmPose);
++    public io.papermc.paper.util.Rotations getLeftArmRotations() {
++        return fromNMSRotations(getHandle().leftArmPose);
 +    }
 +
 +    @Override
-+    public void setLeftArmRotation(org.bukkit.util.Vector rotation) {
-+        getHandle().setLeftArmPose(toNMSRotation(rotation));
++    public void setLeftArmRotations(io.papermc.paper.util.Rotations rotations) {
++        getHandle().setLeftArmPose(toNMSRotations(rotations));
 +    }
 +
 +    @Override
-+    public org.bukkit.util.Vector getRightArmRotation() {
-+        return fromNMSRotation(getHandle().rightArmPose);
++    public io.papermc.paper.util.Rotations getRightArmRotations() {
++        return fromNMSRotations(getHandle().rightArmPose);
 +    }
 +
 +    @Override
-+    public void setRightArmRotation(org.bukkit.util.Vector rotation) {
-+        getHandle().setRightArmPose(toNMSRotation(rotation));
++    public void setRightArmRotations(io.papermc.paper.util.Rotations rotations) {
++        getHandle().setRightArmPose(toNMSRotations(rotations));
 +    }
 +
 +    @Override
-+    public org.bukkit.util.Vector getLeftLegRotation() {
-+        return fromNMSRotation(getHandle().leftLegPose);
++    public io.papermc.paper.util.Rotations getLeftLegRotations() {
++        return fromNMSRotations(getHandle().leftLegPose);
 +    }
 +
 +    @Override
-+    public void setLeftLegRotation(org.bukkit.util.Vector rotation) {
-+        getHandle().setLeftLegPose(toNMSRotation(rotation));
++    public void setLeftLegRotations(io.papermc.paper.util.Rotations rotations) {
++        getHandle().setLeftLegPose(toNMSRotations(rotations));
 +    }
 +
 +    @Override
-+    public org.bukkit.util.Vector getRightLegRotation() {
-+        return fromNMSRotation(getHandle().rightLegPose);
++    public io.papermc.paper.util.Rotations getRightLegRotations() {
++        return fromNMSRotations(getHandle().rightLegPose);
 +    }
 +
 +    @Override
-+    public void setRightLegRotation(org.bukkit.util.Vector rotation) {
-+        getHandle().setRightLegPose(toNMSRotation(rotation));
++    public void setRightLegRotations(io.papermc.paper.util.Rotations rotations) {
++        getHandle().setRightLegPose(toNMSRotations(rotations));
 +    }
 +
 +    @Override
-+    public org.bukkit.util.Vector getHeadRotation() {
-+        return fromNMSRotation(getHandle().headPose);
++    public io.papermc.paper.util.Rotations getHeadRotations() {
++        return fromNMSRotations(getHandle().headPose);
 +    }
 +
 +    @Override
-+    public void setHeadRotation(org.bukkit.util.Vector rotation) {
-+        getHandle().setHeadPose(toNMSRotation(rotation));
++    public void setHeadRotations(io.papermc.paper.util.Rotations rotations) {
++        getHandle().setHeadPose(toNMSRotations(rotations));
 +    }
 +
-+    private static org.bukkit.util.Vector fromNMSRotation(Rotations old) {
-+        return new org.bukkit.util.Vector(old.getX(), old.getY(), old.getZ());
++    private static io.papermc.paper.util.Rotations fromNMSRotations(Rotations old) {
++        return new io.papermc.paper.util.Rotations(old.getX(), old.getY(), old.getZ());
 +    }
 +
-+    private static Rotations toNMSRotation(org.bukkit.util.Vector old) {
++    private static Rotations toNMSRotations(io.papermc.paper.util.Rotations old) {
 +        return new Rotations((float) old.getX(), (float) old.getY(), (float) old.getZ());
 +    }
 +

--- a/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
+++ b/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement Expanded ArmorStand API
 Adds the following:
 - Add proper methods for getting and setting items in both hands. Deprecates old methods
 - Enable/Disable slot interactions
-- Allow using Vectors for ArmorStand rotations
+- Allow using degrees for ArmorStand rotations (via new Rotations class)
 
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 

--- a/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
+++ b/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
@@ -14,7 +14,7 @@ Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 public net.minecraft.world.entity.decoration.ArmorStand isDisabled(Lnet/minecraft/world/entity/EquipmentSlot;)Z
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..5dc1b31db2fffb2e327f7cfa7bc4efa784e4f6fa 100644
+index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..1defa60f8b045831ec4b20a45c89676ddf682fab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 @@ -239,6 +239,147 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
@@ -95,70 +95,70 @@ index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..5dc1b31db2fffb2e327f7cfa7bc4efa7
 +    }
 +
 +    @Override
-+    public io.papermc.paper.util.Rotations getBodyRotations() {
++    public io.papermc.paper.math.Rotations getBodyRotations() {
 +        return fromNMSRotations(getHandle().bodyPose);
 +    }
 +
 +    @Override
-+    public void setBodyRotations(io.papermc.paper.util.Rotations rotations) {
++    public void setBodyRotations(io.papermc.paper.math.Rotations rotations) {
 +        getHandle().setBodyPose(toNMSRotations(rotations));
 +    }
 +
 +    @Override
-+    public io.papermc.paper.util.Rotations getLeftArmRotations() {
++    public io.papermc.paper.math.Rotations getLeftArmRotations() {
 +        return fromNMSRotations(getHandle().leftArmPose);
 +    }
 +
 +    @Override
-+    public void setLeftArmRotations(io.papermc.paper.util.Rotations rotations) {
++    public void setLeftArmRotations(io.papermc.paper.math.Rotations rotations) {
 +        getHandle().setLeftArmPose(toNMSRotations(rotations));
 +    }
 +
 +    @Override
-+    public io.papermc.paper.util.Rotations getRightArmRotations() {
++    public io.papermc.paper.math.Rotations getRightArmRotations() {
 +        return fromNMSRotations(getHandle().rightArmPose);
 +    }
 +
 +    @Override
-+    public void setRightArmRotations(io.papermc.paper.util.Rotations rotations) {
++    public void setRightArmRotations(io.papermc.paper.math.Rotations rotations) {
 +        getHandle().setRightArmPose(toNMSRotations(rotations));
 +    }
 +
 +    @Override
-+    public io.papermc.paper.util.Rotations getLeftLegRotations() {
++    public io.papermc.paper.math.Rotations getLeftLegRotations() {
 +        return fromNMSRotations(getHandle().leftLegPose);
 +    }
 +
 +    @Override
-+    public void setLeftLegRotations(io.papermc.paper.util.Rotations rotations) {
++    public void setLeftLegRotations(io.papermc.paper.math.Rotations rotations) {
 +        getHandle().setLeftLegPose(toNMSRotations(rotations));
 +    }
 +
 +    @Override
-+    public io.papermc.paper.util.Rotations getRightLegRotations() {
++    public io.papermc.paper.math.Rotations getRightLegRotations() {
 +        return fromNMSRotations(getHandle().rightLegPose);
 +    }
 +
 +    @Override
-+    public void setRightLegRotations(io.papermc.paper.util.Rotations rotations) {
++    public void setRightLegRotations(io.papermc.paper.math.Rotations rotations) {
 +        getHandle().setRightLegPose(toNMSRotations(rotations));
 +    }
 +
 +    @Override
-+    public io.papermc.paper.util.Rotations getHeadRotations() {
++    public io.papermc.paper.math.Rotations getHeadRotations() {
 +        return fromNMSRotations(getHandle().headPose);
 +    }
 +
 +    @Override
-+    public void setHeadRotations(io.papermc.paper.util.Rotations rotations) {
++    public void setHeadRotations(io.papermc.paper.math.Rotations rotations) {
 +        getHandle().setHeadPose(toNMSRotations(rotations));
 +    }
 +
-+    private static io.papermc.paper.util.Rotations fromNMSRotations(Rotations old) {
-+        return new io.papermc.paper.util.Rotations(old.getX(), old.getY(), old.getZ());
++    private static io.papermc.paper.math.Rotations fromNMSRotations(Rotations old) {
++        return new io.papermc.paper.math.Rotations(old.getX(), old.getY(), old.getZ());
 +    }
 +
-+    private static Rotations toNMSRotations(io.papermc.paper.util.Rotations old) {
++    private static Rotations toNMSRotations(io.papermc.paper.math.Rotations old) {
 +        return new Rotations((float) old.x(), (float) old.y(), (float) old.z());
 +    }
 +

--- a/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
+++ b/patches/server/0232-Implement-Expanded-ArmorStand-API.patch
@@ -14,7 +14,7 @@ Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 public net.minecraft.world.entity.decoration.ArmorStand isDisabled(Lnet/minecraft/world/entity/EquipmentSlot;)Z
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..1defa60f8b045831ec4b20a45c89676ddf682fab 100644
+index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..f80cafe3544c7e6c3c29073ba6539783adf6666c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 @@ -239,6 +239,147 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
@@ -155,7 +155,7 @@ index 82b9ee993b0d2e7e0685231f7bad2b85756ec959..1defa60f8b045831ec4b20a45c89676d
 +    }
 +
 +    private static io.papermc.paper.math.Rotations fromNMSRotations(Rotations old) {
-+        return new io.papermc.paper.math.Rotations(old.getX(), old.getY(), old.getZ());
++        return io.papermc.paper.math.Rotations.ofDegrees(old.getX(), old.getY(), old.getZ());
 +    }
 +
 +    private static Rotations toNMSRotations(io.papermc.paper.math.Rotations old) {


### PR DESCRIPTION
Introduces the new `Rotations` class that is used for storing rotations in degrees on each axis (X, Y, Z).

Currently, the patch adds usage for it for ArmorStand rotations, which makes manipulations easier and more precise 
(since it follows vanilla logic of using degrees instead of radians).

Example usage to set the right arm's rotation to 90 degrees on the X axis:
```java
armorStand.setRightArmRotations(Rotations.ofDegrees(90, 0, 0));
```

Simple! Before you'd have to use `EulerAngle` with a workaround like `Math.toRadians(90)`.

Feel free to give any feedback :)