### PR TITLE
Add missing important BlockStateListPopulator methods

### DIFF
--- a/patches/server/0910-Add-missing-important-BlockStateListPopulator-method.patch
+++ b/patches/server/0910-Add-missing-important-BlockStateListPopulator-method.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sun, 12 Jun 2022 13:25:52 -0400
+Subject: [PATCH] Add missing important BlockStateListPopulator methods
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java b/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
+index 8e6a71c1e8b53faa70b893c76f5bd25f96a5e142..78c8d96ecc9204e58ac6b1b731cce96548dea4d1 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
+@@ -129,4 +129,27 @@ public class BlockStateListPopulator extends DummyGeneratorAccess {
+     public DimensionType dimensionType() {
+         return this.world.dimensionType();
+     }
++    // Paper start
++    @Override
++    public boolean isFluidAtPosition(BlockPos pos, Predicate<FluidState> state) {
++        return state.test(this.getBlockState(pos).getFluidState());
++    }
++
++    @Override
++    public <T extends BlockEntity> java.util.Optional<T> getBlockEntity(BlockPos pos, net.minecraft.world.level.block.entity.BlockEntityType<T> type) {
++        BlockEntity tileentity = this.getBlockEntity(pos);
++
++        return tileentity != null && tileentity.getType() == type ? (java.util.Optional<T>) java.util.Optional.of(tileentity) : java.util.Optional.empty();
++    }
++
++    @Override
++    public BlockPos getHeightmapPos(net.minecraft.world.level.levelgen.Heightmap.Types heightmap, BlockPos pos) {
++        return world.getHeightmapPos(heightmap, pos);
++    }
++
++    @Override
++    public net.minecraft.world.level.storage.LevelData getLevelData() {
++        return world.getLevelData();
++    }
++    // Paper end
+ }

--- a/patches/server/0912-Add-missing-important-BlockStateListPopulator-method.patch
+++ b/patches/server/0912-Add-missing-important-BlockStateListPopulator-method.patch
@@ -3,9 +3,10 @@ From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 Date: Sun, 12 Jun 2022 13:25:52 -0400
 Subject: [PATCH] Add missing important BlockStateListPopulator methods
 
+Without these methods it causes exceptions due to these being used by certain feature generators.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java b/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
-index 8e6a71c1e8b53faa70b893c76f5bd25f96a5e142..78c8d96ecc9204e58ac6b1b731cce96548dea4d1 100644
+index 8e6a71c1e8b53faa70b893c76f5bd25f96a5e142..03153abb425acf2d615acc386c91a6524aaa80bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
 @@ -129,4 +129,27 @@ public class BlockStateListPopulator extends DummyGeneratorAccess {
@@ -15,7 +16,7 @@ index 8e6a71c1e8b53faa70b893c76f5bd25f96a5e142..78c8d96ecc9204e58ac6b1b731cce965
 +    // Paper start
 +    @Override
 +    public boolean isFluidAtPosition(BlockPos pos, Predicate<FluidState> state) {
-+        return state.test(this.getBlockState(pos).getFluidState());
++        return state.test(this.getFluidState(pos));
 +    }
 +
 +    @Override


### PR DESCRIPTION
Methods like generating a tree (with predicate) throw exceptions due to the dummy generator access class throwing exceptions for these methods.
Override them!

```kt
java.lang.UnsupportedOperationException: Not supported yet.
	at org.bukkit.craftbukkit.util.DummyGeneratorAccess.getLevelData(DummyGeneratorAccess.java:84) ~[main/:?]
	at net.minecraft.world.level.LevelAccessor.createTick(LevelAccessor.java:43) ~[main/:?]
	at net.minecraft.world.level.LevelAccessor.scheduleTick(LevelAccessor.java:61) ~[main/:?]
	at net.minecraft.world.level.block.LiquidBlock.updateShape(LiquidBlock.java:133) ~[main/:?]
	at net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase.updateShape(BlockBehaviour.java:1068) ~[main/:?]
	at net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.lambda$updateShapeAtEdge$4(StructureTemplate.java:420) ~[main/:?]
	at net.minecraft.world.phys.shapes.DiscreteVoxelShape.forAllAxisFaces(DiscreteVoxelShape.java:191) ~[minecraft.jar:?]
	at net.minecraft.world.phys.shapes.DiscreteVoxelShape.forAllFaces(DiscreteVoxelShape.java:171) ~[minecraft.jar:?]
	at net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.updateShapeAtEdge(StructureTemplate.java:409) ~[main/:?]
	at net.minecraft.world.level.levelgen.feature.TreeFeature.lambda$place$11(TreeFeature.java:163) ~[minecraft.jar:?]
	at java.util.Optional.map(Optional.java:260) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.TreeFeature.place(TreeFeature.java:161) ~[minecraft.jar:?]
	at net.minecraft.world.level.levelgen.feature.Feature.place(Feature.java:154) ~[minecraft.jar:?]
	at net.minecraft.world.level.levelgen.feature.ConfiguredFeature.place(ConfiguredFeature.java:24) ~[minecraft.jar:?]
	at org.bukkit.craftbukkit.CraftRegionAccessor.generateTree(CraftRegionAccessor.java:395) ~[main/:?]
	at org.bukkit.craftbukkit.CraftRegionAccessor.generateTree(CraftRegionAccessor.java:311) ~[main/:?]
```

Spigot mapped, but is equal to isFluidAtPosition
```kt
java.lang.UnsupportedOperationException: Not supported yet.
	at org.bukkit.craftbukkit.v1_19_R1.util.DummyGeneratorAccess.b(DummyGeneratorAccess.java:240) ~[paper-1.19.jar:git-Paper-4]
	at net.minecraft.world.level.levelgen.feature.foliageplacers.FoliagePlacer.tryPlaceLeaf(FoliagePlacer.java:89) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.foliageplacers.FoliagePlacer.placeLeavesRow(FoliagePlacer.java:78) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.foliageplacers.BlobFoliagePlacer.createFoliage(BlobFoliagePlacer.java:40) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.foliageplacers.FoliagePlacer.createFoliage(FoliagePlacer.java:39) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.TreeFeature.lambda$doPlace$5(TreeFeature.java:90) ~[?:?]
	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:422) ~[guava-31.0.1-jre.jar:?]
	at net.minecraft.world.level.levelgen.feature.TreeFeature.doPlace(TreeFeature.java:89) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.TreeFeature.place(TreeFeature.java:152) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.Feature.place(Feature.java:154) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.ConfiguredFeature.a(ConfiguredFeature.java:24) ~[?:?]
	at org.bukkit.craftbukkit.v1_19_R1.CraftRegionAccessor.generateTree(CraftRegionAccessor.java:395) ~[paper-1.19.jar:git-Paper-4]
	at org.bukkit.craftbukkit.v1_19_R1.CraftRegionAccessor.generateTree(CraftRegionAccessor.java:311) ~[paper-1.19.jar:git-Paper-4]
```