### PR TITLE
Fix set profile patch issues

### DIFF
--- a/patches/api/0058-Basic-PlayerProfile-API.patch
+++ b/patches/api/0058-Basic-PlayerProfile-API.patch
@@ -321,10 +321,43 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 2ff65157d511108e2902838f37732742b186af6e..d5fd584c109c0a84a4259b10e7b43fae3a1da1ae 100644
+index 2ff65157d511108e2902838f37732742b186af6e..a452adcbf8657c501ad92f4cb361b551992f128f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2153,6 +2153,83 @@ public final class Bukkit {
+@@ -1197,8 +1197,10 @@ public final class Bukkit {
+      * @return the new PlayerProfile
+      * @throws IllegalArgumentException if both the unique id is
+      * <code>null</code> and the name is <code>null</code> or blank
++     * @deprecated use {@link #createProfile(UUID, String)}
+      */
+     @NotNull
++    @Deprecated // Paper
+     public static PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name) {
+         return server.createPlayerProfile(uniqueId, name);
+     }
+@@ -1209,8 +1211,10 @@ public final class Bukkit {
+      * @param uniqueId the unique id
+      * @return the new PlayerProfile
+      * @throws IllegalArgumentException if the unique id is <code>null</code>
++     * @deprecated use {@link #createProfile(UUID)}
+      */
+     @NotNull
++    @Deprecated // Paper
+     public static PlayerProfile createPlayerProfile(@NotNull UUID uniqueId) {
+         return server.createPlayerProfile(uniqueId);
+     }
+@@ -1222,8 +1226,10 @@ public final class Bukkit {
+      * @return the new PlayerProfile
+      * @throws IllegalArgumentException if the name is <code>null</code> or
+      * blank
++     * @deprecated use {@link #createProfile(String)}
+      */
+     @NotNull
++    @Deprecated // Paper
+     public static PlayerProfile createPlayerProfile(@NotNull String name) {
+         return server.createPlayerProfile(name);
+     }
+@@ -2153,6 +2159,83 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
@@ -409,10 +442,43 @@ index 2ff65157d511108e2902838f37732742b186af6e..d5fd584c109c0a84a4259b10e7b43fae
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d9566b18e6109db824cbc1732666771bf124adbf..fab39e4fc595c022da27e87e27bd168939e54381 100644
+index d9566b18e6109db824cbc1732666771bf124adbf..e90056341407f58ff6ce2d9b80c8f3f64464e650 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1886,5 +1886,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1015,8 +1015,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @return the new PlayerProfile
+      * @throws IllegalArgumentException if both the unique id is
+      * <code>null</code> and the name is <code>null</code> or blank
++     * @deprecated use {@link #createProfile(UUID, String)}
+      */
+     @NotNull
++    @Deprecated // Paper
+     PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name);
+ 
+     /**
+@@ -1025,8 +1027,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @param uniqueId the unique id
+      * @return the new PlayerProfile
+      * @throws IllegalArgumentException if the unique id is <code>null</code>
++     * @deprecated use {@link #createProfile(UUID)}
+      */
+     @NotNull
++    @Deprecated // Paper
+     PlayerProfile createPlayerProfile(@NotNull UUID uniqueId);
+ 
+     /**
+@@ -1036,8 +1040,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @return the new PlayerProfile
+      * @throws IllegalArgumentException if the name is <code>null</code> or
+      * blank
++     * @deprecated use {@link #createProfile(String)}
+      */
+     @NotNull
++    @Deprecated
+     PlayerProfile createPlayerProfile(@NotNull String name);
+ 
+     /**
+@@ -1886,5 +1892,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
@@ -487,11 +553,47 @@ index d9566b18e6109db824cbc1732666771bf124adbf..fab39e4fc595c022da27e87e27bd1689
 +    com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);
      // Paper end
  }
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index f9ecac9a2c45e1d428277e43f9cf1a93a53dd84f..6adfde7eebf77a4bad07b337a3cd0a0cc75f6df5 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -2277,6 +2277,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
+      */
+     boolean hasResourcePack();
++
++    /**
++     * Gets a copy of this players profile
++     * @return The players profile object
++     */
++    @NotNull
++    com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile();
+     // Paper end
+ 
+     // Spigot start
 diff --git a/src/main/java/org/bukkit/profile/PlayerProfile.java b/src/main/java/org/bukkit/profile/PlayerProfile.java
-index 16ae1282f3178e8873483a25a5d5cce16b2c21a9..fc46add38bf59dc1a04ea566fd230dcd8ae2708c 100644
+index 16ae1282f3178e8873483a25a5d5cce16b2c21a9..d36b3e3c7e53840132011add365ca2a26d799064 100644
 --- a/src/main/java/org/bukkit/profile/PlayerProfile.java
 +++ b/src/main/java/org/bukkit/profile/PlayerProfile.java
-@@ -93,7 +93,7 @@ public interface PlayerProfile extends Cloneable, ConfigurationSerializable {
+@@ -16,7 +16,9 @@ import org.jetbrains.annotations.Nullable;
+  * <p>
+  * New profiles can be created via
+  * {@link Server#createPlayerProfile(UUID, String)}.
++ * @deprecated see {@link com.destroystokyo.paper.profile.PlayerProfile}
+  */
++@Deprecated // Paper
+ public interface PlayerProfile extends Cloneable, ConfigurationSerializable {
+ 
+     /**
+@@ -25,6 +27,7 @@ public interface PlayerProfile extends Cloneable, ConfigurationSerializable {
+      * @return the player's unique id, or <code>null</code> if not available
+      */
+     @Nullable
++    @Deprecated // Paper
+     UUID getUniqueId();
+ 
+     /**
+@@ -93,7 +96,7 @@ public interface PlayerProfile extends Cloneable, ConfigurationSerializable {
       * PlayerProfile once it is available
       */
      @NotNull

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -5,124 +5,29 @@ Subject: [PATCH] Player.setPlayerProfile API
 
 This can be useful for changing name or skins after a player has logged in.
 
-diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index d5fd584c109c0a84a4259b10e7b43fae3a1da1ae..a452adcbf8657c501ad92f4cb361b551992f128f 100644
---- a/src/main/java/org/bukkit/Bukkit.java
-+++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1197,8 +1197,10 @@ public final class Bukkit {
-      * @return the new PlayerProfile
-      * @throws IllegalArgumentException if both the unique id is
-      * <code>null</code> and the name is <code>null</code> or blank
-+     * @deprecated use {@link #createProfile(UUID, String)}
-      */
-     @NotNull
-+    @Deprecated // Paper
-     public static PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name) {
-         return server.createPlayerProfile(uniqueId, name);
-     }
-@@ -1209,8 +1211,10 @@ public final class Bukkit {
-      * @param uniqueId the unique id
-      * @return the new PlayerProfile
-      * @throws IllegalArgumentException if the unique id is <code>null</code>
-+     * @deprecated use {@link #createProfile(UUID)}
-      */
-     @NotNull
-+    @Deprecated // Paper
-     public static PlayerProfile createPlayerProfile(@NotNull UUID uniqueId) {
-         return server.createPlayerProfile(uniqueId);
-     }
-@@ -1222,8 +1226,10 @@ public final class Bukkit {
-      * @return the new PlayerProfile
-      * @throws IllegalArgumentException if the name is <code>null</code> or
-      * blank
-+     * @deprecated use {@link #createProfile(String)}
-      */
-     @NotNull
-+    @Deprecated // Paper
-     public static PlayerProfile createPlayerProfile(@NotNull String name) {
-         return server.createPlayerProfile(name);
-     }
-diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index fab39e4fc595c022da27e87e27bd168939e54381..e90056341407f58ff6ce2d9b80c8f3f64464e650 100644
---- a/src/main/java/org/bukkit/Server.java
-+++ b/src/main/java/org/bukkit/Server.java
-@@ -1015,8 +1015,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
-      * @return the new PlayerProfile
-      * @throws IllegalArgumentException if both the unique id is
-      * <code>null</code> and the name is <code>null</code> or blank
-+     * @deprecated use {@link #createProfile(UUID, String)}
-      */
-     @NotNull
-+    @Deprecated // Paper
-     PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name);
- 
-     /**
-@@ -1025,8 +1027,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
-      * @param uniqueId the unique id
-      * @return the new PlayerProfile
-      * @throws IllegalArgumentException if the unique id is <code>null</code>
-+     * @deprecated use {@link #createProfile(UUID)}
-      */
-     @NotNull
-+    @Deprecated // Paper
-     PlayerProfile createPlayerProfile(@NotNull UUID uniqueId);
- 
-     /**
-@@ -1036,8 +1040,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
-      * @return the new PlayerProfile
-      * @throws IllegalArgumentException if the name is <code>null</code> or
-      * blank
-+     * @deprecated use {@link #createProfile(String)}
-      */
-     @NotNull
-+    @Deprecated
-     PlayerProfile createPlayerProfile(@NotNull String name);
- 
-     /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d3d3cfc0cf43f2b1f2d1937ef1a924b51f8cbde5..1d3387716f3e4e11155d79f62a759d8c59db84cd 100644
+index 4d3f863d5bd5330ae8868d7ec8362314b3312a80..ce7b23707453ca7f0566a98b60611d34945d33ea 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2298,6 +2298,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-      *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
+@@ -2305,6 +2305,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
-     boolean hasResourcePack();
-+
-+    /**
-+     * Gets a copy of this players profile
-+     * @return The players profile object
-+     */
-+    @NotNull
-+    com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile();
+     @NotNull
+     com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile();
 +
 +    /**
 +     * Changes the PlayerProfile for this player. This will cause this player
 +     * to be reregistered to all clients that can currently see this player
++     * <p>
++     * Note:
++     * Undefined behavior may occur when changing the player's uuid/name.
++     * For example,
++     * Setting a player profile with a different uuid will cause chat messages
++     * to appear as insecure.
++     * It will also cause the player's skin to not change on the client.
++     *
 +     * @param profile The new profile to use
 +     */
 +    void setPlayerProfile(@NotNull com.destroystokyo.paper.profile.PlayerProfile profile);
      // Paper end
  
      // Spigot start
-diff --git a/src/main/java/org/bukkit/profile/PlayerProfile.java b/src/main/java/org/bukkit/profile/PlayerProfile.java
-index fc46add38bf59dc1a04ea566fd230dcd8ae2708c..d36b3e3c7e53840132011add365ca2a26d799064 100644
---- a/src/main/java/org/bukkit/profile/PlayerProfile.java
-+++ b/src/main/java/org/bukkit/profile/PlayerProfile.java
-@@ -16,7 +16,9 @@ import org.jetbrains.annotations.Nullable;
-  * <p>
-  * New profiles can be created via
-  * {@link Server#createPlayerProfile(UUID, String)}.
-+ * @deprecated see {@link com.destroystokyo.paper.profile.PlayerProfile}
-  */
-+@Deprecated // Paper
- public interface PlayerProfile extends Cloneable, ConfigurationSerializable {
- 
-     /**
-@@ -25,6 +27,7 @@ public interface PlayerProfile extends Cloneable, ConfigurationSerializable {
-      * @return the player's unique id, or <code>null</code> if not available
-      */
-     @Nullable
-+    @Deprecated // Paper
-     UUID getUniqueId();
- 
-     /**

--- a/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ece01269623d3114da78b01aa1e3b7e859533dac..6827d0b590c4bc7117eac6e4a64606864f793f3d 100644
+index 2f6bc35817ea901a8354a2e48852337af8adefb2..f07f1878a9aa0e3aa2d530b0d90a944f97ee0991 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2468,6 +2468,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2476,6 +2476,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull com.destroystokyo.paper.profile.PlayerProfile profile);

--- a/patches/api/0195-Add-Player-Client-Options-API.patch
+++ b/patches/api/0195-Add-Player-Client-Options-API.patch
@@ -193,7 +193,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 0aa71faaa3f2afc29a518657bf1515cb70a86ed2..f870a20de42f17dd020057365901fb62afccebbe 100644
+index 453948b9a13e71f56c26fb703e4fdfd2ef5e4944..fcfcfac6238a9c187e6a2a2eebd018853e640d9c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -204,7 +204,7 @@ index 0aa71faaa3f2afc29a518657bf1515cb70a86ed2..f870a20de42f17dd020057365901fb62
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import org.bukkit.DyeColor;
-@@ -2485,6 +2486,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2493,6 +2494,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0214-Brand-support.patch
+++ b/patches/api/0214-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f870a20de42f17dd020057365901fb62afccebbe..f601bd04d6ee0d39d4554d32628912208072a017 100644
+index fcfcfac6238a9c187e6a2a2eebd018853e640d9c..3d28f51f26e0ab2564fe2accfd89c051620f9791 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2620,6 +2620,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2628,6 +2628,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0228-Player-elytra-boost-API.patch
+++ b/patches/api/0228-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f601bd04d6ee0d39d4554d32628912208072a017..0454748478428828ce8b824f90463f4b03a010bd 100644
+index 3d28f51f26e0ab2564fe2accfd89c051620f9791..c1d56def2b809b79c4b6b183b984505ae80e6a34 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2492,6 +2492,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2500,6 +2500,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull ClientOption<T> option);

--- a/patches/api/0256-Add-sendOpLevel-API.patch
+++ b/patches/api/0256-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 0454748478428828ce8b824f90463f4b03a010bd..ae009440a7b1e073f3772b1c3d91b6ae6fca0495 100644
+index c1d56def2b809b79c4b6b183b984505ae80e6a34..7fd7c0f89a7bcfb90103184dd8210b7f0eccb945 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2505,6 +2505,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2513,6 +2513,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0386-More-Teleport-API.patch
+++ b/patches/api/0386-More-Teleport-API.patch
@@ -159,10 +159,10 @@ index 8bc6876c82935988436597161fa0ec94c032174b..03b35d3ba8ba00c0fa0272450f193552
       * Teleports this entity to the given location. If this entity is riding a
       * vehicle, it will be dismounted prior to teleportation.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6ec49c213c87e9dbf7ebfbdb93f1d993a2639ac5..3fcfe8651a9c422fa9c8ff77556477f1461424cf 100644
+index e884e6d306c3fc9a6e70343a35caf6985163487e..11a3eb8ec02802ce0c7bce031cc130dea8037165 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2708,6 +2708,71 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2716,6 +2716,71 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      String getClientBrandName();
      // Paper end
  

--- a/patches/api/0388-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0388-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3fcfe8651a9c422fa9c8ff77556477f1461424cf..b607c229cfb1e95b17b6a0073380089ef5e1b675 100644
+index 11a3eb8ec02802ce0c7bce031cc130dea8037165..63565ebbfef482cb7b8ec7fb831217f907841b75 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2570,6 +2570,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2578,6 +2578,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException If the level is negative or greater than {@code 4} (i.e. not within {@code [0, 4]}).
       */
      void sendOpLevel(byte level);

--- a/patches/server/0140-Basic-PlayerProfile-API.patch
+++ b/patches/server/0140-Basic-PlayerProfile-API.patch
@@ -621,7 +621,7 @@ index 2a0cf0a8a79c09566c598197fc6f8c447d4bbd72..5e3bc0590e59770490b1c6c818d99be0
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 13a6582765c565197ef8d1013b428c45e2ac5d66..adb3c54932a90c4881e6db0ed037d033220e9a7e 100644
+index c4641b210b7d4f09ed84ad1c25d9e7b0b6b97303..90d88637b5690524d1899541abbb310d330d0e50 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -244,6 +244,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -680,6 +680,23 @@ index 13a6582765c565197ef8d1013b428c45e2ac5d66..adb3c54932a90c4881e6db0ed037d033
 +    }
      // Paper end
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index a5418b1c78e1f1eb9f552450367717fee9487193..decfd48a0c0114861177a8a8c3f19ab2da9ee177 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -202,8 +202,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+ 
+     @Override
+-    public PlayerProfile getPlayerProfile() {
+-        return new CraftPlayerProfile(this.getProfile());
++    // Paper start
++    public com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile() {
++        return new com.destroystokyo.paper.profile.CraftPlayerProfile(this).clone();
++    // Paper end
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
 index 9edc5e73819e0b55372f77c5e292eece74d837c7..9001c9dc68dc05944eb839c3354bea29249daa92 100644
 --- a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java

--- a/patches/server/0158-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/server/0158-Expose-client-protocol-version-and-virtual-host.patch
@@ -60,7 +60,7 @@ index 0000000000000000000000000000000000000000..a5a7624f1f372a26b982836cd31cff15
 +
 +}
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index c06f1e1f08c3a854031b48ecc49e35aeb0d9b628..b132a5ca649833043b81578a2439901eaf4c4ab5 100644
+index 9b96d05094c3b83f6388d479fdca8800453ccd1d..308b720a58320aab1e2616542bbdd2e2fc5869ee 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -89,6 +89,10 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -90,10 +90,10 @@ index 9016aced079108aeae09f030a672467a953ef93f..4170bda451df3db43e7d57d87d1abb81
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 198d679a0f46324b2ec483d474cff0829bbd6844..1c620dc2e798c9d4f0816753362cab8564037ca0 100644
+index decfd48a0c0114861177a8a8c3f19ab2da9ee177..3d4fda04aad6a631bcb89cc3fe71a2ea7c4b35a8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -218,6 +218,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -220,6 +220,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0168-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0168-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4ad178d99da224927b785d586bb2057ddd73ccd8..d1271b9c31502407dfeaf8eb47b73f515bf6c0fd 100644
+index 3d4fda04aad6a631bcb89cc3fe71a2ea7c4b35a8..b8d07ce7abb81a25db632fb2806749b99c3859c8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1365,7 +1365,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1367,7 +1367,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override

--- a/patches/server/0181-Player.setPlayerProfile-API.patch
+++ b/patches/server/0181-Player.setPlayerProfile-API.patch
@@ -24,30 +24,10 @@ index fa949d01da7b6c1a489d17955108f7082f959c66..c83395364edb4f2ba8515326b19c4f1a
                          playerName = gameProfile.getName();
                          uniqueId = gameProfile.getId();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 299f2a8c45462d8070312c98554dbcc05298c681..31bcabd4c6ac3aa261c439a154ba7eb0f8caa0b8 100644
+index b8d07ce7abb81a25db632fb2806749b99c3859c8..587676cf3308bf292db213112ae329554e756f13 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -75,6 +75,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
- import net.minecraft.world.inventory.AbstractContainerMenu;
- import net.minecraft.world.level.GameType;
- import net.minecraft.world.level.block.Blocks;
-+import net.minecraft.world.level.biome.BiomeManager;
- import net.minecraft.world.level.block.entity.SignBlockEntity;
- import net.minecraft.world.level.border.BorderChangeListener;
- import net.minecraft.world.level.saveddata.maps.MapDecoration;
-@@ -201,11 +202,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
-         return server.getPlayer(getUniqueId()) != null;
-     }
- 
--    @Override
--    public PlayerProfile getPlayerProfile() {
--        return new CraftPlayerProfile(this.getProfile());
--    }
--
-     @Override
-     public InetSocketAddress getAddress() {
-         if (this.getHandle().connection == null) return null;
-@@ -1498,8 +1494,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1500,8 +1500,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.hiddenEntities.put(entity.getUniqueId(), hidingPlugins);
  
          // Remove this entity from the hidden player's EntityTrackerEntry
@@ -64,7 +44,7 @@ index 299f2a8c45462d8070312c98554dbcc05298c681..31bcabd4c6ac3aa261c439a154ba7eb0
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1512,8 +1515,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1514,8 +1521,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  this.getHandle().connection.send(new ClientboundPlayerInfoPacket(ClientboundPlayerInfoPacket.Action.REMOVE_PLAYER, otherPlayer));
              }
          }
@@ -73,7 +53,7 @@ index 299f2a8c45462d8070312c98554dbcc05298c681..31bcabd4c6ac3aa261c439a154ba7eb0
      }
  
      @Override
-@@ -1550,8 +1551,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1552,8 +1557,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          this.hiddenEntities.remove(entity.getUniqueId());
  
@@ -90,46 +70,54 @@ index 299f2a8c45462d8070312c98554dbcc05298c681..31bcabd4c6ac3aa261c439a154ba7eb0
  
          if (other instanceof ServerPlayer) {
              ServerPlayer otherPlayer = (ServerPlayer) other;
-@@ -1562,9 +1570,51 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1564,10 +1576,60 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (entry != null && !entry.seenBy.contains(this.getHandle().connection)) {
              entry.updatePlayer(this.getHandle());
          }
 +    }
 +    // Paper start
-+    private void reregisterPlayer(ServerPlayer player) {
-+        if (!hiddenEntities.containsKey(player.getUUID())) {
-+            unregisterEntity(player);
-+            registerEntity(player);
-+        }
-+    }
++    @Override
 +    public void setPlayerProfile(com.destroystokyo.paper.profile.PlayerProfile profile) {
-+        ServerPlayer self = getHandle();
-+        self.gameProfile = com.destroystokyo.paper.profile.CraftPlayerProfile.asAuthlibCopy(profile);
++        ServerPlayer self = this.getHandle();
++        GameProfile gameProfile = com.destroystokyo.paper.profile.CraftPlayerProfile.asAuthlibCopy(profile);
 +        if (!self.sentListPacket) {
++            self.gameProfile = gameProfile;
 +            return;
 +        }
-+        List<ServerPlayer> players = server.getServer().getPlayerList().players;
++        List<ServerPlayer> players = this.server.getServer().getPlayerList().players;
++        // First unregister the player for all players with the OLD game profile
 +        for (ServerPlayer player : players) {
-+            player.getBukkitEntity().reregisterPlayer(self);
++            CraftPlayer bukkitPlayer = player.getBukkitEntity();
++            if (bukkitPlayer.canSee(this)) {
++                bukkitPlayer.unregisterEntity(self);
++            }
 +        }
-+        refreshPlayer();
-+    }
-+    public com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile() {
-+        return new com.destroystokyo.paper.profile.CraftPlayerProfile(this).clone();
-+    }
  
 -        server.getPluginManager().callEvent(new PlayerShowEntityEvent(this, entity));
-+    private void refreshPlayer() {
-+        ServerPlayer handle = getHandle();
++        // Set the game profile here, we should have unregistered the entity via iterating all player entities above.
++        self.gameProfile = gameProfile;
 +
-+        Location loc = getLocation();
++        // Re-register the game profile for all players
++        for (ServerPlayer player : players) {
++            CraftPlayer bukkitPlayer = player.getBukkitEntity();
++            if (bukkitPlayer.canSee(this)) {
++                bukkitPlayer.registerEntity(self);
++            }
++        }
++
++        // Refresh misc player things AFTER sending game profile
++        this.refreshPlayer();
+     }
+ 
++    private void refreshPlayer() {
++        ServerPlayer handle = this.getHandle();
++        Location loc = this.getLocation();
 +
 +        ServerGamePacketListenerImpl connection = handle.connection;
-+        reregisterPlayer(handle);
 +
 +        //Respawn the player then update their position and selected slot
 +        ServerLevel worldserver = handle.getLevel();
-+        connection.send(new net.minecraft.network.protocol.game.ClientboundRespawnPacket(worldserver.dimensionTypeId(), worldserver.dimension(), BiomeManager.obfuscateSeed(worldserver.getSeed()), handle.gameMode.getGameModeForPlayer(), handle.gameMode.getPreviousGameModeForPlayer(), worldserver.isDebug(), worldserver.isFlat(), true, this.getHandle().getLastDeathLocation()));
++        connection.send(new net.minecraft.network.protocol.game.ClientboundRespawnPacket(worldserver.dimensionTypeId(), worldserver.dimension(), net.minecraft.world.level.biome.BiomeManager.obfuscateSeed(worldserver.getSeed()), handle.gameMode.getGameModeForPlayer(), handle.gameMode.getPreviousGameModeForPlayer(), worldserver.isDebug(), worldserver.isFlat(), true, this.getHandle().getLastDeathLocation()));
 +        handle.onUpdateAbilities();
 +        connection.internalTeleport(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch(), java.util.Collections.emptySet(), false);
 +        net.minecraft.server.MinecraftServer.getServer().getPlayerList().sendAllPlayerInfo(handle);
@@ -138,8 +126,9 @@ index 299f2a8c45462d8070312c98554dbcc05298c681..31bcabd4c6ac3aa261c439a154ba7eb0
 +            this.setOp(false);
 +            this.setOp(true);
 +        }
-     }
++    }
 +    // Paper end
- 
++
      public void onEntityRemove(Entity entity) {
          this.hiddenEntities.remove(entity.getUUID());
+     }

--- a/patches/server/0186-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0186-Flag-to-disable-the-channel-limit.patch
@@ -9,10 +9,10 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 32554bad10cccec164bc36063333244344c16473..c63831b9ec29ea1589cc87fbe4615f6dfddce473 100644
+index 587676cf3308bf292db213112ae329554e756f13..a92fbdf515c3d86b69989b775c05154ea792a837 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -167,6 +167,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -166,6 +166,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper start
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
@@ -20,7 +20,7 @@ index 32554bad10cccec164bc36063333244344c16473..c63831b9ec29ea1589cc87fbe4615f6d
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1814,7 +1815,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1828,7 +1829,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0215-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0215-InventoryCloseEvent-Reason-API.patch
@@ -173,10 +173,10 @@ index 4ff81744b7c9113f57cf1fa89bb943902711b2dc..404ed5e8f54d70a50de4232c6ea0f616
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7234e96d6d956d84fbcbcb321c1fb05906da6adb..69c3602abfddc9c065736cf08c32f88029df0e5c 100644
+index a92fbdf515c3d86b69989b775c05154ea792a837..8e5dc143a0e88699548dd1fa380397f44c0a3391 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1079,7 +1079,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1085,7 +1085,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {

--- a/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f5259ada3e21b036fd3e3b96d727f1c8c4a042b8..d445ebe4b5055a270b679c353abcecf6dea3dc8c 100644
+index 8e5dc143a0e88699548dd1fa380397f44c0a3391..afc321ec7ab8f2c48da20a951cedf71b1424c5e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2510,6 +2510,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2524,6 +2524,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0255-Improve-death-events.patch
+++ b/patches/server/0255-Improve-death-events.patch
@@ -19,7 +19,7 @@ maybe more (please check patch overrides for drops for more):
 - players, armor stands, foxes, chested donkeys/llamas
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 522c8791edd87feb6cb32ef8e621ae35e53c9cb1..1b3188837069622baaba90c80fe387abfbfad10a 100644
+index 35a6dd9cfed631f66e31c71911433ec880711905..86e3405628b2e64cd59b829d77e40bb3aceb8e7b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -230,6 +230,10 @@ public class ServerPlayer extends Player {
@@ -310,10 +310,10 @@ index f94a74728bd7c02a7f8245c92e7916f0b669ee0d..cd54fa8f7bbcb6036e90f4ef7cdc01d7
          this.gameEvent(GameEvent.ENTITY_DIE);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d445ebe4b5055a270b679c353abcecf6dea3dc8c..df164a6fe8d53d34db93f4f1f2af6a9c1c98a7e8 100644
+index afc321ec7ab8f2c48da20a951cedf71b1424c5e7..26bc0aff6cb1b443a6e70ccac4e1ade11eea331c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2074,7 +2074,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2088,7 +2088,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/patches/server/0292-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0292-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -106,10 +106,10 @@ index e7442952ef1f03969949014492a7ddc6d0796ba5..d7823d7dc88cfba6f6ac9dae220e03de
      public Location getLastDeathLocation() {
          if (this.getData().contains("LastDeathLocation", 10)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0fcde65af63c4fcfbbef5875bec759b209cfd5f1..1a7f5978ad9ab1ee15f2e40e8109cf6dad5f890c 100644
+index 26bc0aff6cb1b443a6e70ccac4e1ade11eea331c..003bed5ef60cf1a794085d8e634beb6b0ea86a48 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -168,6 +168,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -167,6 +167,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
      private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
@@ -117,7 +117,7 @@ index 0fcde65af63c4fcfbbef5875bec759b209cfd5f1..1a7f5978ad9ab1ee15f2e40e8109cf6d
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1686,6 +1687,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1700,6 +1701,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 0fcde65af63c4fcfbbef5875bec759b209cfd5f1..1a7f5978ad9ab1ee15f2e40e8109cf6d
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1708,6 +1721,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1722,6 +1735,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index 0fcde65af63c4fcfbbef5875bec759b209cfd5f1..1a7f5978ad9ab1ee15f2e40e8109cf6d
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1722,6 +1737,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1736,6 +1751,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1a7f5978ad9ab1ee15f2e40e8109cf6dad5f890c..8a349c179e9abcda140546c56ea884422b409b5d 100644
+index 003bed5ef60cf1a794085d8e634beb6b0ea86a48..e82a6f67f19388bb03d8f24856d4fc300daa6d53 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2557,6 +2557,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2571,6 +2571,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0391-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0391-Implement-Player-Client-Options-API.patch
@@ -97,10 +97,10 @@ index 5e1bb276d61ed72027f94defc3f192756af5808f..2a18a60fdb71f1c665bda4a6c04a1fa1
          if (getMainArm() != packet.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8a349c179e9abcda140546c56ea884422b409b5d..71b96630dd6543d8a4d8df5165d7182fb0f35067 100644
+index e82a6f67f19388bb03d8f24856d4fc300daa6d53..092809749ef95e055324be841fd1931fa360f3cc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -574,6 +574,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -580,6 +580,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setSendViewDistance(int viewDistance) {
          throw new UnsupportedOperationException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }

--- a/patches/server/0461-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0461-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1194,10 +1194,10 @@ index b234ba968e82ddf1e8f7c84d3a17659e3beda2b3..af22fa8aa8ddef4d592564b14d0114cc
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 71b96630dd6543d8a4d8df5165d7182fb0f35067..ac232efad56fd69577de8fa4ed47cb852c9a429e 100644
+index 092809749ef95e055324be841fd1931fa360f3cc..56503b56df86e4f3a44ca17f5e2e5fb57192183f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1047,6 +1047,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1053,6 +1053,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
      }
  

--- a/patches/server/0474-Brand-support.patch
+++ b/patches/server/0474-Brand-support.patch
@@ -56,10 +56,10 @@ index 4e8977ab293816fa5dee530eea63193dcc9162b9..40487804d50798a5bfd05754fb882d82
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8db930d54ad97435e367aa670466d8a072ca0b23..1ab74f26cf47372b89b74a077fe06e48f08581a7 100644
+index 56503b56df86e4f3a44ca17f5e2e5fb57192183f..2b6b12eadf8ad8f85ff67701dd4774d3ce15913f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2691,6 +2691,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2705,6 +2705,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0511-Player-elytra-boost-API.patch
+++ b/patches/server/0511-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 03d43fdc119dc526928abf7b0f1b38d35e985ffc..fb4f868457ebf06b26ddc60f5ffc5a1d5273a1bc 100644
+index 2b6b12eadf8ad8f85ff67701dd4774d3ce15913f..7730e7490728a22111c1ba8551017734b8eb96b4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -592,6 +592,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -598,6 +598,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/patches/server/0525-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0525-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fb4f868457ebf06b26ddc60f5ffc5a1d5273a1bc..4c7d84a8f0f186dba18dba528ed324a0808605e3 100644
+index 7730e7490728a22111c1ba8551017734b8eb96b4..33153882c7183f769ba13426ad2d5185ae54ff5f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2273,7 +2273,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2287,7 +2287,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0567-Add-sendOpLevel-API.patch
+++ b/patches/server/0567-Add-sendOpLevel-API.patch
@@ -32,10 +32,10 @@ index fa90f805e87985fae1875ded3b295c4736cc7aee..39ddb080e9a296fa499ea2959e221725
  
      public boolean isWhiteListed(GameProfile profile) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4c7d84a8f0f186dba18dba528ed324a0808605e3..8024b7bcc18a9b2298864d53230d54c23b9d1166 100644
+index 33153882c7183f769ba13426ad2d5185ae54ff5f..f017a41e02b5ceb98a1e2bd9f98e937120b85774 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -606,6 +606,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -612,6 +612,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/patches/server/0642-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0642-additions-to-PlayerGameModeChangeEvent.patch
@@ -139,10 +139,10 @@ index 8dc4eac46bb7f127cb23d3994308d6ceb5dfedf5..1b6cad1fda904a1c76af508325c21c1d
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8608fbd5484498f0e478d857ea1dd548ad6a93e0..0004b78b63a2bf4b34467f9a550f6f0807e4dfb4 100644
+index f017a41e02b5ceb98a1e2bd9f98e937120b85774..400c1414e1fee581538a221a1ef92cb093e01cc3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1396,7 +1396,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1402,7 +1402,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0654-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0654-Add-PlayerKickEvent-causes.patch
@@ -391,10 +391,10 @@ index 63f92d68b91f1049802a1541c7ec4efaa324ac11..c332750833cccee1264a3399ed0539f6
          // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0004b78b63a2bf4b34467f9a550f6f0807e4dfb4..4750ac09f2abfb712b042028a95d23121ffc049f 100644
+index 400c1414e1fee581538a221a1ef92cb093e01cc3..481ea177d7d865fde18ea132e7084cb3ad2dc157 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -516,7 +516,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -522,7 +522,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          org.spigotmc.AsyncCatcher.catchOp("player kick"); // Spigot
          if (this.getHandle().connection == null) return;
  
@@ -403,7 +403,7 @@ index 0004b78b63a2bf4b34467f9a550f6f0807e4dfb4..4750ac09f2abfb712b042028a95d2312
      }
  
      // Paper start
-@@ -528,10 +528,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -534,10 +534,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void kick(final net.kyori.adventure.text.Component message) {

--- a/patches/server/0690-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0690-Add-PlayerSetSpawnEvent.patch
@@ -129,10 +129,10 @@ index c3e49a781f838e6a46cb89744f3f1846de182275..c2f3d3a09327e7cb7d3167609eb3ce68
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bf5931cbcfbfdc6e68706b7e86b24b2478e4bbef..55f4a09bc27c30936e29fa2a2fe2ef0a67b8876d 100644
+index 481ea177d7d865fde18ea132e7084cb3ad2dc157..de923814f95e6e0ca6ad0a55b1d3f8e0c0c610ff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1216,9 +1216,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1222,9 +1222,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0797-Add-player-health-update-API.patch
+++ b/patches/server/0797-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 55f4a09bc27c30936e29fa2a2fe2ef0a67b8876d..67833efdd2c4babe20a01691a44ec6f153656729 100644
+index de923814f95e6e0ca6ad0a55b1d3f8e0c0c610ff..ca63928bd5d35746f67bc3571a188450efb7088a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2152,9 +2152,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2166,9 +2166,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index 55f4a09bc27c30936e29fa2a2fe2ef0a67b8876d..67833efdd2c4babe20a01691a44ec6f1
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2162,7 +2164,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2176,7 +2178,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          // Paper end
      }

--- a/patches/server/0833-Multi-Block-Change-API-Implementation.patch
+++ b/patches/server/0833-Multi-Block-Change-API-Implementation.patch
@@ -25,7 +25,7 @@ index 82ea4fabd5732052a286d50bcff8bbcc2c4aa7d7..652bea6868a03a5315965f79c76172fb
      public void write(FriendlyByteBuf buf) {
          buf.writeLong(this.sectionPos.asLong());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 67833efdd2c4babe20a01691a44ec6f153656729..c569bf167addfedcb0d8c55b2d2cfcb52e05d0a6 100644
+index ca63928bd5d35746f67bc3571a188450efb7088a..55b63366002867988791556e2347b349081cdd00 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -29,6 +29,7 @@ import java.util.logging.Logger;
@@ -36,7 +36,7 @@ index 67833efdd2c4babe20a01691a44ec6f153656729..c569bf167addfedcb0d8c55b2d2cfcb5
  import net.minecraft.nbt.CompoundTag;
  import net.minecraft.network.FriendlyByteBuf;
  import net.minecraft.network.chat.ChatMessageContent;
-@@ -882,6 +883,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -888,6 +889,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  

--- a/patches/server/0854-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0854-Replace-player-chunk-loader-system.patch
@@ -1855,7 +1855,7 @@ index 96a232f22b1c270b91635ce9c7c6cacc63b026cc..59acbf6249f8f5285504c0ddea448a34
                  return true;
              } else {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 856ef0c487af8e8c5689d58decc9acf8d52971c9..836841987ff5dd4901f75f47028a60d8d1b6e04a 100644
+index fff5caddf19611db6c593545d13bd2f13b43556a..93988e90aad6ad670e79b7ce0a9cfa177e624607 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -677,7 +677,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -2148,10 +2148,10 @@ index 1bbc73dcdf890a9383795ffeb0d368293f7146a5..c4f7aa9ffb72d2bc555ace64bb8cedc5
      // Paper end - view distance api
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c569bf167addfedcb0d8c55b2d2cfcb52e05d0a6..2cf84abadc7fd7806566948d4c6e2212bdf2aeb7 100644
+index 55b63366002867988791556e2347b349081cdd00..1f2e86ced3f87f8fd07677ea17b70c3147363647 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -541,45 +541,80 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -547,45 +547,80 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0919-More-Teleport-API.patch
+++ b/patches/server/0919-More-Teleport-API.patch
@@ -69,10 +69,10 @@ index 2a6c67634c31c332102d24bef293da1bacd0c000..b80cc0938b2b3928f4450f1314a9fbd7
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 77339926519057b1c878761780ff2d6621f5ccb7..6f0ffd1895a9c392b643f3595e709ec3706c39b4 100644
+index 1f2e86ced3f87f8fd07677ea17b70c3147363647..939bb853770867a858ba37e9817a908d483f8a2d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1135,7 +1135,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1141,7 +1141,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setRotation(float yaw, float pitch) {
@@ -89,7 +89,7 @@ index 77339926519057b1c878761780ff2d6621f5ccb7..6f0ffd1895a9c392b643f3595e709ec3
      }
  
      // Paper start - Chunk priority
-@@ -1150,8 +1158,79 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1156,8 +1164,79 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public boolean teleport(Location location, PlayerTeleportEvent.TeleportCause cause) {
@@ -169,7 +169,7 @@ index 77339926519057b1c878761780ff2d6621f5ccb7..6f0ffd1895a9c392b643f3595e709ec3
          location.checkFinite();
  
          ServerPlayer entity = this.getHandle();
-@@ -1164,7 +1243,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1170,7 +1249,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
             return false;
          }
  
@@ -178,7 +178,7 @@ index 77339926519057b1c878761780ff2d6621f5ccb7..6f0ffd1895a9c392b643f3595e709ec3
              return false;
          }
  
-@@ -1182,7 +1261,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1188,7 +1267,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          // If this player is riding another entity, we must dismount before teleporting.
@@ -187,7 +187,7 @@ index 77339926519057b1c878761780ff2d6621f5ccb7..6f0ffd1895a9c392b643f3595e709ec3
  
          // SPIGOT-5509: Wakeup, similar to riding
          if (this.isSleeping()) {
-@@ -1204,7 +1283,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1210,7 +1289,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Check if the fromWorld and toWorld are the same.
          if (fromWorld == toWorld) {

--- a/patches/server/0924-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/server/0924-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e6411d8293c36f41b790cf17ecc507507f04d604..743b6e51817ffa1b7e602b1ac82eb1017841b691 100644
+index 939bb853770867a858ba37e9817a908d483f8a2d..7f3444ff2853ee41b89eba77b76dd6cbfe730ff7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -654,6 +654,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -660,6 +660,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          this.getHandle().getServer().getPlayerList().sendPlayerPermissionLevel(this.getHandle(), level, false);
      }


### PR DESCRIPTION
The old setPlayerProfile would cause a duplicate player to appear in tab list because the previous game profile was not removed properly. This caused it to not work at all.

This also moves a bunch of the deprecation patches to the correct patch.
However, it might be better to merge those patches together (merger plz).