### PR TITLE
Fix 1.19.1 code style

### DIFF
--- a/patches/server/0353-Anti-Xray.patch
+++ b/patches/server/0353-Anti-Xray.patch
@@ -1265,10 +1265,10 @@ index 78e20871e4bd8d92c4475f797a55733c68f6aeb4..723608946947fa2792c7284fa5faa85a
 -    public static <T> Codec<PalettedContainer<T>> codecRW(IdMap<T> idList, Codec<T> entryCodec, PalettedContainer.Strategy paletteProvider, T defaultValue) {
 -        PalettedContainerRO.Unpacker<T, PalettedContainer<T>> unpacker = PalettedContainer::unpack;
 +    // Paper start - Anti-Xray - Add preset values
-+    @Deprecated @io.papermc.paper.annotation.DoNotUse public static <T> Codec<PalettedContainer<T>> codecRW(IdMap<T> idList, Codec<T> entryCodec, PalettedContainer.Strategy paletteProvider, T defaultValue) {return codecRW(idList, entryCodec, paletteProvider, defaultValue, null);}
++    @Deprecated @io.papermc.paper.annotation.DoNotUse public static <T> Codec<PalettedContainer<T>> codecRW(IdMap<T> idList, Codec<T> entryCodec, PalettedContainer.Strategy paletteProvider, T defaultValue) { return PalettedContainer.codecRW(idList, entryCodec, paletteProvider, defaultValue, null); }
 +    public static <T> Codec<PalettedContainer<T>> codecRW(IdMap<T> idList, Codec<T> entryCodec, PalettedContainer.Strategy paletteProvider, T defaultValue, T @org.jetbrains.annotations.Nullable [] presetValues) {
-+        PalettedContainerRO.Unpacker<T, PalettedContainer<T>> unpacker = (idMapx, strategyx, packedData) -> {
-+            return unpack(idMapx, strategyx, packedData, defaultValue, presetValues);
++        PalettedContainerRO.Unpacker<T, PalettedContainer<T>> unpacker = (idListx, paletteProviderx, serialized) -> {
++            return unpack(idListx, paletteProviderx, serialized, defaultValue, presetValues);
 +        };
 +        // Paper end
          return codec(idList, entryCodec, paletteProvider, defaultValue, unpacker);


### PR DESCRIPTION
Just some minor Anti-Xray code style fixes and updating of variable names. (Note that I ofc ran an apply and rebuild cycle. The diff is simple because I edited the patch directly and commited, which led to no hash changes at all.)

As always I have also tested and checked all Anti-Xray related stuff by looking at source diffs of relevent (and more) classes and by performing tests. Everything seems to be good.