### PR TITLE
Add PlayerItemConsumedEvent

### DIFF
--- a/patches/api/0387-Add-PlayerItemConsumedEvent.patch
+++ b/patches/api/0387-Add-PlayerItemConsumedEvent.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nopjar <code.nopjar@gmail.com>
+Date: Sun, 10 Jul 2022 17:05:38 +0200
+Subject: [PATCH] Add PlayerItemConsumedEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerItemConsumedEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerItemConsumedEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..b1667c4136043c0f471fbbfdef66b1c285b21c32
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerItemConsumedEvent.java
+@@ -0,0 +1,51 @@
++package io.papermc.paper.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * This event will fire after a player consumed an item (food, potion, milk bucket).
++ * <p>
++ * The consumed ItemStack cannot be modified, therefor you must use
++ * {@link org.bukkit.event.player.PlayerItemConsumeEvent}
++ */
++public class PlayerItemConsumedEvent extends PlayerEvent {
++
++    private static final HandlerList HANDLERS = new HandlerList();
++    private final ItemStack item;
++
++    /**
++     * @param player the player who consumed
++     * @param item the consumed ItemStack
++     */
++    public PlayerItemConsumedEvent(@NotNull final Player player, @NotNull final ItemStack item) {
++        super(player);
++
++        this.item = item;
++    }
++
++    /**
++     * Gets the item that was consumed.
++     *
++     * @return an ItemStack for the consumed item
++     */
++    @NotNull
++    public ItemStack getItem() {
++        return item;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLERS;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLERS;
++    }
++
++}

--- a/patches/server/0925-Add-PlayerItemConsumedEvent.patch
+++ b/patches/server/0925-Add-PlayerItemConsumedEvent.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nopjar <code.nopjar@gmail.com>
+Date: Sun, 10 Jul 2022 17:06:09 +0200
+Subject: [PATCH] Add PlayerItemConsumedEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 279051442ac6cf288a03a16a35ddbf66d1cd1e90..420e7b14efbab0fbaf6d22900180ae488f0a1510 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -3879,6 +3879,7 @@ public abstract class LivingEntity extends Entity {
+                 // Paper start
+                 if (this instanceof ServerPlayer) {
+                     ((ServerPlayer) this).getBukkitEntity().updateInventory();
++                    new io.papermc.paper.event.player.PlayerItemConsumedEvent((Player) this.getBukkitEntity(), CraftItemStack.asBukkitCopy(itemstack)).callEvent(); // Paper - call event after item was consumed
+                 }
+                 // Paper end
+                 }


### PR DESCRIPTION
Adding an event which is called after an item was consumed by a player, which allows building mechanics based on consumption. The `org.bukkit.event.player.PlayerItemConsumeEvent` does not allow those operations safely, as the event can still be cancelled or the consumed Item be changed.