### PR TITLE
Separate Command Sending to Separate Thread Pool

### DIFF
--- a/patches/server/0297-Async-command-map-building.patch
+++ b/patches/server/0297-Async-command-map-building.patch
@@ -5,36 +5,39 @@ Subject: [PATCH] Async command map building
 
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 2bf67468a6c745bc6243c65210477ba129bfcb07..685e04b1f17938d49cd126bcfe2f488f21afbea2 100644
+index 2bf67468a6c745bc6243c65210477ba129bfcb07..91b32a4856a4c9d6dc12871ed080f7a67311ead0 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -34,6 +34,7 @@ import net.minecraft.network.chat.ComponentUtils;
- import net.minecraft.network.chat.HoverEvent;
- import net.minecraft.network.chat.MutableComponent;
- import net.minecraft.network.protocol.game.ClientboundCommandsPacket;
-+import net.minecraft.server.MinecraftServer;
- import net.minecraft.server.commands.AdvancementCommands;
- import net.minecraft.server.commands.AttributeCommand;
- import net.minecraft.server.commands.BanIpCommands;
-@@ -360,6 +361,12 @@ public class Commands {
+@@ -360,6 +360,23 @@ public class Commands {
          if ( org.spigotmc.SpigotConfig.tabComplete < 0 ) return; // Spigot
          // CraftBukkit start
          // Register Vanilla commands into builtRoot as before
 +        // Paper start - Async command map building
-+        net.minecraft.server.MCUtil.scheduleAsyncTask(() -> this.sendAsync(player));
++        COMMAND_SENDING_POOL.execute(() -> {
++                this.sendAsync(player);
++        });
 +    }
++
++    public static final java.util.concurrent.ThreadPoolExecutor COMMAND_SENDING_POOL = new java.util.concurrent.ThreadPoolExecutor(
++        0, 2, 60L, java.util.concurrent.TimeUnit.SECONDS,
++        new java.util.concurrent.LinkedBlockingQueue<>(),
++        new com.google.common.util.concurrent.ThreadFactoryBuilder()
++            .setNameFormat("Paper Async Command Builder Thread Pool - %1$d")
++            .setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER))
++            .build()
++    );
 +
 +    private void sendAsync(ServerPlayer player) {
 +        // Paper end - Async command map building
          Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> map = Maps.newIdentityHashMap(); // Use identity to prevent aliasing issues
          RootCommandNode vanillaRoot = new RootCommandNode();
  
-@@ -377,7 +384,14 @@ public class Commands {
+@@ -377,7 +394,14 @@ public class Commands {
          for (CommandNode node : rootcommandnode.getChildren()) {
              bukkit.add(node.getName());
          }
 +        // Paper start - Async command map building
-+        MinecraftServer.getServer().execute(() -> {
++        net.minecraft.server.MinecraftServer.getServer().execute(() -> {
 +           runSync(player, bukkit, rootcommandnode);
 +        });
 +    }
@@ -44,3 +47,15 @@ index 2bf67468a6c745bc6243c65210477ba129bfcb07..685e04b1f17938d49cd126bcfe2f488f
          PlayerCommandSendEvent event = new PlayerCommandSendEvent(player.getBukkitEntity(), new LinkedHashSet<>(bukkit));
          event.getPlayer().getServer().getPluginManager().callEvent(event);
  
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 89c0c0d0d3458f38a1a0b91617b84f439af667c8..6f6125c3896fb388e0840d3e224b826bfa10eec0 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -879,6 +879,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         }
+ 
+         MinecraftServer.LOGGER.info("Stopping server");
++        Commands.COMMAND_SENDING_POOL.shutdownNow(); // Paper - Shutdown and don't bother finishing
+         MinecraftTimings.stopServer(); // Paper
+         // CraftBukkit start
+         if (this.server != null) {

--- a/patches/server/0297-Async-command-map-building.patch
+++ b/patches/server/0297-Async-command-map-building.patch
@@ -3,6 +3,10 @@ From: Callahan <mr.callahhh@gmail.com>
 Date: Wed, 8 Apr 2020 02:42:14 -0500
 Subject: [PATCH] Async command map building
 
+This adds a custom pool inorder to make sure that they are closed
+without much though, as it doesn't matter if the client is not sent
+commands if the server is restarting. Using the default async pool caused issues to arise
+due to the shutdown logic generally being much later.
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
 index 2bf67468a6c745bc6243c65210477ba129bfcb07..91b32a4856a4c9d6dc12871ed080f7a67311ead0 100644

--- a/patches/server/0298-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0298-Implement-Brigadier-Mojang-API.patch
@@ -34,7 +34,7 @@ index da6250df1c5f3385b683cffde47754bca4606f5e..3384501f83d445f45aa8233e98c7597d
      public void removeCommand(String name) {
          this.children.remove(name);
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index a749ea8578fc8baeebd359e0275f1c3089beec13..981f08a537253516a6ce8b78f6cd04d7e5e1b546 100644
+index 3308d684fc6cd0a83e190a52693b29d30e0087cb..aadddbc16aa719677c3b6fc4969b6145b9b9ee0b 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 @@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec2;
@@ -74,18 +74,18 @@ index a749ea8578fc8baeebd359e0275f1c3089beec13..981f08a537253516a6ce8b78f6cd04d7
      public boolean hasPermission(int level) {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 685e04b1f17938d49cd126bcfe2f488f21afbea2..d4e3dc8d67006dcff2a64d03c29ffc9414557017 100644
+index 91b32a4856a4c9d6dc12871ed080f7a67311ead0..0efb172c31a211e03d5fd922f65b6feff1317381 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -385,6 +385,7 @@ public class Commands {
+@@ -395,6 +395,7 @@ public class Commands {
              bukkit.add(node.getName());
          }
          // Paper start - Async command map building
 +        new com.destroystokyo.paper.event.brigadier.AsyncPlayerSendCommandsEvent<CommandSourceStack>(player.getBukkitEntity(), (RootCommandNode) rootcommandnode, false).callEvent(); // Paper
-         MinecraftServer.getServer().execute(() -> {
+         net.minecraft.server.MinecraftServer.getServer().execute(() -> {
             runSync(player, bukkit, rootcommandnode);
          });
-@@ -392,6 +393,7 @@ public class Commands {
+@@ -402,6 +403,7 @@ public class Commands {
  
      private void runSync(ServerPlayer player, Collection<String> bukkit, RootCommandNode<SharedSuggestionProvider> rootcommandnode) {
          // Paper end - Async command map building
@@ -93,7 +93,7 @@ index 685e04b1f17938d49cd126bcfe2f488f21afbea2..d4e3dc8d67006dcff2a64d03c29ffc94
          PlayerCommandSendEvent event = new PlayerCommandSendEvent(player.getBukkitEntity(), new LinkedHashSet<>(bukkit));
          event.getPlayer().getServer().getPluginManager().callEvent(event);
  
-@@ -410,6 +412,11 @@ public class Commands {
+@@ -420,6 +422,11 @@ public class Commands {
  
          while (iterator.hasNext()) {
              CommandNode<CommandSourceStack> commandnode2 = (CommandNode) iterator.next();
@@ -106,7 +106,7 @@ index 685e04b1f17938d49cd126bcfe2f488f21afbea2..d4e3dc8d67006dcff2a64d03c29ffc94
  
              if (commandnode2.canUse(source)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c60baac35e4ae333971532ad2da6dd0925efc1a9..4f9adc601ccc84beaee91a6ca9d6cd2740c4416e 100644
+index 19924f3d45af6c4006bd2d921cbeab67a4846059..81c6dd957eb990708fd5f6a1b991a5e8370acf80 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -833,8 +833,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic

--- a/patches/server/0311-Server-Tick-Events.patch
+++ b/patches/server/0311-Server-Tick-Events.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Server Tick Events
 Fires event at start and end of a server tick
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1a76a4239213c7b8dc40e656164427c1c4f7c2cf..cadf93de666d9db4b08710e36d4420de312c9e2e 100644
+index 6f6125c3896fb388e0840d3e224b826bfa10eec0..8c48544daae0f18a39511df12f7066fc0e383d2c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1307,6 +1307,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1308,6 +1308,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          });
          isOversleep = false;MinecraftTimings.serverOversleep.stopTiming();
          // Paper end
@@ -17,7 +17,7 @@ index 1a76a4239213c7b8dc40e656164427c1c4f7c2cf..cadf93de666d9db4b08710e36d4420de
  
          ++this.tickCount;
          this.tickChildren(shouldKeepTicking);
-@@ -1345,6 +1346,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1346,6 +1347,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.runAllTasks();
          }
          // Paper end

--- a/patches/server/0318-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0318-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -16,10 +16,10 @@ handling that should have been handled synchronously will be handled
 synchronously when the server gets shut down.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index cadf93de666d9db4b08710e36d4420de312c9e2e..4a1a3fd8a6f5b9008cfdad6cb1b20393f8a20530 100644
+index 8c48544daae0f18a39511df12f7066fc0e383d2c..49fe89baab93ae99a990684d78c5c05a223282c1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2310,7 +2310,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2311,7 +2311,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      // CraftBukkit start
      @Override
      public boolean isSameThread() {

--- a/patches/server/0339-Optimize-Hoppers.patch
+++ b/patches/server/0339-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c774a2e9b55ccb124e923102496af322a9fc1962..8be6de893f1df78afc0e2c023e548a50ff7c2629 100644
+index 5cab48d7db58446310226acfae0dc3fcc1dba920..a02b674a925f2e070ed1bd203de262b513aae0a5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1410,6 +1410,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1411,6 +1411,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper

--- a/patches/server/0373-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0373-Add-tick-times-API-and-mspt-command.patch
@@ -125,7 +125,7 @@ index 6a00f3d38da8107825ab1d405f337fd077b09f72..d31b5ed47cffc61c90c926a0cd2005b7
  
      public static void registerCommands(final MinecraftServer server) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e8b826e431229b80fbba2bcdaed2105e6a9bcbdd..7b646a46d561c3cdb03a488d691e811d40684417 100644
+index 181e35da5919ba3b91246b427f2c5773acf1dd12..0612bf8ecc6e1b76d728fea852e850abc1702edf 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -237,6 +237,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -140,7 +140,7 @@ index e8b826e431229b80fbba2bcdaed2105e6a9bcbdd..7b646a46d561c3cdb03a488d691e811d
      @Nullable
      private KeyPair keyPair;
      @Nullable
-@@ -1360,6 +1365,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1361,6 +1366,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          this.averageTickTime = this.averageTickTime * 0.8F + (float) l / 1000000.0F * 0.19999999F;
          long i1 = Util.getNanos();
  
@@ -153,7 +153,7 @@ index e8b826e431229b80fbba2bcdaed2105e6a9bcbdd..7b646a46d561c3cdb03a488d691e811d
          this.frameTimer.logFrameDuration(i1 - i);
          this.profiler.pop();
          org.spigotmc.WatchdogThread.tick(); // Spigot
-@@ -2522,4 +2533,30 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2523,4 +2534,30 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      public static record ServerResourcePackInfo(String url, String hash, boolean isRequired, @Nullable Component prompt) {
  
      }

--- a/patches/server/0385-Improved-Watchdog-Support.patch
+++ b/patches/server/0385-Improved-Watchdog-Support.patch
@@ -71,7 +71,7 @@ index 336795dff742b7c6957fbd3476aff31d25a5e659..30a58229aa6dac5039511d0c0df5f291
              cause = cause.getCause();
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d8166025ddd229c065e8c4c3082549f1716c0384..e25451056b6eedde2c5ffc281918ca13967e0a67 100644
+index 0612bf8ecc6e1b76d728fea852e850abc1702edf..40945909bbefa59da6be784bcf440dfb2075b670 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -284,7 +284,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -121,7 +121,7 @@ index d8166025ddd229c065e8c4c3082549f1716c0384..e25451056b6eedde2c5ffc281918ca13
          // CraftBukkit end
          if (this.metricsRecorder.isRecording()) {
              this.cancelRecordingMetrics();
-@@ -965,7 +982,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -966,7 +983,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.getProfileCache().save(false); // Paper
          }
          // Spigot end
@@ -140,7 +140,7 @@ index d8166025ddd229c065e8c4c3082549f1716c0384..e25451056b6eedde2c5ffc281918ca13
      }
  
      public String getLocalIp() {
-@@ -1058,6 +1086,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1059,6 +1087,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      protected void runServer() {
          try {
@@ -148,7 +148,7 @@ index d8166025ddd229c065e8c4c3082549f1716c0384..e25451056b6eedde2c5ffc281918ca13
              if (!this.initServer()) {
                  throw new IllegalStateException("Failed to initialize server");
              }
-@@ -1070,6 +1099,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1071,6 +1100,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.updateStatusIcon(this.status);
  
              // Spigot start
@@ -167,7 +167,7 @@ index d8166025ddd229c065e8c4c3082549f1716c0384..e25451056b6eedde2c5ffc281918ca13
              org.spigotmc.WatchdogThread.hasStarted = true; // Paper
              Arrays.fill( recentTps, 20 );
              long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
-@@ -1124,6 +1165,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1125,6 +1166,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  JvmProfiler.INSTANCE.onServerTick(this.averageTickTime);
              }
          } catch (Throwable throwable) {
@@ -180,7 +180,7 @@ index d8166025ddd229c065e8c4c3082549f1716c0384..e25451056b6eedde2c5ffc281918ca13
              MinecraftServer.LOGGER.error("Encountered an unexpected exception", throwable);
              // Spigot Start
              if ( throwable.getCause() != null )
-@@ -1154,14 +1201,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1155,14 +1202,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                      this.services.profileCache().clearExecutor();
                  }
  
@@ -198,7 +198,7 @@ index d8166025ddd229c065e8c4c3082549f1716c0384..e25451056b6eedde2c5ffc281918ca13
              }
  
          }
-@@ -1225,6 +1272,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1226,6 +1273,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      @Override
      public TickTask wrapRunnable(Runnable runnable) {
@@ -211,7 +211,7 @@ index d8166025ddd229c065e8c4c3082549f1716c0384..e25451056b6eedde2c5ffc281918ca13
          return new TickTask(this.tickCount, runnable);
      }
  
-@@ -1451,6 +1504,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1452,6 +1505,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  try {
                      crashreport = CrashReport.forThrowable(throwable, "Exception ticking world");
                  } catch (Throwable t) {
@@ -219,7 +219,7 @@ index d8166025ddd229c065e8c4c3082549f1716c0384..e25451056b6eedde2c5ffc281918ca13
                      throw new RuntimeException("Error generating crash report", t);
                  }
                  // Spigot End
-@@ -1926,7 +1980,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1927,7 +1981,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.packRepository.setSelected(dataPacks);
              this.worldData.setDataPackConfig(MinecraftServer.getSelectedPacks(this.packRepository));
              this.resources.managers.updateRegistryTags(this.registryAccess());
@@ -281,7 +281,7 @@ index dab266e62f837e0efe57c0c4ae33b84c553c969c..48fc5d6ca854de036013586be634b3e0
                  list.stream().map((playerchunk) -> {
                      CompletableFuture completablefuture;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index d67362983816db2b264d30b59423b05843cded16..f5f536549d7daf14ed5f678a55969c540a5dc48d 100644
+index 27dd95242c80d875de8f07e111f06e383eeec0d9..97c670508df6e5ee2a05a4765aafbeb23949b647 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -517,7 +517,7 @@ public abstract class PlayerList {
@@ -343,7 +343,7 @@ index 4b3a431701fa1e1e1595301291baccd5bafa52f6..b5ed78fa95349974c71ac7113e5f6533
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 9a5373304b445408244fe9850c10526d1df21855..0c76f2e8038bf0bc3edf464295c606acf03a8337 100644
+index 3472114c373d7b884d8ae24906e30daa039d0742..987bc4577190d827718b5144656aaddf22599cab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,6 +12,8 @@ import java.util.logging.Level;

--- a/patches/server/0407-misc-debugging-dumps.patch
+++ b/patches/server/0407-misc-debugging-dumps.patch
@@ -29,7 +29,7 @@ index 0000000000000000000000000000000000000000..2d5494d2813b773e60ddba6790b750a9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 140ff101b8568fa6df0a793e0068f59d48e91e07..d6d398ad64ec923e36155f8617aeb8d0906a9d59 100644
+index 40945909bbefa59da6be784bcf440dfb2075b670..b1f8374253d04d1468f5d57792b30f91a274b97f 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -871,6 +871,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -48,7 +48,7 @@ index 140ff101b8568fa6df0a793e0068f59d48e91e07..d6d398ad64ec923e36155f8617aeb8d0
          // Paper start - kill main thread, and kill it hard
          shutdownThread = Thread.currentThread();
          org.spigotmc.WatchdogThread.doStop(); // Paper
-@@ -1014,6 +1016,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1015,6 +1017,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      }
      public void safeShutdown(boolean flag, boolean isRestarting) {
          this.isRestarting = isRestarting;

--- a/patches/server/0417-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0417-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,10 +10,10 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index af2d703fe3cb74ced502ca89c5bf6ca1f47474bb..8e74c4b6b5186663537be304cfe462bb462e92f9 100644
+index b1f8374253d04d1468f5d57792b30f91a274b97f..b6a05542a42b1f44b3a43fbcd333003e864e44ea 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -910,6 +910,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -911,6 +911,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // CraftBukkit start
          if (this.server != null) {
              this.server.disablePlugins();

--- a/patches/server/0442-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0442-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -8,7 +8,7 @@ makes it so that the server keeps the last difficulty used instead
 of restoring the server.properties every single load.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c005fa8d71c224aa7023f01444ea5fb6353f45e0..ed65e192df03fee4ce8b91cd73201ed018cfb68f 100644
+index b6a05542a42b1f44b3a43fbcd333003e864e44ea..f2e6c5ed099a94be3aefca55cffd8e2447e39ac2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -791,7 +791,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -20,7 +20,7 @@ index c005fa8d71c224aa7023f01444ea5fb6353f45e0..ed65e192df03fee4ce8b91cd73201ed0
  
          this.forceTicks = false;
          // CraftBukkit end
-@@ -1693,11 +1693,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1694,11 +1694,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  
@@ -40,7 +40,7 @@ index c005fa8d71c224aa7023f01444ea5fb6353f45e0..ed65e192df03fee4ce8b91cd73201ed0
          }
      }
  
-@@ -1711,7 +1714,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1712,7 +1715,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
  

--- a/patches/server/0448-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0448-incremental-chunk-and-player-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] incremental chunk and player saving
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b80b2674077f23a5fe33d20e771b0e8b0968dc69..b8b82e9fe3273e3b53c4877e47b74f0db4dd8630 100644
+index f2e6c5ed099a94be3aefca55cffd8e2447e39ac2..36e0a9771705f02e67dd507f2c0c9a030f77c02a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -854,7 +854,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -17,7 +17,7 @@ index b80b2674077f23a5fe33d20e771b0e8b0968dc69..b8b82e9fe3273e3b53c4877e47b74f0d
              flag3 = this.saveAllChunks(suppressLogs, flush, force);
          } finally {
              this.isSaving = false;
-@@ -1399,13 +1399,28 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1400,13 +1400,28 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              }
          }
  
@@ -298,7 +298,7 @@ index c3db29bc1b24a976617068a4ddae062857d61097..c7221d169badfae6653d64cb39e14353
          ServerChunkCache chunkproviderserver = this.getChunkSource();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b0dffb7c7c8fece2528ac218acef428731145b92..8faa5ccd643158c59d55a6bf8e0e07a44881e6e9 100644
+index 28944fc50ea43a3ea40bd1e69c560c8fe022337e..0720b748ed42bbd2a12cc5de79224f609a5e29be 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -179,6 +179,7 @@ import org.bukkit.inventory.MainHand;
@@ -310,7 +310,7 @@ index b0dffb7c7c8fece2528ac218acef428731145b92..8faa5ccd643158c59d55a6bf8e0e07a4
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      public ServerGamePacketListenerImpl connection;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4e662c672a554528dca7cdd31ae39957288943e3..0696528f804b1b1b6e80d0bb3611725be6c8318c 100644
+index 0d86536696657ba6eee5f12d3d3afa8e5a167060..20bedb5ce597b8e3e96af910d88137e0a0b10066 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -562,6 +562,7 @@ public abstract class PlayerList {

--- a/patches/server/0493-Cache-block-data-strings.patch
+++ b/patches/server/0493-Cache-block-data-strings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Cache block data strings
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b8b82e9fe3273e3b53c4877e47b74f0db4dd8630..ff2d51aa788d8605f901fa592491b5d2d0da27d1 100644
+index 36e0a9771705f02e67dd507f2c0c9a030f77c02a..f3d51b83acab0e10a1dd2c9ab7e64b0188a1a7f7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2015,6 +2015,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2016,6 +2016,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.getPlayerList().reloadResources();
              this.functionManager.replaceLibrary(this.resources.managers.getFunctionLibrary());
              this.structureTemplateManager.onResourceManagerReload(this.resources.resourceManager);

--- a/patches/server/0502-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
+++ b/patches/server/0502-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix deop kicking non-whitelisted player when white list is
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ff2d51aa788d8605f901fa592491b5d2d0da27d1..6fd6d2a4faf8e72511170fb3c3aa80733ed0e8d9 100644
+index f3d51b83acab0e10a1dd2c9ab7e64b0188a1a7f7..52a60c887753fce32f99adaee8b73077bde663e9 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2081,13 +2081,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2082,13 +2082,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          if (this.isEnforceWhitelist()) {
              PlayerList playerlist = source.getServer().getPlayerList();
              UserWhiteList whitelist = playerlist.getWhiteList();

--- a/patches/server/0558-Added-ServerResourcesReloadedEvent.patch
+++ b/patches/server/0558-Added-ServerResourcesReloadedEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added ServerResourcesReloadedEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 6fd6d2a4faf8e72511170fb3c3aa80733ed0e8d9..04be281c3862707055b143267186169205720ab2 100644
+index 52a60c887753fce32f99adaee8b73077bde663e9..e72af8f8c49dabcbe1d0a80176520ccdb55b1f5b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1977,7 +1977,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1978,7 +1978,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          return this.functionManager;
      }
  
@@ -22,7 +22,7 @@ index 6fd6d2a4faf8e72511170fb3c3aa80733ed0e8d9..04be281c3862707055b1432671861692
          RegistryAccess.Frozen iregistrycustom_dimension = this.registryAccess();
          CompletableFuture<Void> completablefuture = CompletableFuture.supplyAsync(() -> {
              Stream<String> stream = dataPacks.stream(); // CraftBukkit - decompile error
-@@ -2003,6 +2009,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2004,6 +2010,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.packRepository.setSelected(dataPacks);
              this.worldData.setDataPackConfig(MinecraftServer.getSelectedPacks(this.packRepository));
              this.resources.managers.updateRegistryTags(this.registryAccess());

--- a/patches/server/0564-Empty-commands-shall-not-be-dispatched.patch
+++ b/patches/server/0564-Empty-commands-shall-not-be-dispatched.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Empty commands shall not be dispatched
 
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 54bf5558c9048c215aee518874f3d96ab473beb6..d6da53fffd7c0a5a971e4510b7d433ea2cca06d2 100644
+index 0efb172c31a211e03d5fd922f65b6feff1317381..52d2c8d451dce33a5a62f3ec3c5add65a80ce9ca 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -246,6 +246,7 @@ public class Commands {
+@@ -245,6 +245,7 @@ public class Commands {
          command = event.getCommand();
  
          String[] args = command.split(" ");

--- a/patches/server/0569-Add-PaperRegistry.patch
+++ b/patches/server/0569-Add-PaperRegistry.patch
@@ -193,10 +193,10 @@ index 0000000000000000000000000000000000000000..6f39e343147803e15e7681c993b8797a
 +public record RegistryKey<API extends Keyed, MINECRAFT>(Class<API> apiClass, ResourceKey<? extends Registry<MINECRAFT>> resourceKey) {
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 04be281c3862707055b143267186169205720ab2..ea98c98e4449451895c6d91481ace6908c206f45 100644
+index e72af8f8c49dabcbe1d0a80176520ccdb55b1f5b..9484e447959a9c25ac6ef318be1569d236b5915d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2009,6 +2009,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2010,6 +2010,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.packRepository.setSelected(dataPacks);
              this.worldData.setDataPackConfig(MinecraftServer.getSelectedPacks(this.packRepository));
              this.resources.managers.updateRegistryTags(this.registryAccess());
@@ -205,7 +205,7 @@ index 04be281c3862707055b143267186169205720ab2..ea98c98e4449451895c6d91481ace690
              // Paper start
              if (Thread.currentThread() != this.serverThread) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 9f08928bdfc1644b7f902c1685c3324d6ee896c1..87cfa45371a8b1c169a31211e2d468377112d47d 100644
+index 3f45ebeb31264f5f9a99123894fe07bd8e4c65d8..dc034bd793842e02f0fea54d1ae49ac7a66af597 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -512,6 +512,11 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0583-EntityMoveEvent.patch
+++ b/patches/server/0583-EntityMoveEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] EntityMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ea98c98e4449451895c6d91481ace6908c206f45..e4f1ceb934917804fc415d3d06ebf9d093a44f7d 100644
+index 9484e447959a9c25ac6ef318be1569d236b5915d..75cd5667eb0f047cdec56b4131dcd1c4f22d4067 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1494,6 +1494,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1495,6 +1495,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper

--- a/patches/server/0591-Add-support-for-hex-color-codes-in-console.patch
+++ b/patches/server/0591-Add-support-for-hex-color-codes-in-console.patch
@@ -282,10 +282,10 @@ index 0000000000000000000000000000000000000000..b4d0b7ecd56ab952319946854168c129
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e4f1ceb934917804fc415d3d06ebf9d093a44f7d..1387ed71ff09b834361e415e5fc78786f68dd371 100644
+index 75cd5667eb0f047cdec56b4131dcd1c4f22d4067..af21aa771d90ea47cc23457711a17b69e7b56e9a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1671,7 +1671,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1672,7 +1672,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      @Override
      public void sendSystemMessage(Component message) {

--- a/patches/server/0610-forced-whitelist-use-configurable-kick-message.patch
+++ b/patches/server/0610-forced-whitelist-use-configurable-kick-message.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] forced whitelist: use configurable kick message
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1387ed71ff09b834361e415e5fc78786f68dd371..cefa833408ff95890dc5c831276f259022bd95a3 100644
+index af21aa771d90ea47cc23457711a17b69e7b56e9a..486acce909cdd2cacc5f2bb9eab1a600152f9971 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2098,7 +2098,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2099,7 +2099,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  ServerPlayer entityplayer = (ServerPlayer) iterator.next();
  
                  if (!whitelist.isWhiteListed(entityplayer.getGameProfile()) && !this.getPlayerList().isOp(entityplayer.getGameProfile())) { // Paper - Fix kicking ops when whitelist is reloaded (MC-171420)

--- a/patches/server/0632-Send-empty-commands-if-tab-completion-is-disabled.patch
+++ b/patches/server/0632-Send-empty-commands-if-tab-completion-is-disabled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Send empty commands if tab completion is disabled
 
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index d6da53fffd7c0a5a971e4510b7d433ea2cca06d2..edf980cf8992ddfe003ced279fe1324fc2364e5a 100644
+index 52d2c8d451dce33a5a62f3ec3c5add65a80ce9ca..884a7c3a082140d2e1d154851c534ab09f5da4ce 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -359,7 +359,12 @@ public class Commands {
+@@ -358,7 +358,12 @@ public class Commands {
      }
  
      public void sendCommands(ServerPlayer player) {

--- a/patches/server/0655-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0655-Add-PlayerKickEvent-causes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 3f4a2a17790cad61218dcff351d70a2cc50cb56a..660e1b6955115d67cb37161ef556f90acc53bdfa 100644
+index 749421b638bbb5868a426888e42edc461ad0edf3..4f14a5d9b9b14727021fcb2491c15b9978f17f10 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2101,7 +2101,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2102,7 +2102,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  ServerPlayer entityplayer = (ServerPlayer) iterator.next();
  
                  if (!whitelist.isWhiteListed(entityplayer.getGameProfile()) && !this.getPlayerList().isOp(entityplayer.getGameProfile())) { // Paper - Fix kicking ops when whitelist is reloaded (MC-171420)
@@ -391,7 +391,7 @@ index 63f92d68b91f1049802a1541c7ec4efaa324ac11..c332750833cccee1264a3399ed0539f6
          // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7d030d7a8a58f4a031e09d09c9718af3d3c1e707..140730ff3e10066d19321c75e241a1e0d8d3ba17 100644
+index b7803148a96bdf69e1208105ee0ddecf6d9662f0..bf5931cbcfbfdc6e68706b7e86b24b2478e4bbef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -516,7 +516,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0718-Vanilla-command-permission-fixes.patch
+++ b/patches/server/0718-Vanilla-command-permission-fixes.patch
@@ -30,10 +30,10 @@ index 899008b2980d13f1be6280cd8cb959c53a29bebf..f875507241ac6769545e91cd3285232b
      private RedirectModifier<S> modifier = null;
      private boolean forks;
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index edf980cf8992ddfe003ced279fe1324fc2364e5a..e70e5af7e49e4ccf332d9ce44e1a106344b35490 100644
+index 884a7c3a082140d2e1d154851c534ab09f5da4ce..6d480d0332ee9348eacc3269890ee49206623c2a 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -213,7 +213,13 @@ public class Commands {
+@@ -212,7 +212,13 @@ public class Commands {
          if (environment.includeIntegrated) {
              PublishCommand.register(this.dispatcher);
          }

--- a/patches/server/0736-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0736-Execute-chunk-tasks-mid-tick.patch
@@ -19,10 +19,10 @@ index 23e564b05ba438924180c91f9b19a60731eedd1b..5ec241d49ff5e3a161a39006f05823a5
  
      private MinecraftTimings() {}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 660e1b6955115d67cb37161ef556f90acc53bdfa..621956c024d64bcaa868e0bb01c485fe4ac11df3 100644
+index 4f14a5d9b9b14727021fcb2491c15b9978f17f10..2d94390e3b9fa3afd2471cc691d59de0f470b46c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1303,6 +1303,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1304,6 +1304,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      private boolean pollTaskInternal() {
          if (super.pollTask()) {
@@ -30,7 +30,7 @@ index 660e1b6955115d67cb37161ef556f90acc53bdfa..621956c024d64bcaa868e0bb01c485fe
              return true;
          } else {
              if (this.haveTime()) {
-@@ -2658,4 +2659,74 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2659,4 +2660,74 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
      // Paper end

--- a/patches/server/0814-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/patches/server/0814-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -10,7 +10,7 @@ when if this was fixed on the client, that wouldn't be needed.
 Mojira Issue: https://bugs.mojang.com/browse/MC-235045
 
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index b14773074fc4b10ef427eb0ad9e21601a7287901..e0dd0fc1638377f4d4226d4b2976b901d635dff0 100644
+index 6fdbe747645eb83f31b56bca77a9d7962237aed8..dd0143f319d4adef8834c513af34b1cce7a94a84 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 @@ -412,4 +412,20 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
@@ -35,10 +35,10 @@ index b14773074fc4b10ef427eb0ad9e21601a7287901..e0dd0fc1638377f4d4226d4b2976b901
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 8380ab300e192064735fcb54c61951522dec8511..e998b01faa9c1d2e5f0fd91f0afdb24d56e03712 100644
+index 6d480d0332ee9348eacc3269890ee49206623c2a..584d2539d715fef26a2d01f014c7c3f4f8ce8fd9 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -422,6 +422,7 @@ public class Commands {
+@@ -432,6 +432,7 @@ public class Commands {
      private void fillUsableCommands(CommandNode<CommandSourceStack> tree, CommandNode<SharedSuggestionProvider> result, CommandSourceStack source, Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> resultNodes) {
          Iterator iterator = tree.getChildren().iterator();
  
@@ -46,7 +46,7 @@ index 8380ab300e192064735fcb54c61951522dec8511..e998b01faa9c1d2e5f0fd91f0afdb24d
          while (iterator.hasNext()) {
              CommandNode<CommandSourceStack> commandnode2 = (CommandNode) iterator.next();
              // Paper start
-@@ -448,6 +449,12 @@ public class Commands {
+@@ -458,6 +459,12 @@ public class Commands {
  
                      if (requiredargumentbuilder.getSuggestionsProvider() != null) {
                          requiredargumentbuilder.suggests(SuggestionProviders.safelySwap(requiredargumentbuilder.getSuggestionsProvider()));

--- a/patches/server/0846-Execute-chunk-tasks-fairly-for-worlds-while-waiting-.patch
+++ b/patches/server/0846-Execute-chunk-tasks-fairly-for-worlds-while-waiting-.patch
@@ -9,10 +9,10 @@ This might result in chunks loading far slower in the nether,
 for example.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index beaefa13a4635a69d06f652a9ec506072490fd19..ae59d5533a0eb2c427433042512fc560af99940d 100644
+index a4433426efd0823cd8145a50b38127f63e90adc9..1444391ded50ec10e9bfeb073b01c885c429b8bd 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1313,6 +1313,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1314,6 +1314,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.executeMidTickTasks(); // Paper - execute chunk tasks mid tick
              return true;
          } else {
@@ -20,7 +20,7 @@ index beaefa13a4635a69d06f652a9ec506072490fd19..ae59d5533a0eb2c427433042512fc560
              if (this.haveTime()) {
                  Iterator iterator = this.getAllLevels().iterator();
  
-@@ -1320,12 +1321,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1321,12 +1322,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                      ServerLevel worldserver = (ServerLevel) iterator.next();
  
                      if (worldserver.getChunkSource().pollTask()) {

--- a/patches/server/0854-Custom-Potion-Mixes.patch
+++ b/patches/server/0854-Custom-Potion-Mixes.patch
@@ -24,10 +24,10 @@ index 0000000000000000000000000000000000000000..6b0bed550763f34e18c9e92f9a47ec0c
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d18ce42b02076aac74c9f272e5ee03293810e702..025f033ce7816fd32eb2d7d3f3cba0c8468ffd38 100644
+index cd1edd0cb404cab5e71efdb82f3b911c2fe96d01..dca520534feac302b8e0f389ee9286bd719e31a6 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2032,6 +2032,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2033,6 +2033,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.worldData.setDataPackConfig(MinecraftServer.getSelectedPacks(this.packRepository));
              this.resources.managers.updateRegistryTags(this.registryAccess());
              io.papermc.paper.registry.PaperRegistry.clearCaches(); // Paper

--- a/patches/server/0861-Fix-save-problems-on-shutdown.patch
+++ b/patches/server/0861-Fix-save-problems-on-shutdown.patch
@@ -12,10 +12,10 @@ Subject: [PATCH] Fix save problems on shutdown
   processed so that the main process queue can be drained
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 025f033ce7816fd32eb2d7d3f3cba0c8468ffd38..6ff1c5be14332404ae76da1695ce1d494c94bd7c 100644
+index dca520534feac302b8e0f389ee9286bd719e31a6..33cf037bf8ed5ea88f52ee3731cde63c70e813ef 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -956,6 +956,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -957,6 +957,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              }
          }
  
@@ -29,7 +29,7 @@ index 025f033ce7816fd32eb2d7d3f3cba0c8468ffd38..6ff1c5be14332404ae76da1695ce1d49
          while (this.levels.values().stream().anyMatch((worldserver1) -> {
              return worldserver1.getChunkSource().chunkMap.hasWork();
          })) {
-@@ -968,9 +975,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -969,9 +976,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  worldserver.getChunkSource().tick(() -> {
                      return true;
                  }, false);
@@ -42,7 +42,7 @@ index 025f033ce7816fd32eb2d7d3f3cba0c8468ffd38..6ff1c5be14332404ae76da1695ce1d49
          }
  
          this.saveAllChunks(false, true, false);
-@@ -1265,6 +1274,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1266,6 +1275,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      }
  
      private boolean haveTime() {

--- a/patches/server/0901-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0901-Throw-exception-on-world-create-while-being-ticked.patch
@@ -7,7 +7,7 @@ There are no plans to support creating worlds while worlds are
 being ticked themselvess.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 6ff1c5be14332404ae76da1695ce1d494c94bd7c..f23be38ef96a81ce3867a3b6fdccf632fe285f31 100644
+index 33cf037bf8ed5ea88f52ee3731cde63c70e813ef..081c7160cf727646cdec4cd551dbc2aad56326f6 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -297,6 +297,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -18,7 +18,7 @@ index 6ff1c5be14332404ae76da1695ce1d494c94bd7c..f23be38ef96a81ce3867a3b6fdccf632
  
      public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
          AtomicReference<S> atomicreference = new AtomicReference();
-@@ -1526,6 +1527,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1527,6 +1528,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // Paper end
          MinecraftTimings.timeUpdateTimer.stopTiming(); // Spigot // Paper
  
@@ -26,7 +26,7 @@ index 6ff1c5be14332404ae76da1695ce1d494c94bd7c..f23be38ef96a81ce3867a3b6fdccf632
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper
-@@ -1573,6 +1575,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1574,6 +1576,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.profiler.pop();
              worldserver.explosionDensityCache.clear(); // Paper - Optimize explosions
          }

--- a/patches/server/0928-Fix-suggest-command-message-for-brigadier-syntax-exc.patch
+++ b/patches/server/0928-Fix-suggest-command-message-for-brigadier-syntax-exc.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix suggest command message for brigadier syntax exceptions
 This is a bug accidentally introduced in upstream CB
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index a0f5aa8c3cfce63af9cb286278a7fdebd7aa3642..fcc75660a69122eefc100e4de0a62f587bf97d7b 100644
+index 584d2539d715fef26a2d01f014c7c3f4f8ce8fd9..135b341e5b975fc542f66ef9c52e29f4c6dd4a53 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -315,7 +315,7 @@ public class Commands {
+@@ -314,7 +314,7 @@ public class Commands {
                  if (commandsyntaxexception.getInput() != null && commandsyntaxexception.getCursor() >= 0) {
                      int j = Math.min(commandsyntaxexception.getInput().length(), commandsyntaxexception.getCursor());
                      MutableComponent ichatmutablecomponent = Component.empty().withStyle(ChatFormatting.GRAY).withStyle((chatmodifier) -> {


### PR DESCRIPTION
See: https://canary.discord.com/channels/289587909051416579/925530366192779286/999447366639829093

I'm not sure if I should shutdownNow or wait, would like feedback here.
But basically, the idea is to shutdown and stop command sending from being done async and not being closed till very later in the server saving process.

There might be more as to what is causing exceptions like this, but shutting it down might be fine here? 