### PR TITLE
Make leave messages for kicks the same as for quitting

### DIFF
--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -1366,7 +1366,7 @@ index 3431a70a07c08fdc20c7a8d667e6275f212b549e..d4d444b5864073fe86bfc7b5a68344b5
          // CraftBukkit end
          this.chatVisibility = packet.chatVisibility();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3d9a2d4ff540f02163edd023ff86815fda5a35b8..7d624f741291cad59545e465db9c46e56581ed8a 100644
+index 3d9a2d4ff540f02163edd023ff86815fda5a35b8..9dd29a669a10735819d3be03e4693850de58bb28 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -155,6 +155,8 @@ import org.apache.commons.lang3.StringUtils;
@@ -1404,7 +1404,7 @@ index 3d9a2d4ff540f02163edd023ff86815fda5a35b8..7d624f741291cad59545e465db9c46e5
              return;
          }
 -        String leaveMessage = ChatFormatting.YELLOW + this.player.getScoreboardName() + " left the game.";
-+        net.kyori.adventure.text.Component leaveMessage = net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, this.player.getBukkitEntity().displayName()); // Paper - Adventure
++        net.kyori.adventure.text.Component leaveMessage = net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? this.player.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(this.player.getScoreboardName())); // Paper - Adventure
  
 -        PlayerKickEvent event = new PlayerKickEvent(this.player.getBukkitEntity(), s, leaveMessage);
 +        PlayerKickEvent event = new PlayerKickEvent(this.player.getBukkitEntity(), reason, leaveMessage); // Paper - Adventure
@@ -1764,7 +1764,7 @@ index 595b56b2ab9a813ba71399d306117294fa90dc65..3527d40102d512d0e276edc969ea3c18
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d29c6d0536619fab5a48fbb52115dac09e7d7ca3..e2270d75c1ffaf0b68300f0734987e86ab6fedda 100644
+index 66e8fea6bd10af2e19a4f49c556e66a63e6205b6..81e78644417764cee33f81cdb116a91fb1d8ccf3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -586,8 +586,10 @@ public final class CraftServer implements Server {

--- a/patches/server/0660-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0660-Add-PlayerKickEvent-causes.patch
@@ -57,7 +57,7 @@ index 708ac03d5a849bf09c49547306e4a8c5a5ef8d91..5a8df368a4a25839cd4ac9be6972da2e
          }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index bb9881c7e45bfa13f04f9779ec134fa349bd9133..62a006c1869118ed2fe5bc573c83f6398ff64167 100644
+index 4f7cd9209cf6c352817591dd497c2e7ec6265ac6..0a018328dfe2b73f962a1939786b9025ba0ebabe 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -318,7 +318,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -124,7 +124,7 @@ index bb9881c7e45bfa13f04f9779ec134fa349bd9133..62a006c1869118ed2fe5bc573c83f639
          if (this.processedDisconnect) {
 @@ -429,7 +437,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
          }
-         net.kyori.adventure.text.Component leaveMessage = net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, this.player.getBukkitEntity().displayName()); // Paper - Adventure
+         net.kyori.adventure.text.Component leaveMessage = net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? this.player.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(this.player.getScoreboardName())); // Paper - Adventure
  
 -        PlayerKickEvent event = new PlayerKickEvent(this.player.getBukkitEntity(), reason, leaveMessage); // Paper - Adventure
 +        PlayerKickEvent event = new PlayerKickEvent(this.player.getBukkitEntity(), reason, leaveMessage, cause); // Paper - Adventure & kick event reason


### PR DESCRIPTION
When a player quits normally their leave message respects the `use-display-name-in-quit-message` setting, but when they are kicked the leave message always uses their display name.

This PR makes kick messages consistent with quit messages