### PR TITLE
(1.19) Make timings link clickable

### DIFF
--- a/patches/server/0012-Timings-v2.patch
+++ b/patches/server/0012-Timings-v2.patch
@@ -163,10 +163,10 @@ index 0000000000000000000000000000000000000000..b47b7dce26805badd422c1867733ff4b
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4092a227a540a1c5cfb95efcc2a36e049b9a979c
+index 0000000000000000000000000000000000000000..46297ac0a19fd2398ab777a381eff4d0a256161e
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -0,0 +1,384 @@
+@@ -0,0 +1,385 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -194,6 +194,7 @@ index 0000000000000000000000000000000000000000..4092a227a540a1c5cfb95efcc2a36e04
 +
 +import com.google.common.collect.Sets;
 +import io.papermc.paper.adventure.PaperAdventure;
++import net.kyori.adventure.text.event.ClickEvent;
 +import net.kyori.adventure.text.format.NamedTextColor;
 +import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 +import net.minecraft.server.MinecraftServer;
@@ -511,7 +512,7 @@ index 0000000000000000000000000000000000000000..4092a227a540a1c5cfb95efcc2a36e04
 +            }
 +
 +            timingsURL = con.getHeaderField("Location");
-+            listeners.sendMessage(text("View Timings Report: " + timingsURL, NamedTextColor.GREEN));
++            listeners.sendMessage(text("View Timings Report: ", NamedTextColor.GREEN).append(text(timingsURL).clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, timingsURL))));
 +
 +            if (response != null && !response.isEmpty()) {
 +                Bukkit.getLogger().log(Level.INFO, "Timing Response: " + response);
@@ -1877,7 +1878,7 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4c939de8822b064f0e44b741c4b3807ba13e5e9e..f43a728eba966992831d040a0ed96f5720d8d15c 100644
+index 3ac1d0f7ad41ac66d6061fffe32efd7ea4757653..fcff5e05818c81f72cb6e0f83a683c2bb3979737 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2288,6 +2288,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {


### PR DESCRIPTION
Apparently also needs to be backported to 1.18, haven't checked that though.