### PR TITLE
Handle rotation for PlayerMoveEvent

### DIFF
--- a/patches/server/0886-More-Teleport-API.patch
+++ b/patches/server/0886-More-Teleport-API.patch
@@ -5,10 +5,36 @@ Subject: [PATCH] More Teleport API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 421d7e28370085dffa415d71d4e28d3c4d38ac87..92617a19fb328320e17b58956cf0276d5a08325b 100644
+index 421d7e28370085dffa415d71d4e28d3c4d38ac87..23c518d3d0689949e5c28cddc20a5b10daa68b99 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1729,11 +1729,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -760,6 +760,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                         // there to avoid any 'Moved wrongly' or 'Moved too quickly' errors.
+                         // We only do this if the Event was not cancelled.
+                         if (!oldTo.equals(event.getTo()) && !event.isCancelled()) {
++                            // Paper start
++                            if (oldTo.getWorld().equals(event.getTo().getWorld()) && oldTo.getX() == event.getTo().getX() && oldTo.getY() == event.getTo().getY() && oldTo.getZ() == event.getTo().getZ()) {
++                                this.player.getBukkitEntity().setRotation(event.getTo().getYaw(), event.getTo().getPitch());
++                                return;
++                            }
++                            // Paper stop
+                             this.player.getBukkitEntity().teleport(event.getTo(), PlayerTeleportEvent.TeleportCause.PLUGIN);
+                             return;
+                         }
+@@ -1613,6 +1619,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                                         // there to avoid any 'Moved wrongly' or 'Moved too quickly' errors.
+                                         // We only do this if the Event was not cancelled.
+                                         if (!oldTo.equals(event.getTo()) && !event.isCancelled()) {
++                                            // Paper start
++                                            if (oldTo.getWorld().equals(event.getTo().getWorld()) && oldTo.getX() == event.getTo().getX() && oldTo.getY() == event.getTo().getY() && oldTo.getZ() == event.getTo().getZ()) {
++                                                this.player.getBukkitEntity().setRotation(event.getTo().getYaw(), event.getTo().getPitch());
++                                                return;
++                                            }
++                                            // Paper stop
+                                             this.player.getBukkitEntity().teleport(event.getTo(), PlayerTeleportEvent.TeleportCause.PLUGIN);
+                                             return;
+                                         }
+@@ -1729,11 +1741,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              return false; // CraftBukkit - Return event status
          }
  
@@ -29,7 +55,7 @@ index 421d7e28370085dffa415d71d4e28d3c4d38ac87..92617a19fb328320e17b58956cf0276d
              d0 = to.getX();
              d1 = to.getY();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index c4ffccddce33cf461d9b04ccbb90026544f16b7d..99b99fae67e53a688b3519d8a8d0cc5f3468e7e8 100644
+index 2015147126f463f11202d04ca475cc86e5ac12c2..a1e2664c9a6cc41edf0dfb92cd2b9d77170d8fde 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -542,15 +542,33 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0889-Send-block-entities-after-destroy-prediction.patch
+++ b/patches/server/0889-Send-block-entities-after-destroy-prediction.patch
@@ -57,10 +57,10 @@ index 9378e83a67a70dbb1fb4f05b33f1e553d008e62b..5a60f5dc202c44b06ca34e9a19d45cb7
              }
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 92617a19fb328320e17b58956cf0276d5a08325b..e88c82aac6d9947c7205f865c18146e7a5756b40 100644
+index 23c518d3d0689949e5c28cddc20a5b10daa68b99..ab0bbb30a273921aa0fa83a52a8b681686c64737 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1874,8 +1874,28 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1886,8 +1886,28 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                      return;
                  }
                  // Paper end - Don't allow digging in unloaded chunks

--- a/patches/server/0895-Fix-command-preprocess-cancelling-and-command-changi.patch
+++ b/patches/server/0895-Fix-command-preprocess-cancelling-and-command-changi.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix command preprocess cancelling and command changing
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e88c82aac6d9947c7205f865c18146e7a5756b40..8ae8055c185237a76159285c8fce3aacc295fb3b 100644
+index ab0bbb30a273921aa0fa83a52a8b681686c64737..8754ae9382f0939b39a8dedd11be9c84ec5e13ce 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2259,13 +2259,24 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2271,13 +2271,24 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(this.getCraftPlayer(), command, new LazyPlayerSet(this.server));
          this.cserver.getPluginManager().callEvent(event);
  
@@ -38,7 +38,7 @@ index e88c82aac6d9947c7205f865c18146e7a5756b40..8ae8055c185237a76159285c8fce3aac
          // CraftBukkit end
          Iterator iterator = map.values().iterator();
  
-@@ -2569,6 +2580,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2581,6 +2592,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  }
              });
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) { // Re-add "Command Only" flag check

--- a/patches/server/0897-Add-async-catcher-to-PlayerConnection-internalTelepo.patch
+++ b/patches/server/0897-Add-async-catcher-to-PlayerConnection-internalTelepo.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add async catcher to PlayerConnection internalTeleport
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1ff25ce408aba3620455f74e1535b5862b3bbdf9..9eb921fec32afa360f3a402e978411fcf3ec618c 100644
+index 8754ae9382f0939b39a8dedd11be9c84ec5e13ce..5e075a61ef77221123e9498b65474d4dd74eca81 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1757,6 +1757,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1769,6 +1769,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      }
  
      public void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<ClientboundPlayerPositionPacket.RelativeArgument> set, boolean flag) {

--- a/patches/server/0920-Fix-nothing-mlg.patch
+++ b/patches/server/0920-Fix-nothing-mlg.patch
@@ -19,10 +19,10 @@ doCheckFallDamage method is meant to be called repeatedly anyway.
 Mojira-ID: MC-255653
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9eb921fec32afa360f3a402e978411fcf3ec618c..63c9040ed2349eec500ba6e9090440347c514a3b 100644
+index 5e075a61ef77221123e9498b65474d4dd74eca81..612cfe1dbba1d3e4a21d1b4c861c8e0409a559e8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1564,6 +1564,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1570,6 +1570,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                              }
                              if (!this.player.noPhysics && !this.player.isSleeping() && teleportBack) { // Paper end - optimise out extra getCubes
                                  this.internalTeleport(d3, d4, d5, f, f1, Collections.emptySet(), false); // CraftBukkit - SPIGOT-1807: Don't call teleport event, when the client thinks the player is falling, because the chunks are not loaded on the client yet.


### PR DESCRIPTION
This close #8144 by using the new teleport API for handle cases where in PlayerMoveEvent the event only change the rotation of the Player.