### PR TITLE
feat: Add Multiply total operation

### DIFF
--- a/patches/api/0384-implement-multiply-total-operations.patch
+++ b/patches/api/0384-implement-multiply-total-operations.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: DaRacci <racci@racci.dev>
+Date: Sat, 28 May 2022 23:39:28 +1000
+Subject: [PATCH] implement multiply total operations
+
+
+diff --git a/src/main/java/org/bukkit/attribute/AttributeModifier.java b/src/main/java/org/bukkit/attribute/AttributeModifier.java
+index ff8f1231f3e2e71740fd24fa8d4dac5d0e550ae7..378b57aeafd669a48663a905ae360700ebdc0d95 100644
+--- a/src/main/java/org/bukkit/attribute/AttributeModifier.java
++++ b/src/main/java/org/bukkit/attribute/AttributeModifier.java
+@@ -161,6 +161,9 @@ public class AttributeModifier implements ConfigurationSerializable {
+         /**
+          * Multiply amount by this value, after adding 1 to it.
+          */
+-        MULTIPLY_SCALAR_1;
++        // Paper start - Create sensibly named multiplication enum
++        MULTIPLY_SCALAR_1,
++        MULTIPLY_TOTAL;
++        // Paper end
+     }
+ }

--- a/patches/api/0384-implement-multiply-total-operations.patch
+++ b/patches/api/0384-implement-multiply-total-operations.patch
@@ -5,16 +5,21 @@ Subject: [PATCH] implement multiply total operations
 
 
 diff --git a/src/main/java/org/bukkit/attribute/AttributeModifier.java b/src/main/java/org/bukkit/attribute/AttributeModifier.java
-index ff8f1231f3e2e71740fd24fa8d4dac5d0e550ae7..378b57aeafd669a48663a905ae360700ebdc0d95 100644
+index ff8f1231f3e2e71740fd24fa8d4dac5d0e550ae7..3fc19ac7cc08a0d893a34ca6aa8d90b715d78ccb 100644
 --- a/src/main/java/org/bukkit/attribute/AttributeModifier.java
 +++ b/src/main/java/org/bukkit/attribute/AttributeModifier.java
-@@ -161,6 +161,9 @@ public class AttributeModifier implements ConfigurationSerializable {
+@@ -161,6 +161,14 @@ public class AttributeModifier implements ConfigurationSerializable {
          /**
           * Multiply amount by this value, after adding 1 to it.
           */
 -        MULTIPLY_SCALAR_1;
 +        // Paper start - Create sensibly named multiplication enum
 +        MULTIPLY_SCALAR_1,
++
++        /**
++         * Multiply amount by this value.
++         * @apiNote Acts like {@link #MULTIPLY_SCALAR_1} but without the +1.
++         */
 +        MULTIPLY_TOTAL;
 +        // Paper end
      }

--- a/patches/server/0906-implement-real-multiplication-operation.patch
+++ b/patches/server/0906-implement-real-multiplication-operation.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: DaRacci <racci@racci.dev>
+Date: Sat, 28 May 2022 23:44:17 +1000
+Subject: [PATCH] implement real multiplication operation
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeInstance.java b/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeInstance.java
+index 9c58d1190377ca887aa703cb8a96a2b028b63af1..c57578d3b8f66ed1bf355939c6a9340b9ec7ebcc 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeInstance.java
++++ b/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeInstance.java
+@@ -147,7 +147,11 @@ public class AttributeInstance {
+         for(AttributeModifier attributeModifier3 : this.getModifiersOrEmpty(AttributeModifier.Operation.MULTIPLY_TOTAL)) {
+             e *= 1.0D + attributeModifier3.getAmount();
+         }
+-
++        // Paper start - implement proper multiplication operation
++        for(AttributeModifier attributeModifier4 : this.getModifiersOrEmpty(AttributeModifier.Operation.MULTIPLY_TOTAL_REAL)) {
++            e *= attributeModifier4.getAmount();
++        }
++        // Paper end
+         return this.attribute.sanitizeValue(e);
+     }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java b/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java
+index 09b8fa2cee63e6bcb92ffc3694f67d0f90a3805d..ecc109d7463f903a72bc69bd3f462cde7641c197 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java
++++ b/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java
+@@ -98,9 +98,12 @@ public class AttributeModifier {
+     public static enum Operation {
+         ADDITION(0),
+         MULTIPLY_BASE(1),
+-        MULTIPLY_TOTAL(2);
++        // Paper start - implement proper multiplication operation
++        MULTIPLY_TOTAL(2),
++        MULTIPLY_TOTAL_REAL(3);
+ 
+-        private static final AttributeModifier.Operation[] OPERATIONS = new AttributeModifier.Operation[]{ADDITION, MULTIPLY_BASE, MULTIPLY_TOTAL};
++        private static final AttributeModifier.Operation[] OPERATIONS = new AttributeModifier.Operation[]{ADDITION, MULTIPLY_BASE, MULTIPLY_TOTAL, MULTIPLY_TOTAL_REAL};
++        // Paper end
+         private final int value;
+ 
+         private Operation(int id) {

--- a/patches/server/0906-implement-real-multiplication-operation.patch
+++ b/patches/server/0906-implement-real-multiplication-operation.patch
@@ -22,22 +22,38 @@ index 9c58d1190377ca887aa703cb8a96a2b028b63af1..c57578d3b8f66ed1bf355939c6a9340b
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java b/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java
-index 09b8fa2cee63e6bcb92ffc3694f67d0f90a3805d..f49a449bfa7f5372cf89680dfea6db637fce4b18 100644
+index 09b8fa2cee63e6bcb92ffc3694f67d0f90a3805d..e1a6f0a8858f9d276908d9e2b00b6ce804cbfb52 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java
-@@ -98,9 +98,13 @@ public class AttributeModifier {
+@@ -2,6 +2,7 @@ package net.minecraft.world.entity.ai.attributes;
+ 
+ import com.mojang.logging.LogUtils;
+ import io.netty.util.internal.ThreadLocalRandom;
++import java.awt.print.Paper;
+ import java.util.Objects;
+ import java.util.UUID;
+ import java.util.function.Supplier;
+@@ -98,9 +99,11 @@ public class AttributeModifier {
      public static enum Operation {
          ADDITION(0),
          MULTIPLY_BASE(1),
 -        MULTIPLY_TOTAL(2);
-+        // Paper start - implement proper multiplication operation
-+        MULTIPLY_TOTAL(100),
-+        MULTIPLY_TOTAL_REAL(101);
-+        // Paper end
++        MULTIPLY_TOTAL(2),
++        MULTIPLY_TOTAL_REAL(100); // Paper - implement proper multiplication operation
  
--        private static final AttributeModifier.Operation[] OPERATIONS = new AttributeModifier.Operation[]{ADDITION, MULTIPLY_BASE, MULTIPLY_TOTAL};
-+        private static final AttributeModifier.Operation[] OPERATIONS = new AttributeModifier.Operation[]{ADDITION, MULTIPLY_BASE, MULTIPLY_TOTAL, MULTIPLY_TOTAL_REAL};
+         private static final AttributeModifier.Operation[] OPERATIONS = new AttributeModifier.Operation[]{ADDITION, MULTIPLY_BASE, MULTIPLY_TOTAL};
 +        // Paper end
          private final int value;
  
          private Operation(int id) {
+@@ -114,6 +117,10 @@ public class AttributeModifier {
+         public static AttributeModifier.Operation fromValue(int id) {
+             if (id >= 0 && id < OPERATIONS.length) {
+                 return OPERATIONS[id];
++            // Paper start
++            } else if (id == 100) {
++                return MULTIPLY_TOTAL_REAL;
++            // Paper end
+             } else {
+                 throw new IllegalArgumentException("No operation with value " + id);
+             }

--- a/patches/server/0906-implement-real-multiplication-operation.patch
+++ b/patches/server/0906-implement-real-multiplication-operation.patch
@@ -22,17 +22,18 @@ index 9c58d1190377ca887aa703cb8a96a2b028b63af1..c57578d3b8f66ed1bf355939c6a9340b
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java b/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java
-index 09b8fa2cee63e6bcb92ffc3694f67d0f90a3805d..ecc109d7463f903a72bc69bd3f462cde7641c197 100644
+index 09b8fa2cee63e6bcb92ffc3694f67d0f90a3805d..f49a449bfa7f5372cf89680dfea6db637fce4b18 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/attributes/AttributeModifier.java
-@@ -98,9 +98,12 @@ public class AttributeModifier {
+@@ -98,9 +98,13 @@ public class AttributeModifier {
      public static enum Operation {
          ADDITION(0),
          MULTIPLY_BASE(1),
 -        MULTIPLY_TOTAL(2);
 +        // Paper start - implement proper multiplication operation
-+        MULTIPLY_TOTAL(2),
-+        MULTIPLY_TOTAL_REAL(3);
++        MULTIPLY_TOTAL(100),
++        MULTIPLY_TOTAL_REAL(101);
++        // Paper end
  
 -        private static final AttributeModifier.Operation[] OPERATIONS = new AttributeModifier.Operation[]{ADDITION, MULTIPLY_BASE, MULTIPLY_TOTAL};
 +        private static final AttributeModifier.Operation[] OPERATIONS = new AttributeModifier.Operation[]{ADDITION, MULTIPLY_BASE, MULTIPLY_TOTAL, MULTIPLY_TOTAL_REAL};


### PR DESCRIPTION
This allows the use of proper multiplication values, as none of the pre-existing bukkit enums properly convey the way to do this. And as exampled by me, The multiply_scalar_1 operation is frankly quite dumb, why add 1 to the users pre-existing input its just asking for unwanted pain while trying to figure out why the players health it 36 and not 18.