### PR TITLE
fix #8138

### DIFF
--- a/patches/server/0486-Eigencraft-redstone-implementation.patch
+++ b/patches/server/0486-Eigencraft-redstone-implementation.patch
@@ -20,10 +20,10 @@ Just added Bukkit's event system and took a few liberties with dead code and com
 
 diff --git a/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java b/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3e709645f5c35d16beefa4328a0a8e9c95e632aa
+index 0000000000000000000000000000000000000000..22a2547810d0c029f29685faddf7ac21cde2df0b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java
-@@ -0,0 +1,954 @@
+@@ -0,0 +1,957 @@
 +package com.destroystokyo.paper.util;
 +
 +import java.util.List;
@@ -959,6 +959,9 @@ index 0000000000000000000000000000000000000000..3e709645f5c35d16beefa4328a0a8e9c
 +     * redstone wire in an invalid state.
 +     */
 +    public void updateNeighborShapes(Level level, BlockPos pos, BlockState state) {
++        // these updates will be added to the stack and processed after the entire network has updated
++        state.updateIndirectNeighbourShapes(level, pos, Block.UPDATE_KNOWN_SHAPE | Block.UPDATE_CLIENTS);
++
 +        for (Direction dir : UPDATE_SHAPE_ORDER) {
 +            BlockPos neighborPos = pos.relative(dir);
 +            BlockState neighborState = level.getBlockState(neighborPos);


### PR DESCRIPTION
The recent update to the Eigencraft patch introduced a [bug](https://github.com/PaperMC/Paper/issues/8138) that saw indirect shape updates omitted entirely, which can leave newly placed wire blocks in an invalid state (not updating their connections). This PR re-introduces those indirect shape updates to fix that issue. This does result in a slight performance penalty (or rather, it undoes the performance gain from the recent update).