### PR TITLE
Fix suggest command message for brigadier syntax exceptions

### DIFF
--- a/patches/server/0928-Fix-suggest-command-message-for-brigadier-syntax-exc.patch
+++ b/patches/server/0928-Fix-suggest-command-message-for-brigadier-syntax-exc.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: chickeneer <emcchickeneer@gmail.com>
+Date: Mon, 1 Aug 2022 20:13:02 -0500
+Subject: [PATCH] Fix suggest command message for brigadier syntax exceptions
+
+This is a bug accidentally introduced in upstream CB
+
+diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
+index a0f5aa8c3cfce63af9cb286278a7fdebd7aa3642..fcc75660a69122eefc100e4de0a62f587bf97d7b 100644
+--- a/src/main/java/net/minecraft/commands/Commands.java
++++ b/src/main/java/net/minecraft/commands/Commands.java
+@@ -315,7 +315,7 @@ public class Commands {
+                 if (commandsyntaxexception.getInput() != null && commandsyntaxexception.getCursor() >= 0) {
+                     int j = Math.min(commandsyntaxexception.getInput().length(), commandsyntaxexception.getCursor());
+                     MutableComponent ichatmutablecomponent = Component.empty().withStyle(ChatFormatting.GRAY).withStyle((chatmodifier) -> {
+-                        return chatmodifier.withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, label)); // CraftBukkit
++                        return chatmodifier.withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/" + label)); // CraftBukkit // Paper
+                     });
+ 
+                     if (j > 10) {


### PR DESCRIPTION
This is a bug accidentally introduced in upstream CB.

Introduced in this commit. https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/64c15270e76475e68b2167d4bfba162a4a827fe0#nms-patches/net/minecraft/commands/CommandDispatcher.patch