### PR TITLE
Add sendMiniMessage and sendPlainMessage methods

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -1404,7 +1404,7 @@ index 4bfc214685164a38ba4261b2bae7faa8a3bd297e..11af71edd7eaefb3cce3c2b59d390ff9
          if (sendToSource && !(source instanceof ConsoleCommandSender)) {
              source.sendMessage(message);
 diff --git a/src/main/java/org/bukkit/command/CommandSender.java b/src/main/java/org/bukkit/command/CommandSender.java
-index 284be63a125624a8ae43d2c164aede810ce6bfe5..22b654efdcc49d6dc6d52c9d6afa1c9dc7978e35 100644
+index 284be63a125624a8ae43d2c164aede810ce6bfe5..491c5ac3d58736c091a4af84e5a3a182fce9207f 100644
 --- a/src/main/java/org/bukkit/command/CommandSender.java
 +++ b/src/main/java/org/bukkit/command/CommandSender.java
 @@ -6,12 +6,13 @@ import org.bukkit.permissions.Permissible;
@@ -1486,7 +1486,7 @@ index 284be63a125624a8ae43d2c164aede810ce6bfe5..22b654efdcc49d6dc6d52c9d6afa1c9d
          public void sendMessage(@Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -99,4 +111,18 @@ public interface CommandSender extends Permissible {
+@@ -99,4 +111,36 @@ public interface CommandSender extends Permissible {
      @NotNull
      Spigot spigot();
      // Spigot end
@@ -1497,11 +1497,29 @@ index 284be63a125624a8ae43d2c164aede810ce6bfe5..22b654efdcc49d6dc6d52c9d6afa1c9d
 +     *
 +     * @return Name of the sender
 +     */
-+    public @NotNull net.kyori.adventure.text.Component name();
++    @NotNull net.kyori.adventure.text.Component name();
 +
 +    @Override
 +    default void sendMessage(final @NotNull net.kyori.adventure.identity.Identity identity, final @NotNull net.kyori.adventure.text.Component message, final @NotNull net.kyori.adventure.audience.MessageType type) {
 +        this.sendMessage(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(message));
++    }
++
++    /**
++     * Sends a message with the MiniMessage format to the command sender.
++     *
++     * @param message MiniMessage content
++     */
++    default void sendMiniMessage(final @NotNull String message) {
++        this.sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(message));
++    }
++
++    /**
++     * Sends a plain message to the command sender.
++     *
++     * @param message plain message
++     */
++    default void sendPlainMessage(final @NotNull String message) {
++        this.sendMessage(net.kyori.adventure.text.Component.text(message));
 +    }
 +    // Paper end
  }

--- a/patches/api/0021-Add-BaseComponent-sendMessage-methods-to-CommandSend.patch
+++ b/patches/api/0021-Add-BaseComponent-sendMessage-methods-to-CommandSend.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add BaseComponent sendMessage methods to CommandSender
 
 
 diff --git a/src/main/java/org/bukkit/command/CommandSender.java b/src/main/java/org/bukkit/command/CommandSender.java
-index 22b654efdcc49d6dc6d52c9d6afa1c9dc7978e35..daab4d13556150d4a4875f0273795e2c4cb82d63 100644
+index 491c5ac3d58736c091a4af84e5a3a182fce9207f..e81749db2f4fad71c5f409edb0f7a4dc98bed8b4 100644
 --- a/src/main/java/org/bukkit/command/CommandSender.java
 +++ b/src/main/java/org/bukkit/command/CommandSender.java
 @@ -1,6 +1,9 @@
@@ -18,9 +18,9 @@ index 22b654efdcc49d6dc6d52c9d6afa1c9dc7978e35..daab4d13556150d4a4875f0273795e2c
  import org.bukkit.Server;
  import org.bukkit.permissions.Permissible;
  import org.jetbrains.annotations.NotNull;
-@@ -124,5 +127,33 @@ public interface CommandSender extends net.kyori.adventure.audience.Audience, Pe
-     default void sendMessage(final @NotNull net.kyori.adventure.identity.Identity identity, final @NotNull net.kyori.adventure.text.Component message, final @NotNull net.kyori.adventure.audience.MessageType type) {
-         this.sendMessage(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(message));
+@@ -142,5 +145,33 @@ public interface CommandSender extends net.kyori.adventure.audience.Audience, Pe
+     default void sendPlainMessage(final @NotNull String message) {
+         this.sendMessage(net.kyori.adventure.text.Component.text(message));
      }
 +
 +    /**


### PR DESCRIPTION
Not sure about any more in-depth docs there, but there we go, exemplifying how easy it is to use minimessage and at least providing one shorthand method for the most common usecase + having something separate from the legacy text accepting sendMessage method for plain text