### PR TITLE
Use deserialised row keys in config tables

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Paper config files
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 35839e1c2dede1e3a1e54b124667cf2bf63e73f0..a87cf2a4ad955b7429269f2d46adbe59f6e4525e 100644
+index e4e9df9283c1a0fd7fff38a5d9b6a51f15e06b7a..07b7d43796985cff828ff472ddef2a11b543a4af 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -12,6 +12,7 @@ dependencies {
@@ -2405,7 +2405,7 @@ index 0000000000000000000000000000000000000000..add9d16bac9e4570fbdcf8368d7ba031
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/serializer/TableSerializer.java b/src/main/java/io/papermc/paper/configuration/serializer/TableSerializer.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0b235ebe6e79d7aa420d6b8a52aedb3a4d8b6629
+index 0000000000000000000000000000000000000000..346422c5eb791961061cc73b9b827d63bbd67daf
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/serializer/TableSerializer.java
 @@ -0,0 +1,89 @@
@@ -2461,9 +2461,9 @@ index 0000000000000000000000000000000000000000..0b235ebe6e79d7aa420d6b8a52aedb3a
 +        final BasicConfigurationNode rowKeyNode = BasicConfigurationNode.root(node.options());
 +
 +        for (final Object key : node.childrenMap().keySet()) {
-+            rowKeySerializer.deserialize(rowType, rowKeyNode.set(key));
++            final R rowKey = rowKeySerializer.deserialize(rowType, rowKeyNode.set(key));
 +            final Map<C, V> map = columnValueSerializer.deserialize(mapType, node.node(rowKeyNode.raw()));
-+            map.forEach((column, value) -> table.put((R) rowKeyNode.raw(), column, value));
++            map.forEach((column, value) -> table.put(rowKey, column, value));
 +        }
 +    }
 +


### PR DESCRIPTION
When deserialising a Table in the config, the TableDeserializer currently inserts the raw value for the row key rather than the deserialised value (e.g. String rather than EntityType). This has resulted in the sensor and behaviour tick rate settings not working properly