### PR TITLE
Custom Chat Completions API

### DIFF
--- a/patches/api/0389-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0389-Custom-Chat-Completion-Suggestions-API.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sat, 30 Jul 2022 11:23:11 -0400
+Subject: [PATCH] Custom Chat Completion Suggestions API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 3fcfe8651a9c422fa9c8ff77556477f1461424cf..703f9f2f36831e458b2fd1c2cd58247ddca54c1b 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -2570,6 +2570,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @throws IllegalArgumentException If the level is negative or greater than {@code 4} (i.e. not within {@code [0, 4]}).
+      */
+     void sendOpLevel(byte level);
++
++    /**
++     * Adds custom chat completion suggestions that the client will
++     * suggest when typing in chat.
++     *
++     * @param completions custom completions
++     */
++    void addCustomCompletionSuggestions(@NotNull java.util.List<String> completions);
++
++    /**
++     * Removes custom chat completion suggestions that the client
++     * suggests when typing in chat.
++     *
++     * Note: this only applies to previously added custom completions,
++     * online player names are always suggested and cannot be removed.
++     *
++     * @param completions custom completions
++     */
++    void removeCustomCompletionSuggestions(@NotNull java.util.List<String> completions);
+     // Paper end
+ 
+     // Spigot start

--- a/patches/api/0389-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0389-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3fcfe8651a9c422fa9c8ff77556477f1461424cf..703f9f2f36831e458b2fd1c2cd58247ddca54c1b 100644
+index 3fcfe8651a9c422fa9c8ff77556477f1461424cf..e28d213bc1cb73b15ce48a292fbba8f2979e8d69 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2570,6 +2570,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -19,7 +19,7 @@ index 3fcfe8651a9c422fa9c8ff77556477f1461424cf..703f9f2f36831e458b2fd1c2cd58247d
 +     *
 +     * @param completions custom completions
 +     */
-+    void addCustomCompletionSuggestions(@NotNull java.util.List<String> completions);
++    void addAdditionalChatCompletions(@NotNull java.util.List<String> completions);
 +
 +    /**
 +     * Removes custom chat completion suggestions that the client
@@ -30,7 +30,7 @@ index 3fcfe8651a9c422fa9c8ff77556477f1461424cf..703f9f2f36831e458b2fd1c2cd58247d
 +     *
 +     * @param completions custom completions
 +     */
-+    void removeCustomCompletionSuggestions(@NotNull java.util.List<String> completions);
++    void removeAdditionalChatCompletions(@NotNull java.util.List<String> completions);
      // Paper end
  
      // Spigot start

--- a/patches/api/0389-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0389-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3fcfe8651a9c422fa9c8ff77556477f1461424cf..e28d213bc1cb73b15ce48a292fbba8f2979e8d69 100644
+index 3fcfe8651a9c422fa9c8ff77556477f1461424cf..b607c229cfb1e95b17b6a0073380089ef5e1b675 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2570,6 +2570,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -19,7 +19,7 @@ index 3fcfe8651a9c422fa9c8ff77556477f1461424cf..e28d213bc1cb73b15ce48a292fbba8f2
 +     *
 +     * @param completions custom completions
 +     */
-+    void addAdditionalChatCompletions(@NotNull java.util.List<String> completions);
++    void addAdditionalChatCompletions(@NotNull java.util.Collection<String> completions);
 +
 +    /**
 +     * Removes custom chat completion suggestions that the client
@@ -30,7 +30,7 @@ index 3fcfe8651a9c422fa9c8ff77556477f1461424cf..e28d213bc1cb73b15ce48a292fbba8f2
 +     *
 +     * @param completions custom completions
 +     */
-+    void removeAdditionalChatCompletions(@NotNull java.util.List<String> completions);
++    void removeAdditionalChatCompletions(@NotNull java.util.Collection<String> completions);
      // Paper end
  
      // Spigot start

--- a/patches/server/0927-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/server/0927-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9f34358dfcb95104c5bb9e63fbe295e6e049a55d..1b201e66ad7ffcc6530454f25b5e1e82537576ba 100644
+index 9f34358dfcb95104c5bb9e63fbe295e6e049a55d..02ffa796bd9ce5ceb2287a32fbba3ed8ecddb27c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -654,6 +654,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -14,7 +14,7 @@ index 9f34358dfcb95104c5bb9e63fbe295e6e049a55d..1b201e66ad7ffcc6530454f25b5e1e82
      }
 +
 +    @Override
-+    public void addCustomCompletionSuggestions(@NotNull List<String> completions) {
++    public void addAdditionalChatCompletions(@NotNull List<String> completions) {
 +        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket(
 +            net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket.Action.ADD,
 +            completions
@@ -22,7 +22,7 @@ index 9f34358dfcb95104c5bb9e63fbe295e6e049a55d..1b201e66ad7ffcc6530454f25b5e1e82
 +    }
 +
 +    @Override
-+    public void removeCustomCompletionSuggestions(@NotNull List<String> completions) {
++    public void removeAdditionalChatCompletions(@NotNull List<String> completions) {
 +        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket(
 +            net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket.Action.REMOVE,
 +            completions

--- a/patches/server/0927-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/server/0927-Custom-Chat-Completion-Suggestions-API.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sat, 30 Jul 2022 11:23:05 -0400
+Subject: [PATCH] Custom Chat Completion Suggestions API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 9f34358dfcb95104c5bb9e63fbe295e6e049a55d..1b201e66ad7ffcc6530454f25b5e1e82537576ba 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -654,6 +654,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+ 
+         this.getHandle().getServer().getPlayerList().sendPlayerPermissionLevel(this.getHandle(), level, false);
+     }
++
++    @Override
++    public void addCustomCompletionSuggestions(@NotNull List<String> completions) {
++        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket(
++            net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket.Action.ADD,
++            completions
++        ));
++    }
++
++    @Override
++    public void removeCustomCompletionSuggestions(@NotNull List<String> completions) {
++        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket(
++            net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket.Action.REMOVE,
++            completions
++        ));
++    }
+     // Paper end
+ 
+     @Override

--- a/patches/server/0927-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/server/0927-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9f34358dfcb95104c5bb9e63fbe295e6e049a55d..02ffa796bd9ce5ceb2287a32fbba3ed8ecddb27c 100644
+index 9f34358dfcb95104c5bb9e63fbe295e6e049a55d..ef9c3a7b15a4901e1662e6d55504b9cbbb804ad3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -654,6 +654,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -14,18 +14,18 @@ index 9f34358dfcb95104c5bb9e63fbe295e6e049a55d..02ffa796bd9ce5ceb2287a32fbba3ed8
      }
 +
 +    @Override
-+    public void addAdditionalChatCompletions(@NotNull List<String> completions) {
++    public void addAdditionalChatCompletions(@NotNull Collection<String> completions) {
 +        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket(
 +            net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket.Action.ADD,
-+            completions
++            new ArrayList<>(completions)
 +        ));
 +    }
 +
 +    @Override
-+    public void removeAdditionalChatCompletions(@NotNull List<String> completions) {
++    public void removeAdditionalChatCompletions(@NotNull Collection<String> completions) {
 +        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket(
 +            net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket.Action.REMOVE,
-+            completions
++            new ArrayList<>(completions)
 +        ));
 +    }
      // Paper end


### PR DESCRIPTION
Allows you to add custom suggestions in chat.
Better names are appreciated, but it lets you do stuff like this.

![image](https://user-images.githubusercontent.com/23108066/181924667-7ec67143-64d3-4134-873e-5e541c6a8358.png)

I decided not to expose SET chat completions because plugins might override each other, I'm not sure... it might be nice to have as then you have to track which suggestions you have sent in order to reset completions. Feedback? 

(I do not endorse using legacy chars) 