### PR TITLE
Add Disable Vibrations Config

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -416,7 +416,7 @@ index 0000000000000000000000000000000000000000..13d7d1c24ec9192d0163f6eedeac8fca
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3e7086d31b2f101b2d6e982f3935922886cadc77
+index 0000000000000000000000000000000000000000..456595e4b7e0c7f50617aa2694b0d2dfc368ab81
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 @@ -0,0 +1,265 @@
@@ -1378,10 +1378,10 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..32f0cd29d1198fe320d10ccfe0b02f8632ac12aa
+index 0000000000000000000000000000000000000000..bab8c3e8f551aac22a0a3fb5219aac6b844c6f8e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,467 @@
+@@ -0,0 +1,468 @@
 +package io.papermc.paper.configuration;
 +
 +import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray;
@@ -1583,6 +1583,7 @@ index 0000000000000000000000000000000000000000..32f0cd29d1198fe320d10ccfe0b02f86
 +
 +        public class Behavior extends ConfigurationPart {
 +            public boolean disableChestCatDetection = false;
++            public boolean disableVibrations = false;
 +            public boolean spawnerNerfedMobsShouldJump = false;
 +            public int experienceMergeMaxValue = -1;
 +            public boolean shouldRemoveDragon = false;

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -1378,7 +1378,7 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bab8c3e8f551aac22a0a3fb5219aac6b844c6f8e
+index 0000000000000000000000000000000000000000..41b87cd91113231fcab4a3663ddffc949e775c5c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 @@ -0,0 +1,468 @@
@@ -1583,7 +1583,7 @@ index 0000000000000000000000000000000000000000..bab8c3e8f551aac22a0a3fb5219aac6b
 +
 +        public class Behavior extends ConfigurationPart {
 +            public boolean disableChestCatDetection = false;
-+            public boolean disableVibrations = false;
++            public boolean disableGameEvents = false;
 +            public boolean spawnerNerfedMobsShouldJump = false;
 +            public int experienceMergeMaxValue = -1;
 +            public boolean shouldRemoveDragon = false;

--- a/patches/server/0914-Add-Disable-Vibrations-Config.patch
+++ b/patches/server/0914-Add-Disable-Vibrations-Config.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Thu, 16 Jun 2022 11:05:19 -0400
+Subject: [PATCH] Add Disable Vibrations Config
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 0dc7a827aeacc7fae53b1f975f45883da7db6a0c..79e932cb959b029f9a06bb09def82be6c3e414f2 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -1564,6 +1564,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+ 
+     @Override
+     public void gameEvent(GameEvent event, Vec3 emitterPos, GameEvent.Context emitter) {
++        if (this.paperConfig().entities.behavior.disableVibrations) return;
+         int i = event.getNotificationRadius();
+         BlockPos blockposition = new BlockPos(emitterPos);
+         // CraftBukkit start
+diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
+index c46cbbf9ac4c5661933b03bc0b2559f7ade8c798..604a8d58f97ba9a8bbb027bcb8e6d777b187028c 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
++++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
+@@ -437,7 +437,7 @@ public class LevelChunk extends ChunkAccess {
+     public GameEventDispatcher getEventDispatcher(int ySectionCoord) {
+         Level world = this.level;
+ 
+-        if (world instanceof ServerLevel) {
++        if (world instanceof ServerLevel && !this.level.paperConfig().entities.behavior.disableVibrations) { // Paper
+             ServerLevel worldserver = (ServerLevel) world;
+ 
+             return (GameEventDispatcher) this.gameEventDispatcherSections.computeIfAbsent(ySectionCoord, (j) -> {

--- a/patches/server/0915-Add-Disable-Vibrations-Config.patch
+++ b/patches/server/0915-Add-Disable-Vibrations-Config.patch
@@ -5,19 +5,19 @@ Subject: [PATCH] Add Disable Vibrations Config
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 0dc7a827aeacc7fae53b1f975f45883da7db6a0c..79e932cb959b029f9a06bb09def82be6c3e414f2 100644
+index 0dc7a827aeacc7fae53b1f975f45883da7db6a0c..ae61e126b7b8cb4e34b2252d2619db46ad694251 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1564,6 +1564,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
      @Override
      public void gameEvent(GameEvent event, Vec3 emitterPos, GameEvent.Context emitter) {
-+        if (this.paperConfig().entities.behavior.disableVibrations) return;
++        if (this.paperConfig().entities.behavior.disableGameEvents) return;
          int i = event.getNotificationRadius();
          BlockPos blockposition = new BlockPos(emitterPos);
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index c46cbbf9ac4c5661933b03bc0b2559f7ade8c798..604a8d58f97ba9a8bbb027bcb8e6d777b187028c 100644
+index c46cbbf9ac4c5661933b03bc0b2559f7ade8c798..5925c3261a30b67178aad3e62471f4246a05019f 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -437,7 +437,7 @@ public class LevelChunk extends ChunkAccess {
@@ -25,7 +25,7 @@ index c46cbbf9ac4c5661933b03bc0b2559f7ade8c798..604a8d58f97ba9a8bbb027bcb8e6d777
          Level world = this.level;
  
 -        if (world instanceof ServerLevel) {
-+        if (world instanceof ServerLevel && !this.level.paperConfig().entities.behavior.disableVibrations) { // Paper
++        if (world instanceof ServerLevel && !this.level.paperConfig().entities.behavior.disableGameEvents) { // Paper
              ServerLevel worldserver = (ServerLevel) world;
  
              return (GameEventDispatcher) this.gameEventDispatcherSections.computeIfAbsent(ySectionCoord, (j) -> {


### PR DESCRIPTION
Adds an option to disable vibration listeners from being registered/playing in the world.
This causes the following to disable:
- Sculk Catalyst spreading on death
- Sculk Shrieker 
- Sculk Sensor
- Warden vibration listening (they can still attack players if nearby/provoked)
- Allay note block behavior