### PR TITLE
Fix cb's janky level name in WorldCreator

### DIFF
--- a/patches/api/0276-Add-methods-to-get-world-by-key.patch
+++ b/patches/api/0276-Add-methods-to-get-world-by-key.patch
@@ -49,8 +49,23 @@ index afed6bcf923166065ac9f63dd96191cd42eefcb9..181493def187f72b6ff89c3849598428
      /**
       * Create a new virtual {@link WorldBorder}.
       * <p>
+diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
+index abe79e4a2233341d0030742b823a0cfb5af97f41..204ab103eeff976d3da4f5694c31beafab6e1fdd 100644
+--- a/src/main/java/org/bukkit/UnsafeValues.java
++++ b/src/main/java/org/bukkit/UnsafeValues.java
+@@ -157,5 +157,10 @@ public interface UnsafeValues {
+      * @throws IllegalArgumentException if there isn't a registry for that type
+      */
+     <T extends Keyed> @org.jetbrains.annotations.NotNull Registry<T> registryFor(Class<T> classOfT);
++
++    /**
++     * Just don't use it.
++     */
++    @org.jetbrains.annotations.NotNull String getMainLevelName();
+     // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/WorldCreator.java b/src/main/java/org/bukkit/WorldCreator.java
-index cbe6b3a1ba7b04826d97c3558e8eb4e5ba11f92f..9fab6eed92c27ec9dd123171f5c4e1e7cda723e4 100644
+index cbe6b3a1ba7b04826d97c3558e8eb4e5ba11f92f..cbdcac688afb7c13dd7058fa522bbd2c5adc445e 100644
 --- a/src/main/java/org/bukkit/WorldCreator.java
 +++ b/src/main/java/org/bukkit/WorldCreator.java
 @@ -12,6 +12,7 @@ import org.jetbrains.annotations.Nullable;
@@ -61,15 +76,27 @@ index cbe6b3a1ba7b04826d97c3558e8eb4e5ba11f92f..9fab6eed92c27ec9dd123171f5c4e1e7
      private final String name;
      private long seed;
      private World.Environment environment = World.Environment.NORMAL;
-@@ -28,13 +29,67 @@ public class WorldCreator {
+@@ -28,13 +29,80 @@ public class WorldCreator {
       * @param name Name of the world that will be created
       */
      public WorldCreator(@NotNull String name) {
 -        if (name == null) {
 -            throw new IllegalArgumentException("World name cannot be null");
--        }
 +        // Paper start
-+        this(name, NamespacedKey.minecraft(name.toLowerCase(java.util.Locale.ENGLISH).replace(" ", "_")));
++        this(name, getWorldKey(name));
++    }
++
++    private static NamespacedKey getWorldKey(String name) {
++        final String mainLevelName = Bukkit.getUnsafe().getMainLevelName();
++        if (name.equals(mainLevelName)) {
++            return NamespacedKey.minecraft("overworld");
++        } else if (name.equals(mainLevelName + "_nether")) {
++            return NamespacedKey.minecraft("the_nether");
++        } else if (name.equals(mainLevelName + "_the_end")) {
++            return NamespacedKey.minecraft("the_end");
++        } else {
++            return NamespacedKey.minecraft(name.toLowerCase(java.util.Locale.ENGLISH).replace(" ", "_"));
+         }
 +    }
  
 -        this.name = name;

--- a/patches/api/0277-Item-Rarity-API.patch
+++ b/patches/api/0277-Item-Rarity-API.patch
@@ -39,7 +39,7 @@ index 0000000000000000000000000000000000000000..74ef8395cc040ce488c2acaa416db202
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 9e6380ed86b11cc763afa02ddaf124ee98e24797..96199694504da0008998471efe7bc45d5a57b13d 100644
+index b93f0af3a06ee4fb00964066e1b6d1d13dfec5c3..29f90ae1af33623b1c557d408e974c62276f9ad9 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4006,6 +4006,17 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
@@ -61,13 +61,13 @@ index 9e6380ed86b11cc763afa02ddaf124ee98e24797..96199694504da0008998471efe7bc45d
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 0697214210a6e87f690b9454d9651d06ca57a524..8cbd493f695229a7dad46916087aeb3159328bfe 100644
+index 204ab103eeff976d3da4f5694c31beafab6e1fdd..9616630817a3a302636a0d2fe8076cb7244b7996 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -157,5 +157,22 @@ public interface UnsafeValues {
-      * @throws IllegalArgumentException if there isn't a registry for that type
+@@ -162,5 +162,22 @@ public interface UnsafeValues {
+      * Just don't use it.
       */
-     <T extends Keyed> @org.jetbrains.annotations.NotNull Registry<T> registryFor(Class<T> classOfT);
+     @org.jetbrains.annotations.NotNull String getMainLevelName();
 +
 +    /**
 +     * Gets the item rarity of a material. The material <b>MUST</b> be an item.

--- a/patches/api/0278-Expose-protocol-version.patch
+++ b/patches/api/0278-Expose-protocol-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 8cbd493f695229a7dad46916087aeb3159328bfe..45a5e148ae5582a805e350b526cfb3ad87f6f945 100644
+index 9616630817a3a302636a0d2fe8076cb7244b7996..eadba6454530724619872034f6e680b4603b8a69 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -174,5 +174,12 @@ public interface UnsafeValues {
+@@ -179,5 +179,12 @@ public interface UnsafeValues {
       * @return the itemstack rarity
       */
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);

--- a/patches/api/0297-ItemStack-repair-check-API.patch
+++ b/patches/api/0297-ItemStack-repair-check-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack repair check API
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 45a5e148ae5582a805e350b526cfb3ad87f6f945..d712a2c7a8ec02d3abbbcb8e616e002e5cdf1afe 100644
+index eadba6454530724619872034f6e680b4603b8a69..248453b259781aa45516133a0ed824f4e6f6a369 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -175,6 +175,16 @@ public interface UnsafeValues {
+@@ -180,6 +180,16 @@ public interface UnsafeValues {
       */
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);
  

--- a/patches/api/0303-Attributes-API-for-item-defaults.patch
+++ b/patches/api/0303-Attributes-API-for-item-defaults.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Attributes API for item defaults
 
 
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 709ae1eaabd81ee712d7d6f353c4983f20f6dc4f..fb8758970a76ee263fc85aaccbafb0bf1745afb8 100644
+index 29f90ae1af33623b1c557d408e974c62276f9ad9..e0da69edf022ef1f67d2b71830a4f62b9e717ab3 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4017,6 +4017,21 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
@@ -31,10 +31,10 @@ index 709ae1eaabd81ee712d7d6f353c4983f20f6dc4f..fb8758970a76ee263fc85aaccbafb0bf
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index d712a2c7a8ec02d3abbbcb8e616e002e5cdf1afe..2141396d252cb78630181785d5ae0c17f8f7df10 100644
+index 248453b259781aa45516133a0ed824f4e6f6a369..a3045b63c4e63f8eac902beb0f48367a5e3e5d20 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -185,6 +185,18 @@ public interface UnsafeValues {
+@@ -190,6 +190,18 @@ public interface UnsafeValues {
       */
      public boolean isValidRepairItemStack(@org.jetbrains.annotations.NotNull ItemStack itemToBeRepaired, @org.jetbrains.annotations.NotNull ItemStack repairMaterial);
  

--- a/patches/api/0331-Get-entity-default-attributes.patch
+++ b/patches/api/0331-Get-entity-default-attributes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Get entity default attributes
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 2141396d252cb78630181785d5ae0c17f8f7df10..b78d18fc09cee98f0eac907409188c35b3c137fc 100644
+index a3045b63c4e63f8eac902beb0f48367a5e3e5d20..0a9a50251093e1ea605a748eb8d899f34b26ef7b 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -203,5 +203,22 @@ public interface UnsafeValues {
+@@ -208,5 +208,22 @@ public interface UnsafeValues {
       * @return the server's protocol version
       */
      int getProtocolVersion();

--- a/patches/api/0337-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/api/0337-Add-isCollidable-methods-to-various-places.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add isCollidable methods to various places
 
 
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 24df195ed5809969ba8229360b3e57465ae9301d..065ca80518c215cbebb068b0d59bf233a744b0db 100644
+index e0da69edf022ef1f67d2b71830a4f62b9e717ab3..a39e7af2529fb8e65641d76f78e2d8eb12900853 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4032,6 +4032,16 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
@@ -26,10 +26,10 @@ index 24df195ed5809969ba8229360b3e57465ae9301d..065ca80518c215cbebb068b0d59bf233
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index b78d18fc09cee98f0eac907409188c35b3c137fc..54b0fe21d3b6379e6550a3b1dc81c2a44e7699da 100644
+index 0a9a50251093e1ea605a748eb8d899f34b26ef7b..be8d5c172b0a300648f21e2163ccf0a9cd7915ee 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -220,5 +220,14 @@ public interface UnsafeValues {
+@@ -225,5 +225,14 @@ public interface UnsafeValues {
       * @throws IllegalArgumentException if the entity does not exist of have default attributes (use {@link #hasDefaultEntityAttributes(NamespacedKey)} first)
       */
      @org.jetbrains.annotations.NotNull org.bukkit.attribute.Attributable getDefaultEntityAttributes(@org.jetbrains.annotations.NotNull NamespacedKey entityKey);
@@ -45,7 +45,7 @@ index b78d18fc09cee98f0eac907409188c35b3c137fc..54b0fe21d3b6379e6550a3b1dc81c2a4
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index cff83028e9a08466551db4698cf4860553dd750d..3e980c630452c8ea72227bc4cd92c605253cd41b 100644
+index c847bc83c0911007d226f1a8c6f1d0cefa9a1689..cff39708e66208921da15d12d94407d6b6950298 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -481,6 +481,13 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran

--- a/patches/api/0380-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/api/0380-WorldCreator-keepSpawnLoaded.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/WorldCreator.java b/src/main/java/org/bukkit/WorldCreator.java
-index 9fab6eed92c27ec9dd123171f5c4e1e7cda723e4..1386ba7fd6466965d700db9493e009c186c07d43 100644
+index cbdcac688afb7c13dd7058fa522bbd2c5adc445e..355f9f27d29c65efebf099a72c37892a309edef1 100644
 --- a/src/main/java/org/bukkit/WorldCreator.java
 +++ b/src/main/java/org/bukkit/WorldCreator.java
 @@ -22,6 +22,7 @@ public class WorldCreator {
@@ -16,7 +16,7 @@ index 9fab6eed92c27ec9dd123171f5c4e1e7cda723e4..1386ba7fd6466965d700db9493e009c1
  
      /**
       * Creates an empty WorldCreationOptions for the given world name
-@@ -560,4 +561,29 @@ public class WorldCreator {
+@@ -573,4 +574,29 @@ public class WorldCreator {
  
          return result;
      }

--- a/patches/server/0608-Add-methods-to-get-world-by-key.patch
+++ b/patches/server/0608-Add-methods-to-get-world-by-key.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add methods to get world by key
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f904ce285548a81835b1d3af9c05f00f84d5d3da..6f30668471c2076e2bbd8af79791bbe362f4d08e 100644
+index ce93a00aba502b6d3e962c9396a82ae2587a6b52..b651a9d86a5b0e7ec2b10d2e756bbac4624f7f9c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1138,9 +1138,15 @@ public final class CraftServer implements Server {
@@ -51,3 +51,19 @@ index f904ce285548a81835b1d3af9c05f00f84d5d3da..6f30668471c2076e2bbd8af79791bbe3
      public void addWorld(World world) {
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index 9af0bd83c03a7e9fba04f7b9f0c66029a7f4b65a..c2d86ea45fd70e8790b2591d780dca76f08757bb 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -517,6 +517,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+     public <T extends org.bukkit.Keyed> Registry<T> registryFor(Class<T> classOfT) {
+         return io.papermc.paper.registry.PaperRegistry.getRegistry(classOfT);
+     }
++
++    @Override
++    public String getMainLevelName() {
++        return ((net.minecraft.server.dedicated.DedicatedServer) net.minecraft.server.MinecraftServer.getServer()).getProperties().levelName;
++    }
+     // Paper end
+ 
+     /**

--- a/patches/server/0610-Item-Rarity-API.patch
+++ b/patches/server/0610-Item-Rarity-API.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Item Rarity API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 9374dd74d42e005b7573800d3e9a356e1c57ea86..9cd69efe2923fd4c1680d386b8c16084359561c4 100644
+index c2d86ea45fd70e8790b2591d780dca76f08757bb..83ff35f53e8a327757aae9a437ca74640a686c56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -517,6 +517,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
-     public <T extends org.bukkit.Keyed> Registry<T> registryFor(Class<T> classOfT) {
-         return io.papermc.paper.registry.PaperRegistry.getRegistry(classOfT);
+@@ -522,6 +522,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
+     public String getMainLevelName() {
+         return ((net.minecraft.server.dedicated.DedicatedServer) net.minecraft.server.MinecraftServer.getServer()).getProperties().levelName;
      }
 +
 +    @Override

--- a/patches/server/0617-Expose-protocol-version.patch
+++ b/patches/server/0617-Expose-protocol-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 9cd69efe2923fd4c1680d386b8c16084359561c4..61a1992c3cd256c46f9a989bcb041f511f829378 100644
+index 83ff35f53e8a327757aae9a437ca74640a686c56..209ad4d73e7ac0c76600a4c68d9473765f09c240 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -531,6 +531,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -536,6 +536,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(org.bukkit.inventory.ItemStack itemStack) {
          return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
      }

--- a/patches/server/0649-ItemStack-repair-check-API.patch
+++ b/patches/server/0649-ItemStack-repair-check-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack repair check API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 61a1992c3cd256c46f9a989bcb041f511f829378..cdd1c1a5486d3a8a08642aec9a752b2eaeeb8f96 100644
+index 209ad4d73e7ac0c76600a4c68d9473765f09c240..9a98097f2d6beb6e7125ac5a7a2d60747d143a36 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -532,6 +532,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -537,6 +537,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
      }
  

--- a/patches/server/0655-Attributes-API-for-item-defaults.patch
+++ b/patches/server/0655-Attributes-API-for-item-defaults.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Attributes API for item defaults
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index cdd1c1a5486d3a8a08642aec9a752b2eaeeb8f96..0a4a9a151c8f58cd44497bf43c3bed8f9a7d87c5 100644
+index 9a98097f2d6beb6e7125ac5a7a2d60747d143a36..5e6e0b137604ac64e11a2dd883978ff1c8c59012 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -540,6 +540,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -545,6 +545,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftMagicNumbers.getItem(itemToBeRepaired.getType()).isValidRepairItem(CraftItemStack.asNMSCopy(itemToBeRepaired), CraftItemStack.asNMSCopy(repairMaterial));
      }
  

--- a/patches/server/0712-Get-entity-default-attributes.patch
+++ b/patches/server/0712-Get-entity-default-attributes.patch
@@ -90,10 +90,10 @@ index 0000000000000000000000000000000000000000..4ecba0b02c2813a890aecc5586987879
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 0a4a9a151c8f58cd44497bf43c3bed8f9a7d87c5..40574ff722e3cb3dcce0e7fa0b0d2a692d33e3f9 100644
+index 5e6e0b137604ac64e11a2dd883978ff1c8c59012..acd2bbe5807fcf1abc65da63c2a049735aefe977 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -557,6 +557,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -562,6 +562,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public int getProtocolVersion() {
          return net.minecraft.SharedConstants.getCurrentVersion().getProtocolVersion();
      }

--- a/patches/server/0718-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/server/0718-Add-isCollidable-methods-to-various-places.patch
@@ -37,10 +37,10 @@ index 7b9e943b391c061782fccd2b8d705ceec8db50fe..966ac60daebb7bb211ab8096fc0c5f33
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 40574ff722e3cb3dcce0e7fa0b0d2a692d33e3f9..17e67d32522ddeb9a8db06089fb7b7f3ed894d4d 100644
+index acd2bbe5807fcf1abc65da63c2a049735aefe977..2ab43400661fcc98d989e375dbeffa12e187c5e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -569,6 +569,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -574,6 +574,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
          var supplier = net.minecraft.world.entity.ai.attributes.DefaultAttributes.getSupplier((net.minecraft.world.entity.EntityType<? extends net.minecraft.world.entity.LivingEntity>) net.minecraft.core.Registry.ENTITY_TYPE.get(CraftNamespacedKey.toMinecraft(bukkitEntityKey)));
          return new io.papermc.paper.attribute.UnmodifiableAttributeMap(supplier);
      }


### PR DESCRIPTION
I did a quick test wherein a plugin's onEnable method I did
```java
WorldCreator creator = new WorldCreator("world");
Bukkit.createWorld(creator);
```
for `world`, `world_nether`, and `world_the_end` and now all 3 work. (It gets the level name defined in server.properties)