### PR TITLE
Fix command signs patch update

### DIFF
--- a/patches/server/0675-Fix-commands-from-signs-not-firing-command-events.patch
+++ b/patches/server/0675-Fix-commands-from-signs-not-firing-command-events.patch
@@ -58,7 +58,7 @@ index 0000000000000000000000000000000000000000..01a2bc1feec808790bb93618ce46adb9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
-index 831db5ee21938d71e99bf9d17b92a6ca15531740..6c96c3dde4e1b1b1b6952841edb41006e73737e9 100644
+index 831db5ee21938d71e99bf9d17b92a6ca15531740..def4fdd2c7e4f925fa128692a744e5d10ae0203a 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
 @@ -40,6 +40,7 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
@@ -69,10 +69,11 @@ index 831db5ee21938d71e99bf9d17b92a6ca15531740..6c96c3dde4e1b1b1b6952841edb41006
  
      public SignBlockEntity(BlockPos pos, BlockState state) {
          super(BlockEntityType.SIGN, pos, state);
-@@ -225,6 +226,17 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+@@ -224,7 +225,17 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+             ClickEvent chatclickable = chatmodifier.getClickEvent();
  
              if (chatclickable != null && chatclickable.getAction() == ClickEvent.Action.RUN_COMMAND) {
-                 player.getServer().getCommands().performPrefixedCommand(this.createCommandSourceStack(player), chatclickable.getValue());
+-                player.getServer().getCommands().performPrefixedCommand(this.createCommandSourceStack(player), chatclickable.getValue());
 +                // Paper start
 +                String command = chatclickable.getValue().startsWith("/") ? chatclickable.getValue() : "/" + chatclickable.getValue();
 +                if (org.spigotmc.SpigotConfig.logCommands)  {
@@ -82,12 +83,12 @@ index 831db5ee21938d71e99bf9d17b92a6ca15531740..6c96c3dde4e1b1b1b6952841edb41006
 +                if (!event.callEvent()) {
 +                    return false;
 +                }
-+                player.getServer().getCommands().performCommand(this.createCommandSourceStack(((org.bukkit.craftbukkit.entity.CraftPlayer) event.getPlayer()).getHandle()), event.getMessage());
++                player.getServer().getCommands().performPrefixedCommand(this.createCommandSourceStack(((org.bukkit.craftbukkit.entity.CraftPlayer) event.getPlayer()).getHandle()), event.getMessage());
 +                // Paper end
              }
          }
  
-@@ -260,8 +272,21 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+@@ -260,8 +271,21 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
          String s = player == null ? "Sign" : player.getName().getString();
          Object object = player == null ? Component.literal("Sign") : player.getDisplayName();
  


### PR DESCRIPTION
Was messed up in https://github.com/PaperMC/Paper/commit/0e06c77264b59d1df913a94aaa6744b440651e6a

The command was running before the event, and then again after the event (except it wasn't cause the cast was failing cause the command logic had already happened.

Fixes https://github.com/PaperMC/Paper/issues/7970