### PR TITLE
Fix count in origin ItemStack for InventoryMoveItemEvent

### DIFF
--- a/patches/server/0339-Optimize-Hoppers.patch
+++ b/patches/server/0339-Optimize-Hoppers.patch
@@ -78,7 +78,7 @@ index a05acf709735b40ca86f978508c63a86065fd405..6a1405a8630e90db3b5a3c9152259ba6
  
      double getLevelY();
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index a507d7f65a94e49ecd18cd18797b156474558390..a7ac6b528aecae528a17af157f8ec29371e4484c 100644
+index a507d7f65a94e49ecd18cd18797b156474558390..765c7a082e3fa4ed1324aaaf1b6395d3ede6113e 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 @@ -3,7 +3,6 @@ package net.minecraft.world.level.block.entity;
@@ -114,11 +114,11 @@ index a507d7f65a94e49ecd18cd18797b156474558390..a7ac6b528aecae528a17af157f8ec293
 +            if (!item.isEmpty()) {
 +                foundItem = true;
 +                ItemStack origItemStack = item;
-+                ItemStack itemstack = origItemStack;
++                ItemStack itemstack = origItemStack.copy();
 +
 +                final int origCount = origItemStack.getCount();
 +                final int moved = Math.min(level.spigotConfig.hopperAmount, origCount);
-+                origItemStack.setCount(moved);
++                itemstack.setCount(moved);
 +
 +                // We only need to fire the event once to give protection plugins a chance to cancel this event
 +                // Because nothing uses getItem, every event call should end up the same result.
@@ -151,7 +151,7 @@ index a507d7f65a94e49ecd18cd18797b156474558390..a7ac6b528aecae528a17af157f8ec293
 +    }
 +
 +    private static boolean hopperPull(Level level, Hopper ihopper, Container iinventory, ItemStack origItemStack, int i) {
-+        ItemStack itemstack = origItemStack;
++        ItemStack itemstack = origItemStack.copy();
 +        final int origCount = origItemStack.getCount();
 +        final int moved = Math.min(level.spigotConfig.hopperAmount, origCount);
 +        itemstack.setCount(moved);


### PR DESCRIPTION
This fixs #8086 based in the same issue the problem is the item passed to the event not have the change in the amount to pass.

note: need learn more git because when make https://github.com/PaperMC/Paper/blob/master/CONTRIBUTING.md#method-1 this i cannot modify the patch... this was a directly edition in patch.. tested with applyPatches