### PR TITLE
Mark books created by players as resolved

### DIFF
--- a/patches/server/0910-Mark-books-created-by-players-as-resolved.patch
+++ b/patches/server/0910-Mark-books-created-by-players-as-resolved.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: booky10 <boooky10@gmail.com>
+Date: Thu, 2 Jun 2022 17:40:20 +0200
+Subject: [PATCH] Mark books created by players as resolved
+
+Fixes an exploit that causes a hang when resolving a book nbt tag.
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 901fa17d0f0a3f66923f68f13f183bc4c17f7748..98bf6fd606858ac9255630f55bd13dd1e1c30a11 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -3047,6 +3047,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+             }
+             // CraftBukkit end
+ 
++            // Paper start
++            if (flag2 && itemstack.getItem() == Items.WRITTEN_BOOK && itemstack.tag != null) {
++                itemstack.tag.putBoolean("resolved", true);
++            }
++            // Paper end
++
+             if (flag1 && flag2) {
+                 this.player.inventoryMenu.getSlot(packet.getSlotNum()).set(itemstack);
+                 this.player.inventoryMenu.broadcastChanges();


### PR DESCRIPTION
Fixes an exploit that causes a hang when resolving a book nbt tag on book open.

I'm not sure this is something Paper would be interested in fixing, because this can be fixed by plugins and is only caused by giving players creative mode.