### PR TITLE
Fix incorrect random nextLong to nextInt

### DIFF
--- a/patches/server/0070-Use-a-Shared-Random-for-Entities.patch
+++ b/patches/server/0070-Use-a-Shared-Random-for-Entities.patch
@@ -6,16 +6,16 @@ Subject: [PATCH] Use a Shared Random for Entities
 Reduces memory usage and provides ensures more randomness, Especially since a lot of garbage entity objects get created.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 704a5aa2881c6f826d49ad9aed6003db7c5f5843..e3fe98ef3a7537d3717824d3357cc84c632ee0ea 100644
+index 704a5aa2881c6f826d49ad9aed6003db7c5f5843..112942d72a30a722ba929f89fb57f67328366d99 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -158,6 +158,74 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -158,6 +158,79 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return tag.contains("Bukkit.updateLevel") && tag.getInt("Bukkit.updateLevel") >= level;
      }
  
 +    // Paper start
 +    public static RandomSource SHARED_RANDOM = new RandomRandomSource();
-+    private static final class RandomRandomSource extends java.util.Random implements RandomSource {
++    private static final class RandomRandomSource extends java.util.Random implements net.minecraft.world.level.levelgen.BitRandomSource {
 +        private boolean locked = false;
 +
 +        @Override
@@ -38,40 +38,45 @@ index 704a5aa2881c6f826d49ad9aed6003db7c5f5843..e3fe98ef3a7537d3717824d3357cc84c
 +            return new net.minecraft.world.level.levelgen.LegacyRandomSource.LegacyPositionalRandomFactory(this.nextLong());
 +        }
 +
-+        @Override
-+        public int nextInt(int origin, int bound) {
-+            return RandomSource.super.nextInt(origin, bound);
-+        }
-+
 +        // these below are added to fix reobf issues that I don't wanna deal with right now
 +        @Override
++        public int next(int bits) {
++            return super.next(bits);
++        }
++
++        @Override
++        public int nextInt(int origin, int bound) {
++            return net.minecraft.world.level.levelgen.BitRandomSource.super.nextInt(origin, bound);
++        }
++
++        @Override
 +        public long nextLong() {
-+            return super.nextInt();
++            return net.minecraft.world.level.levelgen.BitRandomSource.super.nextLong();
 +        }
 +
 +        @Override
 +        public int nextInt() {
-+            return super.nextInt();
++            return net.minecraft.world.level.levelgen.BitRandomSource.super.nextInt();
 +        }
 +
 +        @Override
 +        public int nextInt(int bound) {
-+            return super.nextInt(bound);
++            return net.minecraft.world.level.levelgen.BitRandomSource.super.nextInt(bound);
 +        }
 +
 +        @Override
 +        public boolean nextBoolean() {
-+            return super.nextBoolean();
++            return net.minecraft.world.level.levelgen.BitRandomSource.super.nextBoolean();
 +        }
 +
 +        @Override
 +        public float nextFloat() {
-+            return super.nextFloat();
++            return net.minecraft.world.level.levelgen.BitRandomSource.super.nextFloat();
 +        }
 +
 +        @Override
 +        public double nextDouble() {
-+            return super.nextDouble();
++            return net.minecraft.world.level.levelgen.BitRandomSource.super.nextDouble();
 +        }
 +
 +        @Override
@@ -84,7 +89,7 @@ index 704a5aa2881c6f826d49ad9aed6003db7c5f5843..e3fe98ef3a7537d3717824d3357cc84c
      private CraftEntity bukkitEntity;
  
      public CraftEntity getBukkitEntity() {
-@@ -345,7 +413,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -345,7 +418,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          this.bb = Entity.INITIAL_AABB;
          this.stuckSpeedMultiplier = Vec3.ZERO;
          this.nextStep = 1.0F;

--- a/patches/server/0091-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0091-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -485,10 +485,10 @@ index 0000000000000000000000000000000000000000..3377b86c337d0234bbb9b0349e4034a7
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e3fe98ef3a7537d3717824d3357cc84c632ee0ea..3d84055afbe0392ca1abf5628b3b621b8833265a 100644
+index 112942d72a30a722ba929f89fb57f67328366d99..1001ac7de9c555aff8da600ff18f1fd28f8d37a5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -226,6 +226,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -231,6 +231,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
      // Paper end
  

--- a/patches/server/0124-Don-t-allow-entities-to-ride-themselves-572.patch
+++ b/patches/server/0124-Don-t-allow-entities-to-ride-themselves-572.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't allow entities to ride themselves - #572
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3d84055afbe0392ca1abf5628b3b621b8833265a..25fb1785e76aa72eb59565dd51f9fc65b0509869 100644
+index 1001ac7de9c555aff8da600ff18f1fd28f8d37a5..3355c705c6ee9de575a822f958c6d051e8a22201 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2316,6 +2316,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2321,6 +2321,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/patches/server/0126-Cap-Entity-Collisions.patch
+++ b/patches/server/0126-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 25fb1785e76aa72eb59565dd51f9fc65b0509869..bfc7736bfe538b615343b6f41f2a670493e2c701 100644
+index 3355c705c6ee9de575a822f958c6d051e8a22201..04ef49808013c3d0c9ec4593d01532549e954270 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -373,6 +373,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -378,6 +378,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public void inactiveTick() { }
      // Spigot end
      // Paper start

--- a/patches/server/0143-Entity-fromMobSpawner.patch
+++ b/patches/server/0143-Entity-fromMobSpawner.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index bfc7736bfe538b615343b6f41f2a670493e2c701..22c9fcb8b0a75e59fc6838b9f33430b6c476cdc1 100644
+index 04ef49808013c3d0c9ec4593d01532549e954270..51a312e841945315a65b42c0c47af5c516eba814 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -374,6 +374,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -379,6 +379,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      // Spigot end
      // Paper start
      protected int numCollisions = 0; // Paper
@@ -16,7 +16,7 @@ index bfc7736bfe538b615343b6f41f2a670493e2c701..22c9fcb8b0a75e59fc6838b9f33430b6
      @javax.annotation.Nullable
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
-@@ -1953,6 +1954,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1958,6 +1959,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  }
                  nbt.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -27,7 +27,7 @@ index bfc7736bfe538b615343b6f41f2a670493e2c701..22c9fcb8b0a75e59fc6838b9f33430b6
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2090,6 +2095,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2095,6 +2100,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.originWorld = originWorld;
                  origin = new org.bukkit.util.Vector(originTag.getDouble(0), originTag.getDouble(1), originTag.getDouble(2));
              }

--- a/patches/server/0218-add-more-information-to-Entity.toString.patch
+++ b/patches/server/0218-add-more-information-to-Entity.toString.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add more information to Entity.toString()
 UUID, ticks lived, valid, dead
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 22c9fcb8b0a75e59fc6838b9f33430b6c476cdc1..57b1d37bfe35215552c138caad8597986f755064 100644
+index 51a312e841945315a65b42c0c47af5c516eba814..6231f373b34d11bfa04c6ea68ed4ab47b92bf031 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2899,7 +2899,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2904,7 +2904,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public String toString() {
          String s = this.level == null ? "~NULL~" : this.level.toString();
  

--- a/patches/server/0236-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/patches/server/0236-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -72,10 +72,10 @@ index 1e559d238441d28c52b3305c42dec0f6115b2626..547aea9a2ead3eff5690f18cfc351b01
              return false;
          } else {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 57b1d37bfe35215552c138caad8597986f755064..d020cbe64e13b479e22a8f6c090165390663af63 100644
+index 6231f373b34d11bfa04c6ea68ed4ab47b92bf031..236b59f5119a4f91919ab93c8edd5269ea34b1ee 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -229,6 +229,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -234,6 +234,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
      private CraftEntity bukkitEntity;
  

--- a/patches/server/0287-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0287-force-entity-dismount-during-teleportation.patch
@@ -41,10 +41,10 @@ index 15b9186ad0e52a55a3f523e4f1d96ef34ca99145..2e42a61e315a6857ca8b2ef4a63c9740
  
          if (entity1 != entity && this.connection != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d020cbe64e13b479e22a8f6c090165390663af63..a5e9b15d52a0134060b9f815560fa20ee610d506 100644
+index 236b59f5119a4f91919ab93c8edd5269ea34b1ee..ce5bb09aef3c2d8a2d30f3887e4c7e3ef0202460 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2312,11 +2312,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2317,11 +2317,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void removeVehicle() {
@@ -62,7 +62,7 @@ index d020cbe64e13b479e22a8f6c090165390663af63..a5e9b15d52a0134060b9f815560fa20e
          }
  
      }
-@@ -2379,7 +2384,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2384,7 +2389,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return true; // CraftBukkit
      }
  
@@ -74,7 +74,7 @@ index d020cbe64e13b479e22a8f6c090165390663af63..a5e9b15d52a0134060b9f815560fa20e
          if (entity.getVehicle() == this) {
              throw new IllegalStateException("Use x.stopRiding(y), not y.removePassenger(x)");
          } else {
-@@ -2389,7 +2397,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2394,7 +2402,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (this.getBukkitEntity() instanceof Vehicle && entity.getBukkitEntity() instanceof LivingEntity) {
                  VehicleExitEvent event = new VehicleExitEvent(
                          (Vehicle) this.getBukkitEntity(),
@@ -83,7 +83,7 @@ index d020cbe64e13b479e22a8f6c090165390663af63..a5e9b15d52a0134060b9f815560fa20e
                  );
                  // Suppress during worldgen
                  if (this.valid) {
-@@ -2403,7 +2411,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2408,7 +2416,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
              // CraftBukkit end
              // Spigot start

--- a/patches/server/0305-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0305-Entity-getEntitySpawnReason.patch
@@ -35,7 +35,7 @@ index c2370cb1128b55dd9d40a72a01296f40e01630b9..7fc211e97da0f3e00abc9e0098df137b
              });
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a5e9b15d52a0134060b9f815560fa20ee610d506..94966ce5d0af77f3ae2e43e84f12470e6fee094b 100644
+index ce5bb09aef3c2d8a2d30f3887e4c7e3ef0202460..882378cb4b5da76fdb0d1180350c7bb927f0df28 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -73,6 +73,8 @@ import net.minecraft.world.InteractionHand;
@@ -47,7 +47,7 @@ index a5e9b15d52a0134060b9f815560fa20ee610d506..94966ce5d0af77f3ae2e43e84f12470e
  import net.minecraft.world.entity.item.ItemEntity;
  import net.minecraft.world.entity.player.Player;
  import net.minecraft.world.entity.vehicle.Boat;
-@@ -225,6 +227,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -230,6 +232,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
      }
      // Paper end
@@ -55,7 +55,7 @@ index a5e9b15d52a0134060b9f815560fa20ee610d506..94966ce5d0af77f3ae2e43e84f12470e
  
      public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
      private CraftEntity bukkitEntity;
-@@ -1956,6 +1959,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1961,6 +1964,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  }
                  nbt.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -65,7 +65,7 @@ index a5e9b15d52a0134060b9f815560fa20ee610d506..94966ce5d0af77f3ae2e43e84f12470e
              // Save entity's from mob spawner status
              if (spawnedViaMobSpawner) {
                  nbt.putBoolean("Paper.FromMobSpawner", true);
-@@ -2099,6 +2105,26 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2104,6 +2110,26 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0349-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0349-Entity-Activation-Range-2.0.patch
@@ -14,7 +14,7 @@ Adds flying monsters to control ghast and phantoms
 Adds villagers as separate config
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 48d561e757c266353e48abf2a2f06571aa5d4623..aff0c117d88afab7d670a1ce95beda3df95fa0c2 100644
+index 63a146cdeed5f01d63488d2e74ad0c80343f5077..b2a8faec6562d784b3f16fe968c778f9abfedeb5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2,7 +2,6 @@ package net.minecraft.server.level;
@@ -108,10 +108,10 @@ index 48d561e757c266353e48abf2a2f06571aa5d4623..aff0c117d88afab7d670a1ce95beda3d
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 94966ce5d0af77f3ae2e43e84f12470e6fee094b..b3d252b822b39c3fbbfbaf5c98284fb4281ab635 100644
+index 882378cb4b5da76fdb0d1180350c7bb927f0df28..5ebfbb58fabebee9dc52ea8c9115965001f4d6aa 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -378,6 +378,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -383,6 +383,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public void inactiveTick() { }
      // Spigot end
      // Paper start
@@ -120,7 +120,7 @@ index 94966ce5d0af77f3ae2e43e84f12470e6fee094b..b3d252b822b39c3fbbfbaf5c98284fb4
      protected int numCollisions = 0; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      @javax.annotation.Nullable
-@@ -851,6 +853,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -856,6 +858,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          } else {
              this.wasOnFire = this.isOnFire();
              if (movementType == MoverType.PISTON) {
@@ -129,7 +129,7 @@ index 94966ce5d0af77f3ae2e43e84f12470e6fee094b..b3d252b822b39c3fbbfbaf5c98284fb4
                  movement = this.limitPistonMovement(movement);
                  if (movement.equals(Vec3.ZERO)) {
                      return;
-@@ -863,6 +867,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -868,6 +872,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }
@@ -693,7 +693,7 @@ index 7bae24598218dcf0012dd21e619e6f5f984bd6f0..c9a032c5331a918453de5e8c6a6d13f5
              isActive = false;
          }
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index c55321ec37b500199eda375cabca21e666612b9c..d4f035aca1d63596fd52b21e34c69e8d08e24e7a 100644
+index d4d2d11cf19167410ec6ad3417495e7130330d11..9c9723e13b5440d4803a7268057d63cbdc973b77 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -199,14 +199,60 @@ public class SpigotWorldConfig

--- a/patches/server/0355-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0355-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b3d252b822b39c3fbbfbaf5c98284fb4281ab635..23e83d6d78d875d38e8ec109ff0effa1ed9634bd 100644
+index 5ebfbb58fabebee9dc52ea8c9115965001f4d6aa..52aa6e789b81e6e8a4c7c15eb49dedda4bf90b5d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3106,6 +3106,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3111,6 +3111,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (flag1) {
                  blockposition1 = ServerLevel.END_SPAWN_POINT;
              } else {

--- a/patches/server/0364-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0364-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 23e83d6d78d875d38e8ec109ff0effa1ed9634bd..97d316a4e14e109e91fba41303b83098895f405c 100644
+index 52aa6e789b81e6e8a4c7c15eb49dedda4bf90b5d..c652aab302357c22a404118cdd113d3162b1a753 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -380,6 +380,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -385,6 +385,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      // Paper start
      public long activatedImmunityTick = Integer.MIN_VALUE; // Paper
      public boolean isTemporarilyActive = false; // Paper
@@ -16,7 +16,7 @@ index 23e83d6d78d875d38e8ec109ff0effa1ed9634bd..97d316a4e14e109e91fba41303b83098
      protected int numCollisions = 0; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      @javax.annotation.Nullable
-@@ -1977,6 +1978,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1982,6 +1983,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (spawnedViaMobSpawner) {
                  nbt.putBoolean("Paper.FromMobSpawner", true);
              }
@@ -26,7 +26,7 @@ index 23e83d6d78d875d38e8ec109ff0effa1ed9634bd..97d316a4e14e109e91fba41303b83098
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2116,6 +2120,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2121,6 +2125,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0381-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/0381-Optimize-Collision-to-not-load-chunks.patch
@@ -26,10 +26,10 @@ index f14d4bfd5ac03eeffefcf98e1077d915fd3fa2cb..d8b34055aff358cb2c236199da1e22d8
              entityplayer1.setPos(entityplayer1.getX(), entityplayer1.getY() + 1.0D, entityplayer1.getZ());
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 97d316a4e14e109e91fba41303b83098895f405c..a9f02cdf5f9d2767fc4a5422d084008f70e6a8e2 100644
+index c652aab302357c22a404118cdd113d3162b1a753..ba6ed98fd09632336980270385165112eb21da46 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -230,6 +230,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -235,6 +235,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper
  
      public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper

--- a/patches/server/0396-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/patches/server/0396-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -7,10 +7,10 @@ The code following this has better support for null worlds to move
 them back to the world spawn.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a9f02cdf5f9d2767fc4a5422d084008f70e6a8e2..3ae5ac2a50930d89daa460855e7bc7fc3143f979 100644
+index ba6ed98fd09632336980270385165112eb21da46..e9fa8e5ebe8a5e40524735ab98e0c413793e5ca0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2093,9 +2093,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2098,9 +2098,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      bworld = server.getWorld(worldName);
                  }
  

--- a/patches/server/0400-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0400-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,10 +16,10 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3ae5ac2a50930d89daa460855e7bc7fc3143f979..782bced79dacc90e1d1914a2025e77b4fff06221 100644
+index e9fa8e5ebe8a5e40524735ab98e0c413793e5ca0..66c728a456dc9b60fb340d6e55626592e17b6ad8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2223,11 +2223,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2228,11 +2228,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          } else {
              // CraftBukkit start - Capture drops for death event
              if (this instanceof net.minecraft.world.entity.LivingEntity && !((net.minecraft.world.entity.LivingEntity) this).forceDrops) {
@@ -34,7 +34,7 @@ index 3ae5ac2a50930d89daa460855e7bc7fc3143f979..782bced79dacc90e1d1914a2025e77b4
  
              entityitem.setDefaultPickUpDelay();
              // CraftBukkit start
-@@ -2991,6 +2992,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2996,6 +2997,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      @Nullable
      public Entity teleportTo(ServerLevel worldserver, BlockPos location) {
          // CraftBukkit end
@@ -47,7 +47,7 @@ index 3ae5ac2a50930d89daa460855e7bc7fc3143f979..782bced79dacc90e1d1914a2025e77b4
          if (this.level instanceof ServerLevel && !this.isRemoved()) {
              this.level.getProfiler().push("changeDimension");
              // CraftBukkit start
-@@ -3017,6 +3024,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3022,6 +3029,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  // CraftBukkit end
  
                  this.level.getProfiler().popPush("reloading");
@@ -59,7 +59,7 @@ index 3ae5ac2a50930d89daa460855e7bc7fc3143f979..782bced79dacc90e1d1914a2025e77b4
                  Entity entity = this.getType().create(worldserver);
  
                  if (entity != null) {
-@@ -3030,10 +3042,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3035,10 +3047,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index 3ae5ac2a50930d89daa460855e7bc7fc3143f979..782bced79dacc90e1d1914a2025e77b4
                      // CraftBukkit end
                  }
  
-@@ -3155,7 +3163,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3160,7 +3168,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public boolean canChangeDimensions() {

--- a/patches/server/0424-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/patches/server/0424-Use-distance-map-to-optimise-entity-tracker.patch
@@ -280,7 +280,7 @@ index 37ed4429e065b0e05f14ed352e191863a3547311..10ef89963ad805c775b9c649f4e17c9d
              return object instanceof ChunkMap.TrackedEntity ? ((ChunkMap.TrackedEntity) object).entity.getId() == this.entity.getId() : false;
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 782bced79dacc90e1d1914a2025e77b4fff06221..f0415a2eeec073943d00c39b12b5edcf751c28ee 100644
+index 66c728a456dc9b60fb340d6e55626592e17b6ad8..d19b6266e96e4ef3ba4319d46086b9ef61fb4efb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -56,6 +56,7 @@ import net.minecraft.network.syncher.EntityDataSerializers;
@@ -291,7 +291,7 @@ index 782bced79dacc90e1d1914a2025e77b4fff06221..f0415a2eeec073943d00c39b12b5edcf
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
-@@ -418,6 +419,39 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -423,6 +424,39 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
      // Paper end
  

--- a/patches/server/0440-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0440-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f0415a2eeec073943d00c39b12b5edcf751c28ee..39c34df3b23eed1ca97234e8df64e9ac0a53ff46 100644
+index d19b6266e96e4ef3ba4319d46086b9ef61fb4efb..a9eb278cef322db446efb6a5c31b53346fe1e59a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -656,8 +656,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -661,8 +661,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void setPos(double x, double y, double z) {
@@ -19,7 +19,7 @@ index f0415a2eeec073943d00c39b12b5edcf751c28ee..39c34df3b23eed1ca97234e8df64e9ac
      }
  
      protected AABB makeBoundingBox() {
-@@ -3868,6 +3868,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3873,6 +3873,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public final void setPosRaw(double x, double y, double z) {
@@ -31,7 +31,7 @@ index f0415a2eeec073943d00c39b12b5edcf751c28ee..39c34df3b23eed1ca97234e8df64e9ac
          if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
-@@ -3885,6 +3890,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3890,6 +3895,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              this.levelCallback.onMove();
          }
  

--- a/patches/server/0461-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0461-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -68,7 +68,7 @@ index af40e473521f408aa0e112953c43bdbce164a48b..68860a3b6db2aa50373d71aec9502c18
      }
  
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index aebfcd07170109b9cf058df0d4e285b0d95fedb5..90ebe2ecd1566acd22e69a134090eb3bd3a8e485 100644
+index 4e29c0a983727fc839a4bcde01d3286396b3587d..613988c9ea892ab15516e1c8b4f376d52415ae34 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -681,6 +681,7 @@ public final class MCUtil {
@@ -1135,10 +1135,10 @@ index 0b301b1f164853bfd23300993288a2958824e287..ec48afe87b5d159b5bdbe035e214ea7c
              if (updatingChunk != null) {
                  return updatingChunk.getEntityTickingChunkFuture();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 39c34df3b23eed1ca97234e8df64e9ac0a53ff46..f6df40664b07bf958331e3d1e88a239dd12fb96b 100644
+index a9eb278cef322db446efb6a5c31b53346fe1e59a..cc8011ca62feb984f41246694d1e50646f2383f7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -287,7 +287,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -292,7 +292,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      private BlockPos blockPosition;
      private ChunkPos chunkPosition;
      private Vec3 deltaMovement;
@@ -1177,7 +1177,7 @@ index 797ff36295412ac8429d573e039d870fd85eb569..3591ac3b7823e109e01ebfa54ac70aa4
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index daa6f460d6a1006f91ea5fe63ce86625796801f4..f05c909f65240d3a9a71ac620c395d1e6a724fcd 100644
+index 914d0bdd82455f938d08d78c75aabead729bb785..4618e1a360c3d5cd875b646c57ce5c16d476976d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1998,6 +1998,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0493-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0493-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -9,7 +9,7 @@ as this is how Vanilla teleports entities.
 Cancel any pending motion when teleported.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 84943c80d4a331b18652854f3ae75b509fde806b..2e6bb067197121c72d249fc31ce46b8b0b17263b 100644
+index 05c18c233c8400c2031f9d7b3e5ce230dd89a25f..df8e091e72901518ef21903bd3890988ea4a5645 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -721,7 +721,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -31,7 +31,7 @@ index 84943c80d4a331b18652854f3ae75b509fde806b..2e6bb067197121c72d249fc31ce46b8b
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f6df40664b07bf958331e3d1e88a239dd12fb96b..ab520a5a34109d2b8c11d0ffe7eeb4fb8889cbbe 100644
+index cc8011ca62feb984f41246694d1e50646f2383f7..eae3fec221518434b989c8084920dc282f8d8981 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -157,6 +157,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -42,7 +42,7 @@ index f6df40664b07bf958331e3d1e88a239dd12fb96b..ab520a5a34109d2b8c11d0ffe7eeb4fb
      static boolean isLevelAtLeast(CompoundTag tag, int level) {
          return tag.contains("Bukkit.updateLevel") && tag.getInt("Bukkit.updateLevel") >= level;
      }
-@@ -1650,6 +1651,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1655,6 +1656,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void moveTo(double x, double y, double z, float yaw, float pitch) {

--- a/patches/server/0498-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0498-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ab520a5a34109d2b8c11d0ffe7eeb4fb8889cbbe..5c59e51005362361c10e075d6e0e1e5c64c7a05e 100644
+index eae3fec221518434b989c8084920dc282f8d8981..bd6bd22830b7c48717f009f237699fcc38f61c70 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4072,4 +4072,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4077,4 +4077,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0500-Entity-isTicking.patch
+++ b/patches/server/0500-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5c59e51005362361c10e075d6e0e1e5c64c7a05e..592bc702b10ad580cbb473f03f9dac2db476f19f 100644
+index bd6bd22830b7c48717f009f237699fcc38f61c70..7003eee4e8c580e719698f7fdb73213a5ef9e047 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -58,6 +58,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index 5c59e51005362361c10e075d6e0e1e5c64c7a05e..592bc702b10ad580cbb473f03f9dac2d
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -4077,5 +4078,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4082,5 +4083,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0530-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0530-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 592bc702b10ad580cbb473f03f9dac2db476f19f..6b49e66f0e45eb7ed525fe4314d2a9615212f7e4 100644
+index 7003eee4e8c580e719698f7fdb73213a5ef9e047..f2f91815137db868bf6968be062ef9e7b96266b8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1831,6 +1831,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1836,6 +1836,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public boolean isPushable() {

--- a/patches/server/0543-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0543-MC-4-Fix-item-position-desync.patch
@@ -27,10 +27,10 @@ index 3768a71491ef7836b9739bdaec7a077c523dbacd..a57957ace1a72b3308487f180a366c38
  
      public Vec3 decode(long x, long y, long z) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6b49e66f0e45eb7ed525fe4314d2a9615212f7e4..b537edf3c219f5064733eec53082db577be51f81 100644
+index f2f91815137db868bf6968be062ef9e7b96266b8..84365010341c1f5a4ed6dcc5c4110944268ce611 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3888,6 +3888,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3893,6 +3893,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
          // Paper end

--- a/patches/server/0570-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0570-Collision-option-for-requiring-a-player-participant.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Collision option for requiring a player participant
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4f9a5837d66c1940385e94f80d865cde1c4cf2a2..db6be2d9144fb1da9583833849f7b5518402c26d 100644
+index 84365010341c1f5a4ed6dcc5c4110944268ce611..26f93888ea0ae5236fe45c809f21e1d004e79b4c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1714,6 +1714,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1719,6 +1719,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public void push(Entity entity) {
          if (!this.isPassengerOfSameVehicle(entity)) {
              if (!entity.noPhysics && !this.noPhysics) {

--- a/patches/server/0663-Fix-dangerous-end-portal-logic.patch
+++ b/patches/server/0663-Fix-dangerous-end-portal-logic.patch
@@ -11,10 +11,10 @@ Move the tick logic into the post tick, where portaling was
 designed to happen in the first place.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index db6be2d9144fb1da9583833849f7b5518402c26d..b5b949a29951b0d1cd1345a2a751eb413484b7e3 100644
+index 26f93888ea0ae5236fe45c809f21e1d004e79b4c..ed0772f1153ac80838895283d41a971a6eaa2ccc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -453,6 +453,36 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -458,6 +458,36 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return chunkMap.playerEntityTrackerTrackMaps[type.ordinal()].getObjectsInRange(MCUtil.getCoordinateKey(this));
      }
      // Paper end - optimise entity tracking
@@ -51,7 +51,7 @@ index db6be2d9144fb1da9583833849f7b5518402c26d..b5b949a29951b0d1cd1345a2a751eb41
  
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
-@@ -2618,6 +2648,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2623,6 +2653,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
  
              this.processPortalCooldown();

--- a/patches/server/0696-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0696-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b5b949a29951b0d1cd1345a2a751eb413484b7e3..f0dfc052cf1c33b422c3e08c88217e3c49ad32ee 100644
+index ed0772f1153ac80838895283d41a971a6eaa2ccc..b7f7ef9d2323848cf17ccd34cdab56aed81cfc56 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3594,26 +3594,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3599,26 +3599,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      private Stream<Entity> getIndirectPassengersStream() {

--- a/patches/server/0706-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0706-Add-back-EntityPortalExitEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f0dfc052cf1c33b422c3e08c88217e3c49ad32ee..7ebbfd7ba4e26539f45b59625a1138a5e053ede4 100644
+index b7f7ef9d2323848cf17ccd34cdab56aed81cfc56..6a12052023cabd2056555aa83e57078eb500f4e4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3095,6 +3095,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3100,6 +3100,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              } else {
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
@@ -32,7 +32,7 @@ index f0dfc052cf1c33b422c3e08c88217e3c49ad32ee..7ebbfd7ba4e26539f45b59625a1138a5
                  if (worldserver == this.level) {
                      // SPIGOT-6782: Just move the entity if a plugin changed the world to the one the entity is already in
                      this.moveTo(shapedetectorshape.pos.x, shapedetectorshape.pos.y, shapedetectorshape.pos.z, shapedetectorshape.yRot, shapedetectorshape.xRot);
-@@ -3114,8 +3131,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3119,8 +3136,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
                  if (entity != null) {
                      entity.restoreFrom(this);

--- a/patches/server/0717-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0717-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7ebbfd7ba4e26539f45b59625a1138a5e053ede4..e6ab931869bb44a2b70029b59140d0327b0898d7 100644
+index 6a12052023cabd2056555aa83e57078eb500f4e4..1f52fc61ed918aa3930d9e9413fd4682b35fd62a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1920,6 +1920,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1925,6 +1925,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
      }
  

--- a/patches/server/0735-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0735-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -914,7 +914,7 @@ index 0000000000000000000000000000000000000000..3ba094e640d7fe7803e2bbdab8ff3beb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 3fc394d82217a273dad07b44cc18a66e1e3886c6..463d665ee708d741440331393e0b0a97fc981200 100644
+index 6317b2aa746db98fa6b881d9fe55a8a9353c68e2..5aa9c963d0d66c506f0abf821367d1b78f3bf58c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -449,7 +449,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -953,10 +953,10 @@ index ba3023c7dd5b3bcf66f829fe5dc9757f96d16b45..05ff7bcc79e617904903cf082f6687d2
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e6ab931869bb44a2b70029b59140d0327b0898d7..6536b992daf856ee84f4fce077d46061bebb90e4 100644
+index 1f52fc61ed918aa3930d9e9413fd4682b35fd62a..69b4b5f895c7ed2928b2de4b896972362eff5c34 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -484,6 +484,56 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -489,6 +489,56 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
      // Paper end - make end portalling safe
  
@@ -1013,7 +1013,7 @@ index e6ab931869bb44a2b70029b59140d0327b0898d7..6536b992daf856ee84f4fce077d46061
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
          this.passengers = ImmutableList.of();
-@@ -2355,11 +2405,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2360,11 +2410,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return InteractionResult.PASS;
      }
  

--- a/patches/server/0741-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0741-Detail-more-information-in-watchdog-dumps.patch
@@ -77,7 +77,7 @@ index a34f22cadc09e53ea4de787b04d050b99dddbcac..c8012de68b997d6270ba4a5d79bc93c0
              });
              throw RunningOnDifferentThreadException.RUNNING_ON_DIFFERENT_THREAD;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 572e635739cf43ddb4b4e51df59d4c2612b77034..d3470ba0b1732356d1082f23632dbe218ceb167e 100644
+index 2c1b2521b995a926c85e58d21926d9a3b8743304..b2c6d72beefe48189aa36f453f8950209b7e3ee1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1001,7 +1001,26 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -123,10 +123,10 @@ index 572e635739cf43ddb4b4e51df59d4c2612b77034..d3470ba0b1732356d1082f23632dbe21
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6536b992daf856ee84f4fce077d46061bebb90e4..2013a0b402b0abcb0a47911cfaa8aa0ccf468f9b 100644
+index 69b4b5f895c7ed2928b2de4b896972362eff5c34..b014794ce7b5a782432a64eeb8a3a9ac69f0b4f3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -965,7 +965,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -970,7 +970,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return this.onGround;
      }
  
@@ -169,7 +169,7 @@ index 6536b992daf856ee84f4fce077d46061bebb90e4..2013a0b402b0abcb0a47911cfaa8aa0c
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -1138,6 +1173,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1143,6 +1178,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.level.getProfiler().pop();
              }
          }
@@ -183,7 +183,7 @@ index 6536b992daf856ee84f4fce077d46061bebb90e4..2013a0b402b0abcb0a47911cfaa8aa0c
      }
  
      protected boolean isHorizontalCollisionMinor(Vec3 adjustedMovement) {
-@@ -3946,7 +3988,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3951,7 +3993,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -193,7 +193,7 @@ index 6536b992daf856ee84f4fce077d46061bebb90e4..2013a0b402b0abcb0a47911cfaa8aa0c
      }
  
      public void setDeltaMovement(double x, double y, double z) {
-@@ -4022,7 +4066,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4027,7 +4071,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
          // Paper end - fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {

--- a/patches/server/0757-Optimise-random-block-ticking.patch
+++ b/patches/server/0757-Optimise-random-block-ticking.patch
@@ -20,18 +20,20 @@ remains the same.
 
 diff --git a/src/main/java/io/papermc/paper/util/math/ThreadUnsafeRandom.java b/src/main/java/io/papermc/paper/util/math/ThreadUnsafeRandom.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..16ca915c33e31b50d33336408b041e401cb9cbfc
+index 0000000000000000000000000000000000000000..7d93652c1abbb6aee6eb7c26cf35d4d032ef7b69
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/math/ThreadUnsafeRandom.java
-@@ -0,0 +1,95 @@
+@@ -0,0 +1,65 @@
 +package io.papermc.paper.util.math;
 +
 +import net.minecraft.util.RandomSource;
++import net.minecraft.world.level.levelgen.LegacyRandomSource;
 +import net.minecraft.world.level.levelgen.PositionalRandomFactory;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
 +
-+import java.util.Random;
-+
-+public final class ThreadUnsafeRandom extends Random implements RandomSource {
++@DefaultQualifier(NonNull.class)
++public final class ThreadUnsafeRandom extends LegacyRandomSource {
 +
 +    // See javadoc and internal comments for java.util.Random where these values come from, how they are used, and the author for them.
 +    private static final long multiplier = 0x5DEECE66DL;
@@ -44,19 +46,18 @@ index 0000000000000000000000000000000000000000..16ca915c33e31b50d33336408b041e40
 +
 +    private long seed;
 +
++    public ThreadUnsafeRandom(long seed) {
++        super(seed);
++    }
++
 +    @Override
 +    public RandomSource fork() {
-+        return new ThreadUnsafeRandom();
++        return new ThreadUnsafeRandom(this.nextLong());
 +    }
 +
 +    @Override
 +    public PositionalRandomFactory forkPositional() {
 +        throw new UnsupportedOperationException();
-+    }
-+
-+    @Override
-+    public int nextInt(int origin, int bound) {
-+        return RandomSource.super.nextInt(origin, bound);
 +    }
 +
 +    @Override
@@ -66,7 +67,7 @@ index 0000000000000000000000000000000000000000..16ca915c33e31b50d33336408b041e40
 +    }
 +
 +    @Override
-+    protected int next(int bits) {
++    public int next(int bits) {
 +        // avoid the expensive CAS logic used by superclass
 +        return (int) (((this.seed = this.seed * multiplier + addend) & mask) >>> (48 - bits));
 +    }
@@ -87,40 +88,9 @@ index 0000000000000000000000000000000000000000..16ca915c33e31b50d33336408b041e40
 +        // however there's nothing that uses this class that relies on it
 +        return fastRandomBounded(this.next(32) & 0xFFFFFFFFL, bound);
 +    }
-+
-+    // these below are added to fix reobf issues that I don't wanna deal with right now
-+    @Override
-+    public long nextLong() {
-+        return super.nextInt();
-+    }
-+
-+    @Override
-+    public int nextInt() {
-+        return super.nextInt();
-+    }
-+
-+    @Override
-+    public boolean nextBoolean() {
-+        return super.nextBoolean();
-+    }
-+
-+    @Override
-+    public float nextFloat() {
-+        return super.nextFloat();
-+    }
-+
-+    @Override
-+    public double nextDouble() {
-+        return super.nextDouble();
-+    }
-+
-+    @Override
-+    public double nextGaussian() {
-+        return super.nextGaussian();
-+    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d3470ba0b1732356d1082f23632dbe218ceb167e..b0c971df2ae296b2ae4516ff121052b3b4526103 100644
+index b2c6d72beefe48189aa36f453f8950209b7e3ee1..1fc9cafbec488240a242b0de5eb2582cef86f413 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -665,6 +665,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -129,7 +99,7 @@ index d3470ba0b1732356d1082f23632dbe218ceb167e..b0c971df2ae296b2ae4516ff121052b3
      }
 +    // Paper start - optimise random block ticking
 +    private final BlockPos.MutableBlockPos chunkTickMutablePosition = new BlockPos.MutableBlockPos();
-+    private final io.papermc.paper.util.math.ThreadUnsafeRandom randomTickRandom = new io.papermc.paper.util.math.ThreadUnsafeRandom();
++    private final io.papermc.paper.util.math.ThreadUnsafeRandom randomTickRandom = new io.papermc.paper.util.math.ThreadUnsafeRandom(this.random.nextLong());
 +    // Paper end
  
      public void tickChunk(LevelChunk chunk, int randomTickSpeed) {

--- a/patches/server/0779-Update-head-rotation-in-missing-places.patch
+++ b/patches/server/0779-Update-head-rotation-in-missing-places.patch
@@ -8,10 +8,10 @@ This is because bukkit uses a separate head rotation field for yaw.
 This issue only applies to players.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2013a0b402b0abcb0a47911cfaa8aa0ccf468f9b..4e1fc9c2a81a7e252a33f301198b9366dac03006 100644
+index b014794ce7b5a782432a64eeb8a3a9ac69f0b4f3..330583ed39e66674eb6ee1d522b808f3bcb31eeb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1748,6 +1748,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1753,6 +1753,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          this.setXRot(Mth.clamp(pitch, -90.0F, 90.0F) % 360.0F);
          this.yRotO = this.getYRot();
          this.xRotO = this.getXRot();
@@ -19,7 +19,7 @@ index 2013a0b402b0abcb0a47911cfaa8aa0ccf468f9b..4e1fc9c2a81a7e252a33f301198b9366
      }
  
      public void absMoveTo(double x, double y, double z) {
-@@ -1786,6 +1787,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1791,6 +1792,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          this.setXRot(pitch);
          this.setOldPosAndRot();
          this.reapplyPosition();

--- a/patches/server/0788-don-t-attempt-to-teleport-dead-entities.patch
+++ b/patches/server/0788-don-t-attempt-to-teleport-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] don't attempt to teleport dead entities
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4e1fc9c2a81a7e252a33f301198b9366dac03006..7d25d2b2c4d334ec5bf78ea13eb8de743cb2e5fb 100644
+index 330583ed39e66674eb6ee1d522b808f3bcb31eeb..0539fa769526d02a5ceb2f1ccc2ff4ae6edee5be 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -773,7 +773,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -778,7 +778,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      // CraftBukkit start
      public void postTick() {
          // No clean way to break out of ticking once the entity has been copied to a new world, so instead we move the portalling later in the tick cycle

--- a/patches/server/0802-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0802-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -1215,10 +1215,10 @@ index d74d6669005d0669503253787636756a0c6590f4..6d013360d35c54d1493849b22c9d65b1
          }
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7d25d2b2c4d334ec5bf78ea13eb8de743cb2e5fb..615b0797c38ffbb3594905db90cbc495cc6df916 100644
+index 0539fa769526d02a5ceb2f1ccc2ff4ae6edee5be..a368cce65c0f05b05eb1031606a3172294025a67 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1154,9 +1154,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1159,9 +1159,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  float f2 = this.getBlockSpeedFactor();
  
                  this.setDeltaMovement(this.getDeltaMovement().multiply((double) f2, 1.0D, (double) f2));
@@ -1266,7 +1266,7 @@ index 7d25d2b2c4d334ec5bf78ea13eb8de743cb2e5fb..615b0797c38ffbb3594905db90cbc495
                      if (this.remainingFireTicks <= 0) {
                          this.setRemainingFireTicks(-this.getFireImmuneTicks());
                      }
-@@ -1300,32 +1335,78 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1305,32 +1340,78 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      private Vec3 collide(Vec3 movement) {
@@ -1366,7 +1366,7 @@ index 7d25d2b2c4d334ec5bf78ea13eb8de743cb2e5fb..615b0797c38ffbb3594905db90cbc495
      }
  
      public static Vec3 collideBoundingBox(@Nullable Entity entity, Vec3 movement, AABB entityBoundingBox, Level world, List<VoxelShape> collisions) {
-@@ -2437,11 +2518,30 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2442,11 +2523,30 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              float f = this.dimensions.width * 0.8F;
              AABB axisalignedbb = AABB.ofSize(this.getEyePosition(), (double) f, 1.0E-6D, (double) f);
  

--- a/patches/server/0811-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0811-Forward-CraftEntity-in-teleport-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 615b0797c38ffbb3594905db90cbc495cc6df916..e0dec7b8acf2ed18bc9d0d60cb12329d9d5c1161 100644
+index a368cce65c0f05b05eb1031606a3172294025a67..36b88c07f51d81e624679f4f0b54e48bc0355239 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3259,6 +3259,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3264,6 +3264,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void restoreFrom(Entity original) {
@@ -22,7 +22,7 @@ index 615b0797c38ffbb3594905db90cbc495cc6df916..e0dec7b8acf2ed18bc9d0d60cb12329d
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3340,10 +3347,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3345,10 +3352,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      if (worldserver.getTypeKey() == LevelStem.END) { // CraftBukkit
                          ServerLevel.makeObsidianPlatform(worldserver, this); // CraftBukkit
                      }

--- a/patches/server/0837-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0837-Freeze-Tick-Lock-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e0dec7b8acf2ed18bc9d0d60cb12329d9d5c1161..1ee13fb0518406382468af125253286996670ec6 100644
+index 36b88c07f51d81e624679f4f0b54e48bc0355239..1a8617207e7be7e3ca52d15408922b0d41047c14 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -391,6 +391,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -396,6 +396,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
      private UUID originWorld;
@@ -16,7 +16,7 @@ index e0dec7b8acf2ed18bc9d0d60cb12329d9d5c1161..1ee13fb0518406382468af1252532869
  
      public void setOrigin(@javax.annotation.Nonnull Location location) {
          this.origin = location.toVector();
-@@ -819,7 +820,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -824,7 +825,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.setRemainingFireTicks(this.remainingFireTicks - 1);
              }
  
@@ -25,7 +25,7 @@ index e0dec7b8acf2ed18bc9d0d60cb12329d9d5c1161..1ee13fb0518406382468af1252532869
                  this.setTicksFrozen(0);
                  this.level.levelEvent((Player) null, 1009, this.blockPosition, 1);
              }
-@@ -2246,6 +2247,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2251,6 +2252,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (fromNetherPortal) {
                  nbt.putBoolean("Paper.FromNetherPortal", true);
              }
@@ -35,7 +35,7 @@ index e0dec7b8acf2ed18bc9d0d60cb12329d9d5c1161..1ee13fb0518406382468af1252532869
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2408,6 +2412,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2413,6 +2417,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (spawnReason == null) {
                  spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT;
              }

--- a/patches/server/0877-Ensure-entity-passenger-world-matches-ridden-entity.patch
+++ b/patches/server/0877-Ensure-entity-passenger-world-matches-ridden-entity.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ensure entity passenger world matches ridden entity
 Bad plugins doing this would cause some obvious problems...
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1ee13fb0518406382468af125253286996670ec6..f360f69256054b84cd5fc9094c5ff6833b5fa1b0 100644
+index 1a8617207e7be7e3ca52d15408922b0d41047c14..4b37207ea687b73edd7550d8ea5d6010cb093706 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2667,6 +2667,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2672,6 +2672,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/patches/server/0878-Guard-against-invalid-entity-positions.patch
+++ b/patches/server/0878-Guard-against-invalid-entity-positions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Guard against invalid entity positions
 Anything not finite should be blocked and logged
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f360f69256054b84cd5fc9094c5ff6833b5fa1b0..9d2cac140f939559eba9149ce13334f8f178c962 100644
+index 4b37207ea687b73edd7550d8ea5d6010cb093706..b100f32518da9d6666b0aba7ba02d356621bf5e5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4171,11 +4171,33 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4176,11 +4176,33 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return this.getZ((2.0D * this.random.nextDouble() - 1.0D) * widthScale);
      }
  

--- a/patches/server/0902-Prevent-entity-loading-causing-async-lookups.patch
+++ b/patches/server/0902-Prevent-entity-loading-causing-async-lookups.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent entity loading causing async lookups
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9d2cac140f939559eba9149ce13334f8f178c962..41922c009f002a2ff27673743e29b32680961a14 100644
+index b100f32518da9d6666b0aba7ba02d356621bf5e5..b0728b66c54dc22a5a98f150910d07f4b38ebd7e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -782,6 +782,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -787,6 +787,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
      public void baseTick() {
          this.level.getProfiler().push("entityBaseTick");


### PR DESCRIPTION
and cleaned up ThreadUnsafeRandom

Fixes https://github.com/PaperMC/Paper/issues/8006

If we wanted to use the `ThreadSafeLegacyRandomSource` deprecated class, we wouldn't have to have all those overrides to super methods to help with re-obfuscation, but idk if we want to do that.