### PR TITLE
Update settings directory path in exceptions

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -1241,11 +1241,11 @@ index 0000000000000000000000000000000000000000..1055a079a061d8761be13d3b9efbbd90
 +            final String legacyFileName = legacyConfig.getFileName().toString();
 +            try {
 +                if (Files.exists(configDir) && !Files.isDirectory(configDir)) {
-+                    throw new RuntimeException("Paper needs to create a '" + CONFIG_DIR + "' folder in the root of your server. You already have a non-directory named '" + CONFIG_DIR + "'. Please remove it and restart the server.");
++                    throw new RuntimeException("Paper needs to create a '" + configDir.getFileName() + "' folder in the root of your server. You already have a non-directory named '" + configDir.getFileName() + "'. Please remove it and restart the server.");
 +                }
 +                final Path backupDir = configDir.resolve(BACKUP_DIR);
 +                if (Files.exists(backupDir) && !Files.isDirectory(backupDir)) {
-+                    throw new RuntimeException("Paper needs to create a '" + BACKUP_DIR + "' directory in the '" + CONFIG_DIR + "' folder. You already have a non-directory named '" + BACKUP_DIR + "'. Please remove it and restart the server.");
++                    throw new RuntimeException("Paper needs to create a '" + BACKUP_DIR + "' directory in the '" + configDir.getFileName() + "' folder. You already have a non-directory named '" + BACKUP_DIR + "'. Please remove it and restart the server.");
 +                }
 +                createDirectoriesSymlinkAware(backupDir);
 +                final String backupFileName = legacyFileName + ".old";

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -1241,17 +1241,17 @@ index 0000000000000000000000000000000000000000..1055a079a061d8761be13d3b9efbbd90
 +            final String legacyFileName = legacyConfig.getFileName().toString();
 +            try {
 +                if (Files.exists(configDir) && !Files.isDirectory(configDir)) {
-+                    throw new RuntimeException("Paper needs to create a '" + configDir.getFileName() + "' folder in the root of your server. You already have a non-directory named '" + configDir.getFileName() + "'. Please remove it and restart the server.");
++                    throw new RuntimeException("Paper needs to create a '" + configDir.toAbsolutePath() + "' folder. You already have a non-directory named '" + configDir.toAbsolutePath() + "'. Please remove it and restart the server.");
 +                }
 +                final Path backupDir = configDir.resolve(BACKUP_DIR);
 +                if (Files.exists(backupDir) && !Files.isDirectory(backupDir)) {
-+                    throw new RuntimeException("Paper needs to create a '" + BACKUP_DIR + "' directory in the '" + configDir.getFileName() + "' folder. You already have a non-directory named '" + BACKUP_DIR + "'. Please remove it and restart the server.");
++                    throw new RuntimeException("Paper needs to create a '" + BACKUP_DIR + "' directory in the '" + configDir.toAbsolutePath() + "' folder. You already have a non-directory named '" + BACKUP_DIR + "'. Please remove it and restart the server.");
 +                }
 +                createDirectoriesSymlinkAware(backupDir);
 +                final String backupFileName = legacyFileName + ".old";
 +                final Path legacyConfigBackup = backupDir.resolve(backupFileName);
 +                if (Files.exists(legacyConfigBackup) && !Files.isRegularFile(legacyConfigBackup)) {
-+                    throw new RuntimeException("Paper needs to create a '" + backupFileName + "' file in the '" + BACKUP_DIR + "' folder. You already have a non-file named '" + backupFileName + "'. Please remove it and restart the server.");
++                    throw new RuntimeException("Paper needs to create a '" + backupFileName + "' file in the '" + backupDir.toAbsolutePath() + "' folder. You already have a non-file named '" + backupFileName + "'. Please remove it and restart the server.");
 +                }
 +                Files.move(legacyConfig.toRealPath(), legacyConfigBackup, StandardCopyOption.REPLACE_EXISTING); // make backup
 +                if (Files.isSymbolicLink(legacyConfig)) {


### PR DESCRIPTION
The settings directory is now configurable using CLI options (since https://github.com/PaperMC/Paper/commit/8b6f4dd482dc5f152a433475f20055f7fbf1b182), but the exceptions message hasn't been updated properly to handle this new behaviour, and will show the default config folder even if the path has changed.