### PR TITLE
Update Eigencraft patch to fix Vanilla parity issues

### DIFF
--- a/patches/server/0485-Eigencraft-redstone-implementation.patch
+++ b/patches/server/0485-Eigencraft-redstone-implementation.patch
@@ -20,16 +20,17 @@ Just added Bukkit's event system and took a few liberties with dead code and com
 
 diff --git a/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java b/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d4273df8124d9d6d4a122f5ecef6f3d011da5860
+index 0000000000000000000000000000000000000000..3e709645f5c35d16beefa4328a0a8e9c95e632aa
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java
-@@ -0,0 +1,913 @@
+@@ -0,0 +1,954 @@
 +package com.destroystokyo.paper.util;
 +
 +import java.util.List;
 +import java.util.Map;
 +import java.util.concurrent.ThreadLocalRandom;
 +import net.minecraft.core.BlockPos;
++import net.minecraft.core.Direction;
 +import net.minecraft.world.item.ItemStack;
 +import net.minecraft.world.item.Items;
 +import net.minecraft.world.level.Level;
@@ -672,7 +673,20 @@ index 0000000000000000000000000000000000000000..d4273df8124d9d6d4a122f5ecef6f3d0
 +                    // already keeping track of all of the neighbor positions
 +                    // that need to be updated.  All on its own, handling neighbors
 +                    // this way reduces block updates by 1/3 (24 instead of 36).
-+                    worldIn.neighborChanged(upd.self, wire, upd.parent);
++//                    worldIn.neighborChanged(upd.self, wire, upd.parent);
++
++                    // [Space Walker]
++                    // The neighbor update system got a significant overhaul in 1.19.
++                    // Shape and block updates are now added to a stack before being
++                    // processed. These changes make it so any neighbor updates emitted
++                    // by this accelerator will not be processed until after the entire
++                    // wire network has updated. This has a significant impact on the
++                    // behavior and introduces Vanilla parity issues.
++                    // To circumvent this issue we bypass the neighbor update stack and
++                    // call BlockStateBase#neighborChanged directly. This change mostly
++                    // restores old behavior, at the cost of bypassing the
++                    // max-chained-neighbor-updates server property.
++                    worldIn.getBlockState(upd.self).neighborChanged(worldIn, upd.self, wire, upd.parent, false);
 +                }
 +            }
 +
@@ -920,11 +934,38 @@ index 0000000000000000000000000000000000000000..d4273df8124d9d6d4a122f5ecef6f3d0
 +            BlockPos pos = new BlockPos(upd.self.getX(), upd.self.getY(), upd.self.getZ());
 +            if (wire.canSurvive(null, worldIn, pos)) {
 +                state = state.setValue(RedStoneWireBlock.POWER, Integer.valueOf(j));
-+                worldIn.setBlock(upd.self, state, 2);
++                // [Space Walker] suppress shape updates and emit those manually to
++                // bypass the new neighbor update stack.
++                if (worldIn.setBlock(upd.self, state, Block.UPDATE_KNOWN_SHAPE | Block.UPDATE_CLIENTS))
++                    updateNeighborShapes(worldIn, upd.self, state);
 +            }
 +        }
 +
 +        return state;
++    }
++
++    private static final Direction[] UPDATE_SHAPE_ORDER = { Direction.WEST, Direction.EAST, Direction.NORTH, Direction.SOUTH, Direction.DOWN, Direction.UP };
++
++    /*
++     * [Space Walker]
++     * This method emits shape updates around the given block,
++     * bypassing the new neighbor update stack. Diagonal shape
++     * updates are omitted, as they are mostly unnecessary.
++     * Diagonal shape updates are emitted exclusively to other
++     * redstone wires, in order to update their connection properties.
++     * Wire connections should never change as a result of power
++     * changes, so the only behavioral change will be in scenarios
++     * where earlier shape updates have been suppressed to keep a
++     * redstone wire in an invalid state.
++     */
++    public void updateNeighborShapes(Level level, BlockPos pos, BlockState state) {
++        for (Direction dir : UPDATE_SHAPE_ORDER) {
++            BlockPos neighborPos = pos.relative(dir);
++            BlockState neighborState = level.getBlockState(neighborPos);
++
++            BlockState newState = neighborState.updateShape(dir.getOpposite(), state, level, neighborPos, pos);
++            Block.updateOrDestroy(neighborState, newState, level, neighborPos, Block.UPDATE_CLIENTS);
++        }
 +    }
 +
 +    /*
@@ -938,10 +979,10 @@ index 0000000000000000000000000000000000000000..d4273df8124d9d6d4a122f5ecef6f3d0
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
-index 74241146a034c5817cddc608c095d829d765f06a..361ac29180bed08d5b5c15d37b4b04eb54ee6bac 100644
+index 74241146a034c5817cddc608c095d829d765f06a..fdee6b7ba4e5e2ab7c4eec8ee0d402f76e7e9a41 100644
 --- a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
-@@ -253,6 +253,121 @@ public class RedStoneWireBlock extends Block {
+@@ -253,6 +253,124 @@ public class RedStoneWireBlock extends Block {
          return floor.isFaceSturdy(world, pos, Direction.UP) || floor.is(Blocks.HOPPER);
      }
  
@@ -1040,7 +1081,10 @@ index 74241146a034c5817cddc608c095d829d765f06a..361ac29180bed08d5b5c15d37b4b04eb
 +            state = state.setValue(POWER, j);
 +
 +            if (worldIn.getBlockState(pos1) == iblockstate) {
-+                worldIn.setBlock(pos1, state, 2);
++                // [Space Walker] suppress shape updates and emit those manually to
++                // bypass the new neighbor update stack.
++                if (worldIn.setBlock(pos1, state, Block.UPDATE_KNOWN_SHAPE | Block.UPDATE_CLIENTS))
++                    turbo.updateNeighborShapes(worldIn, pos1, state);
 +            }
 +
 +            // 1.16(.1?) dropped the need for blocks needing updates.
@@ -1063,7 +1107,7 @@ index 74241146a034c5817cddc608c095d829d765f06a..361ac29180bed08d5b5c15d37b4b04eb
      private void updatePowerStrength(Level world, BlockPos pos, BlockState state) {
          int i = this.calculateTargetStrength(world, pos);
  
-@@ -322,6 +437,7 @@ public class RedStoneWireBlock extends Block {
+@@ -322,6 +440,7 @@ public class RedStoneWireBlock extends Block {
          return Math.max(i, j - 1);
      }
  
@@ -1071,7 +1115,7 @@ index 74241146a034c5817cddc608c095d829d765f06a..361ac29180bed08d5b5c15d37b4b04eb
      private int getWireSignal(BlockState state) {
          return state.is((Block) this) ? (Integer) state.getValue(RedStoneWireBlock.POWER) : 0;
      }
-@@ -344,7 +460,7 @@ public class RedStoneWireBlock extends Block {
+@@ -344,7 +463,7 @@ public class RedStoneWireBlock extends Block {
      @Override
      public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify) {
          if (!oldState.is(state.getBlock()) && !world.isClientSide) {
@@ -1080,7 +1124,7 @@ index 74241146a034c5817cddc608c095d829d765f06a..361ac29180bed08d5b5c15d37b4b04eb
              Iterator iterator = Direction.Plane.VERTICAL.iterator();
  
              while (iterator.hasNext()) {
-@@ -371,7 +487,7 @@ public class RedStoneWireBlock extends Block {
+@@ -371,7 +490,7 @@ public class RedStoneWireBlock extends Block {
                      world.updateNeighborsAt(pos.relative(enumdirection), this);
                  }
  
@@ -1089,7 +1133,7 @@ index 74241146a034c5817cddc608c095d829d765f06a..361ac29180bed08d5b5c15d37b4b04eb
                  this.updateNeighborsOfNeighboringWires(world, pos);
              }
          }
-@@ -406,7 +522,7 @@ public class RedStoneWireBlock extends Block {
+@@ -406,7 +525,7 @@ public class RedStoneWireBlock extends Block {
      public void neighborChanged(BlockState state, Level world, BlockPos pos, Block sourceBlock, BlockPos sourcePos, boolean notify) {
          if (!world.isClientSide) {
              if (state.canSurvive(world, pos)) {

--- a/patches/server/0905-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/0905-Add-Alternate-Current-redstone-implementation.patch
@@ -2054,7 +2054,7 @@ index 9c036f7be422fd8447726478eee15a77637fdb9c..d59dea221ba0f1b9c14f403d3c6ea61b
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
-index 361ac29180bed08d5b5c15d37b4b04eb54ee6bac..0590b12ec3299c3c884b772430a97c0b90c3dc2e 100644
+index fdee6b7ba4e5e2ab7c4eec8ee0d402f76e7e9a41..ee6e15aa3c8cc1c0f663c104af4b4b984dcb881f 100644
 --- a/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/RedStoneWireBlock.java
 @@ -253,7 +253,7 @@ public class RedStoneWireBlock extends Block {
@@ -2066,7 +2066,7 @@ index 361ac29180bed08d5b5c15d37b4b04eb54ee6bac..0590b12ec3299c3c884b772430a97c0b
      // The bulk of the new functionality is found in RedstoneWireTurbo.java
      com.destroystokyo.paper.util.RedstoneWireTurbo turbo = new com.destroystokyo.paper.util.RedstoneWireTurbo(this);
  
-@@ -460,7 +460,13 @@ public class RedStoneWireBlock extends Block {
+@@ -463,7 +463,13 @@ public class RedStoneWireBlock extends Block {
      @Override
      public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify) {
          if (!oldState.is(state.getBlock()) && !world.isClientSide) {
@@ -2081,7 +2081,7 @@ index 361ac29180bed08d5b5c15d37b4b04eb54ee6bac..0590b12ec3299c3c884b772430a97c0b
              Iterator iterator = Direction.Plane.VERTICAL.iterator();
  
              while (iterator.hasNext()) {
-@@ -487,7 +493,13 @@ public class RedStoneWireBlock extends Block {
+@@ -490,7 +496,13 @@ public class RedStoneWireBlock extends Block {
                      world.updateNeighborsAt(pos.relative(enumdirection), this);
                  }
  
@@ -2096,7 +2096,7 @@ index 361ac29180bed08d5b5c15d37b4b04eb54ee6bac..0590b12ec3299c3c884b772430a97c0b
                  this.updateNeighborsOfNeighboringWires(world, pos);
              }
          }
-@@ -521,8 +533,14 @@ public class RedStoneWireBlock extends Block {
+@@ -524,8 +536,14 @@ public class RedStoneWireBlock extends Block {
      @Override
      public void neighborChanged(BlockState state, Level world, BlockPos pos, Block sourceBlock, BlockPos sourcePos, boolean notify) {
          if (!world.isClientSide) {


### PR DESCRIPTION
1.19 made changes to how shape and block updates are processed, adding them to a stack before processing them. This introduces Vanilla parity issues with the Eigencraft redstone implementation. This PR updates the Eigencraft patch to bypass the neighbor update stack for any shape and block updates emitted, mostly restoring old behavior and fixing these issues. The Alternate Current implementation already does this as well.