### PR TITLE
Add new override for setChunckForceLoaded

### DIFF
--- a/patches/api/0389-Add-new-override-for-setChunckForceLoaded.patch
+++ b/patches/api/0389-Add-new-override-for-setChunckForceLoaded.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zJanny <jan.trummer@hotmail.com>
+Date: Fri, 29 Jul 2022 17:28:06 +0200
+Subject: [PATCH] Add new override for setChunckForceLoaded
+
+
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index e8c0c853eb52d1473c20231660355f77b1f7e016..17903d37f5b2bccdea23c319108756bde61ca3cb 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -539,6 +539,19 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+      */
+     public void setChunkForceLoaded(int x, int z, boolean forced);
+ 
++    // Paper start
++    /**
++     * Sets whether the chunk at the specified chunk coordinates is force
++     * loaded.
++     * <p>
++     * A force loaded chunk will not be unloaded due to lack of player activity.
++     *
++     * @param chunk Chunk to be forceloaded
++     * @param forced force load status
++     */
++    public void setChunkForceLoaded(Chunk chunk, boolean forced);
++    // Paper end
++
+     /**
+      * Returns all force loaded chunks in this world.
+      * <p>

--- a/patches/api/0389-Add-new-override-for-setChunckForceLoaded.patch
+++ b/patches/api/0389-Add-new-override-for-setChunckForceLoaded.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add new override for setChunckForceLoaded
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index e8c0c853eb52d1473c20231660355f77b1f7e016..17903d37f5b2bccdea23c319108756bde61ca3cb 100644
+index e8c0c853eb52d1473c20231660355f77b1f7e016..dc843259bf23d60ae54ccebdf02c0cd4f91d04a8 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -539,6 +539,19 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -22,7 +22,7 @@ index e8c0c853eb52d1473c20231660355f77b1f7e016..17903d37f5b2bccdea23c319108756bd
 +     * @param chunk Chunk to be forceloaded
 +     * @param forced force load status
 +     */
-+    public void setChunkForceLoaded(Chunk chunk, boolean forced);
++    public void setChunkForceLoaded(@NotNull Chunk chunk, boolean forced);
 +    // Paper end
 +
      /**

--- a/patches/server/0925-Add-new-override-for-setChunckForceLoaded.patch
+++ b/patches/server/0925-Add-new-override-for-setChunckForceLoaded.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zJanny <jan.trummer@hotmail.com>
+Date: Fri, 29 Jul 2022 17:28:41 +0200
+Subject: [PATCH] Add new override for setChunckForceLoaded
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index a5d8dfc77475845be7c6d37eed04fb19eeef1c0c..64b2b26b13c84ec0189a239c619a30c20dc4a179 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -673,6 +673,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+         this.getHandle().setChunkForced(x, z, forced);
+     }
+ 
++    // Paper start
++    @Override
++    public void setChunkForceLoaded(Chunk chunk, boolean forced) {
++        this.getHandle().setChunkForced(chunk.getX(), chunk.getZ(), forced);
++    }
++    // Paper end
++
+     @Override
+     public Collection<Chunk> getForceLoadedChunks() {
+         Set<Chunk> chunks = new HashSet<>();


### PR DESCRIPTION
I was coding a plugin and noticed that loadChunk has a override with a chunk parameter, but setChunckForceLoaded does not, so i added it.