### PR TITLE
Fix sending incorrect title in CraftPlayer#sendtitle

### DIFF
--- a/patches/server/0906-Fix-sending-incorrect-title-in-CraftPlayer-sendtitle.patch
+++ b/patches/server/0906-Fix-sending-incorrect-title-in-CraftPlayer-sendtitle.patch
@@ -3,6 +3,8 @@ From: Noah van der Aa <ndvdaa@gmail.com>
 Date: Wed, 8 Jun 2022 23:17:32 +0200
 Subject: [PATCH] Fix sending incorrect title in CraftPlayer#sendtitle
 
+Spigot is tracking this issue in SPIGOT-7042
+
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 index 9bda669683a3062f99e798ea0a60d76373d46f4f..8f517cdc2abedc0c44f5aaaee9ad2cca3a4a982d 100644

--- a/patches/server/0906-Fix-sending-incorrect-title-in-CraftPlayer-sendtitle.patch
+++ b/patches/server/0906-Fix-sending-incorrect-title-in-CraftPlayer-sendtitle.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Wed, 8 Jun 2022 23:17:32 +0200
+Subject: [PATCH] Fix sending incorrect title in CraftPlayer#sendtitle
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 9bda669683a3062f99e798ea0a60d76373d46f4f..8f517cdc2abedc0c44f5aaaee9ad2cca3a4a982d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -2233,7 +2233,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         }
+ 
+         if (subtitle != null) {
+-            ClientboundSetSubtitleTextPacket packetSubtitle = new ClientboundSetSubtitleTextPacket(CraftChatMessage.fromString(title)[0]);
++            ClientboundSetSubtitleTextPacket packetSubtitle = new ClientboundSetSubtitleTextPacket(CraftChatMessage.fromString(subtitle)[0]); // Paper - fix incorrect title being sent
+             this.getHandle().connection.send(packetSubtitle);
+         }
+     }


### PR DESCRIPTION
Not sure if this belongs in any existing patch. Fixes [SPIGOT-7042](https://hub.spigotmc.org/jira/browse/SPIGOT-7042). Upstream will probably fix this pretty quickly, so feel free to close if you think this isn't worth the effort.