### PR TITLE
Move old user conversion down slightly (fixes #8050)

### DIFF
--- a/patches/server/0597-fix-converting-txt-to-json-file.patch
+++ b/patches/server/0597-fix-converting-txt-to-json-file.patch
@@ -21,22 +21,22 @@ index d83bed436d2ad51cef83ecbf0c7df227a67ff404..dc96b30c70cd79d7b2a0322f32b9399a
          this.saveUserBanList();
          this.loadIpBanList();
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index ae45abf66d2e7b24d316a5db3d00c0b52f402b7f..0414974fc773a30810f88b54867034f5922eaa55 100644
+index ae45abf66d2e7b24d316a5db3d00c0b52f402b7f..7a2ef21a78c25e18ed61bd989b759783d89b54d5 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -199,6 +199,12 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
-         org.spigotmc.SpigotConfig.init((java.io.File) options.valueOf("spigot-settings"));
-         org.spigotmc.SpigotConfig.registerCommands();
-         // Spigot end
+@@ -203,6 +203,12 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         io.papermc.paper.util.ObfHelper.INSTANCE.getClass(); // Paper - load mappings for stacktrace deobf and etc.
+         paperConfigurations.initializeGlobalConfiguration();
+         paperConfigurations.initializeWorldDefaultsConfiguration();
 +        // Paper start - moved up to right after PlayerList creation but before file load/save
 +        if (this.convertOldUsers()) {
 +            this.getProfileCache().save(false); // Paper
 +        }
 +        this.getPlayerList().loadAndSaveFiles(); // Must be after convertNames
-+        // Paper end
-         // Paper start
-         io.papermc.paper.util.ObfHelper.INSTANCE.getClass(); // Paper - load mappings for stacktrace deobf and etc.
-         paperConfigurations.initializeGlobalConfiguration();
++        // Paper end - moved up
+         org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash);
+         io.papermc.paper.command.PaperCommands.registerCommands(this);
+         com.destroystokyo.paper.Metrics.PaperMetrics.startMetrics();
 @@ -258,9 +264,6 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
              DedicatedServer.LOGGER.warn("To change this, set \"online-mode\" to \"true\" in the server.properties file.");
          }

--- a/patches/server/0615-Enhance-console-tab-completions-for-brigadier-comman.patch
+++ b/patches/server/0615-Enhance-console-tab-completions-for-brigadier-comman.patch
@@ -198,7 +198,7 @@ index 0000000000000000000000000000000000000000..5ab8365b806dd035800ba9b449c9bc92
 +    public void setErrorIndex(final int errorIndex) {}
 +}
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 0414974fc773a30810f88b54867034f5922eaa55..4391bd846b039339c0ef807870c5fb517a6b1708 100644
+index cd65cd0fd6c1135dd53683617808aeb03b98216d..a89036addfc34d4a1be3191c7dbe1612a18a79c2 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -178,7 +178,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -211,8 +211,8 @@ index 0414974fc773a30810f88b54867034f5922eaa55..4391bd846b039339c0ef807870c5fb51
          if (Runtime.getRuntime().maxMemory() / 1024L / 1024L < 512L) {
              DedicatedServer.LOGGER.warn("To start the server with more ram, launch it as \"java -Xmx1024M -Xms1024M -jar minecraft_server.jar\"");
 @@ -210,6 +210,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
-         paperConfigurations.initializeGlobalConfiguration();
-         paperConfigurations.initializeWorldDefaultsConfiguration();
+         this.getPlayerList().loadAndSaveFiles(); // Must be after convertNames
+         // Paper end - moved up
          org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash);
 +        thread.start(); // Paper - start console thread after MinecraftServer.console & PaperConfig are initialized
          io.papermc.paper.command.PaperCommands.registerCommands(this);


### PR DESCRIPTION
Fixes #8050 by moving the old user convertion down slightly (or the config and deobf up, depending on how you look at it).

If you want to test this, turn your server to offline mode and then simply make a file `white-list.txt` and put a player name in it.