### PR TITLE
Fix command pool submitting on shutdown

### DIFF
--- a/patches/server/0296-Async-command-map-building.patch
+++ b/patches/server/0296-Async-command-map-building.patch
@@ -9,14 +9,18 @@ commands if the server is restarting. Using the default async pool caused issues
 due to the shutdown logic generally being much later.
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 2bf67468a6c745bc6243c65210477ba129bfcb07..91b32a4856a4c9d6dc12871ed080f7a67311ead0 100644
+index 2bf67468a6c745bc6243c65210477ba129bfcb07..b89761343fd6125cef3b7949b39c56c2e1e513a2 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -360,6 +360,23 @@ public class Commands {
+@@ -360,6 +360,27 @@ public class Commands {
          if ( org.spigotmc.SpigotConfig.tabComplete < 0 ) return; // Spigot
          // CraftBukkit start
          // Register Vanilla commands into builtRoot as before
 +        // Paper start - Async command map building
++        // Don't send to pool if it's shutdown
++        if (COMMAND_SENDING_POOL.isShutdown()) {
++            return;
++        }
 +        COMMAND_SENDING_POOL.execute(() -> {
 +                this.sendAsync(player);
 +        });
@@ -36,7 +40,7 @@ index 2bf67468a6c745bc6243c65210477ba129bfcb07..91b32a4856a4c9d6dc12871ed080f7a6
          Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> map = Maps.newIdentityHashMap(); // Use identity to prevent aliasing issues
          RootCommandNode vanillaRoot = new RootCommandNode();
  
-@@ -377,7 +394,14 @@ public class Commands {
+@@ -377,7 +398,14 @@ public class Commands {
          for (CommandNode node : rootcommandnode.getChildren()) {
              bukkit.add(node.getName());
          }

--- a/patches/server/0296-Async-command-map-building.patch
+++ b/patches/server/0296-Async-command-map-building.patch
@@ -9,15 +9,14 @@ commands if the server is restarting. Using the default async pool caused issues
 due to the shutdown logic generally being much later.
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 2bf67468a6c745bc6243c65210477ba129bfcb07..5e390e2e5e3af66cd7b596ecde62c8a29a00ffe6 100644
+index 2bf67468a6c745bc6243c65210477ba129bfcb07..c4315531f93f4ed68b4621157b02572886e1ed30 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -360,6 +360,25 @@ public class Commands {
+@@ -360,6 +360,24 @@ public class Commands {
          if ( org.spigotmc.SpigotConfig.tabComplete < 0 ) return; // Spigot
          // CraftBukkit start
          // Register Vanilla commands into builtRoot as before
 +        // Paper start - Async command map building
-+        // Don't send to pool if it's shutdown
 +        COMMAND_SENDING_POOL.execute(() -> {
 +                this.sendAsync(player);
 +        });
@@ -38,7 +37,7 @@ index 2bf67468a6c745bc6243c65210477ba129bfcb07..5e390e2e5e3af66cd7b596ecde62c8a2
          Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> map = Maps.newIdentityHashMap(); // Use identity to prevent aliasing issues
          RootCommandNode vanillaRoot = new RootCommandNode();
  
-@@ -377,7 +396,14 @@ public class Commands {
+@@ -377,7 +395,14 @@ public class Commands {
          for (CommandNode node : rootcommandnode.getChildren()) {
              bukkit.add(node.getName());
          }

--- a/patches/server/0296-Async-command-map-building.patch
+++ b/patches/server/0296-Async-command-map-building.patch
@@ -9,18 +9,15 @@ commands if the server is restarting. Using the default async pool caused issues
 due to the shutdown logic generally being much later.
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 2bf67468a6c745bc6243c65210477ba129bfcb07..b89761343fd6125cef3b7949b39c56c2e1e513a2 100644
+index 2bf67468a6c745bc6243c65210477ba129bfcb07..5e390e2e5e3af66cd7b596ecde62c8a29a00ffe6 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -360,6 +360,27 @@ public class Commands {
+@@ -360,6 +360,25 @@ public class Commands {
          if ( org.spigotmc.SpigotConfig.tabComplete < 0 ) return; // Spigot
          // CraftBukkit start
          // Register Vanilla commands into builtRoot as before
 +        // Paper start - Async command map building
 +        // Don't send to pool if it's shutdown
-+        if (COMMAND_SENDING_POOL.isShutdown()) {
-+            return;
-+        }
 +        COMMAND_SENDING_POOL.execute(() -> {
 +                this.sendAsync(player);
 +        });
@@ -32,7 +29,8 @@ index 2bf67468a6c745bc6243c65210477ba129bfcb07..b89761343fd6125cef3b7949b39c56c2
 +        new com.google.common.util.concurrent.ThreadFactoryBuilder()
 +            .setNameFormat("Paper Async Command Builder Thread Pool - %1$d")
 +            .setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER))
-+            .build()
++            .build(),
++        new java.util.concurrent.ThreadPoolExecutor.DiscardPolicy()
 +    );
 +
 +    private void sendAsync(ServerPlayer player) {
@@ -40,7 +38,7 @@ index 2bf67468a6c745bc6243c65210477ba129bfcb07..b89761343fd6125cef3b7949b39c56c2
          Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> map = Maps.newIdentityHashMap(); // Use identity to prevent aliasing issues
          RootCommandNode vanillaRoot = new RootCommandNode();
  
-@@ -377,7 +398,14 @@ public class Commands {
+@@ -377,7 +396,14 @@ public class Commands {
          for (CommandNode node : rootcommandnode.getChildren()) {
              bukkit.add(node.getName());
          }

--- a/patches/server/0297-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0297-Implement-Brigadier-Mojang-API.patch
@@ -74,10 +74,10 @@ index 3308d684fc6cd0a83e190a52693b29d30e0087cb..aadddbc16aa719677c3b6fc4969b6145
      public boolean hasPermission(int level) {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index b89761343fd6125cef3b7949b39c56c2e1e513a2..a426c447d0dc4d48ca2ed66eee2679bc6436a768 100644
+index 5e390e2e5e3af66cd7b596ecde62c8a29a00ffe6..792bbe83bbe466a63f2f3dc9441f685464432aca 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -399,6 +399,7 @@ public class Commands {
+@@ -397,6 +397,7 @@ public class Commands {
              bukkit.add(node.getName());
          }
          // Paper start - Async command map building
@@ -85,7 +85,7 @@ index b89761343fd6125cef3b7949b39c56c2e1e513a2..a426c447d0dc4d48ca2ed66eee2679bc
          net.minecraft.server.MinecraftServer.getServer().execute(() -> {
             runSync(player, bukkit, rootcommandnode);
          });
-@@ -406,6 +407,7 @@ public class Commands {
+@@ -404,6 +405,7 @@ public class Commands {
  
      private void runSync(ServerPlayer player, Collection<String> bukkit, RootCommandNode<SharedSuggestionProvider> rootcommandnode) {
          // Paper end - Async command map building
@@ -93,7 +93,7 @@ index b89761343fd6125cef3b7949b39c56c2e1e513a2..a426c447d0dc4d48ca2ed66eee2679bc
          PlayerCommandSendEvent event = new PlayerCommandSendEvent(player.getBukkitEntity(), new LinkedHashSet<>(bukkit));
          event.getPlayer().getServer().getPluginManager().callEvent(event);
  
-@@ -424,6 +426,11 @@ public class Commands {
+@@ -422,6 +424,11 @@ public class Commands {
  
          while (iterator.hasNext()) {
              CommandNode<CommandSourceStack> commandnode2 = (CommandNode) iterator.next();

--- a/patches/server/0297-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0297-Implement-Brigadier-Mojang-API.patch
@@ -74,10 +74,10 @@ index 3308d684fc6cd0a83e190a52693b29d30e0087cb..aadddbc16aa719677c3b6fc4969b6145
      public boolean hasPermission(int level) {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 5e390e2e5e3af66cd7b596ecde62c8a29a00ffe6..792bbe83bbe466a63f2f3dc9441f685464432aca 100644
+index c4315531f93f4ed68b4621157b02572886e1ed30..b141d251eedd31bd115342b878afd68dc51a8518 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -397,6 +397,7 @@ public class Commands {
+@@ -396,6 +396,7 @@ public class Commands {
              bukkit.add(node.getName());
          }
          // Paper start - Async command map building
@@ -85,7 +85,7 @@ index 5e390e2e5e3af66cd7b596ecde62c8a29a00ffe6..792bbe83bbe466a63f2f3dc9441f6854
          net.minecraft.server.MinecraftServer.getServer().execute(() -> {
             runSync(player, bukkit, rootcommandnode);
          });
-@@ -404,6 +405,7 @@ public class Commands {
+@@ -403,6 +404,7 @@ public class Commands {
  
      private void runSync(ServerPlayer player, Collection<String> bukkit, RootCommandNode<SharedSuggestionProvider> rootcommandnode) {
          // Paper end - Async command map building
@@ -93,7 +93,7 @@ index 5e390e2e5e3af66cd7b596ecde62c8a29a00ffe6..792bbe83bbe466a63f2f3dc9441f6854
          PlayerCommandSendEvent event = new PlayerCommandSendEvent(player.getBukkitEntity(), new LinkedHashSet<>(bukkit));
          event.getPlayer().getServer().getPluginManager().callEvent(event);
  
-@@ -422,6 +424,11 @@ public class Commands {
+@@ -421,6 +423,11 @@ public class Commands {
  
          while (iterator.hasNext()) {
              CommandNode<CommandSourceStack> commandnode2 = (CommandNode) iterator.next();

--- a/patches/server/0297-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0297-Implement-Brigadier-Mojang-API.patch
@@ -74,10 +74,10 @@ index 3308d684fc6cd0a83e190a52693b29d30e0087cb..aadddbc16aa719677c3b6fc4969b6145
      public boolean hasPermission(int level) {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 91b32a4856a4c9d6dc12871ed080f7a67311ead0..0efb172c31a211e03d5fd922f65b6feff1317381 100644
+index b89761343fd6125cef3b7949b39c56c2e1e513a2..a426c447d0dc4d48ca2ed66eee2679bc6436a768 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -395,6 +395,7 @@ public class Commands {
+@@ -399,6 +399,7 @@ public class Commands {
              bukkit.add(node.getName());
          }
          // Paper start - Async command map building
@@ -85,7 +85,7 @@ index 91b32a4856a4c9d6dc12871ed080f7a67311ead0..0efb172c31a211e03d5fd922f65b6fef
          net.minecraft.server.MinecraftServer.getServer().execute(() -> {
             runSync(player, bukkit, rootcommandnode);
          });
-@@ -402,6 +403,7 @@ public class Commands {
+@@ -406,6 +407,7 @@ public class Commands {
  
      private void runSync(ServerPlayer player, Collection<String> bukkit, RootCommandNode<SharedSuggestionProvider> rootcommandnode) {
          // Paper end - Async command map building
@@ -93,7 +93,7 @@ index 91b32a4856a4c9d6dc12871ed080f7a67311ead0..0efb172c31a211e03d5fd922f65b6fef
          PlayerCommandSendEvent event = new PlayerCommandSendEvent(player.getBukkitEntity(), new LinkedHashSet<>(bukkit));
          event.getPlayer().getServer().getPluginManager().callEvent(event);
  
-@@ -420,6 +422,11 @@ public class Commands {
+@@ -424,6 +426,11 @@ public class Commands {
  
          while (iterator.hasNext()) {
              CommandNode<CommandSourceStack> commandnode2 = (CommandNode) iterator.next();

--- a/patches/server/0813-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/patches/server/0813-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -35,10 +35,10 @@ index 6fdbe747645eb83f31b56bca77a9d7962237aed8..dd0143f319d4adef8834c513af34b1cc
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 6d480d0332ee9348eacc3269890ee49206623c2a..584d2539d715fef26a2d01f014c7c3f4f8ce8fd9 100644
+index 665c35b950c30f1de78552b29cc4e25119caed96..7114033dbf5bbe1764e3dac9f4082e8c7c37f69c 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -432,6 +432,7 @@ public class Commands {
+@@ -436,6 +436,7 @@ public class Commands {
      private void fillUsableCommands(CommandNode<CommandSourceStack> tree, CommandNode<SharedSuggestionProvider> result, CommandSourceStack source, Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> resultNodes) {
          Iterator iterator = tree.getChildren().iterator();
  
@@ -46,7 +46,7 @@ index 6d480d0332ee9348eacc3269890ee49206623c2a..584d2539d715fef26a2d01f014c7c3f4
          while (iterator.hasNext()) {
              CommandNode<CommandSourceStack> commandnode2 = (CommandNode) iterator.next();
              // Paper start
-@@ -458,6 +459,12 @@ public class Commands {
+@@ -462,6 +463,12 @@ public class Commands {
  
                      if (requiredargumentbuilder.getSuggestionsProvider() != null) {
                          requiredargumentbuilder.suggests(SuggestionProviders.safelySwap(requiredargumentbuilder.getSuggestionsProvider()));

--- a/patches/server/0813-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/patches/server/0813-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -35,10 +35,10 @@ index 6fdbe747645eb83f31b56bca77a9d7962237aed8..dd0143f319d4adef8834c513af34b1cc
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 665c35b950c30f1de78552b29cc4e25119caed96..7114033dbf5bbe1764e3dac9f4082e8c7c37f69c 100644
+index 619eefc30e87f44d5e85e7389128a8e4b8220dea..5f502503c04490218aabc618680aec678a3bb72b 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -436,6 +436,7 @@ public class Commands {
+@@ -434,6 +434,7 @@ public class Commands {
      private void fillUsableCommands(CommandNode<CommandSourceStack> tree, CommandNode<SharedSuggestionProvider> result, CommandSourceStack source, Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> resultNodes) {
          Iterator iterator = tree.getChildren().iterator();
  
@@ -46,7 +46,7 @@ index 665c35b950c30f1de78552b29cc4e25119caed96..7114033dbf5bbe1764e3dac9f4082e8c
          while (iterator.hasNext()) {
              CommandNode<CommandSourceStack> commandnode2 = (CommandNode) iterator.next();
              // Paper start
-@@ -462,6 +463,12 @@ public class Commands {
+@@ -460,6 +461,12 @@ public class Commands {
  
                      if (requiredargumentbuilder.getSuggestionsProvider() != null) {
                          requiredargumentbuilder.suggests(SuggestionProviders.safelySwap(requiredargumentbuilder.getSuggestionsProvider()));

--- a/patches/server/0813-Fix-entity-type-tags-suggestions-in-selectors.patch
+++ b/patches/server/0813-Fix-entity-type-tags-suggestions-in-selectors.patch
@@ -35,10 +35,10 @@ index 6fdbe747645eb83f31b56bca77a9d7962237aed8..dd0143f319d4adef8834c513af34b1cc
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 619eefc30e87f44d5e85e7389128a8e4b8220dea..5f502503c04490218aabc618680aec678a3bb72b 100644
+index 27093aed1f4112a5414671fd5d9c4e683011506d..67ab16743b36dbf8b4336e33988d8e78433f566d 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -434,6 +434,7 @@ public class Commands {
+@@ -433,6 +433,7 @@ public class Commands {
      private void fillUsableCommands(CommandNode<CommandSourceStack> tree, CommandNode<SharedSuggestionProvider> result, CommandSourceStack source, Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> resultNodes) {
          Iterator iterator = tree.getChildren().iterator();
  
@@ -46,7 +46,7 @@ index 619eefc30e87f44d5e85e7389128a8e4b8220dea..5f502503c04490218aabc618680aec67
          while (iterator.hasNext()) {
              CommandNode<CommandSourceStack> commandnode2 = (CommandNode) iterator.next();
              // Paper start
-@@ -460,6 +461,12 @@ public class Commands {
+@@ -459,6 +460,12 @@ public class Commands {
  
                      if (requiredargumentbuilder.getSuggestionsProvider() != null) {
                          requiredargumentbuilder.suggests(SuggestionProviders.safelySwap(requiredargumentbuilder.getSuggestionsProvider()));


### PR DESCRIPTION
Don't submit to the command pool while on shutdown.

Submitting throws an exception, might just be better to wrap it in a try catch? Unsure.