### PR TITLE
Call EntityDropItemEvent for goats dropping horns

### DIFF
--- a/patches/server/0922-Add-various-missing-EntityDropItemEvent-calls.patch
+++ b/patches/server/0922-Add-various-missing-EntityDropItemEvent-calls.patch
@@ -57,3 +57,17 @@ index 8f294f10aca2df007830b12da0506f7614206a89..6a66b5d1a3d8615dcc15057f03476e9c
      }
  
      @Override
+diff --git a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
+index 56dd01801f56c56d07101e7e22b58ac059f5f07f..31be36e6b7b6bd0c0d7fda4e1b03ecd38947f3a5 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
++++ b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
+@@ -329,8 +329,7 @@ public class Goat extends Animal {
+             double d2 = (double) Mth.randomBetween(this.random, -0.2F, 0.2F);
+             ItemEntity entityitem = new ItemEntity(this.level, vec3d.x(), vec3d.y(), vec3d.z(), itemstack, d0, d1, d2);
+ 
+-            this.level.addFreshEntity(entityitem);
+-            return true;
++            return this.spawnAtLocation(entityitem) != null; // Paper - call EntityDropItemEvent by calling spawnAtLocation.
+         }
+     }
+ 


### PR DESCRIPTION
Calls the EntityDropItemEvent when a goat drops one of its goat horns.

As with other calls of the EntityDropItemEvent, the event is published
after the modification of the entity and cancellation of it does not
restore the entities state. In this case, the goat would still loose
their horn however the item would not be dropped (See snowmen dropping
their pumpkin).

Resolves: #8093 


-----------------------------------------------------------------------------------------------------

Notes about this PR:

- ~~Most other calls of the EntityDropItemEvent are called from `Entity#spawnAtLocation` in combination with the `Entity.forceDrops` field. However this logic does not allow for custom x/y/z, which the goat computes~~

- As laid out, this event is called after the goat data was mutated to no longer have the horn dropped. This is in line with some other entities that drop something, e.g. Snowmen or Leash. However idk if this is part of the event contract, the javadocs (as with all spigot things) is rather vague.