### PR TITLE
Undeprecate and fix Boat#getBoatMaterial

### DIFF
--- a/patches/api/0246-Add-API-to-get-Material-from-Boats-and-Minecarts.patch
+++ b/patches/api/0246-Add-API-to-get-Material-from-Boats-and-Minecarts.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add API to get Material from Boats and Minecarts
 
 
 diff --git a/src/main/java/org/bukkit/entity/Boat.java b/src/main/java/org/bukkit/entity/Boat.java
-index e5d5d2c944df1e9a81b38d3854fbe70c166588d1..3f848572935a73f637c6a91a97fa70041b0c6361 100644
+index e5d5d2c944df1e9a81b38d3854fbe70c166588d1..3e458b96d5c15a78d3d411d5b88a716213588a94 100644
 --- a/src/main/java/org/bukkit/entity/Boat.java
 +++ b/src/main/java/org/bukkit/entity/Boat.java
-@@ -173,4 +173,16 @@ public interface Boat extends Vehicle {
+@@ -173,4 +173,14 @@ public interface Boat extends Vehicle {
          ON_LAND,
          IN_AIR;
      }
@@ -18,9 +18,7 @@ index e5d5d2c944df1e9a81b38d3854fbe70c166588d1..3f848572935a73f637c6a91a97fa7004
 +     * Gets the {@link Material} that represents this Boat type.
 +     *
 +     * @return the boat material.
-+     * @deprecated use {@link #getBoatType()} and {@link Type#getMaterial()}
 +     */
-+    @Deprecated
 +    @NotNull
 +    public Material getBoatMaterial();
 +    // Paper end

--- a/patches/server/0547-Implement-API-to-get-Material-from-Boats-and-Minecar.patch
+++ b/patches/server/0547-Implement-API-to-get-Material-from-Boats-and-Minecar.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement API to get Material from Boats and Minecarts
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
-index 5871cd149fe07e97c5d68ffd83dae4d3fc6bcf03..40debf1130a8e6cc9510061976a01050cd8ddc05 100644
+index 5871cd149fe07e97c5d68ffd83dae4d3fc6bcf03..f2896aa6fa5a5282b4be106320c0dad9dd6036c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
 @@ -80,6 +80,13 @@ public class CraftBoat extends CraftVehicle implements Boat {
@@ -15,7 +15,7 @@ index 5871cd149fe07e97c5d68ffd83dae4d3fc6bcf03..40debf1130a8e6cc9510061976a01050
 +    // Paper start
 +    @Override
 +    public org.bukkit.Material getBoatMaterial() {
-+        return this.getBoatType().getMaterial();
++        return org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(this.getHandle().getDropItem());
 +    }
 +    // Paper end
 +


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/8216

As explained in attached issue, this method has had a behaviour change at the time it was deprecated. The deprecation was added because the behaviour was the same as what it was changed to. Given that behaviour was incorrect, I've reverted to the correct and original behaviour, and removed the corresponding deprecation.

Tbh moving it into that enum might make sense at some point anyway - but for now this resolves any plugins that relied on getting a boat item back from this function.