### PR TITLE
Remove incorrect throws javadoc in Team

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -4102,10 +4102,10 @@ index 5c855dbd0da895392f7a6e92cdc90782baf614ad..1ada91d790abedbc9b3aeb6e96467a0d
  
      /**
 diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java
-index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..07a9fa68075a2c5f5a4a7519976b506526d95ca0 100644
+index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..47b10df619ad2520b9bb673e2220f36391680f1b 100644
 --- a/src/main/java/org/bukkit/scoreboard/Team.java
 +++ b/src/main/java/org/bukkit/scoreboard/Team.java
-@@ -22,14 +22,102 @@ public interface Team {
+@@ -22,14 +22,100 @@ public interface Team {
       */
      @NotNull
      String getName() throws IllegalStateException;
@@ -4122,8 +4122,6 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..07a9fa68075a2c5f5a4a7519976b5065
 +     * Sets the name displayed to entries for this team
 +     *
 +     * @param displayName New display name
-+     * @throws IllegalArgumentException if displayName is longer than 128
-+     *     characters.
 +     * @throws IllegalStateException if this team has been unregistered
 +     */
 +    void displayName(@Nullable net.kyori.adventure.text.Component displayName) throws IllegalStateException, IllegalArgumentException;
@@ -4208,7 +4206,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..07a9fa68075a2c5f5a4a7519976b5065
      String getDisplayName() throws IllegalStateException;
  
      /**
-@@ -39,7 +127,9 @@ public interface Team {
+@@ -39,7 +125,9 @@ public interface Team {
       * @throws IllegalArgumentException if displayName is longer than 128
       *     characters.
       * @throws IllegalStateException if this team has been unregistered
@@ -4218,7 +4216,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..07a9fa68075a2c5f5a4a7519976b5065
      void setDisplayName(@NotNull String displayName) throws IllegalStateException, IllegalArgumentException;
  
      /**
-@@ -47,8 +137,10 @@ public interface Team {
+@@ -47,8 +135,10 @@ public interface Team {
       *
       * @return Team prefix
       * @throws IllegalStateException if this team has been unregistered
@@ -4229,7 +4227,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..07a9fa68075a2c5f5a4a7519976b5065
      String getPrefix() throws IllegalStateException;
  
      /**
-@@ -59,7 +151,9 @@ public interface Team {
+@@ -59,7 +149,9 @@ public interface Team {
       * @throws IllegalArgumentException if prefix is longer than 64
       *     characters
       * @throws IllegalStateException if this team has been unregistered
@@ -4239,7 +4237,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..07a9fa68075a2c5f5a4a7519976b5065
      void setPrefix(@NotNull String prefix) throws IllegalStateException, IllegalArgumentException;
  
      /**
-@@ -67,8 +161,10 @@ public interface Team {
+@@ -67,8 +159,10 @@ public interface Team {
       *
       * @return the team's current suffix
       * @throws IllegalStateException if this team has been unregistered
@@ -4250,7 +4248,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..07a9fa68075a2c5f5a4a7519976b5065
      String getSuffix() throws IllegalStateException;
  
      /**
-@@ -79,7 +175,9 @@ public interface Team {
+@@ -79,7 +173,9 @@ public interface Team {
       * @throws IllegalArgumentException if suffix is longer than 64
       *     characters
       * @throws IllegalStateException if this team has been unregistered
@@ -4260,7 +4258,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..07a9fa68075a2c5f5a4a7519976b5065
      void setSuffix(@NotNull String suffix) throws IllegalStateException, IllegalArgumentException;
  
      /**
-@@ -90,8 +188,10 @@ public interface Team {
+@@ -90,8 +186,10 @@ public interface Team {
       *
       * @return team color, defaults to {@link ChatColor#RESET}
       * @throws IllegalStateException if this team has been unregistered
@@ -4271,7 +4269,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..07a9fa68075a2c5f5a4a7519976b5065
      ChatColor getColor() throws IllegalStateException;
  
      /**
-@@ -102,7 +202,9 @@ public interface Team {
+@@ -102,7 +200,9 @@ public interface Team {
       *
       * @param color new color, must be non-null. Use {@link ChatColor#RESET} for
       * no color

--- a/patches/api/0346-Improve-scoreboard-entries.patch
+++ b/patches/api/0346-Improve-scoreboard-entries.patch
@@ -110,10 +110,10 @@ index 1ada91d790abedbc9b3aeb6e96467a0d78560f15..fc3456bb79f2fe1504359455b937c162
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java
-index 07a9fa68075a2c5f5a4a7519976b506526d95ca0..51205a71d243195fdf35515374a1e9ef5df26bc0 100644
+index 47b10df619ad2520b9bb673e2220f36391680f1b..cbc82a03c24f746b913b30f14ecb0c08cdb42c24 100644
 --- a/src/main/java/org/bukkit/scoreboard/Team.java
 +++ b/src/main/java/org/bukkit/scoreboard/Team.java
-@@ -310,9 +310,8 @@ public interface Team {
+@@ -308,9 +308,8 @@ public interface Team {
       * @throws IllegalArgumentException if player is null
       * @throws IllegalStateException if this team has been unregistered
       * @see #addEntry(String)
@@ -124,7 +124,7 @@ index 07a9fa68075a2c5f5a4a7519976b506526d95ca0..51205a71d243195fdf35515374a1e9ef
      void addPlayer(@NotNull OfflinePlayer player) throws IllegalStateException, IllegalArgumentException;
  
      /**
-@@ -334,9 +333,8 @@ public interface Team {
+@@ -332,9 +331,8 @@ public interface Team {
       * @throws IllegalArgumentException if player is null
       * @throws IllegalStateException if this team has been unregistered
       * @see #removeEntry(String)
@@ -135,7 +135,7 @@ index 07a9fa68075a2c5f5a4a7519976b506526d95ca0..51205a71d243195fdf35515374a1e9ef
      boolean removePlayer(@NotNull OfflinePlayer player) throws IllegalStateException, IllegalArgumentException;
  
      /**
-@@ -364,9 +362,8 @@ public interface Team {
+@@ -362,9 +360,8 @@ public interface Team {
       * @throws IllegalArgumentException if player is null
       * @throws IllegalStateException if this team has been unregistered
       * @see #hasEntry(String)
@@ -146,7 +146,7 @@ index 07a9fa68075a2c5f5a4a7519976b506526d95ca0..51205a71d243195fdf35515374a1e9ef
      boolean hasPlayer(@NotNull OfflinePlayer player) throws IllegalArgumentException, IllegalStateException;
      /**
       * Checks to see if the specified entry is a member of this team.
-@@ -397,6 +394,42 @@ public interface Team {
+@@ -395,6 +392,42 @@ public interface Team {
       */
      void setOption(@NotNull Option option, @NotNull OptionStatus status) throws IllegalStateException;
  

--- a/patches/api/0355-Multiple-Entries-with-Scoreboards.patch
+++ b/patches/api/0355-Multiple-Entries-with-Scoreboards.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Multiple Entries with Scoreboards
 
 
 diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java
-index 51205a71d243195fdf35515374a1e9ef5df26bc0..0f5c49d41c9460da0ba913b4ca8bef375f2c23df 100644
+index cbc82a03c24f746b913b30f14ecb0c08cdb42c24..06a5d3177ca7ab90c3fd9d2053b2ec5e887c7c62 100644
 --- a/src/main/java/org/bukkit/scoreboard/Team.java
 +++ b/src/main/java/org/bukkit/scoreboard/Team.java
-@@ -325,6 +325,60 @@ public interface Team {
+@@ -323,6 +323,60 @@ public interface Team {
       */
      void addEntry(@NotNull String entry) throws IllegalStateException, IllegalArgumentException;
  
@@ -69,7 +69,7 @@ index 51205a71d243195fdf35515374a1e9ef5df26bc0..0f5c49d41c9460da0ba913b4ca8bef37
      /**
       * Removes the player from this team.
       *
-@@ -347,6 +401,56 @@ public interface Team {
+@@ -345,6 +399,56 @@ public interface Team {
       */
      boolean removeEntry(@NotNull String entry) throws IllegalStateException, IllegalArgumentException;
  


### PR DESCRIPTION
With the adventure team display name method, we don't do upstreams totally not needed 128 length check.

On a related note, even though the setDisplayName(String) method is deprecated, should we remove that 128 length check anyways? I don't think we really care since its deprecated, but thought I'd ask.