### PR TITLE
Add extra raytracing api

### DIFF
--- a/patches/api/0389-Add-extra-raytracing-api.patch
+++ b/patches/api/0389-Add-extra-raytracing-api.patch
@@ -5,17 +5,13 @@ Subject: [PATCH] Add extra raytracing api
 
 Adds the option to ignore specific blocks (based on their position) when performing a raytrace.
 
-diff --git a/src/main/java/io/papermc/paper/raytrace/RayTraceBuilder.java b/src/main/java/io/papermc/paper/raytrace/RayTraceBuilder.java
+diff --git a/src/main/java/io/papermc/paper/raytrace/RayTraceContext.java b/src/main/java/io/papermc/paper/raytrace/RayTraceContext.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..99a45534f9c4b61fbae1abfb79c810ef419f730c
+index 0000000000000000000000000000000000000000..0b3a490df1e114f81fcedc04343d4b105cb498fb
 --- /dev/null
-+++ b/src/main/java/io/papermc/paper/raytrace/RayTraceBuilder.java
-@@ -0,0 +1,187 @@
++++ b/src/main/java/io/papermc/paper/raytrace/RayTraceContext.java
+@@ -0,0 +1,320 @@
 +package io.papermc.paper.raytrace;
-+
-+import java.util.Collection;
-+import java.util.Set;
-+import java.util.function.Predicate;
 +
 +import com.google.common.base.Preconditions;
 +import org.bukkit.FluidCollisionMode;
@@ -28,175 +24,312 @@ index 0000000000000000000000000000000000000000..99a45534f9c4b61fbae1abfb79c810ef
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
++import java.util.Collection;
++import java.util.Set;
++import java.util.function.Predicate;
++
 +/**
-+ * Helps prepare a raytrace to be cast.
-+ *
-+ * Usage of the builder is preferred over the super long {@link World#rayTrace(Location, Vector, double, FluidCollisionMode, boolean, double, Predicate, Collection)} API
++ * Represents the immutable context for performing a raytrace.
++ * <p>Usage of the {@link Builder} is preferred over the super long
++ * {@link World#rayTrace(Location, Vector, double, FluidCollisionMode, boolean, double, Predicate, Collection)} API.
 + */
-+public class RayTraceBuilder {
-+  public static final double MAX_RANGE = 100;
++public class RayTraceContext {
++    public static final double MAX_RANGE = 100;
 +
-+  private Vector origin;
-+  private Vector direction;
++    private final Vector origin;
++    private final Vector direction;
 +
-+  private double range;
-+  private double raySize = 0;
++    private final double range;
++    private final double raySize;
 +
-+  private boolean ignorePassable = true;
++    private final boolean ignorePassable;
 +
-+  private FluidCollisionMode mode = FluidCollisionMode.NEVER;
-+  private Predicate<Entity> entityPredicate = x -> true;
-+  private Set<Block> ignoreBlocks = Set.of();
++    private final FluidCollisionMode fluidMode;
++    private final Predicate<Entity> entityPredicate;
++    private final Set<Block> ignoreBlocks;
 +
-+  private RayTraceBuilder() {
-+  }
++    private RayTraceContext(Builder builder) {
++        this.origin = builder.origin;
++        this.direction = builder.direction;
++        this.range = builder.range;
++        this.raySize = builder.raySize;
++        this.ignorePassable = builder.ignorePassable;
++        this.fluidMode = builder.fluidMode;
++        this.entityPredicate = builder.entityPredicate;
++        this.ignoreBlocks = builder.ignoreBlocks;
++    }
 +
-+  /**
-+   * Sets the raytrace origin.
-+   *
-+   * @param origin the new origin
-+   * @return the modified builder
-+   */
-+  @NotNull
-+  public RayTraceBuilder origin(@NotNull Vector origin) {
-+    Preconditions.checkArgument(origin != null, "Origin cannot be null");
-+    this.origin = origin.clone();
-+    return this;
-+  }
++    /**
++     * Get this context's origin.
++     *
++     * @return a copy of the origin
++     */
++    @NotNull
++    public Vector origin() {
++        return origin.clone();
++    }
 +
-+  /**
-+   * Override the raytrace direction.
-+   *
-+   * @param direction the new direction
-+   * @return the modified builder
-+   */
-+  @NotNull
-+  public RayTraceBuilder direction(@NotNull Vector direction) {
-+    Preconditions.checkArgument(direction != null, "Direction cannot be null");
-+    this.direction = direction.clone();
-+    return this;
-+  }
++    /**
++     * Get this context's direction.
++     *
++     * @return a copy of the direction
++     */
++    @NotNull
++    public Vector direction() {
++        return direction.clone();
++    }
 +
-+  /**
-+   * Override the raytrace range.
-+   * <p>Note: range is clamped at [1, 100].
-+   *
-+   * @param range the new range
-+   * @return the modified builder
-+   */
-+  @NotNull
-+  public RayTraceBuilder range(double range) {
-+    this.range = Math.min(MAX_RANGE, Math.max(1, range));
-+    return this;
-+  }
++    /**
++     * Get this context's range.
++     *
++     * @return the range
++     */
++    public double range() {
++        return range;
++    }
 +
-+  /**
-+   * Override the raytrace ray size.
-+   * Ray size effectively grows the ray's collider when checked against entities.
-+   * Default value is 0.
-+   *
-+   * @param raySize the new non-negative ray size
-+   * @return the modified builder
-+   */
-+  @NotNull
-+  public RayTraceBuilder raySize(double raySize) {
-+    this.raySize = Math.max(0, raySize);
-+    return this;
-+  }
++    /**
++     * Get this context's ray size.
++     *
++     * @return the ray size
++     */
++    public double raySize() {
++        return raySize;
++    }
 +
-+  /**
-+   * Override the fluid collision mode for the raytrace.
-+   * Default value is {@link FluidCollisionMode#NEVER}.
-+   *
-+   * @param mode the new mode
-+   * @return the modified builder
-+   */
-+  @NotNull
-+  public RayTraceBuilder fluids(@NotNull FluidCollisionMode mode) {
-+    Preconditions.checkArgument(mode != null, "Mode cannot be null");
-+    this.mode = mode;
-+    return this;
-+  }
++    /**
++     * Get this context's option for ignoring passable blocks.
++     *
++     * @return the option
++     */
++    public boolean ignorePassable() {
++        return ignorePassable;
++    }
 +
-+  /**
-+   * Override whether the raytrace should ignore passable blocks (blocks that the player can move through).
-+   * Default value is true.
-+   *
-+   * @param ignorePassable the new value
-+   * @return the modified builder
-+   */
-+  @NotNull
-+  public RayTraceBuilder ignorePassable(boolean ignorePassable) {
-+    this.ignorePassable = ignorePassable;
-+    return this;
-+  }
++    /**
++     * Get this context's fluid mode.
++     *
++     * @return the fluid mode
++     */
++    @NotNull
++    public FluidCollisionMode fluidMode() {
++        return fluidMode;
++    }
 +
-+  /**
-+   * Define a set of specific blocks the raytrace should ignore.
-+   * Default value is an empty set.
-+   *
-+   * @param ignoreBlocks the new set of blocks to ignore
-+   * @return the modified builder
-+   */
-+  @NotNull
-+  public RayTraceBuilder ignore(@NotNull Collection<Block> ignoreBlocks) {
-+    Preconditions.checkArgument(ignoreBlocks != null, "Collection cannot be null");
-+    this.ignoreBlocks = Set.copyOf(ignoreBlocks);
-+    return this;
-+  }
++    /**
++     * Get this context's entity filter.
++     *
++     * @return the filter
++     */
++    @NotNull
++    public Predicate<Entity> filter() {
++        return entityPredicate;
++    }
 +
-+  /**
-+   * Define a predicate of entities to filter when casting the raytrace. All other entities will be ignored.
-+   * Default value is colliding with all entities.
-+   *
-+   * @param entityPredicate the new predicate
-+   * @return the modified builder
-+   */
-+  @NotNull
-+  public RayTraceBuilder filter(@NotNull Predicate<Entity> entityPredicate) {
-+    Preconditions.checkArgument(entityPredicate != null, "Predicate cannot be null");
-+    this.entityPredicate = entityPredicate;
-+    return this;
-+  }
++    /**
++     * Get this context's ignored blocks.
++     *
++     * @return an immutable collection of ignored blocks
++     */
++    @NotNull
++    public Set<Block> ignoreBlocks() {
++        return ignoreBlocks;
++    }
 +
-+  /**
-+   * Build and cast the raytrace checking only blocks.
-+   *
-+   * @param world the world to cast the raytrace in
-+   * @return the result
-+   */
-+  @Nullable
-+  public RayTraceResult blocks(@NotNull World world) {
-+    Preconditions.checkArgument(world != null, "World cannot be null");
-+    Location start = new Location(world, origin.getX(), origin.getY(), origin.getZ());
-+    return world.rayTraceBlocks(start, direction, range, mode, ignorePassable, ignoreBlocks);
-+  }
++    /**
++     * Create a builder from this context.
++     *
++     * @return the builder
++     */
++    @NotNull
++    public Builder toBuilder() {
++        return new Builder(this);
++    }
 +
-+  /**
-+   * Build and cast the raytrace checking both blocks and entities.
-+   *
-+   * @param world the world to cast the raytrace in
-+   * @return the result
-+   */
-+  @Nullable
-+  public RayTraceResult entities(@NotNull World world) {
-+    Preconditions.checkArgument(world != null, "World cannot be null");
-+    Location start = new Location(world, origin.getX(), origin.getY(), origin.getZ());
-+    return world.rayTrace(start, direction, range, mode, ignorePassable, raySize, entityPredicate, ignoreBlocks);
-+  }
++    /**
++     * Create a new builder instance using the specified origin and direction.
++     * <p>Note: The range is calculated based on the length of the direction vector.
++     *
++     * @param origin    the origin of the raytrace
++     * @param direction the direction of the raytrace
++     * @return a new builder instance
++     */
++    @NotNull
++    public static Builder builder(@NotNull Vector origin, @NotNull Vector direction) {
++        return new Builder().origin(origin).direction(direction).range(direction.length());
++    }
 +
-+  /**
-+   * Create a new builder instance using the specified origin and direction.
-+   * <p>Note: The range is calculated based on the length of the direction vector.
-+   *
-+   * @param origin the origin of the raytrace
-+   * @param direction the direction of the raytrace
-+   * @return a new builder instance
-+   */
-+  @NotNull
-+  public static RayTraceBuilder of(@NotNull Vector origin, @NotNull Vector direction) {
-+    return new RayTraceBuilder().origin(origin).direction(direction).range(direction.length());
-+  }
++    public static class Builder {
++        private Vector origin;
++        private Vector direction;
++
++        private double range;
++        private double raySize = 0;
++
++        private boolean ignorePassable = true;
++
++        private FluidCollisionMode fluidMode = FluidCollisionMode.NEVER;
++        private Predicate<Entity> entityPredicate = x -> true;
++        private Set<Block> ignoreBlocks = Set.of();
++
++        private Builder() {
++        }
++
++        private Builder(RayTraceContext context) {
++            this.origin = context.origin;
++            this.direction = context.direction;
++            this.range = context.range;
++            this.raySize = context.raySize;
++            this.ignorePassable = context.ignorePassable;
++            this.fluidMode = context.fluidMode;
++            this.entityPredicate = context.entityPredicate;
++            this.ignoreBlocks = context.ignoreBlocks;
++        }
++
++        /**
++         * Override the raytrace origin.
++         *
++         * @param origin the new origin
++         * @return the modified builder
++         */
++        @NotNull
++        public Builder origin(@NotNull Vector origin) {
++            Preconditions.checkArgument(origin != null, "Origin cannot be null");
++            this.origin = origin.clone();
++            return this;
++        }
++
++        /**
++         * Override the raytrace direction.
++         *
++         * @param direction the new direction
++         * @return the modified builder
++         */
++        @NotNull
++        public Builder direction(@NotNull Vector direction) {
++            Preconditions.checkArgument(direction != null, "Direction cannot be null");
++            this.direction = direction.clone();
++            return this;
++        }
++
++        /**
++         * Override the raytrace range.
++         * <p>Note: range is clamped at [1, 100].
++         *
++         * @param range the new range
++         * @return the modified builder
++         */
++        @NotNull
++        public Builder range(double range) {
++            this.range = Math.min(MAX_RANGE, Math.max(1, range));
++            return this;
++        }
++
++        /**
++         * Override the raytrace ray size.
++         * Ray size effectively grows the ray's collider when checked against entities.
++         * Default value is 0.
++         *
++         * @param raySize the new non-negative ray size
++         * @return the modified builder
++         */
++        @NotNull
++        public Builder raySize(double raySize) {
++            this.raySize = Math.max(0, raySize);
++            return this;
++        }
++
++        /**
++         * Override the fluid collision mode for the raytrace.
++         * Default value is {@link FluidCollisionMode#NEVER}.
++         *
++         * @param fluidMode the new mode
++         * @return the modified builder
++         */
++        @NotNull
++        public Builder fluidMode(@NotNull FluidCollisionMode fluidMode) {
++            Preconditions.checkArgument(fluidMode != null, "Mode cannot be null");
++            this.fluidMode = fluidMode;
++            return this;
++        }
++
++        /**
++         * Override whether the raytrace should ignore passable blocks (blocks that the player can move through).
++         * Default value is true.
++         *
++         * @param ignorePassable the new value
++         * @return the modified builder
++         */
++        @NotNull
++        public Builder ignorePassable(boolean ignorePassable) {
++            this.ignorePassable = ignorePassable;
++            return this;
++        }
++
++        /**
++         * Define a set of specific blocks the raytrace should ignore.
++         * Default value is an empty set.
++         *
++         * @param ignoreBlocks the new set of blocks to ignore
++         * @return the modified builder
++         */
++        @NotNull
++        public Builder ignore(@NotNull Collection<Block> ignoreBlocks) {
++            Preconditions.checkArgument(ignoreBlocks != null, "Collection cannot be null");
++            this.ignoreBlocks = Set.copyOf(ignoreBlocks);
++            return this;
++        }
++
++        /**
++         * Define a predicate of entities to filter when casting the raytrace. All other entities will be ignored.
++         * Default value is colliding with all entities.
++         *
++         * @param entityPredicate the new predicate
++         * @return the modified builder
++         */
++        @NotNull
++        public Builder filter(@NotNull Predicate<Entity> entityPredicate) {
++            Preconditions.checkArgument(entityPredicate != null, "Predicate cannot be null");
++            this.entityPredicate = entityPredicate;
++            return this;
++        }
++
++        /**
++         * Build a raytrace context from this builder.
++         *
++         * @return the built context
++         */
++        @Nullable
++        public RayTraceContext build() {
++            return new RayTraceContext(this);
++        }
++
++        /**
++         * Build and cast the raytrace checking only blocks.
++         *
++         * @param world the world to cast the raytrace in
++         * @return the result
++         */
++        @Nullable
++        public RayTraceResult blocks(@NotNull World world) {
++            Preconditions.checkArgument(world != null, "World cannot be null");
++            Location start = new Location(world, origin.getX(), origin.getY(), origin.getZ());
++            return world.rayTraceBlocks(start, direction, range, fluidMode, ignorePassable, ignoreBlocks);
++        }
++
++        /**
++         * Build and cast the raytrace checking both blocks and entities.
++         *
++         * @param world the world to cast the raytrace in
++         * @return the result
++         */
++        @Nullable
++        public RayTraceResult entities(@NotNull World world) {
++            Preconditions.checkArgument(world != null, "World cannot be null");
++            Location start = new Location(world, origin.getX(), origin.getY(), origin.getZ());
++            return world.rayTrace(start, direction, range, fluidMode, ignorePassable, raySize, entityPredicate, ignoreBlocks);
++        }
++    }
 +}
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
 index e8c0c853eb52d1473c20231660355f77b1f7e016..15f9cf10f61c818417b6e063d1df64b8be8cff21 100644

--- a/patches/api/0389-Add-extra-raytracing-api.patch
+++ b/patches/api/0389-Add-extra-raytracing-api.patch
@@ -1,0 +1,282 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: PrimordialMoros <mail@moros.me>
+Date: Fri, 29 Jul 2022 16:04:32 +0300
+Subject: [PATCH] Add extra raytracing api
+
+Adds the option to ignore specific blocks (based on their position) when performing a raytrace.
+
+diff --git a/src/main/java/io/papermc/paper/raytrace/RayTraceBuilder.java b/src/main/java/io/papermc/paper/raytrace/RayTraceBuilder.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..99a45534f9c4b61fbae1abfb79c810ef419f730c
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/raytrace/RayTraceBuilder.java
+@@ -0,0 +1,187 @@
++package io.papermc.paper.raytrace;
++
++import java.util.Collection;
++import java.util.Set;
++import java.util.function.Predicate;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.FluidCollisionMode;
++import org.bukkit.Location;
++import org.bukkit.World;
++import org.bukkit.block.Block;
++import org.bukkit.entity.Entity;
++import org.bukkit.util.RayTraceResult;
++import org.bukkit.util.Vector;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Helps prepare a raytrace to be cast.
++ *
++ * Usage of the builder is preferred over the super long {@link World#rayTrace(Location, Vector, double, FluidCollisionMode, boolean, double, Predicate, Collection)} API
++ */
++public class RayTraceBuilder {
++  public static final double MAX_RANGE = 100;
++
++  private Vector origin;
++  private Vector direction;
++
++  private double range;
++  private double raySize = 0;
++
++  private boolean ignorePassable = true;
++
++  private FluidCollisionMode mode = FluidCollisionMode.NEVER;
++  private Predicate<Entity> entityPredicate = x -> true;
++  private Set<Block> ignoreBlocks = Set.of();
++
++  private RayTraceBuilder() {
++  }
++
++  /**
++   * Sets the raytrace origin.
++   *
++   * @param origin the new origin
++   * @return the modified builder
++   */
++  @NotNull
++  public RayTraceBuilder origin(@NotNull Vector origin) {
++    Preconditions.checkArgument(origin != null, "Origin cannot be null");
++    this.origin = origin.clone();
++    return this;
++  }
++
++  /**
++   * Override the raytrace direction.
++   *
++   * @param direction the new direction
++   * @return the modified builder
++   */
++  @NotNull
++  public RayTraceBuilder direction(@NotNull Vector direction) {
++    Preconditions.checkArgument(direction != null, "Direction cannot be null");
++    this.direction = direction.clone();
++    return this;
++  }
++
++  /**
++   * Override the raytrace range.
++   * <p>Note: range is clamped at [1, 100].
++   *
++   * @param range the new range
++   * @return the modified builder
++   */
++  @NotNull
++  public RayTraceBuilder range(double range) {
++    this.range = Math.min(MAX_RANGE, Math.max(1, range));
++    return this;
++  }
++
++  /**
++   * Override the raytrace ray size.
++   * Ray size effectively grows the ray's collider when checked against entities.
++   * Default value is 0.
++   *
++   * @param raySize the new non-negative ray size
++   * @return the modified builder
++   */
++  @NotNull
++  public RayTraceBuilder raySize(double raySize) {
++    this.raySize = Math.max(0, raySize);
++    return this;
++  }
++
++  /**
++   * Override the fluid collision mode for the raytrace.
++   * Default value is {@link FluidCollisionMode#NEVER}.
++   *
++   * @param mode the new mode
++   * @return the modified builder
++   */
++  @NotNull
++  public RayTraceBuilder fluids(@NotNull FluidCollisionMode mode) {
++    Preconditions.checkArgument(mode != null, "Mode cannot be null");
++    this.mode = mode;
++    return this;
++  }
++
++  /**
++   * Override whether the raytrace should ignore passable blocks (blocks that the player can move through).
++   * Default value is true.
++   *
++   * @param ignorePassable the new value
++   * @return the modified builder
++   */
++  @NotNull
++  public RayTraceBuilder ignorePassable(boolean ignorePassable) {
++    this.ignorePassable = ignorePassable;
++    return this;
++  }
++
++  /**
++   * Define a set of specific blocks the raytrace should ignore.
++   * Default value is an empty set.
++   *
++   * @param ignoreBlocks the new set of blocks to ignore
++   * @return the modified builder
++   */
++  @NotNull
++  public RayTraceBuilder ignore(@NotNull Collection<Block> ignoreBlocks) {
++    Preconditions.checkArgument(ignoreBlocks != null, "Collection cannot be null");
++    this.ignoreBlocks = Set.copyOf(ignoreBlocks);
++    return this;
++  }
++
++  /**
++   * Define a predicate of entities to filter when casting the raytrace. All other entities will be ignored.
++   * Default value is colliding with all entities.
++   *
++   * @param entityPredicate the new predicate
++   * @return the modified builder
++   */
++  @NotNull
++  public RayTraceBuilder filter(@NotNull Predicate<Entity> entityPredicate) {
++    Preconditions.checkArgument(entityPredicate != null, "Predicate cannot be null");
++    this.entityPredicate = entityPredicate;
++    return this;
++  }
++
++  /**
++   * Build and cast the raytrace checking only blocks.
++   *
++   * @param world the world to cast the raytrace in
++   * @return the result
++   */
++  @Nullable
++  public RayTraceResult blocks(@NotNull World world) {
++    Preconditions.checkArgument(world != null, "World cannot be null");
++    Location start = new Location(world, origin.getX(), origin.getY(), origin.getZ());
++    return world.rayTraceBlocks(start, direction, range, mode, ignorePassable, ignoreBlocks);
++  }
++
++  /**
++   * Build and cast the raytrace checking both blocks and entities.
++   *
++   * @param world the world to cast the raytrace in
++   * @return the result
++   */
++  @Nullable
++  public RayTraceResult entities(@NotNull World world) {
++    Preconditions.checkArgument(world != null, "World cannot be null");
++    Location start = new Location(world, origin.getX(), origin.getY(), origin.getZ());
++    return world.rayTrace(start, direction, range, mode, ignorePassable, raySize, entityPredicate, ignoreBlocks);
++  }
++
++  /**
++   * Create a new builder instance using the specified origin and direction.
++   * <p>Note: The range is calculated based on the length of the direction vector.
++   *
++   * @param origin the origin of the raytrace
++   * @param direction the direction of the raytrace
++   * @return a new builder instance
++   */
++  @NotNull
++  public static RayTraceBuilder of(@NotNull Vector origin, @NotNull Vector direction) {
++    return new RayTraceBuilder().origin(origin).direction(direction).range(direction.length());
++  }
++}
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index e8c0c853eb52d1473c20231660355f77b1f7e016..15f9cf10f61c818417b6e063d1df64b8be8cff21 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -1791,6 +1791,34 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+     @Nullable
+     public RayTraceResult rayTraceBlocks(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks);
+ 
++    // Paper start
++    /**
++     * Performs a ray trace that checks for block collisions using the blocks'
++     * precise collision shapes.
++     * <p>
++     * If collisions with passable blocks are ignored, fluid collisions are
++     * ignored as well regardless of the fluid collision mode.
++     * <p>
++     * Portal blocks are only considered passable if the ray starts within
++     * them. Apart from that collisions with portal blocks will be considered
++     * even if collisions with passable blocks are otherwise ignored.
++     * <p>
++     * This may cause loading of chunks! Some implementations may impose
++     * artificial restrictions on the maximum distance.
++     *
++     * @param start the start location
++     * @param direction the ray direction
++     * @param maxDistance the maximum distance
++     * @param fluidCollisionMode the fluid collision mode
++     * @param ignorePassableBlocks whether to ignore passable but collidable
++     *     blocks (ex. tall grass, signs, fluids, ..)
++     * @param ignored a collection of blocks to ignore
++     * @return the ray trace hit result, or <code>null</code> if there is no hit
++     */
++    @Nullable
++    public RayTraceResult rayTraceBlocks(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, @NotNull Collection<Block> ignored);
++    // Paper end
++
+     /**
+      * Performs a ray trace that checks for both block and entity collisions.
+      * <p>
+@@ -1824,6 +1852,42 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+     @Nullable
+     public RayTraceResult rayTrace(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<Entity> filter);
+ 
++    // Paper start
++    /**
++     * Performs a ray trace that checks for both block and entity collisions.
++     * <p>
++     * Block collisions use the blocks' precise collision shapes. The
++     * <code>raySize</code> parameter is only taken into account for entity
++     * collision checks.
++     * <p>
++     * If collisions with passable blocks are ignored, fluid collisions are
++     * ignored as well regardless of the fluid collision mode.
++     * <p>
++     * Portal blocks are only considered passable if the ray starts within them.
++     * Apart from that collisions with portal blocks will be considered even if
++     * collisions with passable blocks are otherwise ignored.
++     * <p>
++     * This may cause loading of chunks! Some implementations may impose
++     * artificial restrictions on the maximum distance.
++     *
++     * @param start the start location
++     * @param direction the ray direction
++     * @param maxDistance the maximum distance
++     * @param fluidCollisionMode the fluid collision mode
++     * @param ignorePassableBlocks whether to ignore passable but collidable
++     *     blocks (ex. tall grass, signs, fluids, ..)
++     * @param raySize entity bounding boxes will be uniformly expanded (or
++     *     shrinked) by this value before doing collision checks
++     * @param filter only entities that fulfill this predicate are considered,
++     *     or <code>null</code> to consider all entities
++     * @param ignored a collection of blocks to ignore
++     * @return the closest ray trace hit result with either a block or an
++     *     entity, or <code>null</code> if there is no hit
++     */
++    @Nullable
++    public RayTraceResult rayTrace(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<Entity> filter, @NotNull Collection<Block> ignored);
++    // Paper end
++
+     /**
+      * Gets the default spawn {@link Location} of this world
+      *

--- a/patches/server/0925-Add-extra-raytracing-api.patch
+++ b/patches/server/0925-Add-extra-raytracing-api.patch
@@ -1,30 +1,28 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: PrimordialMoros <mail@moros.me>
-Date: Fri, 29 Jul 2022 04:18:57 +0300
+Date: Sat, 30 Jul 2022 02:43:27 +0300
 Subject: [PATCH] Add extra raytracing api
 
 Adds the option to ignore specific blocks (based on their position) when performing a raytrace.
 
 diff --git a/src/main/java/net/minecraft/world/level/BlockGetter.java b/src/main/java/net/minecraft/world/level/BlockGetter.java
-index d1eefa6ef3e9abfe7af4d8310aa64465fa2d5463..bcce89bd15bc182b612a9a372f9197786e3a3af8 100644
+index d1eefa6ef3e9abfe7af4d8310aa64465fa2d5463..c04d09523bb02a37d0fef907965375b3acb82e63 100644
 --- a/src/main/java/net/minecraft/world/level/BlockGetter.java
 +++ b/src/main/java/net/minecraft/world/level/BlockGetter.java
-@@ -72,9 +72,13 @@ public interface BlockGetter extends LevelHeightAccessor {
-             return BlockHitResult.miss(clipblockstatecontext1.getTo(), Direction.getNearest(vec3d.x, vec3d.y, vec3d.z), new BlockPos(clipblockstatecontext1.getTo()));
-         });
-     }
-+    // Paper start
-+    default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition) {
-+      return clip(raytrace1, blockposition, java.util.Set.of());
-+    }
+@@ -75,6 +75,12 @@ public interface BlockGetter extends LevelHeightAccessor {
  
      // CraftBukkit start - moved block handling into separate method for use by Block#rayTrace
--    default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition) {
-+    default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition, java.util.Set<BlockPos> ignored) { // Paper end
+     default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition) {
++        // Paper start
++        return clip(raytrace1, blockposition, java.util.Set.of());
++    }
++    // Paper end
++
++    default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition, java.util.Set<BlockPos> ignored) { // Paper add overload
              // Paper start - Prevent raytrace from loading chunks
              BlockState iblockdata = this.getBlockStateIfLoaded(blockposition);
              if (iblockdata == null) {
-@@ -84,7 +88,7 @@ public interface BlockGetter extends LevelHeightAccessor {
+@@ -84,7 +90,7 @@ public interface BlockGetter extends LevelHeightAccessor {
                  return BlockHitResult.miss(raytrace1.getTo(), Direction.getNearest(vec3d.x, vec3d.y, vec3d.z), new BlockPos(raytrace1.getTo()));
              }
              // Paper end
@@ -33,64 +31,67 @@ index d1eefa6ef3e9abfe7af4d8310aa64465fa2d5463..bcce89bd15bc182b612a9a372f919778
              FluidState fluid = iblockdata.getFluidState(); // Paper - don't need to go to world state again
              Vec3 vec3d = raytrace1.getFrom();
              Vec3 vec3d1 = raytrace1.getTo();
-@@ -98,10 +102,14 @@ public interface BlockGetter extends LevelHeightAccessor {
-             return d0 <= d1 ? movingobjectpositionblock : movingobjectpositionblock1;
-     }
+@@ -100,8 +106,14 @@ public interface BlockGetter extends LevelHeightAccessor {
      // CraftBukkit end
--
-+    // Paper start
+
      default BlockHitResult clip(ClipContext context) {
-+      return clip(context, java.util.Set.of());
++        // Paper start
++        return clip(context, java.util.Set.of());
 +    }
 +
 +    default BlockHitResult clip(ClipContext context, java.util.Set<BlockPos> ignored) {
++        // Paper end
          return (BlockHitResult) BlockGetter.traverseBlocks(context.getFrom(), context.getTo(), context, (raytrace1, blockposition) -> {
 -            return this.clip(raytrace1, blockposition); // CraftBukkit - moved into separate method
-+            return this.clip(raytrace1, blockposition, ignored); // CraftBukkit - moved into separate method // Paper end
++            return this.clip(raytrace1, blockposition, ignored); // CraftBukkit - moved into separate method // Paper use overloaded method
          }, (raytrace1) -> {
              Vec3 vec3d = raytrace1.getFrom().subtract(raytrace1.getTo());
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a5d8dfc77475845be7c6d37eed04fb19eeef1c0c..d4b60400ea2c175edb0c15efed05e547ac180a49 100644
+index a5d8dfc77475845be7c6d37eed04fb19eeef1c0c..7ded413dcbecfe8440b8ad5151d6826e63287563 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1169,8 +1169,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-         return this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, false);
-     }
+@@ -1171,6 +1171,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
-+    // Paper start
      @Override
      public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks) {
-+      return this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, Set.of());
++        // Paper start
++        return this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, Set.of());
 +    }
 +
 +    @Override
 +    public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, Collection<Block> ignored) {
++        // Paper end
          Validate.notNull(start, "Start location is null!");
          Validate.isTrue(this.equals(start.getWorld()), "Start location is from different world!");
          start.checkFinite();
-@@ -1188,13 +1194,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1188,14 +1195,27 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Vector dir = direction.clone().normalize().multiply(maxDistance);
          Vec3 startPos = new Vec3(start.getX(), start.getY(), start.getZ());
          Vec3 endPos = new Vec3(start.getX() + dir.getX(), start.getY() + dir.getY(), start.getZ() + dir.getZ());
 -        HitResult nmsHitResult = this.getHandle().clip(new ClipContext(startPos, endPos, ignorePassableBlocks ? ClipContext.Block.COLLIDER : ClipContext.Block.OUTLINE, CraftFluidCollisionMode.toNMS(fluidCollisionMode), null));
--
++        // Paper start
 +        Set<BlockPos> ignoredBlockPositions = new HashSet<>();
 +        for (Block block : ignored) {
 +          ignoredBlockPositions.add(new BlockPos(block.getX(), block.getY(), block.getZ()));
 +        }
 +        HitResult nmsHitResult = this.getHandle().clip(new ClipContext(startPos, endPos, ignorePassableBlocks ? ClipContext.Block.COLLIDER : ClipContext.Block.OUTLINE, CraftFluidCollisionMode.toNMS(fluidCollisionMode), null), ignoredBlockPositions);
 +        // Paper end
+
          return CraftRayTraceResult.fromNMS(this, nmsHitResult);
      }
  
      @Override
      public RayTraceResult rayTrace(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<Entity> filter) {
-+        return rayTrace(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, raySize, filter, Set.of()); // Paper start - add overload method
+-        RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks);
++        // Paper start - add overload method
++        return rayTrace(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, raySize, filter, Set.of());
 +    }
 +
 +    @Override
-+    public RayTraceResult rayTrace(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<Entity> filter, Collection<Block> ignored) { // Paper end
-         RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks);
++    public RayTraceResult rayTrace(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<Entity> filter, Collection<Block> ignored) {
++        RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, ignored);
++        // Paper end
          Vector startVec = null;
          double blockHitDistance = maxDistance;
+ 

--- a/patches/server/0925-Add-extra-raytracing-api.patch
+++ b/patches/server/0925-Add-extra-raytracing-api.patch
@@ -1,0 +1,96 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: PrimordialMoros <mail@moros.me>
+Date: Fri, 29 Jul 2022 04:18:57 +0300
+Subject: [PATCH] Add extra raytracing api
+
+Adds the option to ignore specific blocks (based on their position) when performing a raytrace.
+
+diff --git a/src/main/java/net/minecraft/world/level/BlockGetter.java b/src/main/java/net/minecraft/world/level/BlockGetter.java
+index d1eefa6ef3e9abfe7af4d8310aa64465fa2d5463..bcce89bd15bc182b612a9a372f9197786e3a3af8 100644
+--- a/src/main/java/net/minecraft/world/level/BlockGetter.java
++++ b/src/main/java/net/minecraft/world/level/BlockGetter.java
+@@ -72,9 +72,13 @@ public interface BlockGetter extends LevelHeightAccessor {
+             return BlockHitResult.miss(clipblockstatecontext1.getTo(), Direction.getNearest(vec3d.x, vec3d.y, vec3d.z), new BlockPos(clipblockstatecontext1.getTo()));
+         });
+     }
++    // Paper start
++    default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition) {
++      return clip(raytrace1, blockposition, java.util.Set.of());
++    }
+ 
+     // CraftBukkit start - moved block handling into separate method for use by Block#rayTrace
+-    default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition) {
++    default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition, java.util.Set<BlockPos> ignored) { // Paper end
+             // Paper start - Prevent raytrace from loading chunks
+             BlockState iblockdata = this.getBlockStateIfLoaded(blockposition);
+             if (iblockdata == null) {
+@@ -84,7 +88,7 @@ public interface BlockGetter extends LevelHeightAccessor {
+                 return BlockHitResult.miss(raytrace1.getTo(), Direction.getNearest(vec3d.x, vec3d.y, vec3d.z), new BlockPos(raytrace1.getTo()));
+             }
+             // Paper end
+-            if (iblockdata.isAir()) return null; // Paper - optimise air cases
++            if (iblockdata.isAir() || ignored.contains(blockposition)) return null; // Paper - optimise air cases and ignore predefined blocks
+             FluidState fluid = iblockdata.getFluidState(); // Paper - don't need to go to world state again
+             Vec3 vec3d = raytrace1.getFrom();
+             Vec3 vec3d1 = raytrace1.getTo();
+@@ -98,10 +102,14 @@ public interface BlockGetter extends LevelHeightAccessor {
+             return d0 <= d1 ? movingobjectpositionblock : movingobjectpositionblock1;
+     }
+     // CraftBukkit end
+-
++    // Paper start
+     default BlockHitResult clip(ClipContext context) {
++      return clip(context, java.util.Set.of());
++    }
++
++    default BlockHitResult clip(ClipContext context, java.util.Set<BlockPos> ignored) {
+         return (BlockHitResult) BlockGetter.traverseBlocks(context.getFrom(), context.getTo(), context, (raytrace1, blockposition) -> {
+-            return this.clip(raytrace1, blockposition); // CraftBukkit - moved into separate method
++            return this.clip(raytrace1, blockposition, ignored); // CraftBukkit - moved into separate method // Paper end
+         }, (raytrace1) -> {
+             Vec3 vec3d = raytrace1.getFrom().subtract(raytrace1.getTo());
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index a5d8dfc77475845be7c6d37eed04fb19eeef1c0c..d4b60400ea2c175edb0c15efed05e547ac180a49 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -1169,8 +1169,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+         return this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, false);
+     }
+ 
++    // Paper start
+     @Override
+     public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks) {
++      return this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, Set.of());
++    }
++
++    @Override
++    public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, Collection<Block> ignored) {
+         Validate.notNull(start, "Start location is null!");
+         Validate.isTrue(this.equals(start.getWorld()), "Start location is from different world!");
+         start.checkFinite();
+@@ -1188,13 +1194,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+         Vector dir = direction.clone().normalize().multiply(maxDistance);
+         Vec3 startPos = new Vec3(start.getX(), start.getY(), start.getZ());
+         Vec3 endPos = new Vec3(start.getX() + dir.getX(), start.getY() + dir.getY(), start.getZ() + dir.getZ());
+-        HitResult nmsHitResult = this.getHandle().clip(new ClipContext(startPos, endPos, ignorePassableBlocks ? ClipContext.Block.COLLIDER : ClipContext.Block.OUTLINE, CraftFluidCollisionMode.toNMS(fluidCollisionMode), null));
+-
++        Set<BlockPos> ignoredBlockPositions = new HashSet<>();
++        for (Block block : ignored) {
++          ignoredBlockPositions.add(new BlockPos(block.getX(), block.getY(), block.getZ()));
++        }
++        HitResult nmsHitResult = this.getHandle().clip(new ClipContext(startPos, endPos, ignorePassableBlocks ? ClipContext.Block.COLLIDER : ClipContext.Block.OUTLINE, CraftFluidCollisionMode.toNMS(fluidCollisionMode), null), ignoredBlockPositions);
++        // Paper end
+         return CraftRayTraceResult.fromNMS(this, nmsHitResult);
+     }
+ 
+     @Override
+     public RayTraceResult rayTrace(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<Entity> filter) {
++        return rayTrace(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, raySize, filter, Set.of()); // Paper start - add overload method
++    }
++
++    @Override
++    public RayTraceResult rayTrace(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<Entity> filter, Collection<Block> ignored) { // Paper end
+         RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks);
+         Vector startVec = null;
+         double blockHitDistance = maxDistance;


### PR DESCRIPTION
New api allows to specify a set of blocks (or rather block positions) that will be ignored when performing a raytrace.

It also adds a builder to easily construct raytraces instead of using the world methods with a myriad args.

Should this be consolidated with previous raytrace patches?