### PR TITLE
Add yaw and pitch to CommandSourceStack#getBukkitLocation()

### DIFF
--- a/patches/server/0298-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0298-Implement-Brigadier-Mojang-API.patch
@@ -22,7 +22,7 @@ index 6dbac0f93481256dd57e76630ae9eea9d5c56849..e260462933a9f7065b2360e6bf9e4ee5
      implementation("org.jline:jline-terminal-jansi:3.21.0")
      implementation("net.minecrell:terminalconsoleappender:1.3.0")
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index cd7c33862c7e2e3895efce8a9675aa6a07a8053f..0b8d8b9875acf4c0a6bd47941ff57d01285dd507 100644
+index cd7c33862c7e2e3895efce8a9675aa6a07a8053f..08cdd5807237c709accc989718178bc25428eb74 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 @@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec2;
@@ -34,7 +34,7 @@ index cd7c33862c7e2e3895efce8a9675aa6a07a8053f..0b8d8b9875acf4c0a6bd47941ff57d01
  
      public static final SimpleCommandExceptionType ERROR_NOT_PLAYER = new SimpleCommandExceptionType(Component.translatable("permissions.requires.player"));
      public static final SimpleCommandExceptionType ERROR_NOT_ENTITY = new SimpleCommandExceptionType(Component.translatable("permissions.requires.entity"));
-@@ -163,6 +163,25 @@ public class CommandSourceStack implements SharedSuggestionProvider {
+@@ -163,6 +163,26 @@ public class CommandSourceStack implements SharedSuggestionProvider {
          return this.entity != null ? this.entity.asChatSender() : ChatSender.system(this.getDisplayName());
      }
  
@@ -53,7 +53,8 @@ index cd7c33862c7e2e3895efce8a9675aa6a07a8053f..0b8d8b9875acf4c0a6bd47941ff57d01
 +    public org.bukkit.Location getBukkitLocation() {
 +        Vec3 pos = getPosition();
 +        org.bukkit.World world = getBukkitWorld();
-+        return world != null && pos != null ? new org.bukkit.Location(world, pos.x, pos.y, pos.z) : null;
++        Vec2 rot = getRotation();
++        return world != null && pos != null ? new org.bukkit.Location(world, pos.x, pos.y, pos.z, rot != null ? rot.x : 0, rot != null ? rot.y : 0) : null;
 +    }
 +    // Paper end
 +

--- a/patches/server/0466-Thread-Safe-Vanilla-Command-permission-checking.patch
+++ b/patches/server/0466-Thread-Safe-Vanilla-Command-permission-checking.patch
@@ -26,7 +26,7 @@ index a4f97c1df86c574af9b9824a38034a3d76d6e357..d65defd5fc54086a969c568b93dfb05f
          }
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index 0b8d8b9875acf4c0a6bd47941ff57d01285dd507..3ad9f1327cd99e16e8eca86d72cb8a57f28b245e 100644
+index 08cdd5807237c709accc989718178bc25428eb74..c948b9387e14d7f8bb2cd6236f513d57286d9301 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 @@ -55,7 +55,7 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
@@ -38,7 +38,7 @@ index 0b8d8b9875acf4c0a6bd47941ff57d01285dd507..3ad9f1327cd99e16e8eca86d72cb8a57
  
      public CommandSourceStack(CommandSource output, Vec3 pos, Vec2 rot, ServerLevel world, int level, String name, Component displayName, MinecraftServer server, @Nullable Entity entity) {
          this(output, pos, rot, world, level, name, displayName, server, entity, false, (commandcontext, flag, j) -> {
-@@ -185,9 +185,11 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
+@@ -186,9 +186,11 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
      @Override
      public boolean hasPermission(int level) {
          // CraftBukkit start

--- a/patches/server/0815-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/patches/server/0815-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -10,10 +10,10 @@ when if this was fixed on the client, that wouldn't be needed.
 Mojira Issue: https://bugs.mojang.com/browse/MC-235045
 
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index 3ad9f1327cd99e16e8eca86d72cb8a57f28b245e..0148cadbeb41a882a05d982f0b34770b2829a04a 100644
+index c948b9387e14d7f8bb2cd6236f513d57286d9301..8762a5d88e80bb68872652a4490e76a669e17c22 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-@@ -366,4 +366,20 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
+@@ -367,4 +367,20 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
          return this.source.getBukkitSender(this);
      }
      // CraftBukkit end


### PR DESCRIPTION
The location of a CommandSourceStack can have a rotation (yaw and pitch) in addition to the position. Actually the returned Location is always facing yaw=pitch=0 and we cannot use this to calculate something like local coordinates (local coordinates is a simple example, but it's maybe better to have a clean Location with the entire information).

Notice that :
• CommandSourceStack#getRotation() is usually not null but I followed the same idea of getPosition null check.
• We may improve the code by removing one of the two `rot != null`, however, *getBukkitLocation* is hardly ever used so the gain is negligible (and we get less char to add in the patch).