### PR TITLE
Configurable chat thread limit

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -431,10 +431,10 @@ index 0000000000000000000000000000000000000000..c2dca89291361d60cbf160cab77749cb
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..456595e4b7e0c7f50617aa2694b0d2dfc368ab81
+index 0000000000000000000000000000000000000000..aaecd691922a28e971b859175574c80a330edb8e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,265 @@
+@@ -0,0 +1,274 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -688,6 +688,15 @@ index 0000000000000000000000000000000000000000..456595e4b7e0c7f50617aa2694b0d2df
 +    public Misc misc;
 +
 +    public class Misc extends ConfigurationPart {
++        public class ChatThreads extends ConfigurationPart.Post {
++            private int chatExecutorCoreSize = -1;
++            private int chatExecutorMaxSize = -1;
++
++            @Override
++            public void postProcess() {
++                // TODO: FILL
++            }
++        }
 +        public int maxJoinsPerTick = 3;
 +        public boolean fixEntityPositionDesync = true;
 +        public boolean loadPermissionsYmlBeforePlugins = true;

--- a/patches/server/0943-Configurable-chat-thread-limit.patch
+++ b/patches/server/0943-Configurable-chat-thread-limit.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Sun, 18 Sep 2022 06:33:17 +0100
+Subject: [PATCH] Configurable chat thread limit
+
+By default, spigot shifts chat over to an unbounded thread pool,
+on a normal server, this really offers no gains, the creation of a thread
+on submitting to the pool on these servers eats more time vs just running it in
+the netty pipeline, however, on servers using plugins which do work in here, there
+could be some overall benefits to moving this stuff outside of the pipeline.
+
+In general, this patch does two things:
+1) Exposes the core size for the pool, this allows for ensuring that a number of threads
+sit around in the pool, mitigating the need for creating new threads; This IS however
+caveated, the ThreadPoolExecutor will ONLY create core threads as they're needed, it
+just won't allow for us to dip back under the # of core threads, this can potentially
+be mitigated by calling prestartCoreThread, however, I'm not sure if there is much justification
+for this
+2) Exposes a max size for the pool, as stated, by default this is unbounded, for most
+servers limiting the size of the pool is going to have 0 effects given how fast chat
+is actually processed, this is honestly really just exposed for the misnomers or people
+who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
+
+diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+index aaecd691922a28e971b859175574c80a330edb8e..21b3912dd6a99a7de70db6f5e0dc658b2630626b 100644
+--- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
++++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+@@ -251,13 +251,24 @@ public class GlobalConfiguration extends ConfigurationPart {
+     public Misc misc;
+ 
+     public class Misc extends ConfigurationPart {
++
++        public ChatThreads chatThreads;
+         public class ChatThreads extends ConfigurationPart.Post {
+             private int chatExecutorCoreSize = -1;
+             private int chatExecutorMaxSize = -1;
+ 
+             @Override
+             public void postProcess() {
+-                // TODO: FILL
++                int _chatExecutorMaxSize = (chatExecutorMaxSize <= 0) ? Integer.MAX_VALUE : chatExecutorMaxSize; // This is somewhat dumb, but, this is the default, do we cap this?;
++                int _chatExecutorCoreSize = Math.max(chatExecutorCoreSize, 0);
++
++                if (_chatExecutorMaxSize < _chatExecutorCoreSize) {
++                    _chatExecutorMaxSize = _chatExecutorCoreSize;
++                }
++
++                java.util.concurrent.ThreadPoolExecutor executor = (java.util.concurrent.ThreadPoolExecutor) net.minecraft.server.MinecraftServer.getServer().chatExecutor;
++                executor.setCorePoolSize(_chatExecutorCoreSize);
++                executor.setMaximumPoolSize(_chatExecutorMaxSize);
+             }
+         }
+         public int maxJoinsPerTick = 3;

--- a/patches/server/0943-Configurable-chat-thread-limit.patch
+++ b/patches/server/0943-Configurable-chat-thread-limit.patch
@@ -22,10 +22,10 @@ is actually processed, this is honestly really just exposed for the misnomers or
 who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
 
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index aaecd691922a28e971b859175574c80a330edb8e..21b3912dd6a99a7de70db6f5e0dc658b2630626b 100644
+index aaecd691922a28e971b859175574c80a330edb8e..96b68840ef5c7c726e4c8c2d9f907196561a94bf 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -251,13 +251,24 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -251,13 +251,26 @@ public class GlobalConfiguration extends ConfigurationPart {
      public Misc misc;
  
      public class Misc extends ConfigurationPart {
@@ -38,6 +38,8 @@ index aaecd691922a28e971b859175574c80a330edb8e..21b3912dd6a99a7de70db6f5e0dc658b
              @Override
              public void postProcess() {
 -                // TODO: FILL
++                //noinspection ConstantConditions
++                if (net.minecraft.server.MinecraftServer.getServer() == null) return; // In testing env, this will be null here
 +                int _chatExecutorMaxSize = (chatExecutorMaxSize <= 0) ? Integer.MAX_VALUE : chatExecutorMaxSize; // This is somewhat dumb, but, this is the default, do we cap this?;
 +                int _chatExecutorCoreSize = Math.max(chatExecutorCoreSize, 0);
 +


### PR DESCRIPTION
By default, spigot shifts chat over to an unbounded thread pool,
on a normal server, this really offers no gains, the creation of a thread
on submitting to the pool on these servers eats more time vs just running it in
the netty pipeline, however, on servers using plugins which do work in here, there
could be some overall benefits to moving this stuff outside of the pipeline.

In general, this patch does two things:
1) Exposes the core size for the pool, this allows for ensuring that a number of threads
sit around in the pool, mitigating the need for creating new threads; This IS however
caveated, the ThreadPoolExecutor will ONLY create core threads as they're needed, it
just won't allow for us to dip back under the # of core threads, this can potentially
be mitigated by calling prestartCoreThread, however, I'm not sure if there is much justification
for this
2) Exposes a max size for the pool, as stated, by default, this is unbounded, for most
servers limiting the size of the pool is going to have 0 effects given how fast chat
is actually processed, this is honestly really just exposed for the misnomers or people
who just wanna ensure that this won't grow over a specific size if chat gets stupidly active

This is basically my own take on #7483 