### PR TITLE
Fix playing adventure sounds on World/Server

### DIFF
--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -736,10 +736,10 @@ index 0000000000000000000000000000000000000000..2fd6c3e65354071af71c7d8ebb97b559
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..badde58c5151f838faa4b42db02e767eafa2da18
+index 0000000000000000000000000000000000000000..3dc613116c086444ece88bcb0a569eeea953074f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
-@@ -0,0 +1,355 @@
+@@ -0,0 +1,390 @@
 +package io.papermc.paper.adventure;
 +
 +import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -748,6 +748,8 @@ index 0000000000000000000000000000000000000000..badde58c5151f838faa4b42db02e767e
 +import java.util.ArrayList;
 +import java.util.List;
 +import java.util.Locale;
++import java.util.Optional;
++import java.util.function.BiConsumer;
 +import java.util.regex.Matcher;
 +import java.util.regex.Pattern;
 +import net.kyori.adventure.bossbar.BossBar;
@@ -769,21 +771,27 @@ index 0000000000000000000000000000000000000000..badde58c5151f838faa4b42db02e767e
 +import net.kyori.adventure.util.Codec;
 +import net.minecraft.ChatFormatting;
 +import net.minecraft.commands.CommandSourceStack;
++import net.minecraft.core.Holder;
++import net.minecraft.core.registries.BuiltInRegistries;
 +import net.minecraft.locale.Language;
 +import net.minecraft.nbt.CompoundTag;
 +import net.minecraft.nbt.ListTag;
 +import net.minecraft.nbt.StringTag;
 +import net.minecraft.nbt.TagParser;
 +import net.minecraft.network.chat.ComponentUtils;
++import net.minecraft.network.protocol.Packet;
++import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
++import net.minecraft.network.protocol.game.ClientboundSoundPacket;
 +import net.minecraft.resources.ResourceLocation;
++import net.minecraft.sounds.SoundEvent;
 +import net.minecraft.sounds.SoundSource;
 +import net.minecraft.world.BossEvent;
++import net.minecraft.world.entity.Entity;
 +import net.minecraft.world.item.ItemStack;
 +import net.minecraft.world.item.WrittenBookItem;
 +import org.bukkit.command.CommandSender;
 +import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
 +import org.bukkit.craftbukkit.entity.CraftEntity;
-+import org.bukkit.entity.Entity;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -839,7 +847,8 @@ index 0000000000000000000000000000000000000000..badde58c5151f838faa4b42db02e767e
 +        })
 +        .build();
 +    public static final AttributeKey<Locale> LOCALE_ATTRIBUTE = AttributeKey.valueOf("adventure:locale"); // init after FLATTENER because classloading triggered here might create a logger
-+    @Deprecated public static final PlainComponentSerializer PLAIN = PlainComponentSerializer.builder().flattener(FLATTENER).build();
++    @Deprecated
++    public static final PlainComponentSerializer PLAIN = PlainComponentSerializer.builder().flattener(FLATTENER).build();
 +    private static final Codec<CompoundTag, String, IOException, IOException> NBT_CODEC = new Codec<CompoundTag, String, IOException, IOException>() {
 +        @Override
 +        public @NotNull CompoundTag decode(final @NotNull String encoded) throws IOException {
@@ -942,7 +951,7 @@ index 0000000000000000000000000000000000000000..badde58c5151f838faa4b42db02e767e
 +        );
 +    }
 +
-+    public static Component resolveWithContext(final @NotNull Component component, final @Nullable CommandSender context, final @Nullable Entity scoreboardSubject, final boolean bypassPermissions) throws IOException {
++    public static Component resolveWithContext(final @NotNull Component component, final @Nullable CommandSender context, final @Nullable org.bukkit.entity.Entity scoreboardSubject, final boolean bypassPermissions) throws IOException {
 +        final CommandSourceStack css = context != null ? VanillaCommandWrapper.getListener(context) : null;
 +        Boolean previous = null;
 +        if (css != null && bypassPermissions) {
@@ -1066,6 +1075,32 @@ index 0000000000000000000000000000000000000000..badde58c5151f838faa4b42db02e767e
 +            return null;
 +        }
 +        return asVanilla(source);
++    }
++
++    public static Packet<?> asSoundPacket(final Sound sound, final double x, final double y, final double z, final long seed, @Nullable BiConsumer<Packet<?>, Float> packetConsumer) {
++        final ResourceLocation name = asVanilla(sound.name());
++        final Optional<SoundEvent> soundEvent = BuiltInRegistries.SOUND_EVENT.getOptional(name);
++        final SoundSource source = asVanilla(sound.source());
++
++        final Holder<SoundEvent> soundEventHolder = soundEvent.map(BuiltInRegistries.SOUND_EVENT::wrapAsHolder).orElseGet(() -> Holder.direct(SoundEvent.createVariableRangeEvent(name)));
++        final Packet<?> packet = new ClientboundSoundPacket(soundEventHolder, source, x, y, z, sound.volume(), sound.pitch(), seed);
++        if (packetConsumer != null) {
++            packetConsumer.accept(packet, soundEventHolder.value().getRange(sound.volume()));
++        }
++        return packet;
++    }
++
++    public static Packet<?> asSoundPacket(final Sound sound, final Entity emitter, final long seed, @Nullable BiConsumer<Packet<?>, Float> packetConsumer) {
++        final ResourceLocation name = asVanilla(sound.name());
++        final Optional<SoundEvent> soundEvent = BuiltInRegistries.SOUND_EVENT.getOptional(name);
++        final SoundSource source = asVanilla(sound.source());
++
++        final Holder<SoundEvent> soundEventHolder = soundEvent.map(BuiltInRegistries.SOUND_EVENT::wrapAsHolder).orElseGet(() -> Holder.direct(SoundEvent.createVariableRangeEvent(name)));
++        final Packet<?> packet = new ClientboundSoundEntityPacket(soundEventHolder, source, emitter, sound.volume(), sound.pitch(), seed);
++        if (packetConsumer != null) {
++            packetConsumer.accept(packet, soundEventHolder.value().getRange(sound.volume()));
++        }
++        return packet;
 +    }
 +
 +    // NBT
@@ -2817,7 +2852,7 @@ index 0e04e7467ee27ea9e3ef60fe598cc21ab39f4c68..0f5e92a2256fe22b55d2428f98db403a
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6581c2c498a73c1fb60bb922114e24a43d355748..44f10adc1957436d9067657b95f04a12b9b7a867 100644
+index 6581c2c498a73c1fb60bb922114e24a43d355748..15449084959d4dcd112ea112e2bc79ee7f96006a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -601,8 +601,10 @@ public final class CraftServer implements Server {
@@ -2942,10 +2977,48 @@ index 6581c2c498a73c1fb60bb922114e24a43d355748..44f10adc1957436d9067657b95f04a12
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2383,4 +2435,15 @@ public final class CraftServer implements Server {
+@@ -2383,4 +2435,53 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
++
++    // Paper start - adventure sounds
++    @Override
++    public void playSound(final net.kyori.adventure.sound.Sound sound) {
++        final long seed = sound.seed().orElseGet(this.console.overworld().getRandom()::nextLong);
++        for (ServerPlayer player : this.playerList.getPlayers()) {
++            player.connection.send(io.papermc.paper.adventure.PaperAdventure.asSoundPacket(sound, player.getX(), player.getY(), player.getZ(), seed, null));
++        }
++    }
++
++    @Override
++    public void playSound(final net.kyori.adventure.sound.Sound sound, final double x, final double y, final double z) {
++        io.papermc.paper.adventure.PaperAdventure.asSoundPacket(sound, x, y, z, sound.seed().orElseGet(this.console.overworld().getRandom()::nextLong), this.playSound0(x, y, z, this.console.getAllLevels()));
++    }
++
++    @Override
++    public void playSound(final net.kyori.adventure.sound.Sound sound, final net.kyori.adventure.sound.Sound.Emitter emitter) {
++        final long seed = sound.seed().orElseGet(this.console.overworld().getRandom()::nextLong);
++        if (emitter == net.kyori.adventure.sound.Sound.Emitter.self()) {
++            for (ServerPlayer player : this.playerList.getPlayers()) {
++                player.connection.send(io.papermc.paper.adventure.PaperAdventure.asSoundPacket(sound, player, seed, null));
++            }
++        } else if (emitter instanceof org.bukkit.craftbukkit.entity.CraftEntity craftEntity) {
++            final net.minecraft.world.entity.Entity entity = craftEntity.getHandle();
++            io.papermc.paper.adventure.PaperAdventure.asSoundPacket(sound, entity, seed, this.playSound0(entity.getX(), entity.getY(), entity.getZ(), List.of((ServerLevel) entity.getLevel())));
++        } else {
++            throw new IllegalArgumentException("Sound emitter must be an Entity or self(), but was: " + emitter);
++        }
++    }
++
++    private java.util.function.BiConsumer<net.minecraft.network.protocol.Packet<?>, Float> playSound0(final double x, final double y, final double z, final Iterable<ServerLevel> levels) {
++        return (packet, distance) -> {
++            for (final ServerLevel level : levels) {
++                level.getServer().getPlayerList().broadcast(null, x, y, z, distance, level.dimension(), packet);
++            }
++        };
++    }
++    // Paper end
 +
 +    // Paper start
 +    private Iterable<? extends net.kyori.adventure.audience.Audience> adventure$audiences;
@@ -2959,7 +3032,7 @@ index 6581c2c498a73c1fb60bb922114e24a43d355748..44f10adc1957436d9067657b95f04a12
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 981bfb92cd4d167620631facc51da564633b3adc..2f83e56b59407dc388240676ae5cfd73de2a9066 100644
+index 981bfb92cd4d167620631facc51da564633b3adc..aab8099b9980b4d4b4ee6d7484abcc0b55962a5f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -151,6 +151,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -2970,7 +3043,47 @@ index 981bfb92cd4d167620631facc51da564633b3adc..2f83e56b59407dc388240676ae5cfd73
  
      private static final Random rand = new Random();
  
-@@ -1983,5 +1984,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1595,6 +1596,39 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+             entityTracker.broadcastAndSend(packet);
+         }
+     }
++    // Paper start - Adventure
++    @Override
++    public void playSound(final net.kyori.adventure.sound.Sound sound) {
++        final long seed = sound.seed().orElseGet(this.world.getRandom()::nextLong);
++        for (ServerPlayer player : this.getHandle().players()) {
++            player.connection.send(io.papermc.paper.adventure.PaperAdventure.asSoundPacket(sound, player.getX(), player.getY(), player.getZ(), seed, null));
++        }
++    }
++
++    @Override
++    public void playSound(final net.kyori.adventure.sound.Sound sound, final double x, final double y, final double z) {
++        io.papermc.paper.adventure.PaperAdventure.asSoundPacket(sound, x, y, z, sound.seed().orElseGet(this.world.getRandom()::nextLong), this.playSound0(x, y, z));
++    }
++
++    @Override
++    public void playSound(final net.kyori.adventure.sound.Sound sound, final net.kyori.adventure.sound.Sound.Emitter emitter) {
++        final long seed = sound.seed().orElseGet(this.getHandle().getRandom()::nextLong);
++        if (emitter == net.kyori.adventure.sound.Sound.Emitter.self()) {
++            for (ServerPlayer player : this.getHandle().players()) {
++                player.connection.send(io.papermc.paper.adventure.PaperAdventure.asSoundPacket(sound, player, seed, null));
++            }
++        } else if (emitter instanceof CraftEntity craftEntity) {
++            final net.minecraft.world.entity.Entity entity = craftEntity.getHandle();
++            io.papermc.paper.adventure.PaperAdventure.asSoundPacket(sound, entity, seed, this.playSound0(entity.getX(), entity.getY(), entity.getZ()));
++        } else {
++            throw new IllegalArgumentException("Sound emitter must be an Entity or self(), but was: " + emitter);
++        }
++    }
++
++    private java.util.function.BiConsumer<net.minecraft.network.protocol.Packet<?>, Float> playSound0(final double x, final double y, final double z) {
++        return (packet, distance) -> this.world.getServer().getPlayerList().broadcast(null, x, y, z, distance, this.world.dimension(), packet);
++    }
++    // Paper end
+ 
+     private static Map<String, GameRules.Key<?>> gamerules;
+     public static synchronized Map<String, GameRules.Key<?>> getGameRulesNMS() {
+@@ -1983,5 +2017,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return ret;
      }
@@ -3472,7 +3585,7 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..f1208e752cdab08228d790a5195114a62d16d399 100644
+index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e07921f02 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -283,14 +283,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -3691,7 +3804,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..f1208e752cdab08228d790a5195114a6
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -2111,6 +2198,254 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2111,6 +2198,232 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  
@@ -3868,18 +3981,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..f1208e752cdab08228d790a5195114a6
 +
 +    @Override
 +    public void playSound(final net.kyori.adventure.sound.Sound sound, final double x, final double y, final double z) {
-+        final long seed = sound.seed().orElseGet(this.getHandle().getRandom()::nextLong);
-+        final ResourceLocation name = io.papermc.paper.adventure.PaperAdventure.asVanilla(sound.name());
-+        final java.util.Optional<net.minecraft.sounds.SoundEvent> event = BuiltInRegistries.SOUND_EVENT.getOptional(name);
-+
-+        final Holder<SoundEvent> soundHolder;
-+        if (event.isPresent()) {
-+            soundHolder = BuiltInRegistries.SOUND_EVENT.wrapAsHolder(event.get());
-+        } else {
-+            soundHolder = Holder.direct(SoundEvent.createVariableRangeEvent(name));
-+        }
-+
-+        this.getHandle().connection.send(new ClientboundSoundPacket(soundHolder, io.papermc.paper.adventure.PaperAdventure.asVanilla(sound.source()), x, y, z, sound.volume(), sound.pitch(), seed));
++        this.getHandle().connection.send(io.papermc.paper.adventure.PaperAdventure.asSoundPacket(sound, x, y, z, sound.seed().orElseGet(this.getHandle().getRandom()::nextLong), null));
 +    }
 +
 +    @Override
@@ -3887,23 +3989,12 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..f1208e752cdab08228d790a5195114a6
 +        final Entity entity;
 +        if (emitter == net.kyori.adventure.sound.Sound.Emitter.self()) {
 +            entity = this.getHandle();
-+        } else if (emitter instanceof org.bukkit.entity.Entity) {
-+            entity = ((CraftEntity) emitter).getHandle();
++        } else if (emitter instanceof CraftEntity craftEntity) {
++            entity = craftEntity.getHandle();
 +        } else {
 +            throw new IllegalArgumentException("Sound emitter must be an Entity or self(), but was: " + emitter);
 +        }
-+        final long seed = sound.seed().orElseGet(this.getHandle().getRandom()::nextLong);
-+
-+        final ResourceLocation name = io.papermc.paper.adventure.PaperAdventure.asVanilla(sound.name());
-+        final java.util.Optional<net.minecraft.sounds.SoundEvent> event = BuiltInRegistries.SOUND_EVENT.getOptional(name);
-+        final Holder<SoundEvent> soundHolder;
-+        if (event.isPresent()) {
-+            soundHolder = BuiltInRegistries.SOUND_EVENT.wrapAsHolder(event.get());
-+        } else {
-+            soundHolder = Holder.direct(SoundEvent.createVariableRangeEvent(name));
-+        }
-+
-+        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSoundEntityPacket(soundHolder, io.papermc.paper.adventure.PaperAdventure.asVanilla(sound.source()), entity, sound.volume(), sound.pitch(), seed));
++        this.getHandle().connection.send(io.papermc.paper.adventure.PaperAdventure.asSoundPacket(sound, entity, sound.seed().orElseGet(this.getHandle().getRandom()::nextLong), null));
 +    }
 +
 +    @Override

--- a/patches/server/0011-Paper-command.patch
+++ b/patches/server/0011-Paper-command.patch
@@ -615,7 +615,7 @@ index 1fe07773cf9664164b29164caba22800e5a6bdae..cb6f192c11cda6230ec365e6cefb44a3
  
          this.setPvpAllowed(dedicatedserverproperties.pvp);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 44f10adc1957436d9067657b95f04a12b9b7a867..df1058c8f3198fee567938b91021e253e9fbbf00 100644
+index 15449084959d4dcd112ea112e2bc79ee7f96006a..04a1eb79f8fc5651a39b739cc2bbb2412f8a76c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -905,6 +905,7 @@ public final class CraftServer implements Server {
@@ -626,8 +626,8 @@ index 44f10adc1957436d9067657b95f04a12b9b7a867..df1058c8f3198fee567938b91021e253
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2437,6 +2438,34 @@ public final class CraftServer implements Server {
-     // Spigot end
+@@ -2475,6 +2476,34 @@ public final class CraftServer implements Server {
+     // Paper end
  
      // Paper start
 +    @SuppressWarnings({"rawtypes", "unchecked"})

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -1632,7 +1632,7 @@ index 9c3ce492051199acb8d38ade121ec8a0cbc50f54..aa4f2dc63dd79e6c3d7594d2fd63fa00
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2d112dd2ea808773e364396b26f04bca54a6fa37..78d20c65ac8cb4e3467d0e14397a3c6dfefdc525 100644
+index 7eaf75ac95a5651b6245b406983144a484a0832c..3f68ecca17f297e74bfdb8f93c2cfc71c6719b31 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -362,7 +362,7 @@ public final class CraftServer implements Server {
@@ -1846,10 +1846,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f1208e752cdab08228d790a5195114a62d16d399..f8667311662644ec85ed2af42cff739a8fdc290a 100644
+index 693978b0ca9eacba0b518d121b03c23e07921f02..ec0eeee342340f8fc099d29a234e658672a7ba7c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2531,6 +2531,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2509,6 +2509,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
              CraftPlayer.this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(components, position == net.md_5.bungee.api.ChatMessageType.ACTION_BAR));
          }

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -17854,7 +17854,7 @@ index bf4b2f89d3a7133155c6272379c742318b2c1514..33677ec811ceab939c419bf7d31b9958
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 78d20c65ac8cb4e3467d0e14397a3c6dfefdc525..e6193b5403d4cb762f702b45ca7c07d5f64d8218 100644
+index 3f68ecca17f297e74bfdb8f93c2cfc71c6719b31..c77a7bc3a3e0d244b082ba917412685822df47cb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1125,7 +1125,7 @@ public final class CraftServer implements Server {
@@ -17885,7 +17885,7 @@ index 78d20c65ac8cb4e3467d0e14397a3c6dfefdc525..e6193b5403d4cb762f702b45ca7c07d5
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2f83e56b59407dc388240676ae5cfd73de2a9066..55b560a5a0dc74a29533eb6fb3cd11f6c7ee4258 100644
+index aab8099b9980b4d4b4ee6d7484abcc0b55962a5f..9920eaa5d9efa301462f2dbf7e06835b819df3e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -321,10 +321,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -17947,7 +17947,7 @@ index 2f83e56b59407dc388240676ae5cfd73de2a9066..55b560a5a0dc74a29533eb6fb3cd11f6
              long chunkKey = chunkTickets.getLongKey();
              SortedArraySet<Ticket<?>> tickets = chunkTickets.getValue();
  
-@@ -1917,14 +1907,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1950,14 +1940,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {
@@ -18004,7 +18004,7 @@ index 2f83e56b59407dc388240676ae5cfd73de2a9066..55b560a5a0dc74a29533eb6fb3cd11f6
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f8667311662644ec85ed2af42cff739a8fdc290a..bfd61549b3df0885a03276a2acfc798f078e3245 100644
+index ec0eeee342340f8fc099d29a234e658672a7ba7c..94b8b1c5c624c59cff74be1631cc3e790bf1d4ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -182,6 +182,81 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0067-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0067-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 377e631bb70c4711152ff2895bc8ffd3c032bba4..ec97b740a935196d689fac7ff239968b87884a96 100644
+index 0a0cb354c7a1016a7c1893581591f6b848bf221c..b6f7d306b35b496d1e85e0de588aea631e63c1d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2545,5 +2545,23 @@ public final class CraftServer implements Server {
+@@ -2583,5 +2583,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 94dd69d1b8beaf0edf9faf79a66ba2d41e12b5b8..e2fd156ed79e454f2a4337e5e53e749dd1b02ea1 100644
+index 05b10d3f413021353b6cf84e3ec9c2f8413d5216..8c84447e96945f486a687f73bbd35e55d061a130 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2571,5 +2571,24 @@ public final class CraftServer implements Server {
+@@ -2609,5 +2609,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0135-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0135-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e2fd156ed79e454f2a4337e5e53e749dd1b02ea1..325e65488b31efe609f60b5d6d95ca89eda39f92 100644
+index 8c84447e96945f486a687f73bbd35e55d061a130..be56089f8e44161606aa5bc3ea89bc51a8f4adff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2590,5 +2590,10 @@ public final class CraftServer implements Server {
+@@ -2628,5 +2628,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -631,7 +631,7 @@ index 4038bb76339d43f18770624bd7fecc79b8d7f2a9..2456edc11b29a92b1648937cd3dd6a9a
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 78deb4398cc45cf20d054dcbaacfe04366193ab5..435de87653033ed417d722b99b9acb8e3e68f915 100644
+index 6ec9de5d0a9076a841a183b1c696bb53e48f9f97..b305c6e026ccd0a7f1b2b2ac79da9555c21feeb4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -253,6 +253,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -652,7 +652,7 @@ index 78deb4398cc45cf20d054dcbaacfe04366193ab5..435de87653033ed417d722b99b9acb8e
          CraftItemFactory.instance();
      }
  
-@@ -2605,5 +2609,37 @@ public final class CraftServer implements Server {
+@@ -2643,5 +2647,37 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }

--- a/patches/server/0196-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0196-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -34,10 +34,10 @@ index d273673978c8270f2e0719412372039406e31f5e..65110445ff8a245742c4f7a7055f544f
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 292e810febf9272688ecafdb8c7ed2e8a97ae67b..32ef1eb646a33a022c0fffcff2a293091288c3e2 100644
+index e85189ccf80c166f741eee2ea9bcdd2fd38508d2..06d667c3ab4d4c6902dfc143666b625b306a7782 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1821,11 +1821,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1854,11 +1854,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index db79410d56e0defeb710203f9332dff6d5418ee4..124cc062b8b8f63788d903b5706999dc64b8c974 100644
+index b1d32f9f272b4cb88d0ed745ea5f6b227dc369bb..30c4cc750aac280475b69d1ab6b7e0c52b9d7350 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2817,6 +2817,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2795,6 +2795,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0284-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0284-Make-the-default-permission-message-configurable.patch
@@ -18,10 +18,10 @@ index e3467aaf6d0c8d486b84362e3c20b3fe631b50ff..8f16640fc2f1233c10392d7e32a54d78
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9894d5d10c76469ad6f26100ce3924b65597e738..c4970f883d27fe2082bf5cb1d43fa32e9b9b8a30 100644
+index 153e82a91e01e05cb89a64c88c5660fb9765c3a0..f282954ee9b92749a3bcdcdb0fec67809287f4f0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2631,6 +2631,16 @@ public final class CraftServer implements Server {
+@@ -2669,6 +2669,16 @@ public final class CraftServer implements Server {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }
  

--- a/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ea8dc87ce9a995ace56c27c53a15ef51dc4a871d..5e4735ed74e47c28d85c2e7e08458e74f6559e47 100644
+index 6425c208fb103165b75f7bfde0d9fc937ee08f7a..0f570d7a56c9e7456ce6863af73af19f89a759bc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2864,6 +2864,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2842,6 +2842,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0318-Expose-the-internal-current-tick.patch
+++ b/patches/server/0318-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c4970f883d27fe2082bf5cb1d43fa32e9b9b8a30..5c7bae55758760a67f54c48427ddc3f021c22087 100644
+index f282954ee9b92749a3bcdcdb0fec67809287f4f0..2fb9698b0037a04472c36b801249c6aa82b09b22 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2672,5 +2672,10 @@ public final class CraftServer implements Server {
+@@ -2710,5 +2710,10 @@ public final class CraftServer implements Server {
          profile.getProperties().putAll(((CraftPlayer)player).getHandle().getGameProfile().getProperties());
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }

--- a/patches/server/0364-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0364-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a59e4c85d69f342bb55942e8b12053d907e97dd9..d6ed4cff5dba860f8ccd694052d68034426949be 100644
+index 7912c5c1c2dabe698bb0c748449f7edc8a6ce9f6..808517a5912425a36ae446cf08b8600cc3b67a6e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2687,5 +2687,10 @@ public final class CraftServer implements Server {
+@@ -2725,5 +2725,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0397-Implement-Mob-Goal-API.patch
+++ b/patches/server/0397-Implement-Mob-Goal-API.patch
@@ -792,10 +792,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1f1f63a37fdbed26e7cc77ecc19d546c2ef12c36..d8ff8f02adbe532724d47fef5142fdf9b08de10d 100644
+index 9f4489e69bd69183e2ea158515a85828a6643959..cc3703fb00b0da8ec9d835868dbdf8e03fbee7cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2700,5 +2700,11 @@ public final class CraftServer implements Server {
+@@ -2738,5 +2738,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0431-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0431-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d26c17cda10dd0a816175be9ab3a1fff30fcd9bd..64e59d5c545e6bc4e000e2ca779df427a67e5aae 100644
+index 14e6caf028dd6b44d6435e4cecb4d5dd5156d09b..6737fecddad32e65bbdcb43de70504678d4a5077 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -370,7 +370,7 @@ public final class CraftServer implements Server {
@@ -44,7 +44,7 @@ index d26c17cda10dd0a816175be9ab3a1fff30fcd9bd..64e59d5c545e6bc4e000e2ca779df427
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6c6408710bcb67295e5058631e4d56d7e7386ab8..51b88f432134e162dd63580ef2c086ad853d5ee9 100644
+index 3f1521b4f5a7b76a648fdaf7af9e2753c98ed545..98e2d959aaef16a2249f6701b28c6a038af799d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -278,7 +278,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -116,7 +116,7 @@ index 6c6408710bcb67295e5058631e4d56d7e7386ab8..51b88f432134e162dd63580ef2c086ad
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -2161,6 +2176,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2194,6 +2209,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          io.papermc.paper.chunk.system.ChunkSystem.scheduleChunkLoad(this.getHandle(), x, z, gen, ChunkStatus.FULL, true, priority, (c) -> {
              net.minecraft.server.MinecraftServer.getServer().scheduleOnMain(() -> {
                  net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk)c;

--- a/patches/server/0456-Brand-support.patch
+++ b/patches/server/0456-Brand-support.patch
@@ -56,10 +56,10 @@ index b4f17b9c195081b54d79494d9afaf0da21f292c0..139daac1cc7359be4eebf73b2a578e07
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a77858a6253a3195879aaa3bccccee6c0af5b00a..6cac6959133d90f5755ed5272f7edc261a94cb69 100644
+index 486f3b8c802d2224013c648347c91fc14f522d91..eddb463507bd12477345a661e07e8e111aec90b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2991,6 +2991,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2969,6 +2969,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0534-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0534-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 4a0321f56ef80aa4991e61f586ddd3f6b45e499b..de713f1ca1d61a6b1fca2b66de916255
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2f4bdf2128037b06a3d5e7b340f5f888c8777ca8..0e9b81e16e1da8e72b7871fb6c6563b8e181fea4 100644
+index 1e28cda1faf145c2b72e0eac095a1b8b0b2b5dba..091e5fae3834dd06527c5dc108d1342f763f93b4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1804,8 +1804,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1837,8 +1837,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index 2f4bdf2128037b06a3d5e7b340f5f888c8777ca8..0e9b81e16e1da8e72b7871fb6c6563b8
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1840,8 +1845,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1873,8 +1878,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0600-More-World-API.patch
+++ b/patches/server/0600-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0e9b81e16e1da8e72b7871fb6c6563b8e181fea4..4e73e38dcec36b4ab0a03c6bd1b70811233f9a0a 100644
+index 091e5fae3834dd06527c5dc108d1342f763f93b4..96f0a04cb36e106eb04e0972b5cfe0ed3767b40f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2046,6 +2046,69 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2079,6 +2079,69 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return new CraftStructureSearchResult(CraftStructure.minecraftToBukkit(found.getSecond().value(), this.getHandle().registryAccess()), CraftLocation.toBukkit(found.getFirst(), this));
      }
  

--- a/patches/server/0615-Add-basic-Datapack-API.patch
+++ b/patches/server/0615-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 79a0db289c837cc37e0d1caca91359bc3d96dbfe..08e3da659371dc67db7ebea33ee2528f304a13ae 100644
+index 7b3e69e4b21fb7dc8a1f3abcdc287f3b29d9f511..b61607c55c968e6a0d5c57799d73a8ccb91a2eea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -292,6 +292,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index 79a0db289c837cc37e0d1caca91359bc3d96dbfe..08e3da659371dc67db7ebea33ee2528f
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2775,5 +2777,11 @@ public final class CraftServer implements Server {
+@@ -2813,5 +2815,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0803-Custom-Potion-Mixes.patch
+++ b/patches/server/0803-Custom-Potion-Mixes.patch
@@ -164,7 +164,7 @@ index 424406d2692856cfd82b6f3b7b6228fa3bd20c2f..c57efcb9a79337ec791e4e8f6671612f
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4736b0f3ac468be99a42b5c0e62cffbbe2149610..fc088b26c3fab1afcfbcacfd19dc8a3b6111e94c 100644
+index 7922e466e80bf959f2acdf474d6c44159482e791..6712237bb2b2e68c7081265af7ebdf85f7ac07cd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -295,6 +295,7 @@ public final class CraftServer implements Server {
@@ -184,7 +184,7 @@ index 4736b0f3ac468be99a42b5c0e62cffbbe2149610..fc088b26c3fab1afcfbcacfd19dc8a3b
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2901,5 +2902,10 @@ public final class CraftServer implements Server {
+@@ -2939,5 +2940,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0828-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0828-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -158,10 +158,10 @@ index de713f1ca1d61a6b1fca2b66de9162556d102449..edd2c9d0cf5a81c779011cb4215d496a
              this.onChanged(server);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 75a8c83779f97c430815964e09f1c3ea61ff4659..4f2b709140e30d1676cafc0d4b1d8d3bf4f7e96e 100644
+index 3e1833c6cb57f6e9da83b90b7aa7fd4c52acb5a4..528530682d718573b72d13c3d92396bf9f049650 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1910,7 +1910,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1943,7 +1943,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule));
          handle.deserialize(event.getValue()); // Paper
@@ -170,7 +170,7 @@ index 75a8c83779f97c430815964e09f1c3ea61ff4659..4f2b709140e30d1676cafc0d4b1d8d3b
          return true;
      }
  
-@@ -1950,7 +1950,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1983,7 +1983,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule.getName()));
          handle.deserialize(event.getValue()); // Paper

--- a/patches/server/0867-Warn-on-plugins-accessing-faraway-chunks.patch
+++ b/patches/server/0867-Warn-on-plugins-accessing-faraway-chunks.patch
@@ -18,7 +18,7 @@ index 4ace5a32e8d17303a4b5d9e8935a803d7c0df409..174f5ff8f827dab2d85cee525429d46b
  
      private static boolean isOutsideSpawnableHeight(int y) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4f2b709140e30d1676cafc0d4b1d8d3bf4f7e96e..8d3a32a0538a6065fd0725721ab8a1a011c4d64a 100644
+index 528530682d718573b72d13c3d92396bf9f049650..dafd2c85f89d8822e50db63c21631199c69a97a0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -309,9 +309,24 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -86,7 +86,7 @@ index 4f2b709140e30d1676cafc0d4b1d8d3bf4f7e96e..8d3a32a0538a6065fd0725721ab8a1a0
          // Transient load for this tick
          return this.world.getChunk(x >> 4, z >> 4).getHeight(CraftHeightMap.toNMS(heightMap), x, z);
      }
-@@ -2330,6 +2350,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2363,6 +2383,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot end
      // Paper start
      public java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent) {

--- a/patches/server/0899-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0899-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b764d508951e19634aface33b618bd3d3e114479..1a2eba89fafe45a1221b66a21d9f8dbdceb0e799 100644
+index 1dfdc5046b1fe2907734428d7feaab37a2951ea9..24b1f4f479a49976bbf06d08fc6aea74bc18444d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3161,6 +3161,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3139,6 +3139,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0916-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0916-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1a2eba89fafe45a1221b66a21d9f8dbdceb0e799..652489579c7014b46ebf67b0c72d2e50508955c2 100644
+index 24b1f4f479a49976bbf06d08fc6aea74bc18444d..2af561e773338d58bb88bbcdbdf54afbcce30e21 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3166,6 +3166,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3144,6 +3144,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }


### PR DESCRIPTION
playing adventure sounds on a World/Server had some unexpected side effects due to ForwardingAudience's delegation to each individual audience. This overrides all 3 playSound methods in CraftWorld/CraftServer with better implementations.

----

The issues arrises due to seeded sounds. When you play a sound on a World or Server without a seed, it should pick one seed. For location-specific sounds on World/Server, packets shouldn't be sent to all players, only players within range, so overriding also allows delegation to vanilla packet broadcast mechanics.