### PR TITLE
[ci skip] Show @org.bukkit.UndefinedNullability in javadocs

### DIFF
--- a/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
@@ -183,6 +183,18 @@ index dc26cf95f1769da76dd4d768a0912c1f5346d83e..8c608f9260acd8257b49f9befae510fa
      ScoreboardManager getScoreboardManager();
  
      /**
+diff --git a/src/main/java/org/bukkit/UndefinedNullability.java b/src/main/java/org/bukkit/UndefinedNullability.java
+index f465ea001c190e10eb99db818559d302e5512e99..567f560d145dea6fc7240699175496156c468a6d 100644
+--- a/src/main/java/org/bukkit/UndefinedNullability.java
++++ b/src/main/java/org/bukkit/UndefinedNullability.java
+@@ -13,6 +13,7 @@ import java.lang.annotation.RetentionPolicy;
+  * suggests a bad API design.
+  */
+ @Retention(RetentionPolicy.CLASS)
++@java.lang.annotation.Documented // Paper
+ @Deprecated
+ public @interface UndefinedNullability {
+ 
 diff --git a/src/main/java/org/bukkit/Vibration.java b/src/main/java/org/bukkit/Vibration.java
 index 8d568d21fcbf706f55cda087bd7222ac60889c0a..209a302c3a2ed333780ed760314a6ed352fc0767 100644
 --- a/src/main/java/org/bukkit/Vibration.java


### PR DESCRIPTION
This close #8251 adding the annotation for show in javadocs like mentioned the author in the same issue.

Preview.
![image](https://user-images.githubusercontent.com/3602279/184545314-8a55a6ea-654f-4c8c-be2d-8216c7412f29.png)

Note.
looks very bad the annotation but well....