### PR TITLE
Deprecate Spigot's HumanEntity#getItemInUse, mark LivingEntity#getActiveItem as NotNull

### DIFF
--- a/patches/api/0117-LivingEntity-Hand-Raised-Item-Use-API.patch
+++ b/patches/api/0117-LivingEntity-Hand-Raised-Item-Use-API.patch
@@ -5,29 +5,35 @@ Subject: [PATCH] LivingEntity Hand Raised/Item Use API
 
 How long an entity has raised hands to charge an attack or use an item
 
+diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
+index bd9222b9b5e7ec1f3aebe37838775f345e868150..34c2ae10e2a230ef88a756cf2024edcda2429fbf 100644
+--- a/src/main/java/org/bukkit/entity/HumanEntity.java
++++ b/src/main/java/org/bukkit/entity/HumanEntity.java
+@@ -307,7 +307,9 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      *
+      * @return the item being used by the player, or null if they are not using
+      * an item
++     * @deprecated Deprecated in favor of {@link LivingEntity#getActiveItem()}
+      */
++    @Deprecated // Paper
+     @Nullable
+     public ItemStack getItemInUse();
+ 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 588ad09a764236cf858a4e6689cf4ee5246e6f08..6d8d96976bcef4e176453fede81a529478f11234 100644
+index 588ad09a764236cf858a4e6689cf4ee5246e6f08..1dd9f7ac1f26c253b8181519aa1873784bc54a07 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -12,6 +12,7 @@ import org.bukkit.attribute.Attributable;
- import org.bukkit.block.Block;
- import org.bukkit.entity.memory.MemoryKey;
- import org.bukkit.inventory.EntityEquipment;
-+import org.bukkit.inventory.ItemStack;
- import org.bukkit.potion.PotionEffect;
- import org.bukkit.potion.PotionEffectType;
- import org.bukkit.projectiles.ProjectileSource;
-@@ -649,5 +650,42 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -649,5 +649,42 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param delay Delay in ticks
       */
      void setShieldBlockingDelay(int delay);
 +
 +    /**
 +     * Get's the item being actively "used" or consumed.
-+     * @return The item. Will be null if no active item.
++     * @return The item
 +     */
-+    @Nullable
-+    ItemStack getActiveItem();
++    @NotNull
++    org.bukkit.inventory.ItemStack getActiveItem();
 +
 +    /**
 +     * Get's remaining time a player needs to keep hands raised with an item to finish using it.

--- a/patches/api/0147-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/api/0147-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -65,10 +65,10 @@ index 0000000000000000000000000000000000000000..18a96dbb01d3b34476652264b2d6be37
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 6d8d96976bcef4e176453fede81a529478f11234..ad885a0775b387e3e8ca6bfae80c18465038056c 100644
+index 1dd9f7ac1f26c253b8181519aa1873784bc54a07..a4b1ae0caea94882f601a0420354838c6a52ef28 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -82,6 +82,77 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -81,6 +81,77 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      @NotNull
      public Block getTargetBlock(@Nullable Set<Material> transparent, int maxDistance);
  

--- a/patches/api/0159-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/api/0159-Add-LivingEntity-getTargetEntity.patch
@@ -49,10 +49,10 @@ index 0000000000000000000000000000000000000000..f52644fab1522bdf83ff4f489e9805b2
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index ad885a0775b387e3e8ca6bfae80c18465038056c..93d20f67bf856d80226470ae2442d199d3e2f45b 100644
+index a4b1ae0caea94882f601a0420354838c6a52ef28..f479e8c26e88520a47f7beeec753b3af9978bde1 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -151,6 +151,50 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -150,6 +150,50 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      @Nullable
      public com.destroystokyo.paper.block.TargetBlockInfo getTargetBlockInfo(int maxDistance, @NotNull com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode);

--- a/patches/api/0188-Entity-Jump-API.patch
+++ b/patches/api/0188-Entity-Jump-API.patch
@@ -57,10 +57,10 @@ index 0000000000000000000000000000000000000000..f0067c2e953d18e1a33536980071ba3f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 93d20f67bf856d80226470ae2442d199d3e2f45b..5ab8db52160049e36464df4e20e374b8849ef29c 100644
+index f479e8c26e88520a47f7beeec753b3af9978bde1..c11de6fbaa6fce8b341ac6c4d9478c18481cc0ef 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -802,5 +802,25 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -801,5 +801,25 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      @NotNull
      org.bukkit.inventory.EquipmentSlot getHandRaised();

--- a/patches/api/0219-Add-playPickupItemAnimation-to-LivingEntity.patch
+++ b/patches/api/0219-Add-playPickupItemAnimation-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add playPickupItemAnimation to LivingEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 5ab8db52160049e36464df4e20e374b8849ef29c..1b6c2b2cfb910e7651e7f18ea407e31db685af8a 100644
+index c11de6fbaa6fce8b341ac6c4d9478c18481cc0ef..37bb2f8c0eba7713793ef51a16f7ca5981e39747 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -822,5 +822,28 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -821,5 +821,28 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param jumping entity jump state
       */
      void setJumping(boolean jumping);

--- a/patches/api/0235-Add-LivingEntity-clearActiveItem.patch
+++ b/patches/api/0235-Add-LivingEntity-clearActiveItem.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Add LivingEntity#clearActiveItem
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 1b6c2b2cfb910e7651e7f18ea407e31db685af8a..751a7345b650e96bbfd3ca9d22c9623bd5444f67 100644
+index 37bb2f8c0eba7713793ef51a16f7ca5981e39747..607696debd78e143b5a1de6e90a9b6d15dc98e96 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -773,6 +773,13 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
-     @Nullable
-     ItemStack getActiveItem();
+@@ -772,6 +772,13 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+     @NotNull
+     org.bukkit.inventory.ItemStack getActiveItem();
  
 +    // Paper start
 +    /**

--- a/patches/api/0241-Expose-LivingEntity-hurt-direction.patch
+++ b/patches/api/0241-Expose-LivingEntity-hurt-direction.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose LivingEntity hurt direction
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 751a7345b650e96bbfd3ca9d22c9623bd5444f67..330eab77547ae059f716418f71ad1d3391a57a9b 100644
+index 607696debd78e143b5a1de6e90a9b6d15dc98e96..087a9c54bc11d5d87aa90bf9d8e66fdac2c44457 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -852,5 +852,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -851,5 +851,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param quantity quantity of item
       */
      void playPickupItemAnimation(@NotNull Item item, int quantity);

--- a/patches/api/0311-Add-more-line-of-sight-methods.patch
+++ b/patches/api/0311-Add-more-line-of-sight-methods.patch
@@ -23,10 +23,10 @@ index aa534b1a9a1fb84a2fbd4b372f313bb4b63325fa..43b53c21af01e0f496c8aaacff82dfdf
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 330eab77547ae059f716418f71ad1d3391a57a9b..cda05df6784dd4d6a09710a416dcb71c016dabfc 100644
+index 087a9c54bc11d5d87aa90bf9d8e66fdac2c44457..5238d83788ef39db1f86c22a0b27648cc47a215b 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -483,6 +483,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -482,6 +482,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      public boolean hasLineOfSight(@NotNull Entity other);
  

--- a/patches/api/0317-Stinger-API.patch
+++ b/patches/api/0317-Stinger-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Stinger API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index cda05df6784dd4d6a09710a416dcb71c016dabfc..31353bd20404a8c2acf6bf0df524dc3cae324272 100644
+index 5238d83788ef39db1f86c22a0b27648cc47a215b..8fa8922ad2fb0ea8f770368faff61e56e9761df9 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -336,6 +336,36 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -335,6 +335,36 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      public void setArrowsInBody(int count);
  


### PR DESCRIPTION
LivingEntity#getActiveItem is marked as nullable incorrectly. Additionally, this is duplicate api but spigots is on HumanEntity so deprecate it in favor of paper's method.

Paper (not null, marked incorrectly as nullable) LivingEntity
![image](https://user-images.githubusercontent.com/23108066/173964965-2101a38a-2a69-48ce-8dca-8ba54e54ba41.png)
Spigot (nullable) HumanEntity
![image](https://user-images.githubusercontent.com/23108066/173965036-056aa364-f675-4dea-9295-78427bcaedf6.png)
