### PR TITLE
Add existsStatistic with Material and EntityType check

### DIFF
--- a/patches/api/0389-Add-existsStatistic-with-Material-and-EntityType-che.patch
+++ b/patches/api/0389-Add-existsStatistic-with-Material-and-EntityType-che.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Karl <karl.bene.99@googlemail.com>
+Date: Sat, 30 Jul 2022 00:40:50 +0200
+Subject: [PATCH] Add existsStatistic with Material and EntityType check
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 92a1462261029e804da73da2743bbd68e57841e9..fed9b902c05ba392994d24c7942b88acf2e3d072 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -26,6 +26,7 @@ import org.bukkit.command.CommandSender;
+ import org.bukkit.command.ConsoleCommandSender;
+ import org.bukkit.command.PluginCommand;
+ import org.bukkit.entity.Entity;
++import org.bukkit.entity.EntityType;
+ import org.bukkit.entity.Player;
+ import org.bukkit.entity.SpawnCategory;
+ import org.bukkit.event.inventory.InventoryType;
+@@ -2079,6 +2080,31 @@ public final class Bukkit {
+         return server.advancementIterator();
+     }
+ 
++    // Paper start
++    /**
++     * Checks if a given statistic/material combination exists.
++     * @param statistic A statistic of type Statistic.Type.ITEM or Statistic.Type.BLOCK
++     * @param material A material type
++     * @return true if the given combination exists
++     * @see Statistic.Type
++     */
++    public static boolean existsStatistic(Statistic statistic, Material material) {
++        return server.existsStatistic(statistic, material);
++    }
++
++    /**
++     * Checks if a given statistic/entity type combination exists.
++     * @param statistic A statistic of type Statistic.Type.ENTITY
++     * @param entityType An entity type
++     * @return true if the given combination exists
++     * @see Statistic.Type
++     */
++    public static boolean existsStatistic(Statistic statistic, EntityType entityType) {
++        return server.existsStatistic(statistic, entityType);
++    }
++
++    // Paper end
++
+     /**
+      * Creates a new {@link BlockData} instance for the specified Material, with
+      * all properties initialized to unspecified defaults.
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 56e261efa654e4a6872ccea28f0461df13845d13..54d2e2984a7552bf72e0058060aca3f41e798704 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -26,6 +26,7 @@ import org.bukkit.command.CommandSender;
+ import org.bukkit.command.ConsoleCommandSender;
+ import org.bukkit.command.PluginCommand;
+ import org.bukkit.entity.Entity;
++import org.bukkit.entity.EntityType;
+ import org.bukkit.entity.Player;
+ import org.bukkit.entity.SpawnCategory;
+ import org.bukkit.event.inventory.InventoryType;
+@@ -1760,6 +1761,26 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+     @NotNull
+     Iterator<Advancement> advancementIterator();
+ 
++    // Paper start
++    /**
++     * Checks if a given statistic/material combination exists.
++     * @param statistic A statistic of type Statistic.Type.ITEM or Statistic.Type.BLOCK
++     * @param material A material type
++     * @return true if the given combination exists
++     * @see Statistic.Type
++     */
++    boolean existsStatistic(Statistic statistic, Material material);
++
++    /**
++     * Checks if a given statistic/entity type combination exists.
++     * @param statistic A statistic of type Statistic.Type.ENTITY
++     * @param entityType An entity type
++     * @return true if the given combination exists
++     * @see Statistic.Type
++     */
++    boolean existsStatistic(Statistic statistic, EntityType entityType);
++    // Paper end
++
+     /**
+      * Creates a new {@link BlockData} instance for the specified Material, with
+      * all properties initialized to unspecified defaults.

--- a/patches/server/0925-Add-existsStatistic-with-Material-and-EntityType-che.patch
+++ b/patches/server/0925-Add-existsStatistic-with-Material-and-EntityType-che.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Benedikt Karl <karl.bene.99@googlemail.com>
+Date: Sat, 30 Jul 2022 00:40:17 +0200
+Subject: [PATCH] Add existsStatistic with Material and EntityType check
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index bfde5bbcccfaa754ec6bdf4f3817981a93e465bd..e2eeeb11ffadb7f21bd0f7939422ffa1ec90ba89 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -106,23 +106,9 @@ import net.minecraft.world.level.storage.PrimaryLevelData;
+ import net.minecraft.world.level.storage.loot.LootTables;
+ import net.minecraft.world.phys.Vec3;
+ import org.apache.commons.lang.Validate;
+-import org.bukkit.BanList;
+-import org.bukkit.Bukkit;
+-import org.bukkit.ChatColor;
+-import org.bukkit.GameMode;
+-import org.bukkit.Keyed;
+-import org.bukkit.Location;
+-import org.bukkit.NamespacedKey;
+-import org.bukkit.OfflinePlayer;
+-import org.bukkit.Registry;
+-import org.bukkit.Server;
+-import org.bukkit.StructureType;
+-import org.bukkit.UnsafeValues;
++import org.bukkit.*;
+ import org.bukkit.Warning.WarningState;
+-import org.bukkit.World;
+ import org.bukkit.World.Environment;
+-import org.bukkit.WorldBorder;
+-import org.bukkit.WorldCreator;
+ import org.bukkit.block.data.BlockData;
+ import org.bukkit.boss.BarColor;
+ import org.bukkit.boss.BarFlag;
+@@ -2504,6 +2490,26 @@ public final class CraftServer implements Server {
+         }));
+     }
+ 
++    // Paper start
++
++    @Override
++    public boolean existsStatistic(Statistic statistic, Material material) {
++        if (statistic.getType() != Statistic.Type.BLOCK && statistic.getType() != Statistic.Type.ITEM) {
++            return false;
++        }
++        return CraftStatistic.getMaterialStatistic(statistic, material) != null;
++    }
++
++    @Override
++    public boolean existsStatistic(Statistic statistic, org.bukkit.entity.EntityType entityType) {
++        if (statistic.getType() != Statistic.Type.ENTITY) {
++            return false;
++        }
++        return CraftStatistic.getEntityStatistic(statistic, entityType) != null;
++    }
++
++    // Paper end
++
+     @Override
+     public BlockData createBlockData(org.bukkit.Material material) {
+         Validate.isTrue(material != null, "Must provide material");


### PR DESCRIPTION
When I was trying to modify some statistics in batch, I noticed that there wasn't a way to check if a certain statistic and material/entity type combination exists, instead the methods just threw exceptions whenever a certain combination was invalid.