### PR TITLE
Updated Upstream (Bukkit)

### DIFF
--- a/patches/api/0004-Add-FastUtil-to-Bukkit.patch
+++ b/patches/api/0004-Add-FastUtil-to-Bukkit.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add FastUtil to Bukkit
 Doesn't expose to plugins, just allows Paper-API to use it for optimization
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 044b7c49b569e1170108c912e9307f7fec278762..f0423df165bf7d0f3fad21d26b64f31ba3e6aeee 100644
+index 0b30b1f1be8818934ba530dd263fe6c9484983e8..cedf145d5024e1ed9ae0d815e7ad0afb87c9a8b0 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -18,6 +18,7 @@ dependencies {

--- a/patches/api/0007-Timings-v2.patch
+++ b/patches/api/0007-Timings-v2.patch
@@ -3410,10 +3410,10 @@ index c580ec19cd2b55a4aeca49d9cd984ce7c2848cef..ab127d622b51e423883cbd9a7218f1cf
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index f5710d53296564eb4cd94382dc79f4c29769b672..fca73778c341df36becbf1ad1ad42ce8d1aa634c 100644
+index a69c5d5cad6168aeaae41e8adc319dc8c976b1e2..763b3e9ea24b14c54abf94048931f29228c76df5 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -357,7 +357,6 @@ public final class SimplePluginManager implements PluginManager {
+@@ -358,7 +358,6 @@ public final class SimplePluginManager implements PluginManager {
              }
          }
  
@@ -3421,7 +3421,7 @@ index f5710d53296564eb4cd94382dc79f4c29769b672..fca73778c341df36becbf1ad1ad42ce8
          return result.toArray(new Plugin[result.size()]);
      }
  
-@@ -396,9 +395,9 @@ public final class SimplePluginManager implements PluginManager {
+@@ -397,9 +396,9 @@ public final class SimplePluginManager implements PluginManager {
  
          if (result != null) {
              plugins.add(result);
@@ -3433,7 +3433,7 @@ index f5710d53296564eb4cd94382dc79f4c29769b672..fca73778c341df36becbf1ad1ad42ce8
              }
          }
  
-@@ -427,7 +426,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -428,7 +427,7 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      @Nullable
      public synchronized Plugin getPlugin(@NotNull String name) {
@@ -3442,7 +3442,7 @@ index f5710d53296564eb4cd94382dc79f4c29769b672..fca73778c341df36becbf1ad1ad42ce8
      }
  
      @Override
-@@ -645,7 +644,8 @@ public final class SimplePluginManager implements PluginManager {
+@@ -646,7 +645,8 @@ public final class SimplePluginManager implements PluginManager {
              throw new IllegalPluginAccessException("Plugin attempted to register " + event + " while not enabled");
          }
  
@@ -3452,7 +3452,7 @@ index f5710d53296564eb4cd94382dc79f4c29769b672..fca73778c341df36becbf1ad1ad42ce8
              getEventListeners(event).register(new TimedRegisteredListener(listener, executor, priority, plugin, ignoreCancelled));
          } else {
              getEventListeners(event).register(new RegisteredListener(listener, executor, priority, plugin, ignoreCancelled));
-@@ -860,7 +860,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -866,7 +866,7 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public boolean useTimings() {
@@ -3461,7 +3461,7 @@ index f5710d53296564eb4cd94382dc79f4c29769b672..fca73778c341df36becbf1ad1ad42ce8
      }
  
      /**
-@@ -869,6 +869,6 @@ public final class SimplePluginManager implements PluginManager {
+@@ -875,6 +875,6 @@ public final class SimplePluginManager implements PluginManager {
       * @param use True if per event timing code should be used
       */
      public void useTimings(boolean use) {

--- a/patches/api/0008-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/api/0008-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 35de49ea52b507dd925ed3c118518a335035a710..5c6b7f5095a5bb7290e1edefb0c9e985123f80d8 100644
+index 9b118067de5eb54b266b8349fce7efdec2cb36eb..aecc0bcaeceb0a2db08a528244c08037e58f399b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -75,6 +75,20 @@ public final class Bukkit {
@@ -32,7 +32,7 @@ index 35de49ea52b507dd925ed3c118518a335035a710..5c6b7f5095a5bb7290e1edefb0c9e985
       * Attempts to set the {@link Server} singleton.
       * <p>
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index bbb4eb3c4e46ade7dd939c2b0e4436161d6f8a1e..1dedbea03e259679e101a8443b662b20375adfd0 100644
+index 0a433146ebec4416339c4ab33f3523a22d23d332..b8c47ed7eb7bf52efd1928956584fd993e59f03a 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -60,6 +60,18 @@ import org.jetbrains.annotations.Nullable;
@@ -55,10 +55,10 @@ index bbb4eb3c4e46ade7dd939c2b0e4436161d6f8a1e..1dedbea03e259679e101a8443b662b20
       * Used for all administrative messages, such as an operator using a
       * command.
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index fca73778c341df36becbf1ad1ad42ce8d1aa634c..50a2e8c138c677c91dad65c850acf840f7517e86 100644
+index 763b3e9ea24b14c54abf94048931f29228c76df5..1bfa9fcb1b803eecfe33156f81ee88d2922ca88a 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -110,6 +110,12 @@ public final class SimplePluginManager implements PluginManager {
+@@ -111,6 +111,12 @@ public final class SimplePluginManager implements PluginManager {
      @Override
      @NotNull
      public Plugin[] loadPlugins(@NotNull File directory) {
@@ -71,7 +71,7 @@ index fca73778c341df36becbf1ad1ad42ce8d1aa634c..50a2e8c138c677c91dad65c850acf840
          Preconditions.checkArgument(directory != null, "Directory cannot be null");
          Preconditions.checkArgument(directory.isDirectory(), "Directory must be a directory");
  
-@@ -127,7 +133,11 @@ public final class SimplePluginManager implements PluginManager {
+@@ -128,7 +134,11 @@ public final class SimplePluginManager implements PluginManager {
          Map<String, Collection<String>> softDependencies = new HashMap<String, Collection<String>>();
  
          // This is where it figures out all possible plugins
@@ -84,7 +84,7 @@ index fca73778c341df36becbf1ad1ad42ce8d1aa634c..50a2e8c138c677c91dad65c850acf840
              PluginLoader loader = null;
              for (Pattern filter : filters) {
                  Matcher match = filter.matcher(file.getName());
-@@ -143,14 +153,14 @@ public final class SimplePluginManager implements PluginManager {
+@@ -144,14 +154,14 @@ public final class SimplePluginManager implements PluginManager {
                  description = loader.getPluginDescription(file);
                  String name = description.getName();
                  if (name.equalsIgnoreCase("bukkit") || name.equalsIgnoreCase("minecraft") || name.equalsIgnoreCase("mojang")) {
@@ -102,7 +102,7 @@ index fca73778c341df36becbf1ad1ad42ce8d1aa634c..50a2e8c138c677c91dad65c850acf840
                  continue;
              }
  
-@@ -161,7 +171,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -162,7 +172,7 @@ public final class SimplePluginManager implements PluginManager {
                      description.getName(),
                      file.getPath(),
                      replacedFile.getPath(),
@@ -111,7 +111,7 @@ index fca73778c341df36becbf1ad1ad42ce8d1aa634c..50a2e8c138c677c91dad65c850acf840
                  ));
              }
  
-@@ -182,7 +192,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -183,7 +193,7 @@ public final class SimplePluginManager implements PluginManager {
                              file.getPath(),
                              provided,
                              pluginFile.getPath(),
@@ -120,7 +120,7 @@ index fca73778c341df36becbf1ad1ad42ce8d1aa634c..50a2e8c138c677c91dad65c850acf840
                      ));
                  } else {
                      String replacedPlugin = pluginsProvided.put(provided, description.getName());
-@@ -264,7 +274,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -265,7 +275,7 @@ public final class SimplePluginManager implements PluginManager {
  
                              server.getLogger().log(
                                  Level.SEVERE,
@@ -129,7 +129,7 @@ index fca73778c341df36becbf1ad1ad42ce8d1aa634c..50a2e8c138c677c91dad65c850acf840
                                  new UnknownDependencyException("Unknown dependency " + dependency + ". Please download and install " + dependency + " to run this plugin."));
                              break;
                          }
-@@ -303,11 +313,11 @@ public final class SimplePluginManager implements PluginManager {
+@@ -304,11 +314,11 @@ public final class SimplePluginManager implements PluginManager {
                              loadedPlugins.add(loadedPlugin.getName());
                              loadedPlugins.addAll(loadedPlugin.getDescription().getProvides());
                          } else {
@@ -143,7 +143,7 @@ index fca73778c341df36becbf1ad1ad42ce8d1aa634c..50a2e8c138c677c91dad65c850acf840
                      }
                  }
              }
-@@ -334,11 +344,11 @@ public final class SimplePluginManager implements PluginManager {
+@@ -335,11 +345,11 @@ public final class SimplePluginManager implements PluginManager {
                                  loadedPlugins.add(loadedPlugin.getName());
                                  loadedPlugins.addAll(loadedPlugin.getDescription().getProvides());
                              } else {
@@ -157,7 +157,7 @@ index fca73778c341df36becbf1ad1ad42ce8d1aa634c..50a2e8c138c677c91dad65c850acf840
                          }
                      }
                  }
-@@ -351,7 +361,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -352,7 +362,7 @@ public final class SimplePluginManager implements PluginManager {
                      while (failedPluginIterator.hasNext()) {
                          File file = failedPluginIterator.next();
                          failedPluginIterator.remove();

--- a/patches/api/0010-Add-getTPS-method.patch
+++ b/patches/api/0010-Add-getTPS-method.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add getTPS method
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index fddd0ff9accd661c47c7ccc6d7035c042d991e8b..362b879996623832d436bb987630b115b7d86f99 100644
+index aecc0bcaeceb0a2db08a528244c08037e58f399b..fcdce3b516821d42327452790cc66663e4677613 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1876,6 +1876,17 @@ public final class Bukkit {
@@ -27,7 +27,7 @@ index fddd0ff9accd661c47c7ccc6d7035c042d991e8b..362b879996623832d436bb987630b115
       * Get the advancement specified by this key.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 768ae36e3e2fdff753f4f14aa79eb36026fb38c3..8dda96966061bb3a12b63fff74a378857ec43200 100644
+index b8c47ed7eb7bf52efd1928956584fd993e59f03a..f52dd4c4602638bf02f676f6415d7051c0439cce 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1592,6 +1592,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0020-Add-exception-reporting-event.patch
+++ b/patches/api/0020-Add-exception-reporting-event.patch
@@ -492,10 +492,10 @@ index f99d71301ceaa3af07ff0525f7d657ac6253d0e6..2e23c124311b38aaea64dd274c33afcd
      }
  
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 50a2e8c138c677c91dad65c850acf840f7517e86..b7cd4b9e4fd5f98aafbc0fe5ad6883eeb50dea56 100644
+index 1bfa9fcb1b803eecfe33156f81ee88d2922ca88a..b535ab89b5a04371bac41720d28b4af8b18f1c20 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -487,7 +487,8 @@ public final class SimplePluginManager implements PluginManager {
+@@ -488,7 +488,8 @@ public final class SimplePluginManager implements PluginManager {
              try {
                  plugin.getPluginLoader().enablePlugin(plugin);
              } catch (Throwable ex) {
@@ -505,7 +505,7 @@ index 50a2e8c138c677c91dad65c850acf840f7517e86..b7cd4b9e4fd5f98aafbc0fe5ad6883ee
              }
  
              HandlerList.bakeAll();
-@@ -508,32 +509,37 @@ public final class SimplePluginManager implements PluginManager {
+@@ -509,32 +510,37 @@ public final class SimplePluginManager implements PluginManager {
              try {
                  plugin.getPluginLoader().disablePlugin(plugin);
              } catch (Throwable ex) {
@@ -548,7 +548,7 @@ index 50a2e8c138c677c91dad65c850acf840f7517e86..b7cd4b9e4fd5f98aafbc0fe5ad6883ee
              }
  
              try {
-@@ -546,6 +552,13 @@ public final class SimplePluginManager implements PluginManager {
+@@ -547,6 +553,13 @@ public final class SimplePluginManager implements PluginManager {
          }
      }
  
@@ -562,7 +562,7 @@ index 50a2e8c138c677c91dad65c850acf840f7517e86..b7cd4b9e4fd5f98aafbc0fe5ad6883ee
      @Override
      public void clearPlugins() {
          synchronized (this) {
-@@ -609,7 +622,13 @@ public final class SimplePluginManager implements PluginManager {
+@@ -610,7 +623,13 @@ public final class SimplePluginManager implements PluginManager {
                              ));
                  }
              } catch (Throwable ex) {

--- a/patches/api/0026-Use-ASM-for-event-executors.patch
+++ b/patches/api/0026-Use-ASM-for-event-executors.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 7b8196db1fd1e283dc9ef71e3fe5137cc5920ba9..f0f8047cb3a43b447dc50b730dab3d0bc471b25a 100644
+index 237a0beff61f2384b9e9e18a9d7119fd1916e1bd..a37c830cf5eae14d906854b05564c1b4e8b3284d 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -39,6 +39,9 @@ dependencies {

--- a/patches/api/0029-Add-command-to-reload-permissions.yml-and-require-co.patch
+++ b/patches/api/0029-Add-command-to-reload-permissions.yml-and-require-co.patch
@@ -85,10 +85,10 @@ index 50cc311be7904cc8fc6070a21c8e4de3a489fd20..5fa9d648bc780e874f658597f1a24715
      }
  }
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index b7cd4b9e4fd5f98aafbc0fe5ad6883eeb50dea56..efe0e5e6b43c50c6a41ee3baa44beb7d883b551a 100644
+index b535ab89b5a04371bac41720d28b4af8b18f1c20..77caec9f974077ed6580d3cbbc20feb1199feb11 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -900,4 +900,13 @@ public final class SimplePluginManager implements PluginManager {
+@@ -906,4 +906,13 @@ public final class SimplePluginManager implements PluginManager {
      public void useTimings(boolean use) {
          co.aikar.timings.Timings.setTimingsEnabled(use); // Paper
      }

--- a/patches/api/0060-Shoulder-Entities-Release-API.patch
+++ b/patches/api/0060-Shoulder-Entities-Release-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Shoulder Entities Release API
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index f607c57275958bf1cbf8e77b4d7efa936064c228..8a479c7dfd3825fab8bb057d8afa5ae0cb01b071 100644
+index 864941be2d07de08f63e740ad2becf1dc5790433..bcdf267485f1d68ccc7ea105d5d40bc9bc9db2a2 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
 @@ -318,6 +318,26 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder

--- a/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,7 +14,7 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index f0f8047cb3a43b447dc50b730dab3d0bc471b25a..435db1ffe47476bcb7067802faad7aee7e4c3f54 100644
+index a37c830cf5eae14d906854b05564c1b4e8b3284d..0660174a8c543b3e8ef317cfabcda88a6a53d844 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -39,6 +39,8 @@ dependencies {

--- a/patches/api/0076-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/api/0076-Expose-client-protocol-version-and-virtual-host.patch
@@ -57,7 +57,7 @@ index 0000000000000000000000000000000000000000..7b2af1bd72dfbcf4e962a982940fc49b
 +
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9d23a4019814f4662f4ab9a47b3fceff656c5245..f9f708bda24751353dd61951418731a2eea5abb0 100644
+index cf4beb02cce7b87facd5465291286f1b5e97db59..7f29fd1891b0b0c2037dc6fb7620e6de29083feb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -39,7 +39,7 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0092-getPlayerUniqueId-API.patch
+++ b/patches/api/0092-getPlayerUniqueId-API.patch
@@ -9,7 +9,7 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 39f97dac6af70b45101a7de776009c4fa3874868..098a09baa481f76e63991268d3dfabc413626fcf 100644
+index edbe7363b2da4f89cc31cbf9521c9a6271060ccd..5e5e8147b477b876a579327d5ea3d8d2393c0374 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -656,6 +656,20 @@ public final class Bukkit {
@@ -34,7 +34,7 @@ index 39f97dac6af70b45101a7de776009c4fa3874868..098a09baa481f76e63991268d3dfabc4
       * Gets the plugin manager for interfacing with plugins.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 4597c9b2e4691495b54333711141b83926af193d..2042f4963c53d5a903f0de1fec6a9af3a7b2bba4 100644
+index ca784abeb7f31c65e87df7750ae19aa9a8b65d72..1a4559c88ece08e4a0c27e808f69693fb89fc474 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -558,6 +558,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0102-Close-Plugin-Class-Loaders-on-Disable.patch
+++ b/patches/api/0102-Close-Plugin-Class-Loaders-on-Disable.patch
@@ -66,10 +66,10 @@ index 41e26451fe12d8e6e0ef73c85731b24b4e3f200c..0d1b20f2b5580ea5505ccc2f003925db
       * Gets a {@link Permission} from its fully qualified name
       *
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index efe0e5e6b43c50c6a41ee3baa44beb7d883b551a..6b38b14bfd73f3b7d06b6f747d60373cedf1fa6f 100644
+index 77caec9f974077ed6580d3cbbc20feb1199feb11..9f32b57464352c08617f6adec144111b8fcad50c 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -503,6 +503,21 @@ public final class SimplePluginManager implements PluginManager {
+@@ -504,6 +504,21 @@ public final class SimplePluginManager implements PluginManager {
          }
      }
  

--- a/patches/api/0120-InventoryCloseEvent-Reason-API.patch
+++ b/patches/api/0120-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 6ef0d7f3dcb779fb7dc5786e7433262092908eaa..b007b582d344b79ee67751fd1e21f6cef6a1a950 100644
+index 34c2ae10e2a230ef88a756cf2024edcda2429fbf..f97521acad823ffce08faefc81e3b6a9a374410e 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
 @@ -158,6 +158,15 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder

--- a/patches/api/0133-Remove-deadlock-risk-in-firing-async-events.patch
+++ b/patches/api/0133-Remove-deadlock-risk-in-firing-async-events.patch
@@ -16,10 +16,10 @@ which results in a hard crash.
 This change removes the synchronize and adds some protection around enable/disable
 
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 6b38b14bfd73f3b7d06b6f747d60373cedf1fa6f..45989646f5c32fd1470a9868afca3e3a9074579c 100644
+index 9f32b57464352c08617f6adec144111b8fcad50c..5af99aa87e6d4fbff81bd9de40484f4ed5a8a3ba 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -467,7 +467,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -468,7 +468,7 @@ public final class SimplePluginManager implements PluginManager {
       * @return true if the plugin is enabled, otherwise false
       */
      @Override
@@ -28,7 +28,7 @@ index 6b38b14bfd73f3b7d06b6f747d60373cedf1fa6f..45989646f5c32fd1470a9868afca3e3a
          if ((plugin != null) && (plugins.contains(plugin))) {
              return plugin.isEnabled();
          } else {
-@@ -476,7 +476,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -477,7 +477,7 @@ public final class SimplePluginManager implements PluginManager {
      }
  
      @Override
@@ -37,7 +37,7 @@ index 6b38b14bfd73f3b7d06b6f747d60373cedf1fa6f..45989646f5c32fd1470a9868afca3e3a
          if (!plugin.isEnabled()) {
              List<Command> pluginCommands = PluginCommandYamlParser.parse(plugin);
  
-@@ -519,7 +519,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -520,7 +520,7 @@ public final class SimplePluginManager implements PluginManager {
      // Paper end
  
      @Override
@@ -46,7 +46,7 @@ index 6b38b14bfd73f3b7d06b6f747d60373cedf1fa6f..45989646f5c32fd1470a9868afca3e3a
          if (plugin.isEnabled()) {
              try {
                  plugin.getPluginLoader().disablePlugin(plugin);
-@@ -588,6 +588,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -589,6 +589,7 @@ public final class SimplePluginManager implements PluginManager {
              defaultPerms.get(false).clear();
          }
      }
@@ -54,7 +54,7 @@ index 6b38b14bfd73f3b7d06b6f747d60373cedf1fa6f..45989646f5c32fd1470a9868afca3e3a
  
      /**
       * Calls an event with the given details.
-@@ -596,23 +597,13 @@ public final class SimplePluginManager implements PluginManager {
+@@ -597,23 +598,13 @@ public final class SimplePluginManager implements PluginManager {
       */
      @Override
      public void callEvent(@NotNull Event event) {

--- a/patches/api/0150-Add-Git-information-to-version-command-on-startup.patch
+++ b/patches/api/0150-Add-Git-information-to-version-command-on-startup.patch
@@ -48,7 +48,7 @@ index 0000000000000000000000000000000000000000..909617079db61b675cc7b60b44ef96b3
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 098a09baa481f76e63991268d3dfabc413626fcf..653fe32bd134945e1cb1cf40f2623ffffdf5d762 100644
+index 5e5e8147b477b876a579327d5ea3d8d2393c0374..1c416a48d2a069a0167bc0be6fa1d65d14f35816 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -53,6 +53,7 @@ import org.bukkit.util.CachedServerIcon;

--- a/patches/api/0152-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-values.patch
+++ b/patches/api/0152-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-values.patch
@@ -226,7 +226,7 @@ index c65f0d6569c130b4920a9e71ad24af6427f1f030..01bcb3a1bdb5accdf844d0178cec3d25
          return key;
      }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index a19635c38705e6221ae25d58e976e483e7ed17e4..71c7780424a986a95852b1ca15116096896500df 100644
+index 64114b1a9e201df369fc794fbee984d496385420..35009498aafd1bd36c493085127135fc8a5c36ec 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -444,4 +444,87 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste

--- a/patches/api/0169-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/api/0169-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,7 +16,7 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
-index 9d774a10b9543e9293cb10ee9d7c9adebbfef34c..23e853bae0e051cd43deb9eb24c54e74a56d8ab0 100644
+index 93f86bb30725dff5dbfcccf15012ffd1cee237bf..a7d1f1e701f23e851f735584a30bedadb0d8b9bd 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
 @@ -160,7 +160,9 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio

--- a/patches/api/0190-Add-tick-times-API.patch
+++ b/patches/api/0190-Add-tick-times-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9e33d1a649118613cb28c97a895872949b3bb05b..95c4e23ece5f7bdf814d4259dc89016cd96a0a2f 100644
+index fb5ba85b324eb78c31367bc59f2d1ca7eec1bf2b..4ba11b4a22981472e3fcbfe8ffadaa3f3c140e2f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1948,6 +1948,25 @@ public final class Bukkit {
@@ -35,7 +35,7 @@ index 9e33d1a649118613cb28c97a895872949b3bb05b..95c4e23ece5f7bdf814d4259dc89016c
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 16db591ecb07a238a5bd14c13192198086bda13d..11b281b43e4fd2a23116163e611f11aad179b8fa 100644
+index 05587286b253b6f877aa5fae19d556cc8967a326..a4775467581c351f4c89521c2e017b31d48bf3b5 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1639,6 +1639,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0193-Disable-Sync-Events-firing-Async-errors-during-shutd.patch
+++ b/patches/api/0193-Disable-Sync-Events-firing-Async-errors-during-shutd.patch
@@ -11,10 +11,10 @@ errors.
 This isn't an issue on Spigot
 
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 45989646f5c32fd1470a9868afca3e3a9074579c..9654f4fb230945086a88f64b09a46a5b10e8d1d7 100644
+index 5af99aa87e6d4fbff81bd9de40484f4ed5a8a3ba..7937e240949bbaeb680098a674d27087e3f6acf8 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -600,7 +600,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -601,7 +601,7 @@ public final class SimplePluginManager implements PluginManager {
          // Paper - replace callEvent by merging to below method
          if (event.isAsynchronous() && server.isPrimaryThread()) {
              throw new IllegalStateException(event.getEventName() + " may only be triggered asynchronously.");

--- a/patches/api/0200-Expose-game-version.patch
+++ b/patches/api/0200-Expose-game-version.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 3455de478517a91285bb9d1b306ce1c4be619389..706e42172b938840c6ec06f0f7b686eee17a4a93 100644
+index 88fe6c7dabdcf5c1a81126e7c98a361ec25438a0..e9e7fdcb8b57d07d88c9e9694dd119b07fa5b823 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -154,6 +154,18 @@ public final class Bukkit {
@@ -28,7 +28,7 @@ index 3455de478517a91285bb9d1b306ce1c4be619389..706e42172b938840c6ec06f0f7b686ee
       * Gets a view of all currently logged in players. This {@linkplain
       * Collections#unmodifiableCollection(Collection) view} is a reused
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d59a7e0c9ec50040fb0b2cc3239cae46760aba04..9b2c1eb7e215a9227c60bc85906fed33ec1dd60a 100644
+index 8cf4a6d82278770598dee9191409c676b7fb1b08..dd1bb341714d27c286b57f9410a690f754bd937b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -112,6 +112,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0204-Potential-bed-API.patch
+++ b/patches/api/0204-Potential-bed-API.patch
@@ -8,7 +8,7 @@ Adds a new method to fetch the location of a player's bed without generating any
 getPotentialBedLocation - Gets the last known location of a player's bed. This does not preform any check if the bed is still valid and does not load any chunks.
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index b007b582d344b79ee67751fd1e21f6cef6a1a950..43ab3d1f96179a547630be3494d85642ab2ff029 100644
+index f97521acad823ffce08faefc81e3b6a9a374410e..876215c84cf6915f5af131da38d97c20580c0292 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
 @@ -248,6 +248,19 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder

--- a/patches/api/0210-Support-components-in-ItemMeta.patch
+++ b/patches/api/0210-Support-components-in-ItemMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 5428aeb018c415f8e9bb46c84a627adf70829259..f1e9a7626c4efb99be78f1056dc04b06bbe13c87 100644
+index 1beedb446a9dd554d05d1d94dba8598e4b69eba6..c6b0fd783675cd019048e445d8e959637d90be7a 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -5,6 +5,7 @@ import java.util.Collection;

--- a/patches/api/0216-Add-setMaxPlayers-API.patch
+++ b/patches/api/0216-Add-setMaxPlayers-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 3faefc48a2dca51f19d4289547f0ce875bb61e32..4b2f3e674e634efa42f6840933dd9ee9595d036b 100644
+index 1f2d25a48bfd67f770560e6284e0be27b6b4df38..bd7c7d1cc25f1bc246944de2ffc20cadaacd1d29 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -207,6 +207,17 @@ public final class Bukkit {
@@ -27,7 +27,7 @@ index 3faefc48a2dca51f19d4289547f0ce875bb61e32..4b2f3e674e634efa42f6840933dd9ee9
       * Get the game port that the server runs on.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index c11d802408c793c6410118bd281a21e59394066f..a7ba813396fab77bed292422f881b5a0952972fb 100644
+index 88eab327d5854fd853b1adb5b4f04a2bcfd66849..f05dc6c186c94b940ea69d7ebc32451cc38f7fcf 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -159,6 +159,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0223-Add-additional-open-container-api-to-HumanEntity.patch
+++ b/patches/api/0223-Add-additional-open-container-api-to-HumanEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add additional open container api to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 43ab3d1f96179a547630be3494d85642ab2ff029..ebbe3417369201df231060dd39f1fb200eb7ad48 100644
+index 876215c84cf6915f5af131da38d97c20580c0292..cbeb9d1b99759cf3cd65895ff54fa7eabf511f3a 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
 @@ -153,6 +153,92 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder

--- a/patches/api/0229-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0229-Add-getOfflinePlayerIfCached-String.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b34866d6314ec783661e7a806b3d8c2a3b338dd7..20ff922fe9248b822d751a7edb7468cc023de71b 100644
+index bd7c7d1cc25f1bc246944de2ffc20cadaacd1d29..104738ea3bc2a678f15011ab1c6c7f38b56bf340 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1227,6 +1227,27 @@ public final class Bukkit {
@@ -37,7 +37,7 @@ index b34866d6314ec783661e7a806b3d8c2a3b338dd7..20ff922fe9248b822d751a7edb7468cc
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 8768f544ca3b197a6456bf948c05a4cfb8f776a1..a3ae5651718937bdefff1753b93c7c67aff7ef1d 100644
+index f05dc6c186c94b940ea69d7ebc32451cc38f7fcf..5e8ce65588a4b4be71292f5b92c049ae58d3a9a0 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1022,6 +1022,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0277-Expand-world-key-API.patch
+++ b/patches/api/0277-Expand-world-key-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expand world key API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 7e422716841d3736cce4f0968121231f9c6c33d3..4c6780dd1375f5d2c6e60229cc05c4af9d480b8a 100644
+index 104738ea3bc2a678f15011ab1c6c7f38b56bf340..0ddad5d32494495bb797559a10336a401e445fef 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -810,6 +810,18 @@ public final class Bukkit {
@@ -56,7 +56,7 @@ index 2fa3de66107162ccaa158b369e2c4a926ecaff92..aa534b1a9a1fb84a2fbd4b372f313bb4
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index afed6bcf923166065ac9f63dd96191cd42eefcb9..181493def187f72b6ff89c3849598428f35d31f3 100644
+index 5e8ce65588a4b4be71292f5b92c049ae58d3a9a0..80d762390a42070f1953a388c896cd93640b506e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -670,6 +670,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0281-add-isDeeplySleeping-to-HumanEntity.patch
+++ b/patches/api/0281-add-isDeeplySleeping-to-HumanEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] add isDeeplySleeping to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index ebbe3417369201df231060dd39f1fb200eb7ad48..e8b6cfe7e454c666b4d60b702a3b211dab238830 100644
+index cbeb9d1b99759cf3cd65895ff54fa7eabf511f3a..f9531c0f909c7caeddfb8f06ef9a11469ba7d434 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
 @@ -327,6 +327,15 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder

--- a/patches/api/0300-List-all-missing-hard-depends-not-just-first.patch
+++ b/patches/api/0300-List-all-missing-hard-depends-not-just-first.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] List all missing hard depends not just first
 
 
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 9654f4fb230945086a88f64b09a46a5b10e8d1d7..35aa6dff52944019510f16180e36da0088654432 100644
+index 7937e240949bbaeb680098a674d27087e3f6acf8..60988665eb358d5566e9de61aec841db3f79722c 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -257,6 +257,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -258,6 +258,7 @@ public final class SimplePluginManager implements PluginManager {
  
                  if (dependencies.containsKey(plugin)) {
                      Iterator<String> dependencyIterator = dependencies.get(plugin).iterator();
@@ -16,7 +16,7 @@ index 9654f4fb230945086a88f64b09a46a5b10e8d1d7..35aa6dff52944019510f16180e36da00
  
                      while (dependencyIterator.hasNext()) {
                          String dependency = dependencyIterator.next();
-@@ -267,6 +268,12 @@ public final class SimplePluginManager implements PluginManager {
+@@ -268,6 +269,12 @@ public final class SimplePluginManager implements PluginManager {
  
                          // We have a dependency not found
                          } else if (!plugins.containsKey(dependency) && !pluginsProvided.containsKey(dependency)) {
@@ -29,7 +29,7 @@ index 9654f4fb230945086a88f64b09a46a5b10e8d1d7..35aa6dff52944019510f16180e36da00
                              missingDependency = false;
                              pluginIterator.remove();
                              softDependencies.remove(plugin);
-@@ -275,9 +282,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -276,9 +283,7 @@ public final class SimplePluginManager implements PluginManager {
                              server.getLogger().log(
                                  Level.SEVERE,
                                  "Could not load '" + entry.getValue().getPath() + "' in folder '" + entry.getValue().getParentFile().getPath() + "'", // Paper

--- a/patches/api/0307-Add-PlayerKickEvent-causes.patch
+++ b/patches/api/0307-Add-PlayerKickEvent-causes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 015252e0fbb705c48b2c1e497d4ffd263739b125..40e365e6dad1dfead4d0253d0b4c011bc71b1e71 100644
+index 701b34b02886dcef2837f00a945f813165d914f5..792441dd8465edd1e6c2ffcbb8b2823a5884554f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -243,6 +243,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0327-Fix-plugin-provides-load-order.patch
+++ b/patches/api/0327-Fix-plugin-provides-load-order.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix plugin provides load order
 Fixes https://hub.spigotmc.org/jira/browse/SPIGOT-6740
 
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 35aa6dff52944019510f16180e36da0088654432..34c3df7570479d4f045897fe4e26dfa3f27479c4 100644
+index 60988665eb358d5566e9de61aec841db3f79722c..d1c1df75c011d8b4e10342c864aeb206e5cac23f 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -276,6 +276,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -277,6 +277,7 @@ public final class SimplePluginManager implements PluginManager {
                              // Paper end
                              missingDependency = false;
                              pluginIterator.remove();
@@ -17,7 +17,7 @@ index 35aa6dff52944019510f16180e36da0088654432..34c3df7570479d4f045897fe4e26dfa3
                              softDependencies.remove(plugin);
                              dependencies.remove(plugin);
  
-@@ -309,6 +310,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -310,6 +311,7 @@ public final class SimplePluginManager implements PluginManager {
                      // We're clear to load, no more soft or hard dependencies left
                      File file = plugins.get(plugin);
                      pluginIterator.remove();

--- a/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0343-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 23b57b99169881aa6963694d34f55d9c5c133888..a748f268a992ac8ec9b732f530e3dd4847a3d47b 100644
+index 05186443e25706ed77f7187eea6ac84666613a88..23834c3bd3a5e008b1b05c99a7b2f491731d8459 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1892,6 +1892,24 @@ public final class Bukkit {
@@ -34,7 +34,7 @@ index 23b57b99169881aa6963694d34f55d9c5c133888..a748f268a992ac8ec9b732f530e3dd48
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5c5d124a179e8c0dc0cf24a51d406c9034f48505..e7d1ece4f1e615e2b0f4da1d85ddd60e23433d4d 100644
+index 3d78e555725b48cb7e5750e8b4b3f1f0463bddc2..515e1bc18e04cd94b5aa7b00434a72381277e678 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1589,6 +1589,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0365-Don-t-load-plugins-prefixed-with-a-dot.patch
+++ b/patches/api/0365-Don-t-load-plugins-prefixed-with-a-dot.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't load plugins prefixed with a dot
 
 
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 34c3df7570479d4f045897fe4e26dfa3f27479c4..45114d587a8f201778adcba16c8a019f9959f472 100644
+index d1c1df75c011d8b4e10342c864aeb206e5cac23f..94646b37c77fcb18fc4030306c431684e7e9a5cc 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -137,6 +137,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -138,6 +138,7 @@ public final class SimplePluginManager implements PluginManager {
          final List<File> pluginJars = new ArrayList<>(java.util.Arrays.asList(directory.listFiles()));
          pluginJars.addAll(extraPluginJars);
          for (File file : pluginJars) {

--- a/patches/api/0378-Update-Folder-Uses-Plugin-Name.patch
+++ b/patches/api/0378-Update-Folder-Uses-Plugin-Name.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Update Folder Uses Plugin Name
 
 
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 45114d587a8f201778adcba16c8a019f9959f472..5270e43c629fe63f42691d10c6f77dc1cc987457 100644
+index 94646b37c77fcb18fc4030306c431684e7e9a5cc..1c9d0a81d581d0e6a8b2551a2cb9ed5e18bb2991 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-@@ -395,7 +395,7 @@ public final class SimplePluginManager implements PluginManager {
+@@ -396,7 +396,7 @@ public final class SimplePluginManager implements PluginManager {
      public synchronized Plugin loadPlugin(@NotNull File file) throws InvalidPluginException, UnknownDependencyException {
          Preconditions.checkArgument(file != null, "File cannot be null");
  
@@ -17,7 +17,7 @@ index 45114d587a8f201778adcba16c8a019f9959f472..5270e43c629fe63f42691d10c6f77dc1
  
          Set<Pattern> filters = fileAssociations.keySet();
          Plugin result = null;
-@@ -422,16 +422,61 @@ public final class SimplePluginManager implements PluginManager {
+@@ -423,16 +423,61 @@ public final class SimplePluginManager implements PluginManager {
          return result;
      }
  

--- a/patches/server/0019-Allow-for-toggling-of-spawn-chunks.patch
+++ b/patches/server/0019-Allow-for-toggling-of-spawn-chunks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow for toggling of spawn chunks
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index edf7448e197a2563dd62e4c24b29c139becccaca..5cc0546926ca1403aa325344fc138265f923fe1e 100644
+index 39d64f3aeb998df5452699e098148d86fdd48c98..46d4e56ff939034de79ce045e348753d181c7ce3 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -253,6 +253,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0028-Prevent-tile-entity-and-entity-crashes.patch
+++ b/patches/server/0028-Prevent-tile-entity-and-entity-crashes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent tile entity and entity crashes
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 5cc0546926ca1403aa325344fc138265f923fe1e..b35ca9316bf719e6b45f4d33ca7deecc95321ab3 100644
+index 46d4e56ff939034de79ce045e348753d181c7ce3..a73684fc706beca7342786e5d92d6cae750a891c 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -698,11 +698,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0034-Optimize-explosions.patch
+++ b/patches/server/0034-Optimize-explosions.patch
@@ -120,7 +120,7 @@ index 292571fc9fa999d3b92e0fdd56d07ebfb4ae7402..db7a025cd064c898e33037133b65eecc
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index b35ca9316bf719e6b45f4d33ca7deecc95321ab3..849f83944467ca3c505afebf2b84806e46670fb0 100644
+index a73684fc706beca7342786e5d92d6cae750a891c..2c8ea4f494c25c107bb0b0b44d84be237f77c2c8 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -161,6 +161,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0035-Disable-explosion-knockback.patch
+++ b/patches/server/0035-Disable-explosion-knockback.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Disable explosion knockback
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index c7017b86a3268aef0baff2ae0a56155aafc6a067..4731869c1bd3b8abdd2a5133fd551a2a534a6b41 100644
+index 3e1e2d9711c3c1b05406353f96d706c8abfe7a61..9cdf8a51268fdfefa6efc34a82d4fccb3593dc71 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1399,6 +1399,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0036-Disable-thunder.patch
+++ b/patches/server/0036-Disable-thunder.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Disable thunder
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 41c398b1819d960994922b0ffaf64ae7348d82cf..93f3f935b64850cce748cd2e8d34f4c85163d888 100644
+index bae0b45aba0b04a229f5e098d13a5e6383524e88..64bad03c3be64d7542bb5952b248f755c71f64c0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -582,7 +582,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0037-Disable-ice-and-snow.patch
+++ b/patches/server/0037-Disable-ice-and-snow.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Disable ice and snow
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 93f3f935b64850cce748cd2e8d34f4c85163d888..1775d3c61d9c02cee6b9d89518b3ff7c97abd42d 100644
+index 64bad03c3be64d7542bb5952b248f755c71f64c0..28d6b8c5bebbbfb15ea76dea9e79e6b95978f15f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -606,7 +606,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0044-Disable-spigot-tick-limiters.patch
+++ b/patches/server/0044-Disable-spigot-tick-limiters.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Disable spigot tick limiters
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 849f83944467ca3c505afebf2b84806e46670fb0..17da97bfece600438f6e872e8a1a2bee1d60c804 100644
+index 2c8ea4f494c25c107bb0b0b44d84be237f77c2c8..7b3a81876f04c6aff370ac9cc97b0c9270f34a2e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -664,9 +664,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0052-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/server/0052-Player-Tab-List-and-Title-APIs.patch
@@ -63,7 +63,7 @@ index bd808eb312ade7122973a47f4b96505829511da5..bf0f9cab7c66c089f35b851e799ba4a4
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5d35cd1b790197c92f2340426e5dd17827b3bfaa..b3e12f613117dd417f48981a7c2388597118b515 100644
+index b63c2e2fb802a4f1c5447524474c61ffe18e640e..4293d5d3f413c61ee2bbc611fa850603f6d12425 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@

--- a/patches/server/0067-Add-World-Util-Methods.patch
+++ b/patches/server/0067-Add-World-Util-Methods.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add World Util Methods
 Methods that can be used for other patches to help improve logic.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 1775d3c61d9c02cee6b9d89518b3ff7c97abd42d..e01f380fea580e98e62444902bdef5694dc0ffd0 100644
+index 28d6b8c5bebbbfb15ea76dea9e79e6b95978f15f..e4cf3d46de32ce5982da9c8cce2f1c6f74eddaa7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -215,7 +215,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0068-Custom-replacement-for-eaten-items.patch
+++ b/patches/server/0068-Custom-replacement-for-eaten-items.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Custom replacement for eaten items
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3710cf92bd29f69bb86d72a7adbb8df9bf4f8f08..ef820cd573a3c2366698df658dd8de6981c95e73 100644
+index 30198bf3d05da6e05cca08a8e5f39edc964cb356..55c18329f20e3f95f51119fbde1a6f3863129a8d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3586,9 +3586,10 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0071-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/patches/server/0071-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index e01f380fea580e98e62444902bdef5694dc0ffd0..6414e672dc05c772c49e14aa0cd552d888b29b31 100644
+index e4cf3d46de32ce5982da9c8cce2f1c6f74eddaa7..27186bffd00b9a7b23b6abc053362f3f70a9d481 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -586,7 +586,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0072-Optimize-isInWorldBounds-and-getBlockState-for-inlin.patch
+++ b/patches/server/0072-Optimize-isInWorldBounds-and-getBlockState-for-inlin.patch
@@ -29,7 +29,7 @@ index 4587a3668b6be9222cdd74a38229f89f611d1af6..9f32861d791f7e4cb39d2ad01f48e191
          this.x = x;
          this.y = y;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 19aca3026b2c5a7eb4288ef1a0ea297989d1c948..7c058e32b83847625bd4136bfed9b5804e8beca7 100644
+index e89410b00c8f9ef94cd2baf621802fa847bd6456..d3277e8aa7244ab490a6b354d863d4a9f3c60fec 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -276,7 +276,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0073-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/patches/server/0073-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -18,7 +18,7 @@ index 21e09c039a4c3fa64f6456e5cc7d50463590f787..cfbf7efb06f7ed6064930c4154c6e3e9
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 6414e672dc05c772c49e14aa0cd552d888b29b31..12ab01bae716b72bed1fa4417af4643586d15c5d 100644
+index 27186bffd00b9a7b23b6abc053362f3f70a9d481..dc4788765bbbe15c477c2e975129d63923d3f31f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -214,6 +214,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0074-Entity-AddTo-RemoveFrom-World-Events.patch
+++ b/patches/server/0074-Entity-AddTo-RemoveFrom-World-Events.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity AddTo/RemoveFrom World Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 12ab01bae716b72bed1fa4417af4643586d15c5d..f7270a563835cf43239cdb43bb20cda23053de67 100644
+index dc4788765bbbe15c477c2e975129d63923d3f31f..68a6f4e63bcaff52d69c3532ffa3da15e883a6e4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2118,6 +2118,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0081-Fix-Cancelling-BlockPlaceEvent-triggering-physics.patch
+++ b/patches/server/0081-Fix-Cancelling-BlockPlaceEvent-triggering-physics.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix Cancelling BlockPlaceEvent triggering physics
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f7270a563835cf43239cdb43bb20cda23053de67..47511f73b9924e48b4427ba9a245fb62d824626d 100644
+index 68a6f4e63bcaff52d69c3532ffa3da15e883a6e4..106bdc4ca666fc4db03a2ec4885add5a4d1bb059 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1364,6 +1364,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0087-EntityRegainHealthEvent-isFastRegen-API.patch
+++ b/patches/server/0087-EntityRegainHealthEvent-isFastRegen-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] EntityRegainHealthEvent isFastRegen API
 Don't even get me started
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e9747640adff75df331e794f08397619379ae280..3a597e7ce159b78078b1d64258a6f30e51645f3b 100644
+index 315ad337bddf3c6c95e829d3598d7d4ed87231b8..292f5dddd644880fc759fa8634d633ad40f3bf4f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1250,10 +1250,16 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0090-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
+++ b/patches/server/0090-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
@@ -13,7 +13,7 @@ custom renderers are in use, defaulting to the much simpler Vanilla system.
 Additionally, numerous issues to player position tracking on maps has been fixed.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 47511f73b9924e48b4427ba9a245fb62d824626d..e4d6fe5f19a575acfb08fcb8335f7519ed73b295 100644
+index 106bdc4ca666fc4db03a2ec4885add5a4d1bb059..ddd956828996c9d7a86aa89a01cc5a2ee4606c30 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2139,6 +2139,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0094-Async-GameProfileCache-saving.patch
+++ b/patches/server/0094-Async-GameProfileCache-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Async GameProfileCache saving
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 681121909bdf81d5a05670f0b0150f6276d00281..a4623129ffa537db39ee2f206fa775c950e07a21 100644
+index d3da5327f7826d10428c9fa8b9848fdb06afd04f..c656909a4a5fa990d4412bfa7cf3736cde46ca53 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -942,7 +942,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/0095-Optional-TNT-doesn-t-move-in-water.patch
+++ b/patches/server/0095-Optional-TNT-doesn-t-move-in-water.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
-index 61efa24cb1b24216ae80dcd4e68abc39a9ced1bb..232341fa41b1962d329cc17f3146e41c51d22164 100644
+index 8b3ca38f029b8918f02c51995e4359cbbf741c76..d6f34adbdf45bbef4a39e629dd7cb6d7fcb5db0f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerEntity.java
 +++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
 @@ -65,7 +65,7 @@ public class ServerEntity {

--- a/patches/server/0096-Faster-redstone-torch-rapid-clock-removal.patch
+++ b/patches/server/0096-Faster-redstone-torch-rapid-clock-removal.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Faster redstone torch rapid clock removal
 Only resize the the redstone torch list once, since resizing arrays / lists is costly
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 46c7c63d4dced4e75079588cef2c155859e5ae36..2dc18abb447d1ba51d8b9c301becd7f618e5a404 100644
+index 8359cc9cde98ffe11f2d9ede4350a404bc5086be..aa2098d3af5cc03f3ff3ad663683c5edbe473756 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -167,6 +167,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0097-Add-server-name-parameter.patch
+++ b/patches/server/0097-Add-server-name-parameter.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add server-name parameter
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index eac977169ee071c4961ee63d2f21d76bd3e49760..2595ee05d1b77dee0f1f5bf11c10df186f434d84 100644
+index 8962c8669802dabd6a7bc5b6e506f5d921becea2..d7766aaaaa9fd69aae162046cbd2410f8bfeb14c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -154,6 +154,14 @@ public class Main {

--- a/patches/server/0113-Optimize-World.isLoaded-BlockPosition-Z.patch
+++ b/patches/server/0113-Optimize-World.isLoaded-BlockPosition-Z.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimize World.isLoaded(BlockPosition)Z
 Reduce method invocations for World.isLoaded(BlockPosition)Z
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 2dc18abb447d1ba51d8b9c301becd7f618e5a404..1686dbfc4b45c88105c71d284c024a4101795d08 100644
+index aa2098d3af5cc03f3ff3ad663683c5edbe473756..c8350eae421f5655de490c420dcb284c78f58f62 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -334,6 +334,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0118-String-based-Action-Bar-API.patch
+++ b/patches/server/0118-String-based-Action-Bar-API.patch
@@ -26,7 +26,7 @@ index 32ef3edebe94a2014168b7e438752a80b2687e5f..ab6c58eed6707ab7b0aa3e7549a871ad
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 213037a4c545db70ca5e66018057216cbb6532d3..0b693866af8e0d8de275e87ca1232a03a6a35abe 100644
+index c8d63359c77ce11711df3ebed295fdd989d601a5..7f4ed398c48534eec4303a394f360f476b7757ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -274,6 +274,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0130-Properly-handle-async-calls-to-restart-the-server.patch
+++ b/patches/server/0130-Properly-handle-async-calls-to-restart-the-server.patch
@@ -30,7 +30,7 @@ will have plugins and worlds saving to the disk has a high potential to result
 in corruption/dataloss.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a4623129ffa537db39ee2f206fa775c950e07a21..e4913a7dd431dc861fa93c099e9be97f00519a18 100644
+index c656909a4a5fa990d4412bfa7cf3736cde46ca53..454c3a678886649c268992bc67c6cec83cb04b76 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -219,6 +219,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/0149-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0149-Fix-this-stupid-bullshit.patch
@@ -31,7 +31,7 @@ index e359919de57f97d18667df1b2f1bf54a19a49c2f..c5822637e48fad4ca4e8cf210431b5ea
              Bootstrap.isBootstrapped = true;
              if (Registry.REGISTRY.keySet().isEmpty()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 6da452d463193dc20d39f3c74058d72a4bbd0cbf..2272a3d4cc3877e1f40d77036effa471782aeba8 100644
+index c59c72e36db34820ddaf881086a65ec36d79f58d..beb12dcc620d902594dbe6ba2893062fadb97dc5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -239,10 +239,12 @@ public class Main {

--- a/patches/server/0158-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/server/0158-Expose-client-protocol-version-and-virtual-host.patch
@@ -90,7 +90,7 @@ index 9016aced079108aeae09f030a672467a953ef93f..4170bda451df3db43e7d57d87d1abb81
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4754f603ca1c80129f9ee3868b54d25c52a759cc..b956da482950b7383768d6bd60fa4360e179d7d8 100644
+index 7f4ed398c48534eec4303a394f360f476b7757ad..89f722ba437a5c2563af652431432cbc2a607fdd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -218,6 +218,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0203-Fix-CraftEntity-hashCode.patch
+++ b/patches/server/0203-Fix-CraftEntity-hashCode.patch
@@ -21,7 +21,7 @@ check is essentially the same as this.getHandle() == other.getHandle()
 However, replaced it too to make it clearer of intent.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index e8922397c26617e8051ddfe6d80667b5c1041032..1adc2ad30b174465989c628c4306df011356c93c 100644
+index 41753b72ac6fdf0314d60dbe1ffb60e79b3e4af8..e6b75dfa1a59c9f1f6afde7b4538abf8d51b7261 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -807,14 +807,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0322-Chunk-debug-command.patch
+++ b/patches/server/0322-Chunk-debug-command.patch
@@ -32,7 +32,7 @@ https://bugs.mojang.com/browse/MC-141484?focusedCommentId=528273&page=com.atlass
 https://bugs.mojang.com/browse/MC-141484?focusedCommentId=528577&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-528577
 
 diff --git a/src/main/java/io/papermc/paper/command/PaperCommand.java b/src/main/java/io/papermc/paper/command/PaperCommand.java
-index 12c5b6b740eeb986e4b1acc4b2eda6c2c77b63ac..b7b0d134e3a99a630e493aceb06f6188b2c538c3 100644
+index cd4936ef114b504df8649fba8f1823d94a4bb2a2..395c43f6440c1e0e47919eef096ea8a8d552ccec 100644
 --- a/src/main/java/io/papermc/paper/command/PaperCommand.java
 +++ b/src/main/java/io/papermc/paper/command/PaperCommand.java
 @@ -1,5 +1,6 @@

--- a/patches/server/0355-Tracking-Range-Improvements.patch
+++ b/patches/server/0355-Tracking-Range-Improvements.patch
@@ -8,7 +8,7 @@ Sets tracking range of watermobs to animals instead of misc and simplifies code
 Also ignores Enderdragon, defaulting it to Mojang's setting
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 1c3dacd12ff5f26dd5559d0b99c917a0be3b4d6a..60d47c0afa0b0dd8898193099e3a6c3e109c0817 100644
+index f15ad47696574d7668374729de44286258a36f3b..a80d4620eadd78fcaa0786680766cee196c35f8d 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1915,6 +1915,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0357-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0357-implement-optional-per-player-mob-spawns.patch
@@ -252,7 +252,7 @@ index 0000000000000000000000000000000000000000..11de56afaf059b00fa5bec293516bcdc
 +    }
 +} 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 60d47c0afa0b0dd8898193099e3a6c3e109c0817..43011f5e8cbdf28400701465dd6e1614506d4ece 100644
+index a80d4620eadd78fcaa0786680766cee196c35f8d..e22a472bef6cc5b6b892379160aaea876084e8c8 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -159,6 +159,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0361-Add-debug-for-sync-chunk-loads.patch
+++ b/patches/server/0361-Add-debug-for-sync-chunk-loads.patch
@@ -194,7 +194,7 @@ index 0000000000000000000000000000000000000000..0bb4aaa546939b67a5d22865190f3047
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/command/PaperCommand.java b/src/main/java/io/papermc/paper/command/PaperCommand.java
-index b5b4025c0ec07fbd0ec9bf6f6812d6422f549289..40cd55e610cbee25a7cff0e6001bad40b4418551 100644
+index f44ab1d71210e84328661c0feb662989a5635b6d..25f6d1c15cdfb4abdf1edd2ad9bbdc0e37b546f3 100644
 --- a/src/main/java/io/papermc/paper/command/PaperCommand.java
 +++ b/src/main/java/io/papermc/paper/command/PaperCommand.java
 @@ -5,6 +5,7 @@ import io.papermc.paper.command.subcommands.EntityCommand;

--- a/patches/server/0362-Remove-garbage-Java-version-check.patch
+++ b/patches/server/0362-Remove-garbage-Java-version-check.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Remove garbage Java version check
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 2272a3d4cc3877e1f40d77036effa471782aeba8..fb685e13025bc571896bc999814cb99a17bfb788 100644
+index beb12dcc620d902594dbe6ba2893062fadb97dc5..9a5373304b445408244fe9850c10526d1df21855 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -194,10 +194,6 @@ public class Main {

--- a/patches/server/0371-Optimise-Chunk-getFluid.patch
+++ b/patches/server/0371-Optimise-Chunk-getFluid.patch
@@ -8,7 +8,7 @@ faster on its own, however removing the try catch makes it
 easier to inline due to code size
 
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 1a28b3a60bd568cba7c96152fa8dd2a64dd56801..89f4ea65b20e773bd3782c41db3a2af7b5b405f3 100644
+index ee7296eb561b59a4c0fce200f1a59f66a6526cc2..5f65aa89dfb21fced457a3a9fef6ba05385b6b76 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -381,18 +381,20 @@ public class LevelChunk extends ChunkAccess {
@@ -47,7 +47,7 @@ index 1a28b3a60bd568cba7c96152fa8dd2a64dd56801..89f4ea65b20e773bd3782c41db3a2af7
  
      // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
-index ba4da27861236eb62d208f2a660e232a143232ac..2ad73237f4664535c3d5120a54b713f44cddb793 100644
+index 785fbcf9bafcdec1c5be213de3d8512690023415..066874d27495dcaa3dea254b7328257e46920357 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
 @@ -54,7 +54,7 @@ public class LevelChunkSection {

--- a/patches/server/0379-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
+++ b/patches/server/0379-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
@@ -7,7 +7,7 @@ Suspected case would be around the technique used in .stopRiding
 Stack will identify any causer of this and warn instead of crashing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 43011f5e8cbdf28400701465dd6e1614506d4ece..8d99c45e10da9d8a54a12b1039515da05bd56f6b 100644
+index e22a472bef6cc5b6b892379160aaea876084e8c8..07e397061420556b9f44314f0c459f5cdd30aad3 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1648,6 +1648,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0392-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0392-Implement-Player-Client-Options-API.patch
@@ -97,7 +97,7 @@ index 02a84c3f3ca6b591a1c475b5cf3357cebd41eff6..8ef5f67c0b51bb5d527b36c667a5c235
          if (getMainArm() != packet.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f53b4041fc9ce961350649666521e3cf359cdfc1..7d42e60ec26f3617bb23c12f415b13e5913603fc 100644
+index 226bfb38b8b1c3463e5527c831d22875cfc051ba..daea1ca1d3288b6c3b0cf2e58fe35cb5e4069698 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -574,6 +574,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0394-Fix-Chunk-Post-Processing-deadlock-risk.patch
+++ b/patches/server/0394-Fix-Chunk-Post-Processing-deadlock-risk.patch
@@ -25,7 +25,7 @@ This successfully fixed a reoccurring and highly reproducible crash
 for heightmaps.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 42645114b270b1e7c2b3112abd7eaa90d0e4451c..6354b100499b277c0949c65d454e84da6bce6aa8 100644
+index 3afadbd25cb002966869db6e07cd26cf6d52646b..71d76ce0d873c665597a7d28f6caea5bf059e796 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -182,6 +182,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0395-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/patches/server/0395-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -28,7 +28,7 @@ receives a deterministic result, and should no longer require 1 tick
 delays anymore.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 6354b100499b277c0949c65d454e84da6bce6aa8..4aebad2b6a7b70b335b7aa1d87d7d2383861e587 100644
+index 71d76ce0d873c665597a7d28f6caea5bf059e796..ee64657a838b9b661b8accc997b6d149d21bce56 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1656,6 +1656,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0406-Set-cap-on-JDK-per-thread-native-byte-buffer-cache.patch
+++ b/patches/server/0406-Set-cap-on-JDK-per-thread-native-byte-buffer-cache.patch
@@ -17,7 +17,7 @@ keeping long lived large direct buffers in cache.
 Set system properly at server startup if not set already to help protect from this.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index fcc959aaed86d1e1c6fe551e534bebbd0fb967a4..1b9e91b20dd9a9375a0a2a6a4d7a0bcdce9e7b1a 100644
+index 0c76f2e8038bf0bc3edf464295c606acf03a8337..c55ae77807e0ec3698f0d0443caaf18928b41017 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -28,6 +28,7 @@ public class Main {

--- a/patches/server/0421-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
+++ b/patches/server/0421-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
@@ -18,7 +18,7 @@ index 3167f5c6be39757e3cc42cbb17ab0cf13a2fe470..3768a71491ef7836b9739bdaec7a077c
      private static long encode(double value) {
          return Mth.lfloor(value * 4096.0D);
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 4aebad2b6a7b70b335b7aa1d87d7d2383861e587..fa6329b04ca185c7b12f2d782f109b94b19f9cc6 100644
+index ee64657a838b9b661b8accc997b6d149d21bce56..d6887ac56991eee37cff7f0d978b8f5977e43c39 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1934,9 +1934,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0424-Optimize-anyPlayerCloseEnoughForSpawning-to-use-dist.patch
+++ b/patches/server/0424-Optimize-anyPlayerCloseEnoughForSpawning-to-use-dist.patch
@@ -42,7 +42,7 @@ index 6e7d09cd48048957a14835b857ac708aafe8f664..4e8a79f2d3b6f52c6284bc9b0ce2423d
  
      // Paper start
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index fa6329b04ca185c7b12f2d782f109b94b19f9cc6..37ed4429e065b0e05f14ed352e191863a3547311 100644
+index d6887ac56991eee37cff7f0d978b8f5977e43c39..bc698f8aee7eb5f2dbc1affd24e9af9f7c1ad2d5 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -185,11 +185,23 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0425-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/patches/server/0425-Use-distance-map-to-optimise-entity-tracker.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use distance map to optimise entity tracker
 Use the distance map to find candidate players for tracking.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 37ed4429e065b0e05f14ed352e191863a3547311..10ef89963ad805c775b9c649f4e17c9d4ec7f4b7 100644
+index bc698f8aee7eb5f2dbc1affd24e9af9f7c1ad2d5..86cdc8951544c16f8dc5148bc2c7bf9bbf920c60 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -69,6 +69,7 @@ import net.minecraft.network.protocol.game.ClientboundSetEntityLinkPacket;

--- a/patches/server/0440-Add-permission-for-command-blocks.patch
+++ b/patches/server/0440-Add-permission-for-command-blocks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add permission for command blocks
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 312768054e02847bbc7d2ec7fa6198dad52b86d2..32a6b4d8e6c8f9c05cc7ca811c2188aa554f9e3e 100644
+index af00442931f9f6cf878bd61137c2f29fc7c8d0b1..431ff490760f54be76847c7b370dbbb4b65de102 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -396,7 +396,7 @@ public class ServerPlayerGameMode {

--- a/patches/server/0443-Paper-dumpitem-command.patch
+++ b/patches/server/0443-Paper-dumpitem-command.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Paper dumpitem command
 Let's you quickly view the item in your hands NBT data
 
 diff --git a/src/main/java/io/papermc/paper/command/PaperCommand.java b/src/main/java/io/papermc/paper/command/PaperCommand.java
-index 40cd55e610cbee25a7cff0e6001bad40b4418551..4c85d0a61ce508e4a0e3770f46242fb2b1d17420 100644
+index 25f6d1c15cdfb4abdf1edd2ad9bbdc0e37b546f3..d2536f4ffae721f4df714b5345fa3329c3b8e3f5 100644
 --- a/src/main/java/io/papermc/paper/command/PaperCommand.java
 +++ b/src/main/java/io/papermc/paper/command/PaperCommand.java
 @@ -1,6 +1,7 @@

--- a/patches/server/0457-Add-entity-liquid-API.patch
+++ b/patches/server/0457-Add-entity-liquid-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 5f232c45d6e01943cf1ca1d7802d4915887a6b32..904ce802b2aaebc1f48f7c444e2611fefa14f9a5 100644
+index 6029cb7d8801c471e596ba027b7e408a27c44db9..c0a2cffadb762240ef8fcdec1bd1e49edd3b5c61 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1254,5 +1254,29 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0462-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0462-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -360,7 +360,7 @@ index 36a9d52d9af3bc398010c52dc16ab23e53f2702a..ece4cd0de061969d4d2f07560e6cf38e
          return this.isEntityTickingReady;
      }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index eb74a831fc439c56fe1ac2d4769ebefa1e5759a3..349c311e70758d99ebb4c61ad509a3a975fda04b 100644
+index c468b012197b2c3444ad8bb0d8a9f41c7ab17b10..b486b800399b53cb6d4912e16f2a14f1a3062759 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -134,6 +134,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1148,7 +1148,7 @@ index 173824e96c51c4f1a9f43401cfa3fc79a2432600..c1bf81770f9d00f4e3ba5844260812bb
      public float yRotO;
      public float xRotO;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 797ff36295412ac8429d573e039d870fd85eb569..3591ac3b7823e109e01ebfa54ac70aa4deabd4f6 100644
+index f8a3048fa80758d82f2e92d48bd3cd2c585ae6c2..2981ba61e347b8660082ff946521fc7f219d2c0d 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -141,7 +141,7 @@ public class LevelChunk extends ChunkAccess {

--- a/patches/server/0481-Improve-Chunk-Status-Transition-Speed.patch
+++ b/patches/server/0481-Improve-Chunk-Status-Transition-Speed.patch
@@ -54,7 +54,7 @@ index ece4cd0de061969d4d2f07560e6cf38e631098b3..90f65fdcc4acf6762c67a5cb3023d249
      public ChunkHolder(ChunkPos pos, int level, LevelHeightAccessor world, LevelLightEngine lightingProvider, ChunkHolder.LevelChangeListener levelUpdateListener, ChunkHolder.PlayerProvider playersWatchingChunkProvider) {
          this.futures = new AtomicReferenceArray(ChunkHolder.CHUNK_STATUSES.size());
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 349c311e70758d99ebb4c61ad509a3a975fda04b..82ebf79bdcae552d6e4f5dc4b4c85da26eda356c 100644
+index b486b800399b53cb6d4912e16f2a14f1a3062759..13c4bfa296c854b5dbbffc495a029c6822131529 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -712,7 +712,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0497-Extend-block-drop-capture-to-capture-all-items-added.patch
+++ b/patches/server/0497-Extend-block-drop-capture-to-capture-all-items-added.patch
@@ -23,7 +23,7 @@ index bb8d5868275407fe3c5eb29174bf1970cae498f9..2ac0db36942ecb6dd073bc08f42fb3d1
              if (spawnReason != null && !CraftEventFactory.doEntityAddEventCalling(this, entity, spawnReason)) {
                  return false;
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 32a6b4d8e6c8f9c05cc7ca811c2188aa554f9e3e..32c78828b0c85949832dc25843c881b8eecc63d6 100644
+index 431ff490760f54be76847c7b370dbbb4b65de102..1b45c1483a7ebad47162483b51036f9dfcdf62f6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -428,10 +428,12 @@ public class ServerPlayerGameMode {

--- a/patches/server/0499-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0499-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index eae3fec221518434b989c8084920dc282f8d8981..bd6bd22830b7c48717f009f237699fcc38f61c70 100644
+index 0618606ab87bf0745b667e3b59328bf78de503cf..e0170e0b4318e16c1322cd20e1879ae88e893e7d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -4077,4 +4077,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {

--- a/patches/server/0509-Retain-block-place-order-when-capturing-blockstates.patch
+++ b/patches/server/0509-Retain-block-place-order-when-capturing-blockstates.patch
@@ -10,7 +10,7 @@ In general, look at making this logic more robust (i.e properly handling
 cases where a captured entry is overriden) - but for now this will do.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 7481f7828d66623c9d606761ca37e53138eacb26..bd04c33ae31bfaed508ac5d39db7cb1fd5cf2913 100644
+index d5e80a0d953e7792669f21011bc685adaec78464..d9a88b29cfefcdbce7bfc477b6c1af0e51079102 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -155,7 +155,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0512-Player-elytra-boost-API.patch
+++ b/patches/server/0512-Player-elytra-boost-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a9b80431323b71f171185b4c7bdc2f323c1de124..0bd14df2d73a59dd7c184bc10e46cabec42e00b4 100644
+index d06f6c9a7bfa7585d5dfb7da8654837605866a3e..c94a7ccb3d5420dc0c8493d5cb0381a47ea8f9a0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -592,6 +592,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0531-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0531-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -143,7 +143,7 @@ index 7d60f56b2e8206e8e546abdd06ea74a2ead6e75d..4984b2b3294e425247b595bcf3681272
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
-index 94ae97c7297641ba05402337d1cff28995055b08..904ef44f6bb25a617c6e80d025fa0780a3bd63ec 100644
+index 5d927b6331f3d5cb7dd34be3e7ea4443f52f9ead..8471c34d02ba5819580754f98ce8cc0b50a0b328 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
 @@ -157,7 +157,7 @@ public class Boat extends Entity {

--- a/patches/server/0544-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0544-MC-4-Fix-item-position-desync.patch
@@ -27,7 +27,7 @@ index 3768a71491ef7836b9739bdaec7a077c523dbacd..a57957ace1a72b3308487f180a366c38
  
      public Vec3 decode(long x, long y, long z) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f2f91815137db868bf6968be062ef9e7b96266b8..84365010341c1f5a4ed6dcc5c4110944268ce611 100644
+index 6d2853238897cc7b801af12dc4fe44495e815f26..34594585edbe6990a8f36daff43d9276a655ec74 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3893,6 +3893,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {

--- a/patches/server/0565-Implement-API-to-expose-exact-interaction-point.patch
+++ b/patches/server/0565-Implement-API-to-expose-exact-interaction-point.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement API to expose exact interaction point
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 32c78828b0c85949832dc25843c881b8eecc63d6..06e7a8b8227260c002a88119544b99a11eec8a09 100644
+index 1b45c1483a7ebad47162483b51036f9dfcdf62f6..32746dfbc2fdfc150583676b1bf0762398b76d75 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -507,7 +507,7 @@ public class ServerPlayerGameMode {

--- a/patches/server/0568-Add-sendOpLevel-API.patch
+++ b/patches/server/0568-Add-sendOpLevel-API.patch
@@ -32,7 +32,7 @@ index 6c7105af36339514db02800e651cd0948d48bdaf..42b2f5c61e2bd07c3c86d889949c5f24
  
      public boolean isWhiteListed(GameProfile profile) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 23a92393036fea7631d7610b12d4e72fa6657203..fd6f948adb975f09b07ad7692c6a716616600ccc 100644
+index 39e0f1398e6f09ce7b0a4f1c9b677dca10a32c3f..202c5108f2e15e0d71c4e2854b17a027c7e495af 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -606,6 +606,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0571-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0571-Collision-option-for-requiring-a-player-participant.patch
@@ -29,7 +29,7 @@ index 4984b2b3294e425247b595bcf36812728fb4cd16..3f31a3c17ecca6e93b794478129b95ec
                      // CraftBukkit start
                      VehicleEntityCollisionEvent collisionEvent = new VehicleEntityCollisionEvent((Vehicle) this.getBukkitEntity(), entity.getBukkitEntity());
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
-index 904ef44f6bb25a617c6e80d025fa0780a3bd63ec..502a04ba27184f66e85b2ca31d92f5f306922f4b 100644
+index 8471c34d02ba5819580754f98ce8cc0b50a0b328..5641a7b5c5e3d93cddabd91703c6f001700c5869 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
 @@ -243,6 +243,7 @@ public class Boat extends Entity {

--- a/patches/server/0592-Expose-Tracked-Players.patch
+++ b/patches/server/0592-Expose-Tracked-Players.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index fefd03ffe3c1b4dbdf3035e80d5a00ef2fd6e670..2a3addb00244b8ba68a3eeebba016553782946fd 100644
+index c39b683cbe83618daee0ca00d1107b115af6bf8f..b8e5205c165bcba5b8383334f3d0d1daf9d0a8cd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1282,5 +1282,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0604-Expand-world-key-API.patch
+++ b/patches/server/0604-Expand-world-key-API.patch
@@ -20,7 +20,7 @@ index ee5e59c37301d9a806e2f696d52d9d217b232833..bb5d22125b6cd4e60d2b7e2e00af158c
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0afcf909d93973061c4b0735cba3e091fa79833b..34b365ce84439958eeba04fa50a13e02ddbd9412 100644
+index 0afcf909d93973061c4b0735cba3e091fa79833b..a84fb8c6d4af395da08e9a685f3705bcdf8440a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1141,9 +1141,15 @@ public final class CraftServer implements Server {

--- a/patches/server/0615-Enhance-console-tab-completions-for-brigadier-comman.patch
+++ b/patches/server/0615-Enhance-console-tab-completions-for-brigadier-comman.patch
@@ -198,7 +198,7 @@ index 0000000000000000000000000000000000000000..5ab8365b806dd035800ba9b449c9bc92
 +    public void setErrorIndex(final int errorIndex) {}
 +}
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index cd65cd0fd6c1135dd53683617808aeb03b98216d..a89036addfc34d4a1be3191c7dbe1612a18a79c2 100644
+index 7a2ef21a78c25e18ed61bd989b759783d89b54d5..17d71eeca335fb7c9b56c4ef80a4499def5789cb 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -178,7 +178,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface

--- a/patches/server/0628-Implement-methods-to-convert-between-Component-and-B.patch
+++ b/patches/server/0628-Implement-methods-to-convert-between-Component-and-B.patch
@@ -42,7 +42,7 @@ index 0000000000000000000000000000000000000000..dd6012b6a097575b2d1471be5069ecce
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 4391bd846b039339c0ef807870c5fb517a6b1708..33ebc25607277f4ab8d8bbd185c3d78343d93741 100644
+index 17d71eeca335fb7c9b56c4ef80a4499def5789cb..f99c616006d49d91922abf5283146bc6f4fb5493 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -214,6 +214,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface

--- a/patches/server/0642-Add-basic-Datapack-API.patch
+++ b/patches/server/0642-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 34b365ce84439958eeba04fa50a13e02ddbd9412..b38265b4077f37aaab2701663f6740dd8fd729b4 100644
+index a84fb8c6d4af395da08e9a685f3705bcdf8440a6..887bf340b56177099bc5c55ac185fb66d8a080f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -280,6 +280,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0644-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0644-additions-to-PlayerGameModeChangeEvent.patch
@@ -93,7 +93,7 @@ index eae9d91f5b08b6ac32ca204dbd962245808d63ee..fd131a583b57687837533f0541091a29
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 06e7a8b8227260c002a88119544b99a11eec8a09..4d907501dfe7f1a4641542291f4abdd05cb1644c 100644
+index 32746dfbc2fdfc150583676b1bf0762398b76d75..1ad1f958a9b6e1bc21f1c505aa7ea54950de6cad 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -73,18 +73,24 @@ public class ServerPlayerGameMode {

--- a/patches/server/0650-Add-Unix-domain-socket-support.patch
+++ b/patches/server/0650-Add-Unix-domain-socket-support.patch
@@ -27,7 +27,7 @@ index 91556b52edaa1d5c4dc73a825c77b9a66b002c61..00abdd5bba02b7cdf8dbdc423594f0fd
      }
      // Spigot End
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 33ebc25607277f4ab8d8bbd185c3d78343d93741..0ce34bb9104fb1c29bbcb65cfa5eb9b7a48809b4 100644
+index f99c616006d49d91922abf5283146bc6f4fb5493..9f3165178e744751343df98568113250578c6d2f 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -224,6 +224,20 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface

--- a/patches/server/0656-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0656-Add-PlayerKickEvent-causes.patch
@@ -342,7 +342,7 @@ index a4278a4ca0b41813b8f88d01dcc8d75b4f458908..be163c1cc4c8982b89be86c004299cdc
          // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2562907dd19c4027a5d9928506db8bfd7495c06f..dc0c689864fb312ebdbc742561d73837229947cc 100644
+index 8c07b6e92a7329d72ccf1adf9f788322a4e9b28c..3ca8adc4b8cd76b5d2ec827a439cb47564c0b028 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -516,7 +516,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0686-Add-System.out-err-catcher.patch
+++ b/patches/server/0686-Add-System.out-err-catcher.patch
@@ -105,7 +105,7 @@ index 0000000000000000000000000000000000000000..76d0d00cd6742991e3f3ec827a75ee87
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6ca513be5b3a0c158364487118d25f145f990df5..8417136c411c91e4c163446d7e1c2ced5f0084e1 100644
+index cb2a03fa0fab132db498be708cb2870a6a8549ef..b84d0c8225a9d5f64dda7ba91a3836e1e21a525c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -282,6 +282,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0689-Improve-boat-collision-performance.patch
+++ b/patches/server/0689-Improve-boat-collision-performance.patch
@@ -54,7 +54,7 @@ index 7f39a4955b4819e8a908f4cbf951d707c34fa4a8..b6af4e6b146cc6ceb769a0d1e0d253f0
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
-index 502a04ba27184f66e85b2ca31d92f5f306922f4b..eb753323f67badb1bed28405c07b03078e322b44 100644
+index 5641a7b5c5e3d93cddabd91703c6f001700c5869..29da8a42406feccf7932097b07b1d32a38fa96b7 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
 @@ -691,8 +691,8 @@ public class Boat extends Entity {

--- a/patches/server/0697-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0697-Optimize-indirect-passenger-iteration.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ed0772f1153ac80838895283d41a971a6eaa2ccc..b7f7ef9d2323848cf17ccd34cdab56aed81cfc56 100644
+index e42b62a20adc487a6218d1ba87442dd9bc375182..75f0a60c3158a9fa6e2d64c8b51ede839dd958ba 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3599,26 +3599,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {

--- a/patches/server/0720-Make-CallbackExecutor-strict-again.patch
+++ b/patches/server/0720-Make-CallbackExecutor-strict-again.patch
@@ -10,7 +10,7 @@ schedules. Effectively, use the callback executor as a tool of
 finding issues rather than hiding these issues.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 82ebf79bdcae552d6e4f5dc4b4c85da26eda356c..c0f0f952c5dcd43435e6deae0566757ed6290e80 100644
+index 13c4bfa296c854b5dbbffc495a029c6822131529..ddfb27d71ad6472760ac23fd31cf10780408525b 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -168,17 +168,28 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0725-Fix-chunks-refusing-to-unload-at-low-TPS.patch
+++ b/patches/server/0725-Fix-chunks-refusing-to-unload-at-low-TPS.patch
@@ -10,7 +10,7 @@ chunk future to complete. We can simply schedule to the immediate
 executor to get this effect, rather than the main mailbox.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index c0f0f952c5dcd43435e6deae0566757ed6290e80..511ff04a2609de514d98869934a57cbda10b9633 100644
+index ddfb27d71ad6472760ac23fd31cf10780408525b..da22b189483075b4439538dbfd6185001ca41e64 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1331,9 +1331,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0726-Do-not-allow-ticket-level-changes-while-unloading-pl.patch
+++ b/patches/server/0726-Do-not-allow-ticket-level-changes-while-unloading-pl.patch
@@ -8,7 +8,7 @@ Sync loading the chunk at this stage would cause it to load
 older data, as well as screwing our region state.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 511ff04a2609de514d98869934a57cbda10b9633..753fd5d172c782b6ab9e90aa7c01ed860f8dc3a9 100644
+index da22b189483075b4439538dbfd6185001ca41e64..d9d9f2c6bf56a89ba92856caadf9f52bc9f5d931 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -317,6 +317,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0736-Optimise-chunk-tick-iteration.patch
+++ b/patches/server/0736-Optimise-chunk-tick-iteration.patch
@@ -70,7 +70,7 @@ index b75b3c4d274252a3a5c53059b9702728eeada389..8bea90cb57f38f33e8b3162e24e35399
              int i = 0;
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 753fd5d172c782b6ab9e90aa7c01ed860f8dc3a9..bb8478d9a216ec53f650b887508638965f371d47 100644
+index d9d9f2c6bf56a89ba92856caadf9f52bc9f5d931..0110a63e96a22bc179f5e2451d5c67927fd10ee5 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -163,6 +163,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0738-Do-not-copy-visible-chunks.patch
+++ b/patches/server/0738-Do-not-copy-visible-chunks.patch
@@ -35,7 +35,7 @@ index 613988c9ea892ab15516e1c8b4f376d52415ae34..1eb71004a19866590a3d27fa6e728429
              List<ChunkHolder> allChunks = new ArrayList<>(visibleChunks.values());
              List<ServerPlayer> players = world.players;
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index bb8478d9a216ec53f650b887508638965f371d47..a04a52b5e154d55a7b1d35f0094bbac055612054 100644
+index 0110a63e96a22bc179f5e2451d5c67927fd10ee5..f5b22082aabc30235ca0c1633273e15b16543621 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -126,9 +126,11 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0743-Distance-manager-tick-timings.patch
+++ b/patches/server/0743-Distance-manager-tick-timings.patch
@@ -7,7 +7,7 @@ Recently this has been taking up more time, so add a timings to
 really figure out how much.
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
-index 8563c66834b0b9e77bca42e4f916d82a9bfe66e2..4567ddf1cef02405b44a9e217a72b326fadb19ab 100644
+index 5ec241d49ff5e3a161a39006f05823a5de847c5e..435b3b6d05e00803386d123c66f961c97da83d40 100644
 --- a/src/main/java/co/aikar/timings/MinecraftTimings.java
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
 @@ -45,6 +45,7 @@ public final class MinecraftTimings {

--- a/patches/server/0747-Use-correct-LevelStem-registry-when-loading-default-.patch
+++ b/patches/server/0747-Use-correct-LevelStem-registry-when-loading-default-.patch
@@ -24,7 +24,7 @@ index 8da1226a6c293abb038d10c7921a77ed71ad06cc..f958f0ae738a6fb26400e17e54c8d69e
          } else {
              Holder<E> holder = registry.getOrCreateHolderOrThrow(entryKey);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 6f078f69f4da1bd988f02156351c481b6da04b55..d916f88e48e0097d9852a231b35431a06745d325 100644
+index 07d717295beb6fff7d8b3387b895e046bd7482c2..e977a523759f360854fa0a3ab8bbb956f0c0fdc2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -550,7 +550,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/0751-Time-scoreboard-search.patch
+++ b/patches/server/0751-Time-scoreboard-search.patch
@@ -7,7 +7,7 @@ Plugins leaking scoreboards will make this very expensive,
 let server owners debug it easily
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
-index 4567ddf1cef02405b44a9e217a72b326fadb19ab..8f109e667f09d58f6bc7ce1a8b44e8e70d191579 100644
+index 435b3b6d05e00803386d123c66f961c97da83d40..9da5a6086323ff4c4fd62a035fa8f7efc3d92e38 100644
 --- a/src/main/java/co/aikar/timings/MinecraftTimings.java
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
 @@ -46,6 +46,7 @@ public final class MinecraftTimings {

--- a/patches/server/0754-Oprimise-map-impl-for-tracked-players.patch
+++ b/patches/server/0754-Oprimise-map-impl-for-tracked-players.patch
@@ -7,7 +7,7 @@ Reference2BooleanOpenHashMap is going to have
 better lookups than HashMap.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index a04a52b5e154d55a7b1d35f0094bbac055612054..f77c2eeb6c367df4d72e5908071eb079ee6f0def 100644
+index f5b22082aabc30235ca0c1633273e15b16543621..603b5275221494b146b0f30680362d695c55f30b 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -113,6 +113,7 @@ import org.slf4j.Logger;

--- a/patches/server/0757-Optimise-random-block-ticking.patch
+++ b/patches/server/0757-Optimise-random-block-ticking.patch
@@ -336,7 +336,7 @@ index e7487e0a21727666889cc2ec8841cca2b2c965d5..45be0dc44b98ca90b68e6ff3278e4de2
  
      public boolean noSave() {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
-index 2ad73237f4664535c3d5120a54b713f44cddb793..c2e3df8331cec5fe5650501a4dc4ac47f23ef11b 100644
+index 066874d27495dcaa3dea254b7328257e46920357..c3f1334b2bb97f0633f3ea43b97ee49adfd8bc0d 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
 @@ -27,6 +27,7 @@ public class LevelChunkSection {
@@ -429,7 +429,7 @@ index 2ad73237f4664535c3d5120a54b713f44cddb793..c2e3df8331cec5fe5650501a4dc4ac47
  
      public PalettedContainer<BlockState> getStates() {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java b/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
-index f4b3284d1ad93ca3328fc1c1ddcbcb14296e1545..7b0c3cff4a5048db5ca52d5ea1711a5e5d959af2 100644
+index 0c309a2f10ca75dc90076156b2d666deb37f72ba..d71954c3b080e0d4a082b84925592350d8259aac 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
 @@ -383,6 +383,14 @@ public class PalettedContainer<T> implements PaletteResize<T>, PalettedContainer

--- a/patches/server/0758-Optimise-non-flush-packet-sending.patch
+++ b/patches/server/0758-Optimise-non-flush-packet-sending.patch
@@ -20,7 +20,7 @@ up on this optimisation before he came along.
 Locally this patch drops the entity tracker tick by a full 1.5x.
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 8c6e2aa1a5e98456684f74d677ac0af24aa90246..7ee144a5c734af6e1a8288e13d2d1305535b66a2 100644
+index 1d98e328982255b6dab8e24223c97eaea2612a45..7e2256ac88e874b34b6a0c638bfced368ba29be2 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -50,6 +50,8 @@ import org.slf4j.Logger;

--- a/patches/server/0760-Optimise-WorldServer-notify.patch
+++ b/patches/server/0760-Optimise-WorldServer-notify.patch
@@ -8,7 +8,7 @@ Instead, only iterate over navigators in the current region that are
 eligible for repathing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 17b6c6ee8c2754e1f98badebf506390c0bb7ce87..6671caad52c3a5943334e613b836026c416183b4 100644
+index 640b87d6acb4faf78bb4d6930bf0ac17691f89f7..1a9e6544fed4cab0a2058ba9f576ad1285f6bf08 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -305,15 +305,81 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -110,7 +110,7 @@ index 17b6c6ee8c2754e1f98badebf506390c0bb7ce87..6671caad52c3a5943334e613b836026c
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2c61c756764bc8d2830294ca0c8be8e0e8fb1828..eb1c66e648c20c5cb23227c2f4692a1917b0f55a 100644
+index ecd025798205691892819863a50d7767f663d3d1..7e4c387871c84541712a9b4b0c97d5027d2a30c9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1116,6 +1116,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0763-Use-Velocity-compression-and-cipher-natives.patch
+++ b/patches/server/0763-Use-Velocity-compression-and-cipher-natives.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Use Velocity compression and cipher natives
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index fab25a3e505a9f978ef91b2d7316a7c2b41d08d3..1c350424d0903f0caa9ef688abf8a6c51f22fdbd 100644
+index a02f53c6ee0111e07d78a718a6ca0ec708f70cfc..fb6bfd4967b4ec113463cfaa77e621183f93e441 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -29,6 +29,11 @@ dependencies {
@@ -268,7 +268,7 @@ index 792883afe53d2b7989c25a81c2f9a639d5e21d20..c04379ca8a4db0f4de46ad2b3b338431
          return this.threshold;
      }
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 7ee144a5c734af6e1a8288e13d2d1305535b66a2..0e5f05d091710da9078021eb6e1a26a22e2d63dd 100644
+index 7e2256ac88e874b34b6a0c638bfced368ba29be2..9549e8ed4b245176b340ab2f22f4bdefdbe28a9e 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -641,11 +641,28 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {

--- a/patches/server/0768-Fix-merchant-inventory-not-closing-on-entity-removal.patch
+++ b/patches/server/0768-Fix-merchant-inventory-not-closing-on-entity-removal.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix merchant inventory not closing on entity removal
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index eb1c66e648c20c5cb23227c2f4692a1917b0f55a..3b2a3f5e6db4685c3f8d95dc46c85a2ba7b5ec7c 100644
+index 7e4c387871c84541712a9b4b0c97d5027d2a30c9..01fd17fa845d4f03f3e7e599f42e56f51dd52ff6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2572,6 +2572,11 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0770-Don-t-respond-to-ServerboundCommandSuggestionPacket-.patch
+++ b/patches/server/0770-Don-t-respond-to-ServerboundCommandSuggestionPacket-.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Don't respond to ServerboundCommandSuggestionPacket when
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b23e649f3833ef323643ba4c2b209a7ceca44e6f..8668da69741354a4908179935ec5fb164d8fce0f 100644
+index 28c04f16ddabe33518634759d9a1ea3c7462cb91..d29d71a100967d2cd411b78f55560617d598db52 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -802,6 +802,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0777-Do-not-overload-I-O-threads-with-chunk-data-while-fl.patch
+++ b/patches/server/0777-Do-not-overload-I-O-threads-with-chunk-data-while-fl.patch
@@ -12,7 +12,7 @@ time to save, as flush saving performs a full flush at
 the end anyways.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 6671caad52c3a5943334e613b836026c416183b4..595d414f633e3183147fb4b137a149e948dab332 100644
+index 1a9e6544fed4cab0a2058ba9f576ad1285f6bf08..0b06da8a9d83d7adc6edad721ca167ae6f7d3e4b 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -949,6 +949,16 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0783-Add-config-option-for-logging-player-ip-addresses.patch
+++ b/patches/server/0783-Add-config-option-for-logging-player-ip-addresses.patch
@@ -23,7 +23,7 @@ index c8012de68b997d6270ba4a5d79bc93c09ff4354f..1429f938c36d5a3a33e71837f440b230
                          net.minecraft.network.chat.Component error = net.minecraft.network.chat.Component.literal("Packet processing error");
                          networkmanager.send(new net.minecraft.network.protocol.game.ClientboundDisconnectPacket(error), (future) -> {
 diff --git a/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java b/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java
-index 53e87ea23dacd123cc47bd8ca43d0f19e69acaf2..7f0f50e9ce17747a235b0f5450ca2e8ba5c632ef 100644
+index 0d35e9ff88542b02bb948aa10e064911e73a6913..31a4cd5010cd4ed8eb64b2bad86dc3adfd8ecca8 100644
 --- a/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java
 +++ b/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java
 @@ -183,7 +183,7 @@ public class LegacyQueryHandler extends ChannelInboundHandlerAdapter {
@@ -49,7 +49,7 @@ index af3e70920221b6bd127bb3aed7f1e0a7e9e4c322..597c7660bd517322d8bc9c5acef6956c
  
                              networkmanager.send(new ClientboundDisconnectPacket(ichatmutablecomponent), (future) -> {
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 1a0a8ac23b320b680f475d2b6c679e21f6997edb..4bffd454a1403130d4454a1716aba15034ea9a95 100644
+index 5064ea6767ce17dde271e80f4360549462f6cca0..c098a602ce840db0099b15bd108ea873c7f111d4 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -229,7 +229,10 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener

--- a/patches/server/0786-Add-root-admin-user-detection.patch
+++ b/patches/server/0786-Add-root-admin-user-detection.patch
@@ -57,7 +57,7 @@ index 0000000000000000000000000000000000000000..6bd0afddbcc461149dfe9a5c7a86fff6
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 0ce34bb9104fb1c29bbcb65cfa5eb9b7a48809b4..83cc8db3ca76898f88a56c27c2b6fde6006723ba 100644
+index 9f3165178e744751343df98568113250578c6d2f..2cc45ec6a5f0b0d5c1ba44551d9a126176dfa8f6 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -184,6 +184,16 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface

--- a/patches/server/0789-Prevent-excessive-velocity-through-repeated-crits.patch
+++ b/patches/server/0789-Prevent-excessive-velocity-through-repeated-crits.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent excessive velocity through repeated crits
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 84d8edf3afe0a2a41092d8d2a0b940d1b949da8b..b093d6552c0b0262414ac3e14a99f2d2eea6ce0e 100644
+index b6af4e6b146cc6ceb769a0d1e0d253f0b0f844d2..93cb4d6177cb7ea7a6e9ba5848176d9d74ade3e1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -2626,14 +2626,27 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0791-Rewrite-the-light-engine.patch
+++ b/patches/server/0791-Rewrite-the-light-engine.patch
@@ -5039,7 +5039,7 @@ index c85380c3bf3bf4448a28a91af78f41c235a583e4..d870cefbe5b7485f423817f4f639e3e2
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java b/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
-index 7b0c3cff4a5048db5ca52d5ea1711a5e5d959af2..022412285ad63b4bc26e109956f8263310ae64b4 100644
+index d71954c3b080e0d4a082b84925592350d8259aac..18c4f815888fee0c85ebbb485d21063ce0d143fb 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
 @@ -203,7 +203,7 @@ public class PalettedContainer<T> implements PaletteResize<T>, PalettedContainer

--- a/patches/server/0792-Always-parse-protochunk-light-sources-unless-it-is-m.patch
+++ b/patches/server/0792-Always-parse-protochunk-light-sources-unless-it-is-m.patch
@@ -8,7 +8,7 @@ Chunks not marked as lit will always go through the light engine,
 so they should always have their block sources parsed.
 
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
-index b479c4a617becd3f31080ade0388c50727a56ba0..184d1742e5943f4a438e33fcf19f96196a3824e8 100644
+index 4df5853781a2ac89dd391374d34d9096643a2ab8..3367c75b1c132b42465d4c355a6b5fd00c3efe23 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 @@ -331,16 +331,33 @@ public class ChunkSerializer {

--- a/patches/server/0794-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0794-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -34,7 +34,7 @@ index cc418554b655ea4111631e4a1abf69776e150e7c..319dfa82dff1fe188a52bed5aa2d3957
              }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index b093d6552c0b0262414ac3e14a99f2d2eea6ce0e..0e4dcab5d77c60bfe7f3bc35c95c4da1f7f06800 100644
+index 93cb4d6177cb7ea7a6e9ba5848176d9d74ade3e1..1fed50f7310b276090614d05bbf871727f4dea55 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3109,7 +3109,10 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0795-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0795-Hide-unnecessary-itemmeta-from-clients.patch
@@ -18,7 +18,7 @@ index 319dfa82dff1fe188a52bed5aa2d39575853b793..919758363c7b703cb200582768e68c97
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0e4dcab5d77c60bfe7f3bc35c95c4da1f7f06800..cca07ef0100749a12aa86b0d97bbc61adc0db7f5 100644
+index 1fed50f7310b276090614d05bbf871727f4dea55..7ea4f8003c0da7ea171ac47c27a8bfb7b707be99 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3111,7 +3111,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0801-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0801-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 874f317ebae64ba9f42573e3a412dedbeeb90cc7..8c8cb918c68215310498237e1b710fe8d2978cc2 100644
+index 268a70912722a9ae25b7f88a90daf83f5444781a..df17cd9332d9f9e86480714d161be246fb16af56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2322,6 +2322,90 @@ public final class CraftServer implements Server {
@@ -100,7 +100,7 @@ index 874f317ebae64ba9f42573e3a412dedbeeb90cc7..8c8cb918c68215310498237e1b710fe8
      public BossBar createBossBar(String title, BarColor color, BarStyle style, BarFlag... flags) {
          return new CraftBossBar(title, color, style, flags);
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/OldCraftChunkData.java b/src/main/java/org/bukkit/craftbukkit/generator/OldCraftChunkData.java
-index 6f6bf950cd15b34031618782c82824cf0b191ff8..8d8c7d84a76b11e14ee252e93349d495eec77957 100644
+index 4a23d03757e1735b9ebb8c003adcc0374a7d672d..ce006e1d6c38e5b0bdb336c480fb9d291292f75c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/OldCraftChunkData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/OldCraftChunkData.java
 @@ -23,7 +23,7 @@ import org.bukkit.material.MaterialData;

--- a/patches/server/0802-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0802-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -1548,7 +1548,7 @@ index b8541b54886fc1f48b4c99cf449284ffece1a78a..771c6cf992664b65ffbf4ae0192bc7b0
  
          public Block getBlock() {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
-index c2e3df8331cec5fe5650501a4dc4ac47f23ef11b..5afb598d288d32877834cfb7d9796b334767286d 100644
+index c3f1334b2bb97f0633f3ea43b97ee49adfd8bc0d..b0c9fce9d4e06cac139e341d218d0b6aac1f1943 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
 @@ -46,6 +46,110 @@ public class LevelChunkSection {

--- a/patches/server/0803-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/patches/server/0803-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimise collision checking in player move packet handling
 Move collision logic to just the hasNewCollision call instead of getCubes + hasNewCollision
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8668da69741354a4908179935ec5fb164d8fce0f..5927035f616f341f1d28b569efaf7812e4aa6880 100644
+index d29d71a100967d2cd411b78f55560617d598db52..a84ab1754ffee0436ac3abf05e3fd69f3523e5e6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -614,7 +614,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0804-Actually-unload-POI-data.patch
+++ b/patches/server/0804-Actually-unload-POI-data.patch
@@ -10,7 +10,7 @@ This patch also prevents the saving/unloading of POI data when
 world saving is disabled.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 457cd717d6fce598d4cfc41ea59af601ce2c0a85..4f6473398edd9987dfbb6cef79ed1bc93c3dd809 100644
+index d5c3bd389d36f4d8be167bd6a9a15c329b0fb453..4cbe5dbb1909de40153e3757cfff8d8c36cf66f3 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -869,6 +869,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0806-Update-Log4j.patch
+++ b/patches/server/0806-Update-Log4j.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Update Log4j
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 1c350424d0903f0caa9ef688abf8a6c51f22fdbd..16998a864e1c82bf4c1e1e08c0ebeb820ff33e59 100644
+index fb6bfd4967b4ec113463cfaa77e621183f93e441..effc19371309a1af44e1b660b547b58530a8df3c 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -20,10 +20,11 @@ dependencies {

--- a/patches/server/0813-Entity-powdered-snow-API.patch
+++ b/patches/server/0813-Entity-powdered-snow-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity powdered snow API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index ad3d005992d7f79b4c756410b063427acaddfbc5..4ab2b20529acb61baca3878281258ba0818b8479 100644
+index ff8562821ebb363c755e9d316679226d9febe54f..e12dcc33e859950efec36b91ad9a43e435545d5b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1305,5 +1305,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0823-Validate-usernames.patch
+++ b/patches/server/0823-Validate-usernames.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Validate usernames
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 4bffd454a1403130d4454a1716aba15034ea9a95..f18c24266eecdc3d108c6523da6b75985bba291a 100644
+index c098a602ce840db0099b15bd108ea873c7f111d4..55b7e18507eb68d66b107a1716df948040e659d6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -70,6 +70,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener

--- a/patches/server/0826-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0826-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,7 +18,7 @@ index e977a523759f360854fa0a3ab8bbb956f0c0fdc2..a0f9842bce847d8ff9dfc68801804365
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8c8cb918c68215310498237e1b710fe8d2978cc2..78b7f103f30545bf6dc12c282888c673c841a80e 100644
+index df17cd9332d9f9e86480714d161be246fb16af56..455e48b74f2e2426b811c421611b1b44daa7c49e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1210,7 +1210,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0841-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0841-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,7 +122,7 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 78b7f103f30545bf6dc12c282888c673c841a80e..987fd4e9cd63d7eb63580048c0aac4235af69a42 100644
+index 455e48b74f2e2426b811c421611b1b44daa7c49e..78adaeab6f568caa599c3edf2ad13b1db10b3b99 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1988,6 +1988,13 @@ public final class CraftServer implements Server {

--- a/patches/server/0846-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0846-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 987fd4e9cd63d7eb63580048c0aac4235af69a42..d0a436d38231ee8871b92d7c60e53b96db39466e 100644
+index 78adaeab6f568caa599c3edf2ad13b1db10b3b99..5401d612d440fc63774b4dcfb41e3428d2fcce6b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2162,6 +2162,8 @@ public final class CraftServer implements Server {

--- a/patches/server/0847-Add-GameEvent-tags.patch
+++ b/patches/server/0847-Add-GameEvent-tags.patch
@@ -45,7 +45,7 @@ index 0000000000000000000000000000000000000000..cb78a3d4e21376ea24347187478525d5
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d0a436d38231ee8871b92d7c60e53b96db39466e..18d2af6cfb4133663d20bb80ece85bc92d97ef22 100644
+index 5401d612d440fc63774b4dcfb41e3428d2fcce6b..5cca8ffd11e5d9ab899c7dd75487a41b9f0bb3b8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2568,6 +2568,15 @@ public final class CraftServer implements Server {

--- a/patches/server/0848-Execute-chunk-tasks-fairly-for-worlds-while-waiting-.patch
+++ b/patches/server/0848-Execute-chunk-tasks-fairly-for-worlds-while-waiting-.patch
@@ -9,7 +9,7 @@ This might result in chunks loading far slower in the nether,
 for example.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b0300d08475b4377e26bd5c9c432b554849b452a..9c215a77ca24ab2c75709c867c1d92ad7c97f1ea 100644
+index a0f9842bce847d8ff9dfc68801804365ac12e265..c0139fe1e4edf6e8bc2d0a4988da1567e7967fca 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1312,6 +1312,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/0853-Option-to-have-default-CustomSpawners-in-custom-worl.patch
+++ b/patches/server/0853-Option-to-have-default-CustomSpawners-in-custom-worl.patch
@@ -10,7 +10,7 @@ just looking at the LevelStem key, look at the DimensionType key which
 is one level below that. Defaults to off to keep vanilla behavior.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9c215a77ca24ab2c75709c867c1d92ad7c97f1ea..38e41238cb8629fb511f7d4ba35665c1c41c3c5d 100644
+index c0139fe1e4edf6e8bc2d0a4988da1567e7967fca..4c04c4b65039219be62e8a742fdf6789efa80e87 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -586,7 +586,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/0854-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0854-Put-world-into-worldlist-before-initing-the-world.patch
@@ -23,7 +23,7 @@ index 4c04c4b65039219be62e8a742fdf6789efa80e87..7bcfb1420e67f941df4dd39a3b94c02f
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 18d2af6cfb4133663d20bb80ece85bc92d97ef22..1be97337e241e9321fbb16ca9da42400614978a3 100644
+index 5cca8ffd11e5d9ab899c7dd75487a41b9f0bb3b8..5f0ee7f4e65408c5679e36985ebd23656cf91700 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1239,10 +1239,11 @@ public final class CraftServer implements Server {

--- a/patches/server/0856-Custom-Potion-Mixes.patch
+++ b/patches/server/0856-Custom-Potion-Mixes.patch
@@ -164,7 +164,7 @@ index 3d688e334c7287f41460bd866bfd1155e8bb55d2..55006724ccec9f3de828ec18693728e9
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1be97337e241e9321fbb16ca9da42400614978a3..fb24f97626706f509c38ee4c759666d71bb479cf 100644
+index 5f0ee7f4e65408c5679e36985ebd23656cf91700..749a551149bad76dd1e037100eb3ebee519793c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -283,6 +283,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0885-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0885-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Pass ServerLevel for gamerule callbacks
 
 
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 83cc8db3ca76898f88a56c27c2b6fde6006723ba..aea18838a17fc52e1bf8cd84cd185565e6e2246d 100644
+index 2cc45ec6a5f0b0d5c1ba44551d9a126176dfa8f6..b42327dcf0cc9feaf4fdb67de949dd36cf71bbaa 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -309,7 +309,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface

--- a/patches/server/0889-Trigger-bee_nest_destroyed-trigger-in-the-correct-pl.patch
+++ b/patches/server/0889-Trigger-bee_nest_destroyed-trigger-in-the-correct-pl.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Trigger bee_nest_destroyed trigger in the correct place
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 4d907501dfe7f1a4641542291f4abdd05cb1644c..7572f6d03d315ab4639be211c5ffc7682b326362 100644
+index 1ad1f958a9b6e1bc21f1c505aa7ea54950de6cad..9378e83a67a70dbb1fb4f05b33f1e553d008e62b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -419,12 +419,16 @@ public class ServerPlayerGameMode {

--- a/patches/server/0900-Sanitize-Sent-BlockEntity-NBT.patch
+++ b/patches/server/0900-Sanitize-Sent-BlockEntity-NBT.patch
@@ -18,7 +18,7 @@ index 12d7cb0eb485987d245454fa2d9fef67ea7e9c76..b1e326cf4f7fe447f81b588dcb0eda9a
  
      public static ClientboundBlockEntityDataPacket create(BlockEntity blockEntity) {
 diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
-index 0016d99020d9e9ef9cf0763b81e33be571d511ac..b606f73cd5778c5b987ba4be57667ca1800a3f68 100644
+index 2b35059cfe7a27238e0a74df058733897a26ac1c..76b6437a1d807c7e1b673f8feeed1f171ee9a803 100644
 --- a/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
 +++ b/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
 @@ -183,6 +183,7 @@ public class ClientboundLevelChunkPacketData {

--- a/patches/server/0913-Fix-MC-252439.patch
+++ b/patches/server/0913-Fix-MC-252439.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix MC-252439
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/ZombieVillager.java b/src/main/java/net/minecraft/world/entity/monster/ZombieVillager.java
-index 473f2b7027e7889c5ce502622652a1602a19f64e..0a4c1818f93894b4b6f953a0de91543749a6d22a 100644
+index 05cf30e6572c9bb7e11d71de1cd79df987bf062a..cff0ed9ae6e79f84870343e43574f384dd73ea88 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/ZombieVillager.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/ZombieVillager.java
 @@ -266,6 +266,7 @@ public class ZombieVillager extends Zombie implements VillagerDataHolder {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
d90bdc08 PR-771: Throw IllegalAccessException with non-static getHandlerList