### PR TITLE
Fix entity exit position when teleport using portals

### DIFF
--- a/patches/server/0929-Fix-entity-exit-position-when-teleport-using-portals.patch
+++ b/patches/server/0929-Fix-entity-exit-position-when-teleport-using-portals.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Sun, 24 Jul 2022 17:20:54 -0400
+Subject: [PATCH] Fix entity exit position when teleport using portals
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 353463084d90eb684717e65c56da52cd25a1e375..31c152320898ed0356db143379fa62b0c8eef1f5 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -1195,9 +1195,9 @@ public class ServerPlayer extends Player {
+ 
+     // CraftBukkit start
+     @Override
+-    protected CraftPortalEvent callPortalEvent(Entity entity, ServerLevel exitWorldServer, BlockPos exitPosition, TeleportCause cause, int searchRadius, int creationRadius) {
++    protected CraftPortalEvent callPortalEvent(Entity entity, ServerLevel exitWorldServer, net.minecraft.core.PositionImpl exitPosition, TeleportCause cause, int searchRadius, int creationRadius) { // Paper - replace BlockPosition with Position
+         Location enter = this.getBukkitEntity().getLocation();
+-        Location exit = new Location(exitWorldServer.getWorld(), exitPosition.getX(), exitPosition.getY(), exitPosition.getZ(), getYRot(), getXRot());
++        Location exit = new Location(exitWorldServer.getWorld(), exitPosition.x(), exitPosition.y(), exitPosition.z(), getYRot(), getXRot()); // Paper
+         PlayerPortalEvent event = new PlayerPortalEvent(this.getBukkitEntity(), enter, exit, cause, searchRadius, true, creationRadius);
+         Bukkit.getServer().getPluginManager().callEvent(event);
+         if (event.isCancelled() || event.getTo() == null || event.getTo().getWorld() == null) {
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 76b9beb0d8ebeee0f603d2740ba71beabbf19e25..1bee0f2995f13e50457e9c742c6c0ddc2bdc46d2 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -3431,7 +3431,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+                     portalSearchRadius = (int) (portalSearchRadius / destination.dimensionType().coordinateScale());
+                 }
+                 // Paper end
+-                CraftPortalEvent event = this.callPortalEvent(this, destination, blockposition, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL, portalSearchRadius, destination.paperConfig().environment.portalCreateRadius); // Paper start - configurable portal radius
++                CraftPortalEvent event = this.callPortalEvent(this, destination, new PositionImpl(blockposition.getX(), blockposition.getY(), blockposition.getZ()), PlayerTeleportEvent.TeleportCause.NETHER_PORTAL, portalSearchRadius, destination.paperConfig().environment.portalCreateRadius); // Paper start - configurable portal radius
+                 if (event == null) {
+                     return null;
+                 }
+@@ -3472,7 +3472,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+                 blockposition1 = destination.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, destination.getSharedSpawnPos());
+             }
+             // CraftBukkit start
+-            CraftPortalEvent event = this.callPortalEvent(this, destination, blockposition1.offset(0.5D, 0, 0.5D), PlayerTeleportEvent.TeleportCause.END_PORTAL, 0, 0);
++            CraftPortalEvent event = this.callPortalEvent(this, destination, new PositionImpl(blockposition1.getX() + 0.5D, blockposition1.getY(), blockposition1.getZ() + 0.5D), PlayerTeleportEvent.TeleportCause.END_PORTAL, 0, 0); // Paper
+             if (event == null) {
+                 return null;
+             }
+@@ -3487,10 +3487,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+     }
+ 
+     // CraftBukkit start
+-    protected CraftPortalEvent callPortalEvent(Entity entity, ServerLevel exitWorldServer, BlockPos exitPosition, PlayerTeleportEvent.TeleportCause cause, int searchRadius, int creationRadius) {
++    protected CraftPortalEvent callPortalEvent(Entity entity, ServerLevel exitWorldServer, PositionImpl exitPosition, PlayerTeleportEvent.TeleportCause cause, int searchRadius, int creationRadius) { // Paper - replace BlockPosition with Position
+         org.bukkit.entity.Entity bukkitEntity = entity.getBukkitEntity();
+         Location enter = bukkitEntity.getLocation();
+-        Location exit = new Location(exitWorldServer.getWorld(), exitPosition.getX(), exitPosition.getY(), exitPosition.getZ());
++        Location exit = new Location(exitWorldServer.getWorld(), exitPosition.x(), exitPosition.y(), exitPosition.z()); // Paper
+ 
+         EntityPortalEvent event = new EntityPortalEvent(bukkitEntity, enter, exit, searchRadius);
+         event.getEntity().getServer().getPluginManager().callEvent(event);


### PR DESCRIPTION
This close #8182 
The bug in the issue was introduced by me in upstream... the origin was a [issue](https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-7090) where if use teleport and the location its in another world the coords are change because craftbukkit teleport use `BlockPos` (when change world its related) and this class change the coords from double to int... the fix was use `PositionImpl` and also change the logic when a entity use a portal this cause the issue where decimals was ignored again, this PR change the use of `BlockPos` to `PositionImpl` for this cases and avoid lose this values for plugins.

~~Perdon el mucho texto.. pero mire el error y me dio algo por dentro~~