### PR TITLE
Use safe method for handling Files#createDirectories

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -114,7 +114,7 @@ index 0000000000000000000000000000000000000000..7a4a7a654fe2516ed894a68f2657344d
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/Configurations.java b/src/main/java/io/papermc/paper/configuration/Configurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..13d7d1c24ec9192d0163f6eedeac8fca82b6e80c
+index 0000000000000000000000000000000000000000..28e06fb5a6c4a8b0d9c3d79d8664826773b44d71
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/Configurations.java
 @@ -0,0 +1,296 @@
@@ -301,7 +301,7 @@ index 0000000000000000000000000000000000000000..13d7d1c24ec9192d0163f6eedeac8fca
 +        final Path dir = contextMap.require(WORLD_DIRECTORY);
 +        final Path worldConfigFile = dir.resolve(this.worldConfigFileName);
 +        if (Files.notExists(worldConfigFile)) {
-+            Files.createDirectories(dir);
++            Files.createDirectories(dir.toRealPath());
 +            Files.createFile(worldConfigFile); // create empty file as template
 +            newFile = true;
 +        }
@@ -898,7 +898,7 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..518a00886f7bde1de95150366541fc992f178246
+index 0000000000000000000000000000000000000000..a3bb01c583513764e2f607dda3e57fe002b72324
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 @@ -0,0 +1,405 @@
@@ -1207,7 +1207,7 @@ index 0000000000000000000000000000000000000000..518a00886f7bde1de95150366541fc99
 +                if (Files.exists(backupDir) && !Files.isDirectory(backupDir)) {
 +                    throw new RuntimeException("Paper needs to create a '" + BACKUP_DIR + "' directory in the '" + CONFIG_DIR + "' folder. You already have a non-directory named '" + BACKUP_DIR + "'. Please remove it and restart the server.");
 +                }
-+                Files.createDirectories(backupDir);
++                Files.createDirectories(backupDir.toRealPath());
 +                final String backupFileName = legacyConfig.getFileName().toString() + ".old";
 +                final Path legacyConfigBackup = backupDir.resolve(backupFileName);
 +                if (Files.exists(legacyConfigBackup) && !Files.isRegularFile(legacyConfigBackup)) {
@@ -1220,7 +1220,7 @@ index 0000000000000000000000000000000000000000..518a00886f7bde1de95150366541fc99
 +            }
 +        }
 +        try {
-+            Files.createDirectories(configDir);
++            Files.createDirectories(configDir.toRealPath());
 +            return new PaperConfigurations(configDir);
 +        } catch (final IOException ex) {
 +            throw new RuntimeException("Could not setup PaperConfigurations", ex);

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -114,7 +114,7 @@ index 0000000000000000000000000000000000000000..7a4a7a654fe2516ed894a68f2657344d
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/Configurations.java b/src/main/java/io/papermc/paper/configuration/Configurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..28e06fb5a6c4a8b0d9c3d79d8664826773b44d71
+index 0000000000000000000000000000000000000000..31325994ab441c59a4c0bd9f3f9db3d9440375d0
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/Configurations.java
 @@ -0,0 +1,296 @@
@@ -301,7 +301,7 @@ index 0000000000000000000000000000000000000000..28e06fb5a6c4a8b0d9c3d79d86648267
 +        final Path dir = contextMap.require(WORLD_DIRECTORY);
 +        final Path worldConfigFile = dir.resolve(this.worldConfigFileName);
 +        if (Files.notExists(worldConfigFile)) {
-+            Files.createDirectories(dir.toRealPath());
++            PaperConfigurations.createDirectoriesSymlinkAware(dir);
 +            Files.createFile(worldConfigFile); // create empty file as template
 +            newFile = true;
 +        }
@@ -898,10 +898,10 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a3bb01c583513764e2f607dda3e57fe002b72324
+index 0000000000000000000000000000000000000000..fa191f418079a8ee24326c5952d12d4481f57aef
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
-@@ -0,0 +1,405 @@
+@@ -0,0 +1,412 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.base.Suppliers;
@@ -1207,7 +1207,7 @@ index 0000000000000000000000000000000000000000..a3bb01c583513764e2f607dda3e57fe0
 +                if (Files.exists(backupDir) && !Files.isDirectory(backupDir)) {
 +                    throw new RuntimeException("Paper needs to create a '" + BACKUP_DIR + "' directory in the '" + CONFIG_DIR + "' folder. You already have a non-directory named '" + BACKUP_DIR + "'. Please remove it and restart the server.");
 +                }
-+                Files.createDirectories(backupDir.toRealPath());
++                createDirectoriesSymlinkAware(backupDir);
 +                final String backupFileName = legacyConfig.getFileName().toString() + ".old";
 +                final Path legacyConfigBackup = backupDir.resolve(backupFileName);
 +                if (Files.exists(legacyConfigBackup) && !Files.isRegularFile(legacyConfigBackup)) {
@@ -1220,7 +1220,7 @@ index 0000000000000000000000000000000000000000..a3bb01c583513764e2f607dda3e57fe0
 +            }
 +        }
 +        try {
-+            Files.createDirectories(configDir.toRealPath());
++            createDirectoriesSymlinkAware(configDir);
 +            return new PaperConfigurations(configDir);
 +        } catch (final IOException ex) {
 +            throw new RuntimeException("Could not setup PaperConfigurations", ex);
@@ -1228,7 +1228,7 @@ index 0000000000000000000000000000000000000000..a3bb01c583513764e2f607dda3e57fe0
 +    }
 +
 +    private static void convert(final Path legacyConfig, final Path configDir, final Path worldFolder, final File spigotConfig) throws Exception {
-+        Files.createDirectories(configDir);
++        createDirectoriesSymlinkAware(configDir);
 +
 +        final YamlConfigurationLoader legacyLoader = ConfigurationLoaders.naturallySortedWithoutHeader(legacyConfig);
 +        final YamlConfigurationLoader globalLoader = ConfigurationLoaders.naturallySortedWithoutHeader(configDir.resolve(GLOBAL_CONFIG_FILE_NAME));
@@ -1305,6 +1305,13 @@ index 0000000000000000000000000000000000000000..a3bb01c583513764e2f607dda3e57fe0
 +        ConfigurationOptions options = defaultGlobalOptions(defaultOptions(ConfigurationOptions.defaults()))
 +            .serializers(builder -> builder.register(type -> ConfigurationPart.class.isAssignableFrom(erase(type)), factory.asTypeSerializer()));
 +        return BasicConfigurationNode.root(options);
++    }
++
++    // Sym links are not correctly checked in createDirectories
++    static void createDirectoriesSymlinkAware(Path path) throws IOException {
++        if (!Files.isDirectory(path)) {
++            Files.createDirectories(path);
++        }
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/RemovedConfigurations.java b/src/main/java/io/papermc/paper/configuration/RemovedConfigurations.java


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/7969

Symbolic links seem to not be handled nicely in Files#createDirectories.
There will most likely be a future patch that targets correctly handling symlinks for this method when used in other places in the source code. But I wanted to get this out so that it can specifically target to fix this issue.

There was a bug report on this, but it was marked as NAI: https://bugs.openjdk.org/browse/JDK-8130464
