### PR TITLE
Don't fire TNTPrimeEvent for EnderDragon + fixes

### DIFF
--- a/patches/server/0233-Add-TNTPrimeEvent.patch
+++ b/patches/server/0233-Add-TNTPrimeEvent.patch
@@ -4,22 +4,6 @@ Date: Mon, 16 Jul 2018 00:05:05 +0300
 Subject: [PATCH] Add TNTPrimeEvent
 
 
-diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index d0ebcc23d863be630b55245aa2604c108ee6c93a..3a6e5893181ed681099f2748abca738af45ec9c9 100644
---- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-+++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -532,6 +532,11 @@ public class EnderDragon extends Mob implements Enemy {
-                     });
-                     craftBlock.getNMS().spawnAfterBreak((ServerLevel) level, blockposition, ItemStack.EMPTY, false);
-                 }
-+                // Paper start - TNTPrimeEvent
-+                org.bukkit.block.Block tntBlock = level.getWorld().getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ());
-+                if(!new com.destroystokyo.paper.event.block.TNTPrimeEvent(tntBlock, com.destroystokyo.paper.event.block.TNTPrimeEvent.PrimeReason.EXPLOSION, explosionSource.getSourceMob().getBukkitEntity()).callEvent())
-+                    continue;
-+                // Paper end
-                 nmsBlock.wasExploded(level, blockposition, explosionSource);
- 
-                 this.level.removeBlock(blockposition, false);
 diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
 index 037902b3addd34dfc6b751ca225373a06c2d6a89..2188cfc34ab4bd67fac9aedd861a597c137a5c40 100644
 --- a/src/main/java/net/minecraft/world/level/block/FireBlock.java

--- a/patches/server/0857-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0857-Replace-player-chunk-loader-system.patch
@@ -1942,10 +1942,10 @@ index c0ed1103e649e619c58f59c7bedd6a18a58f71ea..e57636efacedf1c6f1ccd4f01f7e94d6
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 3a6e5893181ed681099f2748abca738af45ec9c9..bb51a85b33e1701c2e445305d68d3453772f73df 100644
+index d0ebcc23d863be630b55245aa2604c108ee6c93a..c3a39d9d0a5701bbec94e7856e00593660d58a1a 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -660,7 +660,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -655,7 +655,7 @@ public class EnderDragon extends Mob implements Enemy {
                  // this.world.b(1028, this.getChunkCoordinates(), 0);
                  //int viewDistance = ((WorldServer) this.world).getServer().getViewDistance() * 16; // Paper - updated to use worlds actual view distance incase we have to uncomment this due to removal of player view distance API
                  for (net.minecraft.server.level.ServerPlayer player : (List<net.minecraft.server.level.ServerPlayer>) ((ServerLevel)level).players()) {

--- a/patches/server/0879-Allow-to-change-the-podium-for-the-EnderDragon.patch
+++ b/patches/server/0879-Allow-to-change-the-podium-for-the-EnderDragon.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow to change the podium for the EnderDragon
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index bb51a85b33e1701c2e445305d68d3453772f73df..47d6236daca806878399890a8d08e55233f19fd9 100644
+index c3a39d9d0a5701bbec94e7856e00593660d58a1a..f872b60697525e3015979f286bfb08d29bb001df 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 @@ -99,6 +99,10 @@ public class EnderDragon extends Mob implements Enemy {
@@ -39,7 +39,7 @@ index bb51a85b33e1701c2e445305d68d3453772f73df..47d6236daca806878399890a8d08e552
      @Override
      public boolean isFlapping() {
          float f = Mth.cos(this.flapTime * 6.2831855F);
-@@ -970,7 +987,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -965,7 +982,7 @@ public class EnderDragon extends Mob implements Enemy {
                  d0 = segment2[1] - segment1[1];
              }
          } else {
@@ -48,7 +48,7 @@ index bb51a85b33e1701c2e445305d68d3453772f73df..47d6236daca806878399890a8d08e552
              double d1 = Math.max(Math.sqrt(blockposition.distToCenterSqr(this.position())) / 4.0D, 1.0D);
  
              d0 = (double) segmentOffset / d1;
-@@ -997,7 +1014,7 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -992,7 +1009,7 @@ public class EnderDragon extends Mob implements Enemy {
                  vec3d = this.getViewVector(tickDelta);
              }
          } else {

--- a/patches/server/0919-EnderDragon-EntityExplodeEvent-Logic-FIxes.patch
+++ b/patches/server/0919-EnderDragon-EntityExplodeEvent-Logic-FIxes.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Wed, 29 Jun 2022 20:50:08 -0400
+Subject: [PATCH] EnderDragon EntityExplodeEvent Fixes
+
+diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+index f872b60697525e3015979f286bfb08d29bb001df..610f5180841c44d78f1510cf8618eb169bb79f78 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
++++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+@@ -530,6 +530,7 @@ public class EnderDragon extends Mob implements Enemy {
+                 this.level.removeBlock(new BlockPos(block.getX(), block.getY(), block.getZ()), false);
+             }
+         } else {
++            flag1 = false; // Paper
+             for (org.bukkit.block.Block block : event.blockList()) {
+                 org.bukkit.Material blockId = block.getType();
+                 if (blockId.isAir()) {
+@@ -549,9 +550,9 @@ public class EnderDragon extends Mob implements Enemy {
+                     });
+                     craftBlock.getNMS().spawnAfterBreak((ServerLevel) level, blockposition, ItemStack.EMPTY, false);
+                 }
+-                nmsBlock.wasExploded(level, blockposition, explosionSource);
++                //nmsBlock.wasExploded(level, blockposition, explosionSource); Paper - It doesn't make sense to have explosion logic here. This isn't technically an explosion.
+ 
+-                this.level.removeBlock(blockposition, false);
++                flag1 = this.level.removeBlock(blockposition, false) || flag1; // Paper
+             }
+         }
+         // CraftBukkit end

--- a/patches/server/0925-EnderDragon-EntityExplodeEvent-Fixes.patch
+++ b/patches/server/0925-EnderDragon-EntityExplodeEvent-Fixes.patch
@@ -3,10 +3,20 @@ From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 Date: Wed, 29 Jun 2022 20:50:08 -0400
 Subject: [PATCH] EnderDragon EntityExplodeEvent Fixes
 
+
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index f872b60697525e3015979f286bfb08d29bb001df..610f5180841c44d78f1510cf8618eb169bb79f78 100644
+index f872b60697525e3015979f286bfb08d29bb001df..605c56a3ee7f13a8b2e437a774582fdfe465a108 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+@@ -485,7 +485,7 @@ public class EnderDragon extends Mob implements Enemy {
+         int i1 = Mth.floor(box.maxY);
+         int j1 = Mth.floor(box.maxZ);
+         boolean flag = false;
+-        boolean flag1 = false;
++        boolean flag1 = false; // Paper - Diff on change
+         // CraftBukkit start - Create a list to hold all the destroyed blocks
+         List<org.bukkit.block.Block> destroyedBlocks = new java.util.ArrayList<org.bukkit.block.Block>();
+         // CraftBukkit end
 @@ -530,6 +530,7 @@ public class EnderDragon extends Mob implements Enemy {
                  this.level.removeBlock(new BlockPos(block.getX(), block.getY(), block.getZ()), false);
              }
@@ -15,7 +25,7 @@ index f872b60697525e3015979f286bfb08d29bb001df..610f5180841c44d78f1510cf8618eb16
              for (org.bukkit.block.Block block : event.blockList()) {
                  org.bukkit.Material blockId = block.getType();
                  if (blockId.isAir()) {
-@@ -549,9 +550,9 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -549,14 +550,14 @@ public class EnderDragon extends Mob implements Enemy {
                      });
                      craftBlock.getNMS().spawnAfterBreak((ServerLevel) level, blockposition, ItemStack.EMPTY, false);
                  }
@@ -27,3 +37,9 @@ index f872b60697525e3015979f286bfb08d29bb001df..610f5180841c44d78f1510cf8618eb16
              }
          }
          // CraftBukkit end
+ 
+-        if (flag1) {
++        if (flag1) { // Paper - Diff on change
+             BlockPos blockposition1 = new BlockPos(i + this.random.nextInt(l - i + 1), j + this.random.nextInt(i1 - j + 1), k + this.random.nextInt(j1 - k + 1));
+ 
+             this.level.levelEvent(2008, blockposition1, 0);


### PR DESCRIPTION
This seems to have been back when the patch was originally made, but it doesn't make much sense for this to be here.

This caused every single block broken by the dragon to fire a TNTPrimeEvent (even if it wasn't TNT) IF EntityExplodeEvent yield was set to anything but 0.
Additionally, blocks that actually were TNT would fire another event because wasExploded calls the event.
This does cause a small behavior change in that this event will no longer cause the block to be removed. 
However, because this event uses an EntityExplodeEvent you can still customize these blocks.

The behavior of tnt exploding/blocks dropping from ender dragons is not vanilla behavior. 