### PR TITLE
Avoid potential place where the world map could be modified after its iterator is created

### DIFF
--- a/patches/server/0900-Throw-exception-on-world-create-unload-while-being-t.patch
+++ b/patches/server/0900-Throw-exception-on-world-create-unload-while-being-t.patch
@@ -1,13 +1,13 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Tue, 22 Mar 2022 12:44:30 -0700
-Subject: [PATCH] Throw exception on world create while being ticked
+Subject: [PATCH] Throw exception on world create/unload while being ticked
 
 There are no plans to support creating worlds while worlds are
-being ticked themselvess.
+being ticked themselves.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 4d920031300a9801debc2eb39a4d3cb9d8fbb330..dd9ab51e904be2f2f2a2981d4f0f6638a6895e8d 100644
+index 4d920031300a9801debc2eb39a4d3cb9d8fbb330..db3d34f0ad2baa2b8685c039a1de162c1b5ec212 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -297,6 +297,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -18,11 +18,20 @@ index 4d920031300a9801debc2eb39a4d3cb9d8fbb330..dd9ab51e904be2f2f2a2981d4f0f6638
  
      public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
          AtomicReference<S> atomicreference = new AtomicReference();
-@@ -1527,6 +1528,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1495,7 +1496,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         this.getFunctions().tick();
+         MinecraftTimings.commandFunctionsTimer.stopTiming(); // Spigot // Paper
+         this.profiler.popPush("levels");
+-        Iterator iterator = this.getAllLevels().iterator();
+ 
+         // CraftBukkit start
+         // Run tasks that are waiting on processing
+@@ -1527,6 +1527,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // Paper end
          MinecraftTimings.timeUpdateTimer.stopTiming(); // Spigot // Paper
  
 +        this.isIteratingOverLevels = true; // Paper
++        Iterator iterator = this.getAllLevels().iterator(); // Paper - move down
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper


### PR DESCRIPTION
The code in net.minecraft.server.MinecraftServer previously looked like this:
```java
public abstract class MinecraftServer ... {
    ...
    public boolean isIteratingOverLevels = false; // Paper
    ...

    public void tickChildren(BooleanSupplier shouldKeepTicking) {
        ...
        Iterator iterator = this.getAllLevels().iterator();

        // CraftBukkit start
        // Run tasks that are waiting on processing
        MinecraftTimings.processQueueTimer.startTiming(); // Spigot
        while (!this.processQueue.isEmpty()) {
            this.processQueue.remove().run();
        }
        MinecraftTimings.processQueueTimer.stopTiming(); // Spigot

        MinecraftTimings.timeUpdateTimer.startTiming(); // Spigot // Paper
        // Send time updates to everyone, it will get the right time from the world the player is in.
        // Paper start - optimize time updates
        for (final ServerLevel world : this.getAllLevels()) {
            ...
        }
        // Paper end
        MinecraftTimings.timeUpdateTimer.stopTiming(); // Spigot // Paper

        this.isIteratingOverLevels = true; // Paper
        while (iterator.hasNext()) {
            ...
        }
        this.isIteratingOverLevels = false; // Paper
        ...
    }
}
```

The flag added by Paper, `isIteratingOverLevels`, is used to prevent `CraftServer#createWorld` and `CraftServer#unloadWorld` from adding or removing from the levels map while the levels map is being iterated through. However, in between the Iterator being created and the flag being set, the process queue and time updates are processed. The time updates are probably not an issue, but the code run by the process queue could potentially try to load or unload a world. As Multiverse/Multiverse-Core#2800 discovered, this causes a crash on older versions of Paper.

With this PR, the code in net.minecraft.server.MinecraftServer now looks like this:
```java
public abstract class MinecraftServer ... {
    ...
    public boolean isIteratingOverLevels = false; // Paper
    ...

    public void tickChildren(BooleanSupplier shouldKeepTicking) {
        ...

        // CraftBukkit start
        // Run tasks that are waiting on processing
        MinecraftTimings.processQueueTimer.startTiming(); // Spigot
        while (!this.processQueue.isEmpty()) {
            this.processQueue.remove().run();
        }
        MinecraftTimings.processQueueTimer.stopTiming(); // Spigot

        MinecraftTimings.timeUpdateTimer.startTiming(); // Spigot // Paper
        // Send time updates to everyone, it will get the right time from the world the player is in.
        // Paper start - optimize time updates
        for (final ServerLevel world : this.getAllLevels()) {
            ...
        }
        // Paper end
        MinecraftTimings.timeUpdateTimer.stopTiming(); // Spigot // Paper

        this.isIteratingOverLevels = true; // Paper
        Iterator iterator = this.getAllLevels().iterator(); // Paper - move down
        while (iterator.hasNext()) {
            ...
        }
        this.isIteratingOverLevels = false; // Paper
        ...
    }
}
```
Simple fix, `Iterator iterator = this.getAllLevels().iterator();` was just moved down to after the processQueue and time updates. Now, there is no instance where the levels iterator has been created but `isIteratingOverLevels` has been set. Following a minimal diff policy, I did not replace the Iterator+while loop with an enhanced for loop.

### A note on the importance of this change:
I said earlier that the current code had the potential to crash on **old** versions of Paper. The example from Multiverse was using [Paper#91](https://papermc.io/downloads). On the current version of Paper, doing the same thing that the Multiverse user did would likely not cause a crash. This is because this problem was already "fixed" by [SPIGOT-7089](https://hub.spigotmc.org/jira/browse/SPIGOT-7089), which was resolved by making the levels map effectively copy-on-write, avoiding the ConcurrentModificationException that crashed the server. This fix has been in Paper since [Paper#126](https://papermc.io/downloads).

However, following the precedence of #8300, Paper aims to avoid the unsafe operation of unloading a world while it is being ticked for its [potential to cause crashes in the future](https://github.com/PaperMC/Paper/issues/8300#issuecomment-1219869083). Without this PR, it is possible for a world to be unloaded by a Runnable in the processQueue, then ticked after it has been unloaded. To avoid this potential problem, this PR should be included.