### PR TITLE
include relative flags in PlayerTeleportEvent

### DIFF
--- a/patches/server/0820-More-Teleport-API.patch
+++ b/patches/server/0820-More-Teleport-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] More Teleport API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 009a14ad5de4bf98ec50cc4ba348445266c1c967..5af57f06717cb1fd891acfacfdd795e6f6426e7d 100644
+index b384af27839b7bb6e028baf817fe844c225963f5..95966fdddc81dcc4e65b075a4df6d5dd9af4e65a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1637,11 +1637,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -24,7 +24,7 @@ index 009a14ad5de4bf98ec50cc4ba348445266c1c967..5af57f06717cb1fd891acfacfdd795e6
  
          if (event.isCancelled() || !to.equals(event.getTo())) {
 -            set.clear(); // Can't relative teleport
-+            //set.clear(); // Can't relative teleport // Paper - Teleport API: Now you can!
++            // set.clear(); // Can't relative teleport // Paper - Teleport API: Now you can!
              to = event.isCancelled() ? event.getFrom() : event.getTo();
              d0 = to.getX();
              d1 = to.getY();
@@ -72,7 +72,7 @@ index 1879ec9e275194cb83f30ec47930a3814fbe1da3..027fa02e855e14b1554ddd141d0a937a
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9d12fab078c0625844b5f07b884b5f5978bf590c..c92ef0b4ab551e3538b11cec9256af25dddf8aa4 100644
+index 9d12fab078c0625844b5f07b884b5f5978bf590c..3fe9670a70cfad5b0babe6bd5bd8d142afb62141 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1207,13 +1207,101 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -144,17 +144,17 @@ index 9d12fab078c0625844b5f07b884b5f5978bf590c..c92ef0b4ab551e3538b11cec9256af25
 +
 +    @Override
 +    public boolean teleport(Location location, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause, io.papermc.paper.entity.TeleportFlag... flags) {
-+        java.util.Set<net.minecraft.world.entity.RelativeMovement> relativeArguments;
-+        java.util.Set<io.papermc.paper.entity.TeleportFlag> allFlags;
++        Set<io.papermc.paper.entity.TeleportFlag.Relative> relativeArguments;
++        Set<io.papermc.paper.entity.TeleportFlag> allFlags;
 +        if (flags.length == 0) {
 +            relativeArguments = Set.of();
 +            allFlags = Set.of();
 +        } else {
-+            relativeArguments = java.util.EnumSet.noneOf(net.minecraft.world.entity.RelativeMovement.class);
++            relativeArguments = java.util.EnumSet.noneOf(io.papermc.paper.entity.TeleportFlag.Relative.class);
 +            allFlags = new HashSet<>();
 +            for (io.papermc.paper.entity.TeleportFlag flag : flags) {
-+                if (flag instanceof io.papermc.paper.entity.TeleportFlag.Relative relativeTeleportFlag) {
-+                    relativeArguments.add(toNmsRelativeFlag(relativeTeleportFlag));
++                if (flag instanceof final io.papermc.paper.entity.TeleportFlag.Relative relativeTeleportFlag) {
++                    relativeArguments.add(relativeTeleportFlag);
 +                }
 +                allFlags.add(flag);
 +            }
@@ -187,6 +187,15 @@ index 9d12fab078c0625844b5f07b884b5f5978bf590c..c92ef0b4ab551e3538b11cec9256af25
              return false;
          }
  
+@@ -1235,7 +1323,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         // To = Players new Location if Teleport is Successful
+         Location to = location;
+         // Create & Call the Teleport Event.
+-        PlayerTeleportEvent event = new PlayerTeleportEvent(this, from, to, cause);
++        PlayerTeleportEvent event = new PlayerTeleportEvent(this, from, to, cause, Set.copyOf(relativeArguments)); // Paper - Teleport API
+         this.server.getPluginManager().callEvent(event);
+ 
+         // Return False to inform the Plugin that the Teleport was unsuccessful/cancelled.
 @@ -1244,7 +1332,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
@@ -208,7 +217,7 @@ index 9d12fab078c0625844b5f07b884b5f5978bf590c..c92ef0b4ab551e3538b11cec9256af25
          // Check if the fromWorld and toWorld are the same.
          if (fromWorld == toWorld) {
 -            entity.connection.teleport(to);
-+            entity.connection.internalTeleport(to.getX(), to.getY(), to.getZ(), to.getYaw(), to.getPitch(), relativeArguments); // Paper - Teleport API
++            entity.connection.internalTeleport(to.getX(), to.getY(), to.getZ(), to.getYaw(), to.getPitch(), relativeArguments.stream().map(CraftPlayer::toNmsRelativeFlag).collect(java.util.stream.Collectors.toSet())); // Paper - Teleport API
          } else {
              // The respawn reason should never be used if the passed location is non null.
              this.server.getHandle().respawn(entity, toWorld, true, to, !toWorld.paperConfig().environment.disableTeleportationSuffocationCheck, null); // Paper

--- a/patches/server/0820-More-Teleport-API.patch
+++ b/patches/server/0820-More-Teleport-API.patch
@@ -72,7 +72,7 @@ index 1879ec9e275194cb83f30ec47930a3814fbe1da3..027fa02e855e14b1554ddd141d0a937a
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9d12fab078c0625844b5f07b884b5f5978bf590c..3fe9670a70cfad5b0babe6bd5bd8d142afb62141 100644
+index 9d12fab078c0625844b5f07b884b5f5978bf590c..800b216c2bbc01828005286e604e4cd6610df73c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1207,13 +1207,101 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -205,7 +205,7 @@ index 9d12fab078c0625844b5f07b884b5f5978bf590c..3fe9670a70cfad5b0babe6bd5bd8d142
  
          // SPIGOT-5509: Wakeup, similar to riding
          if (this.isSleeping()) {
-@@ -1260,13 +1348,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1260,13 +1348,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          ServerLevel toWorld = ((CraftWorld) to.getWorld()).getHandle();
  
          // Close any foreign inventory
@@ -217,7 +217,13 @@ index 9d12fab078c0625844b5f07b884b5f5978bf590c..3fe9670a70cfad5b0babe6bd5bd8d142
          // Check if the fromWorld and toWorld are the same.
          if (fromWorld == toWorld) {
 -            entity.connection.teleport(to);
-+            entity.connection.internalTeleport(to.getX(), to.getY(), to.getZ(), to.getYaw(), to.getPitch(), relativeArguments.stream().map(CraftPlayer::toNmsRelativeFlag).collect(java.util.stream.Collectors.toSet())); // Paper - Teleport API
++            // Paper start - Teleport API
++            final Set<net.minecraft.world.entity.RelativeMovement> nms = java.util.EnumSet.noneOf(net.minecraft.world.entity.RelativeMovement.class);
++            for (final io.papermc.paper.entity.TeleportFlag.Relative bukkit : relativeArguments) {
++                nms.add(toNmsRelativeFlag(bukkit));
++            }
++            entity.connection.internalTeleport(to.getX(), to.getY(), to.getZ(), to.getYaw(), to.getPitch(), nms);
++            // Paper end - Teleport API
          } else {
              // The respawn reason should never be used if the passed location is non null.
              this.server.getHandle().respawn(entity, toWorld, true, to, !toWorld.paperConfig().environment.disableTeleportationSuffocationCheck, null); // Paper

--- a/patches/server/0851-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0851-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a31c1f1bcd54f070d3dd7f33c38e992999c2f383..10db4c791ce72563d6c84c39a68ce69b15b5aef6 100644
+index 42729e12e6a19e99d13d8e8d6af3a0e53aa620c2..05871198b38e7dcedd44057bcc1de2673f4561c8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3183,6 +3183,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3189,6 +3189,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0868-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0868-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 10db4c791ce72563d6c84c39a68ce69b15b5aef6..fb0809ae3ceac3bd3e061305fe8404f0ff9d4449 100644
+index 05871198b38e7dcedd44057bcc1de2673f4561c8..ebbb4e5cbbf505598fb84b39649ff5d27e20d6bc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3188,6 +3188,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3194,6 +3194,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0892-Flying-Fall-Damage.patch
+++ b/patches/server/0892-Flying-Fall-Damage.patch
@@ -26,10 +26,10 @@ index 28fa46f29639a6b643b475912133d601028facb2..7f3466340891b4409d1399ebeb2ca865
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ba68feed47add99da1ea039acb47fd38239dcb65..09e2feda950fce9857b9c2f35941c93714130041 100644
+index a0c6902955296da171548618bfcbf629944f8737..b8b23105d37ac2d461d87d0c8e3c83c6fd09c960 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2466,6 +2466,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2472,6 +2472,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().onUpdateAbilities();
      }
  

--- a/patches/server/0930-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0930-Expand-PlayerItemMendEvent.patch
@@ -33,10 +33,10 @@ index cab5636fe6be9ee7f23ffbd5a399d2aeea1cd538..fb74f13ab2a977224e843a468ea8c72d
              return k > 0 ? this.repairPlayerItems(player, k) : 0;
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3271d5e34df30f4d04c0cae8cfecb2391b5a8cd6..1f0b9b2c96efa68ba071e412fe1b3995e9637fb2 100644
+index b1d12c30dd23e092531c0d4d3af367262ccb5402..809932208bdf8e01d7bc73f885c44497a4ce4a95 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1748,11 +1748,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1754,11 +1754,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              orb.setPosRaw(handle.getX(), handle.getY(), handle.getZ());
  
              int i = Math.min(orb.xpToDurability(amount), itemstack.getDamageValue());
@@ -51,7 +51,7 @@ index 3271d5e34df30f4d04c0cae8cfecb2391b5a8cd6..1f0b9b2c96efa68ba071e412fe1b3995
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8d423a7ace9c140119dd49866c3a4c42017cfb60..864ff2d3c8e2e2bef744e8048ba0cdbb42787268 100644
+index 7bd1147362d057a16cdac0893615483479233c66..d55e1611028a836a34dd85f08c4463f1ec15662e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1321,10 +1321,10 @@ public class CraftEventFactory {

--- a/patches/server/0955-Fix-BanList-API.patch
+++ b/patches/server/0955-Fix-BanList-API.patch
@@ -208,10 +208,10 @@ index 172202accf4448a933fcf1ff820316c7910dd7f7..50ee7656580d386db473c054f5c5ec57
              return null;
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1f0b9b2c96efa68ba071e412fe1b3995e9637fb2..99966f102518decd5f62b5b58837f93bfdb9390f 100644
+index 809932208bdf8e01d7bc73f885c44497a4ce4a95..5e17e19b79e6d98e95e1daae33c6430b3dfb151e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1646,23 +1646,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1652,23 +1652,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override
@@ -240,7 +240,7 @@ index 1f0b9b2c96efa68ba071e412fe1b3995e9637fb2..99966f102518decd5f62b5b58837f93b
          if (kickPlayer) {
              this.kickPlayer(reason);
          }
-@@ -1670,12 +1670,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1676,12 +1676,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override

--- a/patches/server/0983-Add-Listing-API-for-Player.patch
+++ b/patches/server/0983-Add-Listing-API-for-Player.patch
@@ -76,7 +76,7 @@ index aa1c6de4d6cb7bbca33d25895c54707d220ab62a..9810d62c99f5d7dfca61ddfbbc356aeb
  
      static class EntryBuilder {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 098bb36a66e022da30302936aba10d296587ac88..a35638a92479b90afa89cf201fc45b49c9e767f3 100644
+index 683317e8c008fdb501e981490fd62f94597f2fee..e98a455b6bca9d094d0da323bddd7b3f2c07bb23 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -356,14 +356,22 @@ public abstract class PlayerList {
@@ -113,7 +113,7 @@ index 098bb36a66e022da30302936aba10d296587ac88..a35638a92479b90afa89cf201fc45b49
          // Paper end
          player.sentListPacket = true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 96e2dab94c326e9ec863c47b1a55680cd321b1d5..32712c245804a98c8dba00eef916dfde89f09df2 100644
+index 07312502b4cc95d83e8cadebe7bbc906e01f7f7b..274e001882c0fe1127fc636ea42e3a540edfabbf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -182,6 +182,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -124,7 +124,7 @@ index 96e2dab94c326e9ec863c47b1a55680cd321b1d5..32712c245804a98c8dba00eef916dfde
      private static final WeakHashMap<Plugin, WeakReference<Plugin>> pluginWeakReferences = new WeakHashMap<>();
      private int hash = 0;
      private double health = 20;
-@@ -1986,7 +1987,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1992,7 +1993,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  otherPlayer.setUUID(uuidOverride);
              }
              // Paper end
@@ -133,7 +133,7 @@ index 96e2dab94c326e9ec863c47b1a55680cd321b1d5..32712c245804a98c8dba00eef916dfde
              if (original != null) otherPlayer.setUUID(original); // Paper - uuid override
          }
  
-@@ -2093,6 +2094,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2099,6 +2100,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (entity != null) ? this.canSee(entity) : false; // If we can't find it, we can't see it
      }
  

--- a/patches/server/1024-Add-player-idle-duration-API.patch
+++ b/patches/server/1024-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f6abddc962babce7a72bd30a0213c580d3fdad7f..e7a59e33333234cf548769c5318d3a59db5c78b1 100644
+index 3507696d2b83b09b781ac0e6f3eefd6eed632ab4..f125cff31de52c4d761b75e82e1577888da72667 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3305,6 +3305,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3311,6 +3311,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/1046-Keep-previous-behavior-for-setResourcePack.patch
+++ b/patches/server/1046-Keep-previous-behavior-for-setResourcePack.patch
@@ -10,10 +10,10 @@ packs before sending the new pack. Other API exists
 for adding a new pack to the existing packs on a client.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9e03fa9db5d4db2b6f5758d2287e37ae05f9ecfa..1520533c137ace61aa83067186adca349bff8039 100644
+index 558b446cf58f6b66bea23236b24f08f6e281e533..39bf2b92cd8907afa13b9bf7f02553cd2539023b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2345,8 +2345,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2351,8 +2351,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (hash != null) {
              Preconditions.checkArgument(hash.length == 20, "Resource pack hash should be 20 bytes long but was %s", hash.length);
  

--- a/patches/server/1053-Add-experience-points-API.patch
+++ b/patches/server/1053-Add-experience-points-API.patch
@@ -18,10 +18,10 @@ index 7f3466340891b4409d1399ebeb2ca865d77841cd..3e597833b57377b855505b8a0f274480
      // Paper start - send SoundEffect to everyone who can see fromEntity
      private static void sendSoundEffect(Player fromEntity, double x, double y, double z, SoundEvent soundEffect, SoundSource soundCategory, float volume, float pitch) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4ae4436671b05a3535b9955af60842d4c9d1d102..2ec8b8f65661001716d1cb34dcc21cda7286e5d7 100644
+index 39bf2b92cd8907afa13b9bf7f02553cd2539023b..da63b4050be25dcb91d04df8c2fcc643cbb0751d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1815,6 +1815,49 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1821,6 +1821,49 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          Preconditions.checkArgument(exp >= 0, "Total experience points must not be negative (%s)", exp);
          this.getHandle().totalExperience = exp;
      }


### PR DESCRIPTION
Adds the relative flags for a Player#teleport call to the triggered PlayerTeleportEvent.
