### PR TITLE
correct argument check in PlayerHandshakeEvent#setFailMessage(String)

### DIFF
--- a/patches/api/0036-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
+++ b/patches/api/0036-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
@@ -7,17 +7,16 @@ Subject: [PATCH] Add handshake event to allow plugins to handle client
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0f533119af49f77b5e84a68c24b9d4e1b28663f1
+index 0000000000000000000000000000000000000000..59ae7bc3a0a2079fe4b3a92d777aca682a58e4e3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java
-@@ -0,0 +1,278 @@
+@@ -0,0 +1,277 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import com.google.common.base.Preconditions;
 +import net.kyori.adventure.text.Component;
 +import net.kyori.adventure.text.format.NamedTextColor;
 +import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-+import org.apache.commons.lang3.Validate;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
@@ -274,7 +273,7 @@ index 0000000000000000000000000000000000000000..0f533119af49f77b5e84a68c24b9d4e1
 +     */
 +    @Deprecated
 +    public void setFailMessage(@NotNull String failMessage) {
-+        Preconditions.checkArgument(failMessage != null && failMessage.isEmpty(), "fail message cannot be null or empty");
++        Preconditions.checkArgument(failMessage != null && !failMessage.isEmpty(), "fail message cannot be null or empty");
 +        this.failMessage(LegacyComponentSerializer.legacySection().deserialize(failMessage));
 +    }
 +


### PR DESCRIPTION
introduced in the 1.19 update https://github.com/PaperMC/Paper/commit/88f74d1bac173e6cac1b873c096a50f754d931ef#diff-276247018cf7c91d7b8140f7a9a858fb9245e00f774b2faa3c7d0677e9a722acR277