### PR TITLE
Add more needed BlockStateListPopulator Methods

### DIFF
--- a/patches/server/0908-Add-missing-important-BlockStateListPopulator-method.patch
+++ b/patches/server/0908-Add-missing-important-BlockStateListPopulator-method.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing important BlockStateListPopulator methods
 Without these methods it causes exceptions due to these being used by certain feature generators.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java b/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
-index 8e6a71c1e8b53faa70b893c76f5bd25f96a5e142..03153abb425acf2d615acc386c91a6524aaa80bf 100644
+index 8e6a71c1e8b53faa70b893c76f5bd25f96a5e142..19abf7b6000a875be8c7141cfba81b279b2cae60 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
-@@ -129,4 +129,27 @@ public class BlockStateListPopulator extends DummyGeneratorAccess {
+@@ -129,4 +129,32 @@ public class BlockStateListPopulator extends DummyGeneratorAccess {
      public DimensionType dimensionType() {
          return this.world.dimensionType();
      }
@@ -32,8 +32,35 @@ index 8e6a71c1e8b53faa70b893c76f5bd25f96a5e142..03153abb425acf2d615acc386c91a652
 +    }
 +
 +    @Override
++    public int getHeight(net.minecraft.world.level.levelgen.Heightmap.Types heightmap, int x, int z) {
++        return world.getHeight(heightmap, x, z);
++    }
++
++    @Override
 +    public net.minecraft.world.level.storage.LevelData getLevelData() {
 +        return world.getLevelData();
 +    }
 +    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java b/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java
+index fbd82b6be6604bf854e01ed5718e4e072f42b265..cd0dc080fbd8c5b1509d67e2b60264393b2b7dbb 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java
+@@ -269,5 +269,17 @@ public class DummyGeneratorAccess implements WorldGenLevel {
+ 
+     @Override
+     public <T> void getEntitiesByClass(Class<? extends T> clazz, Entity except, AABB box, List<? super T> into, Predicate<? super T> predicate) {}
++
++    @Override
++    public void scheduleTick(BlockPos pos, Fluid fluid, int delay) {
++    }
++
++    @Override
++    public void scheduleTick(BlockPos pos, Block block, int delay, net.minecraft.world.ticks.TickPriority priority) {
++    }
++
++    @Override
++    public void scheduleTick(BlockPos pos, Fluid fluid, int delay, net.minecraft.world.ticks.TickPriority priority) {
++    }
+     // Paper end
  }


### PR DESCRIPTION
Tried to look through and find any more important missing ones.

Put some in the DummyGeneratorAccess as it currently has a schedule tick method already.
![image](https://user-images.githubusercontent.com/23108066/174497139-cdb15efe-cbc3-4f25-bc82-4714425e42cb.png)
 The nextSubTickCount is only called by createTick which is only called by the schedule tick methods. 

Can be reproduced by trying to place a propagule in water (tries to schedule a liquid tick).
```kt
java.lang.UnsupportedOperationException: Not supported yet.
	at org.bukkit.craftbukkit.util.DummyGeneratorAccess.nextSubTickCount(DummyGeneratorAccess.java:64) ~[main/:?]
	at net.minecraft.world.level.LevelAccessor.createTick(LevelAccessor.java:43) ~[main/:?]
	at net.minecraft.world.level.LevelAccessor.scheduleTick(LevelAccessor.java:61) ~[main/:?]
	at net.minecraft.world.level.block.MangroveRootsBlock.updateShape(MangroveRootsBlock.java:40) ~[minecraft.jar:?]
	at net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase.updateShape(BlockBehaviour.java:1068) ~[main/:?]
	at net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.lambda$updateShapeAtEdge$4(StructureTemplate.java:414) ~[main/:?]
	at net.minecraft.world.phys.shapes.DiscreteVoxelShape.forAllAxisFaces(DiscreteVoxelShape.java:191) ~[minecraft.jar:?]
	at net.minecraft.world.phys.shapes.DiscreteVoxelShape.forAllFaces(DiscreteVoxelShape.java:170) ~[minecraft.jar:?]
	at net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.updateShapeAtEdge(StructureTemplate.java:409) ~[main/:?]
	at net.minecraft.world.level.levelgen.feature.TreeFeature.lambda$place$11(TreeFeature.java:163) ~[minecraft.jar:?]
	at java.util.Optional.map(Optional.java:260) ~[?:?]
	at net.minecraft.world.level.levelgen.feature.TreeFeature.place(TreeFeature.java:161) ~[minecraft.jar:?]
	at net.minecraft.world.level.levelgen.feature.Feature.place(Feature.java:154) ~[minecraft.jar:?]
	at net.minecraft.world.level.levelgen.feature.ConfiguredFeature.place(ConfiguredFeature.java:24) ~[minecraft.jar:?]
	at org.bukkit.craftbukkit.CraftRegionAccessor.generateTree(CraftRegionAccessor.java:395) ~[main/:?]
	at org.bukkit.craftbukkit.CraftRegionAccessor.generateTree(CraftRegionAccessor.java:311) ~[main/:?]
	at io.papermc.paper.testplugin.TestPlugin.onInteract(TestPlugin.java:19) ~[test-plugin-1.0.0-SNAPSHOT.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor1.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:75) ~[paper-api-1.19-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.19-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:664) ~[paper-api-1.19-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:544) ~[main/:?]
	at net.minecraft.server.level.ServerPlayerGameMode.useItemOn(ServerPlayerGameMode.java:527) ~[main/:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleUseItemOn(ServerGamePacketListenerImpl.java:1872) ~[main/:?]
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.handle(ServerboundUseItemOnPacket.java:37) ~[main/:?]
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.handle(ServerboundUseItemOnPacket.java:9) ~[main/:?]
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:51) ~[main/:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[minecraft.jar:?]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[main/:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[minecraft.jar:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1358) ~[main/:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:183) ~[main/:?]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[main/:?]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1335) ~[main/:?]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1328) ~[main/:?]
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[main/:?]
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1306) ~[main/:?]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1191) ~[main/:?]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:302) ~[main/:?]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]

```