### PR TITLE
Call PlayerLaunchProjectileEvent for trident

### DIFF
--- a/patches/api/0126-PlayerLaunchProjectileEvent.patch
+++ b/patches/api/0126-PlayerLaunchProjectileEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] PlayerLaunchProjectileEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..13a3d0c75c337e8be105d92c4d08a6cd7f783474
+index 0000000000000000000000000000000000000000..9074b2ede01f76c0560e5318246382163cc91591
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java
-@@ -0,0 +1,85 @@
+@@ -0,0 +1,83 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Player;
@@ -58,7 +58,6 @@ index 0000000000000000000000000000000000000000..13a3d0c75c337e8be105d92c4d08a6cd
 +
 +    /**
 +     * Get whether to consume the ItemStack or not
-+     * Note: this does nothing for reusable and throwable item like the trident
 +     *
 +     * @return True to consume
 +     */
@@ -68,7 +67,6 @@ index 0000000000000000000000000000000000000000..13a3d0c75c337e8be105d92c4d08a6cd
 +
 +    /**
 +     * Set whether to consume the ItemStack or not
-+     * Note: this does nothing for reusable and throwable item like the trident
 +     *
 +     * @param consumeItem True to consume
 +     */

--- a/patches/api/0126-PlayerLaunchProjectileEvent.patch
+++ b/patches/api/0126-PlayerLaunchProjectileEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] PlayerLaunchProjectileEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a605dd83de8ae22cdf6d1861266ae747a3b91198
+index 0000000000000000000000000000000000000000..5450575459f2d95be93db5a8c6d4d88c69deb2ec
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java
-@@ -0,0 +1,85 @@
+@@ -0,0 +1,87 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Player;
@@ -22,8 +22,10 @@ index 0000000000000000000000000000000000000000..a605dd83de8ae22cdf6d1861266ae747
 +
 +/**
 + * Called when a player shoots a projectile.
-+ * For arrows, this event isn't called for that you can
-+ * listen the {@link org.bukkit.event.entity.EntityShootBowEvent EntityShootBowEvent} instead.
++ * <p>
++ * Notably this event is not called for arrows as the player does not launch them, rather shoots them with the help
++ * of a bow or crossbow. A plugin may listen to {@link org.bukkit.event.entity.EntityShootBowEvent} for these actions
++ * instead.
 + */
 +public class PlayerLaunchProjectileEvent extends PlayerEvent implements Cancellable {
 +    private static final HandlerList handlers = new HandlerList();

--- a/patches/api/0126-PlayerLaunchProjectileEvent.patch
+++ b/patches/api/0126-PlayerLaunchProjectileEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] PlayerLaunchProjectileEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9074b2ede01f76c0560e5318246382163cc91591
+index 0000000000000000000000000000000000000000..a605dd83de8ae22cdf6d1861266ae747a3b91198
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,85 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Player;
@@ -21,7 +21,9 @@ index 0000000000000000000000000000000000000000..9074b2ede01f76c0560e531824638216
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Called when a player shoots a projectile
++ * Called when a player shoots a projectile.
++ * For arrows, this event isn't called for that you can
++ * listen the {@link org.bukkit.event.entity.EntityShootBowEvent EntityShootBowEvent} instead.
 + */
 +public class PlayerLaunchProjectileEvent extends PlayerEvent implements Cancellable {
 +    private static final HandlerList handlers = new HandlerList();

--- a/patches/api/0126-PlayerLaunchProjectileEvent.patch
+++ b/patches/api/0126-PlayerLaunchProjectileEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] PlayerLaunchProjectileEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9074b2ede01f76c0560e5318246382163cc91591
+index 0000000000000000000000000000000000000000..13a3d0c75c337e8be105d92c4d08a6cd7f783474
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerLaunchProjectileEvent.java
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,85 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Player;
@@ -58,6 +58,7 @@ index 0000000000000000000000000000000000000000..9074b2ede01f76c0560e531824638216
 +
 +    /**
 +     * Get whether to consume the ItemStack or not
++     * Note: this does nothing for reusable and throwable item like the trident
 +     *
 +     * @return True to consume
 +     */
@@ -67,6 +68,7 @@ index 0000000000000000000000000000000000000000..9074b2ede01f76c0560e531824638216
 +
 +    /**
 +     * Set whether to consume the ItemStack or not
++     * Note: this does nothing for reusable and throwable item like the trident
 +     *
 +     * @param consumeItem True to consume
 +     */

--- a/patches/server/0225-PlayerLaunchProjectileEvent.patch
+++ b/patches/server/0225-PlayerLaunchProjectileEvent.patch
@@ -275,10 +275,10 @@ index 0673f62f25532955f3552b64f122e644d42027e4..de5bdceb4c8578fb972a2fd5ee0dfdae
          return InteractionResultHolder.sidedSuccess(itemStack, world.isClientSide());
      }
 diff --git a/src/main/java/net/minecraft/world/item/TridentItem.java b/src/main/java/net/minecraft/world/item/TridentItem.java
-index 998758be827efbcb7693ed36ab1dffc0ef0369bf..b4d4a26cf721fe4ca7d81c75e171616a07ca7f99 100644
+index 998758be827efbcb7693ed36ab1dffc0ef0369bf..9365f886a23a71c41091b22d46896ff18a5a0635 100644
 --- a/src/main/java/net/minecraft/world/item/TridentItem.java
 +++ b/src/main/java/net/minecraft/world/item/TridentItem.java
-@@ -83,7 +83,10 @@ public class TridentItem extends Item implements Vanishable {
+@@ -83,21 +83,25 @@ public class TridentItem extends Item implements Vanishable {
                              }
  
                              // CraftBukkit start
@@ -290,3 +290,20 @@ index 998758be827efbcb7693ed36ab1dffc0ef0369bf..b4d4a26cf721fe4ca7d81c75e171616a
                                  if (entityhuman instanceof net.minecraft.server.level.ServerPlayer) {
                                      ((net.minecraft.server.level.ServerPlayer) entityhuman).getBukkitEntity().updateInventory();
                                  }
+                                 return;
+                             }
+-
++                            if (event.shouldConsume()) { // Paper
+                             stack.hurtAndBreak(1, entityhuman, (entityhuman1) -> {
+                                 entityhuman1.broadcastBreakEvent(user.getUsedItemHand());
+                             });
++                            } // Paper
+                             entitythrowntrident.tridentItem = stack.copy(); // SPIGOT-4511 update since damage call moved
+                             // CraftBukkit end
+ 
+                             world.playSound((Player) null, (Entity) entitythrowntrident, SoundEvents.TRIDENT_THROW, SoundSource.PLAYERS, 1.0F, 1.0F);
+-                            if (!entityhuman.getAbilities().instabuild) {
++                            if (event.shouldConsume() && !entityhuman.getAbilities().instabuild) { // Paper
+                                 entityhuman.getInventory().removeItem(stack);
+                             }
+                             // CraftBukkit start - SPIGOT-5458 also need in this branch :(

--- a/patches/server/0225-PlayerLaunchProjectileEvent.patch
+++ b/patches/server/0225-PlayerLaunchProjectileEvent.patch
@@ -274,3 +274,19 @@ index 0673f62f25532955f3552b64f122e644d42027e4..de5bdceb4c8578fb972a2fd5ee0dfdae
  
          return InteractionResultHolder.sidedSuccess(itemStack, world.isClientSide());
      }
+diff --git a/src/main/java/net/minecraft/world/item/TridentItem.java b/src/main/java/net/minecraft/world/item/TridentItem.java
+index 998758be827efbcb7693ed36ab1dffc0ef0369bf..b4d4a26cf721fe4ca7d81c75e171616a07ca7f99 100644
+--- a/src/main/java/net/minecraft/world/item/TridentItem.java
++++ b/src/main/java/net/minecraft/world/item/TridentItem.java
+@@ -83,7 +83,10 @@ public class TridentItem extends Item implements Vanishable {
+                             }
+ 
+                             // CraftBukkit start
+-                            if (!world.addFreshEntity(entitythrowntrident)) {
++                            // Paper start
++                            com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent event = new com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent((org.bukkit.entity.Player) entityhuman.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(stack), (org.bukkit.entity.Projectile) entitythrowntrident.getBukkitEntity());
++                            if (!event.callEvent() || !world.addFreshEntity(entitythrowntrident)) {
++                                // Paper end
+                                 if (entityhuman instanceof net.minecraft.server.level.ServerPlayer) {
+                                     ((net.minecraft.server.level.ServerPlayer) entityhuman).getBukkitEntity().updateInventory();
+                                 }


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/7789
Call this event also for trident to avoid listening generic ProjectileLaunchEvent in the spawn area.
Currently i'm not really sure if the souldConsume method should do something or not
Also i think we should document the arrow case for this event (not triggered) and redirect to EntityShootBowEvent ?