### PR TITLE
Add api for disabling conduits attacking entities

### DIFF
--- a/patches/api/0387-Add-api-for-disabling-conduits-attacking-entities.patch
+++ b/patches/api/0387-Add-api-for-disabling-conduits-attacking-entities.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: u9g <git@u9g.dev>
+Date: Mon, 27 Jun 2022 14:03:28 -0400
+Subject: [PATCH] Add api for disabling conduits attacking entities
+
+
+diff --git a/src/main/java/org/bukkit/block/Conduit.java b/src/main/java/org/bukkit/block/Conduit.java
+index 5543165536e84503c2d1476ee2001468cbb724f9..dde9cd2fd1867a70c711a0aad33b0191ae0425d9 100644
+--- a/src/main/java/org/bukkit/block/Conduit.java
++++ b/src/main/java/org/bukkit/block/Conduit.java
+@@ -3,4 +3,9 @@ package org.bukkit.block;
+ /**
+  * Represents a captured state of a conduit.
+  */
+-public interface Conduit extends TileState { }
++// Paper start
++public interface Conduit extends TileState {
++    void setCanAttackEntities(boolean canAttackEntities);
++    boolean getCanAttackEntities();
++}
++// Paper end

--- a/patches/server/0919-Add-api-for-disabling-conduits-attacking-entities.patch
+++ b/patches/server/0919-Add-api-for-disabling-conduits-attacking-entities.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: u9g <git@u9g.dev>
+Date: Mon, 27 Jun 2022 14:02:35 -0400
+Subject: [PATCH] Add api for disabling conduits attacking entities
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/ConduitBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/ConduitBlockEntity.java
+index 05eab04e4aec4151018f25b59f92ddbbb4c09f87..51a1dc233df7da7af0d5841ad76407684a3ec5f9 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/ConduitBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/ConduitBlockEntity.java
+@@ -51,6 +51,7 @@ public class ConduitBlockEntity extends BlockEntity {
+     @Nullable
+     private UUID destroyTargetUUID;
+     private long nextAmbientSoundActivation;
++    private boolean canAttackEntities = true;
+ 
+     public ConduitBlockEntity(BlockPos pos, BlockState state) {
+         super(BlockEntityType.CONDUIT, pos, state);
+@@ -64,6 +65,7 @@ public class ConduitBlockEntity extends BlockEntity {
+         } else {
+             this.destroyTargetUUID = null;
+         }
++        canAttackEntities = nbt.hasUUID("Paper.CanAttackEntities") && nbt.getBoolean("Paper.CanAttackEntities"); // Paper
+ 
+     }
+ 
+@@ -214,6 +216,13 @@ public class ConduitBlockEntity extends BlockEntity {
+     }
+ 
+     private static void updateDestroyTarget(Level world, BlockPos pos, BlockState state, List<BlockPos> activatingBlocks, ConduitBlockEntity blockEntity) {
++        // Paper start
++        if (!blockEntity.canAttackEntities) {
++            blockEntity.destroyTarget = null;
++            blockEntity.destroyTargetUUID = null;
++            return;
++        }
++        // Paper end
+         LivingEntity entityliving = blockEntity.destroyTarget;
+         int i = activatingBlocks.size();
+ 
+@@ -331,4 +340,12 @@ public class ConduitBlockEntity extends BlockEntity {
+     public float getActiveRotation(float tickDelta) {
+         return (this.activeRotation + tickDelta) * -0.0375F;
+     }
++    // Paper start
++    public void setCanAttackEntities(boolean canAttackEntities) {
++        this.canAttackEntities = canAttackEntities;
++    }
++    public boolean getCanAttackEntities() {
++        return canAttackEntities;
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftConduit.java b/src/main/java/org/bukkit/craftbukkit/block/CraftConduit.java
+index a0b17670750f882846954e83a85a1dd59ac09d0f..80c21c80ce4c25a0b0c97011b0cd73470a15965a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftConduit.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftConduit.java
+@@ -9,4 +9,15 @@ public class CraftConduit extends CraftBlockEntityState<ConduitBlockEntity> impl
+     public CraftConduit(World world, ConduitBlockEntity tileEntity) {
+         super(world, tileEntity);
+     }
++    // Paper start
++    @Override
++    public void setCanAttackEntities(boolean canAttackEntities) {
++        getTileEntity().setCanAttackEntities(canAttackEntities);
++    }
++
++    @Override
++    public boolean getCanAttackEntities() {
++        return getTileEntity().getCanAttackEntities();
++    }
++    // Paper end
+ }


### PR DESCRIPTION
Example plugin if curious:
```java
package io.papermc.paper.testplugin;

import net.kyori.adventure.text.minimessage.MiniMessage;
import org.bukkit.Bukkit;
import org.bukkit.block.Conduit;
import org.bukkit.event.EventHandler;
import org.bukkit.event.Listener;
import org.bukkit.event.block.BlockPlaceEvent;
import org.bukkit.event.entity.EntityDeathEvent;
import org.bukkit.inventory.EquipmentSlot;
import org.bukkit.plugin.java.JavaPlugin;
import org.bukkit.scheduler.BukkitRunnable;

public final class TestPlugin extends JavaPlugin implements Listener {
    @Override
    public void onEnable() {
        this.getServer().getPluginManager().registerEvents(this, this);
    }
    @EventHandler
    public void onA(BlockPlaceEvent e) {
        var loc = e.getBlock().getLocation();
        new BukkitRunnable() {
            @Override
            public void run() {
                if (e.getHand() == EquipmentSlot.OFF_HAND) {
                    Bukkit.broadcast(MiniMessage.miniMessage().deserialize("not disabling canAttackEntities on conduit bc placed with offhand"));
                    return;
                }
                if (loc.getBlock().getState(false) instanceof Conduit c) {
                    c.setCanAttackEntities(false);
                    Bukkit.broadcast(MiniMessage.miniMessage().deserialize("disabled canAttackEntities on a conduit"));
                }
            }
        }.runTaskLater(this, 1);
    }
    @EventHandler
    void onDie(EntityDeathEvent e) {
        if (!e.getEntity().getLocation().getNearbyPlayers(10).isEmpty()) {
            Bukkit.broadcast(MiniMessage.miniMessage().deserialize(e.getEntityType()+" has died by " + e.getEntity().getLastDamageCause()));
        }
    }
}
```