### PR TITLE
Fix spigot config not using commands.spam-exclusions

### DIFF
--- a/patches/server/0924-Fix-Spigot-Config-not-using-commands.spam-exclusions.patch
+++ b/patches/server/0924-Fix-Spigot-Config-not-using-commands.spam-exclusions.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Sun, 17 Jul 2022 11:49:43 -0400
+Subject: [PATCH] Fix Spigot Config not using commands.spam-exclusions
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 1290f1c33062b2ea821abca33433a53662b6d340..f342043f4a8aef7e757571ead0e0218fe7e5ee58 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -2400,7 +2400,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+         }
+         // Spigot end
+         // this.chatSpamTickCount += 20;
+-        if (this.chatSpamTickCount.addAndGet(20) > 200 && !this.server.getPlayerList().isOp(this.player.getGameProfile())) {
++        if (counted && this.chatSpamTickCount.addAndGet(20) > 200 && !this.server.getPlayerList().isOp(this.player.getGameProfile())) { // Paper - exclude from SpigotConfig.spamExclusions
+             if (!isSync) {
+                 Waitable waitable = new Waitable() {
+                     @Override


### PR DESCRIPTION
This fix #8145 like mention the issue _someone_ forget validate the old code in the release of Spigot 1.19 then the commands.spam-exclusions is not working.
_This can be a upstream fix but not exists docs about how edit patchs.. then more easy here.. and well only here this was noticed xd_