### PR TITLE
Correctly handle ElderGuardianAppearanceEvent canceling 

### DIFF
--- a/patches/server/0661-Add-ElderGuardianAppearanceEvent.patch
+++ b/patches/server/0661-Add-ElderGuardianAppearanceEvent.patch
@@ -4,17 +4,45 @@ Date: Fri, 19 Mar 2021 23:39:09 -0400
 Subject: [PATCH] Add ElderGuardianAppearanceEvent
 
 
+diff --git a/src/main/java/net/minecraft/world/effect/MobEffectUtil.java b/src/main/java/net/minecraft/world/effect/MobEffectUtil.java
+index f6c22fbad828afa29b9374b13d7bc8ac8cac7891..f0f35b11a63373febfa9a3bad0f62e9475ab5b9c 100644
+--- a/src/main/java/net/minecraft/world/effect/MobEffectUtil.java
++++ b/src/main/java/net/minecraft/world/effect/MobEffectUtil.java
+@@ -53,10 +53,23 @@ public final class MobEffectUtil {
+     }
+ 
+     public static List<ServerPlayer> addEffectToPlayersAround(ServerLevel worldserver, @Nullable Entity entity, Vec3 vec3d, double d0, MobEffectInstance mobeffect, int i, org.bukkit.event.entity.EntityPotionEffectEvent.Cause cause) {
++        // Paper start
++        return addEffectToPlayersAround(worldserver, entity, vec3d, d0, mobeffect, i, cause, null);
++    }
++
++    public static List<ServerPlayer> addEffectToPlayersAround(ServerLevel worldserver, @Nullable Entity entity, Vec3 vec3d, double d0, MobEffectInstance mobeffect, int i, org.bukkit.event.entity.EntityPotionEffectEvent.Cause cause, @Nullable java.util.function.Predicate<ServerPlayer> playerPredicate) {
++        // Paper end
+         // CraftBukkit end
+         MobEffect mobeffectlist = mobeffect.getEffect();
+         List<ServerPlayer> list = worldserver.getPlayers((entityplayer) -> {
+-            return entityplayer.gameMode.isSurvival() && (entity == null || !entity.isAlliedTo((Entity) entityplayer)) && vec3d.closerThan(entityplayer.position(), d0) && (!entityplayer.hasEffect(mobeffectlist) || entityplayer.getEffect(mobeffectlist).getAmplifier() < mobeffect.getAmplifier() || entityplayer.getEffect(mobeffectlist).getDuration() < i);
++            // Paper start
++            boolean condition = entityplayer.gameMode.isSurvival() && (entity == null || !entity.isAlliedTo((Entity) entityplayer)) && vec3d.closerThan(entityplayer.position(), d0) && (!entityplayer.hasEffect(mobeffectlist) || entityplayer.getEffect(mobeffectlist).getAmplifier() < mobeffect.getAmplifier() || entityplayer.getEffect(mobeffectlist).getDuration() < i);
++            if (condition) {
++                return playerPredicate != null && playerPredicate.test(entityplayer); // Only test the player AFTER it is true
++            } else {
++                return false;
++            }
++            // Paper ned
+         });
+ 
+         list.forEach((entityplayer) -> {
 diff --git a/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java b/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java
-index 0b6c6740e1411a558d224589b3786f3ba8e0a1bc..0da2eecda83ba4e4acd4dd0603c77066d4fd060f 100644
+index 0b6c6740e1411a558d224589b3786f3ba8e0a1bc..d02286d553c600fe7e75f48e278e380d21c5b868 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java
-@@ -70,7 +70,9 @@ public class ElderGuardian extends Guardian {
-             List<ServerPlayer> list = MobEffectUtil.addEffectToPlayersAround((ServerLevel) this.level, this, this.position(), 50.0D, mobeffect, 1200, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK); // CraftBukkit
+@@ -67,7 +67,7 @@ public class ElderGuardian extends Guardian {
+         super.customServerAiStep();
+         if ((this.tickCount + this.getId()) % 1200 == 0) {
+             MobEffectInstance mobeffect = new MobEffectInstance(MobEffects.DIG_SLOWDOWN, 6000, 2);
+-            List<ServerPlayer> list = MobEffectUtil.addEffectToPlayersAround((ServerLevel) this.level, this, this.position(), 50.0D, mobeffect, 1200, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK); // CraftBukkit
++            List<ServerPlayer> list = MobEffectUtil.addEffectToPlayersAround((ServerLevel) this.level, this, this.position(), 50.0D, mobeffect, 1200, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK, (player) -> new io.papermc.paper.event.entity.ElderGuardianAppearanceEvent(getBukkitEntity(), player.getBukkitEntity()).callEvent()); // CraftBukkit // Paper
  
              list.forEach((entityplayer) -> {
-+                if (new io.papermc.paper.event.entity.ElderGuardianAppearanceEvent(getBukkitEntity(), entityplayer.getBukkitEntity()).callEvent()) { // Paper - Add Guardian Appearance Event
                  entityplayer.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, this.isSilent() ? 0.0F : 1.0F));
-+                } // Paper
-             });
-         }
- 

--- a/patches/server/0661-Add-ElderGuardianAppearanceEvent.patch
+++ b/patches/server/0661-Add-ElderGuardianAppearanceEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add ElderGuardianAppearanceEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/effect/MobEffectUtil.java b/src/main/java/net/minecraft/world/effect/MobEffectUtil.java
-index f6c22fbad828afa29b9374b13d7bc8ac8cac7891..f0f35b11a63373febfa9a3bad0f62e9475ab5b9c 100644
+index f6c22fbad828afa29b9374b13d7bc8ac8cac7891..aefc65a81c91dac715df6d9a4eaaacd94f918cb5 100644
 --- a/src/main/java/net/minecraft/world/effect/MobEffectUtil.java
 +++ b/src/main/java/net/minecraft/world/effect/MobEffectUtil.java
 @@ -53,10 +53,23 @@ public final class MobEffectUtil {
@@ -25,7 +25,7 @@ index f6c22fbad828afa29b9374b13d7bc8ac8cac7891..f0f35b11a63373febfa9a3bad0f62e94
 +            // Paper start
 +            boolean condition = entityplayer.gameMode.isSurvival() && (entity == null || !entity.isAlliedTo((Entity) entityplayer)) && vec3d.closerThan(entityplayer.position(), d0) && (!entityplayer.hasEffect(mobeffectlist) || entityplayer.getEffect(mobeffectlist).getAmplifier() < mobeffect.getAmplifier() || entityplayer.getEffect(mobeffectlist).getDuration() < i);
 +            if (condition) {
-+                return playerPredicate != null && playerPredicate.test(entityplayer); // Only test the player AFTER it is true
++                return playerPredicate == null || playerPredicate.test(entityplayer); // Only test the player AFTER it is true
 +            } else {
 +                return false;
 +            }


### PR DESCRIPTION
Another one of these yucky shared methods.
This update caused it to no longer cancel the potion effect given to players. 

Instead, filter it if it fits the given predicate initially.

TODO: ApplyDarknessEffectEvent?
Warden and Shrieker would both call this, might be nice to have... or at least add some kind of custom effect reason type here to allow canceling. (There is no warden, guardian, shrieker bukkit effect reason)