### PR TITLE
Add configuration option for MiniMessage-formatted MOTD

### DIFF
--- a/patches/server/0096-Paper-config-files.patch
+++ b/patches/server/0096-Paper-config-files.patch
@@ -416,10 +416,10 @@ index 0000000000000000000000000000000000000000..31325994ab441c59a4c0bd9f3f9db3d9
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..456595e4b7e0c7f50617aa2694b0d2dfc368ab81
+index 0000000000000000000000000000000000000000..f5100edd1bd664326d7b47b50d3a9f687ecb03d2
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,265 @@
+@@ -0,0 +1,269 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -467,6 +467,10 @@ index 0000000000000000000000000000000000000000..456595e4b7e0c7f50617aa2694b0d2df
 +        }
 +
 +        public Component noPermission = Component.text("I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.", NamedTextColor.RED);
++
++        @Nullable
++        public Component motd = null;
++
 +        public boolean useDisplayNameInQuitMessage = false;
 +    }
 +
@@ -4193,7 +4197,7 @@ index 853e7c2019f5147e9681e95a82eaef0825b6341e..a48a12a31a3d09a9373b688dcc093035
              String s = (String) Optional.ofNullable((String) optionset.valueOf("world")).orElse(dedicatedserversettings.getProperties().levelName);
              LevelStorageSource convertable = LevelStorageSource.createDefault(file.toPath());
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e7b1456a123208241d0b1c5956a137d6a5cfbfcd..7740e69617c3d543a67ed0942ba8ec550ad4386d 100644
+index 15ecb1769a0604eed348b0cd31b86ce2010cbda0..8d65c989aef5ec92873a504f5b331dfe7d8b4bff 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -281,6 +281,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -4319,7 +4323,7 @@ index dbaec6fc4967d8140fd5af68456894bad1a0205a..4f67f7541ff257f35701610760fb8e04
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index f264607eb3df1f247c7c36d328405900b52df38e..b05cea49219c6582bacc705f41e72ca7c7eb6a8c 100644
+index eca7833e722a876be29806c92b18b6b58aab5725..e8d71985f2e96574081e4f609d62a3b8bded8249 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -129,6 +129,19 @@ public class Main {

--- a/patches/server/1025-Use-MOTD-provided-in-Paper-config-if-it-exists.patch
+++ b/patches/server/1025-Use-MOTD-provided-in-Paper-config-if-it-exists.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: wordandahalf <10679776+wordandahalf@users.noreply.github.com>
+Date: Sun, 7 Aug 2022 20:06:23 -0500
+Subject: [PATCH] Use MOTD provided in Paper config, if it exists
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index bfde5bbcccfaa754ec6bdf4f3817981a93e465bd..750ed134ebf520ce91f9ea3d4ead3a56b624b566 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -2184,6 +2184,12 @@ public final class CraftServer implements Server {
+     // Paper start
+     @Override
+     public net.kyori.adventure.text.Component motd() {
++        net.kyori.adventure.text.Component paperMotd =
++            io.papermc.paper.configuration.GlobalConfiguration.get().messages.motd;
++
++        if (paperMotd != null)
++            return paperMotd;
++
+         return console.getComponentMotd();
+     }
+     // Paper end


### PR DESCRIPTION
This closes #8230 by adding a new configuration option at `messages.motd` in `paper-global.yml` that overrides the value of `motd` in `server.properties` if it exists.

This is my first contribution, so please let me know if there is anything that I can change; I feel like there may have been some curfuffling in the process of rebuilding of the patches, but it functioned as expected when I tested.

Thanks!