### PR TITLE
Fix the growth modifier for glowberries Fixes #7984

### DIFF
--- a/patches/server/0796-Fix-kelp-modifier-changing-growth-for-other-crops.patch
+++ b/patches/server/0796-Fix-kelp-modifier-changing-growth-for-other-crops.patch
@@ -11,7 +11,7 @@ Also fix above-mentioned modifiers from having the reverse effect
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java b/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java
-index 7d9056f9d841fbbdeaf1e323d818f2f1267b47e8..6659a96b3638265f128a352cc9f12629874bfb4b 100644
+index 7d9056f9d841fbbdeaf1e323d818f2f1267b47e8..4940e101250874111e9c55aeb5b87b28602246f0 100644
 --- a/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java
 @@ -47,9 +47,17 @@ public class CaveVinesBlock extends GrowingPlantHeadBlock implements Bonemealabl
@@ -25,7 +25,7 @@ index 7d9056f9d841fbbdeaf1e323d818f2f1267b47e8..6659a96b3638265f128a352cc9f12629
  
 +    @Override
 +    protected BlockState getGrowIntoState(BlockState state, RandomSource random, @javax.annotation.Nullable Level level) {
-+        final boolean value = random.nextFloat() < (level != null ? (0.11F * (level.spigotConfig.glowBerryModifier * 2)) : 0.11F);
++        final boolean value = random.nextFloat() < (level != null ? (0.11F * (level.spigotConfig.glowBerryModifier / 100.0F)) : 0.11F);
 +        return (BlockState) super.getGrowIntoState(state, random).setValue(CaveVinesBlock.BERRIES, value);
 +    }
 +    // Paper end
@@ -77,7 +77,7 @@ index ae9052efc48dc05c7b41cb18c4330d7e62839a07..4d1e1cf4c541793492a02681087a6242
          return (BlockState) state.cycle(GrowingPlantHeadBlock.AGE);
      }
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 32f8a6aed0f69ad07ab5b42fee38a3471a59d426..b498b027b127996976a394e9a86cfc90f8a8ed3b 100644
+index 40984144a062230fd45cc6c707b03e5cd7d89efc..cf96f9fdc4ae561f01d44503b9851c60140e4ea7 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -103,6 +103,12 @@ public class SpigotWorldConfig


### PR DESCRIPTION
The spigot config default is 100, so we need to divide by 100 to multiply on the vanilla default 0.11 value.

Fixes https://github.com/PaperMC/Paper/issues/7984