### PR TITLE
Properly clone custom nbt tags inside ItemMeta

### DIFF
--- a/patches/server/0979-Deep-clone-unhandled-nbt-tags.patch
+++ b/patches/server/0979-Deep-clone-unhandled-nbt-tags.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Thu, 26 May 2022 03:30:05 +0300
+Subject: [PATCH] Deep clone unhandled nbt tags
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+index 936f8babf74b2be6240e5dbc2d0a84f8badada2e..4a3507143054a8352e513732d1be9da901ddaa88 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -344,8 +344,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+             this.destroyableKeys = new java.util.HashSet<>(meta.destroyableKeys);
+         }
+         // Paper end
+-        this.unhandledTags.putAll(meta.unhandledTags);
+-        this.persistentDataContainer.putAll(meta.persistentDataContainer.getRaw());
++        // Paper start - Deep clone unhandled nbt tags
++        meta.unhandledTags.forEach((key, tag) -> this.unhandledTags.put(key, tag.copy()));
++        this.persistentDataContainer.putAll(meta.persistentDataContainer.getTagsCloned());
++        // Paper end
+ 
+         this.internalTag = meta.internalTag;
+         if (this.internalTag != null) {
+@@ -1388,7 +1390,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+             if (this.hasAttributeModifiers()) {
+                 clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
+             }
+-            clone.persistentDataContainer = new CraftPersistentDataContainer(this.persistentDataContainer.getRaw(), CraftMetaItem.DATA_TYPE_REGISTRY);
++            // Paper start - Deep clone unhandled nbt tags
++            clone.persistentDataContainer = new CraftPersistentDataContainer(this.persistentDataContainer.getTagsCloned(), CraftMetaItem.DATA_TYPE_REGISTRY);
++            clone.unhandledTags.replaceAll((key, tag) -> tag.copy());
++            // Paper end
+             clone.hideFlag = this.hideFlag;
+             clone.unbreakable = this.unbreakable;
+             clone.damage = this.damage;
+diff --git a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
+index 20c7144307ecf1eb5c600f3b84df7bc15fa941d6..ae94fd71b8ea8cdbf6fb0420d826ae24c246d43b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
++++ b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
+@@ -189,5 +189,11 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+             this.putAll(compound);
+         }
+     }
++
++    public Map<String, Tag> getTagsCloned() {
++        Map<String, Tag> tags = new HashMap<>();
++        customDataTags.forEach((key, tag) -> tags.put(key, tag.copy()));
++        return tags;
++    }
+     // Paper end
+ }

--- a/patches/server/1019-Deep-clone-unhandled-nbt-tags.patch
+++ b/patches/server/1019-Deep-clone-unhandled-nbt-tags.patch
@@ -5,9 +5,18 @@ Subject: [PATCH] Deep clone unhandled nbt tags
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 936f8babf74b2be6240e5dbc2d0a84f8badada2e..4a3507143054a8352e513732d1be9da901ddaa88 100644
+index 076e06908a0cf97f86a64a15ca0231c5b0f06fec..3df1822b55358a9bdf41bcacd5b7fecfd8f05dfa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -303,7 +303,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
+ 
+     private CompoundTag internalTag;
+-    final Map<String, Tag> unhandledTags = new TreeMap<String, Tag>(); // Visible for testing only // Paper
++    Map<String, Tag> unhandledTags = new TreeMap<String, Tag>(); // Visible for testing only // Paper // Paper - remove final
+     private CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftMetaItem.DATA_TYPE_REGISTRY);
+ 
+     private int version = CraftMagicNumbers.INSTANCE.getDataVersion(); // Internal use only
 @@ -344,8 +344,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              this.destroyableKeys = new java.util.HashSet<>(meta.destroyableKeys);
          }
@@ -21,20 +30,21 @@ index 936f8babf74b2be6240e5dbc2d0a84f8badada2e..4a3507143054a8352e513732d1be9da9
  
          this.internalTag = meta.internalTag;
          if (this.internalTag != null) {
-@@ -1388,7 +1390,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1393,7 +1395,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
              }
 -            clone.persistentDataContainer = new CraftPersistentDataContainer(this.persistentDataContainer.getRaw(), CraftMetaItem.DATA_TYPE_REGISTRY);
 +            // Paper start - Deep clone unhandled nbt tags
 +            clone.persistentDataContainer = new CraftPersistentDataContainer(this.persistentDataContainer.getTagsCloned(), CraftMetaItem.DATA_TYPE_REGISTRY);
++            clone.unhandledTags = new TreeMap<>(this.unhandledTags);
 +            clone.unhandledTags.replaceAll((key, tag) -> tag.copy());
-+            // Paper end
++            // Paper end - Deep clone unhandled nbt tags
              clone.hideFlag = this.hideFlag;
              clone.unbreakable = this.unbreakable;
              clone.damage = this.damage;
 diff --git a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
-index 20c7144307ecf1eb5c600f3b84df7bc15fa941d6..ae94fd71b8ea8cdbf6fb0420d826ae24c246d43b 100644
+index 65013fd2ca24c4bf1cfd67e314927e72542d3e68..b040bd8be5c1803d0b4045990489ae4182f69568 100644
 --- a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
 @@ -189,5 +189,11 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
@@ -43,8 +53,8 @@ index 20c7144307ecf1eb5c600f3b84df7bc15fa941d6..ae94fd71b8ea8cdbf6fb0420d826ae24
      }
 +
 +    public Map<String, Tag> getTagsCloned() {
-+        Map<String, Tag> tags = new HashMap<>();
-+        customDataTags.forEach((key, tag) -> tags.put(key, tag.copy()));
++        final Map<String, Tag> tags = new HashMap<>();
++        this.customDataTags.forEach((key, tag) -> tags.put(key, tag.copy()));
 +        return tags;
 +    }
      // Paper end


### PR DESCRIPTION
TLDR; Unhandled nbt tags inside ItemMeta are not cloned upon cloning ItemMeta, which, in some very specific cases, leads to unintentionally modifying the original item when modifying the nbt of its clone.
______
ItemMeta stores Map of unhandled nbt tags and upon cloning it (usually either via `clone()` or `new ItemStack(oldItem)`) just puts all existing keys into the new map without cloning them.

Normally this would stay unnoticed (and was for years) and have no side effects since while working with nbt you do not modify the existing objects directly, **BUT** this is not the case at least for the compound tag, changes to which will be applied to every cloned item.

I've run into this issue while messing around with [NBT-API](https://github.com/tr7zw/Item-NBT-API) via the following code:
```java
ItemStack test1 = new ItemStack(Material.STONE);
new NBTItem(test1, true).getOrCreateCompound("TestCompound").setString("key1", "value1");
ItemStack test2 = test1.clone();
getLogger().info("item1: " + new NBTItem(test1));
getLogger().info("item2: " + new NBTItem(test2));
new NBTItem(test1, true).getOrCreateCompound("TestCompound").setString("key2", "value2");
getLogger().info("item1: " + new NBTItem(test1));
getLogger().info("item2: " + new NBTItem(test2));
```

Behavior before this patch:
```
[TestPlugin] item1: {TestCompound:{key1:"value1"}}
[TestPlugin] item2: {TestCompound:{key1:"value1"}}
[TestPlugin] item1: {TestCompound:{key1:"value1",key2:"value2"}}
[TestPlugin] item2: {TestCompound:{key1:"value1",key2:"value2"}}
```

Notice how the nbt of `item2` was affected too despite the item being the cloned one because they still share the same compound tag.
After the patch:
```
[TestPlugin] item1: {TestCompound:{key1:"value1"}}
[TestPlugin] item2: {TestCompound:{key1:"value1"}}
[TestPlugin] item1: {TestCompound:{key1:"value1",key2:"value2"}}
[TestPlugin] item2: {TestCompound:{key1:"value1"}}
```

Vanilla uses similar logic and also clones tags, so I'm not sure why this was not the case for Bukkit's implementation.
I'm open to opinions on this if any.

______
Edit: Simplified explanation in case it's not clear what's going on:
1. Upon cloning an item its meta gets separate name, lore, enchantments, etc. (all vanilla tags)
2. Items also have Map<String, Tag> of unhanled tags that plugins can use for storing custom data.
3. Upon cloning the new map is created and all the previous unhanded tags are put into the new map. (shallow copy)
4. Now we have two items that have their own vanilla tags (that are equals()) and shared custom tags (that are ==).
5. NBT-API accesses the compound tag of the first item and puts a new nbt value into it.
6. Since both the original and the cloned item share the same objects, the second item now has that newly created nbt value too, even though the second item was never touched within the code.