### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -670,10 +670,10 @@ index 0000000000000000000000000000000000000000..bff9a6295db367c6b89d69fb55459a40
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5029d98816c137fcc7068bd5596d6a38d96ee877..ba57a093a2df3c65036377e3093eedabeda7c6f5 100644
+index 72143df182e55b70726b066b6b276021c1f4f4d7..c800da7aba43de995682eb724ccf8b7066d6cad3 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -357,7 +357,9 @@ public final class Bukkit {
+@@ -358,7 +358,9 @@ public final class Bukkit {
       *
       * @param message the message
       * @return the number of players
@@ -683,7 +683,7 @@ index 5029d98816c137fcc7068bd5596d6a38d96ee877..ba57a093a2df3c65036377e3093eedab
      public static int broadcastMessage(@NotNull String message) {
          return server.broadcastMessage(message);
      }
-@@ -1071,6 +1073,19 @@ public final class Bukkit {
+@@ -1072,6 +1074,19 @@ public final class Bukkit {
          server.shutdown();
      }
  
@@ -703,7 +703,7 @@ index 5029d98816c137fcc7068bd5596d6a38d96ee877..ba57a093a2df3c65036377e3093eedab
      /**
       * Broadcasts the specified message to every user with the given
       * permission name.
-@@ -1080,6 +1095,21 @@ public final class Bukkit {
+@@ -1081,6 +1096,21 @@ public final class Bukkit {
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
       */
@@ -725,7 +725,7 @@ index 5029d98816c137fcc7068bd5596d6a38d96ee877..ba57a093a2df3c65036377e3093eedab
      public static int broadcast(@NotNull String message, @NotNull String permission) {
          return server.broadcast(message, permission);
      }
-@@ -1318,6 +1348,7 @@ public final class Bukkit {
+@@ -1319,6 +1349,7 @@ public final class Bukkit {
          return server.createInventory(owner, type);
      }
  
@@ -733,7 +733,7 @@ index 5029d98816c137fcc7068bd5596d6a38d96ee877..ba57a093a2df3c65036377e3093eedab
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1343,6 +1374,38 @@ public final class Bukkit {
+@@ -1344,6 +1375,38 @@ public final class Bukkit {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -772,7 +772,7 @@ index 5029d98816c137fcc7068bd5596d6a38d96ee877..ba57a093a2df3c65036377e3093eedab
      public static Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title) {
          return server.createInventory(owner, type, title);
      }
-@@ -1361,6 +1424,7 @@ public final class Bukkit {
+@@ -1362,6 +1425,7 @@ public final class Bukkit {
          return server.createInventory(owner, size);
      }
  
@@ -780,7 +780,7 @@ index 5029d98816c137fcc7068bd5596d6a38d96ee877..ba57a093a2df3c65036377e3093eedab
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1373,10 +1437,30 @@ public final class Bukkit {
+@@ -1374,10 +1438,30 @@ public final class Bukkit {
       * @throws IllegalArgumentException if the size is not a multiple of 9
       */
      @NotNull
@@ -811,7 +811,7 @@ index 5029d98816c137fcc7068bd5596d6a38d96ee877..ba57a093a2df3c65036377e3093eedab
      /**
       * Creates an empty merchant.
       *
-@@ -1384,7 +1468,20 @@ public final class Bukkit {
+@@ -1385,7 +1469,20 @@ public final class Bukkit {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -832,7 +832,7 @@ index 5029d98816c137fcc7068bd5596d6a38d96ee877..ba57a093a2df3c65036377e3093eedab
      public static Merchant createMerchant(@Nullable String title) {
          return server.createMerchant(title);
      }
-@@ -1501,22 +1598,47 @@ public final class Bukkit {
+@@ -1502,22 +1599,47 @@ public final class Bukkit {
          return server.isPrimaryThread();
      }
  
@@ -1005,10 +1005,10 @@ index 803fa0019869127ee8c7e4fb1777a59c43e66f8a..c65f0d6569c130b4920a9e71ad24af64
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32278b0074 100644
+index c0a3b44c728ec98ecce4d1e71746747d87582aa9..4d5c3af2e1f0030aa7415fbe9d11fe3580854fd5 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -58,13 +58,13 @@ import org.jetbrains.annotations.Nullable;
+@@ -59,13 +59,13 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a server implementation.
   */
@@ -1024,7 +1024,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
       */
      public static final String BROADCAST_CHANNEL_ADMINISTRATIVE = "bukkit.broadcast.admin";
  
-@@ -72,7 +72,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -73,7 +73,7 @@ public interface Server extends PluginMessageRecipient {
       * Used for all announcement messages, such as informing users that a
       * player has joined.
       * <p>
@@ -1033,7 +1033,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
       */
      public static final String BROADCAST_CHANNEL_USERS = "bukkit.broadcast.user";
  
-@@ -294,7 +294,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -295,7 +295,9 @@ public interface Server extends PluginMessageRecipient {
       *
       * @param message the message
       * @return the number of players
@@ -1043,7 +1043,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
      public int broadcastMessage(@NotNull String message);
  
      /**
-@@ -910,8 +912,33 @@ public interface Server extends PluginMessageRecipient {
+@@ -911,8 +913,33 @@ public interface Server extends PluginMessageRecipient {
       * @param permission the required permission {@link Permissible
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
@@ -1077,7 +1077,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
  
      /**
       * Gets the player by the given name, regardless if they are offline or
-@@ -1109,6 +1136,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -1110,6 +1137,7 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type);
  
@@ -1085,7 +1085,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1134,6 +1162,36 @@ public interface Server extends PluginMessageRecipient {
+@@ -1135,6 +1163,36 @@ public interface Server extends PluginMessageRecipient {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -1122,7 +1122,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title);
  
      /**
-@@ -1148,6 +1206,22 @@ public interface Server extends PluginMessageRecipient {
+@@ -1149,6 +1207,22 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, int size) throws IllegalArgumentException;
  
@@ -1145,7 +1145,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1158,10 +1232,13 @@ public interface Server extends PluginMessageRecipient {
+@@ -1159,10 +1233,13 @@ public interface Server extends PluginMessageRecipient {
       *     viewed
       * @return a new inventory
       * @throws IllegalArgumentException if the size is not a multiple of 9
@@ -1159,7 +1159,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
      /**
       * Creates an empty merchant.
       *
-@@ -1169,7 +1246,18 @@ public interface Server extends PluginMessageRecipient {
+@@ -1170,7 +1247,18 @@ public interface Server extends PluginMessageRecipient {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -1178,7 +1178,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
      Merchant createMerchant(@Nullable String title);
  
      /**
-@@ -1265,20 +1353,41 @@ public interface Server extends PluginMessageRecipient {
+@@ -1266,20 +1354,41 @@ public interface Server extends PluginMessageRecipient {
       */
      boolean isPrimaryThread();
  
@@ -1220,7 +1220,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
      String getShutdownMessage();
  
      /**
-@@ -1650,7 +1759,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1661,7 +1770,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends the component to the player
           *
           * @param component the components to send
@@ -1230,7 +1230,7 @@ index 6d6810cc51732830ef139f7099fbc5a45b124e8e..5af7da1d3d62cada69240e2d22db2a32
          public void broadcast(@NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1659,7 +1770,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1670,7 +1781,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends an array of components as a single message to the player
           *
           * @param components the components to send
@@ -4214,7 +4214,7 @@ index 03ca87a1cbace2459174bb7bb8847bda766e80c5..b37938745f916b5f0111b07b1a1c9752
       * Returns the name of the plugin.
       * <p>
 diff --git a/src/main/java/org/bukkit/scoreboard/Objective.java b/src/main/java/org/bukkit/scoreboard/Objective.java
-index ff3fcb2697eb00736238d0efdcaefe43043334d3..75acd6f8f3d774bb79e8e513125e801c5569a244 100644
+index 2ff3a11f1f9c115722ea224873e7eb6dc6dc63e6..474274fdffe4041bf4bfb146fcc66424eb5be78a 100644
 --- a/src/main/java/org/bukkit/scoreboard/Objective.java
 +++ b/src/main/java/org/bukkit/scoreboard/Objective.java
 @@ -19,14 +19,35 @@ public interface Objective {
@@ -4264,10 +4264,10 @@ index ff3fcb2697eb00736238d0efdcaefe43043334d3..75acd6f8f3d774bb79e8e513125e801c
  
      /**
 diff --git a/src/main/java/org/bukkit/scoreboard/Scoreboard.java b/src/main/java/org/bukkit/scoreboard/Scoreboard.java
-index 5c855dbd0da895392f7a6e92cdc90782baf614ad..1ada91d790abedbc9b3aeb6e96467a0d78560f15 100644
+index a15183f302de42956d8965efe5f0585fc2cd030e..ef3e729caf430b08cdf2d680d5a137a1ba56c1c5 100644
 --- a/src/main/java/org/bukkit/scoreboard/Scoreboard.java
 +++ b/src/main/java/org/bukkit/scoreboard/Scoreboard.java
-@@ -27,6 +27,48 @@ public interface Scoreboard {
+@@ -27,6 +27,92 @@ public interface Scoreboard {
      @Deprecated
      @NotNull
      Objective registerNewObjective(@NotNull String name, @NotNull String criteria) throws IllegalArgumentException;
@@ -4288,9 +4288,53 @@ index 5c855dbd0da895392f7a6e92cdc90782baf614ad..1ada91d790abedbc9b3aeb6e96467a0d
 +     *     characters.
 +     * @throws IllegalArgumentException if an objective by that name already
 +     *     exists
++     * @deprecated use {@link #registerNewObjective(String, Criteria, net.kyori.adventure.text.Component)}
 +     */
 +    @NotNull
++    @Deprecated
 +    Objective registerNewObjective(@NotNull String name, @NotNull String criteria, @Nullable net.kyori.adventure.text.Component displayName) throws IllegalArgumentException;
++    /**
++     * Registers an Objective on this Scoreboard
++     *
++     * @param name Name of the Objective
++     * @param criteria Criteria for the Objective
++     * @param displayName Name displayed to players for the Objective.
++     * @param renderType Manner of rendering the Objective
++     * @return The registered Objective
++     * @throws IllegalArgumentException if name is null
++     * @throws IllegalArgumentException if name is longer than 32767
++     *     characters.
++     * @throws IllegalArgumentException if criteria is null
++     * @throws IllegalArgumentException if displayName is null
++     * @throws IllegalArgumentException if displayName is longer than 128
++     *     characters.
++     * @throws IllegalArgumentException if renderType is null
++     * @throws IllegalArgumentException if an objective by that name already
++     *     exists
++     * @deprecated use {@link #registerNewObjective(String, Criteria, net.kyori.adventure.text.Component, RenderType)}
++     */
++    @NotNull
++    @Deprecated
++    Objective registerNewObjective(@NotNull String name, @NotNull String criteria, @Nullable net.kyori.adventure.text.Component displayName, @NotNull RenderType renderType) throws IllegalArgumentException;
++    /**
++     * Registers an Objective on this Scoreboard
++     *
++     * @param name Name of the Objective
++     * @param criteria Criteria for the Objective
++     * @param displayName Name displayed to players for the Objective.
++     * @return The registered Objective
++     * @throws IllegalArgumentException if name is null
++     * @throws IllegalArgumentException if name is longer than 32767
++     *     characters.
++     * @throws IllegalArgumentException if criteria is null
++     * @throws IllegalArgumentException if displayName is null
++     * @throws IllegalArgumentException if displayName is longer than 128
++     *     characters.
++     * @throws IllegalArgumentException if an objective by that name already
++     *     exists
++     */
++    @NotNull
++    Objective registerNewObjective(@NotNull String name, @NotNull Criteria criteria, @Nullable net.kyori.adventure.text.Component displayName) throws IllegalArgumentException;
 +    /**
 +     * Registers an Objective on this Scoreboard
 +     *
@@ -4311,31 +4355,47 @@ index 5c855dbd0da895392f7a6e92cdc90782baf614ad..1ada91d790abedbc9b3aeb6e96467a0d
 +     *     exists
 +     */
 +    @NotNull
-+    Objective registerNewObjective(@NotNull String name, @NotNull String criteria, @Nullable net.kyori.adventure.text.Component displayName, @NotNull RenderType renderType) throws IllegalArgumentException;
++    Objective registerNewObjective(@NotNull String name, @NotNull Criteria criteria, @Nullable net.kyori.adventure.text.Component displayName, @NotNull RenderType renderType) throws IllegalArgumentException;
 +    // Paper end
  
      /**
       * Registers an Objective on this Scoreboard
-@@ -44,8 +86,10 @@ public interface Scoreboard {
-      *     characters.
-      * @throws IllegalArgumentException if an objective by that name already
-      *     exists
-+     * @deprecated in favour of {@link #registerNewObjective(String, String, net.kyori.adventure.text.Component)}
+@@ -47,6 +133,7 @@ public interface Scoreboard {
+      * @deprecated use {@link #registerNewObjective(String, Criteria, String)}
       */
      @NotNull
 +    @Deprecated // Paper
      Objective registerNewObjective(@NotNull String name, @NotNull String criteria, @NotNull String displayName) throws IllegalArgumentException;
  
      /**
-@@ -66,8 +110,10 @@ public interface Scoreboard {
-      * @throws IllegalArgumentException if renderType is null
-      * @throws IllegalArgumentException if an objective by that name already
-      *     exists
-+     * @deprecated in favour of {@link #registerNewObjective(String, String, net.kyori.adventure.text.Component, RenderType)}
+@@ -70,6 +157,7 @@ public interface Scoreboard {
+      * @deprecated use {@link #registerNewObjective(String, Criteria, String, RenderType)}
       */
      @NotNull
 +    @Deprecated // Paper
      Objective registerNewObjective(@NotNull String name, @NotNull String criteria, @NotNull String displayName, @NotNull RenderType renderType) throws IllegalArgumentException;
+ 
+     /**
+@@ -88,8 +176,10 @@ public interface Scoreboard {
+      *     characters.
+      * @throws IllegalArgumentException if an objective by that name already
+      *     exists
++     * @deprecated in favour of {@link #registerNewObjective(String, Criteria, net.kyori.adventure.text.Component)}
+      */
+     @NotNull
++    @Deprecated // Paper
+     Objective registerNewObjective(@NotNull String name, @NotNull Criteria criteria, @NotNull String displayName) throws IllegalArgumentException;
+ 
+     /**
+@@ -110,8 +200,10 @@ public interface Scoreboard {
+      * @throws IllegalArgumentException if renderType is null
+      * @throws IllegalArgumentException if an objective by that name already
+      *     exists
++     * @deprecated in favour of {@link #registerNewObjective(String, Criteria, net.kyori.adventure.text.Component, RenderType)}
+      */
+     @NotNull
++    @Deprecated // Paper
+     Objective registerNewObjective(@NotNull String name, @NotNull Criteria criteria, @NotNull String displayName, @NotNull RenderType renderType) throws IllegalArgumentException;
  
      /**
 diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java

--- a/patches/api/0007-Timings-v2.patch
+++ b/patches/api/0007-Timings-v2.patch
@@ -2791,10 +2791,10 @@ index 0000000000000000000000000000000000000000..5989ee21297935651b0edd44b8239e65
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ba57a093a2df3c65036377e3093eedabeda7c6f5..9b118067de5eb54b266b8349fce7efdec2cb36eb 100644
+index c800da7aba43de995682eb724ccf8b7066d6cad3..557cf1ff29e16fa942545ceca14696c2a50b2d4d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -801,7 +801,6 @@ public final class Bukkit {
+@@ -802,7 +802,6 @@ public final class Bukkit {
       */
      public static void reload() {
          server.reload();
@@ -2803,10 +2803,10 @@ index ba57a093a2df3c65036377e3093eedabeda7c6f5..9b118067de5eb54b266b8349fce7efde
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5af7da1d3d62cada69240e2d22db2a32278b0074..0a433146ebec4416339c4ab33f3523a22d23d332 100644
+index 4d5c3af2e1f0030aa7415fbe9d11fe3580854fd5..a2ae6b84fe20e43292f1442401a472dcce1600ec 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1755,6 +1755,26 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1766,6 +1766,26 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
              throw new UnsupportedOperationException("Not supported yet.");
          }
  

--- a/patches/api/0008-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/api/0008-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9b118067de5eb54b266b8349fce7efdec2cb36eb..aecc0bcaeceb0a2db08a528244c08037e58f399b 100644
+index 557cf1ff29e16fa942545ceca14696c2a50b2d4d..a5c02f744664248f46aa35452318b6a728cd4afd 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -75,6 +75,20 @@ public final class Bukkit {
+@@ -76,6 +76,20 @@ public final class Bukkit {
          return server;
      }
  
@@ -32,10 +32,10 @@ index 9b118067de5eb54b266b8349fce7efdec2cb36eb..aecc0bcaeceb0a2db08a528244c08037
       * Attempts to set the {@link Server} singleton.
       * <p>
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 0a433146ebec4416339c4ab33f3523a22d23d332..b8c47ed7eb7bf52efd1928956584fd993e59f03a 100644
+index a2ae6b84fe20e43292f1442401a472dcce1600ec..da13ae75ca1892c21a35aff02f92b91783a868bf 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -60,6 +60,18 @@ import org.jetbrains.annotations.Nullable;
+@@ -61,6 +61,18 @@ import org.jetbrains.annotations.Nullable;
   */
  public interface Server extends PluginMessageRecipient, net.kyori.adventure.audience.ForwardingAudience { // Paper
  

--- a/patches/api/0010-Add-getTPS-method.patch
+++ b/patches/api/0010-Add-getTPS-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getTPS method
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index aecc0bcaeceb0a2db08a528244c08037e58f399b..fcdce3b516821d42327452790cc66663e4677613 100644
+index a5c02f744664248f46aa35452318b6a728cd4afd..3603bcdadeea10f2babe8d6c609d7eaee3f0f89c 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1876,6 +1876,17 @@ public final class Bukkit {
+@@ -1889,6 +1889,17 @@ public final class Bukkit {
          return server.getEntity(uuid);
      }
  
@@ -27,10 +27,10 @@ index aecc0bcaeceb0a2db08a528244c08037e58f399b..fcdce3b516821d42327452790cc66663
       * Get the advancement specified by this key.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index b8c47ed7eb7bf52efd1928956584fd993e59f03a..f52dd4c4602638bf02f676f6415d7051c0439cce 100644
+index da13ae75ca1892c21a35aff02f92b91783a868bf..36f5e47ffcdce23b0b5594881fdd49a3a3337578 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1592,6 +1592,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1603,6 +1603,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      Entity getEntity(@NotNull UUID uuid);
  

--- a/patches/api/0018-Expose-server-CommandMap.patch
+++ b/patches/api/0018-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index fcdce3b516821d42327452790cc66663e4677613..d225e4a5587aa76a85a4b56e11d4563bdc97fe3f 100644
+index 3603bcdadeea10f2babe8d6c609d7eaee3f0f89c..5475f7df443a31e839d353e251b0d9d55e53a84f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2077,6 +2077,19 @@ public final class Bukkit {
+@@ -2090,6 +2090,19 @@ public final class Bukkit {
          return server.getUnsafe();
      }
  
@@ -29,10 +29,10 @@ index fcdce3b516821d42327452790cc66663e4677613..d225e4a5587aa76a85a4b56e11d4563b
      public static Server.Spigot spigot() {
          return server.spigot();
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f52dd4c4602638bf02f676f6415d7051c0439cce..f6f3297231d3a9e9f142faf992437cc99e241109 100644
+index 36f5e47ffcdce23b0b5594881fdd49a3a3337578..2dac2c6e01b4f230750605ab1f49317927705c6b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1602,6 +1602,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1613,6 +1613,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      public double[] getTPS();
      // Paper end
  

--- a/patches/api/0019-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0019-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Graduate bungeecord chat API from spigot subclasses
 Change Javadoc to be accurate
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index d225e4a5587aa76a85a4b56e11d4563bdc97fe3f..e13ffa85390f2feda49309ba02ccf75856e4c8f2 100644
+index 5475f7df443a31e839d353e251b0d9d55e53a84f..7a8eaf46ecd37163dbe34beb2cf8754bddae302f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -378,6 +378,30 @@ public final class Bukkit {
+@@ -379,6 +379,30 @@ public final class Bukkit {
          return server.broadcastMessage(message);
      }
  
@@ -41,10 +41,10 @@ index d225e4a5587aa76a85a4b56e11d4563bdc97fe3f..e13ffa85390f2feda49309ba02ccf758
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f6f3297231d3a9e9f142faf992437cc99e241109..1dcf90071bae51e6b767ac26eb6624d372acac68 100644
+index 2dac2c6e01b4f230750605ab1f49317927705c6b..1aed052ea337f2875b581064bd8e79d8a5a1a9ec 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -311,6 +311,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -312,6 +312,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Deprecated // Paper
      public int broadcastMessage(@NotNull String message);
  

--- a/patches/api/0029-Add-command-to-reload-permissions.yml-and-require-co.patch
+++ b/patches/api/0029-Add-command-to-reload-permissions.yml-and-require-co.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add command to reload permissions.yml and require confirm to
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index e13ffa85390f2feda49309ba02ccf75856e4c8f2..c015c0b7678a141c84f0c0e339fe7c2a93988685 100644
+index 7a8eaf46ecd37163dbe34beb2cf8754bddae302f..9463169bdb45a53ad774a0e3a5ec07704508685f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2112,6 +2112,13 @@ public final class Bukkit {
+@@ -2125,6 +2125,13 @@ public final class Bukkit {
      public static org.bukkit.command.CommandMap getCommandMap() {
          return server.getCommandMap();
      }
@@ -24,10 +24,10 @@ index e13ffa85390f2feda49309ba02ccf75856e4c8f2..c015c0b7678a141c84f0c0e339fe7c2a
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1dcf90071bae51e6b767ac26eb6624d372acac68..7204f8ea6271dbb94406f07bc98ec322f928fcea 100644
+index 1aed052ea337f2875b581064bd8e79d8a5a1a9ec..cd51a1a9a59cfa868237ab750d98d9df8464152f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1863,4 +1863,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1874,4 +1874,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      Spigot spigot();
      // Spigot end

--- a/patches/api/0042-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/api/0042-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c015c0b7678a141c84f0c0e339fe7c2a93988685..48eb69015cc70b0734f220f95fc0d8ffcd84954a 100644
+index 9463169bdb45a53ad774a0e3a5ec07704508685f..fe5f6494fb0610dd11e59793701b2182fa862419 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2119,6 +2119,15 @@ public final class Bukkit {
+@@ -2132,6 +2132,15 @@ public final class Bukkit {
      public static void reloadPermissions() {
          server.reloadPermissions();
      }
@@ -26,10 +26,10 @@ index c015c0b7678a141c84f0c0e339fe7c2a93988685..48eb69015cc70b0734f220f95fc0d8ff
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 7204f8ea6271dbb94406f07bc98ec322f928fcea..f7c54fbffe6b39d4f73b45cbc7c23f3508217f74 100644
+index cd51a1a9a59cfa868237ab750d98d9df8464152f..29e71b746adcec45657787bf38427027508b0043 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1865,4 +1865,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1876,4 +1876,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      // Spigot end
  
      void reloadPermissions(); // Paper

--- a/patches/api/0053-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/api/0053-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 48eb69015cc70b0734f220f95fc0d8ffcd84954a..aea30cacbf43c4c6d30b0c9e0d59fcd2db444ad8 100644
+index fe5f6494fb0610dd11e59793701b2182fa862419..05908e512b0f2c01124737cf68df79c6c04518ee 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2128,6 +2128,16 @@ public final class Bukkit {
+@@ -2141,6 +2141,16 @@ public final class Bukkit {
      public static boolean reloadCommandAliases() {
          return server.reloadCommandAliases();
      }
@@ -27,10 +27,10 @@ index 48eb69015cc70b0734f220f95fc0d8ffcd84954a..aea30cacbf43c4c6d30b0c9e0d59fcd2
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f7c54fbffe6b39d4f73b45cbc7c23f3508217f74..5e4e6e83ac6b52493cb285561425bed53ffff2b6 100644
+index 29e71b746adcec45657787bf38427027508b0043..f84c37ad591f4d0e4062889941791a3aeb7c5be5 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1867,4 +1867,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1878,4 +1878,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      void reloadPermissions(); // Paper
  
      boolean reloadCommandAliases(); // Paper

--- a/patches/api/0054-Fix-upstream-javadocs.patch
+++ b/patches/api/0054-Fix-upstream-javadocs.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix upstream javadocs
 Upstream still refuses to use Java 8 with the API so they are likely unaware these are even issues.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index aea30cacbf43c4c6d30b0c9e0d59fcd2db444ad8..e25a6532deca1df59eff2ab59697b851535ee952 100644
+index 05908e512b0f2c01124737cf68df79c6c04518ee..2ff65157d511108e2902838f37732742b186af6e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1331,6 +1331,8 @@ public final class Bukkit {
+@@ -1332,6 +1332,8 @@ public final class Bukkit {
  
      /**
       * Gets every player that has ever played on this server.
@@ -19,10 +19,10 @@ index aea30cacbf43c4c6d30b0c9e0d59fcd2db444ad8..e25a6532deca1df59eff2ab59697b851
       * @return an array containing all previous players
       */
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5e4e6e83ac6b52493cb285561425bed53ffff2b6..2bfbb0ce71c8c5f8bd9bbd908488831b94ce583f 100644
+index f84c37ad591f4d0e4062889941791a3aeb7c5be5..d9566b18e6109db824cbc1732666771bf124adbf 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -509,13 +509,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -510,13 +510,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * </ul>
       * <p>
       * <b>Note:</b> If set to 0, {@link SpawnCategory} mobs spawning will be disabled.
@@ -37,7 +37,7 @@ index 5e4e6e83ac6b52493cb285561425bed53ffff2b6..2bfbb0ce71c8c5f8bd9bbd908488831b
       */
      public int getTicksPerSpawns(@NotNull SpawnCategory spawnCategory);
  
-@@ -1126,6 +1123,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1127,6 +1124,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
  
      /**
       * Gets every player that has ever played on this server.

--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -321,10 +321,10 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index e25a6532deca1df59eff2ab59697b851535ee952..be46b7aa492226d2c943b9a15f0e009878be422c 100644
+index 2ff65157d511108e2902838f37732742b186af6e..d5fd584c109c0a84a4259b10e7b43fae3a1da1ae 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2140,6 +2140,83 @@ public final class Bukkit {
+@@ -2153,6 +2153,83 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
@@ -409,10 +409,10 @@ index e25a6532deca1df59eff2ab59697b851535ee952..be46b7aa492226d2c943b9a15f0e0098
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 2bfbb0ce71c8c5f8bd9bbd908488831b94ce583f..04752eebe9df1138207a969fb1492a1f55b0b753 100644
+index d9566b18e6109db824cbc1732666771bf124adbf..fab39e4fc595c022da27e87e27bd168939e54381 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1875,5 +1875,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1886,5 +1886,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index be46b7aa492226d2c943b9a15f0e009878be422c..edbe7363b2da4f89cc31cbf9521c9a6271060ccd 100644
+index d5fd584c109c0a84a4259b10e7b43fae3a1da1ae..a452adcbf8657c501ad92f4cb361b551992f128f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1196,8 +1196,10 @@ public final class Bukkit {
+@@ -1197,8 +1197,10 @@ public final class Bukkit {
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if both the unique id is
       * <code>null</code> and the name is <code>null</code> or blank
@@ -20,7 +20,7 @@ index be46b7aa492226d2c943b9a15f0e009878be422c..edbe7363b2da4f89cc31cbf9521c9a62
      public static PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name) {
          return server.createPlayerProfile(uniqueId, name);
      }
-@@ -1208,8 +1210,10 @@ public final class Bukkit {
+@@ -1209,8 +1211,10 @@ public final class Bukkit {
       * @param uniqueId the unique id
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the unique id is <code>null</code>
@@ -31,7 +31,7 @@ index be46b7aa492226d2c943b9a15f0e009878be422c..edbe7363b2da4f89cc31cbf9521c9a62
      public static PlayerProfile createPlayerProfile(@NotNull UUID uniqueId) {
          return server.createPlayerProfile(uniqueId);
      }
-@@ -1221,8 +1225,10 @@ public final class Bukkit {
+@@ -1222,8 +1226,10 @@ public final class Bukkit {
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the name is <code>null</code> or
       * blank
@@ -43,10 +43,10 @@ index be46b7aa492226d2c943b9a15f0e009878be422c..edbe7363b2da4f89cc31cbf9521c9a62
          return server.createPlayerProfile(name);
      }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 04752eebe9df1138207a969fb1492a1f55b0b753..ca784abeb7f31c65e87df7750ae19aa9a8b65d72 100644
+index fab39e4fc595c022da27e87e27bd168939e54381..e90056341407f58ff6ce2d9b80c8f3f64464e650 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1014,8 +1014,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1015,8 +1015,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if both the unique id is
       * <code>null</code> and the name is <code>null</code> or blank
@@ -57,7 +57,7 @@ index 04752eebe9df1138207a969fb1492a1f55b0b753..ca784abeb7f31c65e87df7750ae19aa9
      PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name);
  
      /**
-@@ -1024,8 +1026,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1025,8 +1027,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param uniqueId the unique id
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the unique id is <code>null</code>
@@ -68,7 +68,7 @@ index 04752eebe9df1138207a969fb1492a1f55b0b753..ca784abeb7f31c65e87df7750ae19aa9
      PlayerProfile createPlayerProfile(@NotNull UUID uniqueId);
  
      /**
-@@ -1035,8 +1039,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1036,8 +1040,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the name is <code>null</code> or
       * blank

--- a/patches/api/0092-getPlayerUniqueId-API.patch
+++ b/patches/api/0092-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index edbe7363b2da4f89cc31cbf9521c9a6271060ccd..5e5e8147b477b876a579327d5ea3d8d2393c0374 100644
+index a452adcbf8657c501ad92f4cb361b551992f128f..908e1aba5257688bb70fbf1ed83d2212305263a1 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -656,6 +656,20 @@ public final class Bukkit {
+@@ -657,6 +657,20 @@ public final class Bukkit {
          return server.getPlayer(id);
      }
  
@@ -34,10 +34,10 @@ index edbe7363b2da4f89cc31cbf9521c9a6271060ccd..5e5e8147b477b876a579327d5ea3d8d2
       * Gets the plugin manager for interfacing with plugins.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ca784abeb7f31c65e87df7750ae19aa9a8b65d72..1a4559c88ece08e4a0c27e808f69693fb89fc474 100644
+index e90056341407f58ff6ce2d9b80c8f3f64464e650..b0e6446c0dc49088878d7ae453dc3eee8b346f4e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -558,6 +558,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -559,6 +559,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      public Player getPlayer(@NotNull UUID id);
  

--- a/patches/api/0150-Add-Git-information-to-version-command-on-startup.patch
+++ b/patches/api/0150-Add-Git-information-to-version-command-on-startup.patch
@@ -48,10 +48,10 @@ index 0000000000000000000000000000000000000000..909617079db61b675cc7b60b44ef96b3
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5e5e8147b477b876a579327d5ea3d8d2393c0374..1c416a48d2a069a0167bc0be6fa1d65d14f35816 100644
+index 908e1aba5257688bb70fbf1ed83d2212305263a1..303e539338383d0d7825b873611ca5843ee1c0a3 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -53,6 +53,7 @@ import org.bukkit.util.CachedServerIcon;
+@@ -54,6 +54,7 @@ import org.bukkit.util.CachedServerIcon;
  import org.jetbrains.annotations.Contract;
  import org.jetbrains.annotations.NotNull;
  import org.jetbrains.annotations.Nullable;
@@ -59,7 +59,7 @@ index 5e5e8147b477b876a579327d5ea3d8d2393c0374..1c416a48d2a069a0167bc0be6fa1d65d
  
  /**
   * Represents the Bukkit core, for version and Server singleton handling
-@@ -102,7 +103,25 @@ public final class Bukkit {
+@@ -103,7 +104,25 @@ public final class Bukkit {
          }
  
          Bukkit.server = server;

--- a/patches/api/0164-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0164-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 1c416a48d2a069a0167bc0be6fa1d65d14f35816..62ecce029f38bd6a3e07981887916bb54e0c62f9 100644
+index 303e539338383d0d7825b873611ca5843ee1c0a3..00295e256c0def25dd3e552ef67eea06ab01ad15 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2180,6 +2180,28 @@ public final class Bukkit {
+@@ -2193,6 +2193,28 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
@@ -38,10 +38,10 @@ index 1c416a48d2a069a0167bc0be6fa1d65d14f35816..62ecce029f38bd6a3e07981887916bb5
       * Creates a PlayerProfile for the specified uuid, with name as null.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1a4559c88ece08e4a0c27e808f69693fb89fc474..85a0de6277aff8a81c8e58b3b29b98d99b6b1fb9 100644
+index b0e6446c0dc49088878d7ae453dc3eee8b346f4e..dc26cf95f1769da76dd4d768a0912c1f5346d83e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1894,6 +1894,23 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1905,6 +1905,23 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  

--- a/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
@@ -9,10 +9,10 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 62ecce029f38bd6a3e07981887916bb54e0c62f9..5f684c9ac218f105efe77ef08cae4b759868b0ea 100644
+index 00295e256c0def25dd3e552ef67eea06ab01ad15..940e93021aba7dade1558054deead5896d74d3c6 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1197,10 +1197,8 @@ public final class Bukkit {
+@@ -1198,10 +1198,8 @@ public final class Bukkit {
       * @param name the name the player to retrieve
       * @return an offline player
       * @see #getOfflinePlayer(java.util.UUID)
@@ -24,7 +24,7 @@ index 62ecce029f38bd6a3e07981887916bb54e0c62f9..5f684c9ac218f105efe77ef08cae4b75
      @NotNull
      public static OfflinePlayer getOfflinePlayer(@NotNull String name) {
          return server.getOfflinePlayer(name);
-@@ -1749,7 +1747,7 @@ public final class Bukkit {
+@@ -1750,7 +1748,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -159,10 +159,10 @@ index 6277451c3c6c551078c237cd767b6d70c4f585ea..10f5cfb1885833a1d2c1027c03974da4
      CRACKED(0x0),
      GLYPHED(0x1),
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 85a0de6277aff8a81c8e58b3b29b98d99b6b1fb9..1fecaed0b5774e3888bd1f5103828cc38f0265d9 100644
+index dc26cf95f1769da76dd4d768a0912c1f5346d83e..8c608f9260acd8257b49f9befae510fa645886a8 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -998,10 +998,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -999,10 +999,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param name the name the player to retrieve
       * @return an offline player
       * @see #getOfflinePlayer(java.util.UUID)
@@ -174,7 +174,7 @@ index 85a0de6277aff8a81c8e58b3b29b98d99b6b1fb9..1fecaed0b5774e3888bd1f5103828cc3
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  
-@@ -1467,7 +1465,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1468,7 +1466,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */

--- a/patches/api/0184-Expose-the-internal-current-tick.patch
+++ b/patches/api/0184-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5f684c9ac218f105efe77ef08cae4b759868b0ea..fb5ba85b324eb78c31367bc59f2d1ca7eec1bf2b 100644
+index 940e93021aba7dade1558054deead5896d74d3c6..d3f784c0c68567ee94befa57e0be1cedc7d586cb 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2276,6 +2276,10 @@ public final class Bukkit {
+@@ -2289,6 +2289,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfileExact(uuid, name);
      }
@@ -20,10 +20,10 @@ index 5f684c9ac218f105efe77ef08cae4b759868b0ea..fb5ba85b324eb78c31367bc59f2d1ca7
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1fecaed0b5774e3888bd1f5103828cc38f0265d9..05587286b253b6f877aa5fae19d556cc8967a326 100644
+index 8c608f9260acd8257b49f9befae510fa645886a8..d092d43178c1795028c33518713a8156648c460b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1977,5 +1977,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1988,5 +1988,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0190-Add-tick-times-API.patch
+++ b/patches/api/0190-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index fb5ba85b324eb78c31367bc59f2d1ca7eec1bf2b..4ba11b4a22981472e3fcbfe8ffadaa3f3c140e2f 100644
+index d3f784c0c68567ee94befa57e0be1cedc7d586cb..dab845c22713c0a3ae044afaf16d7b72eeff8ea5 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1948,6 +1948,25 @@ public final class Bukkit {
+@@ -1961,6 +1961,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index fb5ba85b324eb78c31367bc59f2d1ca7eec1bf2b..4ba11b4a22981472e3fcbfe8ffadaa3f
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 05587286b253b6f877aa5fae19d556cc8967a326..a4775467581c351f4c89521c2e017b31d48bf3b5 100644
+index d092d43178c1795028c33518713a8156648c460b..13e4893049219ff1e50ede8df405561360ae4760 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1639,6 +1639,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1650,6 +1650,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0191-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0191-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 4ba11b4a22981472e3fcbfe8ffadaa3f3c140e2f..88fe6c7dabdcf5c1a81126e7c98a361ec25438a0 100644
+index dab845c22713c0a3ae044afaf16d7b72eeff8ea5..4771149c9fcee5e51c5313fffb105ad6f68a256a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2299,6 +2299,15 @@ public final class Bukkit {
+@@ -2312,6 +2312,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index 4ba11b4a22981472e3fcbfe8ffadaa3f3c140e2f..88fe6c7dabdcf5c1a81126e7c98a361e
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a4775467581c351f4c89521c2e017b31d48bf3b5..8cf4a6d82278770598dee9191409c676b7fb1b08 100644
+index 13e4893049219ff1e50ede8df405561360ae4760..201cbb0d33fc25e90b7960894eb6a9e6ef0d107b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1999,5 +1999,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2010,5 +2010,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0200-Expose-game-version.patch
+++ b/patches/api/0200-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 88fe6c7dabdcf5c1a81126e7c98a361ec25438a0..e9e7fdcb8b57d07d88c9e9694dd119b07fa5b823 100644
+index 4771149c9fcee5e51c5313fffb105ad6f68a256a..022a3de1bc7969a1db7395a910782bde1468758a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -154,6 +154,18 @@ public final class Bukkit {
+@@ -155,6 +155,18 @@ public final class Bukkit {
          return server.getBukkitVersion();
      }
  
@@ -28,10 +28,10 @@ index 88fe6c7dabdcf5c1a81126e7c98a361ec25438a0..e9e7fdcb8b57d07d88c9e9694dd119b0
       * Gets a view of all currently logged in players. This {@linkplain
       * Collections#unmodifiableCollection(Collection) view} is a reused
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 8cf4a6d82278770598dee9191409c676b7fb1b08..dd1bb341714d27c286b57f9410a690f754bd937b 100644
+index 201cbb0d33fc25e90b7960894eb6a9e6ef0d107b..832b19712612fdbac5d2f472aab203b14f7e4a46 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -112,6 +112,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -113,6 +113,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public String getBukkitVersion();
  

--- a/patches/api/0201-Add-Mob-Goal-API.patch
+++ b/patches/api/0201-Add-Mob-Goal-API.patch
@@ -523,10 +523,10 @@ index 0000000000000000000000000000000000000000..8fd399f791b45eb7fc62693ca954eea0
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index e9e7fdcb8b57d07d88c9e9694dd119b07fa5b823..1f2d25a48bfd67f770560e6284e0be27b6b4df38 100644
+index 022a3de1bc7969a1db7395a910782bde1468758a..f3f8a6db7ee1b4ea1aaf6bc972fa02a8af5f3772 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2320,6 +2320,16 @@ public final class Bukkit {
+@@ -2333,6 +2333,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -544,10 +544,10 @@ index e9e7fdcb8b57d07d88c9e9694dd119b07fa5b823..1f2d25a48bfd67f770560e6284e0be27
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index dd1bb341714d27c286b57f9410a690f754bd937b..88eab327d5854fd853b1adb5b4f04a2bcfd66849 100644
+index 832b19712612fdbac5d2f472aab203b14f7e4a46..4f17bc607639bb3d20a1694ffb02d22d283348b3 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2016,5 +2016,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2027,5 +2027,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0216-Add-setMaxPlayers-API.patch
+++ b/patches/api/0216-Add-setMaxPlayers-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 1f2d25a48bfd67f770560e6284e0be27b6b4df38..bd7c7d1cc25f1bc246944de2ffc20cadaacd1d29 100644
+index f3f8a6db7ee1b4ea1aaf6bc972fa02a8af5f3772..2d26f1fd3bbbe95e7a73bb5ebc7d85c9e066c1ee 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -207,6 +207,17 @@ public final class Bukkit {
+@@ -208,6 +208,17 @@ public final class Bukkit {
          return server.getMaxPlayers();
      }
  
@@ -27,10 +27,10 @@ index 1f2d25a48bfd67f770560e6284e0be27b6b4df38..bd7c7d1cc25f1bc246944de2ffc20cad
       * Get the game port that the server runs on.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 88eab327d5854fd853b1adb5b4f04a2bcfd66849..f05dc6c186c94b940ea69d7ebc32451cc38f7fcf 100644
+index 4f17bc607639bb3d20a1694ffb02d22d283348b3..634a7e38987bc18232c07e5f767b37b523f13920 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -159,6 +159,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -160,6 +160,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      public int getMaxPlayers();
  

--- a/patches/api/0229-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0229-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index bd7c7d1cc25f1bc246944de2ffc20cadaacd1d29..104738ea3bc2a678f15011ab1c6c7f38b56bf340 100644
+index 2d26f1fd3bbbe95e7a73bb5ebc7d85c9e066c1ee..f1e1efaebfd9fe4399ff9d23c76f7dde6419ff71 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1227,6 +1227,27 @@ public final class Bukkit {
+@@ -1228,6 +1228,27 @@ public final class Bukkit {
          return server.getOfflinePlayer(name);
      }
  
@@ -37,10 +37,10 @@ index bd7c7d1cc25f1bc246944de2ffc20cadaacd1d29..104738ea3bc2a678f15011ab1c6c7f38
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f05dc6c186c94b940ea69d7ebc32451cc38f7fcf..5e8ce65588a4b4be71292f5b92c049ae58d3a9a0 100644
+index 634a7e38987bc18232c07e5f767b37b523f13920..50542df291d90a667af119fb9fcc3db2535ae6b5 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1022,6 +1022,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1023,6 +1023,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  

--- a/patches/api/0277-Expand-world-key-API.patch
+++ b/patches/api/0277-Expand-world-key-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expand world key API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 104738ea3bc2a678f15011ab1c6c7f38b56bf340..0ddad5d32494495bb797559a10336a401e445fef 100644
+index f1e1efaebfd9fe4399ff9d23c76f7dde6419ff71..db44d88bf169f59a759be165094876497487d756 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -810,6 +810,18 @@ public final class Bukkit {
+@@ -811,6 +811,18 @@ public final class Bukkit {
      public static World getWorld(@NotNull UUID uid) {
          return server.getWorld(uid);
      }
@@ -56,10 +56,10 @@ index 2fa3de66107162ccaa158b369e2c4a926ecaff92..aa534b1a9a1fb84a2fbd4b372f313bb4
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5e8ce65588a4b4be71292f5b92c049ae58d3a9a0..80d762390a42070f1953a388c896cd93640b506e 100644
+index 50542df291d90a667af119fb9fcc3db2535ae6b5..723057dcc769bd29acdb82561ee0126ed467579d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -670,6 +670,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -671,6 +671,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      public World getWorld(@NotNull UUID uid);
  

--- a/patches/api/0295-Add-basic-Datapack-API.patch
+++ b/patches/api/0295-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 0ddad5d32494495bb797559a10336a401e445fef..05186443e25706ed77f7187eea6ac84666613a88 100644
+index db44d88bf169f59a759be165094876497487d756..d8e301befb37b540bc246cf58988923b0ab23375 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2374,6 +2374,14 @@ public final class Bukkit {
+@@ -2387,6 +2387,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index 0ddad5d32494495bb797559a10336a401e445fef..05186443e25706ed77f7187eea6ac846
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 80d762390a42070f1953a388c896cd93640b506e..3d78e555725b48cb7e5750e8b4b3f1f0463bddc2 100644
+index 723057dcc769bd29acdb82561ee0126ed467579d..16f631fdde4b63e0ed3162486dba684697bdffa7 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2063,5 +2063,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2074,5 +2074,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0327-Add-missing-team-sidebar-display-slots.patch
+++ b/patches/api/0327-Add-missing-team-sidebar-display-slots.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add missing team sidebar display slots
 
 
 diff --git a/src/main/java/org/bukkit/scoreboard/DisplaySlot.java b/src/main/java/org/bukkit/scoreboard/DisplaySlot.java
-index 5d58a18b3625fd01ea34969200edc3bc80cbb587..fe7d0a19f970ac5b4e0c4bef4ff7c4ceae60bb86 100644
+index 4959bec21d152a17fe4ca9d3f448aef482a05b5e..fe7d0a19f970ac5b4e0c4bef4ff7c4ceae60bb86 100644
 --- a/src/main/java/org/bukkit/scoreboard/DisplaySlot.java
 +++ b/src/main/java/org/bukkit/scoreboard/DisplaySlot.java
-@@ -1,10 +1,55 @@
+@@ -1,26 +1,55 @@
  package org.bukkit.scoreboard;
  
 +import net.kyori.adventure.text.format.NamedTextColor; // Paper
@@ -18,7 +18,23 @@ index 5d58a18b3625fd01ea34969200edc3bc80cbb587..fe7d0a19f970ac5b4e0c4bef4ff7c4ce
  public enum DisplaySlot {
 -    BELOW_NAME,
 -    PLAYER_LIST,
--    SIDEBAR;
+-    SIDEBAR,
+-    SIDEBAR_BLACK,
+-    SIDEBAR_DARK_BLUE,
+-    SIDEBAR_DARK_GREEN,
+-    SIDEBAR_DARK_AQUA,
+-    SIDEBAR_DARK_RED,
+-    SIDEBAR_DARK_PURPLE,
+-    SIDEBAR_GOLD,
+-    SIDEBAR_GRAY,
+-    SIDEBAR_DARK_GRAY,
+-    SIDEBAR_BLUE,
+-    SIDEBAR_GREEN,
+-    SIDEBAR_AQUA,
+-    SIDEBAR_RED,
+-    SIDEBAR_LIGHT_PURPLE,
+-    SIDEBAR_YELLOW,
+-    SIDEBAR_WHITE;
 +    // Paper start
 +    BELOW_NAME("belowName"),
 +    PLAYER_LIST("list"),

--- a/patches/api/0342-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0342-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 05186443e25706ed77f7187eea6ac84666613a88..23834c3bd3a5e008b1b05c99a7b2f491731d8459 100644
+index d8e301befb37b540bc246cf58988923b0ab23375..77e824f6071782def8865fc178e2f064f109cebb 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1892,6 +1892,24 @@ public final class Bukkit {
+@@ -1905,6 +1905,24 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -34,10 +34,10 @@ index 05186443e25706ed77f7187eea6ac84666613a88..23834c3bd3a5e008b1b05c99a7b2f491
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 3d78e555725b48cb7e5750e8b4b3f1f0463bddc2..515e1bc18e04cd94b5aa7b00434a72381277e678 100644
+index 16f631fdde4b63e0ed3162486dba684697bdffa7..a7e1d81a8a5e14f556d6b462dfba7f2e49f06f5f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1589,6 +1589,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1600,6 +1600,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  

--- a/patches/api/0345-Improve-scoreboard-entries.patch
+++ b/patches/api/0345-Improve-scoreboard-entries.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Improve scoreboard entries
 
 
 diff --git a/src/main/java/org/bukkit/scoreboard/Objective.java b/src/main/java/org/bukkit/scoreboard/Objective.java
-index 75acd6f8f3d774bb79e8e513125e801c5569a244..b93b1b0428d11589605c8edf5c053369e1031076 100644
+index 474274fdffe4041bf4bfb146fcc66424eb5be78a..b236d19d4e4e4f9def610bae8a0c7d222fe2241b 100644
 --- a/src/main/java/org/bukkit/scoreboard/Objective.java
 +++ b/src/main/java/org/bukkit/scoreboard/Objective.java
-@@ -140,9 +140,8 @@ public interface Objective {
+@@ -151,9 +151,8 @@ public interface Objective {
       * @throws IllegalArgumentException if player is null
       * @throws IllegalStateException if this objective has been unregistered
       * @see #getScore(String)
@@ -19,7 +19,7 @@ index 75acd6f8f3d774bb79e8e513125e801c5569a244..b93b1b0428d11589605c8edf5c053369
      @NotNull
      Score getScore(@NotNull OfflinePlayer player) throws IllegalArgumentException, IllegalStateException;
  
-@@ -157,4 +156,16 @@ public interface Objective {
+@@ -168,4 +167,16 @@ public interface Objective {
       */
      @NotNull
      Score getScore(@NotNull String entry) throws IllegalArgumentException, IllegalStateException;
@@ -37,10 +37,10 @@ index 75acd6f8f3d774bb79e8e513125e801c5569a244..b93b1b0428d11589605c8edf5c053369
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/scoreboard/Scoreboard.java b/src/main/java/org/bukkit/scoreboard/Scoreboard.java
-index 1ada91d790abedbc9b3aeb6e96467a0d78560f15..fc3456bb79f2fe1504359455b937c162780110c2 100644
+index ef3e729caf430b08cdf2d680d5a137a1ba56c1c5..880b20bf25f74e9cb54ff3fb282a5b74db6a0a85 100644
 --- a/src/main/java/org/bukkit/scoreboard/Scoreboard.java
 +++ b/src/main/java/org/bukkit/scoreboard/Scoreboard.java
-@@ -163,9 +163,8 @@ public interface Scoreboard {
+@@ -265,9 +265,8 @@ public interface Scoreboard {
       * @return immutable set of all scores tracked for the player
       * @throws IllegalArgumentException if player is null
       * @see #getScores(String)
@@ -51,7 +51,7 @@ index 1ada91d790abedbc9b3aeb6e96467a0d78560f15..fc3456bb79f2fe1504359455b937c162
      @NotNull
      Set<Score> getScores(@NotNull OfflinePlayer player) throws IllegalArgumentException;
  
-@@ -185,9 +184,8 @@ public interface Scoreboard {
+@@ -287,9 +286,8 @@ public interface Scoreboard {
       * @param player the player to drop all current scores for
       * @throws IllegalArgumentException if player is null
       * @see #resetScores(String)
@@ -62,7 +62,7 @@ index 1ada91d790abedbc9b3aeb6e96467a0d78560f15..fc3456bb79f2fe1504359455b937c162
      void resetScores(@NotNull OfflinePlayer player) throws IllegalArgumentException;
  
      /**
-@@ -205,9 +203,8 @@ public interface Scoreboard {
+@@ -307,9 +305,8 @@ public interface Scoreboard {
       * @return the player's Team or null if the player is not on a team
       * @throws IllegalArgumentException if player is null
       * @see #getEntryTeam(String)
@@ -73,7 +73,7 @@ index 1ada91d790abedbc9b3aeb6e96467a0d78560f15..fc3456bb79f2fe1504359455b937c162
      @Nullable
      Team getPlayerTeam(@NotNull OfflinePlayer player) throws IllegalArgumentException;
  
-@@ -276,4 +273,35 @@ public interface Scoreboard {
+@@ -378,4 +375,35 @@ public interface Scoreboard {
       * @throws IllegalArgumentException if slot is null
       */
      void clearSlot(@NotNull DisplaySlot slot) throws IllegalArgumentException;

--- a/patches/api/0362-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0362-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for creating command sender which forwards feedback
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 23834c3bd3a5e008b1b05c99a7b2f491731d8459..ac7674fb1c9d7bd9572c678f57cab44233328bdc 100644
+index 77e824f6071782def8865fc178e2f064f109cebb..1b52cb7d8b894ee73be5754ed44236de01d7d0c6 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1412,6 +1412,20 @@ public final class Bukkit {
+@@ -1413,6 +1413,20 @@ public final class Bukkit {
          return server.getConsoleSender();
      }
  
@@ -30,10 +30,10 @@ index 23834c3bd3a5e008b1b05c99a7b2f491731d8459..ac7674fb1c9d7bd9572c678f57cab442
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 515e1bc18e04cd94b5aa7b00434a72381277e678..871d80d0e0ce7cd80e34bfeebee8c543ea023d8e 100644
+index a7e1d81a8a5e14f556d6b462dfba7f2e49f06f5f..6d056cee2fb727db9fbcc0ee98a7c800a8981ad6 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1178,6 +1178,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1179,6 +1179,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/api/0369-Custom-Potion-Mixes.patch
+++ b/patches/api/0369-Custom-Potion-Mixes.patch
@@ -102,10 +102,10 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ac7674fb1c9d7bd9572c678f57cab44233328bdc..92a1462261029e804da73da2743bbd68e57841e9 100644
+index 1b52cb7d8b894ee73be5754ed44236de01d7d0c6..840aaf9e8fc828b5a7ea02252038c6524680f2e0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2414,6 +2414,15 @@ public final class Bukkit {
+@@ -2427,6 +2427,15 @@ public final class Bukkit {
      public static io.papermc.paper.datapack.DatapackManager getDatapackManager() {
          return server.getDatapackManager();
      }
@@ -122,10 +122,10 @@ index ac7674fb1c9d7bd9572c678f57cab44233328bdc..92a1462261029e804da73da2743bbd68
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 871d80d0e0ce7cd80e34bfeebee8c543ea023d8e..56e261efa654e4a6872ccea28f0461df13845d13 100644
+index 6d056cee2fb727db9fbcc0ee98a7c800a8981ad6..da5cab4246bd253fcc4e4d9574bdae1867ebb5ab 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2097,5 +2097,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2108,5 +2108,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -4193,7 +4193,7 @@ index 853e7c2019f5147e9681e95a82eaef0825b6341e..a48a12a31a3d09a9373b688dcc093035
              String s = (String) Optional.ofNullable((String) optionset.valueOf("world")).orElse(dedicatedserversettings.getProperties().levelName);
              LevelStorageSource convertable = LevelStorageSource.createDefault(file.toPath());
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e7b1456a123208241d0b1c5956a137d6a5cfbfcd..7740e69617c3d543a67ed0942ba8ec550ad4386d 100644
+index 15ecb1769a0604eed348b0cd31b86ce2010cbda0..8d65c989aef5ec92873a504f5b331dfe7d8b4bff 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -281,6 +281,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -4307,10 +4307,10 @@ index c1194f459414dc6ca9626ab8cec48cb48cdd926b..649df119b24dc8c390f45e9f813cf8c3
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dbaec6fc4967d8140fd5af68456894bad1a0205a..4f67f7541ff257f35701610760fb8e04e8379fe3 100644
+index b2a06ca1240e20693ee993928509dd50992b6f6f..3620b8a76b5c13d33ec32e4a0d7fc7fa7290f220 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -870,6 +870,7 @@ public final class CraftServer implements Server {
+@@ -872,6 +872,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
@@ -4319,7 +4319,7 @@ index dbaec6fc4967d8140fd5af68456894bad1a0205a..4f67f7541ff257f35701610760fb8e04
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index f264607eb3df1f247c7c36d328405900b52df38e..b05cea49219c6582bacc705f41e72ca7c7eb6a8c 100644
+index eca7833e722a876be29806c92b18b6b58aab5725..e8d71985f2e96574081e4f609d62a3b8bded8249 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -129,6 +129,19 @@ public class Main {

--- a/patches/server/0006-CB-fixes.patch
+++ b/patches/server/0006-CB-fixes.patch
@@ -67,10 +67,10 @@ index 9998e1c94b72b90dd3ba4bcce1b4b3653b9b1b2b..963ad3ce1ef83888ae1537ff01accdbb
          this.registryAccess = registryManager;
          this.structureTemplateManager = structureTemplateManager;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4f67f7541ff257f35701610760fb8e04e8379fe3..a850bb8a4268c0210ee7af98f51131759ff95f30 100644
+index 3620b8a76b5c13d33ec32e4a0d7fc7fa7290f220..5550dbea555a99ee1612609093292db79a625c94 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2271,7 +2271,13 @@ public final class CraftServer implements Server {
+@@ -2278,7 +2278,13 @@ public final class CraftServer implements Server {
          Validate.notNull(key, "NamespacedKey cannot be null");
  
          LootTables registry = this.getServer().getLootTables();

--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -2546,10 +2546,10 @@ index 595b56b2ab9a813ba71399d306117294fa90dc65..3527d40102d512d0e276edc969ea3c18
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a850bb8a4268c0210ee7af98f51131759ff95f30..837fb51698e6650c6df720f798b7196322b6e7bb 100644
+index 5550dbea555a99ee1612609093292db79a625c94..e4f8ccb45a16c35b5256e209435840609d527695 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -590,8 +590,10 @@ public final class CraftServer implements Server {
+@@ -592,8 +592,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -2560,7 +2560,7 @@ index a850bb8a4268c0210ee7af98f51131759ff95f30..837fb51698e6650c6df720f798b71963
      }
  
      @Override
-@@ -1411,7 +1413,15 @@ public final class CraftServer implements Server {
+@@ -1413,7 +1415,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -2576,7 +2576,7 @@ index a850bb8a4268c0210ee7af98f51131759ff95f30..837fb51698e6650c6df720f798b71963
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1579,7 +1589,20 @@ public final class CraftServer implements Server {
+@@ -1581,7 +1591,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -2597,7 +2597,7 @@ index a850bb8a4268c0210ee7af98f51131759ff95f30..837fb51698e6650c6df720f798b71963
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1587,14 +1610,14 @@ public final class CraftServer implements Server {
+@@ -1589,14 +1612,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -2614,7 +2614,7 @@ index a850bb8a4268c0210ee7af98f51131759ff95f30..837fb51698e6650c6df720f798b71963
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1845,6 +1868,14 @@ public final class CraftServer implements Server {
+@@ -1847,6 +1870,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -2629,7 +2629,7 @@ index a850bb8a4268c0210ee7af98f51131759ff95f30..837fb51698e6650c6df720f798b71963
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1857,13 +1888,28 @@ public final class CraftServer implements Server {
+@@ -1859,13 +1890,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -2658,7 +2658,7 @@ index a850bb8a4268c0210ee7af98f51131759ff95f30..837fb51698e6650c6df720f798b71963
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1928,6 +1974,12 @@ public final class CraftServer implements Server {
+@@ -1930,6 +1976,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -2671,7 +2671,7 @@ index a850bb8a4268c0210ee7af98f51131759ff95f30..837fb51698e6650c6df720f798b71963
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2350,4 +2402,15 @@ public final class CraftServer implements Server {
+@@ -2357,4 +2409,15 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
@@ -4228,10 +4228,10 @@ index 1980240d3dc0331ddf2ff56e163e2bfbd3b231ab..7a7f3f53aef601f124d474d9890e23d8
          public Inventory createInventory(InventoryHolder holder, InventoryType type, String title) {
              // BrewingStand does not extend TileEntityLootable
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
-index e9bb0728ae5c16aad4acc106d332db5095db4033..6752cd9b3bc246fc2a7764df0d2b40d3e638fa62 100644
+index 0d25c7c03f7ac21a4b21bb95b5bd921c43430cf9..b7f0277b50a0f45c32b818bf9fe1218874aa8533 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
-@@ -30,6 +30,21 @@ final class CraftObjective extends CraftScoreboardComponent implements Objective
+@@ -31,6 +31,21 @@ final class CraftObjective extends CraftScoreboardComponent implements Objective
          return this.objective.getName();
      }
  
@@ -4254,20 +4254,28 @@ index e9bb0728ae5c16aad4acc106d332db5095db4033..6752cd9b3bc246fc2a7764df0d2b40d3
      public String getDisplayName() throws IllegalStateException {
          CraftScoreboard scoreboard = this.checkState();
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-index afc059755ae3e7b1c0a4cf3c6b8f32ce13cc458d..9130c478b80fc50ef1fc4e27b1afa51e3f97d618 100644
+index c624867e28dd5187d58a6bcb9067b0c10ff7e733..f367261b119ab48c1d17b2b6552cce481c6effbb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-@@ -27,6 +27,27 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+@@ -28,6 +28,34 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
      public CraftObjective registerNewObjective(String name, String criteria) throws IllegalArgumentException {
          return this.registerNewObjective(name, criteria, name);
      }
 +    // Paper start
 +    @Override
 +    public CraftObjective registerNewObjective(String name, String criteria, net.kyori.adventure.text.Component displayName) {
-+        return registerNewObjective(name, criteria, displayName, org.bukkit.scoreboard.RenderType.INTEGER);
++        return registerNewObjective(name, CraftCriteria.getFromBukkit(criteria), displayName, RenderType.INTEGER);
 +    }
 +    @Override
 +    public CraftObjective registerNewObjective(String name, String criteria, net.kyori.adventure.text.Component displayName, RenderType renderType) {
++        return registerNewObjective(name, CraftCriteria.getFromBukkit(criteria), displayName, renderType);
++    }
++    @Override
++    public CraftObjective registerNewObjective(String name, Criteria criteria, net.kyori.adventure.text.Component displayName) throws IllegalArgumentException {
++        return registerNewObjective(name, criteria, displayName, RenderType.INTEGER);
++    }
++    @Override
++    public CraftObjective registerNewObjective(String name, Criteria criteria, net.kyori.adventure.text.Component displayName, RenderType renderType) throws IllegalArgumentException {
 +        if (displayName == null) {
 +            displayName = net.kyori.adventure.text.Component.empty();
 +        }
@@ -4277,32 +4285,27 @@ index afc059755ae3e7b1c0a4cf3c6b8f32ce13cc458d..9130c478b80fc50ef1fc4e27b1afa51e
 +        Validate.notNull(renderType, "RenderType cannot be null");
 +        Validate.isTrue(name.length() <= Short.MAX_VALUE, "The name '" + name + "' is longer than the limit of 32767 characters");
 +        Validate.isTrue(board.getObjective(name) == null, "An objective of name '" + name + "' already exists");
-+        CraftCriteria craftCriteria = CraftCriteria.getFromBukkit(criteria);
-+        net.minecraft.world.scores.Objective objective = board.addObjective(name, craftCriteria.criteria, io.papermc.paper.adventure.PaperAdventure.asVanilla(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
++        net.minecraft.world.scores.Objective objective = board.addObjective(name, ((CraftCriteria) criteria).criteria, io.papermc.paper.adventure.PaperAdventure.asVanilla(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
 +        return new CraftObjective(this, objective);
 +    }
 +    // Paper end
  
      @Override
      public CraftObjective registerNewObjective(String name, String criteria, String displayName) throws IllegalArgumentException {
-@@ -35,7 +56,7 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+@@ -46,16 +74,7 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
  
      @Override
-     public CraftObjective registerNewObjective(String name, String criteria, String displayName, RenderType renderType) throws IllegalArgumentException {
+     public CraftObjective registerNewObjective(String name, Criteria criteria, String displayName, RenderType renderType) throws IllegalArgumentException {
 -        Validate.notNull(name, "Objective name cannot be null");
-+        /*Validate.notNull(name, "Objective name cannot be null"); // Paper
-         Validate.notNull(criteria, "Criteria cannot be null");
-         Validate.notNull(displayName, "Display name cannot be null");
-         Validate.notNull(renderType, "RenderType cannot be null");
-@@ -45,7 +66,11 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
- 
-         CraftCriteria craftCriteria = CraftCriteria.getFromBukkit(criteria);
-         net.minecraft.world.scores.Objective objective = this.board.addObjective(name, craftCriteria.criteria, CraftChatMessage.fromStringOrNull(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
+-        Validate.notNull(criteria, "Criteria cannot be null");
+-        Validate.notNull(displayName, "Display name cannot be null");
+-        Validate.notNull(renderType, "RenderType cannot be null");
+-        Validate.isTrue(name.length() <= Short.MAX_VALUE, "The name '" + name + "' is longer than the limit of 32767 characters");
+-        Validate.isTrue(displayName.length() <= 128, "The display name '" + displayName + "' is longer than the limit of 128 characters");
+-        Validate.isTrue(this.board.getObjective(name) == null, "An objective of name '" + name + "' already exists");
+-
+-        net.minecraft.world.scores.Objective objective = this.board.addObjective(name, ((CraftCriteria) criteria).criteria, CraftChatMessage.fromStringOrNull(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
 -        return new CraftObjective(this, objective);
-+
-+        CraftCriteria craftCriteria = CraftCriteria.getFromBukkit(criteria);
-+        ScoreboardObjective objective = board.registerObjective(name, craftCriteria.criteria, CraftChatMessage.fromStringOrNull(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
-+        return new CraftObjective(this, objective);*/ // Paper
 +        return registerNewObjective(name, criteria, net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(displayName), renderType); // Paper
      }
  

--- a/patches/server/0009-Paper-command.patch
+++ b/patches/server/0009-Paper-command.patch
@@ -559,10 +559,10 @@ index 08ae7a96e93c0d8547f560b3f753804525621c6b..8f29bb843fc456384f7b4e216afca501
  
          this.setPvpAllowed(dedicatedserverproperties.pvp);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 837fb51698e6650c6df720f798b7196322b6e7bb..80333fe069e417ef692cb7b80292ed42d6e820a1 100644
+index e4f8ccb45a16c35b5256e209435840609d527695..82199864f2046528358af08d4aa4a283fa3e7ffd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -894,6 +894,7 @@ public final class CraftServer implements Server {
+@@ -896,6 +896,7 @@ public final class CraftServer implements Server {
          this.commandMap.clearCommands();
          this.reloadData();
          org.spigotmc.SpigotConfig.registerCommands(); // Spigot
@@ -570,7 +570,7 @@ index 837fb51698e6650c6df720f798b7196322b6e7bb..80333fe069e417ef692cb7b80292ed42
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2404,6 +2405,34 @@ public final class CraftServer implements Server {
+@@ -2411,6 +2412,34 @@ public final class CraftServer implements Server {
      // Spigot end
  
      // Paper start

--- a/patches/server/0012-Timings-v2.patch
+++ b/patches/server/0012-Timings-v2.patch
@@ -729,7 +729,7 @@ index 13421daa96b4ba302581f36abcd730952713d8cd..049e64c355d5f064009b1107ad15d28c
                      } catch (Exception exception) {
                          if (listener.shouldPropagateHandlingExceptions()) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index acc5ce86ae8aa5ada21e6c97f7921caca4b0bd00..35df8fb2d2818df21fe3bd8832d9d81ce3a66233 100644
+index b9a6533afbfe07ff544f9f03f3c254890ee2e068..56fc44274be4592107a89598c7d140b034a18b44 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -177,7 +177,7 @@ import org.bukkit.event.player.AsyncPlayerChatPreviewEvent;
@@ -1262,7 +1262,7 @@ index 95c3273d2379509cf6cd51a718f18b8697908932..1d4d60fa861b5e819c59f06168a09668
                  this.entityManager.saveAll();
              } else {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 59932a4f83461280ab3c097add951e5a138eb53d..4bdb7b50315c68a3f3c929745bf090f5c7a51c52 100644
+index b6436801ab2f10c68c8d6c529997223f84735a4e..955902a36c01697999e08a218887e90946a04b3a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -339,7 +339,6 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -1309,7 +1309,7 @@ index 59932a4f83461280ab3c097add951e5a138eb53d..4bdb7b50315c68a3f3c929745bf090f5
      }
      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 946b2b7341a10c25fae71d76f7b181b555fe38b6..e3e9758827e741a9140c650dafa411144f26e672 100644
+index 521f485366c65527ac3289dd27d8f2e311706a10..5833cc3d5014dad82607afc4d643b6bed885be64 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1,5 +1,6 @@
@@ -1634,10 +1634,10 @@ index 98ba88896c73651591b8ad8e070868fb443ae999..864e2e0355a5fb8c1d4a5b0896ba299f
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 80333fe069e417ef692cb7b80292ed42d6e820a1..7b645fd1bb170a09f56a827048f5d8816254df2f 100644
+index 82199864f2046528358af08d4aa4a283fa3e7ffd..5badb27d2060b0b13c54f8945848afbeb775fc6c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2372,12 +2372,31 @@ public final class CraftServer implements Server {
+@@ -2379,12 +2379,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  
@@ -1839,7 +1839,7 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3fe120364ac61d40d6d8b16339e3086a3c0ac512..7a95748f52ef064af3173deedc229ec0b5f65cac 100644
+index ef5e29e0a66f8d4cb819c4383cf3f1317d4e5bb0..a2dd86fde8882c774ad44be3ca66f7c80bb77389 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2275,6 +2275,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2035,7 +2035,7 @@ index e52ef47b783785dc214746b678e7b549aea9a274..3d90b3426873a3528af14f7f1ab0adae
          this.value = value;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index a9a900f09b95d84b53adbe0405c322d36b6edad1..4f1945f854f4a022184ca4756b59d08b01693d6b 100644
+index 56a3dc9dcbd2229c60aa64e2d4c0ed147539a5ef..e309a589e6ce76294187c906820a88367da25305 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -217,6 +217,12 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0013-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0013-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7b645fd1bb170a09f56a827048f5d8816254df2f..a9d9bc91b150597275d9b15f21dc00b49c5e3b28 100644
+index 5badb27d2060b0b13c54f8945848afbeb775fc6c..45c51529c9f94dfbd575ca94acd3c025bdb909e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -403,10 +403,15 @@ public final class CraftServer implements Server {
+@@ -405,10 +405,15 @@ public final class CraftServer implements Server {
      public void loadPlugins() {
          this.pluginManager.registerInterface(JavaPluginLoader.class);
  
@@ -29,7 +29,7 @@ index 7b645fd1bb170a09f56a827048f5d8816254df2f..a9d9bc91b150597275d9b15f21dc00b4
              for (Plugin plugin : plugins) {
                  try {
                      String message = String.format("Loading %s", plugin.getDescription().getFullName());
-@@ -421,6 +426,35 @@ public final class CraftServer implements Server {
+@@ -423,6 +428,35 @@ public final class CraftServer implements Server {
          }
      }
  
@@ -66,7 +66,7 @@ index 7b645fd1bb170a09f56a827048f5d8816254df2f..a9d9bc91b150597275d9b15f21dc00b4
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index c520e8e53356188ee00dc10a6a74c88b5e2f6e94..155087d30e826205088ad9d449b33d4b29dca716 100644
+index 681b58e6de48cccac82c7b6833f6fcea46d83dde..f64a690ed3173f78ed60b0262c0c868d97a803d5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -147,6 +147,12 @@ public class Main {

--- a/patches/server/0021-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0021-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Show 'Paper' in client crashes, server lists, and Mojang
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 35df8fb2d2818df21fe3bd8832d9d81ce3a66233..c7660c2c9c5e1fb166ba6a3216f14e5fa934528d 100644
+index 56fc44274be4592107a89598c7d140b034a18b44..97e2cbd5fa724ba5ba3f33ac1ce3da2e3e881eb8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1416,7 +1416,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -19,10 +19,10 @@ index 35df8fb2d2818df21fe3bd8832d9d81ce3a66233..c7660c2c9c5e1fb166ba6a3216f14e5f
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a9d9bc91b150597275d9b15f21dc00b49c5e3b28..ae2912c8cb89208a7bbbcdb6e6f143ebc98e8180 100644
+index 45c51529c9f94dfbd575ca94acd3c025bdb909e9..df74d459809da72c55dd93c299dd2b414fb64dea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -244,7 +244,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -246,7 +246,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
  public final class CraftServer implements Server {

--- a/patches/server/0025-Further-improve-server-tick-loop.patch
+++ b/patches/server/0025-Further-improve-server-tick-loop.patch
@@ -12,7 +12,7 @@ Previous implementation did not calculate TPS correctly.
 Switch to a realistic rolling average and factor in std deviation as an extra reporting variable
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c7660c2c9c5e1fb166ba6a3216f14e5fa934528d..494ee4d6de47d10b2f9e4be393f1fe2603a72167 100644
+index 97e2cbd5fa724ba5ba3f33ac1ce3da2e3e881eb8..0e982051f6c833fd5ff2ccbe098cb7a98bd0dc8a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -270,7 +270,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -144,10 +144,10 @@ index c7660c2c9c5e1fb166ba6a3216f14e5fa934528d..494ee4d6de47d10b2f9e4be393f1fe26
                  this.startMetricsRecordingTick();
                  this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ae2912c8cb89208a7bbbcdb6e6f143ebc98e8180..415393e965c7253412ec4d893c3e62ad14dd69f2 100644
+index df74d459809da72c55dd93c299dd2b414fb64dea..bd17e22c6cb3176da054bce3699c278b2354f193 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2402,6 +2402,17 @@ public final class CraftServer implements Server {
+@@ -2409,6 +2409,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0047-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0047-Ensure-commands-are-not-ran-async.patch
@@ -74,10 +74,10 @@ index 955902a36c01697999e08a218887e90946a04b3a..44e9edb76a518b12b1f20e73343ed720
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + s);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 415393e965c7253412ec4d893c3e62ad14dd69f2..846c5144fefd1dfd1bbd8e6f82bd9248be34ad1a 100644
+index bd17e22c6cb3176da054bce3699c278b2354f193..b61a98f2711c8aeca65e6e782c07ace05c56fbe8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -861,6 +861,28 @@ public final class CraftServer implements Server {
+@@ -863,6 +863,28 @@ public final class CraftServer implements Server {
          Validate.notNull(commandLine, "CommandLine cannot be null");
          org.spigotmc.AsyncCatcher.catchOp("command dispatch"); // Spigot
  

--- a/patches/server/0049-Expose-server-CommandMap.patch
+++ b/patches/server/0049-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 846c5144fefd1dfd1bbd8e6f82bd9248be34ad1a..3c1f2bcaedba7ec59d1a865ca8b5615a5c6d3d52 100644
+index b61a98f2711c8aeca65e6e782c07ace05c56fbe8..4c0f321128271f77a54b1ed814033cdd8a712350 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1981,6 +1981,7 @@ public final class CraftServer implements Server {
+@@ -1983,6 +1983,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0054-Add-velocity-warnings.patch
+++ b/patches/server/0054-Add-velocity-warnings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add velocity warnings
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3c1f2bcaedba7ec59d1a865ca8b5615a5c6d3d52..3dc04ad966c9f44f62af918c50ff1e8ed461fe3b 100644
+index 4c0f321128271f77a54b1ed814033cdd8a712350..fe4bf2bdd43d4d85c62d3939305dbecc1ae01eb9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -278,6 +278,7 @@ public final class CraftServer implements Server {
+@@ -280,6 +280,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;

--- a/patches/server/0062-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0062-Default-loading-permissions.yml-before-plugins.patch
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3dc04ad966c9f44f62af918c50ff1e8ed461fe3b..9f9d2c32d184a9ef7f2fbdef85129654b43cf3ab 100644
+index fe4bf2bdd43d4d85c62d3939305dbecc1ae01eb9..63eabacf2743d14bb02147869e51491e392b96bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -460,6 +460,7 @@ public final class CraftServer implements Server {
+@@ -462,6 +462,7 @@ public final class CraftServer implements Server {
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
              this.helpMap.initializeGeneralTopics();
@@ -27,7 +27,7 @@ index 3dc04ad966c9f44f62af918c50ff1e8ed461fe3b..9f9d2c32d184a9ef7f2fbdef85129654
          }
  
          Plugin[] plugins = this.pluginManager.getPlugins();
-@@ -479,7 +480,7 @@ public final class CraftServer implements Server {
+@@ -481,7 +482,7 @@ public final class CraftServer implements Server {
              this.commandMap.registerServerAliases();
              DefaultPermissions.registerCorePermissions();
              CraftDefaultPermissions.registerCorePermissions();

--- a/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9f9d2c32d184a9ef7f2fbdef85129654b43cf3ab..bb90cb49fc2b4bb4034d43d16eee61643773ecfa 100644
+index 63eabacf2743d14bb02147869e51491e392b96bf..858707ce778fad5bbdcc31e61de57dbfed2f94b4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2530,5 +2530,23 @@ public final class CraftServer implements Server {
+@@ -2537,5 +2537,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0064-Remove-Metadata-on-reload.patch
+++ b/patches/server/0064-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bb90cb49fc2b4bb4034d43d16eee61643773ecfa..aa6a40eae3a3897ab3cca93921635e4e3e37db9f 100644
+index 858707ce778fad5bbdcc31e61de57dbfed2f94b4..460d95ece9a9ba053a50d5a1cf69ac3bc85131a3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -948,8 +948,16 @@ public final class CraftServer implements Server {
+@@ -950,8 +950,16 @@ public final class CraftServer implements Server {
              world.spigotConfig.init(); // Spigot
          }
  

--- a/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
@@ -43,10 +43,10 @@ index da98f074ccd5a40c635824112c97fd174c393cb1..6599f874d9f97e9ef4862039ecad7277
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index aa6a40eae3a3897ab3cca93921635e4e3e37db9f..34d4157d187ff8485d860eb4f75b898aee06863c 100644
+index 460d95ece9a9ba053a50d5a1cf69ac3bc85131a3..cc4bd65d8f9f3824e77e4509a8f0dbda5c2f01a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1704,7 +1704,7 @@ public final class CraftServer implements Server {
+@@ -1706,7 +1706,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0109-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0109-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 34d4157d187ff8485d860eb4f75b898aee06863c..8c041ca80cb20800178f8d4a5584e1b26bf3cb15 100644
+index cc4bd65d8f9f3824e77e4509a8f0dbda5c2f01a6..34b35a4e2e723f4bfe6773da1e9958badadec221 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2556,5 +2556,24 @@ public final class CraftServer implements Server {
+@@ -2563,5 +2563,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0132-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0132-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8c041ca80cb20800178f8d4a5584e1b26bf3cb15..be392b054d3fe86118265cbe65067e83b37f36e8 100644
+index 34b35a4e2e723f4bfe6773da1e9958badadec221..593b998592cc340f8ff1f8806394fea7e0871cf0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2575,5 +2575,10 @@ public final class CraftServer implements Server {
+@@ -2582,5 +2582,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0133-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0133-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -112,7 +112,7 @@ index 0000000000000000000000000000000000000000..685deaa0e5d1ddc13e3a7c0471b1cfcf
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 41928abfffbf6102e92cb45532e691b35a603a31..68072a78d241bcfb54a206e7b85f038d51e26e58 100644
+index 2b1a80c1f6825f1b14babaa788fd0350a6f564c9..ea969d79fc3ee4a186a62e226fecb4e59d0e025c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -156,7 +156,7 @@ import org.slf4j.Logger;
@@ -222,7 +222,7 @@ index 5b2980866ae3cd78f1852b0ad396ff1967ddfc16..9411e5664c0067f976018fe19b1e7403
          System.setOut(IoBuilder.forLogger(logger).setLevel(Level.INFO).buildPrintStream());
          System.setErr(IoBuilder.forLogger(logger).setLevel(Level.WARN).buildPrintStream());
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 03a19b3869eea9a59f4003a81ab488603347cd4a..258eee0f5310224b089895745ff11e482fc36dca 100644
+index dee794f1128309c87d02b1a6a19cf9db314994e3..73cf0363ebbe383348f8bcc79a85dcfa4d147443 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -160,8 +160,7 @@ public abstract class PlayerList {
@@ -236,7 +236,7 @@ index 03a19b3869eea9a59f4003a81ab488603347cd4a..258eee0f5310224b089895745ff11e48
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index be392b054d3fe86118265cbe65067e83b37f36e8..ad469e105871105a3918f9213bc9f27263955063 100644
+index 593b998592cc340f8ff1f8806394fea7e0871cf0..4d15fb22c0b12ec438584c672c03a41ea50c4133 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -45,7 +45,6 @@ import java.util.logging.Level;
@@ -247,7 +247,7 @@ index be392b054d3fe86118265cbe65067e83b37f36e8..ad469e105871105a3918f9213bc9f272
  import net.minecraft.advancements.Advancement;
  import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
-@@ -1274,9 +1273,13 @@ public final class CraftServer implements Server {
+@@ -1276,9 +1275,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  

--- a/patches/server/0139-Add-UnknownCommandEvent.patch
+++ b/patches/server/0139-Add-UnknownCommandEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ad469e105871105a3918f9213bc9f27263955063..6d9ec963c1f0c5ee477ee4d84862a3c699eeba46 100644
+index 4d15fb22c0b12ec438584c672c03a41ea50c4133..13a6582765c565197ef8d1013b428c45e2ac5d66 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -890,7 +890,13 @@ public final class CraftServer implements Server {
+@@ -892,7 +892,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0140-Basic-PlayerProfile-API.patch
+++ b/patches/server/0140-Basic-PlayerProfile-API.patch
@@ -621,10 +621,10 @@ index 2a0cf0a8a79c09566c598197fc6f8c447d4bbd72..5e3bc0590e59770490b1c6c818d99be0
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6d9ec963c1f0c5ee477ee4d84862a3c699eeba46..733423010e7941d160b838d614c732980111fb55 100644
+index 13a6582765c565197ef8d1013b428c45e2ac5d66..adb3c54932a90c4881e6db0ed037d033220e9a7e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -242,6 +242,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -244,6 +244,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
@@ -634,7 +634,7 @@ index 6d9ec963c1f0c5ee477ee4d84862a3c699eeba46..733423010e7941d160b838d614c73298
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -282,6 +285,7 @@ public final class CraftServer implements Server {
+@@ -284,6 +287,7 @@ public final class CraftServer implements Server {
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
          ConfigurationSerialization.registerClass(CraftPlayerProfile.class);
@@ -642,7 +642,7 @@ index 6d9ec963c1f0c5ee477ee4d84862a3c699eeba46..733423010e7941d160b838d614c73298
          CraftItemFactory.instance();
      }
  
-@@ -2589,5 +2593,37 @@ public final class CraftServer implements Server {
+@@ -2596,5 +2600,37 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }

--- a/patches/server/0166-AsyncTabCompleteEvent.patch
+++ b/patches/server/0166-AsyncTabCompleteEvent.patch
@@ -16,7 +16,7 @@ Also adds isCommand and getLocation to the sync TabCompleteEvent
 Co-authored-by: Aikar <aikar@aikar.co>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f558d0f8f7b78132510f8c5e61701eccf1f8bcfa..6de0b057d61dbe5939f0c04d8a5d1469837ed305 100644
+index 0ad2e5102df956040715ed77bfa0eb41663b23bc..a9c52b6759aa1f17ecc4c365892c48d8e80c3fe3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -781,27 +781,58 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -85,10 +85,10 @@ index f558d0f8f7b78132510f8c5e61701eccf1f8bcfa..6de0b057d61dbe5939f0c04d8a5d1469
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 733423010e7941d160b838d614c732980111fb55..45d3fc8174ff32c140c1c234b655a6971a27913e 100644
+index adb3c54932a90c4881e6db0ed037d033220e9a7e..be5982fea6f354131e4562e2a109b4c56c77bcd9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2084,7 +2084,7 @@ public final class CraftServer implements Server {
+@@ -2086,7 +2086,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0182-getPlayerUniqueId-API.patch
+++ b/patches/server/0182-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 45d3fc8174ff32c140c1c234b655a6971a27913e..1775174221c84b627ea778c0d0892ce46c1d56b6 100644
+index be5982fea6f354131e4562e2a109b4c56c77bcd9..e8becfe4cfb0b431d99a78b7726e96afbdefcf12 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1706,6 +1706,25 @@ public final class CraftServer implements Server {
+@@ -1708,6 +1708,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0238-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0238-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -9,7 +9,7 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index bb50ca7bcbdf46d29bd749050674dc18d7e282e4..f78e2d7926e665278a4d7dd78529e92abb54be85 100644
+index e7cd33be3c74ca79f9f0fecea010081b24a14417..ac36f50fd721b0087248bfb733fe4ea78a115778 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1061,6 +1061,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -33,10 +33,10 @@ index 9411e5664c0067f976018fe19b1e74032f24bd5f..1e7bccbf551043d822edb1983fa039a4
          com.destroystokyo.paper.Metrics.PaperMetrics.startMetrics();
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1775174221c84b627ea778c0d0892ce46c1d56b6..21f0e1a23d6e9c6c76abfa9af555642fadeba69c 100644
+index e8becfe4cfb0b431d99a78b7726e96afbdefcf12..71415a6ca5bd61fa5652006ed748048d65a0502b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -909,6 +909,7 @@ public final class CraftServer implements Server {
+@@ -911,6 +911,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -44,7 +44,7 @@ index 1775174221c84b627ea778c0d0892ce46c1d56b6..21f0e1a23d6e9c6c76abfa9af555642f
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -997,6 +998,7 @@ public final class CraftServer implements Server {
+@@ -999,6 +1000,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/patches/server/0284-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0284-Make-the-default-permission-message-configurable.patch
@@ -18,10 +18,10 @@ index b3a58bf4b654e336826dc04da9e2f80ff8b9a9a7..cd4936ef114b504df8649fba8f1823d9
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 21f0e1a23d6e9c6c76abfa9af555642fadeba69c..12d789b0abef2dc0e0965579830ad6d341717ba4 100644
+index 71415a6ca5bd61fa5652006ed748048d65a0502b..f8640a3a147322d99dc23a28de0a77692205ff75 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2615,6 +2615,16 @@ public final class CraftServer implements Server {
+@@ -2622,6 +2622,16 @@ public final class CraftServer implements Server {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }
  

--- a/patches/server/0317-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0317-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -29,10 +29,10 @@ index 8c48544daae0f18a39511df12f7066fc0e383d2c..49fe89baab93ae99a990684d78c5c05a
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 12d789b0abef2dc0e0965579830ad6d341717ba4..45c88bfdbc004ff59faae25eacdd72e611034c30 100644
+index f8640a3a147322d99dc23a28de0a77692205ff75..0cc0435e53379208cc9c5f25ca185a26bd595caa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2073,7 +2073,7 @@ public final class CraftServer implements Server {
+@@ -2075,7 +2075,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0323-Expose-the-internal-current-tick.patch
+++ b/patches/server/0323-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 45c88bfdbc004ff59faae25eacdd72e611034c30..6463aeed288c3bb06075107a91a70e66e1420448 100644
+index 0cc0435e53379208cc9c5f25ca185a26bd595caa..c125f4ba687d7622290da3f0e0fef5a8a859b4d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2656,5 +2656,10 @@ public final class CraftServer implements Server {
+@@ -2663,5 +2663,10 @@ public final class CraftServer implements Server {
          profile.getProperties().putAll(((CraftPlayer)player).getHandle().getGameProfile().getProperties());
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }

--- a/patches/server/0352-Anti-Xray.patch
+++ b/patches/server/0352-Anti-Xray.patch
@@ -1551,10 +1551,10 @@ index cf48c93d89da53e0ec771e5c2c8582e30b35e3f5..518dfbb7dbd4221937636cf46d27109d
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6463aeed288c3bb06075107a91a70e66e1420448..36069181cde281f56ca6c6c8e4b127452a9176d8 100644
+index c125f4ba687d7622290da3f0e0fef5a8a859b4d2..3a183c9c85439d9595cc5667743cd7f41cc8c727 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2228,7 +2228,7 @@ public final class CraftServer implements Server {
+@@ -2235,7 +2235,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Validate.notNull(world, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();

--- a/patches/server/0372-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0372-Add-tick-times-API-and-mspt-command.patch
@@ -185,10 +185,10 @@ index 181e35da5919ba3b91246b427f2c5773acf1dd12..0612bf8ecc6e1b76d728fea852e850ab
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 36069181cde281f56ca6c6c8e4b127452a9176d8..aa6d408ab8898dc752f137c24e3b906611f76672 100644
+index 3a183c9c85439d9595cc5667743cd7f41cc8c727..051853707609fc026ab49fcd4a5a3798cdbed94a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2478,6 +2478,16 @@ public final class CraftServer implements Server {
+@@ -2485,6 +2485,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0373-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0373-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index aa6d408ab8898dc752f137c24e3b906611f76672..51aaec29d2d8ed257e22c2538fd95c6e656a8eba 100644
+index 051853707609fc026ab49fcd4a5a3798cdbed94a..fc1ed21c74b12b77544455e3c04453e71409c2c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2671,5 +2671,10 @@ public final class CraftServer implements Server {
+@@ -2678,5 +2678,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0384-Improved-Watchdog-Support.patch
+++ b/patches/server/0384-Improved-Watchdog-Support.patch
@@ -330,10 +330,10 @@ index 5f65aa89dfb21fced457a3a9fef6ba05385b6b76..291bcca206722c86bca6d13058d18c41
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 51aaec29d2d8ed257e22c2538fd95c6e656a8eba..23ed6183c20ab5284e4ceb1e44237b2d3ddb9710 100644
+index fc1ed21c74b12b77544455e3c04453e71409c2c2..bfd785af2d459061054a101def1a6c6bfd9cdda1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2073,7 +2073,7 @@ public final class CraftServer implements Server {
+@@ -2075,7 +2075,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0403-Expose-game-version.patch
+++ b/patches/server/0403-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 23ed6183c20ab5284e4ceb1e44237b2d3ddb9710..3837eda1aab1104265be6a0b0a684c64aa18aa63 100644
+index bfd785af2d459061054a101def1a6c6bfd9cdda1..ed74a0295d3ade16cd3120ef6abc391f662b1263 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -577,6 +577,13 @@ public final class CraftServer implements Server {
+@@ -579,6 +579,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  

--- a/patches/server/0406-misc-debugging-dumps.patch
+++ b/patches/server/0406-misc-debugging-dumps.patch
@@ -74,10 +74,10 @@ index c99266d4782c5d58339e63f7564c28b4b5b7ac1d..d477e9fbe6ffb600d08f8ba49741067d
                  this.connection.send(new ClientboundDisconnectPacket(ichatmutablecomponent));
                  this.connection.disconnect(ichatmutablecomponent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3837eda1aab1104265be6a0b0a684c64aa18aa63..7bc40ce1566821f29d2d199764ef33d2d1c45849 100644
+index ed74a0295d3ade16cd3120ef6abc391f662b1263..8d0a4c3e7fc49bac8af97e8a086f7c12ce874f86 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1000,6 +1000,7 @@ public final class CraftServer implements Server {
+@@ -1002,6 +1002,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getFullName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0409-Implement-Mob-Goal-API.patch
+++ b/patches/server/0409-Implement-Mob-Goal-API.patch
@@ -789,10 +789,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7bc40ce1566821f29d2d199764ef33d2d1c45849..68eb6756098a9923b63e0d4cfcc15fcfee5acf6e 100644
+index 8d0a4c3e7fc49bac8af97e8a086f7c12ce874f86..5ac4ff48b631649eac804553faf67330e9827806 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2684,5 +2684,11 @@ public final class CraftServer implements Server {
+@@ -2691,5 +2691,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0416-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0416-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,10 +22,10 @@ index b1f8374253d04d1468f5d57792b30f91a274b97f..b6a05542a42b1f44b3a43fbcd333003e
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 68eb6756098a9923b63e0d4cfcc15fcfee5acf6e..fdcc0d1300e55fcecc267fe6b989b54588896170 100644
+index 5ac4ff48b631649eac804553faf67330e9827806..fc7db6036a2c1b8f5b33a30e9604173dba63025b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1009,6 +1009,35 @@ public final class CraftServer implements Server {
+@@ -1011,6 +1011,35 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0441-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0441-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -102,10 +102,10 @@ index 893b9557d742ad1d74a7f6a772c4f8f45a7172f6..aea4c331c1bb0e84fc4743dbec539143
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fdcc0d1300e55fcecc267fe6b989b54588896170..701c623fbf4108de3da64174590fe15e97c274fe 100644
+index fc7db6036a2c1b8f5b33a30e9604173dba63025b..979d0116e72417eec26193cd1e106dc9d27cdbe0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -949,8 +949,8 @@ public final class CraftServer implements Server {
+@@ -951,8 +951,8 @@ public final class CraftServer implements Server {
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
          this.console.paperConfigurations.reloadConfigs(this.console);
          for (ServerLevel world : this.console.getAllLevels()) {

--- a/patches/server/0446-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0446-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,10 +22,10 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 701c623fbf4108de3da64174590fe15e97c274fe..fbe09c604315794b462e6be5bc8c7e87c21806f6 100644
+index 979d0116e72417eec26193cd1e106dc9d27cdbe0..c7a6143ebb2ed0a0977e1d38c8adcccf09800638 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -358,7 +358,7 @@ public final class CraftServer implements Server {
+@@ -360,7 +360,7 @@ public final class CraftServer implements Server {
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -34,7 +34,7 @@ index 701c623fbf4108de3da64174590fe15e97c274fe..fbe09c604315794b462e6be5bc8c7e87
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
  
-@@ -929,7 +929,7 @@ public final class CraftServer implements Server {
+@@ -931,7 +931,7 @@ public final class CraftServer implements Server {
          this.console.setMotd(config.motd);
          this.overrideSpawnLimits();
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));

--- a/patches/server/0475-Add-setMaxPlayers-API.patch
+++ b/patches/server/0475-Add-setMaxPlayers-API.patch
@@ -18,10 +18,10 @@ index 8c1b6aa3957a988656eeb2ad6323fdbd2f67cd19..67c50a329e7bdf4056a1217963e29e8c
      private int simulationDistance;
      private boolean allowCheatsForAllPlayers;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fbe09c604315794b462e6be5bc8c7e87c21806f6..369e3807b75b3bdd7609ce64b6da018317642edf 100644
+index c7a6143ebb2ed0a0977e1d38c8adcccf09800638..72e545e9aa01ad7ae4180d5421e16e330b4c9934 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -672,6 +672,13 @@ public final class CraftServer implements Server {
+@@ -674,6 +674,13 @@ public final class CraftServer implements Server {
          return this.playerList.getMaxPlayers();
      }
  

--- a/patches/server/0499-Lazily-track-plugin-scoreboards-by-default.patch
+++ b/patches/server/0499-Lazily-track-plugin-scoreboards-by-default.patch
@@ -14,10 +14,10 @@ this breaks your workflow you can always force all scoreboards to be tracked wit
 settings.track-plugin-scoreboards in paper.yml.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-index 9130c478b80fc50ef1fc4e27b1afa51e3f97d618..167376bcd547f55983ccbb0d46e571c45c7d1ed9 100644
+index f367261b119ab48c1d17b2b6552cce481c6effbb..a038ede38ebb507d6a0182a4a34f2b0722ef024e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-@@ -18,6 +18,7 @@ import org.bukkit.scoreboard.Team;
+@@ -19,6 +19,7 @@ import org.bukkit.scoreboard.Team;
  
  public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
      final Scoreboard board;
@@ -25,34 +25,21 @@ index 9130c478b80fc50ef1fc4e27b1afa51e3f97d618..167376bcd547f55983ccbb0d46e571c4
  
      CraftScoreboard(Scoreboard board) {
          this.board = board;
-@@ -44,6 +45,12 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+@@ -52,6 +53,12 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+         Validate.notNull(renderType, "RenderType cannot be null");
          Validate.isTrue(name.length() <= Short.MAX_VALUE, "The name '" + name + "' is longer than the limit of 32767 characters");
          Validate.isTrue(board.getObjective(name) == null, "An objective of name '" + name + "' already exists");
-         CraftCriteria craftCriteria = CraftCriteria.getFromBukkit(criteria);
 +        // Paper start - the block comment from the old registerNewObjective didnt cause a conflict when rebasing, so this block wasn't added to the adventure registerNewObjective
-+        if (craftCriteria.criteria != net.minecraft.world.scores.criteria.ObjectiveCriteria.DUMMY && !registeredGlobally) {
++        if (((CraftCriteria) criteria).criteria != net.minecraft.world.scores.criteria.ObjectiveCriteria.DUMMY && !registeredGlobally) {
 +            net.minecraft.server.MinecraftServer.getServer().server.getScoreboardManager().registerScoreboardForVanilla(this);
 +            registeredGlobally = true;
 +        }
 +        // Paper end
-         net.minecraft.world.scores.Objective objective = board.addObjective(name, craftCriteria.criteria, io.papermc.paper.adventure.PaperAdventure.asVanilla(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
+         net.minecraft.world.scores.Objective objective = board.addObjective(name, ((CraftCriteria) criteria).criteria, io.papermc.paper.adventure.PaperAdventure.asVanilla(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
          return new CraftObjective(this, objective);
      }
-@@ -68,6 +75,12 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
-         net.minecraft.world.scores.Objective objective = this.board.addObjective(name, craftCriteria.criteria, CraftChatMessage.fromStringOrNull(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
- 
-         CraftCriteria craftCriteria = CraftCriteria.getFromBukkit(criteria);
-+        // Paper start
-+        if (craftCriteria.criteria != net.minecraft.server.IScoreboardCriteria.DUMMY && !registeredGlobally) {
-+            net.minecraft.server.MinecraftServer.getServer().server.getScoreboardManager().registerScoreboardForVanilla(this);
-+            registeredGlobally = true;
-+        }
-+        // Paper end
-         ScoreboardObjective objective = board.registerObjective(name, craftCriteria.criteria, CraftChatMessage.fromStringOrNull(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
-         return new CraftObjective(this, objective);*/ // Paper
-         return registerNewObjective(name, criteria, net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(displayName), renderType); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardManager.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardManager.java
-index ff090edcc85713083449cebb22bd1490123bc1ee..60d5564b5eb9f91db6b02bd4fb037a11fc6dfeb3 100644
+index 71f73db28ca124a49434e9da9eb39d182b7421e2..39e19bea16419b9cbe53016084b8bbf014dcb056 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardManager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardManager.java
 @@ -30,6 +30,7 @@ public final class CraftScoreboardManager implements ScoreboardManager {

--- a/patches/server/0514-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0514-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 369e3807b75b3bdd7609ce64b6da018317642edf..c967e55029e289c8525416122571770ec7c5fe6d 100644
+index 72e545e9aa01ad7ae4180d5421e16e330b4c9934..f5ed17af815f2e7da523e80319dc4021556376b2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1801,6 +1801,28 @@ public final class CraftServer implements Server {
+@@ -1803,6 +1803,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0603-Expand-world-key-API.patch
+++ b/patches/server/0603-Expand-world-key-API.patch
@@ -20,10 +20,10 @@ index ee5e59c37301d9a806e2f696d52d9d217b232833..bb5d22125b6cd4e60d2b7e2e00af158c
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c967e55029e289c8525416122571770ec7c5fe6d..1ddc78682e51bdbff6c4d7779a0c31b119b70899 100644
+index f5ed17af815f2e7da523e80319dc4021556376b2..4a59e48f67a4ebd44562915ee866276c1270604b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1141,9 +1141,15 @@ public final class CraftServer implements Server {
+@@ -1143,9 +1143,15 @@ public final class CraftServer implements Server {
          File folder = new File(this.getWorldContainer(), name);
          World world = this.getWorld(name);
  
@@ -41,7 +41,7 @@ index c967e55029e289c8525416122571770ec7c5fe6d..1ddc78682e51bdbff6c4d7779a0c31b1
  
          if ((folder.exists()) && (!folder.isDirectory())) {
              throw new IllegalArgumentException("File exists with the name '" + name + "' and isn't a folder");
-@@ -1218,7 +1224,7 @@ public final class CraftServer implements Server {
+@@ -1220,7 +1226,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -50,7 +50,7 @@ index c967e55029e289c8525416122571770ec7c5fe6d..1ddc78682e51bdbff6c4d7779a0c31b1
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, worlddimension, this.getServer().progressListenerFactory.create(11),
-@@ -1310,6 +1316,15 @@ public final class CraftServer implements Server {
+@@ -1312,6 +1318,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0640-Add-basic-Datapack-API.patch
+++ b/patches/server/0640-Add-basic-Datapack-API.patch
@@ -92,10 +92,10 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1ddc78682e51bdbff6c4d7779a0c31b119b70899..0b70d313bf7f2ecf37d21608c380097088516136 100644
+index 4a59e48f67a4ebd44562915ee866276c1270604b..7490d6cd392defa93d64fd20cd47caf9b62ddd9b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -280,6 +280,7 @@ public final class CraftServer implements Server {
+@@ -282,6 +282,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -103,7 +103,7 @@ index 1ddc78682e51bdbff6c4d7779a0c31b119b70899..0b70d313bf7f2ecf37d21608c3800970
      public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {
-@@ -366,6 +367,7 @@ public final class CraftServer implements Server {
+@@ -368,6 +369,7 @@ public final class CraftServer implements Server {
          if (this.configuration.getBoolean("settings.use-map-color-cache")) {
              MapPalette.setMapColorCache(new CraftMapColorCache(this.logger));
          }
@@ -111,7 +111,7 @@ index 1ddc78682e51bdbff6c4d7779a0c31b119b70899..0b70d313bf7f2ecf37d21608c3800970
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2763,5 +2765,11 @@ public final class CraftServer implements Server {
+@@ -2770,5 +2772,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0646-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0646-Fix-and-optimise-world-force-upgrading.patch
@@ -356,10 +356,10 @@ index a96a6af2bcec3134b7caa32299bd07af50e83b89..0d96d1c0b66c57c680759f3567ef1b0c
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0b70d313bf7f2ecf37d21608c380097088516136..39884103ad0d27eecdeaf002076e548386650789 100644
+index 7490d6cd392defa93d64fd20cd47caf9b62ddd9b..96e207db7c06f02bdcae9af482bf2d36b5baee9b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1202,12 +1202,7 @@ public final class CraftServer implements Server {
+@@ -1204,12 +1204,7 @@ public final class CraftServer implements Server {
          }
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().shouldReportAsModified());
@@ -373,7 +373,7 @@ index 0b70d313bf7f2ecf37d21608c380097088516136..39884103ad0d27eecdeaf002076e5483
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1219,6 +1214,13 @@ public final class CraftServer implements Server {
+@@ -1221,6 +1216,13 @@ public final class CraftServer implements Server {
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
  

--- a/patches/server/0684-Add-System.out-err-catcher.patch
+++ b/patches/server/0684-Add-System.out-err-catcher.patch
@@ -105,10 +105,10 @@ index 0000000000000000000000000000000000000000..76d0d00cd6742991e3f3ec827a75ee87
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 39884103ad0d27eecdeaf002076e548386650789..0e66d82bd0ab31491dad2ce344935548eb3966b0 100644
+index 96e207db7c06f02bdcae9af482bf2d36b5baee9b..589ee4fd2a7f2c81ef0324662d8349cd3105373f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -282,6 +282,7 @@ public final class CraftServer implements Server {
+@@ -284,6 +284,7 @@ public final class CraftServer implements Server {
      public int reloadCount;
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings

--- a/patches/server/0704-Add-missing-team-sidebar-display-slots.patch
+++ b/patches/server/0704-Add-missing-team-sidebar-display-slots.patch
@@ -5,20 +5,38 @@ Subject: [PATCH] Add missing team sidebar display slots
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardTranslations.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardTranslations.java
-index f1be7a4f96a556569e4a607959bfd085fa0cb64c..ca58cde37f4e5abeb33e2f583b3d53e80697eba9 100644
+index e2d3fe9af7d3bd82bee519b20e141cd58f68bbd6..944a4fee237730c0d89567aaa6ddf268467aa0e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardTranslations.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardTranslations.java
-@@ -7,7 +7,8 @@ import org.bukkit.scoreboard.DisplaySlot;
+@@ -7,36 +7,23 @@ import org.bukkit.scoreboard.DisplaySlot;
  import org.bukkit.scoreboard.RenderType;
  
  public final class CraftScoreboardTranslations {
--    static final int MAX_DISPLAY_SLOT = 3;
+-    static final int MAX_DISPLAY_SLOT = 19;
 +    static final int MAX_DISPLAY_SLOT = Scoreboard.getDisplaySlotNames().length; // Paper
 +    @Deprecated // Paper
-     static ImmutableBiMap<DisplaySlot, String> SLOTS = ImmutableBiMap.of(
-             DisplaySlot.BELOW_NAME, "belowName",
-             DisplaySlot.PLAYER_LIST, "list",
-@@ -16,10 +17,12 @@ public final class CraftScoreboardTranslations {
+     static final ImmutableBiMap<DisplaySlot, String> SLOTS = ImmutableBiMap.<DisplaySlot, String>builder()
+             .put(DisplaySlot.BELOW_NAME, "belowName")
+             .put(DisplaySlot.PLAYER_LIST, "list")
+             .put(DisplaySlot.SIDEBAR, "sidebar")
+-            .put(DisplaySlot.SIDEBAR_BLACK, "sidebar.team.black")
+-            .put(DisplaySlot.SIDEBAR_DARK_BLUE, "sidebar.team.dark_blue")
+-            .put(DisplaySlot.SIDEBAR_DARK_GREEN, "sidebar.team.dark_green")
+-            .put(DisplaySlot.SIDEBAR_DARK_AQUA, "sidebar.team.dark_aqua")
+-            .put(DisplaySlot.SIDEBAR_DARK_RED, "sidebar.team.dark_red")
+-            .put(DisplaySlot.SIDEBAR_DARK_PURPLE, "sidebar.team.dark_purple")
+-            .put(DisplaySlot.SIDEBAR_GOLD, "sidebar.team.gold")
+-            .put(DisplaySlot.SIDEBAR_GRAY, "sidebar.team.gray")
+-            .put(DisplaySlot.SIDEBAR_DARK_GRAY, "sidebar.team.dark_gray")
+-            .put(DisplaySlot.SIDEBAR_BLUE, "sidebar.team.blue")
+-            .put(DisplaySlot.SIDEBAR_GREEN, "sidebar.team.green")
+-            .put(DisplaySlot.SIDEBAR_AQUA, "sidebar.team.aqua")
+-            .put(DisplaySlot.SIDEBAR_RED, "sidebar.team.red")
+-            .put(DisplaySlot.SIDEBAR_LIGHT_PURPLE, "sidebar.team.light_purple")
+-            .put(DisplaySlot.SIDEBAR_YELLOW, "sidebar.team.yellow")
+-            .put(DisplaySlot.SIDEBAR_WHITE, "sidebar.team.white")
+             .buildOrThrow();
+ 
      private CraftScoreboardTranslations() {}
  
      public static DisplaySlot toBukkitSlot(int i) {
@@ -31,6 +49,25 @@ index f1be7a4f96a556569e4a607959bfd085fa0cb64c..ca58cde37f4e5abeb33e2f583b3d53e8
          return Scoreboard.getDisplaySlotByName(CraftScoreboardTranslations.SLOTS.get(slot));
      }
  
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
+index 89a32de0a3fbb7465b078b2aa1cc1d156a4a174d..27646d963bd1158f3fe0a9c0593a312404f0e7b0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
+@@ -252,6 +252,14 @@ public class Commodore
+                             desc = getOriginalOrRewrite( desc );
+                         }
+                         // Paper end
++                        // Paper start - DisplaySlot
++                        if (owner.equals("org/bukkit/scoreboard/DisplaySlot")) {
++                            if (name.startsWith("SIDEBAR_") && !name.startsWith("SIDEBAR_TEAM_")) {
++                                super.visitFieldInsn(opcode, owner, name.replace("SIDEBAR_", "SIDEBAR_TEAM_"), desc);
++                                return;
++                            }
++                        }
++                        // Paper end - DisplaySlot
+ 
+                         if ( owner.equals( "org/bukkit/block/Biome" ) )
+                         {
 diff --git a/src/test/java/io/papermc/paper/scoreboard/DisplaySlotTest.java b/src/test/java/io/papermc/paper/scoreboard/DisplaySlotTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..bb41a2f2c0a5e3b4cb3fe1b584e0ceb7a7116afb

--- a/patches/server/0727-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0727-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -286,10 +286,10 @@ index fa23e9c476d4edc6176d8b8a6cb13c52d2f66a87..4150e8cd7197eac53042d56f0a53a495
          // Paper start - add parameters and int ret type
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0e66d82bd0ab31491dad2ce344935548eb3966b0..dcb6fecaf1df903ce8b29d87d3f84376fb8f5982 100644
+index 589ee4fd2a7f2c81ef0324662d8349cd3105373f..7f874c53cdb1815e3337c51ab564b7dafb20c939 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2154,6 +2154,11 @@ public final class CraftServer implements Server {
+@@ -2156,6 +2156,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {

--- a/patches/server/0779-Fix-CraftCriteria-defaults-map.patch
+++ b/patches/server/0779-Fix-CraftCriteria-defaults-map.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CraftCriteria defaults map
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java
-index 22801e33fa15322c37cd11d73a40a43fa721a8e4..0cd63772871311fc0cb7111657cc9a9dac106167 100644
+index a8728102499ec8a0b4946bcc9b59c16193731f8c..d849ef9a51dc901c8045d63218b8ee5fa5c7ee7a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java
-@@ -37,7 +37,7 @@ final class CraftCriteria {
+@@ -54,7 +54,7 @@ public final class CraftCriteria implements Criteria {
      }
  
      static CraftCriteria getFromNMS(Objective objective) {
@@ -16,17 +16,4 @@ index 22801e33fa15322c37cd11d73a40a43fa721a8e4..0cd63772871311fc0cb7111657cc9a9d
 +        return java.util.Objects.requireNonNullElseGet(CraftCriteria.DEFAULTS.get(objective.getCriteria().getName()), () -> new CraftCriteria(objective.getCriteria())); // Paper
      }
  
-     static CraftCriteria getFromBukkit(String name) {
-@@ -45,6 +45,12 @@ final class CraftCriteria {
-         if (criteria != null) {
-             return criteria;
-         }
-+        // Paper start - fix criteria defaults
-+        var nmsCriteria = ObjectiveCriteria.byName(name);
-+        if (nmsCriteria.isPresent()) {
-+            return new CraftCriteria(nmsCriteria.get());
-+        }
-+        // Paper end
-         return new CraftCriteria(name);
-     }
- 
+     public static CraftCriteria getFromBukkit(String name) {

--- a/patches/server/0799-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0799-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dcb6fecaf1df903ce8b29d87d3f84376fb8f5982..83d48e4ea33c70494a482103eaa78c4d360347ca 100644
+index 7f874c53cdb1815e3337c51ab564b7dafb20c939..fe0b8b623b8853aaa4fd0a105f502cfebb763dfb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2322,6 +2322,90 @@ public final class CraftServer implements Server {
+@@ -2329,6 +2329,90 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(net.minecraft.core.Registry.BIOME_REGISTRY), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0810-Improve-scoreboard-entries.patch
+++ b/patches/server/0810-Improve-scoreboard-entries.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Improve scoreboard entries
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
-index 6752cd9b3bc246fc2a7764df0d2b40d3e638fa62..c5cf800ab8cbb5ebcf1b06ad591f08be75859b8c 100644
+index b7f0277b50a0f45c32b818bf9fe1218874aa8533..20b29f78fe56909e02061021b82a84cb7728d8a8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
-@@ -138,6 +138,14 @@ final class CraftObjective extends CraftScoreboardComponent implements Objective
+@@ -146,6 +146,14 @@ final class CraftObjective extends CraftScoreboardComponent implements Objective
          return new CraftScore(this, entry);
      }
  
@@ -24,10 +24,10 @@ index 6752cd9b3bc246fc2a7764df0d2b40d3e638fa62..c5cf800ab8cbb5ebcf1b06ad591f08be
      public void unregister() throws IllegalStateException {
          CraftScoreboard scoreboard = this.checkState();
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-index 167376bcd547f55983ccbb0d46e571c45c7d1ed9..912d302af733d8ee2517cf5f243301e6452493f9 100644
+index a038ede38ebb507d6a0182a4a34f2b0722ef024e..fe57437155ff9471738d3b85e787350601b79584 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-@@ -234,4 +234,23 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+@@ -247,4 +247,23 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
      public Scoreboard getHandle() {
          return this.board;
      }

--- a/patches/server/0824-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0824-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,10 +18,10 @@ index 68c0bb1d493b3de3c3e80018a1655ec968b0316a..a4433426efd0823cd8145a50b38127f6
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 83d48e4ea33c70494a482103eaa78c4d360347ca..0706649544d315f81964d9153446b2cde7fca4d4 100644
+index fe0b8b623b8853aaa4fd0a105f502cfebb763dfb..3fe38a9a6f4c25b91a25bc2320a7d7fcbe446d9d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1210,7 +1210,7 @@ public final class CraftServer implements Server {
+@@ -1212,7 +1212,7 @@ public final class CraftServer implements Server {
          net.minecraft.core.Registry<LevelStem> iregistry = worlddata.worldGenSettings().dimensions();
          LevelStem worlddimension = (LevelStem) iregistry.get(actualDimension);
  

--- a/patches/server/0839-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0839-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0706649544d315f81964d9153446b2cde7fca4d4..9ffbb711b353208a436e96947e156549507a8202 100644
+index 3fe38a9a6f4c25b91a25bc2320a7d7fcbe446d9d..17d4afb04a0a767283fcccb0cc00ab0043b49e22 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1988,6 +1988,13 @@ public final class CraftServer implements Server {
+@@ -1990,6 +1990,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  

--- a/patches/server/0843-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0843-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9ffbb711b353208a436e96947e156549507a8202..67b7516e41d9201b2ff29d0935f68eaa4692060c 100644
+index 17d4afb04a0a767283fcccb0cc00ab0043b49e22..8669584f7e89e89145631f86bf123b8a82c38e97 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2162,6 +2162,8 @@ public final class CraftServer implements Server {
+@@ -2164,6 +2164,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start

--- a/patches/server/0844-Add-GameEvent-tags.patch
+++ b/patches/server/0844-Add-GameEvent-tags.patch
@@ -45,10 +45,10 @@ index 0000000000000000000000000000000000000000..cb78a3d4e21376ea24347187478525d5
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 67b7516e41d9201b2ff29d0935f68eaa4692060c..127c86cba3616238361aabbd8aecf55969625af0 100644
+index 8669584f7e89e89145631f86bf123b8a82c38e97..ac8f105371e61a93eb416e086ece0243bd251625 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2568,6 +2568,15 @@ public final class CraftServer implements Server {
+@@ -2575,6 +2575,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(net.minecraft.core.Registry.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -64,7 +64,7 @@ index 67b7516e41d9201b2ff29d0935f68eaa4692060c..127c86cba3616238361aabbd8aecf559
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2600,6 +2609,13 @@ public final class CraftServer implements Server {
+@@ -2607,6 +2616,13 @@ public final class CraftServer implements Server {
                  net.minecraft.core.Registry<EntityType<?>> entityTags = net.minecraft.core.Registry.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0851-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0851-Put-world-into-worldlist-before-initing-the-world.patch
@@ -23,10 +23,10 @@ index faa380a0119d5827735a45104beef9880992240a..cd1edd0cb404cab5e71efdb82f3b911c
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 127c86cba3616238361aabbd8aecf55969625af0..54d342d378acc2d16186f1b96e327cf81d1bd99d 100644
+index ac8f105371e61a93eb416e086ece0243bd251625..c08342f861ed60d82c0e341943d94fe7542d0923 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1239,10 +1239,11 @@ public final class CraftServer implements Server {
+@@ -1241,10 +1241,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0853-Custom-Potion-Mixes.patch
+++ b/patches/server/0853-Custom-Potion-Mixes.patch
@@ -164,10 +164,10 @@ index 3d688e334c7287f41460bd866bfd1155e8bb55d2..55006724ccec9f3de828ec18693728e9
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 54d342d378acc2d16186f1b96e327cf81d1bd99d..0c43516bacdc56b6eca7498b51fa49fb65d4dde4 100644
+index c08342f861ed60d82c0e341943d94fe7542d0923..9b24f38406a1017dca430bbaeed4bf4227677972 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -283,6 +283,7 @@ public final class CraftServer implements Server {
+@@ -285,6 +285,7 @@ public final class CraftServer implements Server {
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings
      private final io.papermc.paper.logging.SysoutCatcher sysoutCatcher = new io.papermc.paper.logging.SysoutCatcher(); // Paper
@@ -175,7 +175,7 @@ index 54d342d378acc2d16186f1b96e327cf81d1bd99d..0c43516bacdc56b6eca7498b51fa49fb
  
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
-@@ -309,7 +310,7 @@ public final class CraftServer implements Server {
+@@ -311,7 +312,7 @@ public final class CraftServer implements Server {
          Enchantments.SHARPNESS.getClass();
          org.bukkit.enchantments.Enchantment.stopAcceptingRegistrations();
  
@@ -184,7 +184,7 @@ index 54d342d378acc2d16186f1b96e327cf81d1bd99d..0c43516bacdc56b6eca7498b51fa49fb
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2889,5 +2890,10 @@ public final class CraftServer implements Server {
+@@ -2896,5 +2897,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0868-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0868-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0c43516bacdc56b6eca7498b51fa49fb65d4dde4..dccc21db238a7d591f08ad1c78bbaa1662b3b86f 100644
+index 9b24f38406a1017dca430bbaeed4bf4227677972..dc3a0acfd0b4e5210994f5beb59df4351c67af69 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1287,7 +1287,7 @@ public final class CraftServer implements Server {
+@@ -1289,7 +1289,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0884-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0884-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dccc21db238a7d591f08ad1c78bbaa1662b3b86f..7ff85a35d75b1b267b8795363469e9fcb7a118c1 100644
+index dc3a0acfd0b4e5210994f5beb59df4351c67af69..eaf51d2b6ad149e19585e6cf600dddbf4bb3e68b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1246,6 +1246,7 @@ public final class CraftServer implements Server {
+@@ -1248,6 +1248,7 @@ public final class CraftServer implements Server {
          internal.setSpawnSettings(true, true);
          // Paper - move up
  

--- a/patches/server/0900-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0900-Throw-exception-on-world-create-while-being-ticked.patch
@@ -35,10 +35,10 @@ index 33cf037bf8ed5ea88f52ee3731cde63c70e813ef..081c7160cf727646cdec4cd551dbc2aa
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7ff85a35d75b1b267b8795363469e9fcb7a118c1..61b58188742b679c9bcd476a57721693103421ae 100644
+index eaf51d2b6ad149e19585e6cf600dddbf4bb3e68b..051899f6f6bb656a836045ee36e6a2afe83f34f6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1137,6 +1137,7 @@ public final class CraftServer implements Server {
+@@ -1139,6 +1139,7 @@ public final class CraftServer implements Server {
      @Override
      public World createWorld(WorldCreator creator) {
          Preconditions.checkState(!console.levels.isEmpty(), "Cannot create additional worlds on STARTUP");
@@ -46,7 +46,7 @@ index 7ff85a35d75b1b267b8795363469e9fcb7a118c1..61b58188742b679c9bcd476a57721693
          Validate.notNull(creator, "Creator may not be null");
  
          String name = creator.name();
-@@ -1261,6 +1262,7 @@ public final class CraftServer implements Server {
+@@ -1263,6 +1264,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {

--- a/patches/server/0908-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0908-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index c0195f73cd2c8721e882c681eaead65471710081..861b348f73867af3199f1cc0dab1ddd4
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 61b58188742b679c9bcd476a57721693103421ae..5e8fe876d9214b97acb97de63b36e7b753c43dbe 100644
+index 051899f6f6bb656a836045ee36e6a2afe83f34f6..32eb6efa94bc5ea3b516cbbd7e53f1460c23154d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1756,7 +1756,7 @@ public final class CraftServer implements Server {
+@@ -1758,7 +1758,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {

--- a/patches/server/0932-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0932-Add-Velocity-IP-Forwarding-Support.patch
@@ -197,10 +197,10 @@ index 2f0b2d0f3a3dc02076cee9ab5e6dd6ab931143e3..bf488013e45b9ab97568e587f4dad899
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5e8fe876d9214b97acb97de63b36e7b753c43dbe..bfde5bbcccfaa754ec6bdf4f3817981a93e465bd 100644
+index 32eb6efa94bc5ea3b516cbbd7e53f1460c23154d..964ec590ef5302576ecb3ba2b8ea95dbc2acf103 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -782,7 +782,7 @@ public final class CraftServer implements Server {
+@@ -784,7 +784,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
d43a1e72 SPIGOT-2450: Improve scoreboard criteria API, add missing DisplaySlots
9d6e4847 SPIGOT-7122: New Allay Methods from 1.19.1

CraftBukkit Changes:
c379a6b4e SPIGOT-2450: Improve scoreboard criteria API, add missing DisplaySlots
051fcced1 SPIGOT-7122: New Allay Methods from 1.19.1