### PR TITLE
Fix update future return type

### DIFF
--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -7,16 +7,17 @@ Provides basic elements of a PlayerProfile to be used by future API/events
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d4766e2116c2202d84080637a2832bef0ab3f718
+index 0000000000000000000000000000000000000000..b76f13a0266806544bde13952476d4867caaf25b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PlayerProfile.java
-@@ -0,0 +1,199 @@
+@@ -0,0 +1,231 @@
 +package com.destroystokyo.paper.profile;
 +
 +import java.util.Collection;
 +import java.util.Set;
 +import java.util.UUID;
 +
++import java.util.concurrent.CompletableFuture;
 +import org.bukkit.profile.PlayerTextures;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
@@ -203,8 +204,39 @@ index 0000000000000000000000000000000000000000..d4766e2116c2202d84080637a2832bef
 +    boolean complete(boolean textures, boolean onlineMode);
 +
 +    /**
-+     * Whether or not this Profile has textures associated to it
-+     * @return If has a textures property
++     * Produces an updated player profile based on this profile.
++     * <p>
++     * This tries to produce a completed profile by filling in missing
++     * properties (name, unique id, textures, etc.), and updates existing
++     * properties (e.g. name, textures, etc.) to their official and up-to-date
++     * values. This operation does not alter the current profile, but produces a
++     * new updated {@link PlayerProfile}.
++     * <p>
++     * If no player exists for the unique id or name of this profile, this
++     * operation yields a profile that is equal to the current profile, which
++     * might not be complete.
++     * <p>
++     * This is an asynchronous operation: Updating the profile can result in an
++     * outgoing connection in another thread in order to fetch the latest
++     * profile properties. The returned {@link CompletableFuture} will be
++     * completed once the updated profile is available. In order to not block
++     * the server's main thread, you should not wait for the result of the
++     * returned CompletableFuture on the server's main thread. Instead, if you
++     * want to do something with the updated player profile on the server's main
++     * thread once it is available, you could do something like this:
++     * <pre>
++     * profile.update().thenAcceptAsync(updatedProfile -> {
++     *     // Do something with the updated profile:
++     *     // ...
++     * }, runnable -> Bukkit.getScheduler().runTask(plugin, runnable));
++     * </pre>
++     */
++    @Override
++    @NotNull CompletableFuture<PlayerProfile> update();
++
++    /**
++     * Whether this Profile has textures associated to it
++     * @return If it has a textures property
 +     */
 +    default boolean hasTextures() {
 +        return hasProperty("textures");
@@ -455,3 +487,16 @@ index 2bfbb0ce71c8c5f8bd9bbd908488831b94ce583f..04752eebe9df1138207a969fb1492a1f
 +    com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);
      // Paper end
  }
+diff --git a/src/main/java/org/bukkit/profile/PlayerProfile.java b/src/main/java/org/bukkit/profile/PlayerProfile.java
+index 16ae1282f3178e8873483a25a5d5cce16b2c21a9..fc46add38bf59dc1a04ea566fd230dcd8ae2708c 100644
+--- a/src/main/java/org/bukkit/profile/PlayerProfile.java
++++ b/src/main/java/org/bukkit/profile/PlayerProfile.java
+@@ -93,7 +93,7 @@ public interface PlayerProfile extends Cloneable, ConfigurationSerializable {
+      * PlayerProfile once it is available
+      */
+     @NotNull
+-    CompletableFuture<PlayerProfile> update();
++    CompletableFuture<? extends PlayerProfile> update(); // Paper
+ 
+     @NotNull
+     PlayerProfile clone();

--- a/patches/server/0140-Basic-PlayerProfile-API.patch
+++ b/patches/server/0140-Basic-PlayerProfile-API.patch
@@ -7,7 +7,7 @@ Establishes base extension of profile systems for future edits too
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7a5b24419507d00817aa3e8950d89f5174823387
+index 0000000000000000000000000000000000000000..3ff790cec1ad89caec4be64421dd7d51652be598
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 @@ -0,0 +1,399 @@
@@ -180,7 +180,7 @@ index 0000000000000000000000000000000000000000..7a5b24419507d00817aa3e8950d89f51
 +    }
 +
 +    @Override
-+    public @NotNull CompletableFuture<org.bukkit.profile.PlayerProfile> update() {
++    public @NotNull CompletableFuture<PlayerProfile> update() {
 +        return CompletableFuture.supplyAsync(() -> {
 +            final CraftPlayerProfile clone = clone();
 +            clone.complete(true);


### PR DESCRIPTION
Paper's `PlayerProfile` interface has an `update()` method that returns a `CompletableFuture<bukkit.PlayerProfile>` when it should be a `CompletableFuture<paper.PlayerProfile`.

You should be able to change the return generic param to include `? extends bukkit.PlayerProfile` without breaking ABI.