### PR TITLE
Improve documentation of Inventory#removeItem

### DIFF
--- a/patches/api/0143-Inventory-removeItemAnySlot.patch
+++ b/patches/api/0143-Inventory-removeItemAnySlot.patch
@@ -5,10 +5,26 @@ Subject: [PATCH] Inventory#removeItemAnySlot
 
 
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 5576a6a8df8c95164bf2dde45d756ce8b7ec957a..9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883 100644
+index 5576a6a8df8c95164bf2dde45d756ce8b7ec957a..f1a48eab1a357ae64545e1f1dc941c383cff8707 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
-@@ -125,6 +125,34 @@ public interface Inventory extends Iterable<ItemStack> {
+@@ -104,7 +104,9 @@ public interface Inventory extends Iterable<ItemStack> {
+     public HashMap<Integer, ItemStack> addItem(@NotNull ItemStack... items) throws IllegalArgumentException;
+ 
+     /**
+-     * Removes the given ItemStacks from the inventory.
++     * Removes the given ItemStacks from the storage contents of the inventory.
++     * For removing ItemStacks from the inventories that have other content groups,
++     * like Player inventories, see {@link #removeItemAnySlot(ItemStack...)}.
+      * <p>
+      * It will try to remove 'as much as possible' from the types and amounts
+      * you give as arguments.
+@@ -121,10 +123,39 @@ public interface Inventory extends Iterable<ItemStack> {
+      * @param items The ItemStacks to remove
+      * @return A HashMap containing items that couldn't be removed.
+      * @throws IllegalArgumentException if items is null
++     * @see #removeItemAnySlot(ItemStack...)
+      */
      @NotNull
      public HashMap<Integer, ItemStack> removeItem(@NotNull ItemStack... items) throws IllegalArgumentException;
  

--- a/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
@@ -563,10 +563,10 @@ index 1d442dc16cbb0fed21714d47007f3f11e30c57d4..af8f7b88edf0fa790edcf16356a030c4
          return setInput(input.getItemType(), input.getData());
      }
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883..875c401153349b0f2468525e54cf10ca86430087 100644
+index f1a48eab1a357ae64545e1f1dc941c383cff8707..466d1bd7089b76f48f953e1a51c611ecd93dcd54 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
-@@ -158,8 +158,7 @@ public interface Inventory extends Iterable<ItemStack> {
+@@ -161,8 +161,7 @@ public interface Inventory extends Iterable<ItemStack> {
       *
       * @return An array of ItemStacks from the inventory. Individual items may be null.
       */
@@ -576,7 +576,7 @@ index 9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883..875c401153349b0f2468525e54cf10ca
  
      /**
       * Completely replaces the inventory's contents. Removes all existing
-@@ -170,7 +169,7 @@ public interface Inventory extends Iterable<ItemStack> {
+@@ -173,7 +172,7 @@ public interface Inventory extends Iterable<ItemStack> {
       * @throws IllegalArgumentException If the array has more items than the
       *     inventory.
       */
@@ -585,7 +585,7 @@ index 9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883..875c401153349b0f2468525e54cf10ca
  
      /**
       * Return the contents from the section of the inventory where items can
-@@ -183,8 +182,7 @@ public interface Inventory extends Iterable<ItemStack> {
+@@ -186,8 +185,7 @@ public interface Inventory extends Iterable<ItemStack> {
       *
       * @return inventory storage contents. Individual items may be null.
       */
@@ -595,7 +595,7 @@ index 9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883..875c401153349b0f2468525e54cf10ca
  
      /**
       * Put the given ItemStacks into the storage slots
-@@ -193,7 +191,7 @@ public interface Inventory extends Iterable<ItemStack> {
+@@ -196,7 +194,7 @@ public interface Inventory extends Iterable<ItemStack> {
       * @throws IllegalArgumentException If the array has more items than the
       * inventory.
       */

--- a/patches/api/0207-Inventory-getHolder-method-without-block-snapshot.patch
+++ b/patches/api/0207-Inventory-getHolder-method-without-block-snapshot.patch
@@ -28,10 +28,10 @@ index 83a4642119c3f33749e04c774cf2b39839f797e2..a39d2f1acbbd84ae0e2cf29f85594e09
      public Location getLocation() {
          return getInventory().getLocation();
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 875c401153349b0f2468525e54cf10ca86430087..960626dd64ec9b0c5f4638c1ada463fd20c6b5fc 100644
+index 466d1bd7089b76f48f953e1a51c611ecd93dcd54..129b5ab5062beeb9bb52465a788bc3a3aee9c49e 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
-@@ -382,6 +382,17 @@ public interface Inventory extends Iterable<ItemStack> {
+@@ -385,6 +385,17 @@ public interface Inventory extends Iterable<ItemStack> {
      @Nullable
      public InventoryHolder getHolder();
  

--- a/patches/api/0293-Inventory-close.patch
+++ b/patches/api/0293-Inventory-close.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Inventory#close
 
 
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 960626dd64ec9b0c5f4638c1ada463fd20c6b5fc..1b577c03c3152d22b70f8bdb321b28ad8fbbc3af 100644
+index 129b5ab5062beeb9bb52465a788bc3a3aee9c49e..c574bb94b21eb27974b40c839fce52c6ac4b54b4 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
-@@ -352,6 +352,15 @@ public interface Inventory extends Iterable<ItemStack> {
+@@ -355,6 +355,15 @@ public interface Inventory extends Iterable<ItemStack> {
       */
      public void clear();
  


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/8209

----

Clarifies that Inventory#removeItem only removes items from the storage contents of the inventory.