### PR TITLE
Add option for strict advancement dimension checks

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -419,7 +419,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..3e7086d31b2f101b2d6e982f3935922886cadc77
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,264 @@
+@@ -0,0 +1,265 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -682,6 +682,7 @@ index 0000000000000000000000000000000000000000..3e7086d31b2f101b2d6e982f39359228
 +        public boolean useAlternativeLuckFormula = false;
 +        public boolean lagCompensateBlockBreaking = true;
 +        public boolean useDimensionTypeForCustomSpawners = false;
++        public boolean strictAdvancementDimensionCheck = false;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java b/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java

--- a/patches/server/0911-Add-option-for-strict-advancement-dimension-checks.patch
+++ b/patches/server/0911-Add-option-for-strict-advancement-dimension-checks.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 12 Jun 2022 11:47:24 -0700
+Subject: [PATCH] Add option for strict advancement dimension checks
+
+Craftbukkit attempts to translate worlds that use the
+same generation as the Overworld, The Nether, or The End
+to use those dimensions when checking the `changed_dimension`
+criteria trigger, or whether to trigger the `NETHER_TRAVEL`
+distance trigger. This adds a config option to ignore that
+and use the exact dimension key of the worlds involved.
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index c8057f98e16ba6e19640e0b250e5201e0f4f57db..353463084d90eb684717e65c56da52cd25a1e375 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -1252,6 +1252,12 @@ public class ServerPlayer extends Player {
+         // CraftBukkit start
+         ResourceKey<Level> maindimensionkey = CraftDimensionUtil.getMainDimensionKey(origin);
+         ResourceKey<Level> maindimensionkey1 = CraftDimensionUtil.getMainDimensionKey(this.level);
++        // Paper start - config for strict advancement checks for dimensions
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().misc.strictAdvancementDimensionCheck) {
++            maindimensionkey = resourcekey;
++            maindimensionkey1 = resourcekey1;
++        }
++        // Paper end
+ 
+         CriteriaTriggers.CHANGED_DIMENSION.trigger(this, maindimensionkey, maindimensionkey1);
+         if (maindimensionkey != resourcekey || maindimensionkey1 != resourcekey1) {


### PR DESCRIPTION
Craftbukkit attempts to translate worlds that use the same generation as the Overworld, The Nether, or The End to use those dimensions when checking the `changed_dimension` criteria trigger, or whether to trigger the `NETHER_TRAVEL` distance trigger. This adds a config option to ignore that and use the exact dimension key of the worlds involved.

Option in paper-global.yml: `misc.strict-advancement-dimension-check: false`

Closes https://github.com/PaperMC/Paper/issues/7953