### PR TITLE
Add NamespacedKey biome methods

### DIFF
--- a/patches/api/0391-Add-NamespacedKey-biome-methods.patch
+++ b/patches/api/0391-Add-NamespacedKey-biome-methods.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Josh Roy <10731363+JRoy@users.noreply.github.com>
+Date: Sun, 14 Aug 2022 12:22:54 -0400
+Subject: [PATCH] Add NamespacedKey biome methods
+
+Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
+
+diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
+index 4fcafddf3792b66c618f91e04d102f374de565a8..88acc4d2bd56748630840dc9f1c2cb253711eb38 100644
+--- a/src/main/java/org/bukkit/UnsafeValues.java
++++ b/src/main/java/org/bukkit/UnsafeValues.java
+@@ -242,5 +242,32 @@ public interface UnsafeValues {
+      * @throws IllegalArgumentException if {@link Material#isBlock()} is false
+      */
+     boolean isCollidable(@org.jetbrains.annotations.NotNull Material material);
++
++    /**
++     * Gets the {@link NamespacedKey} for the biome at the given location.
++     *
++     * @param accessor The {@link RegionAccessor} of the provided coordinates
++     * @param x X-coordinate of the block
++     * @param y Y-coordinate of the block
++     * @param z Z-coordinate of the block
++     * @return the biome's {@link NamespacedKey}
++     */
++    @org.jetbrains.annotations.NotNull
++    NamespacedKey getBiomeKey(RegionAccessor accessor, int x, int y, int z);
++
++    /**
++     * Sets the biome at the given location to a biome registered
++     * to the given {@link NamespacedKey}. If no biome by the given
++     * {@link NamespacedKey} exists, an {@link IllegalStateException}
++     * will be thrown.
++     *
++     * @param accessor The {@link RegionAccessor} of the provided coordinates
++     * @param x X-coordinate of the block
++     * @param y Y-coordinate of the block
++     * @param z Z-coordinate of the block
++     * @param biomeKey Biome key
++     * @throws IllegalStateException if no biome by the given key is registered.
++     */
++    void setBiomeKey(RegionAccessor accessor, int x, int y, int z, NamespacedKey biomeKey);
+     // Paper end
+ }

--- a/patches/server/0934-Add-NamespacedKey-biome-methods.patch
+++ b/patches/server/0934-Add-NamespacedKey-biome-methods.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Josh Roy <10731363+JRoy@users.noreply.github.com>
+Date: Sun, 14 Aug 2022 12:23:11 -0400
+Subject: [PATCH] Add NamespacedKey biome methods
+
+Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index 0a4e9b0957c9b0abbb88d472b5b3d7946c256af2..1628913b1e9b91e68dcd942a38da4aed95b12d4a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -604,6 +604,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
+         Preconditions.checkArgument(material.isBlock(), material + " is not a block");
+         return getBlock(material).hasCollision;
+     }
++
++    @Override
++    public org.bukkit.NamespacedKey getBiomeKey(org.bukkit.RegionAccessor accessor, int x, int y, int z) {
++        org.bukkit.craftbukkit.CraftRegionAccessor cra = (org.bukkit.craftbukkit.CraftRegionAccessor) accessor;
++        return org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(cra.getHandle().registryAccess().registryOrThrow(net.minecraft.core.Registry.BIOME_REGISTRY).getKey(cra.getHandle().getBiome(new net.minecraft.core.BlockPos(x, y, z)).value()));
++    }
++
++    @Override
++    public void setBiomeKey(org.bukkit.RegionAccessor accessor, int x, int y, int z, org.bukkit.NamespacedKey biomeKey) {
++        org.bukkit.craftbukkit.CraftRegionAccessor cra = (org.bukkit.craftbukkit.CraftRegionAccessor) accessor;
++        net.minecraft.core.Holder<net.minecraft.world.level.biome.Biome> biomeBase = cra.getHandle().registryAccess().registryOrThrow(net.minecraft.core.Registry.BIOME_REGISTRY).getHolderOrThrow(net.minecraft.resources.ResourceKey.create(net.minecraft.core.Registry.BIOME_REGISTRY, org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(biomeKey)));
++        cra.setBiome(x, y, z, biomeBase);
++    }
+     // Paper end
+ 
+     /**


### PR DESCRIPTION
Methods are in UnsafeValues due to the possibility of them being removed in the future when we do more chunkgen/biome stuff, but for now this is the only way to get the underlying key for actual biomes.

Rebases and Closes #5503