### PR TITLE
Raw Itemstack improvements

### DIFF
--- a/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
@@ -70,7 +70,7 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e42a88dee9f1813d76a0c7c62bb8e46fd1339de0 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..ff77f28bc26617b17587fea8c730a14f56820386 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -126,10 +126,48 @@ public final class CraftItemStack extends ItemStack {
@@ -87,13 +87,13 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e42a88dee9f1813d76a0c7c62bb8e46f
 +            this.handle.setItem(item);
 +
 +            // Adjust size
-+            if(this.handle.getCount() > item.getMaxStackSize()) {
++            if (this.handle.getCount() > item.getMaxStackSize()) {
 +                this.handle.setCount(item.getMaxStackSize());
 +            }
 +
-+            if(this.handle.hasTag()) {
++            if (this.handle.hasTag()) {
 +                // Strip damage
-+                if(this.handle.isDamageableItem() && !item.canBeDepleted()) {
++                if (this.handle.isDamageableItem() && !item.canBeDepleted()) {
 +                    this.handle.getTag().remove(CraftMetaItem.DAMAGE.NBT);
 +                    this.handle.getTag().remove(CraftMetaItem.UNBREAKABLE.NBT);
 +                }
@@ -102,7 +102,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e42a88dee9f1813d76a0c7c62bb8e46f
 +
 +                // Strip invalid enchantments
 +                EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
-+                if(map != null) {
++                if (map != null) {
 +                    for (Enchantment enchant : getEnchantments().keySet()) {
 +                        if (((CraftEnchantment) enchant).getHandle().category.canEnchant(item)) continue;
 +                        map.remove(enchant);
@@ -114,19 +114,19 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e42a88dee9f1813d76a0c7c62bb8e46f
 +                CraftMetaItem.stripInvalidTags(oldType, type, this.handle.getTag());
 +                // Paper end
 +
-+                if(this.handle.getTag().isEmpty()) {
++                if (this.handle.getTag().isEmpty()) {
 +                    handle.tag = null;
 +                    ((ItemStack) this).setItemMeta(null);
 +                }
 +            }
 +
 +            // Adjust damage
-+            if(item.canBeDepleted()) {
++            if (item.canBeDepleted()) {
 +                this.handle.getOrCreateTag().putInt(CraftMetaItem.DAMAGE.NBT, 0);
              }
          }
          setData(null);
-@@ -178,28 +216,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -178,28 +216,13 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Validate.notNull(ench, "Cannot add null enchantment");
  
@@ -153,15 +153,16 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e42a88dee9f1813d76a0c7c62bb8e46f
 -        tag.putShort(ENCHANTMENTS_LVL.NBT, (short) level);
 -        list.add(tag);
 +        // Paper start - replace entire method
-+        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getOrCreateTag(), CraftMetaItem.ENCHANTMENTS);
-+        if(map == null) map = new EnchantmentMap();
++        if (!this.handle.hasTag()) return;
++        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
++        if (map == null) map = new EnchantmentMap();
 +        map.put(ench, level);
 +        CraftMetaItem.applyEnchantments(map, this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
 +        // Paper end
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -232,50 +254,32 @@ public final class CraftItemStack extends ItemStack {
+@@ -232,50 +255,32 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Validate.notNull(ench, "Cannot remove null enchantment");
  
@@ -183,9 +184,9 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e42a88dee9f1813d76a0c7c62bb8e46f
 -            }
 -        }
 +        // Paper start - replace entire method
-+        if(!this.handle.hasTag()) return 0;
++        if (!this.handle.hasTag()) return 0;
 +        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
-+        if(map == null) return 0;
++        if (map == null) return 0;
  
 -        if (index == Integer.MIN_VALUE) {
 -            return 0;
@@ -197,7 +198,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e42a88dee9f1813d76a0c7c62bb8e46f
 -            }
 -            return level;
 +        Integer previousLevel;
-+        if((previousLevel = map.remove(ench)) != null && map.isEmpty()) {
++        if ((previousLevel = map.remove(ench)) != null && map.isEmpty()) {
 +            map = null;
          }
 -
@@ -208,7 +209,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e42a88dee9f1813d76a0c7c62bb8e46f
 -                listCopy.add(list.get(i));
 -            }
 +        CraftMetaItem.applyEnchantments(map, this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
-+        if(map == null) {
++        if (map == null) {
 +            this.handle.getTag().remove(CraftMetaItem.ENCHANTMENTS.NBT);
          }
 -        this.handle.getTag().put(ENCHANTMENTS.NBT, listCopy);
@@ -222,9 +223,9 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e42a88dee9f1813d76a0c7c62bb8e46f
      public Map<Enchantment, Integer> getEnchantments() {
 -        return CraftItemStack.getEnchantments(this.handle);
 +        // Paper start - replace entire method
-+        if(!this.handle.hasTag()) return ImmutableMap.of();
++        if (!this.handle.hasTag()) return ImmutableMap.of();
 +        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
-+        if(map == null) return ImmutableMap.of();
++        if (map == null) return ImmutableMap.of();
 +        return com.google.common.collect.ImmutableSortedMap.copyOfSorted(map);
 +        // Paper end
      }
@@ -260,7 +261,7 @@ index 3a8ff15d1c6ba21ce8bed030e84a9f85b702d72a..94b4638f296c5086198ae3e3866b8935
          super(meta);
          this.material = material;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c67667a39d28e 100644
+index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..388f987a3bf2098a1c8ffb25fef7d71c449ca02d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
@@ -271,51 +272,48 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
  import com.google.common.collect.Lists;
  import com.google.common.collect.Multimap;
  import com.google.common.collect.SetMultimap;
-@@ -19,20 +20,8 @@ import java.lang.annotation.RetentionPolicy;
- import java.lang.annotation.Target;
- import java.lang.reflect.Constructor;
- import java.lang.reflect.InvocationTargetException;
--import java.util.ArrayList;
--import java.util.Arrays;
--import java.util.Base64;
--import java.util.Collection;
--import java.util.EnumSet;
--import java.util.HashMap;
--import java.util.Iterator;
--import java.util.LinkedHashMap;
--import java.util.List;
--import java.util.Locale;
--import java.util.Map;
--import java.util.NoSuchElementException;
--import java.util.Objects;
--import java.util.Set;
-+import java.util.*;
-+import java.util.function.BiConsumer;
+@@ -23,6 +24,7 @@ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.Base64;
+ import java.util.Collection;
++import java.util.Comparator; // Paper
+ import java.util.EnumSet;
+ import java.util.HashMap;
+ import java.util.Iterator;
+@@ -33,6 +35,7 @@ import java.util.Map;
+ import java.util.NoSuchElementException;
+ import java.util.Objects;
+ import java.util.Set;
++import java.util.TreeMap; // Paper
  import java.util.logging.Level;
  import java.util.logging.Logger;
  import javax.annotation.Nonnull;
-@@ -272,7 +261,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -272,7 +275,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private List<String> lore; // null and empty are two different states internally
      private Integer customModelData;
      private CompoundTag blockData;
 -    private Map<Enchantment, Integer> enchantments;
 +    private EnchantmentMap enchantments; // Paper
-+    private final LinkedList<CompoundTag> rawEnchants = new LinkedList<>(); // Paper
++    private final java.util.LinkedList<CompoundTag> rawEnchants = new java.util.LinkedList<>(); // Paper
      private Multimap<Attribute, AttributeModifier> attributeModifiers;
      private int repairCost;
      private int hideFlag;
-@@ -283,7 +273,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -283,8 +287,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
  
      private CompoundTag internalTag;
 -    final Map<String, Tag> unhandledTags = new HashMap<String, Tag>(); // Visible for testing only
 +    final Map<String, Tag> unhandledTags = new TreeMap<String, Tag>(); // Visible for testing only // Paper
      private CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftMetaItem.DATA_TYPE_REGISTRY);
++    private boolean serialized = false; // Paper
  
      private int version = CraftMagicNumbers.INSTANCE.getDataVersion(); // Internal use only
-@@ -304,8 +294,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+@@ -303,9 +308,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+         this.customModelData = meta.customModelData;
          this.blockData = meta.blockData;
  
++        this.serialized = meta.serialized; // Paper
          if (meta.enchantments != null) { // Spigot
 -            this.enchantments = new LinkedHashMap<Enchantment, Integer>(meta.enchantments);
 +            this.enchantments = new EnchantmentMap(meta.enchantments); // Paper
@@ -324,7 +322,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
  
          if (meta.hasAttributeModifiers()) {
              this.attributeModifiers = LinkedHashMultimap.create(meta.attributeModifiers);
-@@ -355,7 +346,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -355,7 +362,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              this.blockData = tag.getCompound(BLOCK_DATA.NBT).copy();
          }
  
@@ -333,7 +331,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
          this.attributeModifiers = CraftMetaItem.buildModifiers(tag, CraftMetaItem.ATTRIBUTES);
  
          if (tag.contains(REPAIR.NBT)) {
-@@ -387,19 +378,25 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -387,19 +394,25 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -343,7 +341,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
 +        return buildEnchantments(tag, key, null);
 +    }
 +    // Paper end
-+    static EnchantmentMap buildEnchantments(CompoundTag tag, ItemMetaKey key, BiConsumer<Enchantment, CompoundTag> callback) { // Paper
++    static EnchantmentMap buildEnchantments(CompoundTag tag, ItemMetaKey key, java.util.function.BiConsumer<Enchantment, CompoundTag> callback) { // Paper
          if (!tag.contains(key.NBT)) {
              return null;
          }
@@ -357,11 +355,19 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
              int level = 0xffff & ((CompoundTag) ench.get(i)).getShort(ENCHANTMENTS_LVL.NBT);
  
              Enchantment enchant = Enchantment.getByKey(CraftNamespacedKey.fromStringOrNull(id));
-+            if(callback != null) callback.accept(enchant, (CompoundTag) ench.get(i)); // Paper
++            if (callback != null) callback.accept(enchant, (CompoundTag) ench.get(i)); // Paper
              if (enchant != null) {
                  enchantments.put(enchant, level);
              }
-@@ -546,13 +543,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -485,6 +498,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+             this.blockData = (CompoundTag) CraftNBTTagConfigSerializer.deserialize(blockData);
+         }
+ 
++        this.serialized = true; // Paper
+         this.enchantments = CraftMetaItem.buildEnchantments(map, CraftMetaItem.ENCHANTMENTS);
+         this.attributeModifiers = CraftMetaItem.buildModifiers(map, CraftMetaItem.ATTRIBUTES);
+ 
+@@ -546,13 +560,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -377,16 +383,22 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
          for (Map.Entry<?, ?> entry : ench.entrySet()) {
              // Doctor older enchants
              String enchantKey = entry.getKey().toString();
-@@ -630,7 +627,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -630,7 +644,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              itemTag.putInt(HIDEFLAGS.NBT, hideFlag);
          }
  
 -        CraftMetaItem.applyEnchantments(this.enchantments, itemTag, CraftMetaItem.ENCHANTMENTS);
-+        applySafeEnchantments(itemTag, CraftMetaItem.ENCHANTMENTS); // Paper
++        // Paper start
++        if (!serialized) {
++            applySafeEnchantments(itemTag, CraftMetaItem.ENCHANTMENTS);
++        } else {
++            CraftMetaItem.applyEnchantments(enchantments, itemTag, CraftMetaItem.ENCHANTMENTS);
++        }
++        // Paper end
          CraftMetaItem.applyModifiers(this.attributeModifiers, itemTag, CraftMetaItem.ATTRIBUTES);
  
          if (this.hasRepairCost()) {
-@@ -674,13 +671,37 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -674,13 +694,37 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return tagList;
      }
  
@@ -400,7 +412,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
          ListTag list = new ListTag();
 +        Iterator<Map.Entry<Enchantment, Integer>> it = enchantments.entrySet().iterator();
 +        for (CompoundTag el : rawEnchants) {
-+            if(el == null) {
++            if (el == null) {
 +                Map.Entry<Enchantment, Integer> entry = it.next();
 +                CompoundTag subtag = new CompoundTag();
 +
@@ -412,7 +424,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
 +                list.add(el);
 +            }
 +        }
- 
++
 +        tag.put(key.NBT, list);
 +    }
 +    // Paper end
@@ -420,12 +432,12 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
 +        if (enchantments == null /*|| enchantments.size() == 0*/) { // Spigot - remove size check
 +            return;
 +        }
-+
+ 
 +        ListTag list = new ListTag();
          for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
              CompoundTag subtag = new CompoundTag();
  
-@@ -828,14 +849,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -828,14 +872,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public Map<Enchantment, Integer> getEnchants() {
@@ -442,7 +454,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
          }
  
          if (ignoreRestrictions || level >= ench.getStartLevel() && level <= ench.getMaxLevel()) {
-@@ -1223,7 +1244,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1223,7 +1267,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.customModelData = this.customModelData;
              clone.blockData = this.blockData;
              if (this.enchantments != null) {
@@ -451,7 +463,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
              }
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
-@@ -1404,6 +1425,126 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1404,6 +1448,126 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.version = version;
      }
  
@@ -478,41 +490,41 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
 +    private static final CraftMetaTropicalFishBucket fishBucketMeta = new CraftMetaTropicalFishBucket((CraftMetaItem) null);
 +
 +    public static void stripInvalidTags(Material mat, Material newMat, CompoundTag tag) {
-+        if(bundleMeta.applicableTo(mat) && !bundleMeta.applicableTo(newMat)) {
++        if (bundleMeta.applicableTo(mat) && !bundleMeta.applicableTo(newMat)) {
 +            tag.remove(bundleMeta.ITEMS.NBT);
 +            return;
 +        }
-+        if(fishBucketMeta.applicableTo(mat) && !fishBucketMeta.applicableTo(newMat)) {
++        if (fishBucketMeta.applicableTo(mat) && !fishBucketMeta.applicableTo(newMat)) {
 +            tag.remove(fishBucketMeta.VARIANT.NBT);
 +            tag.remove(fishBucketMeta.ENTITY_TAG.NBT);
 +            return;
 +        }
-+        if(axolotlBucketMeta.applicableTo(mat) && !axolotlBucketMeta.applicableTo(newMat)) {
++        if (axolotlBucketMeta.applicableTo(mat) && !axolotlBucketMeta.applicableTo(newMat)) {
 +            tag.remove(axolotlBucketMeta.VARIANT.NBT);
 +            tag.remove(axolotlBucketMeta.ENTITY_TAG.NBT);
 +            return;
 +        }
-+        if(armorStandMeta.applicableTo(mat) && !armorStandMeta.applicableTo(newMat)) {
++        if (armorStandMeta.applicableTo(mat) && !armorStandMeta.applicableTo(newMat)) {
 +            tag.remove(armorStandMeta.ENTITY_TAG.NBT);
 +            return;
 +        }
-+        if(entityTagMeta.applicableTo(mat) && !entityTagMeta.applicableTo(newMat)) {
++        if (entityTagMeta.applicableTo(mat) && !entityTagMeta.applicableTo(newMat)) {
 +            tag.remove(entityTagMeta.ENTITY_TAG.NBT);
 +            return;
 +        }
-+        if(spawnEggMeta.applicableTo(mat) && !spawnEggMeta.applicableTo(newMat)) {
++        if (spawnEggMeta.applicableTo(mat) && !spawnEggMeta.applicableTo(newMat)) {
 +            tag.remove(spawnEggMeta.ENTITY_TAG.NBT);
 +            return;
 +        }
-+        if(bannerMeta.applicableTo(mat) && !bannerMeta.applicableTo(newMat)) {
++        if (bannerMeta.applicableTo(mat) && !bannerMeta.applicableTo(newMat)) {
 +            tag.remove("BlockEntityTag");
 +            return;
 +        }
-+        if(blockStateMeta.applicableTo(mat) && !blockStateMeta.applicableTo(newMat)) {
++        if (blockStateMeta.applicableTo(mat) && !blockStateMeta.applicableTo(newMat)) {
 +            tag.remove(blockStateMeta.BLOCK_ENTITY_TAG.NBT);
 +            return;
 +        }
-+        if(bookMeta.applicableTo(mat) && !bookMeta.applicableTo(newMat)) {
++        if (bookMeta.applicableTo(mat) && !bookMeta.applicableTo(newMat)) {
 +            tag.remove(bookMeta.BOOK_TITLE.NBT);
 +            tag.remove(bookMeta.BOOK_AUTHOR.NBT);
 +            tag.remove(bookMeta.BOOK_PAGES.NBT);
@@ -520,55 +532,55 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
 +            tag.remove(bookMeta.GENERATION.NBT);
 +            return;
 +        }
-+        if(chargeMeta.applicableTo(mat) && !chargeMeta.applicableTo(newMat)) {
++        if (chargeMeta.applicableTo(mat) && !chargeMeta.applicableTo(newMat)) {
 +            tag.remove(chargeMeta.EXPLOSION.NBT);
 +            return;
 +        }
-+        if(compassMeta.applicableTo(mat) && !compassMeta.applicableTo(newMat)) {
++        if (compassMeta.applicableTo(mat) && !compassMeta.applicableTo(newMat)) {
 +            tag.remove(compassMeta.LODESTONE_DIMENSION.NBT);
 +            tag.remove(compassMeta.LODESTONE_POS.NBT);
 +            tag.remove(compassMeta.LODESTONE_POS_WORLD.NBT);
 +            tag.remove(compassMeta.LODESTONE_TRACKED.NBT);
 +            return;
 +        }
-+        if(crossbowMeta.applicableTo(mat) && !crossbowMeta.applicableTo(newMat)) {
++        if (crossbowMeta.applicableTo(mat) && !crossbowMeta.applicableTo(newMat)) {
 +            tag.remove(crossbowMeta.CHARGED.NBT);
 +            tag.remove(crossbowMeta.CHARGED_PROJECTILES.NBT);
 +            return;
 +        }
-+        if(enchantedBookMeta.applicableTo(mat) && !enchantedBookMeta.applicableTo(newMat)) {
++        if (enchantedBookMeta.applicableTo(mat) && !enchantedBookMeta.applicableTo(newMat)) {
 +            tag.remove(enchantedBookMeta.STORED_ENCHANTMENTS.NBT);
 +            return;
 +        }
-+        if(fireworkMeta.applicableTo(mat) && !fireworkMeta.applicableTo(newMat)) {
++        if (fireworkMeta.applicableTo(mat) && !fireworkMeta.applicableTo(newMat)) {
 +            tag.remove(fireworkMeta.FIREWORKS.NBT);
 +            return;
 +        }
-+        if(recipeMeta.applicableTo(mat) && !recipeMeta.applicableTo(newMat)) {
++        if (recipeMeta.applicableTo(mat) && !recipeMeta.applicableTo(newMat)) {
 +            tag.remove(recipeMeta.BOOK_RECIPES.NBT);
 +            return;
 +        }
-+        if(leatherArmorMeta.applicableTo(mat) && !leatherArmorMeta.applicableTo(newMat)) {
++        if (leatherArmorMeta.applicableTo(mat) && !leatherArmorMeta.applicableTo(newMat)) {
 +            tag.remove(leatherArmorMeta.DISPLAY.NBT);
 +            return;
 +        }
-+        if(mapMeta.applicableTo(mat) && !mapMeta.applicableTo(newMat)) {
++        if (mapMeta.applicableTo(mat) && !mapMeta.applicableTo(newMat)) {
 +            tag.remove(mapMeta.MAP_SCALING.NBT);
 +            tag.remove(mapMeta.DISPLAY.NBT);
 +            tag.remove(mapMeta.MAP_ID.NBT);
 +            return;
 +        }
-+        if(potionMeta.applicableTo(mat) && !potionMeta.applicableTo(newMat)) {
++        if (potionMeta.applicableTo(mat) && !potionMeta.applicableTo(newMat)) {
 +            tag.remove(potionMeta.DEFAULT_POTION.NBT);
 +            tag.remove(potionMeta.POTION_COLOR.NBT);
 +            tag.remove(potionMeta.POTION_EFFECTS.NBT);
 +            return;
 +        }
-+        if(skullMeta.applicableTo(mat) && !skullMeta.applicableTo(newMat)) {
++        if (skullMeta.applicableTo(mat) && !skullMeta.applicableTo(newMat)) {
 +            tag.remove(skullMeta.SKULL_OWNER.NBT);
 +            return;
 +        }
-+        if(stewMeta.applicableTo(mat) && !stewMeta.applicableTo(newMat)) {
++        if (stewMeta.applicableTo(mat) && !stewMeta.applicableTo(newMat)) {
 +            tag.remove(stewMeta.EFFECTS.NBT);
 +            return;
 +        }
@@ -578,19 +590,19 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c6766
      public static Set<String> getHandledTags() {
          synchronized (CraftMetaItem.HANDLED_TAGS) {
              if (CraftMetaItem.HANDLED_TAGS.isEmpty()) {
-@@ -1458,4 +1599,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1458,4 +1622,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              return CraftMetaItem.HANDLED_TAGS;
          }
      }
 +
 +    // Paper start
-+    public static class EnchantmentMap extends TreeMap<Enchantment, Integer> {
++    public static class EnchantmentMap extends TreeMap<Enchantment, Integer> { // Paper private -> public
 +        private EnchantmentMap(Map<Enchantment, Integer> enchantments) {
 +            this();
 +            putAll(enchantments);
 +        }
 +
-+        protected EnchantmentMap() {
++        protected EnchantmentMap() { // Paper private -> protected
 +            super(Comparator.comparing(o -> o.getKey().toString()));
 +        }
 +

--- a/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
@@ -70,10 +70,10 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..301b81ffd2fceee1fd28f9352c6d3cffc0a4672e 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..4c1941d0a3e00d23e70c62fac3fbda12e7095f5a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -126,10 +126,43 @@ public final class CraftItemStack extends ItemStack {
+@@ -126,10 +126,48 @@ public final class CraftItemStack extends ItemStack {
          } else if (this.handle == null) {
              this.handle = new net.minecraft.world.item.ItemStack(CraftMagicNumbers.getItem(type), 1);
          } else {
@@ -113,6 +113,11 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..301b81ffd2fceee1fd28f9352c6d3cff
 +                // Strip invalid tags
 +                CraftMetaItem.stripInvalidTags(oldType, type, this.handle.getTag());
 +                // Paper end
++
++                if(this.handle.getTag().isEmpty()) {
++                    handle.tag = null;
++                    ((ItemStack) this).setItemMeta(null);
++                }
 +            }
 +
 +            // Adjust damage
@@ -121,7 +126,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..301b81ffd2fceee1fd28f9352c6d3cff
              }
          }
          setData(null);
-@@ -178,28 +211,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -178,28 +216,13 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Validate.notNull(ench, "Cannot add null enchantment");
  
@@ -157,7 +162,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..301b81ffd2fceee1fd28f9352c6d3cff
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -232,50 +250,29 @@ public final class CraftItemStack extends ItemStack {
+@@ -232,50 +255,29 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Validate.notNull(ench, "Cannot remove null enchantment");
  
@@ -254,7 +259,7 @@ index 3a8ff15d1c6ba21ce8bed030e84a9f85b702d72a..94b4638f296c5086198ae3e3866b8935
          super(meta);
          this.material = material;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..d3334ffb931842afe3a906bbdedd80bec60afbc8 100644
+index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..934c9c79f40079f512cf9e7b298c06eb3031e48b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
@@ -378,7 +383,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..d3334ffb931842afe3a906bbdedd80be
              }
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
-@@ -1404,6 +1412,127 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1404,6 +1412,126 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.version = version;
      }
  
@@ -432,8 +437,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..d3334ffb931842afe3a906bbdedd80be
 +            return;
 +        }
 +        if(bannerMeta.applicableTo(mat) && !bannerMeta.applicableTo(newMat)) {
-+            tag.remove(bannerMeta.BASE.NBT);
-+            tag.remove(bannerMeta.PATTERNS.NBT);
++            tag.remove("BlockEntityTag");
 +            return;
 +        }
 +        if(blockStateMeta.applicableTo(mat) && !blockStateMeta.applicableTo(newMat)) {
@@ -506,7 +510,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..d3334ffb931842afe3a906bbdedd80be
      public static Set<String> getHandledTags() {
          synchronized (CraftMetaItem.HANDLED_TAGS) {
              if (CraftMetaItem.HANDLED_TAGS.isEmpty()) {
-@@ -1458,4 +1587,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1458,4 +1586,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              return CraftMetaItem.HANDLED_TAGS;
          }
      }

--- a/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
@@ -70,10 +70,10 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..b4ed47b80b9ad664f01d20bddd7a6df71b79139c 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e078977253805d42c0fda28fbb8525b6f4302a2d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -126,10 +126,37 @@ public final class CraftItemStack extends ItemStack {
+@@ -126,10 +126,40 @@ public final class CraftItemStack extends ItemStack {
          } else if (this.handle == null) {
              this.handle = new net.minecraft.world.item.ItemStack(CraftMagicNumbers.getItem(type), 1);
          } else {
@@ -91,17 +91,15 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..b4ed47b80b9ad664f01d20bddd7a6df7
 +                this.handle.setCount(item.getMaxStackSize());
 +            }
 +
-+            // Adjust damage
-+            if(item.canBeDepleted()) {
-+                this.handle.getTag().putInt(CraftMetaItem.DAMAGE.NBT, 0);
-+            }
-+
 +            if(this.handle.hasTag()) {
 +
 +                // Strip damage
 +                if(this.handle.isDamageableItem() && !item.canBeDepleted()) {
 +                    this.handle.getTag().remove(CraftMetaItem.DAMAGE.NBT);
++                    this.handle.getTag().remove(CraftMetaItem.UNBREAKABLE.NBT);
 +                }
++
++                this.handle.getTag().remove(CraftMetaItem.CUSTOM_MODEL_DATA.NBT);
 +
 +                // Strip invalid enchantments
 +                for (Enchantment enchant : getEnchantments().keySet()) {
@@ -112,10 +110,15 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..b4ed47b80b9ad664f01d20bddd7a6df7
 +                // Strip invalid tags
 +                CraftMetaItem.stripInvalidTags(oldType, type, this.handle.getTag());
 +                // Paper end
++            }
++
++            // Adjust damage
++            if(item.canBeDepleted()) {
++                this.handle.getOrCreateTag().putInt(CraftMetaItem.DAMAGE.NBT, 0);
              }
          }
          setData(null);
-@@ -178,28 +205,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -178,28 +208,13 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Validate.notNull(ench, "Cannot add null enchantment");
  
@@ -151,7 +154,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..b4ed47b80b9ad664f01d20bddd7a6df7
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -232,50 +244,29 @@ public final class CraftItemStack extends ItemStack {
+@@ -232,50 +247,29 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Validate.notNull(ench, "Cannot remove null enchantment");
  

--- a/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
@@ -70,21 +70,43 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..830c137326e284d796bc2d89c36327327184c558 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..8c43819be849f5bc589051722e337b0d5c47c807 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -127,10 +127,6 @@ public final class CraftItemStack extends ItemStack {
+@@ -126,10 +126,28 @@ public final class CraftItemStack extends ItemStack {
+         } else if (this.handle == null) {
              this.handle = new net.minecraft.world.item.ItemStack(CraftMagicNumbers.getItem(type), 1);
          } else {
-             this.handle.setItem(CraftMagicNumbers.getItem(type));
+-            this.handle.setItem(CraftMagicNumbers.getItem(type));
 -            if (this.hasItemMeta()) {
 -                // This will create the appropriate item meta, which will contain all the data we intend to keep
 -                CraftItemStack.setItemMeta(this.handle, CraftItemStack.getItemMeta(this.handle));
--            }
++            // Paper start
++            Item item = CraftMagicNumbers.getItem(type);
++            Material oldType = getType();
++            this.handle.setItem(item);
++
++            if(this.handle.hasTag()) {
++                // Strip damage
++                if(this.handle.isDamageableItem() && !item.canBeDepleted()) {
++                    this.handle.getTag().remove(CraftMetaItem.DAMAGE.NBT);
++                } else {
++                    this.handle.getTag().putInt(CraftMetaItem.DAMAGE.NBT, 0);
++                }
++
++                // Strip invalid enchantments
++                for (Enchantment enchant : getEnchantments().keySet()) {
++                    if (((CraftEnchantment) enchant).getHandle().category.canEnchant(item)) continue;
++                    removeEnchantment(enchant);
++                }
++
++                // Strip invalid tags
++                CraftMetaItem.stripInvalidTags(oldType, type, this.handle.getTag());
++                // Paper end
+             }
          }
          setData(null);
-     }
-@@ -178,28 +174,11 @@ public final class CraftItemStack extends ItemStack {
+@@ -178,28 +196,13 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Validate.notNull(ench, "Cannot add null enchantment");
  
@@ -110,15 +132,17 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..830c137326e284d796bc2d89c3632732
 -        tag.putString(ENCHANTMENTS_ID.NBT, ench.getKey().toString());
 -        tag.putShort(ENCHANTMENTS_LVL.NBT, (short) level);
 -        list.add(tag);
-+        // Paper start - Replace whole method
-+        final ItemMeta itemMeta = this.getItemMeta();
-+        itemMeta.addEnchant(ench, level, true);
-+        this.setItemMeta(itemMeta);
++        // Paper start - replace entire method
++        if(!this.handle.hasTag()) return;
++        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
++        if(map == null) map = new EnchantmentMap();
++        map.put(ench, level);
++        CraftMetaItem.applyEnchantments(map, this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
 +        // Paper end
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -232,50 +211,22 @@ public final class CraftItemStack extends ItemStack {
+@@ -232,50 +235,29 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Validate.notNull(ench, "Cannot remove null enchantment");
  
@@ -150,36 +174,72 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..830c137326e284d796bc2d89c3632732
 -            }
 -            return level;
 -        }
--
++        // Paper start - replace entire method
++        if(!this.handle.hasTag()) return 0;
++        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
++        if(map == null) return 0;
+ 
 -        // This is workaround for not having an index removal
 -        listCopy = new ListTag();
 -        for (int i = 0; i < size; i++) {
 -            if (i != index) {
 -                listCopy.add(list.get(i));
 -            }
-+        // Paper start - replace entire method
-+        final ItemMeta itemMeta = this.getItemMeta();
-+        if (itemMeta == null) return 0;
-+        int level = itemMeta.getEnchantLevel(ench);
-+        if (level > 0) {
-+            itemMeta.removeEnchant(ench);
-+            this.setItemMeta(itemMeta);
++        Integer previousLevel;
++        if((previousLevel = map.remove(ench)) != null && map.isEmpty()) {
++            map = null;
          }
 -        this.handle.getTag().put(ENCHANTMENTS.NBT, listCopy);
-+        // Paper end
++        CraftMetaItem.applyEnchantments(map, this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
  
-         return level;
+-        return level;
++        return previousLevel == null ? 0 : previousLevel;
++        // Paper end
      }
  
      @Override
      public Map<Enchantment, Integer> getEnchantments() {
 -        return CraftItemStack.getEnchantments(this.handle);
-+        return this.hasItemMeta() ? this.getItemMeta().getEnchants() : ImmutableMap.<Enchantment, Integer>of(); // Paper - use Item Meta
++        // Paper start - replace entire method
++        if(!this.handle.hasTag()) return ImmutableMap.of();
++        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
++        if(map == null) return ImmutableMap.of();
++        return com.google.common.collect.ImmutableSortedMap.copyOfSorted(map);
++        // Paper end
      }
  
      static Map<Enchantment, Integer> getEnchantments(net.minecraft.world.item.ItemStack item) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+index 3a8ff15d1c6ba21ce8bed030e84a9f85b702d72a..94b4638f296c5086198ae3e3866b8935e59c0a49 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+@@ -23,9 +23,23 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+     @ItemMetaKey.Specific(ItemMetaKey.Specific.To.NBT)
+     static final ItemMetaKey BLOCK_ENTITY_TAG = new ItemMetaKey("BlockEntityTag");
+ 
+-    final Material material;
++    Material material; // Paper
+     CompoundTag blockEntityTag;
+ 
++    // Paper start
++    CraftMetaBlockState(CraftMetaItem meta) {
++        super(meta);
++
++        if (!(meta instanceof CraftMetaBlockState)) {
++            return;
++        }
++
++        CraftMetaBlockState state = (CraftMetaBlockState) meta;
++        this.material = state.material;
++        this.blockEntityTag = state.blockEntityTag.copy();
++    }
++    // Paper end
++
+     CraftMetaBlockState(CraftMetaItem meta, Material material) {
+         super(meta);
+         this.material = material;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..4d687fa31f4d889ac755c178b9afd2b927c78ee2 100644
+index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..9bfbd0a95769bfcb79a345a4bbc576cadbcf8284 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
@@ -265,7 +325,17 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..4d687fa31f4d889ac755c178b9afd2b9
          for (Map.Entry<?, ?> entry : ench.entrySet()) {
              // Doctor older enchants
              String enchantKey = entry.getKey().toString();
-@@ -828,14 +831,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -676,6 +679,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+     static void applyEnchantments(Map<Enchantment, Integer> enchantments, CompoundTag tag, ItemMetaKey key) {
+         if (enchantments == null /*|| enchantments.size() == 0*/) { // Spigot - remove size check
++            if(key == CraftMetaItem.ENCHANTMENTS) {
++                tag.remove(key.NBT); // Paper delete the key when the list is empty
++            }
+             return;
+         }
+ 
+@@ -828,14 +834,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public Map<Enchantment, Integer> getEnchants() {
@@ -282,7 +352,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..4d687fa31f4d889ac755c178b9afd2b9
          }
  
          if (ignoreRestrictions || level >= ench.getStartLevel() && level <= ench.getMaxLevel()) {
-@@ -1223,7 +1226,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1223,7 +1229,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.customModelData = this.customModelData;
              clone.blockData = this.blockData;
              if (this.enchantments != null) {
@@ -291,19 +361,147 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..4d687fa31f4d889ac755c178b9afd2b9
              }
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
-@@ -1458,4 +1461,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1404,6 +1410,127 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+         this.version = version;
+     }
+ 
++    // Paper start
++    private static final CraftMetaArmorStand armorStandMeta = new CraftMetaArmorStand((CraftMetaItem) null);
++    private static final CraftMetaAxolotlBucket axolotlBucketMeta = new CraftMetaAxolotlBucket((CraftMetaItem) null);
++    private static final CraftMetaBanner bannerMeta = new CraftMetaBanner((CraftMetaItem) null);
++    private static final CraftMetaBlockState blockStateMeta = new CraftMetaBlockState((CraftMetaItem) null);
++    private static final CraftMetaBook bookMeta = new CraftMetaBook((CraftMetaItem) null);
++    private static final CraftMetaBundle bundleMeta = new CraftMetaBundle((CraftMetaItem) null);
++    private static final CraftMetaCharge chargeMeta = new CraftMetaCharge((CraftMetaItem) null);
++    private static final CraftMetaCompass compassMeta = new CraftMetaCompass((CraftMetaItem) null);
++    private static final CraftMetaCrossbow crossbowMeta = new CraftMetaCrossbow((CraftMetaItem) null);
++    private static final CraftMetaEnchantedBook enchantedBookMeta = new CraftMetaEnchantedBook((CraftMetaItem) null);
++    private static final CraftMetaEntityTag entityTagMeta = new CraftMetaEntityTag((CraftMetaItem) null);
++    private static final CraftMetaFirework fireworkMeta = new CraftMetaFirework((CraftMetaItem) null);
++    private static final CraftMetaKnowledgeBook recipeMeta = new CraftMetaKnowledgeBook((CraftMetaItem) null);
++    private static final CraftMetaLeatherArmor leatherArmorMeta = new CraftMetaLeatherArmor((CraftMetaItem) null);
++    private static final CraftMetaMap mapMeta = new CraftMetaMap((CraftMetaItem) null);
++    private static final CraftMetaPotion potionMeta = new CraftMetaPotion((CraftMetaItem) null);
++    private static final CraftMetaSkull skullMeta = new CraftMetaSkull((CraftMetaItem) null);
++    private static final CraftMetaSpawnEgg spawnEggMeta = new CraftMetaSpawnEgg((CraftMetaItem) null);
++    private static final CraftMetaSuspiciousStew stewMeta = new CraftMetaSuspiciousStew((CraftMetaItem) null);
++    private static final CraftMetaTropicalFishBucket fishBucketMeta = new CraftMetaTropicalFishBucket((CraftMetaItem) null);
++
++    public static void stripInvalidTags(Material mat, Material newMat, CompoundTag tag) {
++        if(bundleMeta.applicableTo(mat) && !bundleMeta.applicableTo(newMat)) {
++            tag.remove(bundleMeta.ITEMS.NBT);
++            return;
++        }
++        if(fishBucketMeta.applicableTo(mat) && !fishBucketMeta.applicableTo(newMat)) {
++            tag.remove(fishBucketMeta.VARIANT.NBT);
++            tag.remove(fishBucketMeta.ENTITY_TAG.NBT);
++            return;
++        }
++        if(axolotlBucketMeta.applicableTo(mat) && !axolotlBucketMeta.applicableTo(newMat)) {
++            tag.remove(axolotlBucketMeta.VARIANT.NBT);
++            tag.remove(axolotlBucketMeta.ENTITY_TAG.NBT);
++            return;
++        }
++        if(armorStandMeta.applicableTo(mat) && !armorStandMeta.applicableTo(newMat)) {
++            tag.remove(armorStandMeta.ENTITY_TAG.NBT);
++            return;
++        }
++        if(entityTagMeta.applicableTo(mat) && !entityTagMeta.applicableTo(newMat)) {
++            tag.remove(entityTagMeta.ENTITY_TAG.NBT);
++            return;
++        }
++        if(spawnEggMeta.applicableTo(mat) && !spawnEggMeta.applicableTo(newMat)) {
++            tag.remove(spawnEggMeta.ENTITY_TAG.NBT);
++            return;
++        }
++        if(bannerMeta.applicableTo(mat) && !bannerMeta.applicableTo(newMat)) {
++            tag.remove(bannerMeta.BASE.NBT);
++            tag.remove(bannerMeta.PATTERNS.NBT);
++            return;
++        }
++        if(blockStateMeta.applicableTo(mat) && !blockStateMeta.applicableTo(newMat)) {
++            tag.remove(blockStateMeta.BLOCK_ENTITY_TAG.NBT);
++            return;
++        }
++        if(bookMeta.applicableTo(mat) && !bookMeta.applicableTo(newMat)) {
++            tag.remove(bookMeta.BOOK_TITLE.NBT);
++            tag.remove(bookMeta.BOOK_AUTHOR.NBT);
++            tag.remove(bookMeta.BOOK_PAGES.NBT);
++            tag.remove(bookMeta.RESOLVED.NBT);
++            tag.remove(bookMeta.GENERATION.NBT);
++            return;
++        }
++        if(chargeMeta.applicableTo(mat) && !chargeMeta.applicableTo(newMat)) {
++            tag.remove(chargeMeta.EXPLOSION.NBT);
++            return;
++        }
++        if(compassMeta.applicableTo(mat) && !compassMeta.applicableTo(newMat)) {
++            tag.remove(compassMeta.LODESTONE_DIMENSION.NBT);
++            tag.remove(compassMeta.LODESTONE_POS.NBT);
++            tag.remove(compassMeta.LODESTONE_POS_WORLD.NBT);
++            tag.remove(compassMeta.LODESTONE_TRACKED.NBT);
++            return;
++        }
++        if(crossbowMeta.applicableTo(mat) && !crossbowMeta.applicableTo(newMat)) {
++            tag.remove(crossbowMeta.CHARGED.NBT);
++            tag.remove(crossbowMeta.CHARGED_PROJECTILES.NBT);
++            return;
++        }
++        if(enchantedBookMeta.applicableTo(mat) && !enchantedBookMeta.applicableTo(newMat)) {
++            tag.remove(enchantedBookMeta.STORED_ENCHANTMENTS.NBT);
++            return;
++        }
++        if(fireworkMeta.applicableTo(mat) && !fireworkMeta.applicableTo(newMat)) {
++            tag.remove(fireworkMeta.FIREWORKS.NBT);
++            return;
++        }
++        if(recipeMeta.applicableTo(mat) && !recipeMeta.applicableTo(newMat)) {
++            tag.remove(recipeMeta.BOOK_RECIPES.NBT);
++            return;
++        }
++        if(leatherArmorMeta.applicableTo(mat) && !leatherArmorMeta.applicableTo(newMat)) {
++            tag.remove(leatherArmorMeta.DISPLAY.NBT);
++            return;
++        }
++        if(mapMeta.applicableTo(mat) && !mapMeta.applicableTo(newMat)) {
++            tag.remove(mapMeta.MAP_SCALING.NBT);
++            tag.remove(mapMeta.DISPLAY.NBT);
++            tag.remove(mapMeta.MAP_ID.NBT);
++            return;
++        }
++        if(potionMeta.applicableTo(mat) && !potionMeta.applicableTo(newMat)) {
++            tag.remove(potionMeta.DEFAULT_POTION.NBT);
++            tag.remove(potionMeta.POTION_COLOR.NBT);
++            tag.remove(potionMeta.POTION_EFFECTS.NBT);
++            return;
++        }
++        if(skullMeta.applicableTo(mat) && !skullMeta.applicableTo(newMat)) {
++            tag.remove(skullMeta.SKULL_OWNER.NBT);
++            return;
++        }
++        if(stewMeta.applicableTo(mat) && !stewMeta.applicableTo(newMat)) {
++            tag.remove(stewMeta.EFFECTS.NBT);
++            return;
++        }
++    }
++    // Paper end
++
+     public static Set<String> getHandledTags() {
+         synchronized (CraftMetaItem.HANDLED_TAGS) {
+             if (CraftMetaItem.HANDLED_TAGS.isEmpty()) {
+@@ -1458,4 +1585,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              return CraftMetaItem.HANDLED_TAGS;
          }
      }
 +
 +    // Paper start
-+    private static class EnchantmentMap extends TreeMap<Enchantment, Integer> {
++    public static class EnchantmentMap extends TreeMap<Enchantment, Integer> {
 +        private EnchantmentMap(Map<Enchantment, Integer> enchantments) {
 +            this();
 +            putAll(enchantments);
 +        }
 +
-+        private EnchantmentMap() {
++        protected EnchantmentMap() {
 +            super(Comparator.comparing(o -> o.getKey().toString()));
 +        }
 +

--- a/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
@@ -70,7 +70,7 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..4c1941d0a3e00d23e70c62fac3fbda12e7095f5a 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e42a88dee9f1813d76a0c7c62bb8e46fd1339de0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -126,10 +126,48 @@ public final class CraftItemStack extends ItemStack {
@@ -126,7 +126,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..4c1941d0a3e00d23e70c62fac3fbda12
              }
          }
          setData(null);
-@@ -178,28 +216,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -178,28 +216,12 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Validate.notNull(ench, "Cannot add null enchantment");
  
@@ -153,8 +153,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..4c1941d0a3e00d23e70c62fac3fbda12
 -        tag.putShort(ENCHANTMENTS_LVL.NBT, (short) level);
 -        list.add(tag);
 +        // Paper start - replace entire method
-+        if(!this.handle.hasTag()) return;
-+        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
++        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getOrCreateTag(), CraftMetaItem.ENCHANTMENTS);
 +        if(map == null) map = new EnchantmentMap();
 +        map.put(ench, level);
 +        CraftMetaItem.applyEnchantments(map, this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
@@ -162,7 +161,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..4c1941d0a3e00d23e70c62fac3fbda12
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -232,50 +255,29 @@ public final class CraftItemStack extends ItemStack {
+@@ -232,50 +254,32 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Validate.notNull(ench, "Cannot remove null enchantment");
  
@@ -183,7 +182,11 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..4c1941d0a3e00d23e70c62fac3fbda12
 -                break;
 -            }
 -        }
--
++        // Paper start - replace entire method
++        if(!this.handle.hasTag()) return 0;
++        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
++        if(map == null) return 0;
+ 
 -        if (index == Integer.MIN_VALUE) {
 -            return 0;
 -        }
@@ -193,24 +196,22 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..4c1941d0a3e00d23e70c62fac3fbda12
 -                this.handle.setTag(null);
 -            }
 -            return level;
--        }
-+        // Paper start - replace entire method
-+        if(!this.handle.hasTag()) return 0;
-+        EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
-+        if(map == null) return 0;
- 
++        Integer previousLevel;
++        if((previousLevel = map.remove(ench)) != null && map.isEmpty()) {
++            map = null;
+         }
+-
 -        // This is workaround for not having an index removal
 -        listCopy = new ListTag();
 -        for (int i = 0; i < size; i++) {
 -            if (i != index) {
 -                listCopy.add(list.get(i));
 -            }
-+        Integer previousLevel;
-+        if((previousLevel = map.remove(ench)) != null && map.isEmpty()) {
-+            map = null;
++        CraftMetaItem.applyEnchantments(map, this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
++        if(map == null) {
++            this.handle.getTag().remove(CraftMetaItem.ENCHANTMENTS.NBT);
          }
 -        this.handle.getTag().put(ENCHANTMENTS.NBT, listCopy);
-+        CraftMetaItem.applyEnchantments(map, this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
  
 -        return level;
 +        return previousLevel == null ? 0 : previousLevel;
@@ -259,7 +260,7 @@ index 3a8ff15d1c6ba21ce8bed030e84a9f85b702d72a..94b4638f296c5086198ae3e3866b8935
          super(meta);
          this.material = material;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..934c9c79f40079f512cf9e7b298c06eb3031e48b 100644
+index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..1fed6ffbec64be3d33045faddc3c67667a39d28e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
@@ -270,32 +271,40 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..934c9c79f40079f512cf9e7b298c06eb
  import com.google.common.collect.Lists;
  import com.google.common.collect.Multimap;
  import com.google.common.collect.SetMultimap;
-@@ -23,6 +24,7 @@ import java.util.ArrayList;
- import java.util.Arrays;
- import java.util.Base64;
- import java.util.Collection;
-+import java.util.Comparator; // Paper
- import java.util.EnumSet;
- import java.util.HashMap;
- import java.util.Iterator;
-@@ -33,6 +35,7 @@ import java.util.Map;
- import java.util.NoSuchElementException;
- import java.util.Objects;
- import java.util.Set;
-+import java.util.TreeMap; // Paper
+@@ -19,20 +20,8 @@ import java.lang.annotation.RetentionPolicy;
+ import java.lang.annotation.Target;
+ import java.lang.reflect.Constructor;
+ import java.lang.reflect.InvocationTargetException;
+-import java.util.ArrayList;
+-import java.util.Arrays;
+-import java.util.Base64;
+-import java.util.Collection;
+-import java.util.EnumSet;
+-import java.util.HashMap;
+-import java.util.Iterator;
+-import java.util.LinkedHashMap;
+-import java.util.List;
+-import java.util.Locale;
+-import java.util.Map;
+-import java.util.NoSuchElementException;
+-import java.util.Objects;
+-import java.util.Set;
++import java.util.*;
++import java.util.function.BiConsumer;
  import java.util.logging.Level;
  import java.util.logging.Logger;
  import javax.annotation.Nonnull;
-@@ -272,7 +275,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -272,7 +261,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private List<String> lore; // null and empty are two different states internally
      private Integer customModelData;
      private CompoundTag blockData;
 -    private Map<Enchantment, Integer> enchantments;
 +    private EnchantmentMap enchantments; // Paper
++    private final LinkedList<CompoundTag> rawEnchants = new LinkedList<>(); // Paper
      private Multimap<Attribute, AttributeModifier> attributeModifiers;
      private int repairCost;
      private int hideFlag;
-@@ -283,7 +286,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -283,7 +273,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
  
      private CompoundTag internalTag;
@@ -304,21 +313,37 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..934c9c79f40079f512cf9e7b298c06eb
      private CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftMetaItem.DATA_TYPE_REGISTRY);
  
      private int version = CraftMagicNumbers.INSTANCE.getDataVersion(); // Internal use only
-@@ -304,7 +307,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -304,8 +294,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.blockData = meta.blockData;
  
          if (meta.enchantments != null) { // Spigot
 -            this.enchantments = new LinkedHashMap<Enchantment, Integer>(meta.enchantments);
 +            this.enchantments = new EnchantmentMap(meta.enchantments); // Paper
          }
++        this.rawEnchants.addAll(meta.rawEnchants); // Paper
  
          if (meta.hasAttributeModifiers()) {
-@@ -387,13 +390,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+             this.attributeModifiers = LinkedHashMultimap.create(meta.attributeModifiers);
+@@ -355,7 +346,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+             this.blockData = tag.getCompound(BLOCK_DATA.NBT).copy();
+         }
+ 
+-        this.enchantments = CraftMetaItem.buildEnchantments(tag, CraftMetaItem.ENCHANTMENTS);
++        this.enchantments = CraftMetaItem.buildEnchantments(tag, CraftMetaItem.ENCHANTMENTS, (enchant, el) -> rawEnchants.add(enchant == null ? el : null));
+         this.attributeModifiers = CraftMetaItem.buildModifiers(tag, CraftMetaItem.ATTRIBUTES);
+ 
+         if (tag.contains(REPAIR.NBT)) {
+@@ -387,19 +378,25 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
 -    static Map<Enchantment, Integer> buildEnchantments(CompoundTag tag, ItemMetaKey key) {
-+    static EnchantmentMap buildEnchantments(CompoundTag tag, ItemMetaKey key) { // Paper
++    // Paper start
++    static EnchantmentMap buildEnchantments(CompoundTag tag, ItemMetaKey key) {
++        return buildEnchantments(tag, key, null);
++    }
++    // Paper end
++    static EnchantmentMap buildEnchantments(CompoundTag tag, ItemMetaKey key, BiConsumer<Enchantment, CompoundTag> callback) { // Paper
          if (!tag.contains(key.NBT)) {
              return null;
          }
@@ -329,7 +354,14 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..934c9c79f40079f512cf9e7b298c06eb
  
          for (int i = 0; i < ench.size(); i++) {
              String id = ((CompoundTag) ench.get(i)).getString(ENCHANTMENTS_ID.NBT);
-@@ -546,13 +549,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+             int level = 0xffff & ((CompoundTag) ench.get(i)).getShort(ENCHANTMENTS_LVL.NBT);
+ 
+             Enchantment enchant = Enchantment.getByKey(CraftNamespacedKey.fromStringOrNull(id));
++            if(callback != null) callback.accept(enchant, (CompoundTag) ench.get(i)); // Paper
+             if (enchant != null) {
+                 enchantments.put(enchant, level);
+             }
+@@ -546,13 +543,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -345,19 +377,55 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..934c9c79f40079f512cf9e7b298c06eb
          for (Map.Entry<?, ?> entry : ench.entrySet()) {
              // Doctor older enchants
              String enchantKey = entry.getKey().toString();
-@@ -676,6 +679,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -630,7 +627,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+             itemTag.putInt(HIDEFLAGS.NBT, hideFlag);
+         }
  
-     static void applyEnchantments(Map<Enchantment, Integer> enchantments, CompoundTag tag, ItemMetaKey key) {
+-        CraftMetaItem.applyEnchantments(this.enchantments, itemTag, CraftMetaItem.ENCHANTMENTS);
++        applySafeEnchantments(itemTag, CraftMetaItem.ENCHANTMENTS); // Paper
+         CraftMetaItem.applyModifiers(this.attributeModifiers, itemTag, CraftMetaItem.ATTRIBUTES);
+ 
+         if (this.hasRepairCost()) {
+@@ -674,13 +671,37 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+         return tagList;
+     }
+ 
+-    static void applyEnchantments(Map<Enchantment, Integer> enchantments, CompoundTag tag, ItemMetaKey key) {
++    // Paper start
++    void applySafeEnchantments(CompoundTag tag, ItemMetaKey key) {
          if (enchantments == null /*|| enchantments.size() == 0*/) { // Spigot - remove size check
-+            // Paper start
-+            if(key == CraftMetaItem.ENCHANTMENTS) {
-+                tag.remove(key.NBT); // Paper delete the key when the list is empty because setItemMeta redraw the whole tag from scratch but other enchantment related methods in CraftItemStack doesn't use meta anymore
-+            }
-+            // Paper end
              return;
          }
  
-@@ -828,14 +836,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+         ListTag list = new ListTag();
++        Iterator<Map.Entry<Enchantment, Integer>> it = enchantments.entrySet().iterator();
++        for (CompoundTag el : rawEnchants) {
++            if(el == null) {
++                Map.Entry<Enchantment, Integer> entry = it.next();
++                CompoundTag subtag = new CompoundTag();
++
++                subtag.putString(ENCHANTMENTS_ID.NBT, entry.getKey().getKey().toString());
++                subtag.putShort(ENCHANTMENTS_LVL.NBT, entry.getValue().shortValue());
++
++                list.add(subtag);
++            } else {
++                list.add(el);
++            }
++        }
+ 
++        tag.put(key.NBT, list);
++    }
++    // Paper end
++    static void applyEnchantments(Map<Enchantment, Integer> enchantments, CompoundTag tag, ItemMetaKey key) {
++        if (enchantments == null /*|| enchantments.size() == 0*/) { // Spigot - remove size check
++            return;
++        }
++
++        ListTag list = new ListTag();
+         for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
+             CompoundTag subtag = new CompoundTag();
+ 
+@@ -828,14 +849,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public Map<Enchantment, Integer> getEnchants() {
@@ -374,7 +442,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..934c9c79f40079f512cf9e7b298c06eb
          }
  
          if (ignoreRestrictions || level >= ench.getStartLevel() && level <= ench.getMaxLevel()) {
-@@ -1223,7 +1231,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1223,7 +1244,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.customModelData = this.customModelData;
              clone.blockData = this.blockData;
              if (this.enchantments != null) {
@@ -383,7 +451,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..934c9c79f40079f512cf9e7b298c06eb
              }
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
-@@ -1404,6 +1412,126 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1404,6 +1425,126 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.version = version;
      }
  
@@ -510,7 +578,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..934c9c79f40079f512cf9e7b298c06eb
      public static Set<String> getHandledTags() {
          synchronized (CraftMetaItem.HANDLED_TAGS) {
              if (CraftMetaItem.HANDLED_TAGS.isEmpty()) {
-@@ -1458,4 +1586,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1458,4 +1599,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              return CraftMetaItem.HANDLED_TAGS;
          }
      }

--- a/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
@@ -70,10 +70,10 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..8c43819be849f5bc589051722e337b0d5c47c807 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..b4ed47b80b9ad664f01d20bddd7a6df71b79139c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -126,10 +126,28 @@ public final class CraftItemStack extends ItemStack {
+@@ -126,10 +126,37 @@ public final class CraftItemStack extends ItemStack {
          } else if (this.handle == null) {
              this.handle = new net.minecraft.world.item.ItemStack(CraftMagicNumbers.getItem(type), 1);
          } else {
@@ -86,12 +86,21 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..8c43819be849f5bc589051722e337b0d
 +            Material oldType = getType();
 +            this.handle.setItem(item);
 +
++            // Adjust size
++            if(this.handle.getCount() > item.getMaxStackSize()) {
++                this.handle.setCount(item.getMaxStackSize());
++            }
++
++            // Adjust damage
++            if(item.canBeDepleted()) {
++                this.handle.getTag().putInt(CraftMetaItem.DAMAGE.NBT, 0);
++            }
++
 +            if(this.handle.hasTag()) {
++
 +                // Strip damage
 +                if(this.handle.isDamageableItem() && !item.canBeDepleted()) {
 +                    this.handle.getTag().remove(CraftMetaItem.DAMAGE.NBT);
-+                } else {
-+                    this.handle.getTag().putInt(CraftMetaItem.DAMAGE.NBT, 0);
 +                }
 +
 +                // Strip invalid enchantments
@@ -106,7 +115,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..8c43819be849f5bc589051722e337b0d
              }
          }
          setData(null);
-@@ -178,28 +196,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -178,28 +205,13 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Validate.notNull(ench, "Cannot add null enchantment");
  
@@ -142,7 +151,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..8c43819be849f5bc589051722e337b0d
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -232,50 +235,29 @@ public final class CraftItemStack extends ItemStack {
+@@ -232,50 +244,29 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Validate.notNull(ench, "Cannot remove null enchantment");
  
@@ -239,7 +248,7 @@ index 3a8ff15d1c6ba21ce8bed030e84a9f85b702d72a..94b4638f296c5086198ae3e3866b8935
          super(meta);
          this.material = material;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..9bfbd0a95769bfcb79a345a4bbc576cadbcf8284 100644
+index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..d3334ffb931842afe3a906bbdedd80bec60afbc8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
@@ -325,17 +334,19 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..9bfbd0a95769bfcb79a345a4bbc576ca
          for (Map.Entry<?, ?> entry : ench.entrySet()) {
              // Doctor older enchants
              String enchantKey = entry.getKey().toString();
-@@ -676,6 +679,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -676,6 +679,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      static void applyEnchantments(Map<Enchantment, Integer> enchantments, CompoundTag tag, ItemMetaKey key) {
          if (enchantments == null /*|| enchantments.size() == 0*/) { // Spigot - remove size check
++            // Paper start
 +            if(key == CraftMetaItem.ENCHANTMENTS) {
-+                tag.remove(key.NBT); // Paper delete the key when the list is empty
++                tag.remove(key.NBT); // Paper delete the key when the list is empty because setItemMeta redraw the whole tag from scratch but other enchantment related methods in CraftItemStack doesn't use meta anymore
 +            }
++            // Paper end
              return;
          }
  
-@@ -828,14 +834,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -828,14 +836,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public Map<Enchantment, Integer> getEnchants() {
@@ -352,7 +363,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..9bfbd0a95769bfcb79a345a4bbc576ca
          }
  
          if (ignoreRestrictions || level >= ench.getStartLevel() && level <= ench.getMaxLevel()) {
-@@ -1223,7 +1229,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1223,7 +1231,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.customModelData = this.customModelData;
              clone.blockData = this.blockData;
              if (this.enchantments != null) {
@@ -361,7 +372,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..9bfbd0a95769bfcb79a345a4bbc576ca
              }
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
-@@ -1404,6 +1410,127 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1404,6 +1412,127 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.version = version;
      }
  
@@ -489,7 +500,7 @@ index 0a5f063bc74e1dae67167537437ebd7e4ddf113a..9bfbd0a95769bfcb79a345a4bbc576ca
      public static Set<String> getHandledTags() {
          synchronized (CraftMetaItem.HANDLED_TAGS) {
              if (CraftMetaItem.HANDLED_TAGS.isEmpty()) {
-@@ -1458,4 +1585,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1458,4 +1587,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              return CraftMetaItem.HANDLED_TAGS;
          }
      }

--- a/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
@@ -70,10 +70,10 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e078977253805d42c0fda28fbb8525b6f4302a2d 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..301b81ffd2fceee1fd28f9352c6d3cffc0a4672e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -126,10 +126,40 @@ public final class CraftItemStack extends ItemStack {
+@@ -126,10 +126,43 @@ public final class CraftItemStack extends ItemStack {
          } else if (this.handle == null) {
              this.handle = new net.minecraft.world.item.ItemStack(CraftMagicNumbers.getItem(type), 1);
          } else {
@@ -92,7 +92,6 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e078977253805d42c0fda28fbb8525b6
 +            }
 +
 +            if(this.handle.hasTag()) {
-+
 +                // Strip damage
 +                if(this.handle.isDamageableItem() && !item.canBeDepleted()) {
 +                    this.handle.getTag().remove(CraftMetaItem.DAMAGE.NBT);
@@ -102,9 +101,13 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e078977253805d42c0fda28fbb8525b6
 +                this.handle.getTag().remove(CraftMetaItem.CUSTOM_MODEL_DATA.NBT);
 +
 +                // Strip invalid enchantments
-+                for (Enchantment enchant : getEnchantments().keySet()) {
-+                    if (((CraftEnchantment) enchant).getHandle().category.canEnchant(item)) continue;
-+                    removeEnchantment(enchant);
++                EnchantmentMap map = CraftMetaItem.buildEnchantments(this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
++                if(map != null) {
++                    for (Enchantment enchant : getEnchantments().keySet()) {
++                        if (((CraftEnchantment) enchant).getHandle().category.canEnchant(item)) continue;
++                        map.remove(enchant);
++                    }
++                    CraftMetaItem.applyEnchantments(map, this.handle.getTag(), CraftMetaItem.ENCHANTMENTS);
 +                }
 +
 +                // Strip invalid tags
@@ -118,7 +121,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e078977253805d42c0fda28fbb8525b6
              }
          }
          setData(null);
-@@ -178,28 +208,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -178,28 +211,13 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Validate.notNull(ench, "Cannot add null enchantment");
  
@@ -154,7 +157,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..e078977253805d42c0fda28fbb8525b6
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -232,50 +247,29 @@ public final class CraftItemStack extends ItemStack {
+@@ -232,50 +250,29 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Validate.notNull(ench, "Cannot remove null enchantment");
  

--- a/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
@@ -70,18 +70,21 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..3745033afb8923ce06cbf13b55c4e96f2a89573f 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..830c137326e284d796bc2d89c36327327184c558 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -6,7 +6,6 @@ import java.util.Map;
- import net.minecraft.nbt.CompoundTag;
- import net.minecraft.nbt.ListTag;
- import net.minecraft.world.item.Item;
--import net.minecraft.world.item.enchantment.EnchantmentHelper;
- import org.apache.commons.lang.Validate;
- import org.bukkit.Material;
- import org.bukkit.NamespacedKey;
-@@ -178,28 +177,11 @@ public final class CraftItemStack extends ItemStack {
+@@ -127,10 +127,6 @@ public final class CraftItemStack extends ItemStack {
+             this.handle = new net.minecraft.world.item.ItemStack(CraftMagicNumbers.getItem(type), 1);
+         } else {
+             this.handle.setItem(CraftMagicNumbers.getItem(type));
+-            if (this.hasItemMeta()) {
+-                // This will create the appropriate item meta, which will contain all the data we intend to keep
+-                CraftItemStack.setItemMeta(this.handle, CraftItemStack.getItemMeta(this.handle));
+-            }
+         }
+         setData(null);
+     }
+@@ -178,28 +174,11 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Validate.notNull(ench, "Cannot add null enchantment");
  
@@ -115,25 +118,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..3745033afb8923ce06cbf13b55c4e96f
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -216,66 +198,34 @@ public final class CraftItemStack extends ItemStack {
- 
-     @Override
-     public boolean containsEnchantment(Enchantment ench) {
--        return this.getEnchantmentLevel(ench) > 0;
-+        return this.hasItemMeta() && this.getItemMeta().hasEnchant(ench); // Paper - use meta
-     }
- 
-     @Override
-     public int getEnchantmentLevel(Enchantment ench) {
--        Validate.notNull(ench, "Cannot find null enchantment");
--        if (this.handle == null) {
--            return 0;
--        }
--        return EnchantmentHelper.getItemEnchantmentLevel(CraftEnchantment.getRaw(ench), handle);
-+        return this.hasItemMeta() ? this.getItemMeta().getEnchantLevel(ench) : 0; // Paper - replace entire method with meta
-     }
- 
-     @Override
+@@ -232,50 +211,22 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Validate.notNull(ench, "Cannot remove null enchantment");
  

--- a/patches/server/0174-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0174-Add-ArmorStand-Item-Meta.patch
@@ -255,10 +255,10 @@ index 1b8be8a7103e09065a405a22d427b9a747fc1a3e..2afedf24e485dd36e95988843c70af88
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 4d687fa31f4d889ac755c178b9afd2b927c78ee2..01ceb8de8411193fa407bf19bbd25a4bf44765d3 100644
+index 9bfbd0a95769bfcb79a345a4bbc576cadbcf8284..f67b56691f265ed6824cb4c6fc4f2a286d6a693e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1452,6 +1452,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1576,6 +1576,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaCrossbow.CHARGED.NBT,
                          CraftMetaCrossbow.CHARGED_PROJECTILES.NBT,
                          CraftMetaSuspiciousStew.EFFECTS.NBT,

--- a/patches/server/0174-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0174-Add-ArmorStand-Item-Meta.patch
@@ -255,10 +255,10 @@ index 1b8be8a7103e09065a405a22d427b9a747fc1a3e..2afedf24e485dd36e95988843c70af88
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 1fed6ffbec64be3d33045faddc3c67667a39d28e..6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5 100644
+index 6a83c0534d31084d07068f5e6a0e60bb26da3080..4b73d0e8feb36ebb0e5408ae3aeb81ec8b24f97f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1590,6 +1590,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1613,6 +1613,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaCrossbow.CHARGED.NBT,
                          CraftMetaCrossbow.CHARGED_PROJECTILES.NBT,
                          CraftMetaSuspiciousStew.EFFECTS.NBT,

--- a/patches/server/0174-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0174-Add-ArmorStand-Item-Meta.patch
@@ -255,10 +255,10 @@ index 1b8be8a7103e09065a405a22d427b9a747fc1a3e..2afedf24e485dd36e95988843c70af88
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index d3334ffb931842afe3a906bbdedd80bec60afbc8..7678fdc65378e055809b2ecb13103a01ba799d8c 100644
+index 934c9c79f40079f512cf9e7b298c06eb3031e48b..331d6e45127dca0c3c225339cd67695d09222342 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1578,6 +1578,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1577,6 +1577,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaCrossbow.CHARGED.NBT,
                          CraftMetaCrossbow.CHARGED_PROJECTILES.NBT,
                          CraftMetaSuspiciousStew.EFFECTS.NBT,

--- a/patches/server/0174-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0174-Add-ArmorStand-Item-Meta.patch
@@ -255,10 +255,10 @@ index 1b8be8a7103e09065a405a22d427b9a747fc1a3e..2afedf24e485dd36e95988843c70af88
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 934c9c79f40079f512cf9e7b298c06eb3031e48b..331d6e45127dca0c3c225339cd67695d09222342 100644
+index 1fed6ffbec64be3d33045faddc3c67667a39d28e..6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1577,6 +1577,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1590,6 +1590,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaCrossbow.CHARGED.NBT,
                          CraftMetaCrossbow.CHARGED_PROJECTILES.NBT,
                          CraftMetaSuspiciousStew.EFFECTS.NBT,

--- a/patches/server/0174-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0174-Add-ArmorStand-Item-Meta.patch
@@ -255,10 +255,10 @@ index 1b8be8a7103e09065a405a22d427b9a747fc1a3e..2afedf24e485dd36e95988843c70af88
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 9bfbd0a95769bfcb79a345a4bbc576cadbcf8284..f67b56691f265ed6824cb4c6fc4f2a286d6a693e 100644
+index d3334ffb931842afe3a906bbdedd80bec60afbc8..7678fdc65378e055809b2ecb13103a01ba799d8c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1576,6 +1576,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1578,6 +1578,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaCrossbow.CHARGED.NBT,
                          CraftMetaCrossbow.CHARGED_PROJECTILES.NBT,
                          CraftMetaSuspiciousStew.EFFECTS.NBT,

--- a/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 3745033afb8923ce06cbf13b55c4e96f2a89573f..8b7d9ac312200b82b741a2c0ac26ec0710ea3cbc 100644
+index 830c137326e284d796bc2d89c36327327184c558..eadacf35593399b1aee84327c963c5b29c5fa41e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -173,6 +173,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -170,6 +170,13 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getItem().getMaxStackSize();
      }
  

--- a/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 8c43819be849f5bc589051722e337b0d5c47c807..27a16dd0c72a90663d45999d16388713181c6e49 100644
+index b4ed47b80b9ad664f01d20bddd7a6df71b79139c..b2729006633a9deb75ec852a56c31c6b1f542503 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -192,6 +192,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -201,6 +201,13 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getItem().getMaxStackSize();
      }
  

--- a/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 830c137326e284d796bc2d89c36327327184c558..eadacf35593399b1aee84327c963c5b29c5fa41e 100644
+index 8c43819be849f5bc589051722e337b0d5c47c807..27a16dd0c72a90663d45999d16388713181c6e49 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -170,6 +170,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -192,6 +192,13 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getItem().getMaxStackSize();
      }
  

--- a/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 301b81ffd2fceee1fd28f9352c6d3cffc0a4672e..92c6602be498a0e8d14ca8d510cff03b07025546 100644
+index 4c1941d0a3e00d23e70c62fac3fbda12e7095f5a..b07377f9b858cf4d5b12b9b7536aae0e9cd36057 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -207,6 +207,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -212,6 +212,13 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getItem().getMaxStackSize();
      }
  

--- a/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index e078977253805d42c0fda28fbb8525b6f4302a2d..e5a00bda76fdf52efe8d8deedb30c16232c2af4b 100644
+index 301b81ffd2fceee1fd28f9352c6d3cffc0a4672e..92c6602be498a0e8d14ca8d510cff03b07025546 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -204,6 +204,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -207,6 +207,13 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getItem().getMaxStackSize();
      }
  

--- a/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index b4ed47b80b9ad664f01d20bddd7a6df71b79139c..b2729006633a9deb75ec852a56c31c6b1f542503 100644
+index e078977253805d42c0fda28fbb8525b6f4302a2d..e5a00bda76fdf52efe8d8deedb30c16232c2af4b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -201,6 +201,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -204,6 +204,13 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getItem().getMaxStackSize();
      }
  

--- a/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index e794e6dc101cb4a33aa165d288b927c92fee3c61..086d286c515505828ea459cc84589ec38974bcfc 100644
+index ce37f24d0f5be5599cc9c69dd6cc9d07e8991c7b..351fe7d24d789168ee5a2e99e0fa6237dc8b0299 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -638,7 +638,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -639,7 +639,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 27a16dd0c72a90663d45999d16388713181c6e49..488e933bcf7bf0d84802a77e6be73bea4895426c 100644
+index b2729006633a9deb75ec852a56c31c6b1f542503..406a70f29953dd2bd460e7298663c9f29c558159 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -616,7 +616,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -625,7 +625,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 92c6602be498a0e8d14ca8d510cff03b07025546..32028190b01d43d312beff74784716fb312f677c 100644
+index b07377f9b858cf4d5b12b9b7536aae0e9cd36057..c840af91edd5e7cc911013bfd4479e3bdf647795 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -631,7 +631,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -636,7 +636,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index eadacf35593399b1aee84327c963c5b29c5fa41e..2c5c2857f65f3b8c55de080274976a8bf00fa429 100644
+index 27a16dd0c72a90663d45999d16388713181c6e49..488e933bcf7bf0d84802a77e6be73bea4895426c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -585,7 +585,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -616,7 +616,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index e5a00bda76fdf52efe8d8deedb30c16232c2af4b..4f091686444ce2c67414ce818dc8b3e49bd5ac69 100644
+index 92c6602be498a0e8d14ca8d510cff03b07025546..32028190b01d43d312beff74784716fb312f677c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -628,7 +628,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -631,7 +631,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 8b7d9ac312200b82b741a2c0ac26ec0710ea3cbc..04aabec62f0c89e70681af3846d73659f4c81360 100644
+index eadacf35593399b1aee84327c963c5b29c5fa41e..2c5c2857f65f3b8c55de080274976a8bf00fa429 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -584,7 +584,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -585,7 +585,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index b07377f9b858cf4d5b12b9b7536aae0e9cd36057..c840af91edd5e7cc911013bfd4479e3bdf647795 100644
+index e794e6dc101cb4a33aa165d288b927c92fee3c61..086d286c515505828ea459cc84589ec38974bcfc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -636,7 +636,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -638,7 +638,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0229-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index b2729006633a9deb75ec852a56c31c6b1f542503..406a70f29953dd2bd460e7298663c9f29c558159 100644
+index e5a00bda76fdf52efe8d8deedb30c16232c2af4b..4f091686444ce2c67414ce818dc8b3e49bd5ac69 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -625,7 +625,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -628,7 +628,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
+++ b/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement an API for CanPlaceOn and CanDestroy NBT values
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad3577d142f0 100644
+index 4b73d0e8feb36ebb0e5408ae3aeb81ec8b24f97f..e78528be081a6b0accd63b30abbbeba7dea383f8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -69,6 +69,12 @@ import org.bukkit.persistence.PersistentDataContainer;
+@@ -83,6 +83,12 @@ import org.bukkit.persistence.PersistentDataContainer;
  import static org.spigotmc.ValidateUtils.*;
  // Spigot end
  
@@ -21,7 +21,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
  /**
   * Children must include the following:
   *
-@@ -254,6 +260,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -268,6 +274,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      @Specific(Specific.To.NBT)
      static final ItemMetaKey BLOCK_DATA = new ItemMetaKey("BlockStateTag");
      static final ItemMetaKey BUKKIT_CUSTOM_TAG = new ItemMetaKey("PublicBukkitValues");
@@ -32,7 +32,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
  
      // We store the raw original JSON representation of all text data. See SPIGOT-5063, SPIGOT-5656, SPIGOT-5304
      private String displayName;
-@@ -268,6 +278,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -282,6 +292,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private int hideFlag;
      private boolean unbreakable;
      private int damage;
@@ -43,7 +43,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
  
      private static final Set<String> HANDLED_TAGS = Sets.newHashSet();
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
-@@ -306,6 +320,15 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -322,6 +336,15 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.hideFlag = meta.hideFlag;
          this.unbreakable = meta.unbreakable;
          this.damage = meta.damage;
@@ -59,7 +59,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
          this.unhandledTags.putAll(meta.unhandledTags);
          this.persistentDataContainer.putAll(meta.persistentDataContainer.getRaw());
  
-@@ -369,6 +392,31 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -385,6 +408,31 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  this.persistentDataContainer.put(key, compound.get(key).copy());
              }
          }
@@ -91,7 +91,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
  
          Set<String> keys = tag.getAllKeys();
          for (String key : keys) {
-@@ -513,6 +561,34 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -530,6 +578,34 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              this.setDamage(damage);
          }
  
@@ -126,7 +126,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
          String internal = SerializableMeta.getString(map, "internal", true);
          if (internal != null) {
              ByteArrayInputStream buf = new ByteArrayInputStream(Base64.getDecoder().decode(internal));
-@@ -641,6 +717,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -664,6 +740,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          if (this.hasDamage()) {
              itemTag.putInt(DAMAGE.NBT, damage);
          }
@@ -150,7 +150,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
  
          for (Map.Entry<String, Tag> e : this.unhandledTags.entrySet()) {
              itemTag.put(e.getKey(), e.getValue());
-@@ -657,6 +750,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -680,6 +773,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -172,7 +172,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
      ListTag createStringList(List<String> list) {
          if (list == null) {
              return null;
-@@ -764,7 +872,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -787,7 +895,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
@@ -181,7 +181,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
      }
  
      // Paper start
-@@ -1195,7 +1303,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1218,7 +1326,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hideFlag == that.hideFlag)
                  && (this.isUnbreakable() == that.isUnbreakable())
                  && (this.hasDamage() ? that.hasDamage() && this.damage == that.damage : !that.hasDamage())
@@ -194,7 +194,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
      }
  
      /**
-@@ -1230,6 +1342,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1253,6 +1365,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
          hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
          hash = 61 * hash + this.version;
@@ -205,7 +205,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
          return hash;
      }
  
-@@ -1254,6 +1370,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1277,6 +1393,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.unbreakable = this.unbreakable;
              clone.damage = this.damage;
              clone.version = this.version;
@@ -220,7 +220,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
              return clone;
          } catch (CloneNotSupportedException e) {
              throw new Error(e);
-@@ -1311,6 +1435,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1334,6 +1458,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              builder.put(DAMAGE.BUKKIT, damage);
          }
  
@@ -244,7 +244,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
          final Map<String, Tag> internalTags = new HashMap<String, Tag>(this.unhandledTags);
          this.serializeInternal(internalTags);
          if (!internalTags.isEmpty()) {
-@@ -1597,6 +1738,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1620,6 +1761,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaArmorStand.SHOW_ARMS.NBT,
                          CraftMetaArmorStand.SMALL.NBT,
                          CraftMetaArmorStand.MARKER.NBT,
@@ -253,7 +253,7 @@ index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad35
                          // Paper end
                          CraftMetaCompass.LODESTONE_DIMENSION.NBT,
                          CraftMetaCompass.LODESTONE_POS.NBT,
-@@ -1625,4 +1768,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1648,4 +1791,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
      // Paper end
  

--- a/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
+++ b/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement an API for CanPlaceOn and CanDestroy NBT values
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c6be8911e 100644
+index 6447a8d3b3c6c0108a5d060c4bdcdddd44eff0c5..1da0bfeeff950070cbd4ddaa3201ad3577d142f0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -83,6 +83,12 @@ import org.bukkit.persistence.PersistentDataContainer;
+@@ -69,6 +69,12 @@ import org.bukkit.persistence.PersistentDataContainer;
  import static org.spigotmc.ValidateUtils.*;
  // Spigot end
  
@@ -21,7 +21,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
  /**
   * Children must include the following:
   *
-@@ -268,6 +274,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -254,6 +260,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      @Specific(Specific.To.NBT)
      static final ItemMetaKey BLOCK_DATA = new ItemMetaKey("BlockStateTag");
      static final ItemMetaKey BUKKIT_CUSTOM_TAG = new ItemMetaKey("PublicBukkitValues");
@@ -32,7 +32,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
  
      // We store the raw original JSON representation of all text data. See SPIGOT-5063, SPIGOT-5656, SPIGOT-5304
      private String displayName;
-@@ -281,6 +291,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -268,6 +278,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private int hideFlag;
      private boolean unbreakable;
      private int damage;
@@ -43,7 +43,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
  
      private static final Set<String> HANDLED_TAGS = Sets.newHashSet();
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
-@@ -318,6 +332,15 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -306,6 +320,15 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.hideFlag = meta.hideFlag;
          this.unbreakable = meta.unbreakable;
          this.damage = meta.damage;
@@ -59,7 +59,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
          this.unhandledTags.putAll(meta.unhandledTags);
          this.persistentDataContainer.putAll(meta.persistentDataContainer.getRaw());
  
-@@ -381,6 +404,31 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -369,6 +392,31 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  this.persistentDataContainer.put(key, compound.get(key).copy());
              }
          }
@@ -91,7 +91,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
  
          Set<String> keys = tag.getAllKeys();
          for (String key : keys) {
-@@ -519,6 +567,34 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -513,6 +561,34 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              this.setDamage(damage);
          }
  
@@ -126,7 +126,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
          String internal = SerializableMeta.getString(map, "internal", true);
          if (internal != null) {
              ByteArrayInputStream buf = new ByteArrayInputStream(Base64.getDecoder().decode(internal));
-@@ -647,6 +723,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -641,6 +717,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          if (this.hasDamage()) {
              itemTag.putInt(DAMAGE.NBT, damage);
          }
@@ -150,7 +150,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
  
          for (Map.Entry<String, Tag> e : this.unhandledTags.entrySet()) {
              itemTag.put(e.getKey(), e.getValue());
-@@ -663,6 +756,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -657,6 +750,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -172,7 +172,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
      ListTag createStringList(List<String> list) {
          if (list == null) {
              return null;
-@@ -751,7 +859,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -764,7 +872,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
@@ -181,7 +181,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
      }
  
      // Paper start
-@@ -1182,7 +1290,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1195,7 +1303,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hideFlag == that.hideFlag)
                  && (this.isUnbreakable() == that.isUnbreakable())
                  && (this.hasDamage() ? that.hasDamage() && this.damage == that.damage : !that.hasDamage())
@@ -194,7 +194,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
      }
  
      /**
-@@ -1217,6 +1329,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1230,6 +1342,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
          hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
          hash = 61 * hash + this.version;
@@ -205,7 +205,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
          return hash;
      }
  
-@@ -1241,6 +1357,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1254,6 +1370,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.unbreakable = this.unbreakable;
              clone.damage = this.damage;
              clone.version = this.version;
@@ -220,7 +220,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
              return clone;
          } catch (CloneNotSupportedException e) {
              throw new Error(e);
-@@ -1298,6 +1422,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1311,6 +1435,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              builder.put(DAMAGE.BUKKIT, damage);
          }
  
@@ -244,7 +244,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
          final Map<String, Tag> internalTags = new HashMap<String, Tag>(this.unhandledTags);
          this.serializeInternal(internalTags);
          if (!internalTags.isEmpty()) {
-@@ -1584,6 +1725,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1597,6 +1738,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaArmorStand.SHOW_ARMS.NBT,
                          CraftMetaArmorStand.SMALL.NBT,
                          CraftMetaArmorStand.MARKER.NBT,
@@ -253,7 +253,7 @@ index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c
                          // Paper end
                          CraftMetaCompass.LODESTONE_DIMENSION.NBT,
                          CraftMetaCompass.LODESTONE_POS.NBT,
-@@ -1612,4 +1755,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1625,4 +1768,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
      // Paper end
  

--- a/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
+++ b/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement an API for CanPlaceOn and CanDestroy NBT values
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 7678fdc65378e055809b2ecb13103a01ba799d8c..e8b147470e57bb36a72c331b5a32a903bf98dab6 100644
+index 331d6e45127dca0c3c225339cd67695d09222342..a4205598710265991015f49a4d312d9c6be8911e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -83,6 +83,12 @@ import org.bukkit.persistence.PersistentDataContainer;
@@ -244,7 +244,7 @@ index 7678fdc65378e055809b2ecb13103a01ba799d8c..e8b147470e57bb36a72c331b5a32a903
          final Map<String, Tag> internalTags = new HashMap<String, Tag>(this.unhandledTags);
          this.serializeInternal(internalTags);
          if (!internalTags.isEmpty()) {
-@@ -1585,6 +1726,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1584,6 +1725,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaArmorStand.SHOW_ARMS.NBT,
                          CraftMetaArmorStand.SMALL.NBT,
                          CraftMetaArmorStand.MARKER.NBT,
@@ -253,7 +253,7 @@ index 7678fdc65378e055809b2ecb13103a01ba799d8c..e8b147470e57bb36a72c331b5a32a903
                          // Paper end
                          CraftMetaCompass.LODESTONE_DIMENSION.NBT,
                          CraftMetaCompass.LODESTONE_POS.NBT,
-@@ -1613,4 +1756,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1612,4 +1755,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
      // Paper end
  

--- a/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
+++ b/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement an API for CanPlaceOn and CanDestroy NBT values
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0eea25adbd 100644
+index f67b56691f265ed6824cb4c6fc4f2a286d6a693e..d98d606218ddf0234bb21d787c125a3c71b250e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -83,6 +83,12 @@ import org.bukkit.persistence.PersistentDataContainer;
@@ -172,7 +172,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
      ListTag createStringList(List<String> list) {
          if (list == null) {
              return null;
-@@ -746,7 +854,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -749,7 +857,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
@@ -181,7 +181,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
      }
  
      // Paper start
-@@ -1177,7 +1285,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1180,7 +1288,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hideFlag == that.hideFlag)
                  && (this.isUnbreakable() == that.isUnbreakable())
                  && (this.hasDamage() ? that.hasDamage() && this.damage == that.damage : !that.hasDamage())
@@ -194,7 +194,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
      }
  
      /**
-@@ -1212,6 +1324,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1215,6 +1327,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
          hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
          hash = 61 * hash + this.version;
@@ -205,7 +205,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
          return hash;
      }
  
-@@ -1236,6 +1352,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1239,6 +1355,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.unbreakable = this.unbreakable;
              clone.damage = this.damage;
              clone.version = this.version;
@@ -220,7 +220,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
              return clone;
          } catch (CloneNotSupportedException e) {
              throw new Error(e);
-@@ -1293,6 +1417,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1296,6 +1420,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              builder.put(DAMAGE.BUKKIT, damage);
          }
  
@@ -244,7 +244,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
          final Map<String, Tag> internalTags = new HashMap<String, Tag>(this.unhandledTags);
          this.serializeInternal(internalTags);
          if (!internalTags.isEmpty()) {
-@@ -1459,6 +1600,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1583,6 +1724,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaArmorStand.SHOW_ARMS.NBT,
                          CraftMetaArmorStand.SMALL.NBT,
                          CraftMetaArmorStand.MARKER.NBT,
@@ -253,7 +253,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
                          // Paper end
                          CraftMetaCompass.LODESTONE_DIMENSION.NBT,
                          CraftMetaCompass.LODESTONE_POS.NBT,
-@@ -1487,4 +1630,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1611,4 +1754,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
      // Paper end
  

--- a/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
+++ b/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement an API for CanPlaceOn and CanDestroy NBT values
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index f67b56691f265ed6824cb4c6fc4f2a286d6a693e..d98d606218ddf0234bb21d787c125a3c71b250e0 100644
+index 7678fdc65378e055809b2ecb13103a01ba799d8c..e8b147470e57bb36a72c331b5a32a903bf98dab6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -83,6 +83,12 @@ import org.bukkit.persistence.PersistentDataContainer;
@@ -172,7 +172,7 @@ index f67b56691f265ed6824cb4c6fc4f2a286d6a693e..d98d606218ddf0234bb21d787c125a3c
      ListTag createStringList(List<String> list) {
          if (list == null) {
              return null;
-@@ -749,7 +857,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -751,7 +859,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
@@ -181,7 +181,7 @@ index f67b56691f265ed6824cb4c6fc4f2a286d6a693e..d98d606218ddf0234bb21d787c125a3c
      }
  
      // Paper start
-@@ -1180,7 +1288,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1182,7 +1290,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hideFlag == that.hideFlag)
                  && (this.isUnbreakable() == that.isUnbreakable())
                  && (this.hasDamage() ? that.hasDamage() && this.damage == that.damage : !that.hasDamage())
@@ -194,7 +194,7 @@ index f67b56691f265ed6824cb4c6fc4f2a286d6a693e..d98d606218ddf0234bb21d787c125a3c
      }
  
      /**
-@@ -1215,6 +1327,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1217,6 +1329,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
          hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
          hash = 61 * hash + this.version;
@@ -205,7 +205,7 @@ index f67b56691f265ed6824cb4c6fc4f2a286d6a693e..d98d606218ddf0234bb21d787c125a3c
          return hash;
      }
  
-@@ -1239,6 +1355,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1241,6 +1357,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.unbreakable = this.unbreakable;
              clone.damage = this.damage;
              clone.version = this.version;
@@ -220,7 +220,7 @@ index f67b56691f265ed6824cb4c6fc4f2a286d6a693e..d98d606218ddf0234bb21d787c125a3c
              return clone;
          } catch (CloneNotSupportedException e) {
              throw new Error(e);
-@@ -1296,6 +1420,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1298,6 +1422,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              builder.put(DAMAGE.BUKKIT, damage);
          }
  
@@ -244,7 +244,7 @@ index f67b56691f265ed6824cb4c6fc4f2a286d6a693e..d98d606218ddf0234bb21d787c125a3c
          final Map<String, Tag> internalTags = new HashMap<String, Tag>(this.unhandledTags);
          this.serializeInternal(internalTags);
          if (!internalTags.isEmpty()) {
-@@ -1583,6 +1724,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1585,6 +1726,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaArmorStand.SHOW_ARMS.NBT,
                          CraftMetaArmorStand.SMALL.NBT,
                          CraftMetaArmorStand.MARKER.NBT,
@@ -253,7 +253,7 @@ index f67b56691f265ed6824cb4c6fc4f2a286d6a693e..d98d606218ddf0234bb21d787c125a3c
                          // Paper end
                          CraftMetaCompass.LODESTONE_DIMENSION.NBT,
                          CraftMetaCompass.LODESTONE_POS.NBT,
-@@ -1611,4 +1754,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1613,4 +1756,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
      // Paper end
  

--- a/patches/server/0451-Convert-legacy-attributes-in-Item-Meta.patch
+++ b/patches/server/0451-Convert-legacy-attributes-in-Item-Meta.patch
@@ -30,10 +30,10 @@ index 0520c45197629cbdc2777d9ae11eef572e793160..46c313d581b9af6aa0a48f97ae3cc800
      public CraftAttributeMap(AttributeMap handle) {
          this.handle = handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 4304ee35a9bd912c2ae4058febf22f0eea25adbd..4a91da3561d16995e8cfe04ebbc104da009a2503 100644
+index 1da0bfeeff950070cbd4ddaa3201ad3577d142f0..19e876579023389927a5d99a3f50b50e5111a33c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -480,7 +480,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -474,7 +474,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
              AttributeModifier attribMod = CraftAttributeInstance.convert(nmsModifier);
  

--- a/patches/server/0451-Convert-legacy-attributes-in-Item-Meta.patch
+++ b/patches/server/0451-Convert-legacy-attributes-in-Item-Meta.patch
@@ -30,10 +30,10 @@ index 0520c45197629cbdc2777d9ae11eef572e793160..46c313d581b9af6aa0a48f97ae3cc800
      public CraftAttributeMap(AttributeMap handle) {
          this.handle = handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 1da0bfeeff950070cbd4ddaa3201ad3577d142f0..19e876579023389927a5d99a3f50b50e5111a33c 100644
+index e78528be081a6b0accd63b30abbbeba7dea383f8..3edb49057ce687356e1680fe90d30a2c18fe07e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -474,7 +474,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -490,7 +490,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
              AttributeModifier attribMod = CraftAttributeInstance.convert(nmsModifier);
  

--- a/patches/server/0454-Support-components-in-ItemMeta.patch
+++ b/patches/server/0454-Support-components-in-ItemMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 19e876579023389927a5d99a3f50b50e5111a33c..5168eb0cd7b6373089603136b5d39142f567c919 100644
+index 3edb49057ce687356e1680fe90d30a2c18fe07e8..f65e6d24c89f1b721cacc01ea9589ee9e8550648 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -892,11 +892,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -915,11 +915,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return CraftChatMessage.fromJSONComponent(displayName);
      }
  
@@ -32,7 +32,7 @@ index 19e876579023389927a5d99a3f50b50e5111a33c..5168eb0cd7b6373089603136b5d39142
      @Override
      public boolean hasDisplayName() {
          return this.displayName != null;
-@@ -1039,6 +1051,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1062,6 +1074,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromJSONComponent));
      }
  
@@ -47,7 +47,7 @@ index 19e876579023389927a5d99a3f50b50e5111a33c..5168eb0cd7b6373089603136b5d39142
      @Override
      public void setLore(List<String> lore) {
          if (lore == null || lore.isEmpty()) {
-@@ -1053,6 +1073,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1076,6 +1096,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -69,7 +69,7 @@ index 19e876579023389927a5d99a3f50b50e5111a33c..5168eb0cd7b6373089603136b5d39142
      @Override
      public boolean hasCustomModelData() {
          return this.customModelData != null;
-@@ -1520,6 +1555,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1543,6 +1578,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Object object : addFrom) {

--- a/patches/server/0454-Support-components-in-ItemMeta.patch
+++ b/patches/server/0454-Support-components-in-ItemMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 4a91da3561d16995e8cfe04ebbc104da009a2503..c475ddea1c995df1dfcaf4f491f341761a5f8802 100644
+index e2e9f48af4fe49574edeb6126968bdce46ea6bf9..0fd8cc42af52be2fb23557ba2ab592739e8e24ba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -874,11 +874,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -877,11 +877,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return CraftChatMessage.fromJSONComponent(displayName);
      }
  
@@ -32,7 +32,7 @@ index 4a91da3561d16995e8cfe04ebbc104da009a2503..c475ddea1c995df1dfcaf4f491f34176
      @Override
      public boolean hasDisplayName() {
          return this.displayName != null;
-@@ -1021,6 +1033,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1024,6 +1036,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromJSONComponent));
      }
  
@@ -47,7 +47,7 @@ index 4a91da3561d16995e8cfe04ebbc104da009a2503..c475ddea1c995df1dfcaf4f491f34176
      @Override
      public void setLore(List<String> lore) {
          if (lore == null || lore.isEmpty()) {
-@@ -1035,6 +1055,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1038,6 +1058,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -69,7 +69,7 @@ index 4a91da3561d16995e8cfe04ebbc104da009a2503..c475ddea1c995df1dfcaf4f491f34176
      @Override
      public boolean hasCustomModelData() {
          return this.customModelData != null;
-@@ -1502,6 +1537,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1505,6 +1540,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Object object : addFrom) {

--- a/patches/server/0454-Support-components-in-ItemMeta.patch
+++ b/patches/server/0454-Support-components-in-ItemMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index c35ac6d7c47c4c6932dca3bb943b55f44d008057..2af3f1ab6126fdd3b22b118f63324698dcea8257 100644
+index 19e876579023389927a5d99a3f50b50e5111a33c..5168eb0cd7b6373089603136b5d39142f567c919 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -879,11 +879,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -892,11 +892,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return CraftChatMessage.fromJSONComponent(displayName);
      }
  
@@ -32,7 +32,7 @@ index c35ac6d7c47c4c6932dca3bb943b55f44d008057..2af3f1ab6126fdd3b22b118f63324698
      @Override
      public boolean hasDisplayName() {
          return this.displayName != null;
-@@ -1026,6 +1038,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1039,6 +1051,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromJSONComponent));
      }
  
@@ -47,7 +47,7 @@ index c35ac6d7c47c4c6932dca3bb943b55f44d008057..2af3f1ab6126fdd3b22b118f63324698
      @Override
      public void setLore(List<String> lore) {
          if (lore == null || lore.isEmpty()) {
-@@ -1040,6 +1060,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1053,6 +1073,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -69,7 +69,7 @@ index c35ac6d7c47c4c6932dca3bb943b55f44d008057..2af3f1ab6126fdd3b22b118f63324698
      @Override
      public boolean hasCustomModelData() {
          return this.customModelData != null;
-@@ -1507,6 +1542,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1520,6 +1555,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Object object : addFrom) {

--- a/patches/server/0454-Support-components-in-ItemMeta.patch
+++ b/patches/server/0454-Support-components-in-ItemMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index e2e9f48af4fe49574edeb6126968bdce46ea6bf9..0fd8cc42af52be2fb23557ba2ab592739e8e24ba 100644
+index c35ac6d7c47c4c6932dca3bb943b55f44d008057..2af3f1ab6126fdd3b22b118f63324698dcea8257 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -877,11 +877,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -879,11 +879,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return CraftChatMessage.fromJSONComponent(displayName);
      }
  
@@ -32,7 +32,7 @@ index e2e9f48af4fe49574edeb6126968bdce46ea6bf9..0fd8cc42af52be2fb23557ba2ab59273
      @Override
      public boolean hasDisplayName() {
          return this.displayName != null;
-@@ -1024,6 +1036,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1026,6 +1038,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromJSONComponent));
      }
  
@@ -47,7 +47,7 @@ index e2e9f48af4fe49574edeb6126968bdce46ea6bf9..0fd8cc42af52be2fb23557ba2ab59273
      @Override
      public void setLore(List<String> lore) {
          if (lore == null || lore.isEmpty()) {
-@@ -1038,6 +1058,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1040,6 +1060,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -69,7 +69,7 @@ index e2e9f48af4fe49574edeb6126968bdce46ea6bf9..0fd8cc42af52be2fb23557ba2ab59273
      @Override
      public boolean hasCustomModelData() {
          return this.customModelData != null;
-@@ -1505,6 +1540,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1507,6 +1542,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Object object : addFrom) {

--- a/patches/server/0664-Make-item-validations-configurable.patch
+++ b/patches/server/0664-Make-item-validations-configurable.patch
@@ -32,10 +32,10 @@ index fefa4d83c5699be0b55794cd28d13d27b66ef108..d662cb0567884ec91c900f5c90ecb369
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index c475ddea1c995df1dfcaf4f491f341761a5f8802..a8294bf057e03c5d866f6da31e6cdfa9edd3f146 100644
+index 5168eb0cd7b6373089603136b5d39142f567c919..0db977a9e92b8fae663a2fc602e49221817be25e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -357,7 +357,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -345,7 +345,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              CompoundTag display = tag.getCompound(DISPLAY.NBT);
  
              if (display.contains(NAME.NBT)) {
@@ -44,7 +44,7 @@ index c475ddea1c995df1dfcaf4f491f341761a5f8802..a8294bf057e03c5d866f6da31e6cdfa9
              }
  
              if (display.contains(LOCNAME.NBT)) {
-@@ -368,7 +368,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -356,7 +356,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  ListTag list = display.getList(LORE.NBT, CraftMagicNumbers.NBT.TAG_STRING);
                  this.lore = new ArrayList<String>(list.size());
                  for (int index = 0; index < list.size(); index++) {

--- a/patches/server/0664-Make-item-validations-configurable.patch
+++ b/patches/server/0664-Make-item-validations-configurable.patch
@@ -32,10 +32,10 @@ index fefa4d83c5699be0b55794cd28d13d27b66ef108..d662cb0567884ec91c900f5c90ecb369
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 5168eb0cd7b6373089603136b5d39142f567c919..0db977a9e92b8fae663a2fc602e49221817be25e 100644
+index f65e6d24c89f1b721cacc01ea9589ee9e8550648..d9217b03fb05d9a9925c02a77fcee1df0f2defaa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -345,7 +345,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -361,7 +361,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              CompoundTag display = tag.getCompound(DISPLAY.NBT);
  
              if (display.contains(NAME.NBT)) {
@@ -44,7 +44,7 @@ index 5168eb0cd7b6373089603136b5d39142f567c919..0db977a9e92b8fae663a2fc602e49221
              }
  
              if (display.contains(LOCNAME.NBT)) {
-@@ -356,7 +356,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -372,7 +372,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  ListTag list = display.getList(LORE.NBT, CraftMagicNumbers.NBT.TAG_STRING);
                  this.lore = new ArrayList<String>(list.size());
                  for (int index = 0; index < list.size(); index++) {

--- a/patches/server/0861-More-Projectile-API.patch
+++ b/patches/server/0861-More-Projectile-API.patch
@@ -164,10 +164,10 @@ index b08739dd1ffd041f0885af6c1f57dca9027763b6..c1594f62c06a49ba2d0c2c6e6befcda7
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 04aabec62f0c89e70681af3846d73659f4c81360..c7c5f18cde7a4ad4dd821e452de3068c2e2187d1 100644
+index 2c5c2857f65f3b8c55de080274976a8bf00fa429..d40f9b244ec700d86407a2b3f3e1808d1b473176 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -274,12 +274,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -275,12 +275,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0861-More-Projectile-API.patch
+++ b/patches/server/0861-More-Projectile-API.patch
@@ -164,10 +164,10 @@ index b08739dd1ffd041f0885af6c1f57dca9027763b6..c1594f62c06a49ba2d0c2c6e6befcda7
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index c840af91edd5e7cc911013bfd4479e3bdf647795..438055479b7e7496ecd3b335c9eae3acdcee2762 100644
+index 086d286c515505828ea459cc84589ec38974bcfc..23d1d892ae4b23ebbe2ce72c3f00ced4fb7c4680 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -326,12 +326,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -328,12 +328,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0861-More-Projectile-API.patch
+++ b/patches/server/0861-More-Projectile-API.patch
@@ -164,10 +164,10 @@ index b08739dd1ffd041f0885af6c1f57dca9027763b6..c1594f62c06a49ba2d0c2c6e6befcda7
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4f091686444ce2c67414ce818dc8b3e49bd5ac69..a45b5086ff1e6f770ee011be8b18b6b2cc5a4207 100644
+index 32028190b01d43d312beff74784716fb312f677c..704f92b109ba2e4559df26521fa710c426116159 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -318,12 +318,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -321,12 +321,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0861-More-Projectile-API.patch
+++ b/patches/server/0861-More-Projectile-API.patch
@@ -164,10 +164,10 @@ index b08739dd1ffd041f0885af6c1f57dca9027763b6..c1594f62c06a49ba2d0c2c6e6befcda7
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 32028190b01d43d312beff74784716fb312f677c..704f92b109ba2e4559df26521fa710c426116159 100644
+index c840af91edd5e7cc911013bfd4479e3bdf647795..438055479b7e7496ecd3b335c9eae3acdcee2762 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -321,12 +321,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -326,12 +326,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0861-More-Projectile-API.patch
+++ b/patches/server/0861-More-Projectile-API.patch
@@ -164,10 +164,10 @@ index b08739dd1ffd041f0885af6c1f57dca9027763b6..c1594f62c06a49ba2d0c2c6e6befcda7
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 2c5c2857f65f3b8c55de080274976a8bf00fa429..d40f9b244ec700d86407a2b3f3e1808d1b473176 100644
+index 488e933bcf7bf0d84802a77e6be73bea4895426c..e3c2fd53652c636dfaf9d424f249fbd0c64d951c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -275,12 +275,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -306,12 +306,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0861-More-Projectile-API.patch
+++ b/patches/server/0861-More-Projectile-API.patch
@@ -164,10 +164,10 @@ index b08739dd1ffd041f0885af6c1f57dca9027763b6..c1594f62c06a49ba2d0c2c6e6befcda7
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 406a70f29953dd2bd460e7298663c9f29c558159..318b416e669918133ea0e0704bff8cbfcb4b84a8 100644
+index 4f091686444ce2c67414ce818dc8b3e49bd5ac69..a45b5086ff1e6f770ee011be8b18b6b2cc5a4207 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -315,12 +315,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -318,12 +318,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0861-More-Projectile-API.patch
+++ b/patches/server/0861-More-Projectile-API.patch
@@ -164,10 +164,10 @@ index b08739dd1ffd041f0885af6c1f57dca9027763b6..c1594f62c06a49ba2d0c2c6e6befcda7
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 086d286c515505828ea459cc84589ec38974bcfc..23d1d892ae4b23ebbe2ce72c3f00ced4fb7c4680 100644
+index 351fe7d24d789168ee5a2e99e0fa6237dc8b0299..5c00565e285adf047d7ce50df6609c133354d08e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -328,12 +328,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -329,12 +329,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0861-More-Projectile-API.patch
+++ b/patches/server/0861-More-Projectile-API.patch
@@ -164,10 +164,10 @@ index b08739dd1ffd041f0885af6c1f57dca9027763b6..c1594f62c06a49ba2d0c2c6e6befcda7
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 488e933bcf7bf0d84802a77e6be73bea4895426c..e3c2fd53652c636dfaf9d424f249fbd0c64d951c 100644
+index 406a70f29953dd2bd460e7298663c9f29c558159..318b416e669918133ea0e0704bff8cbfcb4b84a8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -306,12 +306,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -315,12 +315,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0885-Fix-NPE-for-BlockDataMeta-getBlockData.patch
+++ b/patches/server/0885-Fix-NPE-for-BlockDataMeta-getBlockData.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix NPE for BlockDataMeta#getBlockData
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 491158228a5d6ab084965059ded13d1d166c0578..cef85c9c5e1e3866384114ce91c07f5acd1fa199 100644
+index 0db977a9e92b8fae663a2fc602e49221817be25e..c5b98f0b9510c0a5b4232f99d74dbb113f689395 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1098,7 +1098,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1111,7 +1111,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public BlockData getBlockData(Material material) {

--- a/patches/server/0885-Fix-NPE-for-BlockDataMeta-getBlockData.patch
+++ b/patches/server/0885-Fix-NPE-for-BlockDataMeta-getBlockData.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix NPE for BlockDataMeta#getBlockData
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 0db977a9e92b8fae663a2fc602e49221817be25e..c5b98f0b9510c0a5b4232f99d74dbb113f689395 100644
+index d9217b03fb05d9a9925c02a77fcee1df0f2defaa..202c9b30679e51581ec4b9f920d13b49465d0334 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1111,7 +1111,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1134,7 +1134,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public BlockData getBlockData(Material material) {

--- a/patches/server/0885-Fix-NPE-for-BlockDataMeta-getBlockData.patch
+++ b/patches/server/0885-Fix-NPE-for-BlockDataMeta-getBlockData.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix NPE for BlockDataMeta#getBlockData
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index a8294bf057e03c5d866f6da31e6cdfa9edd3f146..3c4dadd0012c11191c873fe25a7625193563915d 100644
+index bffee1fdbd323e0068962e07e006bc70d28f1cc3..dc9d8c217cb5c886def2003bc5e5378281277893 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1093,7 +1093,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1096,7 +1096,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public BlockData getBlockData(Material material) {

--- a/patches/server/0885-Fix-NPE-for-BlockDataMeta-getBlockData.patch
+++ b/patches/server/0885-Fix-NPE-for-BlockDataMeta-getBlockData.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix NPE for BlockDataMeta#getBlockData
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index bffee1fdbd323e0068962e07e006bc70d28f1cc3..dc9d8c217cb5c886def2003bc5e5378281277893 100644
+index 491158228a5d6ab084965059ded13d1d166c0578..cef85c9c5e1e3866384114ce91c07f5acd1fa199 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1096,7 +1096,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1098,7 +1098,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public BlockData getBlockData(Material material) {

--- a/patches/server/0903-Add-missing-spawn-eggs.patch
+++ b/patches/server/0903-Add-missing-spawn-eggs.patch
@@ -22,10 +22,10 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 318b416e669918133ea0e0704bff8cbfcb4b84a8..4e22e82feaeaae61ed78a66921dac265981dd06d 100644
+index a45b5086ff1e6f770ee011be8b18b6b2cc5a4207..58db289d4116ea760fd3738c31a6a674ed0dada8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -465,6 +465,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -468,6 +468,12 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:

--- a/patches/server/0903-Add-missing-spawn-eggs.patch
+++ b/patches/server/0903-Add-missing-spawn-eggs.patch
@@ -22,10 +22,10 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index c7c5f18cde7a4ad4dd821e452de3068c2e2187d1..f5363a753e5d24ccda946a9d65132eed28f19172 100644
+index d40f9b244ec700d86407a2b3f3e1808d1b473176..a99dedcc5ac6e1a414385841411164fc7a96e7ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -424,6 +424,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -425,6 +425,12 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:

--- a/patches/server/0903-Add-missing-spawn-eggs.patch
+++ b/patches/server/0903-Add-missing-spawn-eggs.patch
@@ -22,10 +22,10 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index a45b5086ff1e6f770ee011be8b18b6b2cc5a4207..58db289d4116ea760fd3738c31a6a674ed0dada8 100644
+index 704f92b109ba2e4559df26521fa710c426116159..77ba6c6432f041c1325835bd516cfdd99d06aa0c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -468,6 +468,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -471,6 +471,12 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:

--- a/patches/server/0903-Add-missing-spawn-eggs.patch
+++ b/patches/server/0903-Add-missing-spawn-eggs.patch
@@ -22,10 +22,10 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 23d1d892ae4b23ebbe2ce72c3f00ced4fb7c4680..e2b98ab8b58ab09bde54e0890c429710f6e69892 100644
+index 5c00565e285adf047d7ce50df6609c133354d08e..ddc559a9a4132fbf93266b7849a6989034df6e01 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -478,6 +478,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -479,6 +479,12 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:

--- a/patches/server/0903-Add-missing-spawn-eggs.patch
+++ b/patches/server/0903-Add-missing-spawn-eggs.patch
@@ -22,10 +22,10 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index d40f9b244ec700d86407a2b3f3e1808d1b473176..a99dedcc5ac6e1a414385841411164fc7a96e7ca 100644
+index e3c2fd53652c636dfaf9d424f249fbd0c64d951c..81679673748c309b2373390535c5a8f213259d9c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -425,6 +425,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -456,6 +456,12 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:

--- a/patches/server/0903-Add-missing-spawn-eggs.patch
+++ b/patches/server/0903-Add-missing-spawn-eggs.patch
@@ -22,10 +22,10 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 438055479b7e7496ecd3b335c9eae3acdcee2762..6b66c4f1aff84be6b133f37fa7b93a7e783678a8 100644
+index 23d1d892ae4b23ebbe2ce72c3f00ced4fb7c4680..e2b98ab8b58ab09bde54e0890c429710f6e69892 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -476,6 +476,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -478,6 +478,12 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:

--- a/patches/server/0903-Add-missing-spawn-eggs.patch
+++ b/patches/server/0903-Add-missing-spawn-eggs.patch
@@ -22,10 +22,10 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index e3c2fd53652c636dfaf9d424f249fbd0c64d951c..81679673748c309b2373390535c5a8f213259d9c 100644
+index 318b416e669918133ea0e0704bff8cbfcb4b84a8..4e22e82feaeaae61ed78a66921dac265981dd06d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -456,6 +456,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -465,6 +465,12 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:

--- a/patches/server/0903-Add-missing-spawn-eggs.patch
+++ b/patches/server/0903-Add-missing-spawn-eggs.patch
@@ -22,10 +22,10 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 704f92b109ba2e4559df26521fa710c426116159..77ba6c6432f041c1325835bd516cfdd99d06aa0c 100644
+index 438055479b7e7496ecd3b335c9eae3acdcee2762..6b66c4f1aff84be6b133f37fa7b93a7e783678a8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -471,6 +471,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -476,6 +476,12 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/5188
Paper has fixed enchantment order inconsistencies but has also implemented the fix on getter which is useless because no write operation is done here
In fact i think all methods outside of the ItemMeta class shouldn't call itemmeta at all even for setter (or at least it should be documented) because developer who use this method don't think that the whole tag will be reparsed

Closes https://github.com/PaperMC/Paper/issues/5071
Remove the reparse of the whole itemmeta because the tag is already here at this stage. This method just change the item in the nms class (also remove the bukkit cached itemstack impl), and the itemmeta will be reparsed when the developer recall getItemMeta() without the help of bukkit