### PR TITLE
Don't validate chunk before it's been run through DataConverter

### DIFF
--- a/patches/server/0252-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0252-Asynchronous-chunk-IO-and-loading.patch
@@ -1396,7 +1396,7 @@ index 0000000000000000000000000000000000000000..f1b940704400266e6df186139b57ec72
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/io/chunk/ChunkLoadTask.java b/src/main/java/com/destroystokyo/paper/io/chunk/ChunkLoadTask.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..aaf73da45e6ba6e990a94f63eb3da0e250153053
+index 0000000000000000000000000000000000000000..e9070b6158e7e8c2dd33a9dcb20898a2f0d86e48
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/io/chunk/ChunkLoadTask.java
 @@ -0,0 +1,148 @@
@@ -1487,12 +1487,6 @@ index 0000000000000000000000000000000000000000..aaf73da45e6ba6e990a94f63eb3da0e2
 +            return;
 +        }
 +
-+        if (!ChunkMap.isChunkDataValid(chunkData.chunkData)) {
-+            LOGGER.error("Chunk file at {} is missing level data, skipping", new ChunkPos(this.chunkX, this.chunkZ));
-+            this.complete(ChunkLoadTask.createEmptyHolder());
-+            return;
-+        }
-+
 +        final ChunkPos chunkPos = new ChunkPos(this.chunkX, this.chunkZ);
 +
 +        final ChunkMap chunkManager = this.world.getChunkSource().chunkMap;
@@ -1507,6 +1501,12 @@ index 0000000000000000000000000000000000000000..aaf73da45e6ba6e990a94f63eb3da0e2
 +                    chunkManager.overworldDataStorage, chunkData.chunkData, chunkManager.generator.getTypeNameForDataFixer(), chunkPos, this.world); // clone data for safety, file IO thread does not clone
 +            } catch (final Throwable ex) {
 +                LOGGER.error("Could not apply datafixers for chunk task: " + this.toString(), ex);
++                this.complete(ChunkLoadTask.createEmptyHolder());
++                return;
++            }
++
++            if (!ChunkMap.isChunkDataValid(chunkData.chunkData)) {
++                LOGGER.error("Chunk file at {} is missing level data, skipping", new ChunkPos(this.chunkX, this.chunkZ));
 +                this.complete(ChunkLoadTask.createEmptyHolder());
 +                return;
 +            }


### PR DESCRIPTION
Otherwise chunks from <1.18 won't load, since the status key doesn't exist yet.

[#paper-contrib message, for reference](https://canary.discord.com/channels/289587909051416579/925530366192779286/984490090900381778)