### PR TITLE
Don't send synced player data on join

### DIFF
--- a/patches/server/0933-Dont-send-synced-player-data-on-join.patch
+++ b/patches/server/0933-Dont-send-synced-player-data-on-join.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sat, 6 Aug 2022 22:20:32 -0400
+Subject: [PATCH] Dont send synced player data on join
+
+This was done inorder to fix an issue causing player synced data to be retained with joining another server.
+However, this seems to cause some issues, most significantly is that health on join is not sent correctly.
+
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index 71623c84a5b15023189c14a6bf36e1b08f935fc1..8922e423b712947d020c58437c7079456e726fcd 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -398,7 +398,7 @@ public abstract class PlayerList {
+         ((ServerLevel)player.level).getChunkSource().chunkMap.addEntity(player); // Paper - track entity now
+         // CraftBukkit end
+ 
+-        player.connection.send(new ClientboundSetEntityDataPacket(player.getId(), player.getEntityData(), true)); // CraftBukkit - BungeeCord#2321, send complete data to self on spawn
++        // Paper - Sending player synced data here causes some unexpected issues
+ 
+         // CraftBukkit start - Only add if the player wasn't moved in the event
+         if (player.level == worldserver1 && !worldserver1.players().contains(player)) {


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/4793
Supercedes https://github.com/PaperMC/Paper/pull/5139

(Vanilla does not normally send entity data here at all)
The issue is it reintroduces some of the issues specified in: https://github.com/SpigotMC/BungeeCord/issues/2321

Opinions here?