### PR TITLE
Add missing Material.COPPER_BLOCK in some MaterialTags

### DIFF
--- a/patches/api/0157-Add-Material-Tags.patch
+++ b/patches/api/0157-Add-Material-Tags.patch
@@ -113,7 +113,7 @@ index 0000000000000000000000000000000000000000..a02a02aa0c87e0f0ed9e509e4dcab015
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/MaterialTags.java b/src/main/java/com/destroystokyo/paper/MaterialTags.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..41384ef616c5d3099482ea7d09dea12a240e758a
+index 0000000000000000000000000000000000000000..1a78872e26f8fadbddd9af15fff063d03690077f
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/MaterialTags.java
 @@ -0,0 +1,661 @@
@@ -741,7 +741,7 @@ index 0000000000000000000000000000000000000000..41384ef616c5d3099482ea7d09dea12a
 +     * Combine with other copper-related tags to filter is-un-waxed or not.
 +     */
 +    public static final MaterialSetTag UNWAXED_COPPER_BLOCKS = new MaterialSetTag(keyFor("unwaxed_copper_blocks"))
-+        .contains("CUT_COPPER").endsWith("_COPPER").notContains("WAXED").ensureSize("UNWAXED_COPPER_BLOCKS", 16).lock();
++        .contains("CUT_COPPER").endsWith("_COPPER").notContains("WAXED").add(Material.COPPER_BLOCK).not(Material.RAW_COPPER).ensureSize("UNWAXED_COPPER_BLOCKS", 16).lock();
 +
 +    /**
 +     * Covers all copper block variants.


### PR DESCRIPTION
I noticed that `paper:unwaxed_copper_blocks_settag` and `paper:copper_blocks_settag` both contain `Material.RAW_COPPER` (the item, not the raw block) instead of `Material.COPPER_BLOCK`.

Here is a fix.