### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -475,7 +475,7 @@ index 0000000000000000000000000000000000000000..bff9a6295db367c6b89d69fb55459a40
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c15861905d7af679c4f6ffc27719a900b0fe4284..d5fdc57ffcfac4eb18d7fbf44ce13257915b4afb 100644
+index 9db999c8c9645fa0161bc3a85fbfdd09283989fd..b23b6bf1af91c9460fdb231000df6191ec673544 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -357,7 +357,9 @@ public final class Bukkit {
@@ -488,7 +488,7 @@ index c15861905d7af679c4f6ffc27719a900b0fe4284..d5fdc57ffcfac4eb18d7fbf44ce13257
      public static int broadcastMessage(@NotNull String message) {
          return server.broadcastMessage(message);
      }
-@@ -1051,6 +1053,19 @@ public final class Bukkit {
+@@ -1071,6 +1073,19 @@ public final class Bukkit {
          server.shutdown();
      }
  
@@ -508,7 +508,7 @@ index c15861905d7af679c4f6ffc27719a900b0fe4284..d5fdc57ffcfac4eb18d7fbf44ce13257
      /**
       * Broadcasts the specified message to every user with the given
       * permission name.
-@@ -1060,6 +1075,21 @@ public final class Bukkit {
+@@ -1080,6 +1095,21 @@ public final class Bukkit {
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
       */
@@ -530,7 +530,7 @@ index c15861905d7af679c4f6ffc27719a900b0fe4284..d5fdc57ffcfac4eb18d7fbf44ce13257
      public static int broadcast(@NotNull String message, @NotNull String permission) {
          return server.broadcast(message, permission);
      }
-@@ -1298,6 +1328,7 @@ public final class Bukkit {
+@@ -1318,6 +1348,7 @@ public final class Bukkit {
          return server.createInventory(owner, type);
      }
  
@@ -538,7 +538,7 @@ index c15861905d7af679c4f6ffc27719a900b0fe4284..d5fdc57ffcfac4eb18d7fbf44ce13257
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1323,6 +1354,38 @@ public final class Bukkit {
+@@ -1343,6 +1374,38 @@ public final class Bukkit {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -577,7 +577,7 @@ index c15861905d7af679c4f6ffc27719a900b0fe4284..d5fdc57ffcfac4eb18d7fbf44ce13257
      public static Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title) {
          return server.createInventory(owner, type, title);
      }
-@@ -1341,6 +1404,7 @@ public final class Bukkit {
+@@ -1361,6 +1424,7 @@ public final class Bukkit {
          return server.createInventory(owner, size);
      }
  
@@ -585,7 +585,7 @@ index c15861905d7af679c4f6ffc27719a900b0fe4284..d5fdc57ffcfac4eb18d7fbf44ce13257
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1353,10 +1417,30 @@ public final class Bukkit {
+@@ -1373,10 +1437,30 @@ public final class Bukkit {
       * @throws IllegalArgumentException if the size is not a multiple of 9
       */
      @NotNull
@@ -616,7 +616,7 @@ index c15861905d7af679c4f6ffc27719a900b0fe4284..d5fdc57ffcfac4eb18d7fbf44ce13257
      /**
       * Creates an empty merchant.
       *
-@@ -1364,7 +1448,20 @@ public final class Bukkit {
+@@ -1384,7 +1468,20 @@ public final class Bukkit {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -637,7 +637,7 @@ index c15861905d7af679c4f6ffc27719a900b0fe4284..d5fdc57ffcfac4eb18d7fbf44ce13257
      public static Merchant createMerchant(@Nullable String title) {
          return server.createMerchant(title);
      }
-@@ -1470,22 +1567,47 @@ public final class Bukkit {
+@@ -1501,22 +1598,47 @@ public final class Bukkit {
          return server.isPrimaryThread();
      }
  
@@ -810,7 +810,7 @@ index 803fa0019869127ee8c7e4fb1777a59c43e66f8a..c65f0d6569c130b4920a9e71ad24af64
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index cf53aead2eb5a52f1505ca694e95108fce28aa18..14b078e8fa4347dd0e186e5847693904e4ceb9df 100644
+index 485848dfa12bda15adda0d8f3a83f779a9ec05fe..01f4329d23a5e33f321df394107eaf1b918f8859 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -58,13 +58,13 @@ import org.jetbrains.annotations.Nullable;
@@ -848,7 +848,7 @@ index cf53aead2eb5a52f1505ca694e95108fce28aa18..14b078e8fa4347dd0e186e5847693904
      public int broadcastMessage(@NotNull String message);
  
      /**
-@@ -894,8 +896,33 @@ public interface Server extends PluginMessageRecipient {
+@@ -910,8 +912,33 @@ public interface Server extends PluginMessageRecipient {
       * @param permission the required permission {@link Permissible
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
@@ -882,7 +882,7 @@ index cf53aead2eb5a52f1505ca694e95108fce28aa18..14b078e8fa4347dd0e186e5847693904
  
      /**
       * Gets the player by the given name, regardless if they are offline or
-@@ -1093,6 +1120,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -1109,6 +1136,7 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type);
  
@@ -890,7 +890,7 @@ index cf53aead2eb5a52f1505ca694e95108fce28aa18..14b078e8fa4347dd0e186e5847693904
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1118,6 +1146,36 @@ public interface Server extends PluginMessageRecipient {
+@@ -1134,6 +1162,36 @@ public interface Server extends PluginMessageRecipient {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -927,7 +927,7 @@ index cf53aead2eb5a52f1505ca694e95108fce28aa18..14b078e8fa4347dd0e186e5847693904
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title);
  
      /**
-@@ -1132,6 +1190,22 @@ public interface Server extends PluginMessageRecipient {
+@@ -1148,6 +1206,22 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, int size) throws IllegalArgumentException;
  
@@ -950,7 +950,7 @@ index cf53aead2eb5a52f1505ca694e95108fce28aa18..14b078e8fa4347dd0e186e5847693904
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1142,10 +1216,13 @@ public interface Server extends PluginMessageRecipient {
+@@ -1158,10 +1232,13 @@ public interface Server extends PluginMessageRecipient {
       *     viewed
       * @return a new inventory
       * @throws IllegalArgumentException if the size is not a multiple of 9
@@ -964,7 +964,7 @@ index cf53aead2eb5a52f1505ca694e95108fce28aa18..14b078e8fa4347dd0e186e5847693904
      /**
       * Creates an empty merchant.
       *
-@@ -1153,7 +1230,18 @@ public interface Server extends PluginMessageRecipient {
+@@ -1169,7 +1246,18 @@ public interface Server extends PluginMessageRecipient {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -983,7 +983,7 @@ index cf53aead2eb5a52f1505ca694e95108fce28aa18..14b078e8fa4347dd0e186e5847693904
      Merchant createMerchant(@Nullable String title);
  
      /**
-@@ -1240,20 +1328,41 @@ public interface Server extends PluginMessageRecipient {
+@@ -1265,20 +1353,41 @@ public interface Server extends PluginMessageRecipient {
       */
      boolean isPrimaryThread();
  
@@ -1025,7 +1025,7 @@ index cf53aead2eb5a52f1505ca694e95108fce28aa18..14b078e8fa4347dd0e186e5847693904
      String getShutdownMessage();
  
      /**
-@@ -1610,7 +1719,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1635,7 +1744,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends the component to the player
           *
           * @param component the components to send
@@ -1035,7 +1035,7 @@ index cf53aead2eb5a52f1505ca694e95108fce28aa18..14b078e8fa4347dd0e186e5847693904
          public void broadcast(@NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1619,7 +1730,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1644,7 +1755,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends an array of components as a single message to the player
           *
           * @param components the components to send
@@ -3240,48 +3240,50 @@ index 03bfca9d368bbe4b7c1353d52c883e756bf69bda..943d324435350d3f16fad3e21cb472a0
  
      /**
 diff --git a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
-index b9abfdc61f76c5562de6649f8440aeaab536b3be..c4644f3fd231bff35627ff667e37ccdefbfdbb88 100644
+index 92941af574945936c3714718ed3eea23697c99df..5b8a7b897d9f9d8df3705eef36388f41be4531a6 100644
 --- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
 +++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
-@@ -21,15 +21,16 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
-     private static final int MAGIC_PLAYER_COUNT = Integer.MIN_VALUE;
+@@ -22,15 +22,16 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
      private static final HandlerList handlers = new HandlerList();
      private final InetAddress address;
+     private final boolean shouldSendChatPreviews;
 -    private String motd;
 +    private net.kyori.adventure.text.Component motd; // Paper
      private final int numPlayers;
      private int maxPlayers;
  
 +    @Deprecated // Paper
-     public ServerListPingEvent(@NotNull final InetAddress address, @NotNull final String motd, final int numPlayers, final int maxPlayers) {
+     public ServerListPingEvent(@NotNull final InetAddress address, @NotNull final String motd, final boolean shouldSendChatPreviews, final int numPlayers, final int maxPlayers) {
          super(true);
          Preconditions.checkArgument(numPlayers >= 0, "Cannot have negative number of players online", numPlayers);
          this.address = address;
 -        this.motd = motd;
 +        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd); // Paper
+         this.shouldSendChatPreviews = shouldSendChatPreviews;
          this.numPlayers = numPlayers;
          this.maxPlayers = maxPlayers;
-     }
-@@ -42,14 +43,58 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
-      * @param address the address of the pinger
+@@ -45,15 +46,61 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
       * @param motd the message of the day
+      * @param shouldSendChatPreviews if the server should send chat previews
       * @param maxPlayers the max number of players
-+     * @deprecated in favour of {@link #ServerListPingEvent(java.net.InetAddress, net.kyori.adventure.text.Component, int)}
++     * @deprecated in favour of {@link #ServerListPingEvent(java.net.InetAddress, net.kyori.adventure.text.Component, boolean, int)}
       */
 +    @Deprecated // Paper
-     protected ServerListPingEvent(@NotNull final InetAddress address, @NotNull final String motd, final int maxPlayers) {
+     protected ServerListPingEvent(@NotNull final InetAddress address, @NotNull final String motd, boolean shouldSendChatPreviews, final int maxPlayers) {
          super(true);
          this.numPlayers = MAGIC_PLAYER_COUNT;
          this.address = address;
 +        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd); // Paper
++        this.shouldSendChatPreviews = shouldSendChatPreviews;
 +        this.maxPlayers = maxPlayers;
 +    }
 +    // Paper start
-+    public ServerListPingEvent(@NotNull final InetAddress address, @NotNull final net.kyori.adventure.text.Component motd, final int numPlayers, final int maxPlayers) {
++    public ServerListPingEvent(@NotNull final InetAddress address, @NotNull final net.kyori.adventure.text.Component motd, boolean shouldSendChatPreviews, final int numPlayers, final int maxPlayers) {
 +        super(true);
 +        Preconditions.checkArgument(numPlayers >= 0, "Cannot have negative number of players online (%s)", numPlayers);
 +        this.address = address;
          this.motd = motd;
+         this.shouldSendChatPreviews = shouldSendChatPreviews;
 +        this.numPlayers = numPlayers;
          this.maxPlayers = maxPlayers;
      }
@@ -3294,11 +3296,12 @@ index b9abfdc61f76c5562de6649f8440aeaab536b3be..c4644f3fd231bff35627ff667e37ccde
 +     * @param motd the message of the day
 +     * @param maxPlayers the max number of players
 +     */
-+    protected ServerListPingEvent(@NotNull final InetAddress address, @NotNull final net.kyori.adventure.text.Component motd, final int maxPlayers) {
++    protected ServerListPingEvent(@NotNull final InetAddress address, @NotNull final net.kyori.adventure.text.Component motd, boolean shouldSendChatPreviews, final int maxPlayers) {
 +        super(true);
 +        this.numPlayers = MAGIC_PLAYER_COUNT;
 +        this.address = address;
 +        this.motd = motd;
++        this.shouldSendChatPreviews = shouldSendChatPreviews;
 +        this.maxPlayers = maxPlayers;
 +    }
 +    /**
@@ -3321,7 +3324,7 @@ index b9abfdc61f76c5562de6649f8440aeaab536b3be..c4644f3fd231bff35627ff667e37ccde
  
      /**
       * Get the address the ping is coming from.
-@@ -65,19 +110,23 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+@@ -69,19 +116,23 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
       * Get the message of the day message.
       *
       * @return the message of the day

--- a/patches/api/0007-Timings-v2.patch
+++ b/patches/api/0007-Timings-v2.patch
@@ -2791,7 +2791,7 @@ index 0000000000000000000000000000000000000000..5989ee21297935651b0edd44b8239e65
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index d5fdc57ffcfac4eb18d7fbf44ce13257915b4afb..35de49ea52b507dd925ed3c118518a335035a710 100644
+index b23b6bf1af91c9460fdb231000df6191ec673544..95693bab8051ff3e94c3a184c8a2691eb3b49ec5 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -801,7 +801,6 @@ public final class Bukkit {
@@ -2803,10 +2803,10 @@ index d5fdc57ffcfac4eb18d7fbf44ce13257915b4afb..35de49ea52b507dd925ed3c118518a33
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 14b078e8fa4347dd0e186e5847693904e4ceb9df..bbb4eb3c4e46ade7dd939c2b0e4436161d6f8a1e 100644
+index 01f4329d23a5e33f321df394107eaf1b918f8859..1e717c3096f3cccf1ce4b0e849c43525011c84de 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1715,6 +1715,26 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1740,6 +1740,26 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
              throw new UnsupportedOperationException("Not supported yet.");
          }
  

--- a/patches/api/0010-Add-getTPS-method.patch
+++ b/patches/api/0010-Add-getTPS-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getTPS method
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5c6b7f5095a5bb7290e1edefb0c9e985123f80d8..595d368bc88b6217f1fb2e074de7fd5b07fa96df 100644
+index fddd0ff9accd661c47c7ccc6d7035c042d991e8b..362b879996623832d436bb987630b115b7d86f99 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1845,6 +1845,17 @@ public final class Bukkit {
+@@ -1876,6 +1876,17 @@ public final class Bukkit {
          return server.getEntity(uuid);
      }
  
@@ -27,10 +27,10 @@ index 5c6b7f5095a5bb7290e1edefb0c9e985123f80d8..595d368bc88b6217f1fb2e074de7fd5b
       * Get the advancement specified by this key.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1dedbea03e259679e101a8443b662b20375adfd0..5aa2040dc51f65ad57329a5a235a22c50c62f1b2 100644
+index 768ae36e3e2fdff753f4f14aa79eb36026fb38c3..8dda96966061bb3a12b63fff74a378857ec43200 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1567,6 +1567,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1592,6 +1592,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      Entity getEntity(@NotNull UUID uuid);
  

--- a/patches/api/0018-Expose-server-CommandMap.patch
+++ b/patches/api/0018-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 595d368bc88b6217f1fb2e074de7fd5b07fa96df..4486e8ddcfc3aa1403bbfce28c0356c174709a9b 100644
+index 362b879996623832d436bb987630b115b7d86f99..5345e05755b13553491211a84d263c80ce347adf 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2029,6 +2029,19 @@ public final class Bukkit {
+@@ -2060,6 +2060,19 @@ public final class Bukkit {
          return server.getUnsafe();
      }
  
@@ -29,10 +29,10 @@ index 595d368bc88b6217f1fb2e074de7fd5b07fa96df..4486e8ddcfc3aa1403bbfce28c0356c1
      public static Server.Spigot spigot() {
          return server.spigot();
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5aa2040dc51f65ad57329a5a235a22c50c62f1b2..96d6b49d609142fe93d5d07e65dd126adb5c2bde 100644
+index 8dda96966061bb3a12b63fff74a378857ec43200..aca9050075f3041e2b248368e378c354e7b553d6 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1577,6 +1577,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1602,6 +1602,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      public double[] getTPS();
      // Paper end
  

--- a/patches/api/0029-Add-command-to-reload-permissions.yml-and-require-co.patch
+++ b/patches/api/0029-Add-command-to-reload-permissions.yml-and-require-co.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add command to reload permissions.yml and require confirm to
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 1bd3780f8331074b24f9f4e2bbeeb2b37514aaa3..2b3ced048a48f660ca0859425583d342e7847744 100644
+index de853c6cfd5d00e0f88aa436974d8a439adaff35..6234738637f99e62894efef2b7f6499792771856 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2064,6 +2064,13 @@ public final class Bukkit {
+@@ -2095,6 +2095,13 @@ public final class Bukkit {
      public static org.bukkit.command.CommandMap getCommandMap() {
          return server.getCommandMap();
      }
@@ -24,10 +24,10 @@ index 1bd3780f8331074b24f9f4e2bbeeb2b37514aaa3..2b3ced048a48f660ca0859425583d342
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 75bc4937f7a895c1bbf0a0800035ad8f7e0c5f46..be5f25a51a12082cb6732445c221d61246da89e9 100644
+index 6d9d49e334121a02780e39008df5c14f8bc0bfec..23150f346362322ec042c26717d4c6a58b756a6e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1823,4 +1823,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1848,4 +1848,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      Spigot spigot();
      // Spigot end

--- a/patches/api/0042-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/api/0042-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 2b3ced048a48f660ca0859425583d342e7847744..012b656a43cc0cf33597b835d045f8b5f3d309dd 100644
+index 6234738637f99e62894efef2b7f6499792771856..02476f858240f5f8d1cb5d621cc52f7de351c311 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2071,6 +2071,15 @@ public final class Bukkit {
+@@ -2102,6 +2102,15 @@ public final class Bukkit {
      public static void reloadPermissions() {
          server.reloadPermissions();
      }
@@ -26,10 +26,10 @@ index 2b3ced048a48f660ca0859425583d342e7847744..012b656a43cc0cf33597b835d045f8b5
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index be5f25a51a12082cb6732445c221d61246da89e9..9c1cd95e125b1d7677daea1575a466a1b955053a 100644
+index 23150f346362322ec042c26717d4c6a58b756a6e..f33d66bf9ff18545468949a57004e6b99de2fb9c 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1825,4 +1825,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1850,4 +1850,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      // Spigot end
  
      void reloadPermissions(); // Paper

--- a/patches/api/0053-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/api/0053-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 012b656a43cc0cf33597b835d045f8b5f3d309dd..a5868c0bdee345195e279467b526d5d9ff7f64d2 100644
+index 02476f858240f5f8d1cb5d621cc52f7de351c311..878439cc18eb5f82224e845f073d0bea0aa20e9b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2080,6 +2080,16 @@ public final class Bukkit {
+@@ -2111,6 +2111,16 @@ public final class Bukkit {
      public static boolean reloadCommandAliases() {
          return server.reloadCommandAliases();
      }
@@ -27,10 +27,10 @@ index 012b656a43cc0cf33597b835d045f8b5f3d309dd..a5868c0bdee345195e279467b526d5d9
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 9c1cd95e125b1d7677daea1575a466a1b955053a..acd69a5d946974e0b50439a98712750698768ce5 100644
+index f33d66bf9ff18545468949a57004e6b99de2fb9c..699eb44178522ccdac6f5ee6f8da941dc4a16b59 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1827,4 +1827,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1852,4 +1852,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      void reloadPermissions(); // Paper
  
      boolean reloadCommandAliases(); // Paper

--- a/patches/api/0054-Fix-upstream-javadocs.patch
+++ b/patches/api/0054-Fix-upstream-javadocs.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix upstream javadocs
 Upstream still refuses to use Java 8 with the API so they are likely unaware these are even issues.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index a5868c0bdee345195e279467b526d5d9ff7f64d2..ece84330d2700db8708d2ae2ab7badf4acb428a8 100644
+index 878439cc18eb5f82224e845f073d0bea0aa20e9b..a60ca25736f11c1b72172e8fd4861cfc07905882 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1311,6 +1311,8 @@ public final class Bukkit {
+@@ -1331,6 +1331,8 @@ public final class Bukkit {
  
      /**
       * Gets every player that has ever played on this server.
@@ -19,7 +19,7 @@ index a5868c0bdee345195e279467b526d5d9ff7f64d2..ece84330d2700db8708d2ae2ab7badf4
       * @return an array containing all previous players
       */
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index acd69a5d946974e0b50439a98712750698768ce5..0053327f3df85a568befc280b53a0eb34e0510d8 100644
+index 699eb44178522ccdac6f5ee6f8da941dc4a16b59..5971605d399f4812037ec8217fbd6f43429e55d1 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -509,13 +509,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -37,7 +37,7 @@ index acd69a5d946974e0b50439a98712750698768ce5..0053327f3df85a568befc280b53a0eb3
       */
      public int getTicksPerSpawns(@NotNull SpawnCategory spawnCategory);
  
-@@ -1110,6 +1107,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1126,6 +1123,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
  
      /**
       * Gets every player that has ever played on this server.

--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -289,10 +289,10 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ece84330d2700db8708d2ae2ab7badf4acb428a8..90c875ad60e473c3ec25f209933d48615d0fd6c0 100644
+index a60ca25736f11c1b72172e8fd4861cfc07905882..9368087971288f45056ac16a8087f8c2a7df462f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2092,6 +2092,83 @@ public final class Bukkit {
+@@ -2123,6 +2123,83 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
@@ -377,10 +377,10 @@ index ece84330d2700db8708d2ae2ab7badf4acb428a8..90c875ad60e473c3ec25f209933d4861
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 0053327f3df85a568befc280b53a0eb34e0510d8..451eefff2e6350072d47f59c0e33cca499c5427b 100644
+index 5971605d399f4812037ec8217fbd6f43429e55d1..29196330f4fd875d7c0183e13e484d3c9925db0b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1835,5 +1835,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1860,5 +1860,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();

--- a/patches/api/0090-Add-extended-PaperServerListPingEvent.patch
+++ b/patches/api/0090-Add-extended-PaperServerListPingEvent.patch
@@ -8,7 +8,7 @@ and allows full control of the response sent to the client.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java b/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..baac2e4f090a490372ef4aed92c8a5771955e921
+index 0000000000000000000000000000000000000000..5bacbd0df66953d3c8fdfde5af1338a74339cfda
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java
 @@ -0,0 +1,334 @@
@@ -56,9 +56,9 @@ index 0000000000000000000000000000000000000000..baac2e4f090a490372ef4aed92c8a577
 +    private Object[] players;
 +
 +    @Deprecated
-+    public PaperServerListPingEvent(@NotNull StatusClient client, @NotNull String motd, int numPlayers, int maxPlayers,
++    public PaperServerListPingEvent(@NotNull StatusClient client, @NotNull String motd, boolean shouldSendChatPreviews, int numPlayers, int maxPlayers,
 +            @NotNull String version, int protocolVersion, @Nullable CachedServerIcon favicon) {
-+        super(client.getAddress().getAddress(), motd, numPlayers, maxPlayers);
++        super(client.getAddress().getAddress(), motd, shouldSendChatPreviews, numPlayers, maxPlayers);
 +        this.client = client;
 +        this.numPlayers = numPlayers;
 +        this.version = version;
@@ -66,9 +66,9 @@ index 0000000000000000000000000000000000000000..baac2e4f090a490372ef4aed92c8a577
 +        setServerIcon(favicon);
 +    }
 +
-+    public PaperServerListPingEvent(@NotNull StatusClient client, @NotNull net.kyori.adventure.text.Component motd, int numPlayers, int maxPlayers,
++    public PaperServerListPingEvent(@NotNull StatusClient client, @NotNull net.kyori.adventure.text.Component motd, boolean shouldSendChatPreviews, int numPlayers, int maxPlayers,
 +                                    @NotNull String version, int protocolVersion, @Nullable CachedServerIcon favicon) {
-+        super(client.getAddress().getAddress(), motd, numPlayers, maxPlayers);
++        super(client.getAddress().getAddress(), motd, shouldSendChatPreviews, numPlayers, maxPlayers);
 +        this.client = client;
 +        this.numPlayers = numPlayers;
 +        this.version = version;

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 90c875ad60e473c3ec25f209933d48615d0fd6c0..39f97dac6af70b45101a7de776009c4fa3874868 100644
+index 9368087971288f45056ac16a8087f8c2a7df462f..9d093f2393f2657e16c205b6b8e67c8e4c19bddc 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1176,8 +1176,10 @@ public final class Bukkit {
+@@ -1196,8 +1196,10 @@ public final class Bukkit {
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if both the unique id is
       * <code>null</code> and the name is <code>null</code> or blank
@@ -20,7 +20,7 @@ index 90c875ad60e473c3ec25f209933d48615d0fd6c0..39f97dac6af70b45101a7de776009c4f
      public static PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name) {
          return server.createPlayerProfile(uniqueId, name);
      }
-@@ -1188,8 +1190,10 @@ public final class Bukkit {
+@@ -1208,8 +1210,10 @@ public final class Bukkit {
       * @param uniqueId the unique id
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the unique id is <code>null</code>
@@ -31,7 +31,7 @@ index 90c875ad60e473c3ec25f209933d48615d0fd6c0..39f97dac6af70b45101a7de776009c4f
      public static PlayerProfile createPlayerProfile(@NotNull UUID uniqueId) {
          return server.createPlayerProfile(uniqueId);
      }
-@@ -1201,8 +1205,10 @@ public final class Bukkit {
+@@ -1221,8 +1225,10 @@ public final class Bukkit {
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the name is <code>null</code> or
       * blank
@@ -43,10 +43,10 @@ index 90c875ad60e473c3ec25f209933d48615d0fd6c0..39f97dac6af70b45101a7de776009c4f
          return server.createPlayerProfile(name);
      }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 451eefff2e6350072d47f59c0e33cca499c5427b..4597c9b2e4691495b54333711141b83926af193d 100644
+index 29196330f4fd875d7c0183e13e484d3c9925db0b..a46cb6762b6c88611642625a38230d6cec363a1a 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -998,8 +998,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1014,8 +1014,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if both the unique id is
       * <code>null</code> and the name is <code>null</code> or blank
@@ -57,7 +57,7 @@ index 451eefff2e6350072d47f59c0e33cca499c5427b..4597c9b2e4691495b54333711141b839
      PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name);
  
      /**
-@@ -1008,8 +1010,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1024,8 +1026,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param uniqueId the unique id
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the unique id is <code>null</code>
@@ -68,7 +68,7 @@ index 451eefff2e6350072d47f59c0e33cca499c5427b..4597c9b2e4691495b54333711141b839
      PlayerProfile createPlayerProfile(@NotNull UUID uniqueId);
  
      /**
-@@ -1019,8 +1023,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1035,8 +1039,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the name is <code>null</code> or
       * blank

--- a/patches/api/0164-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0164-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 653fe32bd134945e1cb1cf40f2623ffffdf5d762..f4e1ea578bae0d1dc8badfcbf83ca4550a41867b 100644
+index 1199f1226fb253b89c49b1fc3f190a577c75d4d6..a2d675293583f7dc31c85ad56759c3b95749e71e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2132,6 +2132,28 @@ public final class Bukkit {
+@@ -2163,6 +2163,28 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
@@ -38,10 +38,10 @@ index 653fe32bd134945e1cb1cf40f2623ffffdf5d762..f4e1ea578bae0d1dc8badfcbf83ca455
       * Creates a PlayerProfile for the specified uuid, with name as null.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 2042f4963c53d5a903f0de1fec6a9af3a7b2bba4..475fe51ff7a9f1c1ed5048ea59d6d8ba73f2903c 100644
+index d063e0e60c7dbb62d5dd72b213d2b71cd34c60b8..fb11f3db344593ce6e9b31ea91be1a8725b1561d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1854,6 +1854,23 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1879,6 +1879,23 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  

--- a/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
@@ -9,10 +9,10 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f4e1ea578bae0d1dc8badfcbf83ca4550a41867b..ba0c757346975af6fae9c0ebd72487395c74170d 100644
+index a2d675293583f7dc31c85ad56759c3b95749e71e..da0f084801126f356ee22dbce339bfd58fd6b3e5 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1177,10 +1177,8 @@ public final class Bukkit {
+@@ -1197,10 +1197,8 @@ public final class Bukkit {
       * @param name the name the player to retrieve
       * @return an offline player
       * @see #getOfflinePlayer(java.util.UUID)
@@ -24,7 +24,7 @@ index f4e1ea578bae0d1dc8badfcbf83ca4550a41867b..ba0c757346975af6fae9c0ebd7248739
      @NotNull
      public static OfflinePlayer getOfflinePlayer(@NotNull String name) {
          return server.getOfflinePlayer(name);
-@@ -1718,7 +1716,7 @@ public final class Bukkit {
+@@ -1749,7 +1747,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -159,10 +159,10 @@ index 6277451c3c6c551078c237cd767b6d70c4f585ea..10f5cfb1885833a1d2c1027c03974da4
      CRACKED(0x0),
      GLYPHED(0x1),
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 475fe51ff7a9f1c1ed5048ea59d6d8ba73f2903c..911b26247b3cd5e80c1f0a904ad3f88761091551 100644
+index fb11f3db344593ce6e9b31ea91be1a8725b1561d..605c88f11e9f6fd3abd4a69aa663999044be9527 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -982,10 +982,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -998,10 +998,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param name the name the player to retrieve
       * @return an offline player
       * @see #getOfflinePlayer(java.util.UUID)
@@ -174,7 +174,7 @@ index 475fe51ff7a9f1c1ed5048ea59d6d8ba73f2903c..911b26247b3cd5e80c1f0a904ad3f887
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  
-@@ -1442,7 +1440,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1467,7 +1465,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */

--- a/patches/api/0184-Expose-the-internal-current-tick.patch
+++ b/patches/api/0184-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ba0c757346975af6fae9c0ebd72487395c74170d..346ed194262c045bb12034b1dc949cf9bbbcb4ee 100644
+index da0f084801126f356ee22dbce339bfd58fd6b3e5..9e33d1a649118613cb28c97a895872949b3bb05b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2228,6 +2228,10 @@ public final class Bukkit {
+@@ -2259,6 +2259,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfileExact(uuid, name);
      }
@@ -20,10 +20,10 @@ index ba0c757346975af6fae9c0ebd72487395c74170d..346ed194262c045bb12034b1dc949cf9
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 911b26247b3cd5e80c1f0a904ad3f88761091551..97149dc0142bd910681b8f013803fb3ea9f72dbb 100644
+index 605c88f11e9f6fd3abd4a69aa663999044be9527..16db591ecb07a238a5bd14c13192198086bda13d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1937,5 +1937,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1962,5 +1962,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0190-Add-tick-times-API.patch
+++ b/patches/api/0190-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 346ed194262c045bb12034b1dc949cf9bbbcb4ee..00dce49d4053ce0a10cc9d0a40f90e4ab615cdf1 100644
+index 9e33d1a649118613cb28c97a895872949b3bb05b..95c4e23ece5f7bdf814d4259dc89016cd96a0a2f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1917,6 +1917,25 @@ public final class Bukkit {
+@@ -1948,6 +1948,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index 346ed194262c045bb12034b1dc949cf9bbbcb4ee..00dce49d4053ce0a10cc9d0a40f90e4a
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 97149dc0142bd910681b8f013803fb3ea9f72dbb..b549cb954e4fb4e37277303911d174bedd0ee27d 100644
+index 16db591ecb07a238a5bd14c13192198086bda13d..11b281b43e4fd2a23116163e611f11aad179b8fa 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1614,6 +1614,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1639,6 +1639,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0191-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0191-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 00dce49d4053ce0a10cc9d0a40f90e4ab615cdf1..2e57eaa8bf0b191f82d1ce805458cd2380c22aa9 100644
+index 95c4e23ece5f7bdf814d4259dc89016cd96a0a2f..b96e581cd8821416cf4db452b94486779861ecf0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2251,6 +2251,15 @@ public final class Bukkit {
+@@ -2282,6 +2282,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index 00dce49d4053ce0a10cc9d0a40f90e4ab615cdf1..2e57eaa8bf0b191f82d1ce805458cd23
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index b549cb954e4fb4e37277303911d174bedd0ee27d..8895de971276bc8027c9f02dee41f002dfcb8770 100644
+index 11b281b43e4fd2a23116163e611f11aad179b8fa..8f090f0839aacdaf90b2d4a1f6d87476535d8382 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1959,5 +1959,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1984,5 +1984,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0201-Add-Mob-Goal-API.patch
+++ b/patches/api/0201-Add-Mob-Goal-API.patch
@@ -523,10 +523,10 @@ index 0000000000000000000000000000000000000000..8fd399f791b45eb7fc62693ca954eea0
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 4fa0928f3baa2b69c48bea02fe5746dc58b201a8..9abab2de3ad2b7e6d53c9902df0e750af36e78fc 100644
+index 6a5515ec7aaa11028a9c48ff13b6bc1e809f08d3..a40f40fbd9976160b9bcdc823fa3ff363dece76b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2272,6 +2272,16 @@ public final class Bukkit {
+@@ -2303,6 +2303,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -544,10 +544,10 @@ index 4fa0928f3baa2b69c48bea02fe5746dc58b201a8..9abab2de3ad2b7e6d53c9902df0e750a
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 81b6368189809808d2d42a21a5437b7b215f2ee2..aa621e00d48aafcbc6f9baeff55082248ad487f1 100644
+index 4b2420fe711fb2b5f1512f51366e78baf63e3f62..5eefea06cd6c740fb4e6f2e292f5accdb0a62285 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1976,5 +1976,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2001,5 +2001,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0229-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0229-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 722d06447522d0ad3b2b52bc73e4259761128e77..f53d436374e360150e17191625ab4277a2ff4d6e 100644
+index b34866d6314ec783661e7a806b3d8c2a3b338dd7..20ff922fe9248b822d751a7edb7468cc023de71b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1207,6 +1207,27 @@ public final class Bukkit {
+@@ -1227,6 +1227,27 @@ public final class Bukkit {
          return server.getOfflinePlayer(name);
      }
  
@@ -37,10 +37,10 @@ index 722d06447522d0ad3b2b52bc73e4259761128e77..f53d436374e360150e17191625ab4277
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f2fbbb6ec88357779258a2798dfdb062789803df..aee2ef29628e05636c705e126eb2bd207f0db378 100644
+index 8768f544ca3b197a6456bf948c05a4cfb8f776a1..a3ae5651718937bdefff1753b93c7c67aff7ef1d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1006,6 +1006,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1022,6 +1022,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  

--- a/patches/api/0296-Add-basic-Datapack-API.patch
+++ b/patches/api/0296-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 78778751e225900d8ad12dab56f84c76123904a2..c8efb995bdff6e0888ef479aef4cca3e2d66e34c 100644
+index 044b5fcf2cbb1078dae348fe2960e4757519fd3c..23b57b99169881aa6963694d34f55d9c5c133888 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2326,6 +2326,14 @@ public final class Bukkit {
+@@ -2357,6 +2357,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index 78778751e225900d8ad12dab56f84c76123904a2..c8efb995bdff6e0888ef479aef4cca3e
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index c22fdde77b3d1b00577f45027dd5799bbb1cd3a3..09d72432cd854b929b262112921370138344e39c 100644
+index 7ed0e5d7b86d6bfc6b4218d8c158ada8b34c8461..5c5d124a179e8c0dc0cf24a51d406c9034f48505 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2023,5 +2023,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2048,5 +2048,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c8efb995bdff6e0888ef479aef4cca3e2d66e34c..c2a1df187ca352de24bdc7f76ed667d22ea7a49d 100644
+index 23b57b99169881aa6963694d34f55d9c5c133888..a748f268a992ac8ec9b732f530e3dd4847a3d47b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1861,6 +1861,24 @@ public final class Bukkit {
+@@ -1892,6 +1892,24 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -34,10 +34,10 @@ index c8efb995bdff6e0888ef479aef4cca3e2d66e34c..c2a1df187ca352de24bdc7f76ed667d2
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 09d72432cd854b929b262112921370138344e39c..5a31967313fa96989091f3cd2d4c3184e00e593e 100644
+index 5c5d124a179e8c0dc0cf24a51d406c9034f48505..e7d1ece4f1e615e2b0f4da1d85ddd60e23433d4d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1564,6 +1564,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1589,6 +1589,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  

--- a/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0364-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for creating command sender which forwards feedback
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c2a1df187ca352de24bdc7f76ed667d22ea7a49d..e5271098b97b330566df9a0e11e3b05d5c6b3c8a 100644
+index a748f268a992ac8ec9b732f530e3dd4847a3d47b..49decde8052425dcdaa865040f5aefa7a66667d5 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1392,6 +1392,20 @@ public final class Bukkit {
+@@ -1412,6 +1412,20 @@ public final class Bukkit {
          return server.getConsoleSender();
      }
  
@@ -30,10 +30,10 @@ index c2a1df187ca352de24bdc7f76ed667d22ea7a49d..e5271098b97b330566df9a0e11e3b05d
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5a31967313fa96989091f3cd2d4c3184e00e593e..99821da965069d54820bbbe349ab5dc09226f450 100644
+index e7d1ece4f1e615e2b0f4da1d85ddd60e23433d4d..bd678287c89a2a9578b08399886333e4dc866583 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1162,6 +1162,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1178,6 +1178,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/api/0371-Custom-Potion-Mixes.patch
+++ b/patches/api/0371-Custom-Potion-Mixes.patch
@@ -102,10 +102,10 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index e5271098b97b330566df9a0e11e3b05d5c6b3c8a..fc16e897f4ebaf9d79e49774e15a1cded33ef725 100644
+index 49decde8052425dcdaa865040f5aefa7a66667d5..3506a7fa07ee6e53704b1df8d8d2bb08704bfc37 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2366,6 +2366,15 @@ public final class Bukkit {
+@@ -2397,6 +2397,15 @@ public final class Bukkit {
      public static io.papermc.paper.datapack.DatapackManager getDatapackManager() {
          return server.getDatapackManager();
      }
@@ -122,10 +122,10 @@ index e5271098b97b330566df9a0e11e3b05d5c6b3c8a..fc16e897f4ebaf9d79e49774e15a1cde
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 99821da965069d54820bbbe349ab5dc09226f450..30b49aed62fa67276e8964922ea3f84458d854bb 100644
+index bd678287c89a2a9578b08399886333e4dc866583..e756edf56995f4552387c2e1082307eb3dd48bb3 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2057,5 +2057,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2082,5 +2082,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -49,7 +49,7 @@ index d10ff4a52c22033e2adb2a4e7f2cee98a13ea6c5..e4e9df9283c1a0fd7fff38a5d9b6a51f
          for (tld in setOf("net", "com", "org")) {
              attributes("$tld/bukkit", "Sealed" to true)
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 21a2be907f67d39605210d6bee53b3442665f65f..e5008c75054df38356af193fd049110d7d56e2d4 100644
+index 95da14060be14c5ed8ffbdc65b405cb346e56f6e..80a8872b927ed9de61f1ee36b7769ce104793443 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -190,7 +190,7 @@ public class Main {
@@ -60,7 +60,7 @@ index 21a2be907f67d39605210d6bee53b3442665f65f..e5008c75054df38356af193fd049110d
 +                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -14);
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 index 93046379d0cefd5d3236fc59e698809acdc18f80..774556a62eb240da42e84db4502e2ed43495be17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -4158,7 +4158,7 @@ index 570db14d930e15a96621d0d24ce11a27dc38494b..e476f93547f386ded0174693a6218d79
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index e45b71fa8ac1c3d0bca5f2c1737f302e787a1df3..3dadcddc9b4954e2c572e76e6b6c7d570fd47b8e 100644
+index 808142eef47d05679c50d654d3c6adfe055ca85b..de3965861b5e78ab6cc0dd02c4af53cb4fc063b5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -226,7 +226,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -4199,10 +4199,10 @@ index c1194f459414dc6ca9626ab8cec48cb48cdd926b..649df119b24dc8c390f45e9f813cf8c3
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1d94c0fbdead83155aefc8d4a16dbcb95b3c9838..42be8ab024e5c889b2a114f1098e1bedd1193d80 100644
+index 38b4aca711ee49e0a7fb751c5ccb40f19600b5db..ad73ec1f211cd6fca6bc04ba9e23850c7bacdf35 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -861,6 +861,7 @@ public final class CraftServer implements Server {
+@@ -868,6 +868,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
@@ -4211,7 +4211,7 @@ index 1d94c0fbdead83155aefc8d4a16dbcb95b3c9838..42be8ab024e5c889b2a114f1098e1bed
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index e5008c75054df38356af193fd049110d7d56e2d4..df98326c49973183e81ccb96d4b1a7a7626dffee 100644
+index 80a8872b927ed9de61f1ee36b7769ce104793443..1db503b3c7f2cc04d417d3b9373a21171c112231 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -129,6 +129,19 @@ public class Main {

--- a/patches/server/0006-CB-fixes.patch
+++ b/patches/server/0006-CB-fixes.patch
@@ -17,7 +17,7 @@ Subject: [PATCH] CB fixes
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 3dadcddc9b4954e2c572e76e6b6c7d570fd47b8e..06b1821ea08eccc5bb1ae856d35b13912ab491ec 100644
+index de3965861b5e78ab6cc0dd02c4af53cb4fc063b5..fb8e2bcbe27438fa5274d440751b6733cce550cb 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -292,7 +292,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -27,7 +27,7 @@ index 3dadcddc9b4954e2c572e76e6b6c7d570fd47b8e..06b1821ea08eccc5bb1ae856d35b1391
 -        this.structureCheck = new StructureCheck(this.chunkSource.chunkScanner(), this.registryAccess(), minecraftserver.getStructureManager(), resourcekey, chunkgenerator, this.chunkSource.randomState(), this, chunkgenerator.getBiomeSource(), l, datafixer);
 +        this.structureCheck = new StructureCheck(this.chunkSource.chunkScanner(), this.registryAccess(), minecraftserver.getStructureManager(), this.getTypeKey(), chunkgenerator, this.chunkSource.randomState(), this, chunkgenerator.getBiomeSource(), l, datafixer); // Paper - Fix missing CB diff
          this.structureManager = new StructureManager(this, this.serverLevelData.worldGenSettings(), this.structureCheck); // CraftBukkit
-         if (this.dimension() == Level.END && this.dimensionTypeRegistration().is(BuiltinDimensionTypes.END)) {
+         if ((this.dimension() == Level.END && this.dimensionTypeRegistration().is(BuiltinDimensionTypes.END)) || env == org.bukkit.World.Environment.THE_END) { // CraftBukkit - Allow to create EnderDragonBattle in default and custom END
              this.dragonFight = new EndDragonFight(this, this.serverLevelData.worldGenSettings().seed(), this.serverLevelData.endDragonFightData()); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/world/entity/Marker.java b/src/main/java/net/minecraft/world/entity/Marker.java
 index aef33a96cf8df9400cc60285ef1f7c5ded03b495..059c4c3b59f66ea2b2b23fe1eb106bf9447b607c 100644
@@ -67,10 +67,10 @@ index 9998e1c94b72b90dd3ba4bcce1b4b3653b9b1b2b..963ad3ce1ef83888ae1537ff01accdbb
          this.registryAccess = registryManager;
          this.structureTemplateManager = structureTemplateManager;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 42be8ab024e5c889b2a114f1098e1bedd1193d80..d239bc3f3cd1490acbac9d50239cc0a3d824148e 100644
+index ad73ec1f211cd6fca6bc04ba9e23850c7bacdf35..a888631dc866a784def3e59cd6cc644905f866b3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2247,7 +2247,13 @@ public final class CraftServer implements Server {
+@@ -2269,7 +2269,13 @@ public final class CraftServer implements Server {
          Validate.notNull(key, "NamespacedKey cannot be null");
  
          LootTables registry = this.getServer().getLootTables();

--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -1593,15 +1593,15 @@ index fc2910ee691da96591811e4c97987ebd2cb93ac3..ff8773f3671970bd759303f7a4bbc17d
                              }
                          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
-index 8670f3fab7ec2a80d69e5dd3f945fc15aaa1a36f..5d368e34c90fc5191d9ed2352f7aa44c4a299eed 100644
+index 3a587073dbe5e8a599d342c5f758d842b7b6cddb..a426adfba3fccf1815177e0b8065684c9497ef45 100644
 --- a/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
 @@ -54,7 +54,7 @@ public class ServerStatusPacketListenerImpl implements ServerStatusPacketListene
                  CraftIconCache icon = server.server.getServerIcon();
  
                  ServerListPingEvent() {
--                    super(((InetSocketAddress) ServerStatusPacketListenerImpl.this.connection.getRemoteAddress()).getAddress(), ServerStatusPacketListenerImpl.this.server.getMotd(), ServerStatusPacketListenerImpl.this.server.getPlayerList().getMaxPlayers());
-+                    super(((InetSocketAddress) ServerStatusPacketListenerImpl.this.connection.getRemoteAddress()).getAddress(), ServerStatusPacketListenerImpl.this.server.server.getMotd(), ServerStatusPacketListenerImpl.this.server.getPlayerList().getMaxPlayers()); // Paper - Adventure
+-                    super(((InetSocketAddress) ServerStatusPacketListenerImpl.this.connection.getRemoteAddress()).getAddress(), ServerStatusPacketListenerImpl.this.server.getMotd(), ServerStatusPacketListenerImpl.this.server.previewsChat(), ServerStatusPacketListenerImpl.this.server.getPlayerList().getMaxPlayers());
++                    super(((InetSocketAddress) ServerStatusPacketListenerImpl.this.connection.getRemoteAddress()).getAddress(), ServerStatusPacketListenerImpl.this.server.server.getMotd(), ServerStatusPacketListenerImpl.this.server.previewsChat(), ServerStatusPacketListenerImpl.this.server.getPlayerList().getMaxPlayers()); // Paper - Adventure
                  }
  
                  @Override
@@ -1839,10 +1839,10 @@ index 595b56b2ab9a813ba71399d306117294fa90dc65..3527d40102d512d0e276edc969ea3c18
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d239bc3f3cd1490acbac9d50239cc0a3d824148e..33e1a2c12a82f04d2a1da02b915402bbee76e1dd 100644
+index a888631dc866a784def3e59cd6cc644905f866b3..5251b5d91f4b7d8afc5dc8cf6cbb2820a29594e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -581,8 +581,10 @@ public final class CraftServer implements Server {
+@@ -588,8 +588,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1853,7 +1853,7 @@ index d239bc3f3cd1490acbac9d50239cc0a3d824148e..33e1a2c12a82f04d2a1da02b915402bb
      }
  
      @Override
-@@ -1402,7 +1404,15 @@ public final class CraftServer implements Server {
+@@ -1409,7 +1411,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -1869,7 +1869,7 @@ index d239bc3f3cd1490acbac9d50239cc0a3d824148e..33e1a2c12a82f04d2a1da02b915402bb
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1560,7 +1570,20 @@ public final class CraftServer implements Server {
+@@ -1577,7 +1587,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1890,7 +1890,7 @@ index d239bc3f3cd1490acbac9d50239cc0a3d824148e..33e1a2c12a82f04d2a1da02b915402bb
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1568,14 +1591,14 @@ public final class CraftServer implements Server {
+@@ -1585,14 +1608,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -1907,7 +1907,7 @@ index d239bc3f3cd1490acbac9d50239cc0a3d824148e..33e1a2c12a82f04d2a1da02b915402bb
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1826,6 +1849,14 @@ public final class CraftServer implements Server {
+@@ -1843,6 +1866,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -1922,7 +1922,7 @@ index d239bc3f3cd1490acbac9d50239cc0a3d824148e..33e1a2c12a82f04d2a1da02b915402bb
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1838,13 +1869,28 @@ public final class CraftServer implements Server {
+@@ -1855,13 +1886,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -1951,7 +1951,7 @@ index d239bc3f3cd1490acbac9d50239cc0a3d824148e..33e1a2c12a82f04d2a1da02b915402bb
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1904,6 +1950,12 @@ public final class CraftServer implements Server {
+@@ -1926,6 +1972,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -1964,7 +1964,7 @@ index d239bc3f3cd1490acbac9d50239cc0a3d824148e..33e1a2c12a82f04d2a1da02b915402bb
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2321,4 +2373,15 @@ public final class CraftServer implements Server {
+@@ -2343,4 +2395,15 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
@@ -2012,7 +2012,7 @@ index 40421cc8ef25f1bef32a0a5d2f0f25165efe230a..1357bc97801f892e59fc8e89c3cc2d69
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index df98326c49973183e81ccb96d4b1a7a7626dffee..18652607d36a980a4b0956584f8a722be776dad2 100644
+index 1db503b3c7f2cc04d417d3b9373a21171c112231..99cfa663b79eb7126f87d6fd1ecd7619ae763f45 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -19,6 +19,12 @@ public class Main {
@@ -2915,7 +2915,7 @@ index eebd8c56d319100f1f5ad9bc0b4d5a0d01e27fba..028d7a4cec039312bef59c693ef3d996
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 76ee5046fcfa2b66934cab2dee6af0226a906aee..1f74088858aff5deb8aac7057ad07727234f817e 100644
+index 464ff8c925d95e203481561dd6c910d008f4ad02..4b64ca4dba6319c6e8a55202952e7160c5e61d16 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -815,9 +815,9 @@ public class CraftEventFactory {
@@ -2933,9 +2933,9 @@ index 76ee5046fcfa2b66934cab2dee6af0226a906aee..1f74088858aff5deb8aac7057ad07727
 @@ -842,7 +842,7 @@ public class CraftEventFactory {
       * Server methods
       */
-     public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, int numPlayers, int maxPlayers) {
--        ServerListPingEvent event = new ServerListPingEvent(address, motd, numPlayers, maxPlayers);
-+        ServerListPingEvent event = new ServerListPingEvent(address, craftServer.motd(), numPlayers, maxPlayers); // Paper - Adventure
+     public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, boolean shouldSendChatPreviews, int numPlayers, int maxPlayers) {
+-        ServerListPingEvent event = new ServerListPingEvent(address, motd, shouldSendChatPreviews, numPlayers, maxPlayers);
++        ServerListPingEvent event = new ServerListPingEvent(address, craftServer.motd(), shouldSendChatPreviews, numPlayers, maxPlayers); // Paper - Adventure
          craftServer.getPluginManager().callEvent(event);
          return event;
      }

--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -2915,10 +2915,10 @@ index eebd8c56d319100f1f5ad9bc0b4d5a0d01e27fba..028d7a4cec039312bef59c693ef3d996
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 464ff8c925d95e203481561dd6c910d008f4ad02..4b64ca4dba6319c6e8a55202952e7160c5e61d16 100644
+index d0699be22411796174b58733cfb79b80c89f9769..97a614e2367439dbface4a258f966c0440ef965d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -815,9 +815,9 @@ public class CraftEventFactory {
+@@ -816,9 +816,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -2930,7 +2930,7 @@ index 464ff8c925d95e203481561dd6c910d008f4ad02..4b64ca4dba6319c6e8a55202952e7160
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          org.bukkit.World world = entity.getWorld();
-@@ -842,7 +842,7 @@ public class CraftEventFactory {
+@@ -843,7 +843,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, boolean shouldSendChatPreviews, int numPlayers, int maxPlayers) {

--- a/patches/server/0009-Paper-command.patch
+++ b/patches/server/0009-Paper-command.patch
@@ -341,10 +341,10 @@ index e476f93547f386ded0174693a6218d793ccc450b..393e465b0bac55d407f2ec66d7b11ed0
  
          this.setPvpAllowed(dedicatedserverproperties.pvp);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 33e1a2c12a82f04d2a1da02b915402bbee76e1dd..c8c205db57a8a88b76589998819166e43f9d8c1d 100644
+index 5251b5d91f4b7d8afc5dc8cf6cbb2820a29594e9..55265d09707056160b44d15e2e66ad1336d4f9c8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -885,6 +885,7 @@ public final class CraftServer implements Server {
+@@ -892,6 +892,7 @@ public final class CraftServer implements Server {
          this.commandMap.clearCommands();
          this.reloadData();
          org.spigotmc.SpigotConfig.registerCommands(); // Spigot
@@ -352,7 +352,7 @@ index 33e1a2c12a82f04d2a1da02b915402bbee76e1dd..c8c205db57a8a88b76589998819166e4
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2375,6 +2376,34 @@ public final class CraftServer implements Server {
+@@ -2397,6 +2398,34 @@ public final class CraftServer implements Server {
      // Spigot end
  
      // Paper start

--- a/patches/server/0012-Timings-v2.patch
+++ b/patches/server/0012-Timings-v2.patch
@@ -1146,7 +1146,7 @@ index 186a8f5895fedbaf27a7949d9bdbb1a9f2e36fbf..86acdd910eebb8beac4536942119c9e9
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 45c2002bbbdf838a3340b87756de1af6338aad64..823b0d6ce2ad55532532abec07b7920ee546eb56 100644
+index 58da012345126bbfc9980538adf3f79bd87412bb..a14386502e9b3ccec23233db2ddfedeec94ffb91 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1,6 +1,8 @@
@@ -1425,7 +1425,7 @@ index cdf8020194f2ec1fe7b65b22c8e1f5b1c23eaefa..2db27f5e3e3c1bb0502c055f78c4a81e
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ba7037a44b2fba6aafcbc4081c5c481a2cdcfd3b..c7017b86a3268aef0baff2ae0a56155aafc6a067 100644
+index 1f9701128aedb0343709866207f3044b890fe1be..3e1e2d9711c3c1b05406353f96d706c8abfe7a61 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -140,7 +140,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -1634,10 +1634,10 @@ index 98ba88896c73651591b8ad8e070868fb443ae999..864e2e0355a5fb8c1d4a5b0896ba299f
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c8c205db57a8a88b76589998819166e43f9d8c1d..441ec74f965744c384fd44795540ec1906a4815c 100644
+index 55265d09707056160b44d15e2e66ad1336d4f9c8..99e1ea52493ff2ab620e32054d0ee2b2c78db6b4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2343,12 +2343,31 @@ public final class CraftServer implements Server {
+@@ -2365,12 +2365,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  

--- a/patches/server/0013-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0013-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 441ec74f965744c384fd44795540ec1906a4815c..3a9d6ba52f512e8d2468d99783e518ef613a5822 100644
+index 99e1ea52493ff2ab620e32054d0ee2b2c78db6b4..e8d46fffea6c6db14fce1a451ca81863ae69c512 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -394,10 +394,15 @@ public final class CraftServer implements Server {
+@@ -401,10 +401,15 @@ public final class CraftServer implements Server {
      public void loadPlugins() {
          this.pluginManager.registerInterface(JavaPluginLoader.class);
  
@@ -29,7 +29,7 @@ index 441ec74f965744c384fd44795540ec1906a4815c..3a9d6ba52f512e8d2468d99783e518ef
              for (Plugin plugin : plugins) {
                  try {
                      String message = String.format("Loading %s", plugin.getDescription().getFullName());
-@@ -412,6 +417,35 @@ public final class CraftServer implements Server {
+@@ -419,6 +424,35 @@ public final class CraftServer implements Server {
          }
      }
  
@@ -66,7 +66,7 @@ index 441ec74f965744c384fd44795540ec1906a4815c..3a9d6ba52f512e8d2468d99783e518ef
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 18652607d36a980a4b0956584f8a722be776dad2..556ab2908c2a9f448d4bd856bb9fbf82867148b1 100644
+index 99cfa663b79eb7126f87d6fd1ecd7619ae763f45..81a0dd4ad673146db94966e2a8cf58a80061343f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -147,6 +147,12 @@ public class Main {

--- a/patches/server/0021-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0021-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -19,10 +19,10 @@ index 1190d62594c5b1be1c11d55e646ee0bac27307cb..c38cfd4781911db0fe191412f089c55c
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3a9d6ba52f512e8d2468d99783e518ef613a5822..bca3b028410ca6a6d114bc192e0605ee22e3c29b 100644
+index e8d46fffea6c6db14fce1a451ca81863ae69c512..0071c7edfea658223ca565129d6bbb8ac5cd3aa1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -241,7 +241,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -243,7 +243,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
  public final class CraftServer implements Server {
@@ -32,11 +32,11 @@ index 3a9d6ba52f512e8d2468d99783e518ef613a5822..bca3b028410ca6a6d114bc192e0605ee
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 556ab2908c2a9f448d4bd856bb9fbf82867148b1..eac977169ee071c4961ee63d2f21d76bd3e49760 100644
+index 81a0dd4ad673146db94966e2a8cf58a80061343f..746416c8cadf4a60a417d27faace398ce8eab6cb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -221,12 +221,25 @@ public class Main {
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -14);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");
 -                        System.err.println("*** Please download a new build as per instructions from https://www.spigotmc.org/go/outdated-spigot ***");

--- a/patches/server/0025-Further-improve-server-tick-loop.patch
+++ b/patches/server/0025-Further-improve-server-tick-loop.patch
@@ -144,10 +144,10 @@ index c38cfd4781911db0fe191412f089c55cc4e40f2a..8cc5b6bbe2d8cbeb72e88b9e08e87fbb
                  this.startMetricsRecordingTick();
                  this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fe2eaed213c3f816b23fb4debb4f8c508e76fb0d..e700b38d8884f4228a8925f07c4cf1500dbdfa20 100644
+index 0071c7edfea658223ca565129d6bbb8ac5cd3aa1..079cc8db76f08db578828d0114aee52231fef250 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2373,6 +2373,17 @@ public final class CraftServer implements Server {
+@@ -2395,6 +2395,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0047-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0047-Ensure-commands-are-not-ran-async.patch
@@ -48,10 +48,10 @@ index 357ff7f3ade2d59a7a2b3d93d7d35534565b6add..e27be8fb00360d546557bdbfec290773
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e700b38d8884f4228a8925f07c4cf1500dbdfa20..71be195aa194aa1c12a7e7b8f2cffcd81a1ebbba 100644
+index 079cc8db76f08db578828d0114aee52231fef250..101bc3c3742d6d2d477ff4350a037d130149069c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -852,6 +852,28 @@ public final class CraftServer implements Server {
+@@ -859,6 +859,28 @@ public final class CraftServer implements Server {
          Validate.notNull(commandLine, "CommandLine cannot be null");
          org.spigotmc.AsyncCatcher.catchOp("command dispatch"); // Spigot
  

--- a/patches/server/0049-Expose-server-CommandMap.patch
+++ b/patches/server/0049-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 71be195aa194aa1c12a7e7b8f2cffcd81a1ebbba..4cb1d15c7f6d7720d696608cbb8fb4572358ffc7 100644
+index 101bc3c3742d6d2d477ff4350a037d130149069c..f1371173f2a3eed6a400f22867ff281205764347 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1957,6 +1957,7 @@ public final class CraftServer implements Server {
+@@ -1979,6 +1979,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0054-Add-velocity-warnings.patch
+++ b/patches/server/0054-Add-velocity-warnings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add velocity warnings
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4cb1d15c7f6d7720d696608cbb8fb4572358ffc7..a8b963b336045c11c71dfff4e0ad0d66a9b47a92 100644
+index f1371173f2a3eed6a400f22867ff281205764347..65fa69c9b6fa91b6bfa46da35ebcdc377a1f8691 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -274,6 +274,7 @@ public final class CraftServer implements Server {
+@@ -276,6 +276,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;

--- a/patches/server/0062-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0062-Default-loading-permissions.yml-before-plugins.patch
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a8b963b336045c11c71dfff4e0ad0d66a9b47a92..c5095243aad4fc39bbdc8784837b111993f8b9e3 100644
+index 65fa69c9b6fa91b6bfa46da35ebcdc377a1f8691..92c14b5a6d0952b595f636eccee17fe9e579da3c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -451,6 +451,7 @@ public final class CraftServer implements Server {
+@@ -458,6 +458,7 @@ public final class CraftServer implements Server {
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
              this.helpMap.initializeGeneralTopics();
@@ -27,7 +27,7 @@ index a8b963b336045c11c71dfff4e0ad0d66a9b47a92..c5095243aad4fc39bbdc8784837b1119
          }
  
          Plugin[] plugins = this.pluginManager.getPlugins();
-@@ -470,7 +471,7 @@ public final class CraftServer implements Server {
+@@ -477,7 +478,7 @@ public final class CraftServer implements Server {
              this.commandMap.registerServerAliases();
              DefaultPermissions.registerCorePermissions();
              CraftDefaultPermissions.registerCorePermissions();

--- a/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c5095243aad4fc39bbdc8784837b111993f8b9e3..0f8d35e2c37088b98e47e046e40544c4e7bb01c8 100644
+index 92c14b5a6d0952b595f636eccee17fe9e579da3c..67843ddc9b68e819c77dc0c47dd57bb2e78cdd20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2501,5 +2501,23 @@ public final class CraftServer implements Server {
+@@ -2523,5 +2523,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0064-Remove-Metadata-on-reload.patch
+++ b/patches/server/0064-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cffa98b42f1837755c9a8ad95e7517acd4f2d3b5..c67c35e840bc21bbc58d8cf9199ea94d5bb991ef 100644
+index 67843ddc9b68e819c77dc0c47dd57bb2e78cdd20..9c44dea69a39eea480f5ffb1ce6842e32354a072 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -939,8 +939,16 @@ public final class CraftServer implements Server {
+@@ -946,8 +946,16 @@ public final class CraftServer implements Server {
              world.spigotConfig.init(); // Spigot
          }
  

--- a/patches/server/0098-Only-send-Dragon-Wither-Death-sounds-to-same-world.patch
+++ b/patches/server/0098-Only-send-Dragon-Wither-Death-sounds-to-same-world.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Only send Dragon/Wither Death sounds to same world
 Also fix view distance lookup
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 13fa9c47a95571d63b590c595e15e9a15c2f6a65..7b64b14b1d2c0e242a5d8e8602e49b185fcf8839 100644
+index dd1d606543da93e6068b8fa4239d369a4b648523..0dff7a47ecac1916ad23739fbb06ddd0f0052a65 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -633,8 +633,9 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -653,8 +653,9 @@ public class EnderDragon extends Mob implements Enemy {
              if (this.dragonDeathTime == 1 && !this.isSilent()) {
                  // CraftBukkit start - Use relative location for far away sounds
                  // this.world.b(1028, this.getChunkCoordinates(), 0);

--- a/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
@@ -43,10 +43,10 @@ index da98f074ccd5a40c635824112c97fd174c393cb1..6599f874d9f97e9ef4862039ecad7277
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 90a2ed1b851a948b8ebf4ad6157003db19f1916f..ad7efac7d32837c8de2c2a61552538398d24cf44 100644
+index 9c44dea69a39eea480f5ffb1ce6842e32354a072..af54e83dd80b4d791c020c304d35040519d1199e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1685,7 +1685,7 @@ public final class CraftServer implements Server {
+@@ -1702,7 +1702,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0106-Add-EntityZapEvent.patch
+++ b/patches/server/0106-Add-EntityZapEvent.patch
@@ -28,10 +28,10 @@ index 2a7c82be934a965ba26dc7bf1f60689360bda487..33d1a6b31afec4dbeb00dcabf50c5840
              entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
              entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1f74088858aff5deb8aac7057ad07727234f817e..c5a6de1b37c78d0146224597d7008cadad723cea 100644
+index 97a614e2367439dbface4a258f966c0440ef965d..a2e289ac5e3d0d04b65ec3bf03bebbaad585cc24 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1152,6 +1152,14 @@ public class CraftEventFactory {
+@@ -1153,6 +1153,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0109-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0109-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ad7efac7d32837c8de2c2a61552538398d24cf44..437d479e319becb8d9d4ec9544a9fa2aebc72160 100644
+index af54e83dd80b4d791c020c304d35040519d1199e..442fd837e5ab21f03dd4c5c6d55bb9504b34ca0e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2527,5 +2527,24 @@ public final class CraftServer implements Server {
+@@ -2549,5 +2549,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0110-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0110-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index dba0bc7dc8fd1993f45716a398b1ccf52d3d868b..b3433ce9c722bdab81848a6c2d121ca5
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c5a6de1b37c78d0146224597d7008cadad723cea..87a1f13c07a3cebb75155b7d8186befa63d147c9 100644
+index a2e289ac5e3d0d04b65ec3bf03bebbaad585cc24..09a5c7a95f87e35c43d07974f5884e28833f9777 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1111,6 +1111,17 @@ public class CraftEventFactory {
+@@ -1112,6 +1112,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0111-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0111-Add-ProjectileCollideEvent.patch
@@ -87,10 +87,10 @@ index 88181c59e604ba3b132b9e695cef5eaf5b836029..94d09b05737679b133ec462815b010b1
  
          this.checkInsideBlocks();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 87a1f13c07a3cebb75155b7d8186befa63d147c9..4de19058b61d4def69161f26bed6c43aa63a4403 100644
+index 09a5c7a95f87e35c43d07974f5884e28833f9777..e00f87e4a9384c60e5fe4c33a9f27541366ae81b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1255,6 +1255,16 @@ public class CraftEventFactory {
+@@ -1256,6 +1256,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/patches/server/0125-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0125-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -129,13 +129,13 @@ index b3433ce9c722bdab81848a6c2d121ca510c48509..227aca795efc99c4f81dfb30c00d31d2
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3a597e7ce159b78078b1d64258a6f30e51645f3b..86a624e505db71241e3acb0b9269372ea693031d 100644
+index 292f5dddd644880fc759fa8634d633ad40f3bf4f..8c5e4958f087a3f688261a44377dde39bc134b80 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1723,7 +1723,8 @@ public abstract class LivingEntity extends Entity {
      protected void dropExperience() {
          // CraftBukkit start - Update getExpReward() above if the removed if() changes!
-         if (true) {
+         if (true && !(this instanceof net.minecraft.world.entity.boss.enderdragon.EnderDragon)) { // CraftBukkit - SPIGOT-2420: Special case ender dragon will drop the xp over time
 -            ExperienceOrb.award((ServerLevel) this.level, this.position(), this.expToDrop);
 +            LivingEntity attacker = this.lastHurtByPlayer != null ? this.lastHurtByPlayer : this.lastHurtByMob; // Paper
 +            ExperienceOrb.award((ServerLevel) this.level, this.position(), this.expToDrop, this instanceof ServerPlayer ? org.bukkit.entity.ExperienceOrb.SpawnReason.PLAYER_DEATH : org.bukkit.entity.ExperienceOrb.SpawnReason.ENTITY_DEATH, attacker, this); // Paper
@@ -182,22 +182,22 @@ index 7c90063be2a7eb66b7f0981059018f20413256c6..37125ffe47fcd5fe93ab62ad8a46e818
  
          }
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 7b64b14b1d2c0e242a5d8e8602e49b185fcf8839..dc2e57bfc5e85c9ef548cb895b3fcd1c09c4dacb 100644
+index 0dff7a47ecac1916ad23739fbb06ddd0f0052a65..d0ebcc23d863be630b55245aa2604c108ee6c93a 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -627,7 +627,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -647,7 +647,7 @@ public class EnderDragon extends Mob implements Enemy {
  
          if (this.level instanceof ServerLevel) {
-             if (this.dragonDeathTime > 150 && this.dragonDeathTime % 5 == 0 && flag) {
+             if (this.dragonDeathTime > 150 && this.dragonDeathTime % 5 == 0 && true) {  // CraftBukkit - SPIGOT-2420: Already checked for the game rule when calculating the xp
 -                ExperienceOrb.award((ServerLevel) this.level, this.position(), Mth.floor((float) short0 * 0.08F));
 +                ExperienceOrb.award((ServerLevel) this.level, this.position(), Mth.floor((float) short0 * 0.08F), org.bukkit.entity.ExperienceOrb.SpawnReason.ENTITY_DEATH, this.lastHurtByPlayer, this); // Paper
              }
  
              if (this.dragonDeathTime == 1 && !this.isSilent()) {
-@@ -658,7 +658,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -678,7 +678,7 @@ public class EnderDragon extends Mob implements Enemy {
          this.yBodyRot = this.getYRot();
          if (this.dragonDeathTime == 200 && this.level instanceof ServerLevel) {
-             if (flag) {
+             if (true) { // CraftBukkit - SPIGOT-2420: Already checked for the game rule when calculating the xp
 -                ExperienceOrb.award((ServerLevel) this.level, this.position(), Mth.floor((float) short0 * 0.2F));
 +                ExperienceOrb.award((ServerLevel) this.level, this.position(), Mth.floor((float) short0 * 0.2F), org.bukkit.entity.ExperienceOrb.SpawnReason.ENTITY_DEATH, this.lastHurtByPlayer, this); // Paper
              }

--- a/patches/server/0132-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0132-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 437d479e319becb8d9d4ec9544a9fa2aebc72160..d4f944daae8139973b615983620957cf89d96e7b 100644
+index 442fd837e5ab21f03dd4c5c6d55bb9504b34ca0e..04a04855602ddc857288fe57c05feb3ccc349c12 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2546,5 +2546,10 @@ public final class CraftServer implements Server {
+@@ -2568,5 +2568,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0133-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0133-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a87cf2a4ad955b7429269f2d46adbe59f6e4525e..30bd0b7d980652b982088b09145266bc48b07216 100644
+index 07b7d43796985cff828ff472ddef2a11b543a4af..64c16b051594b95760ad626f703857efd6e7a8df 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -8,7 +8,17 @@ plugins {
@@ -236,7 +236,7 @@ index b28bb51e5476b250d9de91f2e380dd8ed2aa7041..9cb9e0a4d1467cb5c23dfd38e83d495a
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 285d6aef955692adf93808589a8dac2248c9e1a5..14d0c9f5f50aef75d67a7794a46f80f55bccf6aa 100644
+index 04a04855602ddc857288fe57c05feb3ccc349c12..49d0e5e5cf1c529cbd0f4c58c88acf802f42a5bd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -44,7 +44,6 @@ import java.util.logging.Level;
@@ -247,7 +247,7 @@ index 285d6aef955692adf93808589a8dac2248c9e1a5..14d0c9f5f50aef75d67a7794a46f80f5
  import net.minecraft.advancements.Advancement;
  import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
-@@ -1265,9 +1264,13 @@ public final class CraftServer implements Server {
+@@ -1272,9 +1271,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  
@@ -262,7 +262,7 @@ index 285d6aef955692adf93808589a8dac2248c9e1a5..14d0c9f5f50aef75d67a7794a46f80f5
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 2595ee05d1b77dee0f1f5bf11c10df186f434d84..254a06a07e99642f96a8df052166676928dcb855 100644
+index a65a6a3fd0c33442c7f2e34565cbbe7d1fe3621f..6da452d463193dc20d39f3c74058d72a4bbd0cbf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,7 +12,7 @@ import java.util.logging.Level;

--- a/patches/server/0138-Add-UnknownCommandEvent.patch
+++ b/patches/server/0138-Add-UnknownCommandEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a04f678289551208cfa42523ec6bf3d2e77e2fa4..19e5fade2c694664930e31c6b0acf82598db315b 100644
+index 49d0e5e5cf1c529cbd0f4c58c88acf802f42a5bd..cf913f0678178d03c63eaa2b7a67e18abe17a7c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -881,7 +881,13 @@ public final class CraftServer implements Server {
+@@ -888,7 +888,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0139-Basic-PlayerProfile-API.patch
+++ b/patches/server/0139-Basic-PlayerProfile-API.patch
@@ -621,10 +621,10 @@ index c7edbd12361cfd3dcf1359917d579fae4c3cc8a7..2a4f8aa6697ed6144440970c9abaf9f6
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 19e5fade2c694664930e31c6b0acf82598db315b..eed64dedb3430bd01c53c230c280a7c475fdbfd5 100644
+index cf913f0678178d03c63eaa2b7a67e18abe17a7c5..c334fa4dcd0ecab1a1cdfe7ebb0b6615e710f164 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -239,6 +239,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -241,6 +241,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
@@ -634,7 +634,7 @@ index 19e5fade2c694664930e31c6b0acf82598db315b..eed64dedb3430bd01c53c230c280a7c4
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -278,6 +281,7 @@ public final class CraftServer implements Server {
+@@ -280,6 +283,7 @@ public final class CraftServer implements Server {
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
          ConfigurationSerialization.registerClass(CraftPlayerProfile.class);
@@ -642,7 +642,7 @@ index 19e5fade2c694664930e31c6b0acf82598db315b..eed64dedb3430bd01c53c230c280a7c4
          CraftItemFactory.instance();
      }
  
-@@ -2560,5 +2564,37 @@ public final class CraftServer implements Server {
+@@ -2582,5 +2586,37 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }

--- a/patches/server/0148-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0148-Fix-this-stupid-bullshit.patch
@@ -31,12 +31,12 @@ index e359919de57f97d18667df1b2f1bf54a19a49c2f..c5822637e48fad4ca4e8cf210431b5ea
              Bootstrap.isBootstrapped = true;
              if (Registry.REGISTRY.keySet().isEmpty()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 254a06a07e99642f96a8df052166676928dcb855..edda95afdde52df3a809c3826a3f099d5b4691ad 100644
+index 6da452d463193dc20d39f3c74058d72a4bbd0cbf..2272a3d4cc3877e1f40d77036effa471782aeba8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -239,10 +239,12 @@ public class Main {
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -14);
                      if (buildDate.before(deadline.getTime())) {
 -                        System.err.println("*** Error, this build is outdated ***");
 +                        // Paper start - This is some stupid bullshit

--- a/patches/server/0165-AsyncTabCompleteEvent.patch
+++ b/patches/server/0165-AsyncTabCompleteEvent.patch
@@ -72,10 +72,10 @@ index 86f9991cfe6aca5923c64d8cdde6e90b9ba5591d..7f17875e359855a25618a52bc2e844fe
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e674b45ee77480cd3c1da86b6f32a3ff2edd865f..c699d1eecac2b3f87f89b2e801ab909f863233b2 100644
+index c334fa4dcd0ecab1a1cdfe7ebb0b6615e710f164..a9731e89f2cddc2ae256bf955945f4d2f3cd0c28 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2060,7 +2060,7 @@ public final class CraftServer implements Server {
+@@ -2082,7 +2082,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0178-Implement-extended-PaperServerListPingEvent.patch
+++ b/patches/server/0178-Implement-extended-PaperServerListPingEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement extended PaperServerListPingEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/network/PaperServerListPingEventImpl.java b/src/main/java/com/destroystokyo/paper/network/PaperServerListPingEventImpl.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4ecd0c5bbea55f68549c85aa27e80e2c7e6265d4
+index 0000000000000000000000000000000000000000..f57792d3f883a710c51bc736cff513aca4b75915
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/network/PaperServerListPingEventImpl.java
 @@ -0,0 +1,31 @@
@@ -25,7 +25,7 @@ index 0000000000000000000000000000000000000000..4ecd0c5bbea55f68549c85aa27e80e2c
 +    private final MinecraftServer server;
 +
 +    PaperServerListPingEventImpl(MinecraftServer server, StatusClient client, int protocolVersion, @Nullable CachedServerIcon icon) {
-+        super(client, server.getMotd(), server.getPlayerCount(), server.getMaxPlayers(),
++        super(client, server.getMotd(), server.previewsChat(), server.getPlayerCount(), server.getMaxPlayers(),
 +                server.getServerModName() + ' ' + server.getServerVersion(), protocolVersion, icon);
 +        this.server = server;
 +    }
@@ -190,7 +190,7 @@ index 67455a5ba75c9b816213e44d6872c5ddf8e27e98..23efad80934930beadf15e65781551d4
  
      public ClientboundStatusResponsePacket(ServerStatus metadata) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 2cdde6eaf2221bb634fd0d34db849c0a6833cfbd..94201e91ee67c00fb9d5af0c6db9d96999164c06 100644
+index 037749e1f6a6dcd53fc4455869f5b41417ae8e94..f532aba1f180f0c86b4360bb85993732207b2345 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2,6 +2,9 @@ package net.minecraft.server;
@@ -213,7 +213,7 @@ index 2cdde6eaf2221bb634fd0d34db849c0a6833cfbd..94201e91ee67c00fb9d5af0c6db9d969
  
                  for (int k = 0; k < agameprofile.length; ++k) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
-index 5d368e34c90fc5191d9ed2352f7aa44c4a299eed..d21549bb272e4848c5ce7c29862f0303aea7f9b7 100644
+index a426adfba3fccf1815177e0b8065684c9497ef45..29a22da1b94d51300481c071aa16bfd8cd02178f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
 @@ -46,6 +46,8 @@ public class ServerStatusPacketListenerImpl implements ServerStatusPacketListene
@@ -225,7 +225,7 @@ index 5d368e34c90fc5191d9ed2352f7aa44c4a299eed..d21549bb272e4848c5ce7c29862f0303
              // CraftBukkit start
              // this.connection.send(new PacketStatusOutServerInfo(this.server.getStatus()));
              final Object[] players = this.server.getPlayerList().players.toArray();
-@@ -149,6 +151,9 @@ public class ServerStatusPacketListenerImpl implements ServerStatusPacketListene
+@@ -150,6 +152,9 @@ public class ServerStatusPacketListenerImpl implements ServerStatusPacketListene
  
              this.connection.send(new ClientboundStatusResponsePacket(ping));
              // CraftBukkit end
@@ -236,7 +236,7 @@ index 5d368e34c90fc5191d9ed2352f7aa44c4a299eed..d21549bb272e4848c5ce7c29862f0303
      }
  
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index 2e684d28948d23a310b5d5029903a871e6f9b1ca..f4aa98ed573ffa25659ed19a8a391e04bf2bd8b2 100644
+index c2e3d32e51902503af88f089e366e784f42d999a..645643d102118ad4916a152abfb9ab0d02751e11 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -289,7 +289,7 @@ public class SpigotConfig

--- a/patches/server/0181-getPlayerUniqueId-API.patch
+++ b/patches/server/0181-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3f84c3579b1b37f98120d20bae008a1030b93adf..8ede5166c3764f75c27e170ef40b89a103389073 100644
+index a9731e89f2cddc2ae256bf955945f4d2f3cd0c28..53834d226cf577413d1514c54f5a4b0294a432e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1687,6 +1687,25 @@ public final class CraftServer implements Server {
+@@ -1704,6 +1704,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0184-Call-PaperServerListPingEvent-for-legacy-pings.patch
+++ b/patches/server/0184-Call-PaperServerListPingEvent-for-legacy-pings.patch
@@ -84,15 +84,15 @@ index 0000000000000000000000000000000000000000..74c012fd40491f1d870fbc1aa8c318a2
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java b/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java
-index 2818495aa221f8195f095e39091bd478cebb3807..53e87ea23dacd123cc47bd8ca43d0f19e69acaf2 100644
+index c4f1de1413e37e91492e7dd3fa33da5ef87fdbd5..0d35e9ff88542b02bb948aa10e064911e73a6913 100644
 --- a/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java
 +++ b/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java
 @@ -47,12 +47,19 @@ public class LegacyQueryHandler extends ChannelInboundHandlerAdapter {
              MinecraftServer minecraftserver = this.serverConnectionListener.getServer();
              int i = bytebuf.readableBytes();
              String s;
--            org.bukkit.event.server.ServerListPingEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callServerListPingEvent(minecraftserver.server, inetsocketaddress.getAddress(), minecraftserver.getMotd(), minecraftserver.getPlayerCount(), minecraftserver.getMaxPlayers()); // CraftBukkit
-+            //org.bukkit.event.server.ServerListPingEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callServerListPingEvent(minecraftserver.server, inetsocketaddress.getAddress(), minecraftserver.getMotd(), minecraftserver.getPlayerCount(), minecraftserver.getMaxPlayers()); // CraftBukkit // Paper
+-            org.bukkit.event.server.ServerListPingEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callServerListPingEvent(minecraftserver.server, inetsocketaddress.getAddress(), minecraftserver.getMotd(), minecraftserver.previewsChat(), minecraftserver.getPlayerCount(), minecraftserver.getMaxPlayers()); // CraftBukkit
++            //org.bukkit.event.server.ServerListPingEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callServerListPingEvent(minecraftserver.server, inetsocketaddress.getAddress(), minecraftserver.getMotd(), minecraftserver.previewsChat(), minecraftserver.getPlayerCount(), minecraftserver.getMaxPlayers()); // CraftBukkit // Paper
 +            com.destroystokyo.paper.event.server.PaperServerListPingEvent event; // Paper
  
              switch (i) {

--- a/patches/server/0214-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0214-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 96723a042c23d53a955c766d7899164684c32b74..1e559d238441d28c52b3305c42dec0f6115b2626 100644
+index d394f7dd4ef1faa1b92a56945e5dab96b6dd17b8..0531b9c5b10fe250531b0c04cb2ffe2751e7d1c5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1158,7 +1158,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -186,10 +186,10 @@ index 64f891db064ab1ad74479a5d7fb4d7828217afc7..d426534e7c16a307b93e9170c7eb9bcd
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4de19058b61d4def69161f26bed6c43aa63a4403..0f2371490d7dda84366271187f7ed4deed6bb0f9 100644
+index e00f87e4a9384c60e5fe4c33a9f27541366ae81b..479835a1fb087e18a1098438f6a3d71cd5589001 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1224,7 +1224,7 @@ public class CraftEventFactory {
+@@ -1225,7 +1225,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -198,7 +198,7 @@ index 4de19058b61d4def69161f26bed6c43aa63a4403..0f2371490d7dda84366271187f7ed4de
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1390,8 +1390,18 @@ public class CraftEventFactory {
+@@ -1391,8 +1391,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0225-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0225-Vanished-players-don-t-have-rights.patch
@@ -99,10 +99,10 @@ index 056531554bf6e8743111607237d942af13d47848..13fcd9d885043444d3a2c5a3d9bd1c90
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0f2371490d7dda84366271187f7ed4deed6bb0f9..49ec76720dea8c756817ded7d02bfea02f86d428 100644
+index 479835a1fb087e18a1098438f6a3d71cd5589001..1bc3edad4fa79b2efb34e92b4af492769a8fcf83 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1260,6 +1260,14 @@ public class CraftEventFactory {
+@@ -1261,6 +1261,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0237-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0237-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -33,10 +33,10 @@ index b248c0f481436b1b101dc1f75eaaf8023f4ba0ea..02ea5304a3f99d69005ab1a7ea85e6a1
          com.destroystokyo.paper.Metrics.PaperMetrics.startMetrics();
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 07c8c19e5bbd887a74192b94cbd13df50260b69d..c2bda04775fd4406ee44ac99c56e592eca31bc9f 100644
+index 53834d226cf577413d1514c54f5a4b0294a432e7..3ffb9cb08dc3b71662364bd5553b895ddc0f9ab7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -900,6 +900,7 @@ public final class CraftServer implements Server {
+@@ -907,6 +907,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -44,7 +44,7 @@ index 07c8c19e5bbd887a74192b94cbd13df50260b69d..c2bda04775fd4406ee44ac99c56e592e
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -988,6 +989,7 @@ public final class CraftServer implements Server {
+@@ -995,6 +996,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/patches/server/0254-Improve-death-events.patch
+++ b/patches/server/0254-Improve-death-events.patch
@@ -70,7 +70,7 @@ index 0ef0b7fa2af5ac6608f9b8b37317434f15df6bfa..67316da1b90024e58b572606798eba0f
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 831e8c32c85a45daff36449f2d6ef57a522fa7cf..b4906b20b48badd4ebff662cb830b36f346b7977 100644
+index 642b496926d8f6ef5ba5f12e44043d4d769f06ef..b1af9e9a4e530854049d7907c099c169692b12ab 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -262,6 +262,7 @@ public abstract class LivingEntity extends Entity {
@@ -330,10 +330,10 @@ index 1a10eec46b9b0c3fb94b72e022e75ed89434c189..14ea624eeb87451578138d1eedb4268a
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2dac07a71474fd9c92955914f121094fcad23212..4fc682e1b7de1fe68aac90134c2bb313b5f6842a 100644
+index 518e44f783f5062ce53e9907501bd3a54c8014bb..64cd5b2bc4032bfb0c917cc33884062ddba2738f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -815,9 +815,16 @@ public class CraftEventFactory {
+@@ -816,9 +816,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -350,7 +350,7 @@ index 2dac07a71474fd9c92955914f121094fcad23212..4fc682e1b7de1fe68aac90134c2bb313
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -834,8 +841,15 @@ public class CraftEventFactory {
+@@ -835,8 +842,15 @@ public class CraftEventFactory {
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
@@ -366,7 +366,7 @@ index 2dac07a71474fd9c92955914f121094fcad23212..4fc682e1b7de1fe68aac90134c2bb313
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -852,6 +866,31 @@ public class CraftEventFactory {
+@@ -853,6 +867,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0272-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0272-Add-Velocity-IP-Forwarding-Support.patch
@@ -189,10 +189,10 @@ index 1b075033f0640433341957f6e26ebe25f18928ee..8b5eddce4845619603ccfeec158d97cb
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c2bda04775fd4406ee44ac99c56e592eca31bc9f..6a2e65401130ca885864e9952f594237d089769d 100644
+index 3ffb9cb08dc3b71662364bd5553b895ddc0f9ab7..0b13ff4c656615b19a4cdffa7390c4dd01c5a82d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -755,7 +755,7 @@ public final class CraftServer implements Server {
+@@ -762,7 +762,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0284-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0284-Make-the-default-permission-message-configurable.patch
@@ -18,10 +18,10 @@ index b506cd11b76901827cbe66f46db8df400f7015de..13a5062e539f6f43e6fe582318c36302
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6a2e65401130ca885864e9952f594237d089769d..62fb88baefcf22a49474ea8362db8f99b7318687 100644
+index 0b13ff4c656615b19a4cdffa7390c4dd01c5a82d..8dc5d79130949ec0b38737060124fe4421af1fe9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2586,6 +2586,16 @@ public final class CraftServer implements Server {
+@@ -2608,6 +2608,16 @@ public final class CraftServer implements Server {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }
  

--- a/patches/server/0317-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0317-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -29,10 +29,10 @@ index 7d1ca1dbd0c1f882b4c59fb6c56e9ba86d81ae42..97e964030a5cc449543252933f8a7b48
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 62fb88baefcf22a49474ea8362db8f99b7318687..a18523d5a9377d11f9cb9a794b8c1ca55ded856a 100644
+index 8dc5d79130949ec0b38737060124fe4421af1fe9..5ca45150a429a01e7871c9fd4248034b942b70bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2049,7 +2049,7 @@ public final class CraftServer implements Server {
+@@ -2071,7 +2071,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0323-Expose-the-internal-current-tick.patch
+++ b/patches/server/0323-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a18523d5a9377d11f9cb9a794b8c1ca55ded856a..66bd0ff02c6085d41251808140aceefa02782b1f 100644
+index 5ca45150a429a01e7871c9fd4248034b942b70bf..b395d3a20a1c71bfe18e7344b910f545630b7e92 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2627,5 +2627,10 @@ public final class CraftServer implements Server {
+@@ -2649,5 +2649,10 @@ public final class CraftServer implements Server {
          profile.getProperties().putAll(((CraftPlayer)player).getHandle().getGameProfile().getProperties());
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }

--- a/patches/server/0352-Anti-Xray.patch
+++ b/patches/server/0352-Anti-Xray.patch
@@ -1172,7 +1172,7 @@ index d95db45e21861eb9f1623c44dd797429ae158760..1c3dacd12ff5f26dd5559d0b99c917a0
          List<Entity> list = Lists.newArrayList();
          List<Entity> list1 = Lists.newArrayList();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index b2a8faec6562d784b3f16fe968c778f9abfedeb5..651e8fa620273c64ed94680c2c0ed378d152f459 100644
+index ff902ae5a96616bb70897d9326fc65a3261b07d9..57abbcd9d59ea29e2feb238ee342f28a66122006 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -402,7 +402,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -1606,10 +1606,10 @@ index cf48c93d89da53e0ec771e5c2c8582e30b35e3f5..518dfbb7dbd4221937636cf46d27109d
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 66bd0ff02c6085d41251808140aceefa02782b1f..0c2658c2cd411b6e5e5dcb9a190e7b223eeb0ffc 100644
+index b395d3a20a1c71bfe18e7344b910f545630b7e92..de114eda44d475c50f25f8dfedf17c41e783c5d9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2204,7 +2204,7 @@ public final class CraftServer implements Server {
+@@ -2226,7 +2226,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Validate.notNull(world, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();

--- a/patches/server/0372-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0372-Add-tick-times-API-and-mspt-command.patch
@@ -129,7 +129,7 @@ index 82bce89dc174c8c4a4ab8efeffaaf22ddeb377fb..37d28625b9528bbe0cd6d9623e702bbb
  
      public static void registerCommands(final MinecraftServer server) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8de56cabd8fdc68e136d41c4d172f3574e21e57a..f69ed252f55623ee5cba6ac9d28096c2cc92ea04 100644
+index f7427ea6bf11ef837dd38d25cd3abed57de5e8de..ce7b96819bf8d7e992c2aafd3013e8a9478e500d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -234,6 +234,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -189,10 +189,10 @@ index 8de56cabd8fdc68e136d41c4d172f3574e21e57a..f69ed252f55623ee5cba6ac9d28096c2
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0c2658c2cd411b6e5e5dcb9a190e7b223eeb0ffc..452f7de1b7c1e2b03c311a1a5f63a6d925b7543f 100644
+index de114eda44d475c50f25f8dfedf17c41e783c5d9..9e2a90b2b5173667f336d64da111221d0093a7d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2449,6 +2449,16 @@ public final class CraftServer implements Server {
+@@ -2471,6 +2471,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0373-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0373-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 452f7de1b7c1e2b03c311a1a5f63a6d925b7543f..943060b67d962a53bba8c2caa39de435060e036d 100644
+index 9e2a90b2b5173667f336d64da111221d0093a7d4..bfbf43661acbdcda1417b1782579c603022a0adb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2642,5 +2642,10 @@ public final class CraftServer implements Server {
+@@ -2664,5 +2664,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0384-Improved-Watchdog-Support.patch
+++ b/patches/server/0384-Improved-Watchdog-Support.patch
@@ -330,10 +330,10 @@ index 89f4ea65b20e773bd3782c41db3a2af7b5b405f3..3fe94e580d2aaae9616ba83c0d3a4468
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 943060b67d962a53bba8c2caa39de435060e036d..10d81c2300b17b9d8981450fc03915dba7f458d1 100644
+index bfbf43661acbdcda1417b1782579c603022a0adb..602838f3615e4fac1798a99bd2d322c0b2b94863 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2049,7 +2049,7 @@ public final class CraftServer implements Server {
+@@ -2071,7 +2071,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {
@@ -343,7 +343,7 @@ index 943060b67d962a53bba8c2caa39de435060e036d..10d81c2300b17b9d8981450fc03915db
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 94b46dde76b186a441e6b0ef64553dcab5dfa717..37d38fe2077e92adc8d9ddf3bb0a02b7313fd9b5 100644
+index fb685e13025bc571896bc999814cb99a17bfb788..fcc959aaed86d1e1c6fe551e534bebbd0fb967a4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,6 +12,8 @@ import java.util.logging.Level;

--- a/patches/server/0400-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0400-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -80,7 +80,7 @@ index e9fa8e5ebe8a5e40524735ab98e0c413793e5ca0..66c728a456dc9b60fb340d6e55626592
  
      public float getBlockExplosionResistance(Explosion explosion, BlockGetter world, BlockPos pos, BlockState blockState, FluidState fluidState, float max) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2021b9592a1a32981075d169a61aef2e7f827192..cf04841c7e30b9f45c4922977c12e0fed6049450 100644
+index d6dc08d5501cc8b09cec3da107506760a99f5f81..cf691b94b478dc058af706e1f2d13b51df231779 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1643,9 +1643,9 @@ public abstract class LivingEntity extends Entity {
@@ -135,10 +135,10 @@ index cd54fa8f7bbcb6036e90f4ef7cdc01d7af835a13..808e564789d826c1778c053ab91038e3
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5e1f13641140dca8982af8fd876230f7700c54a7..cd28e59602cba810c0c123f01b992f6eef0ea207 100644
+index 3aa82c7d26ef9fed3d4b670ac330204b55609396..22da112f45ddb20d113550eae67ac08eb2fcb727 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -818,6 +818,11 @@ public class CraftEventFactory {
+@@ -819,6 +819,11 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
@@ -150,7 +150,7 @@ index 5e1f13641140dca8982af8fd876230f7700c54a7..cd28e59602cba810c0c123f01b992f6e
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
          populateFields(victim, event); // Paper - make cancellable
-@@ -831,11 +836,13 @@ public class CraftEventFactory {
+@@ -832,11 +837,13 @@ public class CraftEventFactory {
          playDeathSound(victim, event);
          // Paper end
          victim.expToDrop = event.getDroppedExp();

--- a/patches/server/0403-Expose-game-version.patch
+++ b/patches/server/0403-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 10d81c2300b17b9d8981450fc03915dba7f458d1..09a9148e74a9924e288a5e419ba2f7054c415394 100644
+index 602838f3615e4fac1798a99bd2d322c0b2b94863..3ebb0b615d337474f11bb00adcea32cb18de2706 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -568,6 +568,13 @@ public final class CraftServer implements Server {
+@@ -575,6 +575,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  

--- a/patches/server/0406-misc-debugging-dumps.patch
+++ b/patches/server/0406-misc-debugging-dumps.patch
@@ -29,7 +29,7 @@ index 0000000000000000000000000000000000000000..2d5494d2813b773e60ddba6790b750a9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 691fbbb720a3a58aa4e0daee715e9ce36d37ec4c..59ad3053c951457602899462ac548038151fee62 100644
+index 53320d5d9cadb8702f82d94bada32db4c1b32f26..407cfb88d3a6c9c699ca42df2642d9f6fad87cbd 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -868,6 +868,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -58,7 +58,7 @@ index 691fbbb720a3a58aa4e0daee715e9ce36d37ec4c..59ad3053c951457602899462ac548038
          this.running = false;
          if (flag) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 22a2380388ed9fd6d28edbfbbb5ed3f646217525..ae93ca7bcc7347ee165cbb0e9fd20aa3da54616c 100644
+index ec2825b6d276b6200c4bec5580d012f1eaed722e..e51c03e05c4407ad3a51e573a5e79b003f86d9f1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -206,6 +206,11 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
@@ -74,10 +74,10 @@ index 22a2380388ed9fd6d28edbfbbb5ed3f646217525..ae93ca7bcc7347ee165cbb0e9fd20aa3
                  this.connection.send(new ClientboundDisconnectPacket(ichatmutablecomponent));
                  this.connection.disconnect(ichatmutablecomponent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 09a9148e74a9924e288a5e419ba2f7054c415394..2bbbb509c35b178d56119214bef446b2682694a9 100644
+index 3ebb0b615d337474f11bb00adcea32cb18de2706..af8269bc1bf737e80ab7bc9a353b262871af454a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -991,6 +991,7 @@ public final class CraftServer implements Server {
+@@ -998,6 +998,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getFullName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0409-Implement-Mob-Goal-API.patch
+++ b/patches/server/0409-Implement-Mob-Goal-API.patch
@@ -789,10 +789,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2bbbb509c35b178d56119214bef446b2682694a9..df53043c9123be95d69a57c9076db23603e03a3b 100644
+index af8269bc1bf737e80ab7bc9a353b262871af454a..f6adc73c6c1cdf0a182131b87edd103966212017 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2655,5 +2655,11 @@ public final class CraftServer implements Server {
+@@ -2677,5 +2677,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0416-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0416-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,7 +10,7 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 59ad3053c951457602899462ac548038151fee62..0e745e52e9900ef523abf6c5b33cca2ef2a8a2b6 100644
+index 407cfb88d3a6c9c699ca42df2642d9f6fad87cbd..df40ab29f928fa31ccedb9afb64da7e193a8d1f7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -907,6 +907,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -22,10 +22,10 @@ index 59ad3053c951457602899462ac548038151fee62..0e745e52e9900ef523abf6c5b33cca2e
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index df53043c9123be95d69a57c9076db23603e03a3b..a82aab154b862eaa1c136e3d5cbb25bbe4902ca5 100644
+index f6adc73c6c1cdf0a182131b87edd103966212017..9ad5772fcb115d47cc4c0ff8d7f4ffeaa5b7edee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1000,6 +1000,35 @@ public final class CraftServer implements Server {
+@@ -1007,6 +1007,35 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0441-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0441-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -8,7 +8,7 @@ makes it so that the server keeps the last difficulty used instead
 of restoring the server.properties every single load.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0e745e52e9900ef523abf6c5b33cca2ef2a8a2b6..d40623b3ed69a0821057f82e6164b4c94b4a7087 100644
+index df40ab29f928fa31ccedb9afb64da7e193a8d1f7..049ec7c3be31f957e0a662a16939d5ef1868a4e3 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -788,7 +788,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -89,7 +89,7 @@ index 9075ff5455422feacb6edb6f4fe424a2becf94ed..ea1f0477f416f9e852ea92083781d7eb
  
                  playerlist.sendPlayerPermissionLevel(this);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 32786e1c13ffda722aaabf518e2ace7f13e0bf96..08d28184c7e90878b72a606c7800cfffba90472c 100644
+index 30d0c22d4576f0aef49bb9fb08ff3c9a8edf8d5a..41250053943118526ee36e296b19c1a68c434aa5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -3258,7 +3258,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -102,10 +102,10 @@ index 32786e1c13ffda722aaabf518e2ace7f13e0bf96..08d28184c7e90878b72a606c7800cfff
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a82aab154b862eaa1c136e3d5cbb25bbe4902ca5..47f08915f821af2ddac80c58a484061ba51eeade 100644
+index 9ad5772fcb115d47cc4c0ff8d7f4ffeaa5b7edee..97f80d43c7f88c9cae6bf2beb9ceb59743bcae60 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -940,8 +940,8 @@ public final class CraftServer implements Server {
+@@ -947,8 +947,8 @@ public final class CraftServer implements Server {
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
          this.console.paperConfigurations.reloadConfigs(this.console);
          for (ServerLevel world : this.console.getAllLevels()) {

--- a/patches/server/0446-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0446-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,10 +22,10 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 47f08915f821af2ddac80c58a484061ba51eeade..e0c7109a78977118a30b6eb3b54cb896f8c7100e 100644
+index 97f80d43c7f88c9cae6bf2beb9ceb59743bcae60..0efc62fce74e545ed87fa96c25f1178945c87ea5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -354,7 +354,7 @@ public final class CraftServer implements Server {
+@@ -356,7 +356,7 @@ public final class CraftServer implements Server {
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -33,8 +33,8 @@ index 47f08915f821af2ddac80c58a484061ba51eeade..e0c7109a78977118a30b6eb3b54cb896
 +        TicketType.PLUGIN.timeout = Math.min(20, this.configuration.getInt("chunk-gc.period-in-ticks")); // Paper - cap plugin loads to 1 second
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
-     }
-@@ -920,7 +920,7 @@ public final class CraftServer implements Server {
+ 
+@@ -927,7 +927,7 @@ public final class CraftServer implements Server {
          this.console.setMotd(config.motd);
          this.overrideSpawnLimits();
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -44,7 +44,7 @@ index 47f08915f821af2ddac80c58a484061ba51eeade..e0c7109a78977118a30b6eb3b54cb896
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 759370eff9dd53f41d7b00b8372154acf43908e6..daa6f460d6a1006f91ea5fe63ce86625796801f4 100644
+index 86e512629b5ee0133b1c0b9e3d8ec2d4023661f0..914d0bdd82455f938d08d78c75aabead729bb785 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -277,8 +277,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0459-Add-PrepareResultEvent.patch
+++ b/patches/server/0459-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index cdebd0cdf6eb901464cf4c16089b10ea0147b54d..b47dc7671fab2117b989d647d7e8e36d
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1507a172d10986f717cbdaae9890e28c917cf4b3..b0aec2a6174048f38dd85360a4dda883ecff7111 100644
+index 9b94df9940040f51fdcc1af5c7da96117af9017e..c2eefe215f47e36cc2b8476750ae00ec88f826a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1593,19 +1593,44 @@ public class CraftEventFactory {
+@@ -1594,19 +1594,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0475-Add-setMaxPlayers-API.patch
+++ b/patches/server/0475-Add-setMaxPlayers-API.patch
@@ -18,10 +18,10 @@ index be7a25560cd5521ddfe4793c7e51b1036fc8a19c..869fa7c3913185c3537185426e75c076
      private int simulationDistance;
      private boolean allowCheatsForAllPlayers;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e0c7109a78977118a30b6eb3b54cb896f8c7100e..e824869ede5b6bd531609c2f4e5cb7edfafb4904 100644
+index 0efc62fce74e545ed87fa96c25f1178945c87ea5..d7d1c374aac8d7ba9b1eeed41b5caa20add19d72 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -663,6 +663,13 @@ public final class CraftServer implements Server {
+@@ -670,6 +670,13 @@ public final class CraftServer implements Server {
          return this.playerList.getMaxPlayers();
      }
  

--- a/patches/server/0514-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0514-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e824869ede5b6bd531609c2f4e5cb7edfafb4904..41eaca0ef3d5d309fab7e7dddff0310d24c88966 100644
+index d7d1c374aac8d7ba9b1eeed41b5caa20add19d72..ae0395fb03177f29707d14a4ddd090eafe06d1f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1782,6 +1782,28 @@ public final class CraftServer implements Server {
+@@ -1799,6 +1799,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0559-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0559-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 1415ad60163f6584619cc7caa61f1848d6ebaa93..801c4c120e98584bcf218a4ef9bd66d7
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 46189c02e94af8520bf7e226f3924ba8952e72d6..f89228c0c38c4acc299248e7d9639442eedca08b 100644
+index 7f8dbc94ad04ff58e0ee7591b42e268ee4b75576..5162109ea1f8284f0302306f8dac3048ce0b7010 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1867,4 +1867,12 @@ public class CraftEventFactory {
+@@ -1868,4 +1868,12 @@ public class CraftEventFactory {
          EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
      }

--- a/patches/server/0575-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0575-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 85c5319837295bd2f85baebfe8d6660b267f1d5f..8f55d0753fa26924235c943595f0d1a0
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a45ed570a7bf1becbc91c97c3890e99c0e5ebc0c..142a51d7ed13da93ecc3dc790d880b7c81365d78 100644
+index 7bafab016aeb3b1177b23f44696e7178f25d414a..2c45c71274e026936c0e1c91e1b0555f21a7a611 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1885,5 +1885,11 @@ public class CraftEventFactory {
+@@ -1886,5 +1886,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0579-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0579-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index 7eb315aac7737cf443c693147c2cfd871f201724..03de59302041b0bc13922ec129501417
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 142a51d7ed13da93ecc3dc790d880b7c81365d78..7893c10295abcd6ab2e3c4458c31f0b8914ba4c3 100644
+index 2c45c71274e026936c0e1c91e1b0555f21a7a611..9ccfe52a61b72addfa675af797ea4bafbff30bdb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1526,8 +1526,10 @@ public class CraftEventFactory {
+@@ -1527,8 +1527,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0603-Expand-world-key-API.patch
+++ b/patches/server/0603-Expand-world-key-API.patch
@@ -20,10 +20,10 @@ index ee5e59c37301d9a806e2f696d52d9d217b232833..bb5d22125b6cd4e60d2b7e2e00af158c
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 41eaca0ef3d5d309fab7e7dddff0310d24c88966..5a84f867bd3b422706d03b75800adb9d7c445fc9 100644
+index ae0395fb03177f29707d14a4ddd090eafe06d1f4..484e0a506f29189b14fd5570ad926d941513ca43 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1132,9 +1132,15 @@ public final class CraftServer implements Server {
+@@ -1139,9 +1139,15 @@ public final class CraftServer implements Server {
          File folder = new File(this.getWorldContainer(), name);
          World world = this.getWorld(name);
  
@@ -41,7 +41,7 @@ index 41eaca0ef3d5d309fab7e7dddff0310d24c88966..5a84f867bd3b422706d03b75800adb9d
  
          if ((folder.exists()) && (!folder.isDirectory())) {
              throw new IllegalArgumentException("File exists with the name '" + name + "' and isn't a folder");
-@@ -1209,7 +1215,7 @@ public final class CraftServer implements Server {
+@@ -1216,7 +1222,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -50,7 +50,7 @@ index 41eaca0ef3d5d309fab7e7dddff0310d24c88966..5a84f867bd3b422706d03b75800adb9d
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, worlddimension, this.getServer().progressListenerFactory.create(11),
-@@ -1301,6 +1307,15 @@ public final class CraftServer implements Server {
+@@ -1308,6 +1314,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0641-Add-basic-Datapack-API.patch
+++ b/patches/server/0641-Add-basic-Datapack-API.patch
@@ -92,10 +92,10 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5a84f867bd3b422706d03b75800adb9d7c445fc9..2e1dd08b7bd9836c8ff590db43008ec83a0fd51f 100644
+index 484e0a506f29189b14fd5570ad926d941513ca43..67918c88f1db2c84067cf707407ce9bd3c70f31d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -276,6 +276,7 @@ public final class CraftServer implements Server {
+@@ -278,6 +278,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -103,15 +103,15 @@ index 5a84f867bd3b422706d03b75800adb9d7c445fc9..2e1dd08b7bd9836c8ff590db43008ec8
      public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {
-@@ -357,6 +358,7 @@ public final class CraftServer implements Server {
-         TicketType.PLUGIN.timeout = Math.min(20, this.configuration.getInt("chunk-gc.period-in-ticks")); // Paper - cap plugin loads to 1 second
-         this.minimumAPI = this.configuration.getString("settings.minimum-api");
-         this.loadIcon();
+@@ -364,6 +365,7 @@ public final class CraftServer implements Server {
+         if (this.configuration.getBoolean("settings.use-map-color-cache")) {
+             MapPalette.setMapColorCache(new CraftMapColorCache(this.logger));
+         }
 +        datapackManager = new io.papermc.paper.datapack.PaperDatapackManager(console.getPackRepository()); // Paper
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2734,5 +2736,11 @@ public final class CraftServer implements Server {
+@@ -2756,5 +2758,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0647-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0647-Fix-and-optimise-world-force-upgrading.patch
@@ -272,7 +272,7 @@ index ce4aed84d751a48dcd2a8409190db4a22d78f77b..0a843e0afbcb1af8e2641515eb244b79
          Main.LOGGER.info("Forcing world upgrade! {}", session.getLevelId()); // CraftBukkit
          WorldUpgrader worldupgrader = new WorldUpgrader(session, dataFixer, generatorOptions, eraseCache);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ff2a9dbacffdb1e4b790aedd61b82c7adf0831aa..e232039b939ea226348405836dece6e5ac926aa8 100644
+index f73f16ffc65467db8fa370beddffb7cae054a13c..4ad7c5377c67fd156353166145b1edd39e41cd02 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -542,11 +542,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -356,10 +356,10 @@ index a96a6af2bcec3134b7caa32299bd07af50e83b89..0d96d1c0b66c57c680759f3567ef1b0c
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2e1dd08b7bd9836c8ff590db43008ec83a0fd51f..4c5228b4e2fc3bf817011391b18b39ac95666e71 100644
+index 67918c88f1db2c84067cf707407ce9bd3c70f31d..649f78cc3491d0a14627485eadb67315135fda27 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1193,12 +1193,7 @@ public final class CraftServer implements Server {
+@@ -1200,12 +1200,7 @@ public final class CraftServer implements Server {
          }
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().shouldReportAsModified());
@@ -373,7 +373,7 @@ index 2e1dd08b7bd9836c8ff590db43008ec83a0fd51f..4c5228b4e2fc3bf817011391b18b39ac
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1210,6 +1205,13 @@ public final class CraftServer implements Server {
+@@ -1217,6 +1212,13 @@ public final class CraftServer implements Server {
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
  

--- a/patches/server/0685-Add-System.out-err-catcher.patch
+++ b/patches/server/0685-Add-System.out-err-catcher.patch
@@ -105,10 +105,10 @@ index 0000000000000000000000000000000000000000..76d0d00cd6742991e3f3ec827a75ee87
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4c5228b4e2fc3bf817011391b18b39ac95666e71..93f6e89de9c595d0ee492cd3fce99c9f3c5611ec 100644
+index 649f78cc3491d0a14627485eadb67315135fda27..61879f872dfc56890246a96f44f4a397b19c63d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -278,6 +278,7 @@ public final class CraftServer implements Server {
+@@ -280,6 +280,7 @@ public final class CraftServer implements Server {
      public int reloadCount;
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings

--- a/patches/server/0712-Add-critical-damage-API.patch
+++ b/patches/server/0712-Add-critical-damage-API.patch
@@ -72,10 +72,10 @@ index f02fb03c63975e5c1ccdd848f5727559929cce00..8564ecd20578d907bcfa1b9c149da22e
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 7570d5254b5807e967e7ab2560f091a9d601a876..1d8ec0f85ec42f2dcd9405df83b526ae1c59de6f 100644
+index 82d8a8c2199673315c7b52e694f798cc59c5f96c..03d389f3458cd77166a0319fa38c7207e8714e6f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -978,7 +978,7 @@ public class CraftEventFactory {
+@@ -979,7 +979,7 @@ public class CraftEventFactory {
                  } else {
                      damageCause = DamageCause.ENTITY_EXPLOSION;
                  }
@@ -84,7 +84,7 @@ index 7570d5254b5807e967e7ab2560f091a9d601a876..1d8ec0f85ec42f2dcd9405df83b526ae
              }
              event.setCancelled(cancelled);
  
-@@ -1007,7 +1007,7 @@ public class CraftEventFactory {
+@@ -1008,7 +1008,7 @@ public class CraftEventFactory {
                  cause = DamageCause.SONIC_BOOM;
              }
  
@@ -93,7 +93,7 @@ index 7570d5254b5807e967e7ab2560f091a9d601a876..1d8ec0f85ec42f2dcd9405df83b526ae
          } else if (source == DamageSource.OUT_OF_WORLD) {
              EntityDamageEvent event = new EntityDamageByBlockEvent(null, entity.getBukkitEntity(), DamageCause.VOID, modifiers, modifierFunctions);
              event.setCancelled(cancelled);
-@@ -1077,7 +1077,7 @@ public class CraftEventFactory {
+@@ -1078,7 +1078,7 @@ public class CraftEventFactory {
              } else {
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager.getHandle(), source.msgId));
              }
@@ -102,7 +102,7 @@ index 7570d5254b5807e967e7ab2560f091a9d601a876..1d8ec0f85ec42f2dcd9405df83b526ae
              event.setCancelled(cancelled);
              CraftEventFactory.callEvent(event);
              if (!event.isCancelled()) {
-@@ -1122,20 +1122,28 @@ public class CraftEventFactory {
+@@ -1123,20 +1123,28 @@ public class CraftEventFactory {
          }
  
          if (cause != null) {

--- a/patches/server/0729-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0729-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -293,10 +293,10 @@ index fa23e9c476d4edc6176d8b8a6cb13c52d2f66a87..4150e8cd7197eac53042d56f0a53a495
          // Paper start - add parameters and int ret type
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 93f6e89de9c595d0ee492cd3fce99c9f3c5611ec..de43370cb6a4f2e8d32a8c35478af27dd9f909a4 100644
+index 61879f872dfc56890246a96f44f4a397b19c63d3..0d89472359ac6fed10a20c825a0b3b28064f86fc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2130,6 +2130,11 @@ public final class CraftServer implements Server {
+@@ -2152,6 +2152,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
@@ -309,7 +309,7 @@ index 93f6e89de9c595d0ee492cd3fce99c9f3c5611ec..de43370cb6a4f2e8d32a8c35478af27d
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7a2a8e1aeca2002378a40be5cef32238350086a7..9bcfcd0f61cba99ff74b35a50a6e419dfea880ee 100644
+index 422655d6ab17d075d045df8e5ce1666c92f9321a..9528bc7e6c0a2d9020869d0a81ed39e1a8ab9605 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1706,9 +1706,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0801-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0801-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index de43370cb6a4f2e8d32a8c35478af27dd9f909a4..bb9badc79bd153bda9cd841a5817f36bb93ff1a0 100644
+index 0d89472359ac6fed10a20c825a0b3b28064f86fc..9add1f02d75925e3d6a0767f0d65b2c0ef8ad697 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2298,6 +2298,90 @@ public final class CraftServer implements Server {
+@@ -2320,6 +2320,90 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0826-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0826-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose vanilla BiomeProvider from WorldInfo
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d916f88e48e0097d9852a231b35431a06745d325..b0300d08475b4377e26bd5c9c432b554849b452a 100644
+index e977a523759f360854fa0a3ab8bbb956f0c0fdc2..a0f9842bce847d8ff9dfc68801804365ac12e265 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -559,7 +559,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -18,10 +18,10 @@ index d916f88e48e0097d9852a231b35431a06745d325..b0300d08475b4377e26bd5c9c432b554
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bb9badc79bd153bda9cd841a5817f36bb93ff1a0..1d6622f7b549aced182975c64341d61fa14db86c 100644
+index 9add1f02d75925e3d6a0767f0d65b2c0ef8ad697..d66f8e409ece3b06fe14ab3eca8b74991bcfe2db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1201,7 +1201,7 @@ public final class CraftServer implements Server {
+@@ -1208,7 +1208,7 @@ public final class CraftServer implements Server {
          Registry<LevelStem> iregistry = worlddata.worldGenSettings().dimensions();
          LevelStem worlddimension = (LevelStem) iregistry.get(actualDimension);
  
@@ -31,7 +31,7 @@ index bb9badc79bd153bda9cd841a5817f36bb93ff1a0..1d6622f7b549aced182975c64341d61f
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c4913fd3efb52669645d2d71bce1bdf71d4fa063..335bf78d95418fbc7718177f012c71c392ab554c 100644
+index 73ad41f2a6f43a05fdb4c8a7787d8e5fae9694ed..377e80a80e60173a709d805ed94bb3af91930453 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -195,6 +195,30 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0841-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0841-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1d6622f7b549aced182975c64341d61fa14db86c..5f7a77ec7047d2fb0bc64608e0e74a7e524c93c9 100644
+index d66f8e409ece3b06fe14ab3eca8b74991bcfe2db..b90bb11b12fa88c10ec4ffde740ab8f5a4afec69 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1969,6 +1969,13 @@ public final class CraftServer implements Server {
+@@ -1986,6 +1986,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  

--- a/patches/server/0846-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0846-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5f7a77ec7047d2fb0bc64608e0e74a7e524c93c9..4e5cdd103758c5c17467a72dcaee837d7dbf4b8e 100644
+index b90bb11b12fa88c10ec4ffde740ab8f5a4afec69..50d617133ef73713ce5329e826c8a97e1d89a023 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2138,6 +2138,8 @@ public final class CraftServer implements Server {
+@@ -2160,6 +2160,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start

--- a/patches/server/0847-Add-GameEvent-tags.patch
+++ b/patches/server/0847-Add-GameEvent-tags.patch
@@ -45,10 +45,10 @@ index 0000000000000000000000000000000000000000..cb78a3d4e21376ea24347187478525d5
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4e5cdd103758c5c17467a72dcaee837d7dbf4b8e..9035189f4640ecd7c642410824b61b0cbd309358 100644
+index 50d617133ef73713ce5329e826c8a97e1d89a023..14c06e1643878b5307c7177f0c05bd5e7b31f0af 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2544,6 +2544,15 @@ public final class CraftServer implements Server {
+@@ -2566,6 +2566,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(Registry.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -64,7 +64,7 @@ index 4e5cdd103758c5c17467a72dcaee837d7dbf4b8e..9035189f4640ecd7c642410824b61b0c
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2576,6 +2585,13 @@ public final class CraftServer implements Server {
+@@ -2598,6 +2607,13 @@ public final class CraftServer implements Server {
                  Registry<EntityType<?>> entityTags = Registry.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0854-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0854-Put-world-into-worldlist-before-initing-the-world.patch
@@ -7,7 +7,7 @@ Some parts of legacy conversion will need the overworld
 to get the legacy structure data storage
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 38e41238cb8629fb511f7d4ba35665c1c41c3c5d..0ab7cf2b3b3fcb76a0f2eea300da7a29c258cd48 100644
+index 4c04c4b65039219be62e8a742fdf6789efa80e87..7bcfb1420e67f941df4dd39a3b94c02f03ee27fa 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -598,9 +598,10 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -23,10 +23,10 @@ index 38e41238cb8629fb511f7d4ba35665c1c41c3c5d..0ab7cf2b3b3fcb76a0f2eea300da7a29
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9035189f4640ecd7c642410824b61b0cbd309358..9dc43d848aacd6c5855652ef193d980307a0adc4 100644
+index 14c06e1643878b5307c7177f0c05bd5e7b31f0af..f2a18511119bc52ef3ab06165be68b6afa57bfad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1230,10 +1230,11 @@ public final class CraftServer implements Server {
+@@ -1237,10 +1237,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0856-Custom-Potion-Mixes.patch
+++ b/patches/server/0856-Custom-Potion-Mixes.patch
@@ -164,10 +164,10 @@ index 3d688e334c7287f41460bd866bfd1155e8bb55d2..55006724ccec9f3de828ec18693728e9
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9dc43d848aacd6c5855652ef193d980307a0adc4..0e5b0c53f7540655dd9b5d9af67161233ef6df65 100644
+index f2a18511119bc52ef3ab06165be68b6afa57bfad..6ffd1c69bf9372dadaadbb36de8ca4b8a56cc1a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -279,6 +279,7 @@ public final class CraftServer implements Server {
+@@ -281,6 +281,7 @@ public final class CraftServer implements Server {
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings
      private final io.papermc.paper.logging.SysoutCatcher sysoutCatcher = new io.papermc.paper.logging.SysoutCatcher(); // Paper
@@ -175,7 +175,7 @@ index 9dc43d848aacd6c5855652ef193d980307a0adc4..0e5b0c53f7540655dd9b5d9af6716123
  
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
-@@ -305,7 +306,7 @@ public final class CraftServer implements Server {
+@@ -307,7 +308,7 @@ public final class CraftServer implements Server {
          Enchantments.SHARPNESS.getClass();
          org.bukkit.enchantments.Enchantment.stopAcceptingRegistrations();
  
@@ -184,7 +184,7 @@ index 9dc43d848aacd6c5855652ef193d980307a0adc4..0e5b0c53f7540655dd9b5d9af6716123
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2860,5 +2861,10 @@ public final class CraftServer implements Server {
+@@ -2882,5 +2883,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0857-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0857-Replace-player-chunk-loader-system.patch
@@ -1218,7 +1218,7 @@ index 0000000000000000000000000000000000000000..b53402903eb6845df361daf6b05a6686
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 0e5f05d091710da9078021eb6e1a26a22e2d63dd..c1e8d8674738eebaaf7bd918eacb5227a1331b67 100644
+index 9549e8ed4b245176b340ab2f22f4bdefdbe28a9e..b65a3626d2e0817cd1e223ec3b10e82fa0339663 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -104,6 +104,28 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -1855,7 +1855,7 @@ index 96a232f22b1c270b91635ce9c7c6cacc63b026cc..59acbf6249f8f5285504c0ddea448a34
                  return true;
              } else {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 68267114d6e54323258483d59e8971b0e031218c..da1533ade2d51a6a978ba4334d07b07681421693 100644
+index 01fd17fa845d4f03f3e7e599f42e56f51dd52ff6..b021fc77687cf7f569e5bf6fbb481c486e27e5a6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -676,7 +676,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -1942,10 +1942,10 @@ index c0ed1103e649e619c58f59c7bedd6a18a58f71ea..e57636efacedf1c6f1ccd4f01f7e94d6
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 21d26be5edbc05ac78c2f4a092594d772d98c982..266bce9339253df972062fe85ba7e5b4f289a2c5 100644
+index 3a6e5893181ed681099f2748abca738af45ec9c9..bb51a85b33e1701c2e445305d68d3453772f73df 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -640,7 +640,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -660,7 +660,7 @@ public class EnderDragon extends Mob implements Enemy {
                  // this.world.b(1028, this.getChunkCoordinates(), 0);
                  //int viewDistance = ((WorldServer) this.world).getServer().getViewDistance() * 16; // Paper - updated to use worlds actual view distance incase we have to uncomment this due to removal of player view distance API
                  for (net.minecraft.server.level.ServerPlayer player : (List<net.minecraft.server.level.ServerPlayer>) ((ServerLevel)level).players()) {

--- a/patches/server/0872-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0872-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0e5b0c53f7540655dd9b5d9af67161233ef6df65..74b19b0fa6a0f8e5c75338930e75a40618d135c8 100644
+index 6ffd1c69bf9372dadaadbb36de8ca4b8a56cc1a7..cf808977652d51a0e6ab2931ca6a2748d577f39d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1278,7 +1278,7 @@ public final class CraftServer implements Server {
+@@ -1285,7 +1285,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0880-Allow-to-change-the-podium-for-the-EnderDragon.patch
+++ b/patches/server/0880-Allow-to-change-the-podium-for-the-EnderDragon.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow to change the podium for the EnderDragon
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 266bce9339253df972062fe85ba7e5b4f289a2c5..219877901fb5fc6401646253d6e5d7bd8416ffe1 100644
+index bb51a85b33e1701c2e445305d68d3453772f73df..47d6236daca806878399890a8d08e55233f19fd9 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 @@ -99,6 +99,10 @@ public class EnderDragon extends Mob implements Enemy {
@@ -39,7 +39,7 @@ index 266bce9339253df972062fe85ba7e5b4f289a2c5..219877901fb5fc6401646253d6e5d7bd
      @Override
      public boolean isFlapping() {
          float f = Mth.cos(this.flapTime * 6.2831855F);
-@@ -944,7 +961,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -970,7 +987,7 @@ public class EnderDragon extends Mob implements Enemy {
                  d0 = segment2[1] - segment1[1];
              }
          } else {
@@ -48,7 +48,7 @@ index 266bce9339253df972062fe85ba7e5b4f289a2c5..219877901fb5fc6401646253d6e5d7bd
              double d1 = Math.max(Math.sqrt(blockposition.distToCenterSqr(this.position())) / 4.0D, 1.0D);
  
              d0 = (double) segmentOffset / d1;
-@@ -971,7 +988,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -997,7 +1014,7 @@ public class EnderDragon extends Mob implements Enemy {
                  vec3d = this.getViewVector(tickDelta);
              }
          } else {

--- a/patches/server/0888-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0888-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 74b19b0fa6a0f8e5c75338930e75a40618d135c8..4ac6b213b5fd3b5da2f084472fac853cd360ac45 100644
+index cf808977652d51a0e6ab2931ca6a2748d577f39d..925c9359a3e33abfdc6463572b96191381cec480 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1237,6 +1237,7 @@ public final class CraftServer implements Server {
+@@ -1244,6 +1244,7 @@ public final class CraftServer implements Server {
          internal.setSpawnSettings(true, true);
          // Paper - move up
  

--- a/patches/server/0904-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0904-Throw-exception-on-world-create-while-being-ticked.patch
@@ -7,7 +7,7 @@ There are no plans to support creating worlds while worlds are
 being ticked themselvess.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 60de49a9888b6dfe17dcb0d9dd0dd3d2e7d829aa..9e1d3a22ed7e34e4968b5fb34cc77b661eb4747d 100644
+index ed799a59411d637d0f50a62c73e2b23053fbcb0e..77cd45f616e2ff38ad6a648b8b865a99e544f3ec 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -294,6 +294,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -35,10 +35,10 @@ index 60de49a9888b6dfe17dcb0d9dd0dd3d2e7d829aa..9e1d3a22ed7e34e4968b5fb34cc77b66
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4ac6b213b5fd3b5da2f084472fac853cd360ac45..f1e5ccfbcd08a73ac3aba9a1cb7b414faef81f9e 100644
+index 925c9359a3e33abfdc6463572b96191381cec480..6e4ccdcd1e9d3be217f26ad187300e15531fe811 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1128,6 +1128,7 @@ public final class CraftServer implements Server {
+@@ -1135,6 +1135,7 @@ public final class CraftServer implements Server {
      @Override
      public World createWorld(WorldCreator creator) {
          Preconditions.checkState(!console.levels.isEmpty(), "Cannot create additional worlds on STARTUP");

--- a/patches/server/0915-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0915-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index c0195f73cd2c8721e882c681eaead65471710081..861b348f73867af3199f1cc0dab1ddd4
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f1e5ccfbcd08a73ac3aba9a1cb7b414faef81f9e..72311b27bb642ee05dba45b76935277d183012eb 100644
+index 6e4ccdcd1e9d3be217f26ad187300e15531fe811..61c2f864bb23e75f6c377f7ccbf2ec44a670348c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1736,7 +1736,7 @@ public final class CraftServer implements Server {
+@@ -1753,7 +1753,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
05ae036c PR-746: Add option to use cached map color palette
57849c1b PR-759: Add preview chat option in ServerListPingEvent
0169e65d PR-758: Add missing server properties methods from 1.19

CraftBukkit Changes:
622dbe6c2 SPIGOT-7068: SKULK and SKULK_VEIN BlockSpreadEvents Still do not reference the correct source (SKULK_CATALYST)
6c61b73f3 PR-1052: Add option to use cached map color palette
c882f38ea SPIGOT-7066: Fix custom END worlds not generating DragonBattle
6866aab59 SPIGOT-2420: Can't set exp drops for EnderDragon death
9dcd46530 PR-1067: Add preview chat option in ServerListPingEvent
36c2681af PR-1066: Add missing server properties methods from 1.19
031eaadd0 Increase outdated build delay
8fda4b12f SPIGOT-7060: SCULK and SCULK_VEIN BlockSpreadEvents do not reference the correct source