### PR TITLE
Don't print component in resource pack rejection message

### DIFF
--- a/patches/server/0919-Don-t-print-component-in-resource-pack-rejection-mes.patch
+++ b/patches/server/0919-Don-t-print-component-in-resource-pack-rejection-mes.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pop4959 <pop4959@gmail.com>
+Date: Fri, 1 Jul 2022 22:00:06 -0700
+Subject: [PATCH] Don't print component in resource pack rejection message
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 630a762b71861bfe21c47a11d4fe05e1a3b7d339..3486b3eed20b25525569154cb1457a9270a943f9 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1979,7 +1979,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+     public void handleResourcePackResponse(ServerboundResourcePackPacket packet) {
+         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
+         if (packet.getAction() == ServerboundResourcePackPacket.Action.DECLINED && this.server.isResourcePackRequired()) {
+-            ServerGamePacketListenerImpl.LOGGER.info("Disconnecting {} due to resource pack rejection", this.player.getName());
++            ServerGamePacketListenerImpl.LOGGER.info("Disconnecting {} due to resource pack rejection", this.player.getGameProfile().getName()); // Paper - Don't print component in resource pack rejection message
+             this.disconnect(Component.translatable("multiplayer.requiredTexturePrompt.disconnect"), org.bukkit.event.player.PlayerKickEvent.Cause.RESOURCE_PACK_REJECTION); // Paper - add cause
+         }
+         // Paper start


### PR DESCRIPTION
Just fixes a dumb looking console log message when resource packs are required and a user rejects them

```
[21:55:52 INFO]: Disconnecting TextComponent{text='pop4959', siblings=[], style=Style{ color=null, bold=null, italic=null, underlined=null, strikethrough=null, obfuscated=null, clickEvent=null, hoverEvent=null, insertion=null, font=minecraft:default}} due to resource pack rejection
```
->
```
[21:55:52 INFO]: Disconnecting pop4959 due to resource pack rejection
```