### PR TITLE
Supports block state for adventure tags (item meta)

### DIFF
--- a/patches/api/0152-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-values.patch
+++ b/patches/api/0152-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-values.patch
@@ -226,10 +226,10 @@ index c65f0d6569c130b4920a9e71ad24af6427f1f030..01bcb3a1bdb5accdf844d0178cec3d25
          return key;
      }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index a19635c38705e6221ae25d58e976e483e7ed17e4..71c7780424a986a95852b1ca15116096896500df 100644
+index 64114b1a9e201df369fc794fbee984d496385420..25f6c5e5590363bc3e6e535faf93fdddb685e030 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -444,4 +444,87 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -444,4 +444,117 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @SuppressWarnings("javadoc")
      @NotNull
      ItemMeta clone();
@@ -287,6 +287,21 @@ index a19635c38705e6221ae25d58e976e483e7ed17e4..71c7780424a986a95852b1ca15116096
 +    void setDestroyableKeys(@NotNull Collection<com.destroystokyo.paper.Namespaced> canDestroy);
 +
 +    /**
++     * Gets the collection of block datas that the item can destroy in {@link org.bukkit.GameMode#ADVENTURE}
++     *
++     * @return Set of {@link org.bukkit.block.data.BlockData}
++     */
++    @NotNull
++    Set<org.bukkit.block.data.BlockData> getDestroyableDatas();
++
++    /**
++     * Sets the collection of block datas that the item can destroy in {@link org.bukkit.GameMode#ADVENTURE}
++     *
++     * @param canDestroy Collection of {@link org.bukkit.block.data.BlockData}
++     */
++    void setDestroyableDatas(@NotNull Collection<org.bukkit.block.data.BlockData> canDestroy);
++
++    /**
 +     * Gets the collection of namespaced keys that the item can be placed on in {@link org.bukkit.GameMode#ADVENTURE}
 +     *
 +     * @return Set of {@link com.destroystokyo.paper.Namespaced}
@@ -295,7 +310,7 @@ index a19635c38705e6221ae25d58e976e483e7ed17e4..71c7780424a986a95852b1ca15116096
 +    Set<com.destroystokyo.paper.Namespaced> getPlaceableKeys();
 +
 +    /**
-+     * Sets the set of namespaced keys that the item can be placed on in {@link org.bukkit.GameMode#ADVENTURE}
++     * Sets the collection of namespaced keys that the item can be placed on in {@link org.bukkit.GameMode#ADVENTURE}
 +     *
 +     * @param canPlaceOn Collection of {@link com.destroystokyo.paper.Namespaced}
 +     */
@@ -303,16 +318,31 @@ index a19635c38705e6221ae25d58e976e483e7ed17e4..71c7780424a986a95852b1ca15116096
 +    void setPlaceableKeys(@NotNull Collection<com.destroystokyo.paper.Namespaced> canPlaceOn);
 +
 +    /**
-+     * Checks for the existence of any keys that the item can be placed on
++     * Gets the collection of block datas that the item can be placed on in {@link org.bukkit.GameMode#ADVENTURE}
 +     *
-+     * @return true if this item has placeable keys
++     * @return Set of {@link org.bukkit.block.data.BlockData}
++     */
++    @NotNull
++    Set<org.bukkit.block.data.BlockData> getPlaceableDatas();
++
++    /**
++     * Sets the collection of block datas that the item can be placed on in {@link org.bukkit.GameMode#ADVENTURE}
++     *
++     * @param canPlaceOn Collection of {@link org.bukkit.block.data.BlockData}
++     */
++    void setPlaceableDatas(@NotNull Collection<org.bukkit.block.data.BlockData> canPlaceOn);
++
++    /**
++     * Checks for the existence of any keys or block datas that the item can be placed on
++     *
++     * @return true if this item has placeable keys and block datas
 +     */
 +    boolean hasPlaceableKeys();
 +
 +    /**
-+     * Checks for the existence of any keys that the item can destroy
++     * Checks for the existence of any keys or block datas that the item can destroy
 +     *
-+     * @return true if this item has destroyable keys
++     * @return true if this item has destroyable keys and block datas
 +     */
 +    boolean hasDestroyableKeys();
 +    // Paper end

--- a/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
+++ b/patches/server/0258-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
@@ -4,8 +4,21 @@ Date: Wed, 12 Sep 2018 18:53:55 +0300
 Subject: [PATCH] Implement an API for CanPlaceOn and CanDestroy NBT values
 
 
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+index 8ec78b26d6bfbcdad443c9649e35f79dd336b095..43afedc7bbd7f420e6bb7647d2cba0c9a3d7f1e6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+@@ -32,7 +32,7 @@ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+ public class CraftBlockData implements BlockData {
+ 
+     private BlockState state;
+-    private Map<Property<?>, Comparable<?>> parsedStates;
++    public Map<Property<?>, Comparable<?>> parsedStates; // Paper private -> public
+ 
+     protected CraftBlockData() {
+         throw new AssertionError("Template Constructor");
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0eea25adbd 100644
+index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..c5e4a8942ac96ab8c37dabe42e76fb09c5cb9c55 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -83,6 +83,12 @@ import org.bukkit.persistence.PersistentDataContainer;
@@ -32,34 +45,42 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
  
      // We store the raw original JSON representation of all text data. See SPIGOT-5063, SPIGOT-5656, SPIGOT-5304
      private String displayName;
-@@ -281,6 +291,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -281,6 +291,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private int hideFlag;
      private boolean unbreakable;
      private int damage;
 +    // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
-+    private Set<Namespaced> placeableKeys = Sets.newHashSet();
-+    private Set<Namespaced> destroyableKeys = Sets.newHashSet();
++    private Set<NamespacedTag> placeableTags = Sets.newHashSet();
++    private Set<NamespacedTag> destroyableTags = Sets.newHashSet();
++    private Set<BlockData> placeableDatas = Sets.newHashSet();
++    private Set<BlockData> destroyableDatas = Sets.newHashSet();
 +    // Paper end
  
      private static final Set<String> HANDLED_TAGS = Sets.newHashSet();
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
-@@ -318,6 +332,15 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -318,6 +334,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.hideFlag = meta.hideFlag;
          this.unbreakable = meta.unbreakable;
          this.damage = meta.damage;
 +        // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
-+        if (meta.hasPlaceableKeys()) {
-+            this.placeableKeys = new java.util.HashSet<>(meta.placeableKeys);
++        if (meta.placeableTags != null && !meta.placeableTags.isEmpty()) {
++            this.placeableTags = new java.util.HashSet<>(meta.placeableTags);
++        }
++        if (meta.placeableDatas != null && !meta.placeableDatas.isEmpty()) {
++            this.placeableDatas = new java.util.HashSet<>(meta.placeableDatas);
 +        }
 +
-+        if (meta.hasDestroyableKeys()) {
-+            this.destroyableKeys = new java.util.HashSet<>(meta.destroyableKeys);
++        if (meta.destroyableTags != null && !meta.destroyableTags.isEmpty()) {
++            this.destroyableTags = new java.util.HashSet<>(meta.destroyableTags);
++        }
++        if (meta.destroyableDatas != null && !meta.destroyableDatas.isEmpty()) {
++            this.destroyableDatas = new java.util.HashSet<>(meta.destroyableDatas);
 +        }
 +        // Paper end
          this.unhandledTags.putAll(meta.unhandledTags);
          this.persistentDataContainer.putAll(meta.persistentDataContainer.getRaw());
  
-@@ -381,6 +404,31 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -381,6 +412,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  this.persistentDataContainer.put(key, compound.get(key).copy());
              }
          }
@@ -67,31 +88,21 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
 +        if (tag.contains(CAN_DESTROY.NBT)) {
 +            ListTag list = tag.getList(CAN_DESTROY.NBT, CraftMagicNumbers.NBT.TAG_STRING);
 +            for (int i = 0; i < list.size(); i++) {
-+                Namespaced namespaced = this.deserializeNamespaced(list.getString(i));
-+                if (namespaced == null) {
-+                    continue;
-+                }
-+
-+                this.destroyableKeys.add(namespaced);
++                deserializeNamespaced(list.getString(i), destroyableTags, destroyableDatas);
 +            }
 +        }
 +
 +        if (tag.contains(CAN_PLACE_ON.NBT)) {
 +            ListTag list = tag.getList(CAN_PLACE_ON.NBT, CraftMagicNumbers.NBT.TAG_STRING);
 +            for (int i = 0; i < list.size(); i++) {
-+                Namespaced namespaced = this.deserializeNamespaced(list.getString(i));
-+                if (namespaced == null) {
-+                    continue;
-+                }
-+
-+                this.placeableKeys.add(namespaced);
++                deserializeNamespaced(list.getString(i), placeableTags, placeableDatas);
 +            }
 +        }
 +        // Paper end
  
          Set<String> keys = tag.getAllKeys();
          for (String key : keys) {
-@@ -519,6 +567,34 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -519,6 +565,24 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              this.setDamage(damage);
          }
  
@@ -100,12 +111,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
 +        if (canPlaceOnSerialized != null) {
 +            for (Object canPlaceOnElement : canPlaceOnSerialized) {
 +                String canPlaceOnRaw = (String) canPlaceOnElement;
-+                Namespaced value = this.deserializeNamespaced(canPlaceOnRaw);
-+                if (value == null) {
-+                    continue;
-+                }
-+
-+                this.placeableKeys.add(value);
++                deserializeNamespaced(canPlaceOnRaw, placeableTags, placeableDatas);
 +            }
 +        }
 +
@@ -113,12 +119,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
 +        if (canDestroySerialized != null) {
 +            for (Object canDestroyElement : canDestroySerialized) {
 +                String canDestroyRaw = (String) canDestroyElement;
-+                Namespaced value = this.deserializeNamespaced(canDestroyRaw);
-+                if (value == null) {
-+                    continue;
-+                }
-+
-+                this.destroyableKeys.add(value);
++                deserializeNamespaced(canDestroyRaw, destroyableTags, destroyableDatas);
 +            }
 +        }
 +        // Paper end
@@ -126,31 +127,40 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
          String internal = SerializableMeta.getString(map, "internal", true);
          if (internal != null) {
              ByteArrayInputStream buf = new ByteArrayInputStream(Base64.getDecoder().decode(internal));
-@@ -647,6 +723,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -647,6 +711,32 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          if (this.hasDamage()) {
              itemTag.putInt(DAMAGE.NBT, damage);
          }
 +        // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
 +        if (hasPlaceableKeys()) {
-+            List<String> items = this.placeableKeys.stream()
-+                .map(this::serializeNamespaced)
-+                .collect(java.util.stream.Collectors.toList());
++            List<String> items = this.placeableTags.stream()
++                .map(CraftMetaItem::serializeNamespaced).toList();
 +
-+            itemTag.put(CAN_PLACE_ON.NBT, createNonComponentStringList(items));
++            List<String> datas = this.placeableDatas.stream()
++                .map(CraftMetaItem::serializeData).toList();
++
++            List<String> itemsTotal = new ArrayList<>(items);
++            itemsTotal.addAll(datas);
++            itemTag.put(CAN_PLACE_ON.NBT, createNonComponentStringList(itemsTotal));
 +        }
 +
 +        if (hasDestroyableKeys()) {
-+            List<String> items = this.destroyableKeys.stream()
-+                .map(this::serializeNamespaced)
-+                .collect(java.util.stream.Collectors.toList());
++            List<String> items = this.destroyableTags.stream()
++                .map(CraftMetaItem::serializeNamespaced).toList();
 +
-+            itemTag.put(CAN_DESTROY.NBT, createNonComponentStringList(items));
++            List<String> datas = this.destroyableDatas.stream()
++                .map(CraftMetaItem::serializeData).toList();
++
++            List<String> itemsTotal = new ArrayList<>(items);
++            itemsTotal.addAll(datas);
++
++            itemTag.put(CAN_DESTROY.NBT, createNonComponentStringList(itemsTotal));
 +        }
 +        // Paper end
  
          for (Map.Entry<String, Tag> e : this.unhandledTags.entrySet()) {
              itemTag.put(e.getKey(), e.getValue());
-@@ -663,6 +756,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -663,6 +753,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -172,7 +182,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
      ListTag createStringList(List<String> list) {
          if (list == null) {
              return null;
-@@ -746,7 +854,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -746,7 +851,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
@@ -181,70 +191,88 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
      }
  
      // Paper start
-@@ -1177,7 +1285,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1177,7 +1282,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hideFlag == that.hideFlag)
                  && (this.isUnbreakable() == that.isUnbreakable())
                  && (this.hasDamage() ? that.hasDamage() && this.damage == that.damage : !that.hasDamage())
 -                && (this.version == that.version);
 +                && (this.version == that.version)
 +                // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
-+                && (this.hasPlaceableKeys() ? that.hasPlaceableKeys() && this.placeableKeys.equals(that.placeableKeys) : !that.hasPlaceableKeys())
-+                && (this.hasDestroyableKeys() ? that.hasDestroyableKeys() && this.destroyableKeys.equals(that.destroyableKeys) : !that.hasDestroyableKeys());
++                && (this.hasPlaceableKeys() ? that.hasPlaceableKeys() && Objects.equals(placeableTags, that.placeableTags) && Objects.equals(placeableDatas, that.placeableDatas) : !that.hasPlaceableKeys())
++                && (this.hasDestroyableKeys() ? that.hasDestroyableKeys() && Objects.equals(destroyableTags, that.destroyableTags) && Objects.equals(destroyableDatas, that.destroyableDatas) : !that.hasDestroyableKeys());
 +                // Paper end
      }
  
      /**
-@@ -1212,6 +1324,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1212,6 +1321,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
          hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
          hash = 61 * hash + this.version;
 +        // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
-+        hash = 61 * hash + (this.hasPlaceableKeys() ? this.placeableKeys.hashCode() : 0);
-+        hash = 61 * hash + (this.hasDestroyableKeys() ? this.destroyableKeys.hashCode() : 0);
++        hash = 61 * hash + (this.placeableTags != null && !this.placeableTags.isEmpty() ? this.placeableTags.hashCode() : 0);
++        hash = 61 * hash + (this.placeableDatas != null && !this.placeableDatas.isEmpty() ? this.placeableDatas.hashCode() : 0);
++        hash = 61 * hash + (this.destroyableTags != null && !this.destroyableTags.isEmpty() ? this.destroyableTags.hashCode() : 0);
++        hash = 61 * hash + (this.destroyableDatas != null && !this.destroyableDatas.isEmpty() ? this.destroyableDatas.hashCode() : 0);
 +        // Paper end
          return hash;
      }
  
-@@ -1236,6 +1352,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1236,6 +1351,20 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.unbreakable = this.unbreakable;
              clone.damage = this.damage;
              clone.version = this.version;
 +            // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
-+            if (this.placeableKeys != null) {
-+                clone.placeableKeys = Sets.newHashSet(this.placeableKeys);
++            if (this.placeableTags != null) {
++                clone.placeableTags = Sets.newHashSet(this.placeableTags);
 +            }
-+            if (this.destroyableKeys != null) {
-+                clone.destroyableKeys = Sets.newHashSet(this.destroyableKeys);
++            if (this.placeableDatas != null) {
++                clone.placeableDatas = Sets.newHashSet(this.placeableDatas);
++            }
++            if (this.destroyableTags != null) {
++                clone.destroyableTags = Sets.newHashSet(this.destroyableTags);
++            }
++            if(this.destroyableDatas != null) {
++                clone.destroyableDatas = Sets.newHashSet(this.destroyableDatas);
 +            }
 +            // Paper end
              return clone;
          } catch (CloneNotSupportedException e) {
              throw new Error(e);
-@@ -1293,6 +1417,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1293,6 +1422,33 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              builder.put(DAMAGE.BUKKIT, damage);
          }
  
 +        // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
 +        if (this.hasPlaceableKeys()) {
-+            List<String> cerealPlaceable = this.placeableKeys.stream()
-+                .map(this::serializeNamespaced)
-+                .collect(java.util.stream.Collectors.toList());
++            List<String> cerealPlaceable = this.placeableTags.stream()
++                .map(CraftMetaItem::serializeNamespaced).toList();
 +
-+            builder.put(CAN_PLACE_ON.BUKKIT, cerealPlaceable);
++            List<String> cerealPlaceableData = this.placeableDatas.stream()
++                .map(CraftMetaItem::serializeData).toList();
++
++            List<String> cerealPlaceableTotal = new ArrayList<>(cerealPlaceable);
++            cerealPlaceableTotal.addAll(cerealPlaceableData);
++
++            builder.put(CAN_PLACE_ON.BUKKIT, cerealPlaceableTotal);
 +        }
 +
 +        if (this.hasDestroyableKeys()) {
-+            List<String> cerealDestroyable = this.destroyableKeys.stream()
-+                .map(this::serializeNamespaced)
-+                .collect(java.util.stream.Collectors.toList());
++            List<String> cerealDestroyable = this.destroyableTags.stream()
++                .map(CraftMetaItem::serializeNamespaced).toList();
 +
-+            builder.put(CAN_DESTROY.BUKKIT, cerealDestroyable);
++            List<String> cerealDestroyableData = this.destroyableDatas.stream()
++                .map(CraftMetaItem::serializeData).toList();
++
++            List<String> cerealDestroyableTotal = new ArrayList<>(cerealDestroyable);
++            cerealDestroyableTotal.addAll(cerealDestroyableData);
++
++            builder.put(CAN_DESTROY.BUKKIT, cerealDestroyableTotal);
 +        }
 +        // Paper end
          final Map<String, Tag> internalTags = new HashMap<String, Tag>(this.unhandledTags);
          this.serializeInternal(internalTags);
          if (!internalTags.isEmpty()) {
-@@ -1459,6 +1600,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1459,6 +1615,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaArmorStand.SHOW_ARMS.NBT,
                          CraftMetaArmorStand.SMALL.NBT,
                          CraftMetaArmorStand.MARKER.NBT,
@@ -253,7 +281,7 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
                          // Paper end
                          CraftMetaCompass.LODESTONE_DIMENSION.NBT,
                          CraftMetaCompass.LODESTONE_POS.NBT,
-@@ -1487,4 +1630,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1487,4 +1645,186 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
      // Paper end
  
@@ -261,77 +289,115 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
 +    @Override
 +    @SuppressWarnings("deprecation")
 +    public Set<Material> getCanDestroy() {
-+        return !hasDestroyableKeys() ? Collections.emptySet() : legacyGetMatsFromKeys(this.destroyableKeys);
++        return !hasDestroyableKeys() ? Collections.emptySet() : legacyGetMatsFromKeys(this.destroyableTags, this.destroyableDatas);
 +    }
 +
 +    @Override
 +    @SuppressWarnings("deprecation")
 +    public void setCanDestroy(Set<Material> canDestroy) {
 +        Validate.notNull(canDestroy, "Cannot replace with null set!");
-+        legacyClearAndReplaceKeys(this.destroyableKeys, canDestroy);
++        legacyClearAndReplaceKeys(this.destroyableDatas, canDestroy);
 +    }
 +
 +    @Override
 +    @SuppressWarnings("deprecation")
 +    public Set<Material> getCanPlaceOn() {
-+        return !hasPlaceableKeys() ? Collections.emptySet() : legacyGetMatsFromKeys(this.placeableKeys);
++        return !hasPlaceableKeys() ? Collections.emptySet() : legacyGetMatsFromKeys(this.placeableTags, this.placeableDatas);
 +    }
 +
 +    @Override
 +    @SuppressWarnings("deprecation")
 +    public void setCanPlaceOn(Set<Material> canPlaceOn) {
 +        Validate.notNull(canPlaceOn, "Cannot replace with null set!");
-+        legacyClearAndReplaceKeys(this.placeableKeys, canPlaceOn);
++        legacyClearAndReplaceKeys(this.placeableDatas, canPlaceOn);
 +    }
 +
 +    @Override
 +    public Set<Namespaced> getDestroyableKeys() {
-+        return !hasDestroyableKeys() ? Collections.emptySet() : Sets.newHashSet(this.destroyableKeys);
++        return !(this.destroyableTags != null && !this.destroyableTags.isEmpty()) ? Collections.emptySet() : Sets.newHashSet(this.destroyableTags);
 +    }
 +
 +    @Override
 +    public void setDestroyableKeys(Collection<Namespaced> canDestroy) {
 +        Validate.notNull(canDestroy, "Cannot replace with null collection!");
 +        Validate.isTrue(ofAcceptableType(canDestroy), "Can only use NamespacedKey or NamespacedTag objects!");
-+        this.destroyableKeys.clear();
-+        this.destroyableKeys.addAll(canDestroy);
++        this.destroyableTags.clear();
++        this.destroyableDatas.clear();
++        for(Namespaced namespaced : canDestroy) {
++            if(namespaced instanceof NamespacedTag namespacedTag) {
++                this.destroyableTags.add(namespacedTag);
++            } else {
++                this.destroyableDatas.add(CraftBlockData.newData(null, namespaced.toString()));
++            }
++        }
++    }
++
++    @Override
++    public Set<BlockData> getDestroyableDatas() {
++        return !(this.destroyableDatas != null && !this.destroyableDatas.isEmpty()) ? Collections.emptySet() : Sets.newHashSet(this.destroyableDatas);
++    }
++
++    @Override
++    public void setDestroyableDatas(Collection<BlockData> canDestroy) {
++        Validate.notNull(canDestroy, "Cannot replace with null collection!");
++        this.destroyableDatas.clear();
++        this.destroyableDatas.addAll(canDestroy);
 +    }
 +
 +    @Override
 +    public Set<Namespaced> getPlaceableKeys() {
-+        return !hasPlaceableKeys() ? Collections.emptySet() : Sets.newHashSet(this.placeableKeys);
++        return !(this.placeableTags != null && !this.placeableTags.isEmpty()) ? Collections.emptySet() : Sets.newHashSet(this.placeableTags);
 +    }
 +
 +    @Override
 +    public void setPlaceableKeys(Collection<Namespaced> canPlaceOn) {
 +        Validate.notNull(canPlaceOn, "Cannot replace with null collection!");
 +        Validate.isTrue(ofAcceptableType(canPlaceOn), "Can only use NamespacedKey or NamespacedTag objects!");
-+        this.placeableKeys.clear();
-+        this.placeableKeys.addAll(canPlaceOn);
++        this.placeableTags.clear();
++        this.placeableDatas.clear();
++        for(Namespaced namespaced : canPlaceOn) {
++            if(namespaced instanceof NamespacedTag namespacedTag) {
++                this.placeableTags.add(namespacedTag);
++            } else {
++                this.placeableDatas.add(CraftBlockData.newData(null, namespaced.toString()));
++            }
++        }
++    }
++
++    @Override
++    public Set<BlockData> getPlaceableDatas() {
++        return !(this.placeableDatas != null && !this.placeableDatas.isEmpty()) ? Collections.emptySet() : Sets.newHashSet(this.placeableDatas);
++    }
++
++    @Override
++    public void setPlaceableDatas(Collection<BlockData> canPlaceOn) {
++        Validate.notNull(canPlaceOn, "Cannot replace with null collection!");
++        this.placeableDatas.clear();
++        this.placeableDatas.addAll(canPlaceOn);
 +    }
 +
 +    @Override
 +    public boolean hasPlaceableKeys() {
-+        return this.placeableKeys != null && !this.placeableKeys.isEmpty();
++        return (this.placeableTags != null && !this.placeableTags.isEmpty()) || (this.placeableDatas != null && !this.placeableDatas.isEmpty());
 +    }
 +
 +    @Override
 +    public boolean hasDestroyableKeys() {
-+        return this.destroyableKeys != null && !this.destroyableKeys.isEmpty();
++        return (this.destroyableTags != null && !this.destroyableTags.isEmpty()) || (this.destroyableDatas != null && !this.destroyableDatas.isEmpty());
 +    }
 +
 +    @Deprecated
-+    private void legacyClearAndReplaceKeys(Collection<Namespaced> toUpdate, Collection<Material> beingSet) {
++    private static void legacyClearAndReplaceKeys(Collection<BlockData> toUpdate, Collection<Material> beingSet) {
 +        if (beingSet.stream().anyMatch(Material::isLegacy)) {
 +            throw new IllegalArgumentException("Set must not contain any legacy materials!");
 +        }
 +
 +        toUpdate.clear();
-+        toUpdate.addAll(beingSet.stream().map(Material::getKey).collect(java.util.stream.Collectors.toSet()));
++        toUpdate.addAll(beingSet.stream().map(mat ->  CraftBlockData.newData(mat, null)).collect(java.util.stream.Collectors.toSet()));
 +    }
 +
 +    @Deprecated
-+    private Set<Material> legacyGetMatsFromKeys(Collection<Namespaced> names) {
++    private static Set<Material> legacyGetMatsFromKeys(Collection<NamespacedTag> names, Collection<BlockData> datas) {
 +        Set<Material> mats = Sets.newHashSet();
 +        for (Namespaced key : names) {
 +            if (!(key instanceof org.bukkit.NamespacedKey)) {
@@ -344,51 +410,53 @@ index 01ceb8de8411193fa407bf19bbd25a4bf44765d3..4304ee35a9bd912c2ae4058febf22f0e
 +            }
 +        }
 +
++        for(BlockData data : datas) {
++            mats.add(data.getMaterial());
++        }
++
 +        return mats;
 +    }
 +
-+    private @Nullable Namespaced deserializeNamespaced(String raw) {
++    private static void deserializeNamespaced(String raw, Collection<NamespacedTag> tags, Collection<BlockData> datas) {
 +        boolean isTag = raw.length() > 0 && raw.codePointAt(0) == '#';
 +        com.mojang.datafixers.util.Either<net.minecraft.commands.arguments.blocks.BlockStateParser.BlockResult, net.minecraft.commands.arguments.blocks.BlockStateParser.TagResult> result;
 +        try {
 +            result = net.minecraft.commands.arguments.blocks.BlockStateParser.parseForTesting(net.minecraft.core.Registry.BLOCK, raw, false);
 +        } catch (com.mojang.brigadier.exceptions.CommandSyntaxException e) {
-+            return null;
++            return;
 +        }
 +
 +        net.minecraft.resources.ResourceLocation key = null;
 +        if (isTag && result.right().isPresent() && result.right().get().tag() instanceof net.minecraft.core.HolderSet.Named<net.minecraft.world.level.block.Block> namedSet) {
 +            key = namedSet.key().location();
 +        } else if (result.left().isPresent()) {
-+            key = net.minecraft.core.Registry.BLOCK.getKey(result.left().get().blockState().getBlock());
-+        }
-+
-+        if (key == null) {
-+            return null;
++            CraftBlockData data = CraftBlockData.fromData(result.left().get().blockState());
++            data.parsedStates = result.left().get().properties();
++            datas.add(data);
++            return;
 +        }
 +
 +        // don't DC the player if something slips through somehow
-+        Namespaced resource = null;
-+        try {
-+            if (isTag) {
-+                resource = new NamespacedTag(key.getNamespace(), key.getPath());
-+            } else {
-+                resource = CraftNamespacedKey.fromMinecraft(key);
++        if(key != null && isTag) {
++            try {
++                tags.add(new NamespacedTag(key.getNamespace(), key.getPath()));
++            } catch (IllegalArgumentException ex) {
++                org.bukkit.Bukkit.getLogger().warning("Namespaced tag does not validate: " + key);
++                ex.printStackTrace();
 +            }
-+        } catch (IllegalArgumentException ex) {
-+            org.bukkit.Bukkit.getLogger().warning("Namespaced resource does not validate: " + key.toString());
-+            ex.printStackTrace();
 +        }
-+
-+        return resource;
 +    }
 +
-+    private @Nonnull String serializeNamespaced(Namespaced resource) {
++    private static @Nonnull String serializeNamespaced(Namespaced resource) {
 +        return resource.toString();
 +    }
 +
++    private static @Nonnull String serializeData(BlockData data) {
++        return data.getAsString(true);
++    }
++
 +    // not a fan of this
-+    private boolean ofAcceptableType(Collection<Namespaced> namespacedResources) {
++    private static boolean ofAcceptableType(Collection<Namespaced> namespacedResources) {
 +        
 +        for (Namespaced resource : namespacedResources) {
 +            if (!(resource instanceof org.bukkit.NamespacedKey || resource instanceof com.destroystokyo.paper.NamespacedTag)) {

--- a/patches/server/0452-Convert-legacy-attributes-in-Item-Meta.patch
+++ b/patches/server/0452-Convert-legacy-attributes-in-Item-Meta.patch
@@ -30,10 +30,10 @@ index 0520c45197629cbdc2777d9ae11eef572e793160..46c313d581b9af6aa0a48f97ae3cc800
      public CraftAttributeMap(AttributeMap handle) {
          this.handle = handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 4304ee35a9bd912c2ae4058febf22f0eea25adbd..4a91da3561d16995e8cfe04ebbc104da009a2503 100644
+index c5e4a8942ac96ab8c37dabe42e76fb09c5cb9c55..24df01f1e5cdaf57525e00b7cd79b2b8a1e6edd5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -480,7 +480,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -478,7 +478,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
              AttributeModifier attribMod = CraftAttributeInstance.convert(nmsModifier);
  

--- a/patches/server/0455-Support-components-in-ItemMeta.patch
+++ b/patches/server/0455-Support-components-in-ItemMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 4a91da3561d16995e8cfe04ebbc104da009a2503..c475ddea1c995df1dfcaf4f491f341761a5f8802 100644
+index 24df01f1e5cdaf57525e00b7cd79b2b8a1e6edd5..231011562f1161747a2771a83e3ddc74005778d5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -874,11 +874,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -871,11 +871,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return CraftChatMessage.fromJSONComponent(displayName);
      }
  
@@ -32,7 +32,7 @@ index 4a91da3561d16995e8cfe04ebbc104da009a2503..c475ddea1c995df1dfcaf4f491f34176
      @Override
      public boolean hasDisplayName() {
          return this.displayName != null;
-@@ -1021,6 +1033,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1018,6 +1030,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromJSONComponent));
      }
  
@@ -47,7 +47,7 @@ index 4a91da3561d16995e8cfe04ebbc104da009a2503..c475ddea1c995df1dfcaf4f491f34176
      @Override
      public void setLore(List<String> lore) {
          if (lore == null || lore.isEmpty()) {
-@@ -1035,6 +1055,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1032,6 +1052,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -69,7 +69,7 @@ index 4a91da3561d16995e8cfe04ebbc104da009a2503..c475ddea1c995df1dfcaf4f491f34176
      @Override
      public boolean hasCustomModelData() {
          return this.customModelData != null;
-@@ -1502,6 +1537,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1517,6 +1552,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Object object : addFrom) {

--- a/patches/server/0666-Make-item-validations-configurable.patch
+++ b/patches/server/0666-Make-item-validations-configurable.patch
@@ -32,10 +32,10 @@ index fefa4d83c5699be0b55794cd28d13d27b66ef108..d662cb0567884ec91c900f5c90ecb369
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index c475ddea1c995df1dfcaf4f491f341761a5f8802..a8294bf057e03c5d866f6da31e6cdfa9edd3f146 100644
+index 231011562f1161747a2771a83e3ddc74005778d5..afe754d3c936a9ecb9d266e8e0391e70237920c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -357,7 +357,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -365,7 +365,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              CompoundTag display = tag.getCompound(DISPLAY.NBT);
  
              if (display.contains(NAME.NBT)) {
@@ -44,7 +44,7 @@ index c475ddea1c995df1dfcaf4f491f341761a5f8802..a8294bf057e03c5d866f6da31e6cdfa9
              }
  
              if (display.contains(LOCNAME.NBT)) {
-@@ -368,7 +368,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -376,7 +376,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  ListTag list = display.getList(LORE.NBT, CraftMagicNumbers.NBT.TAG_STRING);
                  this.lore = new ArrayList<String>(list.size());
                  for (int index = 0; index < list.size(); index++) {

--- a/patches/server/0888-Fix-NPE-for-BlockDataMeta-getBlockData.patch
+++ b/patches/server/0888-Fix-NPE-for-BlockDataMeta-getBlockData.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix NPE for BlockDataMeta#getBlockData
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index a8294bf057e03c5d866f6da31e6cdfa9edd3f146..3c4dadd0012c11191c873fe25a7625193563915d 100644
+index afe754d3c936a9ecb9d266e8e0391e70237920c9..5dac799e1b955cffa1367efee7f12a0bfcdc6af5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1093,7 +1093,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1090,7 +1090,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public BlockData getBlockData(Material material) {


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/6719

This allow block data into the CanDestroyOn and CanPlaceOn tags for vanilla state.
The deprecated material and namespaced key will now be backed into a block data with default state (internal)
The getters now check both tags, data and namespaced keys.

Examples:
```Java
	ItemStack stack = new ItemStack(Material.DIAMOND_PICKAXE);
        ItemMeta meta = stack.getItemMeta();
        meta.setCanDestroy(Set.of(Material.CHEST));
        stack.setItemMeta(meta);

        ItemStack stack2 = new ItemStack(Material.DIAMOND_PICKAXE);
        ItemMeta meta2 = stack2.getItemMeta();
        meta2.setDestroyableKeys(Set.of(Material.CHEST.getKey()));
        stack2.setItemMeta(meta2);

        ItemStack stack3 = new ItemStack(Material.DIAMOND_PICKAXE);
        ItemMeta meta3 = stack3.getItemMeta();
        meta3.setDestroyableDatas(Set.of(Material.CHEST.createBlockData("[facing=north]")));
        stack3.setItemMeta(meta3);

        e.getPlayer().getInventory().setItem(0, stack);
        e.getPlayer().getInventory().setItem(1, stack2);
        e.getPlayer().getInventory().setItem(2, stack3);
```