### PR TITLE
Fire ServerListPingEvent for secondary motd send (fixes #8073)

### DIFF
--- a/patches/server/0178-Implement-extended-PaperServerListPingEvent.patch
+++ b/patches/server/0178-Implement-extended-PaperServerListPingEvent.patch
@@ -60,10 +60,10 @@ index 0000000000000000000000000000000000000000..d926ad804355ee2fdc5910b2505e8671
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/network/StandardPaperServerListPingEventImpl.java b/src/main/java/com/destroystokyo/paper/network/StandardPaperServerListPingEventImpl.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4c2351b03b58511b80017b58ee9b20ab5193adc9
+index 0000000000000000000000000000000000000000..84285d5235b66aee9a4059b1d4db4a99e296f22f
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/network/StandardPaperServerListPingEventImpl.java
-@@ -0,0 +1,110 @@
+@@ -0,0 +1,121 @@
 +package com.destroystokyo.paper.network;
 +
 +import com.destroystokyo.paper.profile.CraftPlayerProfile;
@@ -140,13 +140,25 @@ index 0000000000000000000000000000000000000000..4c2351b03b58511b80017b58ee9b20ab
 +
 +    @SuppressWarnings("deprecation")
 +    public static void processRequest(MinecraftServer server, Connection networkManager) {
++        ServerStatus ping = getEventResponse(server, networkManager);
++
++        if (ping == null) {
++            networkManager.disconnect(null);
++            return;
++        }
++
++        // Send response
++        networkManager.send(new ClientboundStatusResponsePacket(ping));
++    }
++
++    @SuppressWarnings("deprecation")
++    public static ServerStatus getEventResponse(MinecraftServer server, Connection networkManager) {
 +        StandardPaperServerListPingEventImpl event = new StandardPaperServerListPingEventImpl(server, networkManager, server.getStatus());
 +        server.server.getPluginManager().callEvent(event);
 +
 +        // Close connection immediately if event is cancelled
 +        if (event.isCancelled()) {
-+            networkManager.disconnect(null);
-+            return;
++            return null;
 +        }
 +
 +        // Setup response
@@ -169,8 +181,7 @@ index 0000000000000000000000000000000000000000..4c2351b03b58511b80017b58ee9b20ab
 +            ping.setFavicon(event.getServerIcon().getData());
 +        }
 +
-+        // Send response
-+        networkManager.send(new ClientboundStatusResponsePacket(ping));
++        return ping;
 +    }
 +
 +}
@@ -235,6 +246,27 @@ index a426adfba3fccf1815177e0b8065684c9497ef45..29a22da1b94d51300481c071aa16bfd8
          }
      }
  
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index 4a94be565a3a7f7b8b330a35d97a14ef52ac4e50..dc09ae50baa71358a714d33cfa94adb1382d2672 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -331,7 +331,15 @@ public abstract class PlayerList {
+         this.server.getServerResourcePack().ifPresent((minecraftserver_serverresourcepackinfo) -> {
+             player.sendTexturePack(minecraftserver_serverresourcepackinfo.url(), minecraftserver_serverresourcepackinfo.hash(), minecraftserver_serverresourcepackinfo.isRequired(), minecraftserver_serverresourcepackinfo.prompt());
+         });
+-        player.sendServerStatus(this.server.getStatus());
++        // Paper start - fire ServerListPingEvent
++        net.minecraft.server.MCUtil.scheduleAsyncTask(() -> {
++            if (player.hasDisconnected()) return;
++            net.minecraft.network.protocol.status.ServerStatus status = com.destroystokyo.paper.network.StandardPaperServerListPingEventImpl.getEventResponse(this.server, player.networkManager);
++            if (status != null) {
++                player.sendServerStatus(status);
++            }
++        });
++        // Paper end
+         Iterator iterator = player.getActiveEffects().iterator();
+ 
+         while (iterator.hasNext()) {
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
 index c2e3d32e51902503af88f089e366e784f42d999a..645643d102118ad4916a152abfb9ab0d02751e11 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java

--- a/patches/server/0214-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0214-InventoryCloseEvent-Reason-API.patch
@@ -104,10 +104,10 @@ index d729042a22f01decbf30d35d7842e43cab283c05..8b9e569ccefaa5123c966590a9bba77c
          this.player.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4a94be565a3a7f7b8b330a35d97a14ef52ac4e50..4c9d595234a849d87157678383d220051c556962 100644
+index dc09ae50baa71358a714d33cfa94adb1382d2672..a0fcb3c93e02bfc933f791c42fbcad3782024e89 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -506,7 +506,7 @@ public abstract class PlayerList {
+@@ -514,7 +514,7 @@ public abstract class PlayerList {
          // CraftBukkit start - Quitting must be before we do final save of data, in case plugins need to modify it
          // See SPIGOT-5799, SPIGOT-6145
          if (entityplayer.containerMenu != entityplayer.inventoryMenu) {

--- a/patches/server/0238-Use-ConcurrentHashMap-in-JsonList.patch
+++ b/patches/server/0238-Use-ConcurrentHashMap-in-JsonList.patch
@@ -23,10 +23,10 @@ Modified isEmpty to use the isEmpty() method instead of the slightly confusing s
 The point of this is readability, but does have a side-benefit of a small microptimization
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4c9d595234a849d87157678383d220051c556962..5285cd8f395871c8bb55e0dc143216ae3acc0310 100644
+index a0fcb3c93e02bfc933f791c42fbcad3782024e89..29ef9c3b2e668ce0d8a9d9e0e669ef278e7ffd2b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -622,7 +622,7 @@ public abstract class PlayerList {
+@@ -630,7 +630,7 @@ public abstract class PlayerList {
          } else if (!this.isWhiteListed(gameprofile, event)) { // Paper
              //ichatmutablecomponent = Component.translatable("multiplayer.disconnect.not_whitelisted"); // Paper
              //event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(org.spigotmc.SpigotConfig.whitelistMessage)); // Spigot // Paper - Adventure - moved to isWhitelisted

--- a/patches/server/0304-Call-WhitelistToggleEvent-when-whitelist-is-toggled.patch
+++ b/patches/server/0304-Call-WhitelistToggleEvent-when-whitelist-is-toggled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Call WhitelistToggleEvent when whitelist is toggled
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index fee344bc4457fb4cd21d2e7ed9845f0bd3ce84da..c2370cb1128b55dd9d40a72a01296f40e01630b9 100644
+index 227be72a38e10e8d90eee4076c2d7da206158d61..b4d36387645f1b519ea088ffe638b4f91ee7a0e4 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1127,6 +1127,7 @@ public abstract class PlayerList {
+@@ -1135,6 +1135,7 @@ public abstract class PlayerList {
      }
  
      public void setUsingWhiteList(boolean whitelistEnabled) {

--- a/patches/server/0305-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0305-Entity-getEntitySpawnReason.patch
@@ -10,7 +10,7 @@ persistenting Living Entity, SPAWNER for spawners,
 or DEFAULT since data was not stored.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f9b02224c455077ab37d60e830403681ca12ccc5..40a0f98acf26e104912ff2db71aab744a6c727cb 100644
+index bde271171b035633ff263b6c60e85f2db5264879..65eaf93c135871b3898cd418bfe3aca8368e092e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1212,6 +1212,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -22,10 +22,10 @@ index f9b02224c455077ab37d60e830403681ca12ccc5..40a0f98acf26e104912ff2db71aab744
              // Paper start
              if (DEBUG_ENTITIES) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c2370cb1128b55dd9d40a72a01296f40e01630b9..7fc211e97da0f3e00abc9e0098df137bcfda3c80 100644
+index b4d36387645f1b519ea088ffe638b4f91ee7a0e4..e13c00186e68d9e3fd079b5e110dde54cb63f15c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -346,7 +346,7 @@ public abstract class PlayerList {
+@@ -354,7 +354,7 @@ public abstract class PlayerList {
              // CraftBukkit start
              ServerLevel finalWorldServer = worldserver1;
              Entity entity = EntityType.loadEntityRecursive(nbttagcompound1.getCompound("Entity"), finalWorldServer, (entity1) -> {

--- a/patches/server/0308-Implement-PlayerPostRespawnEvent.patch
+++ b/patches/server/0308-Implement-PlayerPostRespawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement PlayerPostRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 7fc211e97da0f3e00abc9e0098df137bcfda3c80..eeb014dfd4376090eb95bbf372a6b2c1f660593c 100644
+index e13c00186e68d9e3fd079b5e110dde54cb63f15c..84e5d7f04d6d93cc85c450df720404fc85001728 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -726,9 +726,14 @@ public abstract class PlayerList {
+@@ -734,9 +734,14 @@ public abstract class PlayerList {
  
          boolean flag2 = false;
  
@@ -24,7 +24,7 @@ index 7fc211e97da0f3e00abc9e0098df137bcfda3c80..eeb014dfd4376090eb95bbf372a6b2c1
              ServerLevel worldserver1 = this.server.getLevel(entityplayer.getRespawnDimension());
              if (worldserver1 != null) {
                  Optional optional;
-@@ -780,6 +785,7 @@ public abstract class PlayerList {
+@@ -788,6 +793,7 @@ public abstract class PlayerList {
  
              location = respawnEvent.getRespawnLocation();
              if (!flag) entityplayer.reset(); // SPIGOT-4785
@@ -32,7 +32,7 @@ index 7fc211e97da0f3e00abc9e0098df137bcfda3c80..eeb014dfd4376090eb95bbf372a6b2c1
          } else {
              location.setWorld(worldserver.getWorld());
          }
-@@ -837,6 +843,13 @@ public abstract class PlayerList {
+@@ -845,6 +851,13 @@ public abstract class PlayerList {
          if (entityplayer.connection.isDisconnected()) {
              this.save(entityplayer);
          }

--- a/patches/server/0329-Fix-MC-158900.patch
+++ b/patches/server/0329-Fix-MC-158900.patch
@@ -7,10 +7,10 @@ The problem was we were checking isExpired() on the entry, but if it
 was expired at that point, then it would be null.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index eeb014dfd4376090eb95bbf372a6b2c1f660593c..f14d4bfd5ac03eeffefcf98e1077d915fd3fa2cb 100644
+index 84e5d7f04d6d93cc85c450df720404fc85001728..bb0e6ed49b978d6a2480c914f7398047f7754e35 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -610,8 +610,10 @@ public abstract class PlayerList {
+@@ -618,8 +618,10 @@ public abstract class PlayerList {
          Player player = entity.getBukkitEntity();
          PlayerLoginEvent event = new PlayerLoginEvent(player, hostname, ((java.net.InetSocketAddress) socketaddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.connection.getRawAddress()).getAddress());
  

--- a/patches/server/0381-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/0381-Optimize-Collision-to-not-load-chunks.patch
@@ -14,10 +14,10 @@ movement will load only the chunk the player enters anyways and avoids loading
 massive amounts of surrounding chunks due to large AABB lookups.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f14d4bfd5ac03eeffefcf98e1077d915fd3fa2cb..d8b34055aff358cb2c236199da1e22d84213ea1e 100644
+index bb0e6ed49b978d6a2480c914f7398047f7754e35..272804ba1373f55344790ac1a55ac7ad96136f01 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -795,6 +795,7 @@ public abstract class PlayerList {
+@@ -803,6 +803,7 @@ public abstract class PlayerList {
          entityplayer1.forceSetPositionRotation(location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
          // CraftBukkit end
  

--- a/patches/server/0384-Improved-Watchdog-Support.patch
+++ b/patches/server/0384-Improved-Watchdog-Support.patch
@@ -281,10 +281,10 @@ index 8d99c45e10da9d8a54a12b1039515da05bd56f6b..42645114b270b1e7c2b3112abd7eaa90
                  list.stream().map((playerchunk) -> {
                      CompletableFuture completablefuture;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index d6b8796ed7eca4ba2af979fb5c2cbff4b92ae329..3459a7b74be03de8cf29ea1f54b7d54de2838911 100644
+index af32d76a7a0fefba98880dea9c528d0dac2e6d94..e613e9adbab81a52e0267bc75fa281a04b4f2c3c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -516,7 +516,7 @@ public abstract class PlayerList {
+@@ -524,7 +524,7 @@ public abstract class PlayerList {
          this.cserver.getPluginManager().callEvent(playerQuitEvent);
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  
@@ -330,7 +330,7 @@ index 89f4ea65b20e773bd3782c41db3a2af7b5b405f3..3fe94e580d2aaae9616ba83c0d3a4468
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bfbf43661acbdcda1417b1782579c603022a0adb..602838f3615e4fac1798a99bd2d322c0b2b94863 100644
+index 883ee423077b016846b99e9e8597b2a8e70af0d2..cd5a34fdd086d5b9d59897cc4319fe81ccdfebcc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2071,7 +2071,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0394-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/patches/server/0394-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -52,7 +52,7 @@ index 8ef5f67c0b51bb5d527b36c667a5c23594da7d03..55aae33d3b296ff8e02b1c36c5567897
      public String kickLeaveMessage = null; // SPIGOT-3034: Forward leave message to PlayerQuitEvent
      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3459a7b74be03de8cf29ea1f54b7d54de2838911..ac0bae0f7ce766a67cf2dc2c5c35f244e5a08837 100644
+index e613e9adbab81a52e0267bc75fa281a04b4f2c3c..ffc8d84be8d63c80a205c5caf9482188d28bacf5 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -280,6 +280,12 @@ public abstract class PlayerList {
@@ -77,7 +77,7 @@ index 3459a7b74be03de8cf29ea1f54b7d54de2838911..ac0bae0f7ce766a67cf2dc2c5c35f244
          // CraftBukkit end
  
          player.connection.send(new ClientboundSetEntityDataPacket(player.getId(), player.getEntityData(), true)); // CraftBukkit - BungeeCord#2321, send complete data to self on spawn
-@@ -343,6 +351,11 @@ public abstract class PlayerList {
+@@ -351,6 +359,11 @@ public abstract class PlayerList {
              playerconnection.send(new ClientboundUpdateMobEffectPacket(player.getId(), mobeffect));
          }
  
@@ -89,7 +89,7 @@ index 3459a7b74be03de8cf29ea1f54b7d54de2838911..ac0bae0f7ce766a67cf2dc2c5c35f244
          if (nbttagcompound != null && nbttagcompound.contains("RootVehicle", 10)) {
              CompoundTag nbttagcompound1 = nbttagcompound.getCompound("RootVehicle");
              // CraftBukkit start
-@@ -391,6 +404,10 @@ public abstract class PlayerList {
+@@ -399,6 +412,10 @@ public abstract class PlayerList {
              }
          }
  
@@ -100,7 +100,7 @@ index 3459a7b74be03de8cf29ea1f54b7d54de2838911..ac0bae0f7ce766a67cf2dc2c5c35f244
          player.initInventoryMenu();
          // CraftBukkit - Moved from above, added world
          // Paper start - Add to collideRule team if needed
-@@ -400,6 +417,7 @@ public abstract class PlayerList {
+@@ -408,6 +425,7 @@ public abstract class PlayerList {
              scoreboard.addPlayerToTeam(player.getScoreboardName(), collideRuleTeam);
          }
          // Paper end

--- a/patches/server/0395-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0395-Load-Chunks-for-Login-Asynchronously.patch
@@ -37,7 +37,7 @@ index be677d437d17b74c6188ce1bd5fc6fdc228fd92f..78fbb4c3e52e900956ae0811aaf934c8
      public static final TicketType<ChunkPos> UNKNOWN = TicketType.create("unknown", Comparator.comparingLong(ChunkPos::toLong), 1);
      public static final TicketType<Unit> PLUGIN = TicketType.create("plugin", (a, b) -> 0); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 912e98d589f7469c6ea000d28f87e3fbe1ef3aab..766a5ce5d18aed80e37075f7cfc3b6cb9d33e63a 100644
+index fcbd099d77b4dec7a91da2b7fb219c300482a83b..ec82608da0d39a1b60d1595cee9aeae3efef9fac 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -238,6 +238,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -74,7 +74,7 @@ index 912e98d589f7469c6ea000d28f87e3fbe1ef3aab..766a5ce5d18aed80e37075f7cfc3b6cb
          this.server.getProfiler().push("keepAlive");
          // Paper Start - give clients a longer time to respond to pings as per pre 1.12.2 timings
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index b070624c7ee85b6692f1f44ded6c78139925b669..22a2380388ed9fd6d28edbfbbb5ed3f646217525 100644
+index 8b5eddce4845619603ccfeec158d97cb86568e0d..ec2825b6d276b6200c4bec5580d012f1eaed722e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -93,7 +93,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
@@ -96,7 +96,7 @@ index b070624c7ee85b6692f1f44ded6c78139925b669..22a2380388ed9fd6d28edbfbbb5ed3f6
              try {
                  ServerPlayer entityplayer1 = this.server.getPlayerList().getPlayerForLogin(this.gameProfile, s); // CraftBukkit - add player reference
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ac0bae0f7ce766a67cf2dc2c5c35f244e5a08837..4b9e030016bef762c01ace5181ade7d1480b8702 100644
+index ffc8d84be8d63c80a205c5caf9482188d28bacf5..61c8bd0e97dad692685ed3b8a351052830c46974 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -138,6 +138,7 @@ public abstract class PlayerList {
@@ -198,7 +198,7 @@ index ac0bae0f7ce766a67cf2dc2c5c35f244e5a08837..4b9e030016bef762c01ace5181ade7d1
          MutableComponent ichatmutablecomponent;
  
          if (player.getGameProfile().getName().equalsIgnoreCase(s)) {
-@@ -504,6 +560,7 @@ public abstract class PlayerList {
+@@ -512,6 +568,7 @@ public abstract class PlayerList {
  
      protected void save(ServerPlayer player) {
          if (!player.getBukkitEntity().isPersistent()) return; // CraftBukkit
@@ -206,7 +206,7 @@ index ac0bae0f7ce766a67cf2dc2c5c35f244e5a08837..4b9e030016bef762c01ace5181ade7d1
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -531,7 +588,7 @@ public abstract class PlayerList {
+@@ -539,7 +596,7 @@ public abstract class PlayerList {
          }
  
          PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
@@ -215,7 +215,7 @@ index ac0bae0f7ce766a67cf2dc2c5c35f244e5a08837..4b9e030016bef762c01ace5181ade7d1
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  
          if (server.isSameThread()) entityplayer.doTick(); // SPIGOT-924 // Paper - don't tick during emergency shutdowns (Watchdog)
-@@ -576,6 +633,13 @@ public abstract class PlayerList {
+@@ -584,6 +641,13 @@ public abstract class PlayerList {
              // this.advancements.remove(uuid);
              // CraftBukkit end
          }
@@ -229,7 +229,7 @@ index ac0bae0f7ce766a67cf2dc2c5c35f244e5a08837..4b9e030016bef762c01ace5181ade7d1
  
          // CraftBukkit start
          // this.broadcastAll(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, new EntityPlayer[]{entityplayer}));
-@@ -593,7 +657,7 @@ public abstract class PlayerList {
+@@ -601,7 +665,7 @@ public abstract class PlayerList {
          this.cserver.getScoreboardManager().removePlayer(entityplayer.getBukkitEntity());
          // CraftBukkit end
  
@@ -238,7 +238,7 @@ index ac0bae0f7ce766a67cf2dc2c5c35f244e5a08837..4b9e030016bef762c01ace5181ade7d1
      }
  
      // CraftBukkit start - Whole method, SocketAddress to LoginListener, added hostname to signature, return EntityPlayer
-@@ -612,6 +676,13 @@ public abstract class PlayerList {
+@@ -620,6 +684,13 @@ public abstract class PlayerList {
                  list.add(entityplayer);
              }
          }

--- a/patches/server/0447-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0447-incremental-chunk-and-player-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] incremental chunk and player saving
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d40623b3ed69a0821057f82e6164b4c94b4a7087..54a155295ed2ee2386f180bf8f5d413984febe96 100644
+index 049ec7c3be31f957e0a662a16939d5ef1868a4e3..9ce0c366b81ee8468cfcca1bd9fb8ed49ffea0ba 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -851,7 +851,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -256,7 +256,7 @@ index 1d9a0f6effa1654609f4d0752ec69eed6ab7134b..585892f19bc0aea89889a358c0407f29
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 13354b9e626ce7fec74cbaac68304a912517c40e..69611eaafe2edc0e937f54b63bfbf3a23ca7a857 100644
+index 443044aa09b80bdbbcd202b53d265c635b50015f..848690e6dfaec00ec9b8a8397d2a6d37f24c8d12 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1082,6 +1082,37 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -310,10 +310,10 @@ index ea1f0477f416f9e852ea92083781d7eb6ab24861..58c67cc9a4c9c238fae89e165dc6ad01
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      public ServerGamePacketListenerImpl connection;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4b9e030016bef762c01ace5181ade7d1480b8702..c1e62a0d1655993430da7e4cbd8075cd4239adb4 100644
+index 61c8bd0e97dad692685ed3b8a351052830c46974..ac6a83052a312b465ba2e77a582009877ede1bad 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -561,6 +561,7 @@ public abstract class PlayerList {
+@@ -569,6 +569,7 @@ public abstract class PlayerList {
      protected void save(ServerPlayer player) {
          if (!player.getBukkitEntity().isPersistent()) return; // CraftBukkit
          if (!player.didPlayerJoinEvent) return; // Paper - If we never fired PJE, we disconnected during login. Data has not changed, and additionally, our saved vehicle is not loaded! If we save now, we will lose our vehicle (CraftBukkit bug)
@@ -321,7 +321,7 @@ index 4b9e030016bef762c01ace5181ade7d1480b8702..c1e62a0d1655993430da7e4cbd8075cd
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -1163,10 +1164,22 @@ public abstract class PlayerList {
+@@ -1171,10 +1172,22 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {

--- a/patches/server/0466-Fix-SPIGOT-5989.patch
+++ b/patches/server/0466-Fix-SPIGOT-5989.patch
@@ -10,10 +10,10 @@ This fixes that by checking if the modified spawn location is
 still at a respawn anchor.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ec48afe87b5d159b5bdbe035e214ea7c9024fadb..be7a25560cd5521ddfe4793c7e51b1036fc8a19c 100644
+index 1e4359450cf2c4670c981d2fbb67b355e9ac437d..b1a36148322dea67b8d842c3868e065a847c8ebc 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -835,6 +835,7 @@ public abstract class PlayerList {
+@@ -843,6 +843,7 @@ public abstract class PlayerList {
          // Paper start
          boolean isBedSpawn = false;
          boolean isRespawn = false;
@@ -21,7 +21,7 @@ index ec48afe87b5d159b5bdbe035e214ea7c9024fadb..be7a25560cd5521ddfe4793c7e51b103
          // Paper end
  
          // CraftBukkit start - fire PlayerRespawnEvent
-@@ -845,7 +846,7 @@ public abstract class PlayerList {
+@@ -853,7 +854,7 @@ public abstract class PlayerList {
                  Optional optional;
  
                  if (blockposition != null) {
@@ -30,7 +30,7 @@ index ec48afe87b5d159b5bdbe035e214ea7c9024fadb..be7a25560cd5521ddfe4793c7e51b103
                  } else {
                      optional = Optional.empty();
                  }
-@@ -889,7 +890,12 @@ public abstract class PlayerList {
+@@ -897,7 +898,12 @@ public abstract class PlayerList {
              }
              // Spigot End
  
@@ -44,7 +44,7 @@ index ec48afe87b5d159b5bdbe035e214ea7c9024fadb..be7a25560cd5521ddfe4793c7e51b103
              if (!flag) entityplayer.reset(); // SPIGOT-4785
              isRespawn = true; // Paper
          } else {
-@@ -927,8 +933,12 @@ public abstract class PlayerList {
+@@ -935,8 +941,12 @@ public abstract class PlayerList {
          }
          // entityplayer1.initInventoryMenu();
          entityplayer1.setHealth(entityplayer1.getHealth());

--- a/patches/server/0521-Add-API-for-quit-reason.patch
+++ b/patches/server/0521-Add-API-for-quit-reason.patch
@@ -37,7 +37,7 @@ index 315ada5d45e8681a8f0695410201758d8748b7ec..f0ef38377ae735800323c486d9e42cd0
      public ServerPlayer(MinecraftServer server, ServerLevel world, GameProfile profile, @Nullable ProfilePublicKey publicKey) {
          super(world, world.getSharedSpawnPos(), world.getSharedSpawnAngle(), profile, publicKey);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 979bdc8a7547e96d3a9dcf9597b58d6a8a4aeee7..3c608f12c2500d11bd209c3c8797a9909165668c 100644
+index bbe945c7c26ece9d8589f46388d0e465f07b1e81..336274ad506034bbed408c2f62aa520a39d5d49d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -469,6 +469,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -49,10 +49,10 @@ index 979bdc8a7547e96d3a9dcf9597b58d6a8a4aeee7..3c608f12c2500d11bd209c3c8797a990
              this.connection.disconnect(ichatbasecomponent);
          });
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 869fa7c3913185c3537185426e75c076fbbdb7fe..0dad9a0c98cc128d990d9bd2357895d9a07a0ac7 100644
+index 7134ff0a5407bc35eb50a547e84238f7556fa964..d277badaf8c2641be90d44f3732ac7d1488752d4 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -600,7 +600,7 @@ public abstract class PlayerList {
+@@ -608,7 +608,7 @@ public abstract class PlayerList {
              entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  

--- a/patches/server/0523-Expose-world-spawn-angle.patch
+++ b/patches/server/0523-Expose-world-spawn-angle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose world spawn angle
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0dad9a0c98cc128d990d9bd2357895d9a07a0ac7..75c713f7afd8c4fd5fffada7397b102751eb6423 100644
+index d277badaf8c2641be90d44f3732ac7d1488752d4..21770022d40b210a0d97ae933a744a787d8ea1a4 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -878,7 +878,7 @@ public abstract class PlayerList {
+@@ -886,7 +886,7 @@ public abstract class PlayerList {
              if (location == null) {
                  worldserver1 = this.server.getLevel(Level.OVERWORLD);
                  blockposition = entityplayer1.getSpawnPoint(worldserver1);

--- a/patches/server/0566-Fix-villager-boat-exploit.patch
+++ b/patches/server/0566-Fix-villager-boat-exploit.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix villager boat exploit
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 75c713f7afd8c4fd5fffada7397b102751eb6423..6c7105af36339514db02800e651cd0948d48bdaf 100644
+index 21770022d40b210a0d97ae933a744a787d8ea1a4..82b1d06d887b929b900041a1e93a4deae5a149aa 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -625,6 +625,14 @@ public abstract class PlayerList {
+@@ -633,6 +633,14 @@ public abstract class PlayerList {
                  PlayerList.LOGGER.debug("Removing player mount");
                  entityplayer.stopRiding();
                  entity.getPassengersAndSelf().forEach((entity1) -> {

--- a/patches/server/0567-Add-sendOpLevel-API.patch
+++ b/patches/server/0567-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6c7105af36339514db02800e651cd0948d48bdaf..42b2f5c61e2bd07c3c86d889949c5f24345680d6 100644
+index 82b1d06d887b929b900041a1e93a4deae5a149aa..34596c06737398af24b68e4e9d46416285f809ae 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1123,6 +1123,11 @@ public abstract class PlayerList {
+@@ -1131,6 +1131,11 @@ public abstract class PlayerList {
      }
  
      private void sendPlayerPermissionLevel(ServerPlayer player, int permissionLevel) {
@@ -20,7 +20,7 @@ index 6c7105af36339514db02800e651cd0948d48bdaf..42b2f5c61e2bd07c3c86d889949c5f24
          if (player.connection != null) {
              byte b0;
  
-@@ -1137,8 +1142,10 @@ public abstract class PlayerList {
+@@ -1145,8 +1150,10 @@ public abstract class PlayerList {
              player.connection.send(new ClientboundEntityEventPacket(player, b0));
          }
  

--- a/patches/server/0608-Drop-carried-item-when-player-has-disconnected.patch
+++ b/patches/server/0608-Drop-carried-item-when-player-has-disconnected.patch
@@ -7,10 +7,10 @@ Fixes disappearance of held items, when a player gets disconnected and PlayerDro
 Closes #5036
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 2266e4608ff5ed11cbd76767365fe74742b8bc63..39857a042d13c3660cd7cd49cd1117cafbc5dfad 100644
+index 3b23fd943ff671807a4dc07aeecb8f41d689682a..9c9980d990a0456e903fca406e293327546559fd 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -618,6 +618,14 @@ public abstract class PlayerList {
+@@ -626,6 +626,14 @@ public abstract class PlayerList {
          }
          // Paper end
  

--- a/patches/server/0628-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
+++ b/patches/server/0628-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix anchor respawn acting as a bed respawn from the end
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 39857a042d13c3660cd7cd49cd1117cafbc5dfad..fec39b8a3f67af2628913056634d6ee62b77d05d 100644
+index 9c9980d990a0456e903fca406e293327546559fd..419881af791b4ed349377031049bd117d31972ee 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -851,6 +851,7 @@ public abstract class PlayerList {
+@@ -859,6 +859,7 @@ public abstract class PlayerList {
  
          // Paper start
          boolean isBedSpawn = false;
@@ -17,7 +17,7 @@ index 39857a042d13c3660cd7cd49cd1117cafbc5dfad..fec39b8a3f67af2628913056634d6ee6
          boolean isRespawn = false;
          boolean isLocAltered = false; // Paper - Fix SPIGOT-5989
          // Paper end
-@@ -871,6 +872,7 @@ public abstract class PlayerList {
+@@ -879,6 +880,7 @@ public abstract class PlayerList {
                  if (optional.isPresent()) {
                      BlockState iblockdata = worldserver1.getBlockState(blockposition);
                      boolean flag3 = iblockdata.is(Blocks.RESPAWN_ANCHOR);
@@ -25,7 +25,7 @@ index 39857a042d13c3660cd7cd49cd1117cafbc5dfad..fec39b8a3f67af2628913056634d6ee6
                      Vec3 vec3d = (Vec3) optional.get();
                      float f1;
  
-@@ -899,7 +901,7 @@ public abstract class PlayerList {
+@@ -907,7 +909,7 @@ public abstract class PlayerList {
              }
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();

--- a/patches/server/0630-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/server/0630-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] add RespawnFlags to PlayerRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d9d0811cef7a5fcbc7f4fcb9de6a874268345b16..dde41b71132354eb52fe34408afcbade41da41f3 100644
+index 33354c6ca4005d3ae1aedc4fac57dcd047bab853..24025a814b2659829983c902f40214a2b7b6bcf4 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2674,7 +2674,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -18,10 +18,10 @@ index d9d0811cef7a5fcbc7f4fcb9de6a874268345b16..dde41b71132354eb52fe34408afcbade
                  } else {
                      if (this.player.getHealth() > 0.0F) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index fec39b8a3f67af2628913056634d6ee62b77d05d..a4278a4ca0b41813b8f88d01dcc8d75b4f458908 100644
+index 419881af791b4ed349377031049bd117d31972ee..1c378986a3c3b29704e45bc949ed84d5fd8ad2a3 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -810,6 +810,12 @@ public abstract class PlayerList {
+@@ -818,6 +818,12 @@ public abstract class PlayerList {
      }
  
      public ServerPlayer respawn(ServerPlayer entityplayer, ServerLevel worldserver, boolean flag, Location location, boolean avoidSuffocation) {
@@ -34,7 +34,7 @@ index fec39b8a3f67af2628913056634d6ee62b77d05d..a4278a4ca0b41813b8f88d01dcc8d75b
          entityplayer.stopRiding(); // CraftBukkit
          this.players.remove(entityplayer);
          this.playersByName.remove(entityplayer.getScoreboardName().toLowerCase(java.util.Locale.ROOT)); // Spigot
-@@ -901,7 +907,7 @@ public abstract class PlayerList {
+@@ -909,7 +915,7 @@ public abstract class PlayerList {
              }
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();

--- a/patches/server/0655-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0655-Add-PlayerKickEvent-causes.patch
@@ -318,10 +318,10 @@ index f3a8b36956dbb8b9396bac4fc17aae7a3cb1d594..c8e99e115c0c40834cc73c8373bb757e
          }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index a4278a4ca0b41813b8f88d01dcc8d75b4f458908..be163c1cc4c8982b89be86c004299cdcb8ba7387 100644
+index 1c378986a3c3b29704e45bc949ed84d5fd8ad2a3..8f91eda5f9281e4512ec6e8d14c923758a80d9ae 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -719,7 +719,7 @@ public abstract class PlayerList {
+@@ -727,7 +727,7 @@ public abstract class PlayerList {
          while (iterator.hasNext()) {
              entityplayer = (ServerPlayer) iterator.next();
              this.save(entityplayer); // CraftBukkit - Force the player's inventory to be saved
@@ -330,7 +330,7 @@ index a4278a4ca0b41813b8f88d01dcc8d75b4f458908..be163c1cc4c8982b89be86c004299cdc
          }
  
          // Instead of kicking then returning, we need to store the kick reason
-@@ -1350,8 +1350,8 @@ public abstract class PlayerList {
+@@ -1358,8 +1358,8 @@ public abstract class PlayerList {
          // Paper end
          // CraftBukkit start - disconnect safely
          for (ServerPlayer player : this.players) {

--- a/patches/server/0677-Fixes-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0677-Fixes-kick-event-leave-message-not-being-sent.patch
@@ -17,7 +17,7 @@ index f5b37334d21c3c3812b4f343e5af17234dd9f907..5db3349f4e366caef84b0d1e811c031e
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0e5d424c5af7429a95a5906572b5ff0fbb221dd4..853e7edbb977394d2860ce3f63e4712c921bc741 100644
+index b3cc17742c095a4fe7a4a43fbd7fe27284c34825..9a9f4b985c01c8e076d26c22c37d090bb7348371 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -474,7 +474,6 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -59,10 +59,10 @@ index 0e5d424c5af7429a95a5906572b5ff0fbb221dd4..853e7edbb977394d2860ce3f63e4712c
              this.server.getPlayerList().broadcastSystemMessage(PaperAdventure.asVanilla(quitMessage), ChatType.SYSTEM);
              // Paper end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index be163c1cc4c8982b89be86c004299cdcb8ba7387..56c9dc2bf76204cd40775d9f47a9ba20919bc04f 100644
+index 8f91eda5f9281e4512ec6e8d14c923758a80d9ae..625880e429578cb5148b2ae94db6a601ff135657 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -591,6 +591,11 @@ public abstract class PlayerList {
+@@ -599,6 +599,11 @@ public abstract class PlayerList {
      }
  
      public net.kyori.adventure.text.Component remove(ServerPlayer entityplayer) { // Paper - return Component
@@ -74,7 +74,7 @@ index be163c1cc4c8982b89be86c004299cdcb8ba7387..56c9dc2bf76204cd40775d9f47a9ba20
          ServerLevel worldserver = entityplayer.getLevel();
  
          entityplayer.awardStat(Stats.LEAVE_GAME);
-@@ -601,7 +606,7 @@ public abstract class PlayerList {
+@@ -609,7 +614,7 @@ public abstract class PlayerList {
              entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  

--- a/patches/server/0691-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0691-Add-PlayerSetSpawnEvent.patch
@@ -89,10 +89,10 @@ index eb0d36082d3e6af7463b767dbb64be146941cc6d..157be83b74298b848a47436ab0fea9a0
  
      public void trackChunk(ChunkPos chunkPos, Packet<?> chunkDataPacket) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 56c9dc2bf76204cd40775d9f47a9ba20919bc04f..bf2888b678567ace5959d989e5dd119c65a9500d 100644
+index 625880e429578cb5148b2ae94db6a601ff135657..46f22d8ffa48f1a164353e902591d80aa9f4ee20 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -895,13 +895,13 @@ public abstract class PlayerList {
+@@ -903,13 +903,13 @@ public abstract class PlayerList {
                          f1 = (float) Mth.wrapDegrees(Mth.atan2(vec3d1.z, vec3d1.x) * 57.2957763671875D - 90.0D);
                      }
  

--- a/patches/server/0802-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0802-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -1202,10 +1202,10 @@ index c0f876bb11f8620390e6c38d9090eac73a28ad09..b0213404e1fb78dccfd3735f128032c0
              }
          }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index d74d6669005d0669503253787636756a0c6590f4..6d013360d35c54d1493849b22c9d65b18147cc33 100644
+index 344146891fe25bdbc9855ad33136f9025a660c74..976ec812f63444110a6c464c9341829b15c56ec5 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -936,7 +936,7 @@ public abstract class PlayerList {
+@@ -944,7 +944,7 @@ public abstract class PlayerList {
          // CraftBukkit end
  
          worldserver1.getChunkSource().addRegionTicket(net.minecraft.server.level.TicketType.POST_TELEPORT, new net.minecraft.world.level.ChunkPos(location.getBlockX() >> 4, location.getBlockZ() >> 4), 1, entityplayer.getId()); // Paper

--- a/patches/server/0823-Validate-usernames.patch
+++ b/patches/server/0823-Validate-usernames.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Validate usernames
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 4bffd454a1403130d4454a1716aba15034ea9a95..f18c24266eecdc3d108c6523da6b75985bba291a 100644
+index c098a602ce840db0099b15bd108ea873c7f111d4..55b7e18507eb68d66b107a1716df948040e659d6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -70,6 +70,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
@@ -56,10 +56,10 @@ index 4bffd454a1403130d4454a1716aba15034ea9a95..f18c24266eecdc3d108c6523da6b7598
          try {
              this.playerProfilePublicKey = ServerLoginPacketListenerImpl.validatePublicKey(packet, this.server.getServiceSignatureValidator(), this.server.enforceSecureProfile());
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6d013360d35c54d1493849b22c9d65b18147cc33..c0ed1103e649e619c58f59c7bedd6a18a58f71ea 100644
+index 976ec812f63444110a6c464c9341829b15c56ec5..cc9540a069889bb1a7f7983af2243afd98337876 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -707,7 +707,7 @@ public abstract class PlayerList {
+@@ -715,7 +715,7 @@ public abstract class PlayerList {
  
          for (int i = 0; i < this.players.size(); ++i) {
              entityplayer = (ServerPlayer) this.players.get(i);

--- a/patches/server/0857-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0857-Replace-player-chunk-loader-system.patch
@@ -1900,7 +1900,7 @@ index b0213404e1fb78dccfd3735f128032c0ac4988c8..da302fbaad018eb51ab6df4389942a5b
 +    public final int getViewDistance() { throw new UnsupportedOperationException("Use PlayerChunkLoader"); } // Paper - placeholder
  }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c0ed1103e649e619c58f59c7bedd6a18a58f71ea..e57636efacedf1c6f1ccd4f01f7e94d6fda2ff4f 100644
+index cc9540a069889bb1a7f7983af2243afd98337876..0eff90aa5ff57e6858966b61f6a77b7bba0ae18e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -273,7 +273,7 @@ public abstract class PlayerList {
@@ -1912,7 +1912,7 @@ index c0ed1103e649e619c58f59c7bedd6a18a58f71ea..e57636efacedf1c6f1ccd4f01f7e94d6
          player.getBukkitEntity().sendSupportedChannels(); // CraftBukkit
          playerconnection.send(new ClientboundCustomPayloadPacket(ClientboundCustomPayloadPacket.BRAND, (new FriendlyByteBuf(Unpooled.buffer())).writeUtf(this.getServer().getServerModName())));
          playerconnection.send(new ClientboundChangeDifficultyPacket(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
-@@ -942,8 +942,8 @@ public abstract class PlayerList {
+@@ -950,8 +950,8 @@ public abstract class PlayerList {
          // CraftBukkit start
          LevelData worlddata = worldserver1.getLevelData();
          entityplayer1.connection.send(new ClientboundRespawnPacket(worldserver1.dimensionTypeId(), worldserver1.dimension(), BiomeManager.obfuscateSeed(worldserver1.getSeed()), entityplayer1.gameMode.getGameModeForPlayer(), entityplayer1.gameMode.getPreviousGameModeForPlayer(), worldserver1.isDebug(), worldserver1.isFlat(), flag, entityplayer1.getLastDeathLocation()));
@@ -1923,7 +1923,7 @@ index c0ed1103e649e619c58f59c7bedd6a18a58f71ea..e57636efacedf1c6f1ccd4f01f7e94d6
          entityplayer1.spawnIn(worldserver1);
          entityplayer1.unsetRemoved();
          entityplayer1.connection.teleport(new Location(worldserver1.getWorld(), entityplayer1.getX(), entityplayer1.getY(), entityplayer1.getZ(), entityplayer1.getYRot(), entityplayer1.getXRot()));
-@@ -1485,7 +1485,7 @@ public abstract class PlayerList {
+@@ -1493,7 +1493,7 @@ public abstract class PlayerList {
  
      public void setViewDistance(int viewDistance) {
          this.viewDistance = viewDistance;
@@ -1932,7 +1932,7 @@ index c0ed1103e649e619c58f59c7bedd6a18a58f71ea..e57636efacedf1c6f1ccd4f01f7e94d6
          Iterator iterator = this.server.getAllLevels().iterator();
  
          while (iterator.hasNext()) {
-@@ -1500,7 +1500,7 @@ public abstract class PlayerList {
+@@ -1508,7 +1508,7 @@ public abstract class PlayerList {
  
      public void setSimulationDistance(int simulationDistance) {
          this.simulationDistance = simulationDistance;

--- a/patches/server/0860-Force-close-world-loading-screen.patch
+++ b/patches/server/0860-Force-close-world-loading-screen.patch
@@ -10,10 +10,10 @@ so we do not need that. The client only needs the chunk it is currently in to
 be loaded to close the loading screen, so we just send an empty one.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index e57636efacedf1c6f1ccd4f01f7e94d6fda2ff4f..c247d27e516d1d7c5dc1e4b50ff6c81cbc54b0cc 100644
+index 0eff90aa5ff57e6858966b61f6a77b7bba0ae18e..89422b96f18551d8b0e97faed2faa2819152ad2e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -422,6 +422,16 @@ public abstract class PlayerList {
+@@ -430,6 +430,16 @@ public abstract class PlayerList {
  
          // Paper start - move vehicle into method so it can be called above - short circuit around that code
          onPlayerJoinFinish(player, worldserver1, s1);

--- a/patches/server/0884-Use-username-instead-of-display-name-in-PlayerList-g.patch
+++ b/patches/server/0884-Use-username-instead-of-display-name-in-PlayerList-g.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Use username instead of display name in
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c247d27e516d1d7c5dc1e4b50ff6c81cbc54b0cc..20cdfdb3b9351f74e89bc45b3ab972384165659a 100644
+index 89422b96f18551d8b0e97faed2faa2819152ad2e..6fc713f3f4fe7f9e2a925e4ec9c0ee5e31ab6a93 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1449,7 +1449,7 @@ public abstract class PlayerList {
+@@ -1457,7 +1457,7 @@ public abstract class PlayerList {
      // CraftBukkit start
      public ServerStatsCounter getPlayerStats(ServerPlayer entityhuman) {
          ServerStatsCounter serverstatisticmanager = entityhuman.getStats();


### PR DESCRIPTION
Fixes #8073. Not sure if there should be a flag on the event indicating whether it was fired for a connected player or just someone pinging.