### PR TITLE
Dont reassign the hiddenConfigs field in TimingsManager

### DIFF
--- a/patches/server/0012-Timings-v2.patch
+++ b/patches/server/0012-Timings-v2.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Timings v2
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9fdc3e9936262b8eb8d502c4dd2ba47a7eceacce
+index 0000000000000000000000000000000000000000..3f540dc05315103ef97fd53628f681c67f7e7c2d
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
 @@ -0,0 +1,168 @@
@@ -171,7 +171,7 @@ index 0000000000000000000000000000000000000000..9fdc3e9936262b8eb8d502c4dd2ba47a
 +        if (!config.hiddenConfigEntries.contains("proxies.velocity.secret")) {
 +            config.hiddenConfigEntries.add("proxies.velocity.secret");
 +        }
-+        TimingsManager.hiddenConfigs = config.hiddenConfigEntries;
++        TimingsManager.hiddenConfigs.addAll(config.hiddenConfigEntries);
 +        co.aikar.timings.Timings.setVerboseTimingsEnabled(config.verbose);
 +        co.aikar.timings.Timings.setTimingsEnabled(config.enabled);
 +        co.aikar.timings.Timings.setHistoryInterval(config.historyInterval * 20);


### PR DESCRIPTION
Best to not assign the field so if anything adds to that field, it doesn't also add to the list on the paper config class.