### PR TITLE
Check if is light status or above / isLightOn / starlight version fits

### DIFF
--- a/patches/server/0789-Rewrite-the-light-engine.patch
+++ b/patches/server/0789-Rewrite-the-light-engine.patch
@@ -5040,7 +5040,7 @@ index 5ce6a2b83546f4dbc3183a386f51b4bacc173744..a7231ceda4f3e96c0e0c11eee953f129
          this.fluidTicks = fluidTickScheduler;
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
-index be9c15fe141ede1132dbe07ba4bfcf22036ab194..ae8da73b98ccc957125d67e1cb4416c5edcb84ea 100644
+index be9c15fe141ede1132dbe07ba4bfcf22036ab194..3a2d6200d41c9758763d7a975d62e6e6842da3e2 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 @@ -94,6 +94,14 @@ public class ChunkSerializer {
@@ -5096,7 +5096,7 @@ index be9c15fe141ede1132dbe07ba4bfcf22036ab194..ae8da73b98ccc957125d67e1cb4416c5
 -            if (flag3 || flag4) {
 -                if (!flag2) {
 +            // Paper start - rewrite the light engine
-+            if (flag && (flag3 || flag4)) {
++            if (flag) {
 +                if ((flag3 || flag4) && !flag2) {
                      tasksToExecuteOnMain.add(() -> { // Paper - delay this task since we're executing off-main
                      lightengine.retainData(chunkPos, true);

--- a/patches/server/0789-Rewrite-the-light-engine.patch
+++ b/patches/server/0789-Rewrite-the-light-engine.patch
@@ -5040,7 +5040,7 @@ index 5ce6a2b83546f4dbc3183a386f51b4bacc173744..a7231ceda4f3e96c0e0c11eee953f129
          this.fluidTicks = fluidTickScheduler;
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
-index be9c15fe141ede1132dbe07ba4bfcf22036ab194..3c220d833ca6bb9409bc71d6f61e61783dba236b 100644
+index be9c15fe141ede1132dbe07ba4bfcf22036ab194..ae8da73b98ccc957125d67e1cb4416c5edcb84ea 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 @@ -94,6 +94,14 @@ public class ChunkSerializer {
@@ -5096,7 +5096,7 @@ index be9c15fe141ede1132dbe07ba4bfcf22036ab194..3c220d833ca6bb9409bc71d6f61e6178
 -            if (flag3 || flag4) {
 -                if (!flag2) {
 +            // Paper start - rewrite the light engine
-+            if (true || flag3 || flag4) {
++            if (flag && (flag3 || flag4)) {
 +                if ((flag3 || flag4) && !flag2) {
                      tasksToExecuteOnMain.add(() -> { // Paper - delay this task since we're executing off-main
                      lightengine.retainData(chunkPos, true);


### PR DESCRIPTION
This check was removed, so this would basically always try to read the light data.