### PR TITLE
Strip legacy color chars in gui

### DIFF
--- a/patches/server/0918-Strip-color-char-in-console-gui.patch
+++ b/patches/server/0918-Strip-color-char-in-console-gui.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com>
+Date: Fri, 1 Jul 2022 18:58:08 +0200
+Subject: [PATCH] Strip color char in console gui
+
+
+diff --git a/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java b/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java
+index c07918aa1ed2469ad7a76a0add60ab648ff7f421..8da178a3c08ce139a36000d87631a5fe57ce052b 100644
+--- a/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java
++++ b/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java
+@@ -175,6 +175,11 @@ public class MinecraftServerGui extends JComponent {
+         this.finalizers.forEach(Runnable::run);
+     }
+ 
++    // Paper start
++    private static final char COLOR_CHAR = 0x7f;
++    private static final java.util.regex.Pattern COLOR_PATTERN = java.util.regex.Pattern.compile(COLOR_CHAR + "([0-9a-fk-orA-FK-OR])|" + COLOR_CHAR + "#([0-9a-fA-F]){6}");
++    // Paper end
++
+     private static final java.util.regex.Pattern ANSI = java.util.regex.Pattern.compile("\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})*)?[m|K]"); // CraftBukkit
+     public void print(JTextArea textArea, JScrollPane scrollPane, String message) {
+         if (!SwingUtilities.isEventDispatchThread()) {
+@@ -191,7 +196,7 @@ public class MinecraftServerGui extends JComponent {
+             }
+ 
+             try {
+-                document.insertString(document.getLength(), MinecraftServerGui.ANSI.matcher(message).replaceAll(""), (AttributeSet) null); // CraftBukkit
++                document.insertString(document.getLength(), COLOR_PATTERN.matcher(message).replaceAll(""), (AttributeSet) null); // Paper // CraftBukkit
+             } catch (BadLocationException badlocationexception) {
+                 ;
+             }

--- a/patches/server/0976-Strip-color-char-in-console-gui.patch
+++ b/patches/server/0976-Strip-color-char-in-console-gui.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Strip color char in console gui
 
 
 diff --git a/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java b/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java
-index c07918aa1ed2469ad7a76a0add60ab648ff7f421..8da178a3c08ce139a36000d87631a5fe57ce052b 100644
+index c07918aa1ed2469ad7a76a0add60ab648ff7f421..5e9006f47217a8fa4df9f4293d6a13750ee16234 100644
 --- a/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java
 +++ b/src/main/java/net/minecraft/server/gui/MinecraftServerGui.java
 @@ -175,6 +175,11 @@ public class MinecraftServerGui extends JComponent {
@@ -14,7 +14,7 @@ index c07918aa1ed2469ad7a76a0add60ab648ff7f421..8da178a3c08ce139a36000d87631a5fe
  
 +    // Paper start
 +    private static final char COLOR_CHAR = 0x7f;
-+    private static final java.util.regex.Pattern COLOR_PATTERN = java.util.regex.Pattern.compile(COLOR_CHAR + "([0-9a-fk-orA-FK-OR])|" + COLOR_CHAR + "#([0-9a-fA-F]){6}");
++    private static final java.util.regex.Pattern COLOR_PATTERN = java.util.regex.Pattern.compile(COLOR_CHAR + "[0-9a-fk-orA-FK-OR]|" + COLOR_CHAR + "#[0-9a-fA-F]{6}");
 +    // Paper end
 +
      private static final java.util.regex.Pattern ANSI = java.util.regex.Pattern.compile("\\x1B\\[([0-9]{1,2}(;[0-9]{1,2})*)?[m|K]"); // CraftBukkit
@@ -25,7 +25,7 @@ index c07918aa1ed2469ad7a76a0add60ab648ff7f421..8da178a3c08ce139a36000d87631a5fe
  
              try {
 -                document.insertString(document.getLength(), MinecraftServerGui.ANSI.matcher(message).replaceAll(""), (AttributeSet) null); // CraftBukkit
-+                document.insertString(document.getLength(), COLOR_PATTERN.matcher(message).replaceAll(""), (AttributeSet) null); // Paper // CraftBukkit
++                document.insertString(document.getLength(), COLOR_PATTERN.matcher(message).replaceAll(""), (AttributeSet) null); // CraftBukkit // Paper
              } catch (BadLocationException badlocationexception) {
                  ;
              }


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/7827
It seems the gui doesn't receive any form of ANSI char but just the legacy char code
And spigot strip only ANSI
This new patch strip both legacy named char and most recent syntax using hexadecimal for all other rgb colors