### PR TITLE
Add FurnaceBurnEvent.setBurnTime(short burnTime)

### DIFF
--- a/patches/api/0389-Add-FurnaceBurnEvent-setBurnTime-short-burnTime.patch
+++ b/patches/api/0389-Add-FurnaceBurnEvent-setBurnTime-short-burnTime.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nossr50 <nossr50@gmail.com>
+Date: Sat, 23 Jul 2022 15:21:43 -0700
+Subject: [PATCH] Add FurnaceBurnEvent::setBurnTime(short burnTime) Fixes #8178
+
+
+diff --git a/src/main/java/org/bukkit/event/inventory/FurnaceBurnEvent.java b/src/main/java/org/bukkit/event/inventory/FurnaceBurnEvent.java
+index caef53d0f6546516fa7aabb2cb3abed70808b3ba..9581e66a984d5188e9c50f2dcc1dd3bae15e930b 100644
+--- a/src/main/java/org/bukkit/event/inventory/FurnaceBurnEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/FurnaceBurnEvent.java
+@@ -49,8 +49,19 @@ public class FurnaceBurnEvent extends BlockEvent implements Cancellable {
+      * Sets the burn time for this fuel
+      *
+      * @param burnTime the burn time for this fuel
++     * @deprecated use {@link #setBurnTime(short)} instead
+      */
++    @Deprecated
+     public void setBurnTime(int burnTime) {
++        this.burnTime = Math.min(Short.MAX_VALUE, burnTime);
++    }
++
++    /**
++     * Sets the burn time for this fuel
++     *
++     * @param burnTime the burn time for this fuel
++     */
++    public void setBurnTime(short burnTime) {
+         this.burnTime = burnTime;
+     }
+ 


### PR DESCRIPTION
This also deprecates setBurnTime(int burnTime) and fixes its implementation as well
Fixes #8178