### PR TITLE
[ci skip] Correct upstream/paper javadoc

### DIFF
--- a/patches/api/0022-Add-exception-reporting-event.patch
+++ b/patches/api/0022-Add-exception-reporting-event.patch
@@ -322,7 +322,7 @@ index 0000000000000000000000000000000000000000..be3f92e3c6bcefe8b78da701b7512127
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/exception/ServerPluginMessageException.java b/src/main/java/com/destroystokyo/paper/exception/ServerPluginMessageException.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..89e132525cfae0ce979e37b3e2793df781e47227
+index 0000000000000000000000000000000000000000..2faef4cb358ec65e32a6aba6426f0dd7ddf90d2a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/exception/ServerPluginMessageException.java
 @@ -0,0 +1,64 @@
@@ -364,7 +364,7 @@ index 0000000000000000000000000000000000000000..89e132525cfae0ce979e37b3e2793df7
 +    }
 +
 +    /**
-+     * Gets the channel to which the error occurred from recieving data from
++     * Gets the channel to which the error occurred from receiving data from
 +     *
 +     * @return exception channel
 +     */

--- a/patches/api/0055-Fix-upstream-javadocs.patch
+++ b/patches/api/0055-Fix-upstream-javadocs.patch
@@ -5,11 +5,70 @@ Subject: [PATCH] Fix upstream javadocs
 
 Upstream still refuses to use Java 8 with the API so they are likely unaware these are even issues.
 
+diff --git a/src/main/java/org/bukkit/BanList.java b/src/main/java/org/bukkit/BanList.java
+index 96ef22fe879c7be4f67bbb4d60c45ad11764dd5b..5dc9f9ede98d93925c99ee382e93f15f33589583 100644
+--- a/src/main/java/org/bukkit/BanList.java
++++ b/src/main/java/org/bukkit/BanList.java
+@@ -27,6 +27,9 @@ public interface BanList {
+ 
+     /**
+      * Gets a {@link BanEntry} by target.
++     * <p>
++     * Bans by name for ban type {@link Type#NAME NAME} are no longer supported and this method will return
++     * null when trying to request them. The replacement is bans by UUID.
+      *
+      * @param target entry parameter to search for
+      * @return the corresponding entry, or null if none found
+@@ -35,8 +38,11 @@ public interface BanList {
+     public BanEntry getBanEntry(@NotNull String target);
+ 
+     /**
+-     * Adds a ban to the this list. If a previous ban exists, this will
++     * Adds a ban to this list. If a previous ban exists, this will
+      * update the previous entry.
++     * <p>
++     * Bans by name for ban type {@link Type#NAME NAME} are no longer supported and this method will return
++     * null when trying to request them. The replacement is bans by UUID.
+      *
+      * @param target the target of the ban
+      * @param reason reason for the ban, null indicates implementation default
+@@ -60,6 +66,9 @@ public interface BanList {
+     /**
+      * Gets if a {@link BanEntry} exists for the target, indicating an active
+      * ban status.
++     * <p>
++     * Bans by name for ban type {@link Type#NAME NAME} are no longer supported.
++     * The replacement is bans by UUID.
+      *
+      * @param target the target to find
+      * @return true if a {@link BanEntry} exists for the name, indicating an
+@@ -70,6 +79,9 @@ public interface BanList {
+     /**
+      * Removes the specified target from this list, therefore indicating a
+      * "not banned" status.
++     * <p>
++     * Bans by name for ban type {@link Type#NAME NAME} are no longer supported.
++     * The replacement is bans by UUID.
+      *
+      * @param target the target to remove from this list
+      */
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index d3d8c5ac59cee2ec24e91223e0c994016a4f9752..82757d3013e01a6bfbb685929955d3e7dad8508c 100644
+index f66552fd08092761ac83b112aa1aa7584cfe0c32..72d414b756d3531ca83362b20097ab63656fecb1 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1334,6 +1334,8 @@ public final class Bukkit {
+@@ -1269,10 +1269,7 @@ public final class Bukkit {
+     }
+ 
+     /**
+-     * Gets a ban list for the supplied type.
+-     * <p>
+-     * Bans by name are no longer supported and this method will return
+-     * null when trying to request them. The replacement is bans by UUID.
++     * Gets a ban list for the supplied type. <!-- Paper Remove notice: wrong place -->
+      *
+      * @param type the type of list to fetch, cannot be null
+      * @return a ban list of the specified type
+@@ -1334,6 +1331,8 @@ public final class Bukkit {
  
      /**
       * Gets every player that has ever played on this server.
@@ -31,8 +90,47 @@ index 0cf808356a1a5c6fc4bcf97a694ed9beb80a776a..dc765dea47a9a1c1520fb16ddb24f814
       * @param z Z-coordinate (0-15)
       * @return temperature at given coordinate
       */
+diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
+index a89fff5c164881be0286ec2240e94dd5883ecc40..0272ed71899a53b6f3761a3283391caa744d464d 100644
+--- a/src/main/java/org/bukkit/RegionAccessor.java
++++ b/src/main/java/org/bukkit/RegionAccessor.java
+@@ -158,7 +158,7 @@ public interface RegionAccessor {
+      * Creates a tree at the given {@link Location}
+      *
+      * @param location Location to spawn the tree
+-     * @param random Random to use to generated the tree
++     * @param random Random to use to generate the tree
+      * @param type Type of the tree to create
+      * @return true if the tree was created successfully, otherwise false
+      */
+@@ -170,14 +170,14 @@ public interface RegionAccessor {
+      * The provided consumer gets called for every block which gets changed
+      * as a result of the tree generation. When the consumer gets called no
+      * modifications to the world are done yet. Which means, that calling
+-     * {@link #getBlockState(Location)} in the consumer while return the state
++     * {@link #getBlockState(Location)} in the consumer will return the state
+      * of the block before the generation.
+      * <p>
+      * Modifications done to the {@link BlockState} in the consumer are respected,
+      * which means that it is not necessary to call {@link BlockState#update()}
+      *
+      * @param location Location to spawn the tree
+-     * @param random Random to use to generated the tree
++     * @param random Random to use to generate the tree
+      * @param type Type of the tree to create
+      * @param stateConsumer The consumer which should get called for every block which gets changed
+      * @return true if the tree was created successfully, otherwise false
+@@ -197,7 +197,7 @@ public interface RegionAccessor {
+      * If it returns {@code false} the block won't get set in the world.
+      *
+      * @param location Location to spawn the tree
+-     * @param random Random to use to generated the tree
++     * @param random Random to use to generate the tree
+      * @param type Type of the tree to create
+      * @param statePredicate The predicate which should get used to test if a block should be set or not.
+      * @return true if the tree was created successfully, otherwise false
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a8d3addae5b0ed261d6a27052ad4e54970de597c..3485db7548e93242f99977a236eb3bcebedfb964 100644
+index 7d06f2a8f17cf42eeb05567e3f5c0c16074af9bc..9b5dcd897df91e6ba3c71c216e7a180b76a96694 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -510,13 +510,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -50,7 +148,19 @@ index a8d3addae5b0ed261d6a27052ad4e54970de597c..3485db7548e93242f99977a236eb3bce
       */
      public int getTicksPerSpawns(@NotNull SpawnCategory spawnCategory);
  
-@@ -1129,6 +1126,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1076,10 +1073,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+     public Set<OfflinePlayer> getBannedPlayers();
+ 
+     /**
+-     * Gets a ban list for the supplied type.
+-     * <p>
+-     * Bans by name are no longer supported and this method will return
+-     * null when trying to request them. The replacement is bans by UUID.
++     * Gets a ban list for the supplied type. <!-- Paper Remove notice: wrong place -->
+      *
+      * @param type the type of list to fetch, cannot be null
+      * @return a ban list of the specified type
+@@ -1129,6 +1123,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
  
      /**
       * Gets every player that has ever played on this server.
@@ -59,6 +169,50 @@ index a8d3addae5b0ed261d6a27052ad4e54970de597c..3485db7548e93242f99977a236eb3bce
       *
       * @return an array containing all previous players
       */
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 749d3de7dad480965be536938733d72bdfc2995b..d6b9d7c790399ea5dface159dd41c46920f71dda 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -1258,11 +1258,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+ 
+     /**
+      * Spawn a {@link FallingBlock} entity at the given {@link Location} of
+-     * the specified {@link Material}. The material dictates what is falling.
++     * the specified {@link BlockData}. The block data dictates what is falling.
+      * When the FallingBlock hits the ground, it will place that block.
+-     * <p>
+-     * The Material must be a block type, check with {@link Material#isBlock()
+-     * material.isBlock()}. The Material may not be air.
+      *
+      * @param location The {@link Location} to spawn the FallingBlock
+      * @param data The block data
+@@ -2612,7 +2609,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+     /**
+      * Find the closest nearby structure of a given {@link StructureType}.
+      * Finding unexplored structures can, and will, block if the world is
+-     * looking in chunks that gave not generated yet. This can lead to the world
++     * looking in chunks that have not generated yet. This can lead to the world
+      * temporarily freezing while locating an unexplored structure.
+      * <p>
+      * The {@code radius} is not a rigid square radius. Each structure may alter
+@@ -2646,7 +2643,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+     /**
+      * Find the closest nearby structure of a given {@link StructureType}.
+      * Finding unexplored structures can, and will, block if the world is
+-     * looking in chunks that gave not generated yet. This can lead to the world
++     * looking in chunks that have not generated yet. This can lead to the world
+      * temporarily freezing while locating an unexplored structure.
+      * <p>
+      * The {@code radius} is not a rigid square radius. Each structure may alter
+@@ -2679,7 +2676,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+     /**
+      * Find the closest nearby structure of a given {@link Structure}. Finding
+      * unexplored structures can, and will, block if the world is looking in
+-     * chunks that gave not generated yet. This can lead to the world
++     * chunks that have not generated yet. This can lead to the world
+      * temporarily freezing while locating an unexplored structure.
+      * <p>
+      * The {@code radius} is not a rigid square radius. Each structure may alter
 diff --git a/src/main/java/org/bukkit/block/Bed.java b/src/main/java/org/bukkit/block/Bed.java
 index f9bd74f9ce6bd6650726e5a993f9b6e292cdc74d..f4c37ce1fe7aac3dde8485ee51fc8888ed56e79e 100644
 --- a/src/main/java/org/bukkit/block/Bed.java
@@ -102,6 +256,67 @@ index 12a7ca1808cb80daceb7695a2f0e8f97e0e21a49..0d5ef61e100d972a5cf308b23d5e8f2f
       */
      @NotNull
      Material getPlacementMaterial();
+diff --git a/src/main/java/org/bukkit/block/data/FaceAttachable.java b/src/main/java/org/bukkit/block/data/FaceAttachable.java
+index 9599e1237b9717ddbf84c3738bf6c1293e8b3c54..950266b4bb0a2fabeb9539c5676ed58f0b0fe620 100644
+--- a/src/main/java/org/bukkit/block/data/FaceAttachable.java
++++ b/src/main/java/org/bukkit/block/data/FaceAttachable.java
+@@ -38,7 +38,7 @@ public interface FaceAttachable extends BlockData {
+          */
+         WALL,
+         /**
+-         * The switch is mounted to the ceiling and pointing dowanrds.
++         * The switch is mounted to the ceiling and pointing downwards.
+          */
+         CEILING;
+     }
+diff --git a/src/main/java/org/bukkit/block/data/type/CommandBlock.java b/src/main/java/org/bukkit/block/data/type/CommandBlock.java
+index 9a7122c907308e4e0a4d0eab815df16899503c19..3b1dab4c1c38477fbe651382f37fdb042ce67cd1 100644
+--- a/src/main/java/org/bukkit/block/data/type/CommandBlock.java
++++ b/src/main/java/org/bukkit/block/data/type/CommandBlock.java
+@@ -4,7 +4,7 @@ import org.bukkit.block.data.Directional;
+ 
+ /**
+  * 'conditional' denotes whether this command block is conditional or not, i.e.
+- * will only execute if the preceeding command block also executed successfully.
++ * will only execute if the preceding command block also executed successfully.
+  */
+ public interface CommandBlock extends Directional {
+ 
+diff --git a/src/main/java/org/bukkit/block/data/type/Gate.java b/src/main/java/org/bukkit/block/data/type/Gate.java
+index 494f97d47b52bc99b13748c1b57730fbd37d8f51..ebc98607b93294847f95e793304bc5d2528de2a3 100644
+--- a/src/main/java/org/bukkit/block/data/type/Gate.java
++++ b/src/main/java/org/bukkit/block/data/type/Gate.java
+@@ -5,7 +5,7 @@ import org.bukkit.block.data.Openable;
+ import org.bukkit.block.data.Powerable;
+ 
+ /**
+- * 'in_wall" indicates if the fence gate is attached to a wall, and if true the
++ * 'in_wall' indicates if the fence gate is attached to a wall, and if true the
+  * texture is lowered by a small amount to blend in better.
+  */
+ public interface Gate extends Directional, Openable, Powerable {
+diff --git a/src/main/java/org/bukkit/block/data/type/Switch.java b/src/main/java/org/bukkit/block/data/type/Switch.java
+index be06f8db02ca41d5cc3a5dc02951ad27e3cc8f9d..d91a07c7bcb36b3810bb2db89afef1eefd89253d 100644
+--- a/src/main/java/org/bukkit/block/data/type/Switch.java
++++ b/src/main/java/org/bukkit/block/data/type/Switch.java
+@@ -21,7 +21,7 @@ public interface Switch extends Directional, FaceAttachable, Powerable {
+      * Sets the value of the 'face' property.
+      *
+      * @param face the new 'face' value
+-     * @deprecated use {@link #getAttachedFace()}
++     * @deprecated use {@link #setAttachedFace(AttachedFace)}
+      */
+     @Deprecated
+     void setFace(@NotNull Face face);
+@@ -42,7 +42,7 @@ public interface Switch extends Directional, FaceAttachable, Powerable {
+          */
+         WALL,
+         /**
+-         * The switch is mounted to the ceiling and pointing dowanrds.
++         * The switch is mounted to the ceiling and pointing downwards.
+          */
+         CEILING;
+     }
 diff --git a/src/main/java/org/bukkit/entity/ArmorStand.java b/src/main/java/org/bukkit/entity/ArmorStand.java
 index 91fc11dda99de506be83d40df8929bf7cd8e8d85..7dc631ebd009f5f5c3ac1699c3f3515c47609c05 100644
 --- a/src/main/java/org/bukkit/entity/ArmorStand.java
@@ -115,6 +330,32 @@ index 91fc11dda99de506be83d40df8929bf7cd8e8d85..7dc631ebd009f5f5c3ac1699c3f3515c
 +    org.bukkit.inventory.@NotNull EntityEquipment getEquipment();
      // Paper end
  }
+diff --git a/src/main/java/org/bukkit/entity/Arrow.java b/src/main/java/org/bukkit/entity/Arrow.java
+index 8814519df13c5e9475774f4bce4c8c6a462c2978..be9a35790fc664721ac94f3708613eb77631a0c5 100644
+--- a/src/main/java/org/bukkit/entity/Arrow.java
++++ b/src/main/java/org/bukkit/entity/Arrow.java
+@@ -73,7 +73,7 @@ public interface Arrow extends AbstractArrow {
+      * Removes a custom potion effect from this arrow.
+      *
+      * @param type the potion effect type to remove
+-     * @return true if the an effect was removed as a result of this call
++     * @return true if the effect was removed as a result of this call
+      * @throws IllegalArgumentException if this operation would leave the Arrow
+      * in a state with no Custom Effects and PotionType.UNCRAFTABLE
+      */
+diff --git a/src/main/java/org/bukkit/entity/EnderDragon.java b/src/main/java/org/bukkit/entity/EnderDragon.java
+index 0449664d7cd0c52ac34d2101110f1ab42070257c..57f8e7bf4c7b4c4a4e793cfd5d7db74384d8b1b5 100644
+--- a/src/main/java/org/bukkit/entity/EnderDragon.java
++++ b/src/main/java/org/bukkit/entity/EnderDragon.java
+@@ -30,7 +30,7 @@ public interface EnderDragon extends ComplexLivingEntity, Boss, Mob, Enemy {
+          */
+         FLY_TO_PORTAL,
+         /**
+-         * The dragon will land on on the portal. If the dragon is not near
++         * The dragon will land on the portal. If the dragon is not near
+          * the portal, it will fly to it before mounting.
+          */
+         LAND_ON_PORTAL,
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
 index 09936f3a2376a46721bbc8365c989581c2a789ef..3845a726adbd0e75d7bf2aeeb6da8cb571d51a8f 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
@@ -131,6 +372,19 @@ index 09936f3a2376a46721bbc8365c989581c2a789ef..3845a726adbd0e75d7bf2aeeb6da8cb5
      /**
       * Returns the name of this player
       *
+diff --git a/src/main/java/org/bukkit/entity/ItemFrame.java b/src/main/java/org/bukkit/entity/ItemFrame.java
+index b688b3856cb3068a539fcecfbfa113f8ab4160a9..c275b881cbd11307a6dcc7190d7a7d4063000ad8 100644
+--- a/src/main/java/org/bukkit/entity/ItemFrame.java
++++ b/src/main/java/org/bukkit/entity/ItemFrame.java
+@@ -75,7 +75,7 @@ public interface ItemFrame extends Hanging {
+     public void setRotation(@NotNull Rotation rotation) throws IllegalArgumentException;
+ 
+     /**
+-     * Returns whether the item frame is be visible or not.
++     * Returns whether the item frame is visible or not.
+      *
+      * @return whether the item frame is visible or not
+      */
 diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java
 index 2926fa6071bc7640cc10280b5c3962b0ce7686f1..4f63988848443aff55619bc12ef12c925642a3f9 100644
 --- a/src/main/java/org/bukkit/entity/Mob.java
@@ -146,8 +400,21 @@ index 2926fa6071bc7640cc10280b5c3962b0ce7686f1..4f63988848443aff55619bc12ef12c92
      /**
       * Instructs this Mob to set the specified LivingEntity as its target.
       * <p>
+diff --git a/src/main/java/org/bukkit/entity/PigZombie.java b/src/main/java/org/bukkit/entity/PigZombie.java
+index ae9eaaa8e38e1d9dfc459926c7fc51ddb89de84a..b2ec535bb1b0ce0c114ddd7638b90218b05cd835 100644
+--- a/src/main/java/org/bukkit/entity/PigZombie.java
++++ b/src/main/java/org/bukkit/entity/PigZombie.java
+@@ -44,8 +44,6 @@ public interface PigZombie extends Zombie {
+ 
+     /**
+      * <b>Not applicable to this entity</b>
+-     *
+-     * @return UnsuppotedOperationException
+      */
+     @Override
+     public int getConversionTime();
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index be2626e57d77f570a61cb822d3804245c0419cb3..a95efd61d171d1194ae545d8d89710aca82e40a6 100644
+index 0833c4dbc31d90ae0e7f37fe86359b9d46bb8d41..5d8cd14e4511daedaf46b926e2c3a470bf5c480a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -310,15 +310,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -170,6 +437,15 @@ index be2626e57d77f570a61cb822d3804245c0419cb3..a95efd61d171d1194ae545d8d89710ac
       * <p>
       * Note: This will overwrite the players current inventory, health,
       * motion, etc, with the state from the saved dat file.
+@@ -553,7 +553,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     /**
+      * Plays an effect to just this player.
+      *
+-     * @param <T> the data based based on the type of the effect
++     * @param <T> the data based on the type of the effect
+      * @param loc the location to play the effect at
+      * @param effect the {@link Effect}
+      * @param data a data bit needed for some effects
 @@ -831,7 +831,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * Use supplied alternative character to the section symbol to represent legacy color codes.
@@ -179,6 +455,24 @@ index be2626e57d77f570a61cb822d3804245c0419cb3..a95efd61d171d1194ae545d8d89710ac
       * @param message The message to send
       * @deprecated use {@link #sendActionBar(net.kyori.adventure.text.Component)}
       */
+@@ -1264,7 +1264,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+ 
+     /**
+      * Allows this player to see a player that was previously hidden. If
+-     * another another plugin had hidden the player too, then the player will
++     * another plugin had hidden the player too, then the player will
+      * remain hidden until the other plugin calls this method too.
+      *
+      * @param plugin Plugin that wants to show the player
+@@ -1293,7 +1293,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+ 
+     /**
+      * Allows this player to see an entity that was previously hidden. If
+-     * another another plugin had hidden the entity too, then the entity will
++     * another plugin had hidden the entity too, then the entity will
+      * remain hidden until the other plugin calls this method too.
+      *
+      * @param plugin Plugin that wants to show the entity
 diff --git a/src/main/java/org/bukkit/entity/Slime.java b/src/main/java/org/bukkit/entity/Slime.java
 index a5ad3250cebfeb302c58e0bfd6db1295913c927e..bfac874840cf1f36afba16ae4d176c5821a68cfb 100644
 --- a/src/main/java/org/bukkit/entity/Slime.java
@@ -200,6 +494,19 @@ index a5ad3250cebfeb302c58e0bfd6db1295913c927e..bfac874840cf1f36afba16ae4d176c58
       * @param sz The new size of the slime.
       */
      public void setSize(int sz);
+diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
+index 6bf3af3ed81b66f61e53105d3591165ea74dba0e..a91400cd8bb4c72d1f3200a17f6de025540fe09d 100644
+--- a/src/main/java/org/bukkit/entity/Villager.java
++++ b/src/main/java/org/bukkit/entity/Villager.java
+@@ -202,7 +202,7 @@ public interface Villager extends AbstractVillager {
+          */
+         NITWIT,
+         /**
+-         * Sheperd profession. Wears a brown robe. Shepherds primarily trade for
++         * Shepherd profession. Wears a brown robe. Shepherds primarily trade for
+          * wool items, and shears.
+          */
+         SHEPHERD,
 diff --git a/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java b/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
 index 44f7f6939a27b9a0a796d91eac4b7c97ec90a643..641c71ab66bd2499b35cf3c1d533fd105d096e10 100644
 --- a/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
@@ -215,11 +522,55 @@ index 44f7f6939a27b9a0a796d91eac4b7c97ec90a643..641c71ab66bd2499b35cf3c1d533fd10
   */
  public class BlockExplodeEvent extends BlockEvent implements Cancellable {
      private static final HandlerList handlers = new HandlerList();
+diff --git a/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java b/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
+index be0a2d1f234d8265d98e54e518a994957b1f3ab7..4e3c406ba883aae553e8d69b6b719b872cd6096c 100644
+--- a/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockPlaceEvent.java
+@@ -114,7 +114,7 @@ public class BlockPlaceEvent extends BlockEvent implements Cancellable {
+ 
+     /**
+      * Gets the value whether the player would be allowed to build here.
+-     * Defaults to spawn if the server was going to stop them (such as, the
++     * Defaults to false if the server was going to stop them (such as, the
+      * player is in Spawn). Note that this is an entirely different check
+      * than BLOCK_CANBUILD, as this refers to a player, not universe-physics
+      * rule like cactus on dirt.
+diff --git a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
+index 2ff1b1308571d8f8056d3359e8a8ba4a589c3726..e9a6e5be5f33a342f7e5c496f0f1c64b2f302ace 100644
+--- a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
++++ b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
+@@ -80,7 +80,7 @@ public class PrepareItemEnchantEvent extends InventoryEvent implements Cancellab
+     /**
+      * Get a list of available {@link EnchantmentOffer} for the player. You can
+      * modify the values to change the available offers for the player. An offer
+-     * may be null, if there isn't a enchantment offer at a specific slot. There
++     * may be null, if there isn't an enchantment offer at a specific slot. There
+      * are 3 slots in the enchantment table available to modify.
+      *
+      * @return list of available enchantment offers
+diff --git a/src/main/java/org/bukkit/event/entity/AreaEffectCloudApplyEvent.java b/src/main/java/org/bukkit/event/entity/AreaEffectCloudApplyEvent.java
+index a37febd0d4dd5b733e9ee72628fdf9395fec4367..9cee218b9ee14688356f16b1f58512186286e7e9 100644
+--- a/src/main/java/org/bukkit/event/entity/AreaEffectCloudApplyEvent.java
++++ b/src/main/java/org/bukkit/event/entity/AreaEffectCloudApplyEvent.java
+@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
+ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+- * Called when a lingering potion applies it's effects. Happens
++ * Called when a lingering potion applies its effects. Happens
+  * once every 5 ticks
+  */
+ public class AreaEffectCloudApplyEvent extends EntityEvent implements Cancellable {
 diff --git a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java b/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
-index e9de00e9e434d36117a672fa9fbfc7c52f284b67..9a06487e0f76cd7765e6f900b7458a3cf0aa44e7 100644
+index e9de00e9e434d36117a672fa9fbfc7c52f284b67..4065432c884324b107d04f4ccd486085b0c440e7 100644
 --- a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
-@@ -158,7 +158,8 @@ public class CreatureSpawnEvent extends EntitySpawnEvent {
+@@ -154,11 +154,12 @@ public class CreatureSpawnEvent extends EntitySpawnEvent {
+          */
+         DROWNED,
+         /**
+-         * When an cow is spawned by shearing a mushroom cow
++         * When a cow is spawned by shearing a mushroom cow
           */
          SHEARED,
          /**
@@ -244,6 +595,54 @@ index 10d0e18dfd423b108fe381e8142867eb10399359..099efafa14c10910e4ed04abb1823f0c
   */
  public class EntityExplodeEvent extends EntityEvent implements Cancellable {
      private static final HandlerList handlers = new HandlerList();
+diff --git a/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java b/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java
+index c866df03d66dd8724e12c7353da4cf144c70b2c8..94ee5a3354722aa5d825da727b7b7071fdc6bacc 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
+ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+- * Thrown when a entity picks an item up from the ground
++ * Thrown when an entity picks an item up from the ground
+  */
+ public class EntityPickupItemEvent extends EntityEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+diff --git a/src/main/java/org/bukkit/event/entity/EntityPlaceEvent.java b/src/main/java/org/bukkit/event/entity/EntityPlaceEvent.java
+index 327876e0ad7dcfeb71d9d22afe1c04bcd71c3bf9..71d664dd89995f088c47d17b38547d530319470c 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityPlaceEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityPlaceEvent.java
+@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Nullable;
+ 
+ /**
+- * Triggered when a entity is created in the world by a player "placing" an item
++ * Triggered when an entity is created in the world by a player "placing" an item
+  * on a block.
+  * <br>
+  * Note that this event is currently only fired for four specific placements:
+diff --git a/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java b/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
+index 01c5e8b71338fbb4b1605e45bf2a2e705188f6b5..c9f395064656dd0126410eb3c6e197baa450c063 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityPotionEffectEvent.java
+@@ -133,7 +133,7 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable
+     public enum Action {
+ 
+         /**
+-         * When the potion effect is added because the entity didn't have it's
++         * When the potion effect is added because the entity didn't have its
+          * type.
+          */
+         ADDED,
+@@ -238,7 +238,7 @@ public class EntityPotionEffectEvent extends EntityEvent implements Cancellable
+          */
+         SPIDER_SPAWN,
+         /**
+-         * When the entity gets effects from a totem item saving it's life.
++         * When the entity gets effects from a totem item saving its life.
+          */
+         TOTEM,
+         /**
 diff --git a/src/main/java/org/bukkit/event/entity/EntityRegainHealthEvent.java b/src/main/java/org/bukkit/event/entity/EntityRegainHealthEvent.java
 index d51d2ec1d04d9ea8a25a70d0d856f2355ebfcb4a..7ecff9fcee19fc94be784474fea620e5dd434731 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityRegainHealthEvent.java
@@ -256,6 +655,19 @@ index d51d2ec1d04d9ea8a25a70d0d856f2355ebfcb4a..7ecff9fcee19fc94be784474fea620e5
 +         * When an animal regains health from eating consumables
           */
          EATING,
+         /**
+diff --git a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+index dee186e99463a56394bbc2039d1e763d109125b9..c6e4d69eecd2789b1d78fe99fe590932e9758ba1 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+@@ -156,7 +156,7 @@ public class EntityTargetEvent extends EntityEvent implements Cancellable {
+         FOLLOW_LEADER,
+         /**
+          * When another entity tempts this entity by having a desired item such
+-         * as wheat in it's hand.
++         * as wheat in its hand.
+          */
+         TEMPT,
          /**
 diff --git a/src/main/java/org/bukkit/event/entity/PiglinBarterEvent.java b/src/main/java/org/bukkit/event/entity/PiglinBarterEvent.java
 index c17ff41a688b2cbd877cda25d4ec033ac8ef5524..bd67b7cba78b9bbdd82a5a40048e658a979e3108 100644
@@ -271,8 +683,72 @@ index c17ff41a688b2cbd877cda25d4ec033ac8ef5524..bd67b7cba78b9bbdd82a5a40048e658a
   */
  public class PiglinBarterEvent extends EntityEvent implements Cancellable {
  
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
+index 79797a2be7fb139d528116d34d13e51d39b96e56..0921484e921dbd200725b9298f655720618b5362 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
+@@ -92,7 +92,7 @@ public class InventoryClickEvent extends InventoryInteractEvent {
+     /**
+      * Gets the ItemStack currently in the clicked slot.
+      *
+-     * @return the item in the clicked
++     * @return the item in the clicked slot
+      */
+     @Nullable
+     public ItemStack getCurrentItem() {
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryOpenEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryOpenEvent.java
+index 9013d043503d175004ad276799e5935b7fa59dc4..ceae092eb782698803c6c3df41267dde20ba62b2 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryOpenEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryOpenEvent.java
+@@ -7,7 +7,7 @@ import org.bukkit.inventory.InventoryView;
+ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+- * Represents a player related inventory event
++ * Called when a player opens an inventory
+  */
+ public class InventoryOpenEvent extends InventoryEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+diff --git a/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java b/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java
+index 6782024735a885ba0b1b4dba4a576740c1410366..8977f7609431c3c46324a82de84d4a32f4b71c57 100644
+--- a/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java
+@@ -24,6 +24,20 @@ public class PrepareAnvilEvent extends PrepareInventoryResultEvent {
+         return (AnvilInventory) super.getInventory();
+     }
+ 
++    /**
++     * {@inheritDoc}
++     *
++     * <p>
++     * Note: by default custom recipes in anvil are disabled
++     * you should define a repair cost on the anvil inventory
++     * greater or equals to zero in order to allow that.
++     *
++     * @param result result item
++     */
++    public void setResult(@Nullable ItemStack result) {
++        super.setResult(result);
++    }
++
+     @NotNull
+     @Override
+     public HandlerList getHandlers() {
+diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
+index 0cc6e29a5af28e95f87f415d6b2424d4622a6f34..c0b749a5bbf4980d01fed74768bb61909b579cb9 100644
+--- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
++++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
+@@ -627,7 +627,7 @@ public abstract class ChunkGenerator {
+          * Get the biome at x, y, z within chunk being generated
+          *
+          * @param x the x location in the chunk from 0-15 inclusive
+-         * @param y the y location in the chunk from minimum (inclusive) -
++         * @param y the y location in the chunk from minHeight (inclusive) -
+          * maxHeight (exclusive)
+          * @param z the z location in the chunk from 0-15 inclusive
+          * @return Biome value
 diff --git a/src/main/java/org/bukkit/inventory/EntityEquipment.java b/src/main/java/org/bukkit/inventory/EntityEquipment.java
-index d5b50a4a954fed35d37f03f1a277cc173ca106df..a91fa5386afd7a1137adb921ad5adb798604772f 100644
+index d5b50a4a954fed35d37f03f1a277cc173ca106df..c69904f3ee7f3a41d6cebcd401abf8385dfbf868 100644
 --- a/src/main/java/org/bukkit/inventory/EntityEquipment.java
 +++ b/src/main/java/org/bukkit/inventory/EntityEquipment.java
 @@ -37,9 +37,23 @@ public interface EntityEquipment {
@@ -362,9 +838,9 @@ index d5b50a4a954fed35d37f03f1a277cc173ca106df..a91fa5386afd7a1137adb921ad5adb79
 +     * <pre>{@code
 +     * EntityEquipment equipment = entity.getEquipment();
 +     * if (equipment instanceof PlayerInventory) {
-+     *     equipment.getItemInHand(); // will return a mirror
++     *     equipment.getHelmet(); // will return a mirror
 +     * } else {
-+     *     equipment.getItemInHand(); // will return a copy
++     *     equipment.getHelmet(); // will return a copy
 +     * }
 +     * }</pre>
       *
@@ -529,3 +1005,139 @@ index 62fbd7f6d8195bebcab7f704a0a485a1bbeca26c..5461f7fa75f5a065bb333b4a113640b5
       *
       * @return the currently held item
       * @see #getItemInMainHand()
+diff --git a/src/main/java/org/bukkit/inventory/ShapedRecipe.java b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
+index e57e600283702dd7fc60fa3baa1e1cc1b8574873..76b78f388dd3539917976e66831e51006692a2aa 100644
+--- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
++++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
+@@ -38,8 +38,7 @@ public class ShapedRecipe implements Recipe, Keyed {
+      * @param result The item you want the recipe to create.
+      * @see ShapedRecipe#shape(String...)
+      * @see ShapedRecipe#setIngredient(char, Material)
+-     * @see ShapedRecipe#setIngredient(char, Material, int)
+-     * @see ShapedRecipe#setIngredient(char, MaterialData)
++     * @see ShapedRecipe#setIngredient(char, RecipeChoice)
+      */
+     public ShapedRecipe(@NotNull NamespacedKey key, @NotNull ItemStack result) {
+         Preconditions.checkArgument(key != null, "key");
+diff --git a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
+index df4c52f1f0be2409c7506b09167bd58b5602fa7a..74449a635aca84adcc1652e1e85f2d27dcaf6842 100644
+--- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
++++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
+@@ -38,11 +38,8 @@ public class ShapelessRecipe implements Recipe, Keyed {
+      * @param key the unique recipe key
+      * @param result The item you want the recipe to create.
+      * @see ShapelessRecipe#addIngredient(Material)
+-     * @see ShapelessRecipe#addIngredient(MaterialData)
+-     * @see ShapelessRecipe#addIngredient(Material,int)
+      * @see ShapelessRecipe#addIngredient(int,Material)
+-     * @see ShapelessRecipe#addIngredient(int,MaterialData)
+-     * @see ShapelessRecipe#addIngredient(int,Material,int)
++     * @see ShapelessRecipe#addIngredient(RecipeChoice)
+      */
+     public ShapelessRecipe(@NotNull NamespacedKey key, @NotNull ItemStack result) {
+         Preconditions.checkArgument(result.getType() != Material.AIR, "Recipe must have non-AIR result.");
+@@ -184,7 +181,7 @@ public class ShapelessRecipe implements Recipe, Keyed {
+ 
+     /**
+      * Removes multiple instances of an ingredient from the list. If there are
+-     * less instances then specified, all will be removed. Only removes exact
++     * fewer instances than specified, all will be removed. Only removes exact
+      * matches, with a data value of 0.
+      *
+      * @param count The number of copies to remove.
+diff --git a/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java b/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java
+index 07c3dff4d6190ef388d9c1e1c36f67f00a3e8e66..597a18a767b68b47e81454b7d44613c7178c1366 100644
+--- a/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java
++++ b/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java
+@@ -28,7 +28,7 @@ public class StonecuttingRecipe implements Recipe, Keyed {
+     }
+ 
+     /**
+-     * Create a cooking recipe to craft the specified ItemStack.
++     * Create a Stonecutting recipe to craft the specified ItemStack.
+      *
+      * @param key The unique recipe key
+      * @param result The item you want the recipe to create.
+@@ -42,7 +42,7 @@ public class StonecuttingRecipe implements Recipe, Keyed {
+     }
+ 
+     /**
+-     * Sets the input of this cooking recipe.
++     * Sets the input of this Stonecutting recipe.
+      *
+      * @param input The input material.
+      * @return The changed recipe, so you can chain calls.
+@@ -64,7 +64,7 @@ public class StonecuttingRecipe implements Recipe, Keyed {
+     }
+ 
+     /**
+-     * Sets the input of this cooking recipe.
++     * Sets the input of this Stonecutting recipe.
+      *
+      * @param input The input choice.
+      * @return The changed recipe, so you can chain calls.
+diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+index 049c70c935fd7a781280d223f74bbbf87223f505..f78714c2a6d9da162c9802552984cbfad76ff728 100644
+--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+@@ -305,7 +305,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+     /**
+      * Return an immutable copy of all {@link Attribute}s and their
+      * {@link AttributeModifier}s for a given {@link EquipmentSlot}.<br>
+-     * Any {@link AttributeModifier} that does have have a given
++     * Any {@link AttributeModifier} that does have a given
+      * {@link EquipmentSlot} will be returned. This is because
+      * AttributeModifiers without a slot are active in any slot.<br>
+      * If there are no attributes set for the given slot, an empty map
+diff --git a/src/main/java/org/bukkit/scoreboard/Objective.java b/src/main/java/org/bukkit/scoreboard/Objective.java
+index 86a0a6f9e8487d6dfaf60876ace3dcc9b4722826..571b43c2809d2b248feebc7decba6017a67c8aee 100644
+--- a/src/main/java/org/bukkit/scoreboard/Objective.java
++++ b/src/main/java/org/bukkit/scoreboard/Objective.java
+@@ -88,7 +88,7 @@ public interface Objective {
+      *
+      * @return true if scores are modifiable
+      * @throws IllegalStateException if this objective has been unregistered
+-     * @see Criterias#HEALTH
++     * @see Criteria#HEALTH
+      */
+     boolean isModifiable() throws IllegalStateException;
+ 
+diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java
+index 4d625f79ba2e3fe074feade98f7c1bc2798cb82e..937a28638c251509ebeb254178a4583fe03c52d0 100644
+--- a/src/main/java/org/bukkit/scoreboard/Team.java
++++ b/src/main/java/org/bukkit/scoreboard/Team.java
+@@ -277,7 +277,7 @@ public interface Team {
+      * Gets the Set of entries on the team
+      *
+      * @return entries on the team
+-     * @throws IllegalStateException if this entries has been unregistered\
++     * @throws IllegalStateException if this team has been unregistered
+      */
+     @NotNull
+     Set<String> getEntries() throws IllegalStateException;
+diff --git a/src/main/java/org/bukkit/util/BoundingBox.java b/src/main/java/org/bukkit/util/BoundingBox.java
+index 9883983c33fcff0f4c1e23867adafa436e2ed96f..5017b73bcec0d4d5256d89db14201c03829dc981 100644
+--- a/src/main/java/org/bukkit/util/BoundingBox.java
++++ b/src/main/java/org/bukkit/util/BoundingBox.java
+@@ -358,7 +358,7 @@ public class BoundingBox implements Cloneable, ConfigurationSerializable {
+      * <p>
+      * Negative values will shrink the bounding box in the corresponding
+      * direction. Shrinking will be limited to the point where the affected
+-     * opposite faces would meet if the they shrank at uniform speeds.
++     * opposite faces would meet if they shrank at uniform speeds.
+      *
+      * @param negativeX the amount of expansion in the negative x direction
+      * @param negativeY the amount of expansion in the negative y direction
+diff --git a/src/main/java/org/bukkit/util/CachedServerIcon.java b/src/main/java/org/bukkit/util/CachedServerIcon.java
+index 612958a331575d1da2715531ebdf6b1168f2e860..9a7768d41270714d4a1c89b4dcb436cc66f57545 100644
+--- a/src/main/java/org/bukkit/util/CachedServerIcon.java
++++ b/src/main/java/org/bukkit/util/CachedServerIcon.java
+@@ -5,7 +5,7 @@ import org.bukkit.event.server.ServerListPingEvent;
+ import org.jetbrains.annotations.Nullable;
+ 
+ /**
+- * This is a cached version of a server-icon. It's internal representation
++ * This is a cached version of a server-icon. Its internal representation
+  * and implementation is undefined.
+  *
+  * @see Server#getServerIcon()

--- a/patches/api/0059-Basic-PlayerProfile-API.patch
+++ b/patches/api/0059-Basic-PlayerProfile-API.patch
@@ -321,10 +321,10 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 82757d3013e01a6bfbb685929955d3e7dad8508c..a6a792babe69712594c18f49542feb30ff591810 100644
+index 72d414b756d3531ca83362b20097ab63656fecb1..e6707eca1dd96a4fb6c019285c764684aa336ebf 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2155,6 +2155,83 @@ public final class Bukkit {
+@@ -2152,6 +2152,83 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
@@ -409,10 +409,10 @@ index 82757d3013e01a6bfbb685929955d3e7dad8508c..a6a792babe69712594c18f49542feb30
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 3485db7548e93242f99977a236eb3bcebedfb964..bf1102b4481b8c9b9c4f5ba0c561556b75fea077 100644
+index 9b5dcd897df91e6ba3c71c216e7a180b76a96694..d769ad908c3454fa9088a42f32250bbdf8f9fa7e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1888,5 +1888,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1885,5 +1885,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();

--- a/patches/api/0066-ensureServerConversions-API.patch
+++ b/patches/api/0066-ensureServerConversions-API.patch
@@ -7,7 +7,7 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 159e5a908b35b84b7fabc36581e093d9aa4c4b67..66ffc658dba85942f179760dc6c50258e24ab903 100644
+index 159e5a908b35b84b7fabc36581e093d9aa4c4b67..349da0065ddf000cacdc259fab0f2c759332e9ad 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -192,5 +192,17 @@ public interface ItemFactory {
@@ -18,7 +18,7 @@ index 159e5a908b35b84b7fabc36581e093d9aa4c4b67..66ffc658dba85942f179760dc6c50258
 +    /**
 +     * Minecraft updates are converting simple item stacks into more complex NBT oriented Item Stacks.
 +     *
-+     * Use this method to to ensure any desired data conversions are processed.
++     * Use this method to ensure any desired data conversions are processed.
 +     * The input itemstack will not be the same as the returned itemstack.
 +     *
 +     * @param item The item to process conversions on
@@ -48,7 +48,7 @@ index 87f7942082ad943a97058f58c09ea2fe9caf5bfe..9d32283ee612a50b8a2bfe5151f42c9f
 +    /**
 +     * Minecraft updates are converting simple item stacks into more complex NBT oriented Item Stacks.
 +     *
-+     * Use this method to to ensure any desired data conversions are processed.
++     * Use this method to ensure any desired data conversions are processed.
 +     * The input itemstack will not be the same as the returned itemstack.
 +     *
 +     * @return A potentially Data Converted ItemStack

--- a/patches/api/0081-PreCreatureSpawnEvent.patch
+++ b/patches/api/0081-PreCreatureSpawnEvent.patch
@@ -117,7 +117,7 @@ index 0000000000000000000000000000000000000000..02e421b0bb4ce3529ef1c4d34ec8a0c0
 +    }
 +
 +    /**
-+     * Cancelling this event is more effecient than cancelling CreatureSpawnEvent
++     * Cancelling this event is more efficient than cancelling CreatureSpawnEvent
 +     * @param cancel true if you wish to cancel this event, and abort the spawn of this creature
 +     */
 +    @Override

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index a6a792babe69712594c18f49542feb30ff591810..ec1af46667d8590ea218370249286f86652f3ac4 100644
+index e6707eca1dd96a4fb6c019285c764684aa336ebf..008a960a63cf3efe87aab1e237c3b87056f58302 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1199,8 +1199,10 @@ public final class Bukkit {
@@ -56,7 +56,7 @@ index c5eed3234a8c04bfa9d707685746fc2b40ec8bfc..3ba8ff1a41ac9fd96fd4dec5cbe0f714
      /**
       * Checks if this player is banned or not
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index bf1102b4481b8c9b9c4f5ba0c561556b75fea077..8539bac19bf9ba1a66689a9af90e088a03f9c152 100644
+index d769ad908c3454fa9088a42f32250bbdf8f9fa7e..2eaf31f1053787b39184dfa8ac6df87d93b0a7b7 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1017,8 +1017,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -93,7 +93,7 @@ index bf1102b4481b8c9b9c4f5ba0c561556b75fea077..8539bac19bf9ba1a66689a9af90e088a
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index af92443e50b66e526d382c820e1b2e27c6e1b461..95163d95b80f245712839af4c03e0df721809117 100644
+index cadea6a5b8cb04da6de2b8bb70c098dc14157ff4..c1030fb291f8e218a1bfd744850d0c1e4925bc0a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2386,6 +2386,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0092-getPlayerUniqueId-API.patch
+++ b/patches/api/0092-getPlayerUniqueId-API.patch
@@ -9,7 +9,7 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ec1af46667d8590ea218370249286f86652f3ac4..aa4217c87756cffe774aaa2d390217b9056c4b95 100644
+index 008a960a63cf3efe87aab1e237c3b87056f58302..d0bc1943f6a3a17fe890b018c2b99f815a5c9b61 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -657,6 +657,20 @@ public final class Bukkit {
@@ -34,7 +34,7 @@ index ec1af46667d8590ea218370249286f86652f3ac4..aa4217c87756cffe774aaa2d390217b9
       * Gets the plugin manager for interfacing with plugins.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 8539bac19bf9ba1a66689a9af90e088a03f9c152..c46cae77e6a1d3f01b08ff03407eb1a564d000de 100644
+index 2eaf31f1053787b39184dfa8ac6df87d93b0a7b7..f5223be2d011b56a6138257bcae3ea2335a5940b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -559,6 +559,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
@@ -211,7 +211,7 @@ index 3a9dd66d8f30c04342180097d8de44933304b88c..c43cf2bdf24de153d16017e50d9b5723
 +     * Does not ban the Profile, use {@link #banPlayerFull(String, java.util.Date, String)}
 +     * @param reason Reason for Ban
 +     * @param expires When to expire the ban
-+     * @param source Source of the banm or null for default
++     * @param source Source of the ban or null for default
 +     * @return Ban Entry
 +     */
 +    @Nullable
@@ -224,7 +224,7 @@ index 3a9dd66d8f30c04342180097d8de44933304b88c..c43cf2bdf24de153d16017e50d9b5723
 +     * Does not ban the Profile, use {@link #banPlayerFull(String, java.util.Date, String)}
 +     * @param reason Reason for Ban
 +     * @param expires When to expire the ban
-+     * @param source Source of the banm or null for default
++     * @param source Source of the ban or null for default
 +     * @param kickPlayer if the targeted player should be kicked
 +     * @return Ban Entry
 +     */

--- a/patches/api/0098-Additional-world.getNearbyEntities-API-s.patch
+++ b/patches/api/0098-Additional-world.getNearbyEntities-API-s.patch
@@ -276,17 +276,3 @@ index 749d3de7dad480965be536938733d72bdfc2995b..dad7de7246741d6f3f2a444cf0b88f39
      /**
       * Get a list of all players in this World
       *
-diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index c30b44ff26f8f253902754452a0816f07c7fd035..9acf1fb404ccf9b3bc06a448c3099ca2e838facf 100644
---- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-+++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-@@ -42,8 +42,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
-         return profile;
-     }
- 
--    /**
--     * Changes the PlayerProfile the player will login as
-+    /*    * Changes the PlayerProfile the player will login as
-      * @param profile The profile to use
-      */
-     public void setPlayerProfile(@NotNull PlayerProfile profile) {

--- a/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -522,10 +522,10 @@ index 0ca7955003eea0556a04a54056152ec27d93a9ee..93244e6d940891f1297d4a26a80ba155
       * Options which can be applied to redstone dust particles - a particle
       * color and size.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index dad7de7246741d6f3f2a444cf0b88f396302a8af..ae102dddda30ff0e15f70bdb17385c8d9d4b9a08 100644
+index 9ad652054b32c650769d6c6934ceefd8fc1f38ab..089f06c97082e7828946c3cb1951b2f625c6fc2f 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2812,7 +2812,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2809,7 +2809,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
       */

--- a/patches/api/0106-WitchReadyPotionEvent.patch
+++ b/patches/api/0106-WitchReadyPotionEvent.patch
@@ -7,7 +7,7 @@ Control what potion the witch readies to use
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/WitchReadyPotionEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/WitchReadyPotionEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5351b523defa054ba56ae3fb591029283ca7510d
+index 0000000000000000000000000000000000000000..57f93af14acc6346c5a343e05fe8f5d44d6adbc6
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/WitchReadyPotionEvent.java
 @@ -0,0 +1,80 @@
@@ -31,7 +31,7 @@ index 0000000000000000000000000000000000000000..5351b523defa054ba56ae3fb59102928
 +    }
 +
 +    /**
-+     * Fires thee event, returning the desired potion, or air of cancelled
++     * Fires the event, returning the desired potion, or air of cancelled
 +     * @param witch the witch whom is readying to use a potion
 +     * @param potion the potion to be used
 +     * @return The ItemStack to be used

--- a/patches/api/0136-Slime-Pathfinder-Events.patch
+++ b/patches/api/0136-Slime-Pathfinder-Events.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Slime Pathfinder Events
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimeChangeDirectionEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimeChangeDirectionEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2638bbd3e1392b3d8640be58163f6eb2789dee4a
+index 0000000000000000000000000000000000000000..473fbded8ab534308f2c0bd0b87512fcce5c9e58
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimeChangeDirectionEvent.java
 @@ -0,0 +1,38 @@
@@ -17,7 +17,7 @@ index 0000000000000000000000000000000000000000..2638bbd3e1392b3d8640be58163f6eb2
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Fired when a Slime decides to change it's facing direction.
++ * Fired when a Slime decides to change its facing direction.
 + * <p>
 + * This event does not fire for the entity's actual movement. Only when it
 + * is choosing to change direction.

--- a/patches/api/0142-Async-Chunks-API.patch
+++ b/patches/api/0142-Async-Chunks-API.patch
@@ -56,8 +56,8 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * on the main Server Thread.
 +     *
 +     * @deprecated Use either the Future or the Consumer based methods
-+     * @param x Chunk X-coordinate of the chunk - (world coordinate / 16)
-+     * @param z Chunk Z-coordinate of the chunk - (world coordinate / 16)
++     * @param x Chunk X-coordinate of the chunk - floor(world coordinate / 16)
++     * @param z Chunk Z-coordinate of the chunk - floor(world coordinate / 16)
 +     * @param cb Callback to receive the chunk when it is loaded.
 +     *           will be executed synchronously
 +     */
@@ -134,8 +134,8 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * The {@link java.util.function.Consumer} will always be executed synchronously
 +     * on the main Server Thread.
 +     *
-+     * @param x Chunk X-coordinate of the chunk - (world coordinate / 16)
-+     * @param z Chunk Z-coordinate of the chunk - (world coordinate / 16)
++     * @param x Chunk X-coordinate of the chunk - floor(world coordinate / 16)
++     * @param z Chunk Z-coordinate of the chunk - floor(world coordinate / 16)
 +     * @param cb Callback to receive the chunk when it is loaded.
 +     *           will be executed synchronously
 +     */
@@ -159,9 +159,9 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * The {@link java.util.function.Consumer} will always be executed synchronously
 +     * on the main Server Thread.
 +     *
-+     * @param x Chunk X-coordinate of the chunk - (world coordinate / 16)
-+     * @param z Chunk Z-coordinate of the chunk - (world coordinate / 16)
-+     * @param gen Should we generate a chunk if it doesn't exists or not
++     * @param x Chunk X-coordinate of the chunk - floor(world coordinate / 16)
++     * @param z Chunk Z-coordinate of the chunk - floor(world coordinate / 16)
++     * @param gen Should we generate a chunk if it doesn't exist or not
 +     * @param cb Callback to receive the chunk when it is loaded.
 +     *           will be executed synchronously
 +     */
@@ -207,7 +207,7 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * on the main Server Thread.
 +     *
 +     * @param loc Location of the chunk
-+     * @param gen Should the chunk generate
++     * @param gen Should the chunk generate if it doesn't exist
 +     * @param cb Callback to receive the chunk when it is loaded.
 +     *           will be executed synchronously
 +     */
@@ -250,7 +250,7 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * on the main Server Thread.
 +     *
 +     * @param block Block to get the containing chunk from
-+     * @param gen Should the chunk generate
++     * @param gen Should the chunk generate if it doesn't exist
 +     * @param cb Callback to receive the chunk when it is loaded.
 +     *           will be executed synchronously
 +     */
@@ -291,7 +291,7 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * The future will always be executed synchronously
 +     * on the main Server Thread.
 +     * @param loc Location to load the corresponding chunk from
-+     * @param gen Should the chunk generate
++     * @param gen Should the chunk generate if it doesn't exist
 +     * @return Future that will resolve when the chunk is loaded
 +     */
 +    @NotNull
@@ -332,7 +332,7 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * The future will always be executed synchronously
 +     * on the main Server Thread.
 +     * @param block Block to load the corresponding chunk from
-+     * @param gen Should the chunk generate
++     * @param gen Should the chunk generate if it doesn't exist
 +     * @return Future that will resolve when the chunk is loaded
 +     */
 +    @NotNull
@@ -353,8 +353,8 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * The future will always be executed synchronously
 +     * on the main Server Thread.
 +     *
-+     * @param x X Coord
-+     * @param z Z Coord
++     * @param x Chunk X-coordinate of the chunk - floor(world coordinate / 16)
++     * @param z Chunk Z-coordinate of the chunk - floor(world coordinate / 16)
 +     * @return Future that will resolve when the chunk is loaded
 +     */
 +    @NotNull
@@ -375,9 +375,9 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * The future will always be executed synchronously
 +     * on the main Server Thread.
 +     *
-+     * @param x Chunk X-coordinate of the chunk - (world coordinate / 16)
-+     * @param z Chunk Z-coordinate of the chunk - (world coordinate / 16)
-+     * @param gen Should we generate a chunk if it doesn't exists or not
++     * @param x Chunk X-coordinate of the chunk - floor(world coordinate / 16)
++     * @param z Chunk Z-coordinate of the chunk - floor(world coordinate / 16)
++     * @param gen Should we generate a chunk if it doesn't exist or not
 +     * @return Future that will resolve when the chunk is loaded
 +     */
 +    @NotNull
@@ -418,7 +418,7 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * The future will always be executed synchronously
 +     * on the main Server Thread.
 +     * @param loc Location to load the corresponding chunk from
-+     * @param gen Should the chunk generate
++     * @param gen Should the chunk generate if it doesn't exist
 +     * @return Future that will resolve when the chunk is loaded
 +     */
 +    @NotNull
@@ -459,7 +459,7 @@ index 8075ff77eddb971a0a73dad3c9b809131b5db343..12c1731cd3e7138b30a509bf1c6de937
 +     * The future will always be executed synchronously
 +     * on the main Server Thread.
 +     * @param block Block to load the corresponding chunk from
-+     * @param gen Should the chunk generate
++     * @param gen Should the chunk generate if it doesn't exist
 +     * @return Future that will resolve when the chunk is loaded
 +     */
 +    @NotNull

--- a/patches/api/0145-Improve-death-events.patch
+++ b/patches/api/0145-Improve-death-events.patch
@@ -15,7 +15,7 @@ items and experience which is otherwise only properly possible by using
 internal code.
 
 diff --git a/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java b/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
-index a5984ab06cce95d30e70511e125f69339b574c04..e19a3df9aa2204b44c0b029bda141ae6306f60a1 100644
+index a5984ab06cce95d30e70511e125f69339b574c04..130cf9e5981f701dff4fa72e71e0b5dc8295bfc8 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
 @@ -5,14 +5,24 @@ import org.bukkit.entity.LivingEntity;
@@ -44,7 +44,7 @@ index a5984ab06cce95d30e70511e125f69339b574c04..e19a3df9aa2204b44c0b029bda141ae6
  
      public EntityDeathEvent(@NotNull final LivingEntity entity, @NotNull final List<ItemStack> drops) {
          this(entity, drops, 0);
-@@ -74,4 +84,134 @@ public class EntityDeathEvent extends EntityEvent {
+@@ -74,4 +84,133 @@ public class EntityDeathEvent extends EntityEvent {
      public static HandlerList getHandlerList() {
          return handlers;
      }
@@ -84,7 +84,6 @@ index a5984ab06cce95d30e70511e125f69339b574c04..e19a3df9aa2204b44c0b029bda141ae6
 +        }
 +        this.reviveHealth = reviveHealth;
 +    }
-+
 +
 +    /**
 +     * Whether or not the death sound should play when the entity dies. If the event is cancelled it does not play!
@@ -170,7 +169,7 @@ index a5984ab06cce95d30e70511e125f69339b574c04..e19a3df9aa2204b44c0b029bda141ae6
 +    }
 +
 +    /**
-+     * GSetet the pitch that the death sound should play with.
++     * Set the pitch that the death sound should play with.
 +     *
 +     * @param pitch The pitch the death sound should play with
 +     */

--- a/patches/api/0160-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0160-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 6567da9e9c89f1995b9c3544b4dd767d66e6f5f2..c59700bcec0938bd5a0f10c4e0d5e3e2c446d622 100644
+index 12cb4630257669222dded61c54ce210cd082a720..c02b663ab711daa06de054a92f09485231824458 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2195,6 +2195,28 @@ public final class Bukkit {
+@@ -2192,6 +2192,28 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
@@ -38,10 +38,10 @@ index 6567da9e9c89f1995b9c3544b4dd767d66e6f5f2..c59700bcec0938bd5a0f10c4e0d5e3e2
       * Creates a PlayerProfile for the specified uuid, with name as null.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index c46cae77e6a1d3f01b08ff03407eb1a564d000de..7e51025404bdc64e5eff48423280ad53244c6631 100644
+index f5223be2d011b56a6138257bcae3ea2335a5940b..20f9384c30f46e11631a7f79c48915bf55762858 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1907,6 +1907,23 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1904,6 +1904,23 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  
@@ -66,7 +66,7 @@ index c46cae77e6a1d3f01b08ff03407eb1a564d000de..7e51025404bdc64e5eff48423280ad53
       * Creates a PlayerProfile for the specified uuid, with name as null.
       *
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
-index a26df5f6341d22ecd5e71da59b8f091848e627ad..608b541aef01f33891a492fff5b8400496832c3a 100644
+index 1c6205cc667bbec8f6aca479f13b3e9cfcd63ab2..b791358f90fe92bc2264d9a26492245763813af3 100644
 --- a/src/main/java/org/bukkit/command/Command.java
 +++ b/src/main/java/org/bukkit/command/Command.java
 @@ -184,10 +184,9 @@ public abstract class Command {

--- a/patches/api/0166-Add-ItemStack-Recipe-API-helper-methods.patch
+++ b/patches/api/0166-Add-ItemStack-Recipe-API-helper-methods.patch
@@ -9,10 +9,10 @@ Redirects some of upstream's APIs to these new methods to avoid
 usage of magic values and the deprecated RecipeChoice#getItemStack
 
 diff --git a/src/main/java/org/bukkit/inventory/ShapedRecipe.java b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
-index 7be830ea0a3b24c5cdfb8e6ab62cb2ee506a4026..baba8485587baab945add8bc91e91a1bfa27c84b 100644
+index beaccd383df0d1fa1b1c88953d72198c2237a6a6..7a73a8dc30c5c3acfe8c686a0328728c17bd8e66 100644
 --- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
 +++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
-@@ -146,6 +146,13 @@ public class ShapedRecipe implements Recipe, Keyed {
+@@ -145,6 +145,13 @@ public class ShapedRecipe implements Recipe, Keyed {
          return this;
      }
  
@@ -27,10 +27,10 @@ index 7be830ea0a3b24c5cdfb8e6ab62cb2ee506a4026..baba8485587baab945add8bc91e91a1b
       * Get a copy of the ingredients map.
       *
 diff --git a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
-index 62675962d1b7882b953d2618aed1f363c046e97d..61b3a1b1d03fe6cdacb82b07e6c7197f56b4a1b3 100644
+index 05ef88225415cd30de36f4517b6fb40d826ce996..8bf26da12dcb03f22f842a57798948d5513c227d 100644
 --- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
 +++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
-@@ -144,6 +144,40 @@ public class ShapelessRecipe implements Recipe, Keyed {
+@@ -141,6 +141,40 @@ public class ShapelessRecipe implements Recipe, Keyed {
          return this;
      }
  
@@ -71,7 +71,7 @@ index 62675962d1b7882b953d2618aed1f363c046e97d..61b3a1b1d03fe6cdacb82b07e6c7197f
      /**
       * Removes an ingredient from the list.
       *
-@@ -167,7 +201,7 @@ public class ShapelessRecipe implements Recipe, Keyed {
+@@ -164,7 +198,7 @@ public class ShapelessRecipe implements Recipe, Keyed {
       */
      @NotNull
      public ShapelessRecipe removeIngredient(@NotNull Material ingredient) {
@@ -80,7 +80,7 @@ index 62675962d1b7882b953d2618aed1f363c046e97d..61b3a1b1d03fe6cdacb82b07e6c7197f
      }
  
      /**
-@@ -194,7 +228,7 @@ public class ShapelessRecipe implements Recipe, Keyed {
+@@ -191,7 +225,7 @@ public class ShapelessRecipe implements Recipe, Keyed {
       */
      @NotNull
      public ShapelessRecipe removeIngredient(int count, @NotNull Material ingredient) {

--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -9,7 +9,7 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c59700bcec0938bd5a0f10c4e0d5e3e2c446d622..9abb50fb10bb2fbd21d5f31e54b135416cae3433 100644
+index c02b663ab711daa06de054a92f09485231824458..befbbefc97abbac819f4034e3df62f8437844c39 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1200,10 +1200,8 @@ public final class Bukkit {
@@ -24,7 +24,7 @@ index c59700bcec0938bd5a0f10c4e0d5e3e2c446d622..9abb50fb10bb2fbd21d5f31e54b13541
      @NotNull
      public static OfflinePlayer getOfflinePlayer(@NotNull String name) {
          return server.getOfflinePlayer(name);
-@@ -1752,7 +1750,7 @@ public final class Bukkit {
+@@ -1749,7 +1747,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -79,7 +79,7 @@ index 20978b269a7757a561d6b872cc77898b44bbd272..2b9a117804a8ca54b47e51e23359bd6e
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index b96bae74f0c9619609590737d9b856292cb56691..a5fe6fe103df59c01649ddcd0e1f27c27a452cff 100644
+index 92b6563712b1622bbf2a987f7ddc4b460b3ead0e..c154e94acda00924f81368f2aad1933726596b17 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4419,11 +4419,11 @@ public enum Material implements Keyed, Translatable {
@@ -175,7 +175,7 @@ index 6277451c3c6c551078c237cd767b6d70c4f585ea..10f5cfb1885833a1d2c1027c03974da4
      CRACKED(0x0),
      GLYPHED(0x1),
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 7e51025404bdc64e5eff48423280ad53244c6631..60897ff659a468f80f6ddf554c8facb136ecb24b 100644
+index 20f9384c30f46e11631a7f79c48915bf55762858..291abd48c3c8af0807bce312c18d8cf287c1f8cf 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1001,10 +1001,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -190,7 +190,7 @@ index 7e51025404bdc64e5eff48423280ad53244c6631..60897ff659a468f80f6ddf554c8facb1
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  
-@@ -1470,7 +1468,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1467,7 +1465,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -243,7 +243,7 @@ index e455eb21abf121dc6ff10ff8a13dd06f67096a8f..bbc01e7c192ae6689c301670047ff114
          return origin;
      }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 0ece998826c8e5d5a02a4a348172274b82bb2086..f57e59dd5db687fb4feb13e8283e4ff327c3e8c4 100644
+index 915c7fb937432f9cb33021d482eaae52b4807c67..cea7a1bd51418863b831334739310bc80a30d7e8 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -430,9 +430,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -331,6 +331,20 @@ index f124b35ec76e6cb6a1a0dc464005087043c3efd0..f50aaddf8582be55fd4860ad374d8f22
   */
 +@Deprecated(forRemoval = true) // Paper
  public interface LingeringPotion extends ThrownPotion { }
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 94fad96f8fd57314c571b6396f44cd9d91254cfc..b4c41ab64ef35ac0d172c041d97e8fe9b3eb8aa6 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -640,7 +640,9 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+      * This may have unexpected results if the entity is not in water.
+      *
+      * @param swimming True if the entity is swimming.
++     * @deprecated This does nothing and is immediately reverted by the server, in the next tick <!-- Paper - future note: should wait a mojang input client/server side -->
+      */
++    @Deprecated // Paper
+     public void setSwimming(boolean swimming);
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/entity/Minecart.java b/src/main/java/org/bukkit/entity/Minecart.java
 index 95c79c5fa0c4e30201f887da6467ce5f81c8a255..7f9c4d4b430a3f0276461346ff2621bacf864075 100644
 --- a/src/main/java/org/bukkit/entity/Minecart.java
@@ -357,7 +371,7 @@ index 95c79c5fa0c4e30201f887da6467ce5f81c8a255..7f9c4d4b430a3f0276461346ff2621ba
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2904aa66e83d8cde9954c13d89f8337bbfc75137..65ce6e016bcbb43711d6a1ae077330eafb8037e0 100644
+index 83c431dbaeceb5a28d0aaf3b8e5eae7462aeef40..dea53d5efe073fb3c516af9af6c650301b3239bd 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1463,9 +1463,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -432,7 +446,7 @@ index 9cb08fe7201a9f91e88c7b1ee22c17889a7bf1c3..c0fcfccdf476106b48e626a099658c04
 +@Deprecated(forRemoval = true) // Paper
  public interface SplashPotion extends ThrownPotion { }
 diff --git a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
-index 2ff1b1308571d8f8056d3359e8a8ba4a589c3726..8eb6f4090578d9e1b12aff813840108fdeece730 100644
+index e9a6e5be5f33a342f7e5c496f0f1c64b2f302ace..f0db59a556deaefefbdaca121585c0fd199c13c2 100644
 --- a/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
 +++ b/src/main/java/org/bukkit/event/enchantment/PrepareItemEnchantEvent.java
 @@ -23,7 +23,7 @@ public class PrepareItemEnchantEvent extends InventoryEvent implements Cancellab
@@ -462,6 +476,25 @@ index 2ff1b1308571d8f8056d3359e8a8ba4a589c3726..8eb6f4090578d9e1b12aff813840108f
          return offers;
      }
  
+diff --git a/src/main/java/org/bukkit/event/entity/EntityToggleSwimEvent.java b/src/main/java/org/bukkit/event/entity/EntityToggleSwimEvent.java
+index e1123295b9511a2c610a1baf7195638f7f3e64c4..273ae8e5da0a858d3b82d1b0f5992318ff49f145 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityToggleSwimEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityToggleSwimEvent.java
+@@ -24,6 +24,14 @@ public class EntityToggleSwimEvent extends EntityEvent implements Cancellable {
+         return cancel;
+     }
+ 
++    /**
++     * @deprecated This does nothing, the server and the client doesn't work
++     * correctly when the server try to bypass this. A current workaround
++     * exists. If you want to cancel the switch from the ground state to the
++     * swimming state you need to disable the sprinting flag for the player after
++     * the cancel action.
++     */
++    @Deprecated // Paper
+     @Override
+     public void setCancelled(boolean cancel) {
+         this.cancel = cancel;
 diff --git a/src/main/java/org/bukkit/event/player/PlayerHideEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerHideEntityEvent.java
 index d8a73cd22268e90eb438f522b9019f826f343275..78869fdb9cf4c541dff7d67b51866914987abf18 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerHideEntityEvent.java
@@ -533,7 +566,7 @@ index 6bafc62e2235a6b783cbf96f4dabeeaf02bd5178..50c762d777ac90a05772501a28cacff8
          cancelledCollision = cancel;
      }
 diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
-index 0cc6e29a5af28e95f87f415d6b2424d4622a6f34..acba500393e1736e6081facac6ef9ab10da655de 100644
+index c0b749a5bbf4980d01fed74768bb61909b579cb9..7e7a53b41013f1bf8956c0e278820f18d77b2f0d 100644
 --- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
 +++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
 @@ -656,7 +656,9 @@ public abstract class ChunkGenerator {
@@ -605,7 +638,7 @@ index df81bac9ecff697f98941e5c8490e10391e90090..a32977ba3ba60a1c9aee6e469d5d6cd1
      /**
       * Get the current recipe formed on the crafting inventory, if any.
 diff --git a/src/main/java/org/bukkit/inventory/EntityEquipment.java b/src/main/java/org/bukkit/inventory/EntityEquipment.java
-index a91fa5386afd7a1137adb921ad5adb798604772f..42f76751ec414648ee719c341d471d947bf85be6 100644
+index c69904f3ee7f3a41d6cebcd401abf8385dfbf868..62c1c3f01fd58db39f635eee415fcbc19fb36ec9 100644
 --- a/src/main/java/org/bukkit/inventory/EntityEquipment.java
 +++ b/src/main/java/org/bukkit/inventory/EntityEquipment.java
 @@ -511,6 +511,6 @@ public interface EntityEquipment {
@@ -674,7 +707,7 @@ index f1a48eab1a357ae64545e1f1dc941c383cff8707..466d1bd7089b76f48f953e1a51c611ec
      /**
       * Checks if the inventory contains any ItemStacks with the given
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 66ffc658dba85942f179760dc6c50258e24ab903..50fe28b48d885c782278bdb53a0bbae303f4a32d 100644
+index 349da0065ddf000cacdc259fab0f2c759332e9ad..abf95d917eca248ff3f5a5caa008c1c87fa1e029 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -26,7 +26,7 @@ public interface ItemFactory {
@@ -687,7 +720,7 @@ index 66ffc658dba85942f179760dc6c50258e24ab903..50fe28b48d885c782278bdb53a0bbae3
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index a70de962712c14cb895708e89ad3811041728935..b15645cd56c245214bb5b87b36395fbc8e86e3d3 100644
+index 83a0631a80db156ace1d977df71d5fc653b70bb6..60a25898fb17c467ffae05039fcd4d3b154a99ff 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -8,6 +8,7 @@ import java.util.Map;
@@ -773,10 +806,10 @@ index 5461f7fa75f5a065bb333b4a113640b5fe1e3825..c4d657727e508cb941320730a9d3aa54
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ShapedRecipe.java b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
-index baba8485587baab945add8bc91e91a1bfa27c84b..038a82b865afee02380805bd1f3816149143c811 100644
+index 7a73a8dc30c5c3acfe8c686a0328728c17bd8e66..60745c16264991ab9365e8f9704ff87cf1fadd43 100644
 --- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
 +++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
-@@ -97,8 +97,10 @@ public class ShapedRecipe implements Recipe, Keyed {
+@@ -96,8 +96,10 @@ public class ShapedRecipe implements Recipe, Keyed {
       * @param key The character that represents the ingredient in the shape.
       * @param ingredient The ingredient.
       * @return The changed recipe, so you can chain calls.
@@ -787,7 +820,7 @@ index baba8485587baab945add8bc91e91a1bfa27c84b..038a82b865afee02380805bd1f381614
      public ShapedRecipe setIngredient(char key, @NotNull MaterialData ingredient) {
          return setIngredient(key, ingredient.getItemType(), ingredient.getData());
      }
-@@ -157,7 +159,9 @@ public class ShapedRecipe implements Recipe, Keyed {
+@@ -156,7 +158,9 @@ public class ShapedRecipe implements Recipe, Keyed {
       * Get a copy of the ingredients map.
       *
       * @return The mapping of character to ingredients.
@@ -798,10 +831,10 @@ index baba8485587baab945add8bc91e91a1bfa27c84b..038a82b865afee02380805bd1f381614
      public Map<Character, ItemStack> getIngredientMap() {
          HashMap<Character, ItemStack> result = new HashMap<Character, ItemStack>();
 diff --git a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
-index 61b3a1b1d03fe6cdacb82b07e6c7197f56b4a1b3..402eef14987f00d2a5fccc45f0b7e3b1c16706dc 100644
+index 8bf26da12dcb03f22f842a57798948d5513c227d..e5a2febc26a2b0aca0b83c48cd35ccdea1e6a222 100644
 --- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
 +++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
-@@ -56,8 +56,10 @@ public class ShapelessRecipe implements Recipe, Keyed {
+@@ -53,8 +53,10 @@ public class ShapelessRecipe implements Recipe, Keyed {
       *
       * @param ingredient The ingredient to add.
       * @return The changed recipe, so you can chain calls.
@@ -812,7 +845,7 @@ index 61b3a1b1d03fe6cdacb82b07e6c7197f56b4a1b3..402eef14987f00d2a5fccc45f0b7e3b1
      public ShapelessRecipe addIngredient(@NotNull MaterialData ingredient) {
          return addIngredient(1, ingredient);
      }
-@@ -93,8 +95,10 @@ public class ShapelessRecipe implements Recipe, Keyed {
+@@ -90,8 +92,10 @@ public class ShapelessRecipe implements Recipe, Keyed {
       * @param count How many to add (can't be more than 9!)
       * @param ingredient The ingredient to add.
       * @return The changed recipe, so you can chain calls.
@@ -823,7 +856,7 @@ index 61b3a1b1d03fe6cdacb82b07e6c7197f56b4a1b3..402eef14987f00d2a5fccc45f0b7e3b1
      public ShapelessRecipe addIngredient(int count, @NotNull MaterialData ingredient) {
          return addIngredient(count, ingredient.getItemType(), ingredient.getData());
      }
-@@ -211,8 +215,10 @@ public class ShapelessRecipe implements Recipe, Keyed {
+@@ -208,8 +212,10 @@ public class ShapelessRecipe implements Recipe, Keyed {
       *
       * @param ingredient The ingredient to remove
       * @return The changed recipe.
@@ -834,7 +867,7 @@ index 61b3a1b1d03fe6cdacb82b07e6c7197f56b4a1b3..402eef14987f00d2a5fccc45f0b7e3b1
      public ShapelessRecipe removeIngredient(@NotNull MaterialData ingredient) {
          return removeIngredient(ingredient.getItemType(), ingredient.getData());
      }
-@@ -239,8 +245,10 @@ public class ShapelessRecipe implements Recipe, Keyed {
+@@ -236,8 +242,10 @@ public class ShapelessRecipe implements Recipe, Keyed {
       * @param count The number of copies to remove.
       * @param ingredient The ingredient to remove.
       * @return The changed recipe.
@@ -845,7 +878,7 @@ index 61b3a1b1d03fe6cdacb82b07e6c7197f56b4a1b3..402eef14987f00d2a5fccc45f0b7e3b1
      public ShapelessRecipe removeIngredient(int count, @NotNull MaterialData ingredient) {
          return removeIngredient(count, ingredient.getItemType(), ingredient.getData());
      }
-@@ -301,7 +309,9 @@ public class ShapelessRecipe implements Recipe, Keyed {
+@@ -298,7 +306,9 @@ public class ShapelessRecipe implements Recipe, Keyed {
       * Get the list of ingredients used for this recipe.
       *
       * @return The input list
@@ -856,7 +889,7 @@ index 61b3a1b1d03fe6cdacb82b07e6c7197f56b4a1b3..402eef14987f00d2a5fccc45f0b7e3b1
      public List<ItemStack> getIngredientList() {
          ArrayList<ItemStack> result = new ArrayList<ItemStack>(ingredients.size());
 diff --git a/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java b/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java
-index 07c3dff4d6190ef388d9c1e1c36f67f00a3e8e66..aa5e7f37d20d6976f33e04876ae625ed0e5b2b41 100644
+index 597a18a767b68b47e81454b7d44613c7178c1366..bc3440eb72127824b3961fbdae583bb61385f65e 100644
 --- a/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java
 +++ b/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java
 @@ -57,7 +57,9 @@ public class StonecuttingRecipe implements Recipe, Keyed {
@@ -870,7 +903,7 @@ index 07c3dff4d6190ef388d9c1e1c36f67f00a3e8e66..aa5e7f37d20d6976f33e04876ae625ed
      public ItemStack getInput() {
          return this.ingredient.getItemStack();
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 35009498aafd1bd36c493085127135fc8a5c36ec..1beedb446a9dd554d05d1d94dba8598e4b69eba6 100644
+index 55e9dc5d1d87fbc9d0dabbb7bd59584fe2c5f379..5c1ca0e47f0ac1525c3d37b55f52874878f44c28 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -74,8 +74,10 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste

--- a/patches/api/0173-Server-Tick-Events.patch
+++ b/patches/api/0173-Server-Tick-Events.patch
@@ -7,7 +7,7 @@ Fires event at start and end of a server tick
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/ServerTickEndEvent.java b/src/main/java/com/destroystokyo/paper/event/server/ServerTickEndEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9fd28e03649f66f71fb7f0536a137557ec32cd25
+index 0000000000000000000000000000000000000000..dd7327c70fb72089dec6552317ba28961236db56
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/server/ServerTickEndEvent.java
 @@ -0,0 +1,59 @@
@@ -52,7 +52,7 @@ index 0000000000000000000000000000000000000000..9fd28e03649f66f71fb7f0536a137557
 +     *
 +     * If this value is negative, then that means the server has exceeded the tick time limit and TPS has been lost.
 +     *
-+     * Method will continously return the updated time remaining value. (return value is not static)
++     * Method will continuously return the updated time remaining value. (return value is not static)
 +     *
 +     * @return Amount of nanoseconds remaining before the next tick should start
 +     */

--- a/patches/api/0180-Expose-the-internal-current-tick.patch
+++ b/patches/api/0180-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9abb50fb10bb2fbd21d5f31e54b135416cae3433..75be5b6c2f01fa794ed4d69082d34ab0a422e8cb 100644
+index befbbefc97abbac819f4034e3df62f8437844c39..16e6d0929ce4c7313418aa4635fb77bf112b2936 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2291,6 +2291,10 @@ public final class Bukkit {
+@@ -2288,6 +2288,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfileExact(uuid, name);
      }
@@ -20,10 +20,10 @@ index 9abb50fb10bb2fbd21d5f31e54b135416cae3433..75be5b6c2f01fa794ed4d69082d34ab0
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 60897ff659a468f80f6ddf554c8facb136ecb24b..2cd6826cb5d8e5b545644e063c0d67d68f2c1322 100644
+index 291abd48c3c8af0807bce312c18d8cf287c1f8cf..411031322c97d220957e4cff43ca3758c18d60a8 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1990,5 +1990,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1987,5 +1987,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0184-Entity-Jump-API.patch
+++ b/patches/api/0184-Entity-Jump-API.patch
@@ -57,10 +57,10 @@ index 0000000000000000000000000000000000000000..f0067c2e953d18e1a33536980071ba3f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 94fad96f8fd57314c571b6396f44cd9d91254cfc..f76090f1f7ae7e3c026896b82e6379e5c2fd26fe 100644
+index b4c41ab64ef35ac0d172c041d97e8fe9b3eb8aa6..9e6ad506611ec05f75da29bef074edebd9d54715 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -945,5 +945,25 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -947,5 +947,25 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      @NotNull
      org.bukkit.inventory.EquipmentSlot getHandRaised();

--- a/patches/api/0186-Add-tick-times-API.patch
+++ b/patches/api/0186-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 75be5b6c2f01fa794ed4d69082d34ab0a422e8cb..18acd00146e073cfd7912b05c87cdcb124a9ff9f 100644
+index 16e6d0929ce4c7313418aa4635fb77bf112b2936..0a03654b5f15650c0acbbdb464b87cfed3bcaa30 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1963,6 +1963,25 @@ public final class Bukkit {
+@@ -1960,6 +1960,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index 75be5b6c2f01fa794ed4d69082d34ab0a422e8cb..18acd00146e073cfd7912b05c87cdcb1
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 2cd6826cb5d8e5b545644e063c0d67d68f2c1322..38f9977e302322dc511214553bcd727ef08c14c5 100644
+index 411031322c97d220957e4cff43ca3758c18d60a8..770c4ffa0243578b5cdd3502d137f218f38c7491 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1652,6 +1652,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1649,6 +1649,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0187-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0187-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 18acd00146e073cfd7912b05c87cdcb124a9ff9f..51a43429e58fbebf8c95d23257cd9c84ce57b1aa 100644
+index 0a03654b5f15650c0acbbdb464b87cfed3bcaa30..ecc06036d928f9b23cd0798a1e97154a005d1427 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2314,6 +2314,15 @@ public final class Bukkit {
+@@ -2311,6 +2311,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index 18acd00146e073cfd7912b05c87cdcb124a9ff9f..51a43429e58fbebf8c95d23257cd9c84
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 38f9977e302322dc511214553bcd727ef08c14c5..122ef60bcb1548713f2e355cb77eccbebcd17f04 100644
+index 770c4ffa0243578b5cdd3502d137f218f38c7491..b334869de8cb51474dcbd4cf24d7552166e0be8b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2012,5 +2012,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2009,5 +2009,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0195-Add-Mob-Goal-API.patch
+++ b/patches/api/0195-Add-Mob-Goal-API.patch
@@ -524,10 +524,10 @@ index 0000000000000000000000000000000000000000..dddbb661265aa23f88d93d0681f418f4
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f4897529322f57eaf0d26ce82307dcd785511af8..93a74792837e6dcff354e5f0afb7aacd0a19f7e1 100644
+index c0908574e079e203b7815b1bf3d304c1d202a4d3..d5e12a33d6f79b2f3ec5079cb4e91830cabe9711 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2335,6 +2335,16 @@ public final class Bukkit {
+@@ -2332,6 +2332,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -545,10 +545,10 @@ index f4897529322f57eaf0d26ce82307dcd785511af8..93a74792837e6dcff354e5f0afb7aacd
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 97c2708b69ff01f9e7898ad7282016cac605bc79..cd3ce4155ff46d85d4c603a688dd96893400ed77 100644
+index e21801904d24e15a9db250b75051347418e20670..ea821f079770a30828519f10b013f80640296442 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2029,5 +2029,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2026,5 +2026,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0203-added-2-new-TargetReasons-for-1.16-mob-behavior.patch
+++ b/patches/api/0203-added-2-new-TargetReasons-for-1.16-mob-behavior.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] added 2 new TargetReasons for 1.16 mob behavior
 
 
 diff --git a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
-index dee186e99463a56394bbc2039d1e763d109125b9..601904150156d475c18286b485f3409307a75950 100644
+index c6e4d69eecd2789b1d78fe99fe590932e9758ba1..85b318d9ee56a3c22c6b7c9ac408f021e51cb609 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
 @@ -159,6 +159,14 @@ public class EntityTargetEvent extends EntityEvent implements Cancellable {
-          * as wheat in it's hand.
+          * as wheat in its hand.
           */
          TEMPT,
 +        /**
@@ -17,7 +17,7 @@ index dee186e99463a56394bbc2039d1e763d109125b9..601904150156d475c18286b485f34093
 +         */
 +        TARGET_OTHER_LEVEL, // Paper
 +        /**
-+         * When the target is in creative or spectator mode, or the gamemode is peaceful, or other reasons
++         * When the target is in creative or spectator gamemode, or the difficulty is peaceful, or other reasons
 +         */
 +        TARGET_INVALID, // Paper
          /**

--- a/patches/api/0205-Add-PrepareResultEvent-PrepareGrindstoneEvent.patch
+++ b/patches/api/0205-Add-PrepareResultEvent-PrepareGrindstoneEvent.patch
@@ -87,7 +87,7 @@ index 0000000000000000000000000000000000000000..25e5f0354b3b65c656d6c173ec108825
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java b/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java
-index 6782024735a885ba0b1b4dba4a576740c1410366..8695715c10d81b06c088ff0c8d401875d26879b5 100644
+index 8977f7609431c3c46324a82de84d4a32f4b71c57..d884ecf40af964e718168ac055dd6c672d108eb1 100644
 --- a/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java
 +++ b/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java
 @@ -10,9 +10,9 @@ import org.jetbrains.annotations.Nullable;
@@ -102,8 +102,8 @@ index 6782024735a885ba0b1b4dba4a576740c1410366..8695715c10d81b06c088ff0c8d401875
  
      public PrepareAnvilEvent(@NotNull InventoryView inventory, @Nullable ItemStack result) {
          super(inventory, result);
-@@ -24,14 +24,5 @@ public class PrepareAnvilEvent extends PrepareInventoryResultEvent {
-         return (AnvilInventory) super.getInventory();
+@@ -38,14 +38,5 @@ public class PrepareAnvilEvent extends PrepareInventoryResultEvent {
+         super.setResult(result);
      }
  
 -    @NotNull

--- a/patches/api/0210-Add-playPickupItemAnimation-to-LivingEntity.patch
+++ b/patches/api/0210-Add-playPickupItemAnimation-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add playPickupItemAnimation to LivingEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index f76090f1f7ae7e3c026896b82e6379e5c2fd26fe..76fdfa7b00cb905163567a204a727cf047d9261a 100644
+index 9e6ad506611ec05f75da29bef074edebd9d54715..f686a92ec450c2fdf0c94ebdbab1d94af7c342d1 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -965,5 +965,28 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -967,5 +967,28 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param jumping entity jump state
       */
      void setJumping(boolean jumping);

--- a/patches/api/0220-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0220-Add-getOfflinePlayerIfCached-String.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 6d98664f2da191c2327e80b8212c1ad979f7d6ac..ceb8d207843df5ddc852d44928286648a652eedb 100644
+index af5ce8bef3529a008a4f105e3812e3aec20e90fa..7cef6511b9b986fd5b3c59072e099f7a4ebb5fc4 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1230,6 +1230,27 @@ public final class Bukkit {
@@ -37,7 +37,7 @@ index 6d98664f2da191c2327e80b8212c1ad979f7d6ac..ceb8d207843df5ddc852d44928286648
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 936ebaf531a76cab12809cfa334e2b0d89e625c3..02b898d441c42771903d5839c3cde544b1a25778 100644
+index 5b4fc4fa5122cea783e64ff61ae43e5ce45f6af6..9dcd94bc1aedac589192f4bb07d7ae821586f58a 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1025,6 +1025,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0223-Beacon-API-custom-effect-ranges.patch
+++ b/patches/api/0223-Beacon-API-custom-effect-ranges.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Beacon API - custom effect ranges
 
 
 diff --git a/src/main/java/org/bukkit/block/Beacon.java b/src/main/java/org/bukkit/block/Beacon.java
-index 6349fa9da3f96df3553fb9552c1cab95338cecb0..78475fc6faff0f295828d7b53792001d51aa2889 100644
+index 6349fa9da3f96df3553fb9552c1cab95338cecb0..7d212c409035ccb8b22d4ffc322b4a1aea367627 100644
 --- a/src/main/java/org/bukkit/block/Beacon.java
 +++ b/src/main/java/org/bukkit/block/Beacon.java
 @@ -64,4 +64,26 @@ public interface Beacon extends TileState, Lockable, Nameable {
@@ -29,7 +29,7 @@ index 6349fa9da3f96df3553fb9552c1cab95338cecb0..78475fc6faff0f295828d7b53792001d
 +    void setEffectRange(double range);
 +
 +    /**
-+     * Resets the custom range from this beacon and falls back to the range based on the the beacon tier.
++     * Resets the custom range from this beacon and falls back to the range based on the beacon tier.
 +     * Shortcut for setting the effect range to a negative number.
 +     */
 +    void resetEffectRange();

--- a/patches/api/0226-Add-LivingEntity-clearActiveItem.patch
+++ b/patches/api/0226-Add-LivingEntity-clearActiveItem.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#clearActiveItem
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 76fdfa7b00cb905163567a204a727cf047d9261a..b09c9eb92c069f76e0fba4a08ed0a5c66ced3a40 100644
+index f686a92ec450c2fdf0c94ebdbab1d94af7c342d1..511a48df780364d054858079273fe408aa0bc749 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -916,6 +916,13 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -918,6 +918,13 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      @NotNull
      org.bukkit.inventory.ItemStack getActiveItem();
  

--- a/patches/api/0231-Expose-LivingEntity-hurt-direction.patch
+++ b/patches/api/0231-Expose-LivingEntity-hurt-direction.patch
@@ -26,10 +26,10 @@ index b0de996c7cbfc36a3f749091068a70885b009832..b21325401f59a02c0fb52d203e90b0f6
       * Get the sleep ticks of the player. This value may be capped.
       *
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index b09c9eb92c069f76e0fba4a08ed0a5c66ced3a40..16536dae04b020de43f9e13ff32c659b9e6cab0c 100644
+index 511a48df780364d054858079273fe408aa0bc749..6a4c54ea92478be6e53b62ebe4e73068b9ed4a29 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -995,5 +995,21 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -997,5 +997,21 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param quantity quantity of item
       */
      void playPickupItemAnimation(@NotNull Item item, int quantity);

--- a/patches/api/0252-Added-PlayerChangeBeaconEffectEvent.patch
+++ b/patches/api/0252-Added-PlayerChangeBeaconEffectEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Added PlayerChangeBeaconEffectEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c80183a79713b1e73549911e474a8c585cfdeb52
+index 0000000000000000000000000000000000000000..7646050f4bfc9092afaae9f769b0f7ecb42262ff
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java
 @@ -0,0 +1,141 @@
@@ -88,9 +88,9 @@ index 0000000000000000000000000000000000000000..c80183a79713b1e73549911e474a8c58
 +    }
 +
 +    /**
-+     * Gets if the item used to change the beacon will be consume.
++     * Gets if the item used to change the beacon will be consumed.
 +     * <p>
-+     * Independant of {@link #isCancelled()}. If the event is cancelled
++     * Independent of {@link #isCancelled()}. If the event is cancelled
 +     * the item will <b>NOT</b> be consumed.
 +     *
 +     * @return true if item will be consumed
@@ -102,7 +102,7 @@ index 0000000000000000000000000000000000000000..c80183a79713b1e73549911e474a8c58
 +    /**
 +     * Sets if the item used to change the beacon should be consumed.
 +     * <p>
-+     * Independant of {@link #isCancelled()}. If the event is cancelled
++     * Independent of {@link #isCancelled()}. If the event is cancelled
 +     * the item will <b>NOT</b> be consumed.
 +     *
 +     * @param consumeItem true if item should be consumed

--- a/patches/api/0263-Add-worldborder-events.patch
+++ b/patches/api/0263-Add-worldborder-events.patch
@@ -126,7 +126,7 @@ index 0000000000000000000000000000000000000000..126fe50b519a8d7cd158f799058cb235
 +}
 diff --git a/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeFinishEvent.java b/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeFinishEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c3d578ae2c5615b0ebace99d9bacf100b086c971
+index 0000000000000000000000000000000000000000..60eabed056ee9b9cdd6f5d13307b9be38705330f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/world/border/WorldBorderBoundsChangeFinishEvent.java
 @@ -0,0 +1,65 @@
@@ -138,7 +138,7 @@ index 0000000000000000000000000000000000000000..c3d578ae2c5615b0ebace99d9bacf100
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Called when a moving world border has finished it's move.
++ * Called when a moving world border has finished its move.
 + */
 +public class WorldBorderBoundsChangeFinishEvent extends WorldBorderEvent {
 +

--- a/patches/api/0267-Expand-world-key-API.patch
+++ b/patches/api/0267-Expand-world-key-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expand world key API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 95a981218615b9ed167a317aaa5224e9613aa42a..244c836dd24cb49f6219634e3f323befcd68d9da 100644
+index 7cef6511b9b986fd5b3c59072e099f7a4ebb5fc4..041c6a9a1adce389f3a7ca6e5bbb7cfed0ab6fd8 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -811,6 +811,18 @@ public final class Bukkit {
@@ -28,7 +28,7 @@ index 95a981218615b9ed167a317aaa5224e9613aa42a..244c836dd24cb49f6219634e3f323bef
      /**
       * Create a new virtual {@link WorldBorder}.
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index 2fa3de66107162ccaa158b369e2c4a926ecaff92..aa534b1a9a1fb84a2fbd4b372f313bb4b63325fa 100644
+index 393470e6a567d74d692fad30a7cecdff4e522ea3..f30fff08bf04c4d274b2ce242a135a14924f1cb0 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
 @@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
@@ -56,7 +56,7 @@ index 2fa3de66107162ccaa158b369e2c4a926ecaff92..aa534b1a9a1fb84a2fbd4b372f313bb4
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 3327810c2ae80b47f6ccbc5b2034b880a774879f..8390b1d4718a4c67d222e19609462d20c36506b7 100644
+index 9dcd94bc1aedac589192f4bb07d7ae821586f58a..b283a9ba0c6ea1b24cb03b690984b93d25ddf010 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -671,6 +671,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0274-More-World-API.patch
+++ b/patches/api/0274-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 30d5ed45df901a4931a35cc62aec08818307ec99..6da379edbf35321f7265606228695f40a9ea6977 100644
+index cebf905e78ea5fcc5f8208c62cf06a3fc52d169e..04c9329bb0309a1d3b0a1bbc755af7190a6ad0d4 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3734,6 +3734,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3731,6 +3731,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      StructureSearchResult locateNearestStructure(@NotNull Location origin, @NotNull Structure structure, int radius, boolean findUnexplored);
  

--- a/patches/api/0282-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/api/0282-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add raw address to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index 9acf1fb404ccf9b3bc06a448c3099ca2e838facf..baee5038ec7c3e190a328016d9ab290ae48badf6 100644
+index c30b44ff26f8f253902754452a0816f07c7fd035..34e4d666b6af58f64c6c001df80fadf818847e6a 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 @@ -20,6 +20,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
@@ -16,7 +16,7 @@ index 9acf1fb404ccf9b3bc06a448c3099ca2e838facf..baee5038ec7c3e190a328016d9ab290a
      //private UUID uniqueId; // Paper - Not used anymore
  
      @Deprecated
-@@ -49,7 +50,23 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -50,7 +51,23 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this.profile = profile;
      }
  
@@ -40,7 +40,7 @@ index 9acf1fb404ccf9b3bc06a448c3099ca2e838facf..baee5038ec7c3e190a328016d9ab290a
          super(true);
          this.profile = profile;
          // Paper end
-@@ -57,6 +74,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -58,6 +75,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this.message = net.kyori.adventure.text.Component.empty(); // Paper
          //this.name = name; // Paper - Not used anymore
          this.ipAddress = ipAddress;

--- a/patches/api/0283-Inventory-close.patch
+++ b/patches/api/0283-Inventory-close.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Inventory#close
 
 
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 129b5ab5062beeb9bb52465a788bc3a3aee9c49e..c574bb94b21eb27974b40c839fce52c6ac4b54b4 100644
+index 129b5ab5062beeb9bb52465a788bc3a3aee9c49e..0d519813c12d98b28d62e6d01d7ec6e8c2dba3c3 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
 @@ -355,6 +355,15 @@ public interface Inventory extends Iterable<ItemStack> {
@@ -16,7 +16,7 @@ index 129b5ab5062beeb9bb52465a788bc3a3aee9c49e..c574bb94b21eb27974b40c839fce52c6
 +    /**
 +     * Closes the inventory for all viewers.
 +     *
-+     * @return the number if viewers the inventory was closed for
++     * @return the number of viewers the inventory was closed for
 +     */
 +    public int close();
 +    // Paper end

--- a/patches/api/0285-Add-basic-Datapack-API.patch
+++ b/patches/api/0285-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 197cf8cdd3d51c3e01ec737981601f37764315c6..b0d2d45ad2394313be752e92bc594095bfc93120 100644
+index 041c6a9a1adce389f3a7ca6e5bbb7cfed0ab6fd8..890328e1204fc9d8836a69dfbf50ba82d950d6f8 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2389,6 +2389,14 @@ public final class Bukkit {
+@@ -2386,6 +2386,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index 197cf8cdd3d51c3e01ec737981601f37764315c6..b0d2d45ad2394313be752e92bc594095
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1a3b4f20c7126caf8a34040028f735083bf47150..a11d02cc17b1e9bea06ab61cd3ae21c3c41aaceb 100644
+index b283a9ba0c6ea1b24cb03b690984b93d25ddf010..ce3598bd4be5eab4c9b6008bca78c7a470adbf31 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2076,5 +2076,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2073,5 +2073,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0321-Add-more-advancement-API.patch
+++ b/patches/api/0321-Add-more-advancement-API.patch
@@ -178,10 +178,10 @@ index 0000000000000000000000000000000000000000..19202e17f362fdffca472178b102d133
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/advancement/Advancement.java b/src/main/java/org/bukkit/advancement/Advancement.java
-index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..3f6b9e59c2ea38031ca74962e02d710fde61fb1f 100644
+index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..51cab9c3ab0293fcc003db8a540a358ba5fadb84 100644
 --- a/src/main/java/org/bukkit/advancement/Advancement.java
 +++ b/src/main/java/org/bukkit/advancement/Advancement.java
-@@ -19,13 +19,53 @@ public interface Advancement extends Keyed {
+@@ -19,13 +19,55 @@ public interface Advancement extends Keyed {
      @NotNull
      Collection<String> getCriteria();
  
@@ -194,8 +194,13 @@ index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..3f6b9e59c2ea38031ca74962e02d710f
 +     * recipes.
       *
 -     * This includes it's name, description and other visible tags.
++     * This includes its name, description and other visible tags.
+      *
+-     * @return a AdvancementDisplay object, or null if not set.
 +     * @return the display info
-+     */
+      */
+-    @Nullable
+-    AdvancementDisplay getDisplay();
 +    @org.jetbrains.annotations.Nullable
 +    io.papermc.paper.advancement.AdvancementDisplay getDisplay();
 +
@@ -205,13 +210,10 @@ index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..3f6b9e59c2ea38031ca74962e02d710f
 +     * completes the advancement. Will return the same as
 +     * {@link io.papermc.paper.advancement.AdvancementDisplay#displayName()} when an
 +     * {@link io.papermc.paper.advancement.AdvancementDisplay} is present.
-      *
--     * @return a AdvancementDisplay object, or null if not set.
++     *
 +     * @return the display name
 +     * @see io.papermc.paper.advancement.AdvancementDisplay#displayName()
-      */
--    @Nullable
--    AdvancementDisplay getDisplay();
++     */
 +    @NotNull net.kyori.adventure.text.Component displayName();
 +
 +    /**

--- a/patches/api/0331-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0331-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b0d2d45ad2394313be752e92bc594095bfc93120..85dc2bf97175207bcc169d5d7e0d86dae39aecf2 100644
+index 890328e1204fc9d8836a69dfbf50ba82d950d6f8..b0a1ae0028387397998c2a53031f6f767c7bf3f4 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1907,6 +1907,24 @@ public final class Bukkit {
+@@ -1904,6 +1904,24 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -34,10 +34,10 @@ index b0d2d45ad2394313be752e92bc594095bfc93120..85dc2bf97175207bcc169d5d7e0d86da
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a11d02cc17b1e9bea06ab61cd3ae21c3c41aaceb..c07eef17aac9140e1f461aa20e3a90fcb3f4ae74 100644
+index ce3598bd4be5eab4c9b6008bca78c7a470adbf31..492d783eb1376730ac79853bfb0abb7b4d555c0f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1602,6 +1602,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1599,6 +1599,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  
@@ -61,7 +61,7 @@ index a11d02cc17b1e9bea06ab61cd3ae21c3c41aaceb..c07eef17aac9140e1f461aa20e3a90fc
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
-index acba500393e1736e6081facac6ef9ab10da655de..f1f60710ea44a078aa071dbf2d5c0ed3724e31b3 100644
+index 7e7a53b41013f1bf8956c0e278820f18d77b2f0d..c942b7101a38ac7dc70e11e87afa1f9210000bc1 100644
 --- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
 +++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
 @@ -577,6 +577,22 @@ public abstract class ChunkGenerator {

--- a/patches/api/0334-Improve-scoreboard-entries.patch
+++ b/patches/api/0334-Improve-scoreboard-entries.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Improve scoreboard entries
 
 
 diff --git a/src/main/java/org/bukkit/scoreboard/Objective.java b/src/main/java/org/bukkit/scoreboard/Objective.java
-index 474274fdffe4041bf4bfb146fcc66424eb5be78a..b236d19d4e4e4f9def610bae8a0c7d222fe2241b 100644
+index de8789b79c8c36ba909c9532642acf22136a0faa..79bfae9626f0ed6c279eda21ddd1e25b09ed0be9 100644
 --- a/src/main/java/org/bukkit/scoreboard/Objective.java
 +++ b/src/main/java/org/bukkit/scoreboard/Objective.java
 @@ -151,9 +151,8 @@ public interface Objective {
@@ -37,7 +37,7 @@ index 474274fdffe4041bf4bfb146fcc66424eb5be78a..b236d19d4e4e4f9def610bae8a0c7d22
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/scoreboard/Scoreboard.java b/src/main/java/org/bukkit/scoreboard/Scoreboard.java
-index ef3e729caf430b08cdf2d680d5a137a1ba56c1c5..880b20bf25f74e9cb54ff3fb282a5b74db6a0a85 100644
+index ef3e729caf430b08cdf2d680d5a137a1ba56c1c5..ec264ecfe6835d00afa3622024d2cbb200bd3d63 100644
 --- a/src/main/java/org/bukkit/scoreboard/Scoreboard.java
 +++ b/src/main/java/org/bukkit/scoreboard/Scoreboard.java
 @@ -265,9 +265,8 @@ public interface Scoreboard {
@@ -80,7 +80,7 @@ index ef3e729caf430b08cdf2d680d5a137a1ba56c1c5..880b20bf25f74e9cb54ff3fb282a5b74
 +
 +    // Paper start
 +    /**
-+     * Gets all scores for a entity on this Scoreboard
++     * Gets all scores for an entity on this Scoreboard
 +     *
 +     * @param entity the entity whose scores are being retrieved
 +     * @return immutable set of all scores tracked for the entity
@@ -90,7 +90,7 @@ index ef3e729caf430b08cdf2d680d5a137a1ba56c1c5..880b20bf25f74e9cb54ff3fb282a5b74
 +    @NotNull Set<Score> getScoresFor(@NotNull org.bukkit.entity.Entity entity) throws IllegalArgumentException;
 +
 +    /**
-+     * Removes all scores for a entity on this Scoreboard
++     * Removes all scores for an entity on this Scoreboard
 +     *
 +     * @param entity the entity to drop all current scores for
 +     * @throws IllegalArgumentException if entity is null
@@ -99,7 +99,7 @@ index ef3e729caf430b08cdf2d680d5a137a1ba56c1c5..880b20bf25f74e9cb54ff3fb282a5b74
 +    void resetScoresFor(@NotNull org.bukkit.entity.Entity entity) throws IllegalArgumentException;
 +
 +    /**
-+     * Gets a entity's Team on this Scoreboard
++     * Gets an entity's Team on this Scoreboard
 +     *
 +     * @param entity the entity to search for
 +     * @return the entity's Team or null if the entity is not on a team
@@ -110,7 +110,7 @@ index ef3e729caf430b08cdf2d680d5a137a1ba56c1c5..880b20bf25f74e9cb54ff3fb282a5b74
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java
-index 47b10df619ad2520b9bb673e2220f36391680f1b..cbc82a03c24f746b913b30f14ecb0c08cdb42c24 100644
+index eaf5d2cf07b97a6bc23e52b40b63b9eba82bced3..2014bca326ec67f178129d8b044fa0b0654e1ffd 100644
 --- a/src/main/java/org/bukkit/scoreboard/Team.java
 +++ b/src/main/java/org/bukkit/scoreboard/Team.java
 @@ -308,9 +308,8 @@ public interface Team {

--- a/patches/api/0342-Multiple-Entries-with-Scoreboards.patch
+++ b/patches/api/0342-Multiple-Entries-with-Scoreboards.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Multiple Entries with Scoreboards
 
 
 diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java
-index cbc82a03c24f746b913b30f14ecb0c08cdb42c24..06a5d3177ca7ab90c3fd9d2053b2ec5e887c7c62 100644
+index 2014bca326ec67f178129d8b044fa0b0654e1ffd..376a873ce809fa6ce4dce49d9e00ddbdabb1315e 100644
 --- a/src/main/java/org/bukkit/scoreboard/Team.java
 +++ b/src/main/java/org/bukkit/scoreboard/Team.java
 @@ -323,6 +323,60 @@ public interface Team {
@@ -75,7 +75,7 @@ index cbc82a03c24f746b913b30f14ecb0c08cdb42c24..06a5d3177ca7ab90c3fd9d2053b2ec5e
  
 +    // Paper start
 +    /**
-+     * Removes a collection of entities from this team  which results in one
++     * Removes a collection of entities from this team which results in one
 +     * packet for the updates rather than a packet-per-entity.
 +     *
 +     * @param entities the entries to remove
@@ -88,7 +88,7 @@ index cbc82a03c24f746b913b30f14ecb0c08cdb42c24..06a5d3177ca7ab90c3fd9d2053b2ec5e
 +    }
 +
 +    /**
-+     * Removes a collection of entities from this team  which results in one
++     * Removes a collection of entities from this team which results in one
 +     * packet for the updates rather than a packet-per-entity.
 +     *
 +     * @param entities the entries to remove
@@ -99,7 +99,7 @@ index cbc82a03c24f746b913b30f14ecb0c08cdb42c24..06a5d3177ca7ab90c3fd9d2053b2ec5e
 +    boolean removeEntities(@NotNull java.util.Collection<org.bukkit.entity.Entity> entities) throws IllegalStateException, IllegalArgumentException;
 +
 +    /**
-+     * Removes a collection of entries from this team  which results in one
++     * Removes a collection of entries from this team which results in one
 +     * packet for the updates rather than a packet-per-entry.
 +     *
 +     * @param entries the entries to remove
@@ -112,7 +112,7 @@ index cbc82a03c24f746b913b30f14ecb0c08cdb42c24..06a5d3177ca7ab90c3fd9d2053b2ec5e
 +    }
 +
 +    /**
-+     * Removes a collection of entries from this team  which results in one
++     * Removes a collection of entries from this team which results in one
 +     * packet for the updates rather than a packet-per-entry.
 +     *
 +     * @param entries the entries to remove

--- a/patches/api/0343-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/api/0343-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Added getHostname to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index baee5038ec7c3e190a328016d9ab290ae48badf6..635b8787fc235b61c0d5677def034656e4ec4cef 100644
+index 34e4d666b6af58f64c6c001df80fadf818847e6a..fc2d9e85b65347b90bde3b0b13ccae759e33d466 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 @@ -22,6 +22,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
@@ -16,7 +16,7 @@ index baee5038ec7c3e190a328016d9ab290ae48badf6..635b8787fc235b61c0d5677def034656
  
      @Deprecated
      public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress) {
-@@ -66,7 +67,14 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -67,7 +68,14 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this(name, ipAddress, ipAddress, uniqueId, profile);
      }
  
@@ -31,7 +31,7 @@ index baee5038ec7c3e190a328016d9ab290ae48badf6..635b8787fc235b61c0d5677def034656
          super(true);
          this.profile = profile;
          // Paper end
-@@ -76,6 +84,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -77,6 +85,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this.ipAddress = ipAddress;
          this.rawAddress = rawAddress; // Paper
          //this.uniqueId = uniqueId; // Paper - Not used anymore
@@ -39,7 +39,7 @@ index baee5038ec7c3e190a328016d9ab290ae48badf6..635b8787fc235b61c0d5677def034656
      }
  
      /**
-@@ -261,6 +270,19 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -262,6 +271,19 @@ public class AsyncPlayerPreLoginEvent extends Event {
          return profile.getId(); // Paper
      }
  

--- a/patches/api/0350-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0350-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for creating command sender which forwards feedback
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 85dc2bf97175207bcc169d5d7e0d86dae39aecf2..1934a4521a43ad14beacf0c56e5914e35da8bc59 100644
+index b0a1ae0028387397998c2a53031f6f767c7bf3f4..6b7f6d7f5a6622b41fc4468262985fa0a1266bfc 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1415,6 +1415,20 @@ public final class Bukkit {
+@@ -1412,6 +1412,20 @@ public final class Bukkit {
          return server.getConsoleSender();
      }
  
@@ -30,10 +30,10 @@ index 85dc2bf97175207bcc169d5d7e0d86dae39aecf2..1934a4521a43ad14beacf0c56e5914e3
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index c07eef17aac9140e1f461aa20e3a90fcb3f4ae74..23063ebcf36dd4f02ad4670839295064c95e3aec 100644
+index 492d783eb1376730ac79853bfb0abb7b4d555c0f..70a22d26beec7b4e82f4ab6be06875a53e622002 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1181,6 +1181,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1178,6 +1178,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/api/0356-Custom-Potion-Mixes.patch
+++ b/patches/api/0356-Custom-Potion-Mixes.patch
@@ -102,10 +102,10 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 1934a4521a43ad14beacf0c56e5914e35da8bc59..41ea6212b52359927bd5c944c886ef32322b9a08 100644
+index 6b7f6d7f5a6622b41fc4468262985fa0a1266bfc..d7d6897b1f697f48aa3890d70797dd3195de125e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2429,6 +2429,15 @@ public final class Bukkit {
+@@ -2426,6 +2426,15 @@ public final class Bukkit {
      public static io.papermc.paper.datapack.DatapackManager getDatapackManager() {
          return server.getDatapackManager();
      }
@@ -122,10 +122,10 @@ index 1934a4521a43ad14beacf0c56e5914e35da8bc59..41ea6212b52359927bd5c944c886ef32
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 23063ebcf36dd4f02ad4670839295064c95e3aec..fe50eb0820b99ce5ad8fb8c53ced08709aa4caef 100644
+index 70a22d26beec7b4e82f4ab6be06875a53e622002..dcd04d2181037c91f004fee339373f0b15534e1d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2110,5 +2110,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2107,5 +2107,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();

--- a/patches/api/0369-Add-method-isTickingWorlds-to-Bukkit.patch
+++ b/patches/api/0369-Add-method-isTickingWorlds-to-Bukkit.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add method isTickingWorlds() to Bukkit.
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 41ea6212b52359927bd5c944c886ef32322b9a08..ac9b690fcccb60b587e5345f12f1383afd0a73a1 100644
+index d7d6897b1f697f48aa3890d70797dd3195de125e..f1af93319d6b29d7bc709e7e273e8abe26c7b4af 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -753,12 +753,26 @@ public final class Bukkit {
@@ -56,7 +56,7 @@ index 41ea6212b52359927bd5c944c886ef32322b9a08..ac9b690fcccb60b587e5345f12f1383a
       * @param world the world to unload
       * @param save whether to save the chunks before unloading
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index fe50eb0820b99ce5ad8fb8c53ced08709aa4caef..2204336d8800311b65e894739ab1b27273e7c6f2 100644
+index dcd04d2181037c91f004fee339373f0b15534e1d..8621dba7f10ab822b5b99ce0d05da58823605cb6 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -622,34 +622,55 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0381-Added-byte-array-serialization-deserialization-for-P.patch
+++ b/patches/api/0381-Added-byte-array-serialization-deserialization-for-P.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Added byte array serialization/deserialization for
 
 
 diff --git a/src/main/java/org/bukkit/persistence/PersistentDataContainer.java b/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
-index eebb3da156e2d95efbe22d4afa470b977ce19f10..d30ad7cae1dfbb47ab1a6e3e2fcd6fb76163fe78 100644
+index eebb3da156e2d95efbe22d4afa470b977ce19f10..57609b7793122e135fa0c3b926500849379637b2 100644
 --- a/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
 +++ b/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
 @@ -164,5 +164,38 @@ public interface PersistentDataContainer {
@@ -18,7 +18,7 @@ index eebb3da156e2d95efbe22d4afa470b977ce19f10..d30ad7cae1dfbb47ab1a6e3e2fcd6fb7
 +     * Serialize this {@link PersistentDataContainer} instance to a
 +     * byte array.
 +     *
-+     * @return a binary represenation of this container
++     * @return a binary representation of this container
 +     * @throws java.io.IOException if we fail to write this container to a byte array
 +     */
 +    byte @NotNull [] serializeToBytes() throws java.io.IOException;

--- a/patches/api/0389-Add-LivingEntity-swingHand-EquipmentSlot-convenience.patch
+++ b/patches/api/0389-Add-LivingEntity-swingHand-EquipmentSlot-convenience.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#swingHand(EquipmentSlot) convenience method
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 4febec3623b936cf40daba6196392ebce4b8d5a8..c689003cbec3936a8e02829f0fdfa0e7989df6ee 100644
+index 08167783b6e4e7d393779c92500793518ee346a6..68248bf3d6c84cb6debd9ddd3c0623353bed71f0 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1054,5 +1054,23 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1056,5 +1056,23 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      @Deprecated
      void setHurtDirection(float hurtDirection);

--- a/patches/api/0390-Add-entity-knockback-API.patch
+++ b/patches/api/0390-Add-entity-knockback-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index c689003cbec3936a8e02829f0fdfa0e7989df6ee..454376eada83adc3c7c83a7b720500f998f5593d 100644
+index 68248bf3d6c84cb6debd9ddd3c0623353bed71f0..84b78742f2bac07322e8a758ca9abc6b763ccc28 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1072,5 +1072,17 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1074,5 +1074,17 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
              this.swingOffHand();
          }
      }

--- a/patches/api/0397-ItemStack-damage-API.patch
+++ b/patches/api/0397-ItemStack-damage-API.patch
@@ -8,10 +8,10 @@ to simulate damage done to an itemstack and all
 the logic associated with damaging them
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 454376eada83adc3c7c83a7b720500f998f5593d..329ca07b6e166729d33446c4cd1ae19e09b7f444 100644
+index 84b78742f2bac07322e8a758ca9abc6b763ccc28..5b0e14a7397d3de683d17ee2f1a805d289597a4b 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1084,5 +1084,52 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1086,5 +1086,52 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param directionZ The relative z position of the knockback source direction
       */
      void knockback(double strength, double directionX, double directionZ);
@@ -65,7 +65,7 @@ index 454376eada83adc3c7c83a7b720500f998f5593d..329ca07b6e166729d33446c4cd1ae19e
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 6f33145f1ccc7645616f310a68676207318c2a58..449d6e1995eedbfaeffdc5d1f1c2295378006aa8 100644
+index eac7adf622b91489711a2f8bcff77fb31292dd67..d15a74c38576c49df61cfab02c70fc5d8c0dd5f7 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -971,5 +971,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat

--- a/patches/api/0412-Add-Entity-Body-Yaw-API.patch
+++ b/patches/api/0412-Add-Entity-Body-Yaw-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Entity Body Yaw API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 3f35fc2e2311c6c568afd2ed9896584e1ebb716f..059dfc40edc6c52f95a30e9ac72f45b6aaf5f9a8 100644
+index ec5fe22b8092c8fc837e5c36e4f17053e48a77a8..ffca32ae2464ea5a669029079a50585ca259a4f8 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1131,5 +1131,21 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1133,5 +1133,21 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param amount the amount of damage to do
       */
      void damageItemStack(org.bukkit.inventory.@NotNull EquipmentSlot slot, int amount);


### PR DESCRIPTION
Correct some legacy/typo in javadoc
Most important changes is the deprecation of the setSwimming method for all entities,
the cancellation of the EntityToggleSwimEvent, ~the ocelot_baby spawn reason and
the shouldGenerateBedrock~ (beaten by upstream, again) method
These features has been either removed by spigot due to mojang changes or simply doesn't work. I'm okay to remove theses deprecation notice when theses features are re-implemented by spigot or paper ? But for now the developers should be aware of that.