### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0004-Add-FastUtil-to-Bukkit.patch
+++ b/patches/api/0004-Add-FastUtil-to-Bukkit.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add FastUtil to Bukkit
 Doesn't expose to plugins, just allows Paper-API to use it for optimization
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 0b30b1f1be8818934ba530dd263fe6c9484983e8..cedf145d5024e1ed9ae0d815e7ad0afb87c9a8b0 100644
+index 8472feb05de7955999bdfbbe721f2cfb847a9019..79bf95d5a19046b142d0162dd6b739b7f0f52e59 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -18,6 +18,7 @@ dependencies {

--- a/patches/api/0026-Use-ASM-for-event-executors.patch
+++ b/patches/api/0026-Use-ASM-for-event-executors.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 237a0beff61f2384b9e9e18a9d7119fd1916e1bd..a37c830cf5eae14d906854b05564c1b4e8b3284d 100644
+index 84432bf9dd99332098f952ea777ee97d987f9eb2..47e08784c71b0e25c21bc6b15da0385e4a1806d4 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -39,6 +39,9 @@ dependencies {

--- a/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,7 +14,7 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a37c830cf5eae14d906854b05564c1b4e8b3284d..0660174a8c543b3e8ef317cfabcda88a6a53d844 100644
+index 47e08784c71b0e25c21bc6b15da0385e4a1806d4..e950bce5047552bdd3f5664eb24ce290b0a06225 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -39,6 +39,8 @@ dependencies {

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -105,7 +105,7 @@ index dc8740d5410aebaa17e014d43b7d9fb29ae2a3d0..6768ab96fa14d3e297c37fb899943b9f
  
      // Spigot start
 diff --git a/src/main/java/org/bukkit/profile/PlayerProfile.java b/src/main/java/org/bukkit/profile/PlayerProfile.java
-index 16ae1282f3178e8873483a25a5d5cce16b2c21a9..c4aa20fbb0865a0b43ece475ee115ad6a7c65a48 100644
+index fc46add38bf59dc1a04ea566fd230dcd8ae2708c..d36b3e3c7e53840132011add365ca2a26d799064 100644
 --- a/src/main/java/org/bukkit/profile/PlayerProfile.java
 +++ b/src/main/java/org/bukkit/profile/PlayerProfile.java
 @@ -16,7 +16,9 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0118-RangedEntity-API.patch
+++ b/patches/api/0118-RangedEntity-API.patch
@@ -152,10 +152,10 @@ index 818efe2a4d1ac0c4d8dca6c757850d99cdc2cb4b..10f8f6d45ae9280651c3ebddd1f90acb
      /**
       * Gets whether this snowman is in "derp mode", meaning it is not wearing a
 diff --git a/src/main/java/org/bukkit/entity/Witch.java b/src/main/java/org/bukkit/entity/Witch.java
-index b4343903b66a7fb5250c1da2e09c9e5863c20daf..aa88aede6c4e66a608a63d07bc66d60357b0bee9 100644
+index 0ebd54df0bb072df25a6ebcf137a39829cf71bf9..6618f2129e108c0a6cd15f6d0e86426021b6ff0d 100644
 --- a/src/main/java/org/bukkit/entity/Witch.java
 +++ b/src/main/java/org/bukkit/entity/Witch.java
-@@ -1,7 +1,9 @@
+@@ -1,9 +1,11 @@
  package org.bukkit.entity;
  
 +import com.destroystokyo.paper.entity.RangedEntity;
@@ -165,7 +165,9 @@ index b4343903b66a7fb5250c1da2e09c9e5863c20daf..aa88aede6c4e66a608a63d07bc66d603
   */
 -public interface Witch extends Raider {
 +public interface Witch extends Raider, RangedEntity { // Paper
- }
+ 
+     /**
+      * Gets whether the witch is drinking a potion
 diff --git a/src/main/java/org/bukkit/entity/Wither.java b/src/main/java/org/bukkit/entity/Wither.java
 index 225c65a20a3e33dfb14e108a36f2f4bc60f7920c..b86f0196e6eb8070830f63a94f732522c2a6c2f1 100644
 --- a/src/main/java/org/bukkit/entity/Wither.java

--- a/patches/api/0161-Turtle-API.patch
+++ b/patches/api/0161-Turtle-API.patch
@@ -221,10 +221,10 @@ index 0000000000000000000000000000000000000000..abeb24fccda2acfdb0dfdadacb8fe688
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Turtle.java b/src/main/java/org/bukkit/entity/Turtle.java
-index 0a4cd29930c2f1c28f5a3e6884c7dec45b5cac11..8bee07c81172e189fab9b82b398983f509099474 100644
+index 5584936158e3762d348cb2eaee2082da24ede367..aa83615a0c6565c9874c906a83cfe20c2a964b22 100644
 --- a/src/main/java/org/bukkit/entity/Turtle.java
 +++ b/src/main/java/org/bukkit/entity/Turtle.java
-@@ -1,6 +1,62 @@
+@@ -1,5 +1,8 @@
  package org.bukkit.entity;
  
 +import org.bukkit.Location;
@@ -233,10 +233,12 @@ index 0a4cd29930c2f1c28f5a3e6884c7dec45b5cac11..8bee07c81172e189fab9b82b398983f5
  /**
   * Represents a turtle.
   */
--public interface Turtle extends Animals { }
-+public interface Turtle extends Animals {
-+    // Paper start
+@@ -18,4 +21,42 @@ public interface Turtle extends Animals {
+      * @return Whether the turtle is laying an egg
+      */
+     boolean isLayingEgg();
 +
++    // Paper start
 +    /**
 +     * Get the turtle's home location
 +     *
@@ -267,24 +269,10 @@ index 0a4cd29930c2f1c28f5a3e6884c7dec45b5cac11..8bee07c81172e189fab9b82b398983f5
 +    boolean isDigging();
 +
 +    /**
-+     * Get if turtle is carrying egg
-+     *
-+     * @return True if carrying egg
-+     */
-+    boolean hasEgg();
-+
-+    /**
 +     * Set if turtle is carrying egg
 +     *
 +     * @param hasEgg True if carrying egg
 +     */
 +    void setHasEgg(boolean hasEgg);
-+
-+    /**
-+     * Returns whether the turtle is currently laying an egg.
-+     *
-+     * @return whether the turtle is laying an egg
-+     */
-+    boolean isLayingEgg();
 +    // Paper end
-+}
+ }

--- a/patches/api/0163-Add-more-Witch-API.patch
+++ b/patches/api/0163-Add-more-Witch-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add more Witch API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Witch.java b/src/main/java/org/bukkit/entity/Witch.java
-index aa88aede6c4e66a608a63d07bc66d60357b0bee9..b7f9db08fb2e4633e1dfad5c752451f6ac23d437 100644
+index 6618f2129e108c0a6cd15f6d0e86426021b6ff0d..4badeafe2f20cb123ef95897c90d5e61251cc40f 100644
 --- a/src/main/java/org/bukkit/entity/Witch.java
 +++ b/src/main/java/org/bukkit/entity/Witch.java
-@@ -2,8 +2,53 @@ package org.bukkit.entity;
+@@ -2,6 +2,11 @@ package org.bukkit.entity;
  
  import com.destroystokyo.paper.entity.RangedEntity;
  
@@ -20,15 +20,12 @@ index aa88aede6c4e66a608a63d07bc66d60357b0bee9..b7f9db08fb2e4633e1dfad5c752451f6
  /**
   * Represents a Witch
   */
- public interface Witch extends Raider, RangedEntity { // Paper
-+    // Paper start
-+    /**
-+     * Check if Witch is drinking a potion
-+     *
-+     * @return True if drinking a potion
-+     */
-+    boolean isDrinkingPotion();
+@@ -13,4 +18,37 @@ public interface Witch extends Raider, RangedEntity { // Paper
+      * @return whether the witch is drinking a potion
+      */
+     boolean isDrinkingPotion();
 +
++    // Paper start
 +    /**
 +     * Get time remaining (in ticks) the Witch is drinking a potion
 +     *
@@ -51,8 +48,7 @@ index aa88aede6c4e66a608a63d07bc66d60357b0bee9..b7f9db08fb2e4633e1dfad5c752451f6
 +     *
 +     * @return The potion the witch is drinking
 +     */
-+    @Nullable
-+    ItemStack getDrinkingPotion();
++    @Nullable ItemStack getDrinkingPotion();
 +
 +    /**
 +     * Set the potion the Witch should drink

--- a/patches/api/0166-Add-more-Zombie-API.patch
+++ b/patches/api/0166-Add-more-Zombie-API.patch
@@ -5,13 +5,14 @@ Subject: [PATCH] Add more Zombie API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Zombie.java b/src/main/java/org/bukkit/entity/Zombie.java
-index a5b20b0454af5ea78e2bb7f16a56c38670c84efb..1217576e6f08abf0175ab800cfca058d5deda116 100644
+index 336b3efaf0a8ed5a238e8b941193d690e8b72d71..227560e04854088d162b4b6ed4cd1503d55c3200 100644
 --- a/src/main/java/org/bukkit/entity/Zombie.java
 +++ b/src/main/java/org/bukkit/entity/Zombie.java
-@@ -90,4 +90,55 @@ public interface Zombie extends Monster, Ageable {
-      * @param time new conversion time
+@@ -107,4 +107,56 @@ public interface Zombie extends Monster, Ageable {
+      * @param flag Whether this zombie can break doors
       */
-     void setConversionTime(int time);
+     void setCanBreakDoors(boolean flag);
++
 +    // Paper start
 +    /**
 +     * Check if zombie is drowning

--- a/patches/api/0248-Zombie-API-breaking-doors.patch
+++ b/patches/api/0248-Zombie-API-breaking-doors.patch
@@ -5,30 +5,26 @@ Subject: [PATCH] Zombie API - breaking doors
 
 
 diff --git a/src/main/java/org/bukkit/entity/Zombie.java b/src/main/java/org/bukkit/entity/Zombie.java
-index 1217576e6f08abf0175ab800cfca058d5deda116..6eeab75e985ece3fb606551bc42b05f958da4d60 100644
+index 227560e04854088d162b4b6ed4cd1503d55c3200..bb4f55f7d42d9789737f4b83974993aa166ca950 100644
 --- a/src/main/java/org/bukkit/entity/Zombie.java
 +++ b/src/main/java/org/bukkit/entity/Zombie.java
-@@ -140,5 +140,32 @@ public interface Zombie extends Monster, Ageable {
+@@ -100,8 +100,10 @@ public interface Zombie extends Monster, Ageable {
+ 
+     /**
+      * Sets whether this zombie can break doors
+-     *
+-     * This will be ignored if the entity is a Drowned. Will also stop the action if
++     * <p>
++     * Check {@link #supportsBreakingDoors()} to see
++     * if this zombie type will even be affected by using
++     * this method. Will also stop the action if
+      * the entity is currently breaking a door.
+      *
+      * @param flag Whether this zombie can break doors
+@@ -158,5 +160,15 @@ public interface Zombie extends Monster, Ageable {
       * @param shouldBurnInDay True to burn in sunlight
       */
      void setShouldBurnInDay(boolean shouldBurnInDay);
-+
-+    /**
-+     * Check if this zombie can break doors
-+     *
-+     * @return True if zombie can break doors
-+     */
-+    boolean canBreakDoors();
-+
-+    /**
-+     * Sets if this zombie can break doors.
-+     * Check {@link #supportsBreakingDoors()} to see
-+     * if this zombie type will even be affected by using
-+     * this method.
-+     *
-+     * @param canBreakDoors True if zombie can break doors
-+     */
-+    void setCanBreakDoors(boolean canBreakDoors);
 +
 +    /**
 +     * Checks if this zombie type supports breaking doors.
@@ -36,7 +32,7 @@ index 1217576e6f08abf0175ab800cfca058d5deda116..6eeab75e985ece3fb606551bc42b05f9
 +     * so using {@link #setCanBreakDoors(boolean)} on them has
 +     * no effect.
 +     *
-+     * @return
++     * @return true if entity supports breaking doors
 +     */
 +    boolean supportsBreakingDoors();
      // Paper end

--- a/patches/api/0313-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0313-Missing-Entity-Behavior-API.patch
@@ -185,10 +185,10 @@ index 94f3a8c4bf8cf14263d34d866db66728e98dfdb0..7937a0e082199554d3e8db1f9811be29
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Fox.java b/src/main/java/org/bukkit/entity/Fox.java
-index 498e182846b81d50b3a594254e8b341fb23e8763..3826363a1954afcddaadec7f96ac18300f8e89e9 100644
+index c61a473453f33f9d10c330fc46cfa9d52251fe49..473a7e36ad64f866d1d2e09e2ecb2e9881668faf 100644
 --- a/src/main/java/org/bukkit/entity/Fox.java
 +++ b/src/main/java/org/bukkit/entity/Fox.java
-@@ -85,4 +85,62 @@ public interface Fox extends Animals, Sittable {
+@@ -92,4 +92,55 @@ public interface Fox extends Animals, Sittable {
          RED,
          SNOW;
      }
@@ -242,42 +242,18 @@ index 498e182846b81d50b3a594254e8b341fb23e8763..3826363a1954afcddaadec7f96ac1830
 +     * @param faceplanted face planted
 +     */
 +    public void setFaceplanted(boolean faceplanted);
-+
-+    /**
-+     * Gets if the fox face planted.
-+     *
-+     * @return fox face planted
-+     */
-+    public boolean isFaceplanted();
 +    // Paper end - Add more fox behavior API
  }
 diff --git a/src/main/java/org/bukkit/entity/Ghast.java b/src/main/java/org/bukkit/entity/Ghast.java
-index 3f5edf76ce303502cf4eeeb76f22f21f568dad5a..5930dc682c5c9273c748595e487b364b818a2fac 100644
+index d8eb2b5007091c25a14321cb389f3219d76ce452..0fc8a4fcc3ec2ce60bb095c31eb353337d57be34 100644
 --- a/src/main/java/org/bukkit/entity/Ghast.java
 +++ b/src/main/java/org/bukkit/entity/Ghast.java
-@@ -3,4 +3,37 @@ package org.bukkit.entity;
- /**
-  * Represents a Ghast.
-  */
--public interface Ghast extends Flying {}
-+// Paper start
-+public interface Ghast extends Flying {
+@@ -18,4 +18,21 @@ public interface Ghast extends Flying {
+      * @param flag Whether the Ghast is charging
+      */
+     void setCharging(boolean flag);
 +
-+    /**
-+     * Returns whether the ghast is charging an attack.
-+     *
-+     * @return whether the ghast is charging an attack
-+     */
-+    boolean isCharging();
-+
-+    /**
-+     * Sets whether the ghast is charging an attack.
-+     * This determines whether the client displays the charging animation.
-+     *
-+     * @param charging whether the ghast is charging an attack
-+     */
-+    void setCharging(boolean charging);
-+
++    // Paper start
 +    /**
 +     * Returns the explosion power of shot fireballs.
 +     *
@@ -293,25 +269,15 @@ index 3f5edf76ce303502cf4eeeb76f22f21f568dad5a..5930dc682c5c9273c748595e487b364b
 +     */
 +    void setExplosionPower(int explosionPower);
 +    // Paper end
-+}
+ }
 diff --git a/src/main/java/org/bukkit/entity/Panda.java b/src/main/java/org/bukkit/entity/Panda.java
-index a6a7429ed2e1eefb2b12b7480ed74fcc3963a864..1dcc2c8f4899da029af8b1c1b2ff1b5e368e82c1 100644
+index 1f027927a1194f4f8e86c1375a2772e6e261c151..57cf24cfd15a541f60aafc8507c189344aead0f7 100644
 --- a/src/main/java/org/bukkit/entity/Panda.java
 +++ b/src/main/java/org/bukkit/entity/Panda.java
-@@ -5,7 +5,7 @@ import org.jetbrains.annotations.NotNull;
- /**
-  * Panda entity.
-  */
--public interface Panda extends Animals {
-+public interface Panda extends Animals, Sittable { // Paper
+@@ -107,6 +107,87 @@ public interface Panda extends Animals, Sittable {
+      */
+     int getUnhappyTicks();
  
-     /**
-      * Gets this Panda's main gene.
-@@ -63,4 +63,125 @@ public interface Panda extends Animals {
-             return recessive;
-         }
-     }
-+
 +    // Paper start - Panda API
 +    /**
 +     * Sets the sneeze progress in this animation.
@@ -327,22 +293,6 @@ index a6a7429ed2e1eefb2b12b7480ed74fcc3963a864..1dcc2c8f4899da029af8b1c1b2ff1b5e
 +     * @return sneeze progress
 +     */
 +    int getSneezeTicks();
-+
-+    /**
-+     * Sets if the panda is sneezing, which causes the sneeze counter to count.
-+     * <p>
-+     * When false, this will automatically set the sneeze ticks to 0.
-+     *
-+     * @param sneeze if the panda is sneezing or not
-+     */
-+    void setSneezing(boolean sneeze);
-+
-+    /**
-+     * Gets if the panda is sneezing
-+     *
-+     * @return is sneezing
-+     */
-+    boolean isSneezing();
 +
 +    /**
 +     * Sets the eating ticks for this panda.
@@ -371,39 +321,15 @@ index a6a7429ed2e1eefb2b12b7480ed74fcc3963a864..1dcc2c8f4899da029af8b1c1b2ff1b5e
 +    void setUnhappyTicks(int ticks);
 +
 +    /**
-+     * Gets how many ticks this panda will be unhappy for.
-+     *
-+     * @return unhappy ticks
-+     */
-+    int getUnhappyTicks();
-+
-+    /**
-+     * Sets if this panda is currently rolling.
-+     *
-+     * @param rolling should roll
-+     */
-+    void setRolling(boolean rolling);
-+
-+    /**
-+     * Gets if this panda is currently rolling on the ground.
-+     *
-+     * @return is rolling
-+     */
-+    boolean isRolling();
-+
-+    /**
 +     * Sets if this panda is currently on its back.
 +     *
 +     * @param onBack is on its back
++     * @deprecated use {@link #setOnBack(boolean)}
 +     */
-+    void setIsOnBack(boolean onBack);
-+
-+    /**
-+     * Gets if this panda is currently on its back.
-+     *
-+     * @return is on back
-+     */
-+    boolean isOnBack();
++    @Deprecated(forRemoval = true)
++    default void setIsOnBack(boolean onBack) {
++        this.setOnBack(onBack);
++    }
 +
 +    /**
 +     * Sets if this panda is currently sitting.
@@ -432,7 +358,10 @@ index a6a7429ed2e1eefb2b12b7480ed74fcc3963a864..1dcc2c8f4899da029af8b1c1b2ff1b5e
 +    @Override
 +    boolean isSitting();
 +    // Paper end - Panda API
- }
++
+     public enum Gene {
+ 
+         NORMAL(false),
 diff --git a/src/main/java/org/bukkit/entity/Piglin.java b/src/main/java/org/bukkit/entity/Piglin.java
 index 6fdc0e0bb62189dbf3cf9ce7a87b7fbb995956a3..d4cb4b0ed1d9766a87867dcf1a3a839526ba9332 100644
 --- a/src/main/java/org/bukkit/entity/Piglin.java
@@ -672,33 +601,6 @@ index b86f0196e6eb8070830f63a94f732522c2a6c2f1..a1b42ae35dda2da90ba00a2d6666514f
 +     * @param value whether the wither can travel through portals
 +     */
 +    void setCanTravelThroughPortals(boolean value);
-+    // Paper end
- }
-diff --git a/src/main/java/org/bukkit/entity/Wolf.java b/src/main/java/org/bukkit/entity/Wolf.java
-index 0e5decadf31140d6cb121c298f935ccc12c7a7e7..490395f38c4d9977d30a6f48585a4ea0e7faff0f 100644
---- a/src/main/java/org/bukkit/entity/Wolf.java
-+++ b/src/main/java/org/bukkit/entity/Wolf.java
-@@ -39,4 +39,22 @@ public interface Wolf extends Tameable, Sittable {
-      * @param color the color to apply
-      */
-     public void setCollarColor(@NotNull DyeColor color);
-+
-+    // Paper start
-+    /**
-+     * Sets if the wolf is interested.
-+     * <p>
-+     * This causes the wolf to tilt its head to the side.
-+     *
-+     * @param interested is interested
-+     */
-+    void setInterested(boolean interested);
-+
-+    /**
-+     * Gets if the wolf is interested.
-+     *
-+     * @return is interested
-+     */
-+    boolean isInterested();
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/ZombieVillager.java b/src/main/java/org/bukkit/entity/ZombieVillager.java

--- a/patches/api/0380-Add-EntityDyeEvent-and-CollarColorable-interface.patch
+++ b/patches/api/0380-Add-EntityDyeEvent-and-CollarColorable-interface.patch
@@ -146,7 +146,7 @@ index c340fecb61bac66baf0f44189d21bc85289b1269..97b0d8ccd3fd3a711ec5fa4ce3d87035
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Wolf.java b/src/main/java/org/bukkit/entity/Wolf.java
-index 490395f38c4d9977d30a6f48585a4ea0e7faff0f..297b65a6cf7d25f02bbd824ea507c5c083e0abec 100644
+index 6d5597a8d48ee65a1b54422c7a39a0f5b461b711..84db38388bf7a58e66d6cd29620b4fe64b0a897e 100644
 --- a/src/main/java/org/bukkit/entity/Wolf.java
 +++ b/src/main/java/org/bukkit/entity/Wolf.java
 @@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
@@ -173,7 +173,7 @@ index 490395f38c4d9977d30a6f48585a4ea0e7faff0f..297b65a6cf7d25f02bbd824ea507c5c0
 +    @Override // Paper
      public void setCollarColor(@NotNull DyeColor color);
  
-     // Paper start
+     /**
 diff --git a/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java b/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java
 index 10d2466fb69919cead26af2fcdf6bd2e678f2927..ddf4aec01e4873aa799721ce615f5d7c929dc915 100644
 --- a/src/main/java/org/bukkit/event/entity/SheepDyeWoolEvent.java

--- a/patches/server/0212-RangedEntity-API.patch
+++ b/patches/server/0212-RangedEntity-API.patch
@@ -135,7 +135,7 @@ index 6a82d567d96a42bfea0e38afb4e8de13eb3ad5a2..659e2959c5330e4764ea1edc7f8de9f4
          super(server, entity);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWitch.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWitch.java
-index 60e00e539d214eb8854a53364c92c3cf55ca1062..d4eeb071dbbfca3ecea256228853bcb5c11f49ee 100644
+index 5fbb06e28d5c797cfb6859ce7ef05ba00949f690..eada1f0ff10d4c00f82a6f4411fe18b7184e9901 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWitch.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftWitch.java
 @@ -4,7 +4,7 @@ import org.bukkit.craftbukkit.CraftServer;

--- a/patches/server/0270-Turtle-API.patch
+++ b/patches/server/0270-Turtle-API.patch
@@ -52,18 +52,18 @@ index 37125ffe47fcd5fe93ab62ad8a46e8188f362436..69c98c2cb2fd8f149a39bbddcbfe0c5c
  
          @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftTurtle.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftTurtle.java
-index ed08089f21c8958fc9fc7e6e73a2b6ff9108242c..b78289dd6a71b962c02247af578e939bc97847c8 100644
+index 96462a29551c301d3c80029cab2bec3839914237..318f7bc921283ad83daebbf6080821cdc53b2257 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftTurtle.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftTurtle.java
-@@ -24,4 +24,41 @@ public class CraftTurtle extends CraftAnimals implements Turtle {
-     public EntityType getType() {
-         return EntityType.TURTLE;
+@@ -34,4 +34,31 @@ public class CraftTurtle extends CraftAnimals implements Turtle {
+     public boolean isLayingEgg() {
+         return this.getHandle().isLayingEgg();
      }
 +
 +    // Paper start
 +    @Override
 +    public org.bukkit.Location getHome() {
-+        return net.minecraft.server.MCUtil.toLocation(getHandle().level, getHandle().getHomePos());
++        return net.minecraft.server.MCUtil.toLocation(getHandle().getLevel(), getHandle().getHomePos());
 +    }
 +
 +    @Override
@@ -82,18 +82,8 @@ index ed08089f21c8958fc9fc7e6e73a2b6ff9108242c..b78289dd6a71b962c02247af578e939b
 +    }
 +
 +    @Override
-+    public boolean hasEgg() {
-+        return getHandle().hasEgg();
-+    }
-+
-+    @Override
 +    public void setHasEgg(boolean hasEgg) {
 +        getHandle().setHasEgg(hasEgg);
-+    }
-+
-+    @Override
-+    public boolean isLayingEgg() {
-+        return this.getHandle().isLayingEgg();
 +    }
 +    // Paper end
  }

--- a/patches/server/0274-Add-more-Witch-API.patch
+++ b/patches/server/0274-Add-more-Witch-API.patch
@@ -5,19 +5,10 @@ Subject: [PATCH] Add more Witch API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Witch.java b/src/main/java/net/minecraft/world/entity/monster/Witch.java
-index 1ee8fec8f9f581fa68497ebf4f90aad9d425ec71..f9eb4a3a37454de78c65f895a82e67a854b6909b 100644
+index 1ee8fec8f9f581fa68497ebf4f90aad9d425ec71..b7bc64818387288955d0723cd071d4203bd2f121 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Witch.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Witch.java
-@@ -1,5 +1,8 @@
- package net.minecraft.world.entity.monster;
- 
-+// Paper start
-+import com.destroystokyo.paper.event.entity.WitchReadyPotionEvent;
-+import org.bukkit.craftbukkit.inventory.CraftItemStack;
- import java.util.Iterator;
- import java.util.List;
- import java.util.UUID;
-@@ -156,21 +159,24 @@ public class Witch extends Raider implements RangedAttackMob {
+@@ -156,21 +156,24 @@ public class Witch extends Raider implements RangedAttackMob {
                  }
  
                  if (potionregistry != null) {
@@ -54,7 +45,7 @@ index 1ee8fec8f9f581fa68497ebf4f90aad9d425ec71..f9eb4a3a37454de78c65f895a82e67a8
                  }
              }
  
-@@ -182,6 +188,24 @@ public class Witch extends Raider implements RangedAttackMob {
+@@ -182,6 +185,24 @@ public class Witch extends Raider implements RangedAttackMob {
          super.aiStep();
      }
  
@@ -80,7 +71,7 @@ index 1ee8fec8f9f581fa68497ebf4f90aad9d425ec71..f9eb4a3a37454de78c65f895a82e67a8
      public SoundEvent getCelebrateSound() {
          return SoundEvents.WITCH_CELEBRATE;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWitch.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWitch.java
-index d4eeb071dbbfca3ecea256228853bcb5c11f49ee..8625d8d7ac94dca2acc348a4c3c912d39cd22b47 100644
+index eada1f0ff10d4c00f82a6f4411fe18b7184e9901..9039db1a72009342063d4db08e18e6aee18836e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWitch.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftWitch.java
 @@ -3,6 +3,13 @@ package org.bukkit.craftbukkit.entity;
@@ -97,16 +88,11 @@ index d4eeb071dbbfca3ecea256228853bcb5c11f49ee..8625d8d7ac94dca2acc348a4c3c912d3
  
  public class CraftWitch extends CraftRaider implements Witch, com.destroystokyo.paper.entity.CraftRangedEntity<net.minecraft.world.entity.monster.Witch> { // Paper
      public CraftWitch(CraftServer server, net.minecraft.world.entity.monster.Witch entity) {
-@@ -23,4 +30,28 @@ public class CraftWitch extends CraftRaider implements Witch, com.destroystokyo.
-     public EntityType getType() {
-         return EntityType.WITCH;
+@@ -28,4 +35,23 @@ public class CraftWitch extends CraftRaider implements Witch, com.destroystokyo.
+     public boolean isDrinkingPotion() {
+         return this.getHandle().isDrinkingPotion();
      }
-+
 +    // Paper start
-+    public boolean isDrinkingPotion() {
-+        return getHandle().isDrinkingPotion();
-+    }
-+
 +    public int getPotionUseTimeLeft() {
 +        return getHandle().usingTime;
 +    }

--- a/patches/server/0289-Add-more-Zombie-API.patch
+++ b/patches/server/0289-Add-more-Zombie-API.patch
@@ -67,7 +67,7 @@ index 1b48576beca178af14bfab297bd427b5f5bdaf42..1ff02c66fcc291b6ccc456673ad4c6c0
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
-index 2e643e92569512ac4e75c0ef2ee7aa4b688e7356..77e4875484bdaedfba576a6b008245c488b2a112 100644
+index 9e249a194980796248d07481df2cd04e80f079d8..1e0154f2d06b0cc5bc58ec2de98cbdce1346da35 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
 @@ -93,6 +93,42 @@ public class CraftZombie extends CraftMonster implements Zombie {

--- a/patches/server/0553-Zombie-API-breaking-doors.patch
+++ b/patches/server/0553-Zombie-API-breaking-doors.patch
@@ -5,23 +5,13 @@ Subject: [PATCH] Zombie API - breaking doors
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
-index 77e4875484bdaedfba576a6b008245c488b2a112..bcd765abe0317fe5c1fa2efcbc43d7b8503f80a6 100644
+index 1e0154f2d06b0cc5bc58ec2de98cbdce1346da35..9f4da46dce54fe4207e24b49402fe0d3fa548e29 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
-@@ -128,6 +128,21 @@ public class CraftZombie extends CraftMonster implements Zombie {
+@@ -128,6 +128,11 @@ public class CraftZombie extends CraftMonster implements Zombie {
      public void setShouldBurnInDay(boolean shouldBurnInDay) {
          getHandle().setShouldBurnInDay(shouldBurnInDay);
      }
-+
-+    @Override
-+    public boolean canBreakDoors() {
-+        return getHandle().canBreakDoors();
-+    }
-+
-+    @Override
-+    public void setCanBreakDoors(boolean canBreakDoors) {
-+        getHandle().setCanBreakDoors(canBreakDoors);
-+    }
 +
 +    @Override
 +    public boolean supportsBreakingDoors() {

--- a/patches/server/0672-Missing-Entity-Behavior-API.patch
+++ b/patches/server/0672-Missing-Entity-Behavior-API.patch
@@ -301,13 +301,14 @@ index ae669a970aa1f17ed786640de8a481364543c58e..acdc4e578d70f8121c8c6be7682ba1ec
      public EnderMan getHandle() {
          return (EnderMan) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftFox.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftFox.java
-index b647a5b9fdc1da61c4035d6f2cef7814033dc608..9795341efa748c2d94567e882cd5f26adf0f1591 100644
+index f6369a1b0ea3fc64e9e7902d9da25924a0745855..fce96b67300b8808984904ee19d4e987f5235bfd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftFox.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftFox.java
-@@ -114,4 +114,45 @@ public class CraftFox extends CraftAnimals implements Fox {
- 
-         this.getHandle().getEntityData().set(net.minecraft.world.entity.animal.Fox.DATA_TRUSTED_ID_1, player == null ? Optional.empty() : Optional.of(player.getUniqueId()));
+@@ -119,4 +119,41 @@ public class CraftFox extends CraftAnimals implements Fox {
+     public boolean isFaceplanted() {
+         return this.getHandle().isFaceplanted();
      }
++
 +    // Paper start - Add more fox behavior API
 +    @Override
 +    public void setInterested(boolean interested) {
@@ -343,33 +344,18 @@ index b647a5b9fdc1da61c4035d6f2cef7814033dc608..9795341efa748c2d94567e882cd5f26a
 +    public void setFaceplanted(boolean faceplanted) {
 +        this.getHandle().setFaceplanted(faceplanted);
 +    }
-+
-+    @Override
-+    public boolean isFaceplanted() {
-+        return this.getHandle().isFaceplanted();
-+    }
 +    // Paper end - Add more fox behavior API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftGhast.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftGhast.java
-index f0f0392a51db75e88df0e68c0db98d6dc1968c20..d0f0f380e9b185668580f31b061bdc08f0573a40 100644
+index 7adda5c93e7c172ea0ba4a3f15828b5e54a283e7..fffaf4108b632ceabac4186d93b34ad0eb069a04 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftGhast.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftGhast.java
-@@ -24,4 +24,27 @@ public class CraftGhast extends CraftFlying implements Ghast {
-     public EntityType getType() {
-         return EntityType.GHAST;
+@@ -34,4 +34,17 @@ public class CraftGhast extends CraftFlying implements Ghast {
+     public void setCharging(boolean flag) {
+         this.getHandle().setCharging(flag);
      }
 +
 +    // Paper start
-+    @Override
-+    public boolean isCharging() {
-+        return this.getHandle().isCharging();
-+    }
-+
-+    @Override
-+    public void setCharging(boolean charging) {
-+        this.getHandle().setCharging(charging);
-+    }
-+
 +    @Override
 +    public int getExplosionPower() {
 +        return this.getHandle().getExplosionPower();
@@ -383,10 +369,10 @@ index f0f0392a51db75e88df0e68c0db98d6dc1968c20..d0f0f380e9b185668580f31b061bdc08
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
-index 2d2620dbb16aec850e8afda02174508a4be5a313..ba4e6deaaa725296be830324d2c6486844a4e886 100644
+index ff9f711b83a8ea1bf4135751a9ba865224bce787..1f6dcad764240e15083731d017f9bb1c5c84622f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
-@@ -46,6 +46,77 @@ public class CraftPanda extends CraftAnimals implements Panda {
+@@ -46,6 +46,32 @@ public class CraftPanda extends CraftAnimals implements Panda {
      public void setHiddenGene(Gene gene) {
          this.getHandle().setHiddenGene(CraftPanda.toNms(gene));
      }
@@ -399,16 +385,6 @@ index 2d2620dbb16aec850e8afda02174508a4be5a313..ba4e6deaaa725296be830324d2c64868
 +    @Override
 +    public int getSneezeTicks() {
 +        return this.getHandle().getSneezeCounter();
-+    }
-+
-+    @Override
-+    public void setSneezing(boolean sneeze) {
-+        this.getHandle().sneeze(sneeze);
-+    }
-+
-+    @Override
-+    public boolean isSneezing() {
-+        return this.getHandle().isSneezing();
 +    }
 +
 +    @Override
@@ -425,45 +401,10 @@ index 2d2620dbb16aec850e8afda02174508a4be5a313..ba4e6deaaa725296be830324d2c64868
 +    public void setUnhappyTicks(int ticks) {
 +        this.getHandle().setUnhappyCounter(ticks);
 +    }
-+
-+    @Override
-+    public int getUnhappyTicks() {
-+        return this.getHandle().getUnhappyCounter();
-+    }
-+
-+    @Override
-+    public boolean isRolling() {
-+        return this.getHandle().isRolling();
-+    }
-+
-+    @Override
-+    public void setRolling(boolean rolling) {
-+        this.getHandle().roll(rolling);
-+    }
-+
-+    @Override
-+    public boolean isOnBack() {
-+        return this.getHandle().isOnBack();
-+    }
-+
-+    @Override
-+    public void setIsOnBack(boolean onBack) {
-+        this.getHandle().setOnBack(onBack);
-+    }
-+
-+    @Override
-+    public boolean isSitting() {
-+        return this.getHandle().isSitting();
-+    }
-+
-+    @Override
-+    public void setSitting(boolean sitting) {
-+        this.getHandle().sit(sitting);
-+    }
 +    // Paper end - Panda API
  
-     public static Gene fromNms(net.minecraft.world.entity.animal.Panda.Gene gene) {
-         Preconditions.checkArgument(gene != null, "Gene may not be null");
+     @Override
+     public boolean isRolling() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java
 index aeda5fc001fe4ce55ee467240b275b6050a29f98..48d0a4e42e1b90d1323784d1284acabfe9497dd6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java
@@ -648,26 +589,6 @@ index e92355fa2042c4cf15354a11b7058cacbe996f0d..4cf3a374c9ee7c7bcf82e778aa094eb4
 +    @Override
 +    public void setCanTravelThroughPortals(boolean value) {
 +        getHandle().setCanTravelThroughPortals(value);
-+    }
-+    // Paper end
- }
-diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWolf.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWolf.java
-index f856b42201c17f8da21251e54fcf052336916e70..a3bec00368aef0f8cc6aa21cce1389938d15f91b 100644
---- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWolf.java
-+++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftWolf.java
-@@ -43,4 +43,15 @@ public class CraftWolf extends CraftTameableAnimal implements Wolf {
-     public void setCollarColor(DyeColor color) {
-         this.getHandle().setCollarColor(net.minecraft.world.item.DyeColor.byId(color.getWoolData()));
-     }
-+    // Paper start
-+    @Override
-+    public void setInterested(boolean interested) {
-+        this.getHandle().setIsInterested(interested);
-+    }
-+
-+    @Override
-+    public boolean isInterested() {
-+        return this.getHandle().isInterested();
 +    }
 +    // Paper end
  }

--- a/scripts/upstreamCommit.sh
+++ b/scripts/upstreamCommit.sh
@@ -5,7 +5,7 @@ PS1="$"
 
 function changelog() {
     base=$(git ls-tree HEAD $1  | cut -d' ' -f3 | cut -f1)
-    cd $1 && git log --oneline ${base}...HEAD | sed -E 's/(^[0-9a-f]{8,} |Revert ")#([0-9]+)/\1PR-\2/'
+    cd $1 && git log --oneline ${base}...HEAD | sed -E 's/(^[0-9a-f]{8,}( SPIGOT-[0-9]{1,4},?)* |Revert ")#([0-9]+)/\1PR-\3/'
 }
 bukkit=$(changelog work/Bukkit)
 cb=$(changelog work/CraftBukkit)


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
23f557a0 SPIGOT-5380, SPIGOT-6958, PR-772: Add some missing entity API

CraftBukkit Changes:
fc3071161 SPIGOT-5380, SPIGOT-6958, PR-1085: Add some missing entity API

---
I changed the upstreamMerge.sh script to run rebuildPatches with `-Ppaperweight.filter-patches=false` to fix all the indexes. Also I updated the upstreamCommit.sh sed regex replacement.