### PR TITLE
Log IOException in plugin update

### DIFF
--- a/patches/api/0378-Update-Folder-Uses-Plugin-Name.patch
+++ b/patches/api/0378-Update-Folder-Uses-Plugin-Name.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Update Folder Uses Plugin Name
 
 
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 45114d587a8f201778adcba16c8a019f9959f472..ed07f5820281b139739f673fa4e25171de81b894 100644
+index 45114d587a8f201778adcba16c8a019f9959f472..5270e43c629fe63f42691d10c6f77dc1cc987457 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 @@ -395,7 +395,7 @@ public final class SimplePluginManager implements PluginManager {
@@ -17,7 +17,7 @@ index 45114d587a8f201778adcba16c8a019f9959f472..ed07f5820281b139739f673fa4e25171
  
          Set<Pattern> filters = fileAssociations.keySet();
          Plugin result = null;
-@@ -422,16 +422,56 @@ public final class SimplePluginManager implements PluginManager {
+@@ -422,16 +422,61 @@ public final class SimplePluginManager implements PluginManager {
          return result;
      }
  
@@ -48,16 +48,21 @@ index 45114d587a8f201778adcba16c8a019f9959f472..ed07f5820281b139739f673fa4e25171
 +                    continue;
 +                }
 +                if (!pluginName.equals(updatePluginName)) continue;
-+                if (!FileUtil.copy(updateFile, file)) continue;
++                try {
++                    java.nio.file.Files.copy(updateFile.toPath(), file.toPath());
++                } catch (java.io.IOException exception) {
++                    server.getLogger().log(Level.SEVERE, "Could not copy '" + updateFile.getPath() + "' to '" + file.getPath() + "' in update plugin process", exception);
++                    continue;
++                }
 +                File newName = new File(file.getParentFile(), updateFile.getName());
 +                file.renameTo(newName);
 +                updateFile.delete();
 +                return newName;
 +            }
-+        }
+         }
 +        catch (InvalidDescriptionException e) {
 +            throw new InvalidPluginException(e);
-         }
++        }
 +        return file;
 +    }
  


### PR DESCRIPTION
Yeah im a stalking... this handle to fix #7958 

This PR change the Bukkit util for copy things to the native java things and add a LOG when a issue is found, this not change the current behaviour where if the copy fails pass to another file.

Not sure if this is better o can be better add the log in the Bukkit util...