### PR TITLE
Make slime spawn checks use tag again and rename config option

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -1293,7 +1293,7 @@ index 0000000000000000000000000000000000000000..d69d203eea014fc9fb40a556f0771dba
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4a1a7e9764dc6f64cc2968baf5958d0cde87cbe2
+index 0000000000000000000000000000000000000000..5bcce63166657f80eaa8446d3dd64a5cba62f198
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 @@ -0,0 +1,465 @@
@@ -1444,9 +1444,9 @@ index 0000000000000000000000000000000000000000..4a1a7e9764dc6f64cc2968baf5958d0c
 +
 +            public class SlimeSpawnHeight extends ConfigurationPart {
 +
-+                public SwampBiome swampBiome;
++                public SurfaceSpawnableSlimeBiome surfaceBiome;
 +
-+                public class SwampBiome extends ConfigurationPart {
++                public class SurfaceSpawnableSlimeBiome extends ConfigurationPart {
 +                    public double maximum = 70;
 +                    public double minimum = 50;
 +                }
@@ -3053,10 +3053,10 @@ index 0000000000000000000000000000000000000000..75f612b04f872d0d014fdc40b07c1511
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/transformation/world/LegacyPaperWorldConfig.java b/src/main/java/io/papermc/paper/configuration/transformation/world/LegacyPaperWorldConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..da56027e1ddb0649e5b860ffa6c95af388a75442
+index 0000000000000000000000000000000000000000..749498b349a0504270e2ba84fd8f30bd749833a7
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/transformation/world/LegacyPaperWorldConfig.java
-@@ -0,0 +1,320 @@
+@@ -0,0 +1,321 @@
 +package io.papermc.paper.configuration.transformation.world;
 +
 +import io.papermc.paper.configuration.Configuration;
@@ -3244,6 +3244,7 @@ index 0000000000000000000000000000000000000000..da56027e1ddb0649e5b860ffa6c95af3
 +        moveFromRoot(builder, "spawn-limits", "entities", "spawning");
 +        moveFromRoot(builder, "despawn-ranges", "entities", "spawning");
 +        moveFromRoot(builder, "wateranimal-spawn-height", "entities", "spawning");
++        builder.addAction(path("slime-spawn-height", "swamp-biome"), TransformAction.rename("surface-biome"));
 +        moveFromRoot(builder, "slime-spawn-height", "entities", "spawning");
 +        moveFromRoot(builder, "wandering-trader", "entities", "spawning");
 +        moveFromRoot(builder, "all-chunks-are-slime-chunks", "entities", "spawning");

--- a/patches/server/0830-Add-configurable-height-for-slime-spawn.patch
+++ b/patches/server/0830-Add-configurable-height-for-slime-spawn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add configurable height for slime spawn
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Slime.java b/src/main/java/net/minecraft/world/entity/monster/Slime.java
-index 15d5a8290be35c2caebf8e296300e8f32cb597c7..14c4de88aefe052b3379f13274bcab228f61332d 100644
+index 15d5a8290be35c2caebf8e296300e8f32cb597c7..fa79316adb11ab39cf921475e12a50058fd82a87 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Slime.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Slime.java
 @@ -320,7 +320,11 @@ public class Slime extends Mob implements Enemy {
@@ -14,9 +14,9 @@ index 15d5a8290be35c2caebf8e296300e8f32cb597c7..14c4de88aefe052b3379f13274bcab22
          if (world.getDifficulty() != Difficulty.PEACEFUL) {
 -            if (world.getBiome(pos).is(BiomeTags.ALLOWS_SURFACE_SLIME_SPAWNS) && pos.getY() > 50 && pos.getY() < 70 && random.nextFloat() < 0.5F && random.nextFloat() < world.getMoonBrightness() && world.getMaxLocalRawBrightness(pos) <= random.nextInt(8)) {
 +            // Paper start - Replace rules for Height in Swamp Biome
-+            final double maxHeightSwamp = world.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.swampBiome.maximum;
-+            final double minHeightSwamp = world.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.swampBiome.minimum;
-+            if (world.getBiome(pos).is(net.minecraft.world.level.biome.Biomes.SWAMP) && pos.getY() > minHeightSwamp && pos.getY() < maxHeightSwamp && random.nextFloat() < 0.5F && random.nextFloat() < world.getMoonBrightness() && world.getMaxLocalRawBrightness(pos) <= random.nextInt(8)) {
++            final double maxHeightSwamp = world.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.surfaceBiome.maximum;
++            final double minHeightSwamp = world.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.surfaceBiome.minimum;
++            if (world.getBiome(pos).is(BiomeTags.ALLOWS_SURFACE_SLIME_SPAWNS) && pos.getY() > minHeightSwamp && pos.getY() < maxHeightSwamp && random.nextFloat() < 0.5F && random.nextFloat() < world.getMoonBrightness() && world.getMaxLocalRawBrightness(pos) <= random.nextInt(8)) {
 +                // Paper end
                  return checkMobSpawnRules(type, world, spawnReason, pos, random);
              }

--- a/patches/server/0882-Fix-slime-spawners-not-spawning-outside-slime-chunks.patch
+++ b/patches/server/0882-Fix-slime-spawners-not-spawning-outside-slime-chunks.patch
@@ -7,7 +7,7 @@ Fixes MC-50647 by just checking if the spawn type is a SPAWNER
 and then bypassing the spawn check logic if on slimes if it is.
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Slime.java b/src/main/java/net/minecraft/world/entity/monster/Slime.java
-index 14c4de88aefe052b3379f13274bcab228f61332d..ae95867efd21280d81180f2c4ac27fd6c94d868f 100644
+index fa79316adb11ab39cf921475e12a50058fd82a87..7e85ad7ba31bbb32ea1e1dff5d1c83e7ce68b4b3 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Slime.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Slime.java
 @@ -320,6 +320,11 @@ public class Slime extends Mob implements Enemy {
@@ -20,5 +20,5 @@ index 14c4de88aefe052b3379f13274bcab228f61332d..ae95867efd21280d81180f2c4ac27fd6
 +            }
 +            // Paper end
              // Paper start - Replace rules for Height in Swamp Biome
-             final double maxHeightSwamp = world.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.swampBiome.maximum;
-             final double minHeightSwamp = world.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.swampBiome.minimum;
+             final double maxHeightSwamp = world.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.surfaceBiome.maximum;
+             final double minHeightSwamp = world.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.surfaceBiome.minimum;


### PR DESCRIPTION
Changes the check to check for BiomeTags again (instead of the biome) and renames the config option.

from the 1.19 todo issue