### PR TITLE
Add method to get highest anger level of warden

### DIFF
--- a/patches/api/0312-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0312-Missing-Entity-Behavior-API.patch
@@ -563,6 +563,29 @@ index 627e3c1a96ae3331f5aa2dd7803dd2a31c7204be..3c447d2300c866ae605eeca97bd869f4
 +    void setLimitedLifetimeTicks(int ticks);
      // Paper end
  }
+diff --git a/src/main/java/org/bukkit/entity/Warden.java b/src/main/java/org/bukkit/entity/Warden.java
+index 25bbecc89b01faa4905def014d07a616e39df992..5cd34abcc42aa2582dee6770ff1563b1b7b0ee21 100644
+--- a/src/main/java/org/bukkit/entity/Warden.java
++++ b/src/main/java/org/bukkit/entity/Warden.java
+@@ -18,6 +18,18 @@ public interface Warden extends Monster {
+      */
+     int getAnger(@NotNull Entity entity);
+ 
++    // Paper start
++    /**
++     * Gets the highest anger level of this warden.
++     * <p>
++     * Anger is an integer from 0 to 150. Once a Warden reaches 80 anger at a
++     * target it will actively pursue it.
++     *
++     * @return highest anger level
++     */
++    int getHighestAnger();
++    // Paper end
++
+     /**
+      * Increases the anger level of this warden.
+      *
 diff --git a/src/main/java/org/bukkit/entity/Wither.java b/src/main/java/org/bukkit/entity/Wither.java
 index b86f0196e6eb8070830f63a94f732522c2a6c2f1..a1b42ae35dda2da90ba00a2d6666514f7c5b11dd 100644
 --- a/src/main/java/org/bukkit/entity/Wither.java

--- a/patches/server/0670-Missing-Entity-Behavior-API.patch
+++ b/patches/server/0670-Missing-Entity-Behavior-API.patch
@@ -556,6 +556,24 @@ index 8a0a905f6701c6e94cbbf15793788350958fb728..2a74e6ecb4f57bc6879b37f7bc067541
          }
      }
  
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java
+index 024107a70cc517224b98581389db5cbf1977a1a3..4bec74bd45e3abc0fd0f2e07ed5ad9003b6aea33 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java
+@@ -34,6 +34,13 @@ public class CraftWarden extends CraftMonster implements org.bukkit.entity.Warde
+         return this.getHandle().getAngerManagement().getActiveAnger(((CraftEntity) entity).getHandle());
+     }
+ 
++    // Paper start
++    @Override
++    public int getHighestAnger() {
++        return this.getHandle().getAngerManagement().getActiveAnger(null);
++    }
++    // Paper end
++
+     @Override
+     public void increaseAnger(Entity entity, int increase) {
+         Preconditions.checkArgument(entity != null, "Entity cannot be null");
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java
 index e92355fa2042c4cf15354a11b7058cacbe996f0d..4cf3a374c9ee7c7bcf82e778aa094eb4f8463595 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWither.java


### PR DESCRIPTION
Passing null into the vanilla method returns the anger level towards whatever entity it has the highest anger