### PR TITLE
Call StructureGrowEvent for mangrove propagule

### DIFF
--- a/patches/server/0922-Call-StructureGrowEvent-for-mangrove-propagule.patch
+++ b/patches/server/0922-Call-StructureGrowEvent-for-mangrove-propagule.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Mon, 20 Jun 2022 15:46:46 +0200
+Subject: [PATCH] Call StructureGrowEvent for mangrove propagule
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/MangrovePropaguleBlock.java b/src/main/java/net/minecraft/world/level/block/MangrovePropaguleBlock.java
+index 4eaf75ef7362ee781762f5e8def6bc4d986e9db7..0a60918ec9b2374cd9ae375a8d36ed1a212c19ae 100644
+--- a/src/main/java/net/minecraft/world/level/block/MangrovePropaguleBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/MangrovePropaguleBlock.java
+@@ -90,7 +90,28 @@ public class MangrovePropaguleBlock extends SaplingBlock implements SimpleWaterl
+     public void randomTick(BlockState state, ServerLevel world, BlockPos pos, RandomSource random) {
+         if (!isHanging(state)) {
+             if (random.nextInt(7) == 0) {
++                world.captureTreeGeneration = true; // Paper
+                 this.advanceTree(world, pos, state, random);
++                // Paper start
++                world.captureTreeGeneration = false;
++                if (world.capturedBlockStates.size() > 0) {
++                    org.bukkit.TreeType treeType = SaplingBlock.treeType;
++                    SaplingBlock.treeType = null;
++                    org.bukkit.Location location = new org.bukkit.Location(world.getWorld(), pos.getX(), pos.getY(), pos.getZ());
++                    java.util.List<org.bukkit.block.BlockState> blocks = new java.util.ArrayList<>(world.capturedBlockStates.values());
++                    world.capturedBlockStates.clear();
++                    org.bukkit.event.world.StructureGrowEvent event = null;
++                    if (treeType != null) {
++                        event = new org.bukkit.event.world.StructureGrowEvent(location, treeType, false, null, blocks);
++                        org.bukkit.Bukkit.getPluginManager().callEvent(event);
++                    }
++                    if (event == null || !event.isCancelled()) {
++                        for (org.bukkit.block.BlockState blockstate : blocks) {
++                            blockstate.update(true);
++                        }
++                    }
++                }
++                // Paper end
+             }
+ 
+         } else {


### PR DESCRIPTION
Fixes #8022. Event capturing code is the exact same as in `SaplingBlock#randomTick`.