### PR TITLE
Update Adventure to 4.11.0 and implement ComponentLogger

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -7,14 +7,14 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 98afa6a25131dc626ea7a5122f33df6bd2d39178..eefc024acc3e14ae21855df7f2f358bd1e0a9e38 100644
+index 98afa6a25131dc626ea7a5122f33df6bd2d39178..fc37b3ef788b43d5523e8af416f8dbb6387ec92e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -8,18 +8,37 @@ java {
+@@ -8,18 +8,38 @@ java {
      withJavadocJar()
  }
  
-+val adventureVersion = "4.10.1"
++val adventureVersion = "4.11.0"
 +val apiAndDocs: Configuration by configurations.creating {
 +    attributes {
 +        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
@@ -46,10 +46,11 @@ index 98afa6a25131dc626ea7a5122f33df6bd2d39178..eefc024acc3e14ae21855df7f2f358bd
 +    apiAndDocs("net.kyori:adventure-text-serializer-gson")
 +    apiAndDocs("net.kyori:adventure-text-serializer-legacy")
 +    apiAndDocs("net.kyori:adventure-text-serializer-plain")
++    apiAndDocs("net.kyori:adventure-text-logger-slf4j")
      // Paper end
  
      compileOnly("org.apache.maven:maven-resolver-provider:3.8.4")
-@@ -77,9 +96,24 @@ tasks.withType<Javadoc> {
+@@ -77,9 +97,24 @@ tasks.withType<Javadoc> {
          "https://guava.dev/releases/31.0.1-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/1.30/",
          "https://javadoc.io/doc/org.jetbrains/annotations/23.0.0/", // Paper - we don't want Java 5 annotations
@@ -3939,6 +3940,35 @@ index 228421154913116069c20323afb519bdde2134df..26791db3c267670d5782f1d2b67ff7d5
 +    }
 +    // Paper end
  }
+diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
+index 03ca87a1cbace2459174bb7bb8847bda766e80c5..72ed40496d4b1259f88df5ac7fb1d4aee8e17fae 100644
+--- a/src/main/java/org/bukkit/plugin/Plugin.java
++++ b/src/main/java/org/bukkit/plugin/Plugin.java
+@@ -189,4 +189,7 @@ public interface Plugin extends TabExecutor {
+      */
+     @NotNull
+     public String getName();
++
++    @NotNull
++    public net.kyori.adventure.text.logger.slf4j.ComponentLogger getComponentLogger();
+ }
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+index 50a479488917b4ce019fa71a496c41e843e9c5c4..7c3215cd7c3ab7e046c82e845161c4fdbc8cba63 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+@@ -358,6 +358,12 @@ public abstract class JavaPlugin extends PluginBase {
+         return logger;
+     }
+ 
++    @NotNull
++    @Override
++    public net.kyori.adventure.text.logger.slf4j.ComponentLogger getComponentLogger() {
++        return net.kyori.adventure.text.logger.slf4j.ComponentLogger.logger(getLogger().getName());
++    }
++
+     @NotNull
+     @Override
+     public String toString() {
 diff --git a/src/main/java/org/bukkit/scoreboard/Objective.java b/src/main/java/org/bukkit/scoreboard/Objective.java
 index ff3fcb2697eb00736238d0efdcaefe43043334d3..75acd6f8f3d774bb79e8e513125e801c5569a244 100644
 --- a/src/main/java/org/bukkit/scoreboard/Objective.java

--- a/patches/api/0026-Use-ASM-for-event-executors.patch
+++ b/patches/api/0026-Use-ASM-for-event-executors.patch
@@ -6,13 +6,13 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 19b65a9b56b73f873ef646d14a6cf091b69d3873..bc6f68a0cadeec865401e9cb0dce89460484b148 100644
+index fc37b3ef788b43d5523e8af416f8dbb6387ec92e..677a6d377bcc5ed5db32601073a0a90c74100786 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -39,6 +39,9 @@ dependencies {
-     apiAndDocs("net.kyori:adventure-text-serializer-gson")
+@@ -40,6 +40,9 @@ dependencies {
      apiAndDocs("net.kyori:adventure-text-serializer-legacy")
      apiAndDocs("net.kyori:adventure-text-serializer-plain")
+     apiAndDocs("net.kyori:adventure-text-logger-slf4j")
 +
 +    implementation("org.ow2.asm:asm:9.2")
 +    implementation("org.ow2.asm:asm-commons:9.2")

--- a/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,20 +14,20 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index bc6f68a0cadeec865401e9cb0dce89460484b148..d6c4abc30af2b535644707a240b60d1b613785e9 100644
+index 677a6d377bcc5ed5db32601073a0a90c74100786..46016bd1a2403c9f449ba92ec942cd349da747ac 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -39,6 +39,8 @@ dependencies {
-     apiAndDocs("net.kyori:adventure-text-serializer-gson")
+@@ -40,6 +40,8 @@ dependencies {
      apiAndDocs("net.kyori:adventure-text-serializer-legacy")
      apiAndDocs("net.kyori:adventure-text-serializer-plain")
+     apiAndDocs("net.kyori:adventure-text-logger-slf4j")
 +    api("org.apache.logging.log4j:log4j-api:2.17.1")
 +    api("org.slf4j:slf4j-api:1.8.0-beta4")
  
      implementation("org.ow2.asm:asm:9.2")
      implementation("org.ow2.asm:asm-commons:9.2")
 diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
-index 03ca87a1cbace2459174bb7bb8847bda766e80c5..34438b5362b0ba0949625d81e8371fe0d1f76fdf 100644
+index 72ed40496d4b1259f88df5ac7fb1d4aee8e17fae..5fbac5d76589860ff1b4c24cc2eef73ec6ff6e0a 100644
 --- a/src/main/java/org/bukkit/plugin/Plugin.java
 +++ b/src/main/java/org/bukkit/plugin/Plugin.java
 @@ -179,6 +179,22 @@ public interface Plugin extends TabExecutor {

--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -3441,6 +3441,22 @@ index 1980240d3dc0331ddf2ff56e163e2bfbd3b231ab..7a7f3f53aef601f124d474d9890e23d8
          @Override
          public Inventory createInventory(InventoryHolder holder, InventoryType type, String title) {
              // BrewingStand does not extend TileEntityLootable
+diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java b/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java
+index 909b2c98e7a9117d2f737245e4661792ffafb744..699ae694e351372e87fa3e94da1c351b63db66c2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java
++++ b/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java
+@@ -78,6 +78,11 @@ public class MinecraftInternalPlugin extends PluginBase {
+         throw new UnsupportedOperationException("Not supported.");
+     }
+ 
++    @Override
++    public net.kyori.adventure.text.logger.slf4j.ComponentLogger getComponentLogger() {
++        throw new UnsupportedOperationException("Not supported.");
++    }
++
+     @Override
+     public PluginLoader getPluginLoader() {
+         throw new UnsupportedOperationException("Not supported.");
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
 index e9bb0728ae5c16aad4acc106d332db5095db4033..6752cd9b3bc246fc2a7764df0d2b40d3e638fa62 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java


### PR DESCRIPTION
Updated Adventure to version 4.11.0 and added the getComponentLogger method to the Plugin interface to be able to display components in the console through the respective plugin's logger instead of using ConsoleCommandSender#sendMessage