### PR TITLE
Only create paper.yml-README.txt when config conversion happens

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -708,7 +708,7 @@ index 0000000000000000000000000000000000000000..84785fed0d85d78c4caf8fabe35c0e89
 +        public boolean lagCompensateBlockBreaking = true;
 +        public boolean useDimensionTypeForCustomSpawners = false;
 +        public boolean strictAdvancementDimensionCheck = false;
-+        public boolean doNotCreateReadme = true;
++        public boolean doNotCreateReadme = false;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java b/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java
@@ -924,7 +924,7 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3734d9728f88957bea55d8568b3d8913784f94d9
+index 0000000000000000000000000000000000000000..0a0d492f40559d89bf52146e09cd7f34a5d83839
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 @@ -0,0 +1,437 @@
@@ -1237,10 +1237,10 @@ index 0000000000000000000000000000000000000000..3734d9728f88957bea55d8568b3d8913
 +        final Path legacy = Files.isSymbolicLink(legacyConfig) ? Files.readSymbolicLink(legacyConfig) : legacyConfig;
 +        final Path replacementFile = legacy.resolveSibling(legacyConfig.getFileName() + "-README.txt");
 +        if (Files.notExists(replacementFile)) {
-+            Path globalConfig = configDir.resolve(GLOBAL_CONFIG_FILE_NAME);
-+            if (globalConfig.toFile().exists()) {
-+                YamlConfiguration globalConfiguration = YamlConfiguration.loadConfiguration(globalConfig.toFile());
-+                if (!globalConfiguration.getBoolean("misc.do-not-create-readme")) {
++            Path globalConfigFile = configDir.resolve(GLOBAL_CONFIG_FILE_NAME);
++            if (globalConfigFile.toFile().exists()) {
++                YamlConfiguration globalConfig = YamlConfiguration.loadConfiguration(globalConfigFile.toFile());
++                if (!globalConfig.getBoolean("misc.do-not-create-readme")) {
 +                    Files.createFile(replacementFile);
 +                    Files.writeString(replacementFile, String.format(MOVED_NOTICE, configDir.toAbsolutePath()));
 +                }

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -924,10 +924,10 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0a0d492f40559d89bf52146e09cd7f34a5d83839
+index 0000000000000000000000000000000000000000..8f3426d92fd4c884080e79f523a043737c2604b4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
-@@ -0,0 +1,437 @@
+@@ -0,0 +1,434 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.base.Suppliers;
@@ -1239,11 +1239,8 @@ index 0000000000000000000000000000000000000000..0a0d492f40559d89bf52146e09cd7f34
 +        if (Files.notExists(replacementFile)) {
 +            Path globalConfigFile = configDir.resolve(GLOBAL_CONFIG_FILE_NAME);
 +            if (globalConfigFile.toFile().exists()) {
-+                YamlConfiguration globalConfig = YamlConfiguration.loadConfiguration(globalConfigFile.toFile());
-+                if (!globalConfig.getBoolean("misc.do-not-create-readme")) {
-+                    Files.createFile(replacementFile);
-+                    Files.writeString(replacementFile, String.format(MOVED_NOTICE, configDir.toAbsolutePath()));
-+                }
++                Files.createFile(replacementFile);
++                Files.writeString(replacementFile, String.format(MOVED_NOTICE, configDir.toAbsolutePath()));
 +            }
 +        }
 +        if (needsConverting(legacyConfig)) {

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -708,7 +708,6 @@ index 0000000000000000000000000000000000000000..84785fed0d85d78c4caf8fabe35c0e89
 +        public boolean lagCompensateBlockBreaking = true;
 +        public boolean useDimensionTypeForCustomSpawners = false;
 +        public boolean strictAdvancementDimensionCheck = false;
-+        public boolean doNotCreateReadme = false;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java b/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -923,10 +923,10 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8f3426d92fd4c884080e79f523a043737c2604b4
+index 0000000000000000000000000000000000000000..ed877d8199b883bdf08cd10e7c3c2001bb66a5f1
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
-@@ -0,0 +1,434 @@
+@@ -0,0 +1,429 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.base.Suppliers;
@@ -1235,13 +1235,6 @@ index 0000000000000000000000000000000000000000..8f3426d92fd4c884080e79f523a04373
 +    public static PaperConfigurations setup(final Path legacyConfig, final Path configDir, final Path worldFolder, final File spigotConfig) throws Exception {
 +        final Path legacy = Files.isSymbolicLink(legacyConfig) ? Files.readSymbolicLink(legacyConfig) : legacyConfig;
 +        final Path replacementFile = legacy.resolveSibling(legacyConfig.getFileName() + "-README.txt");
-+        if (Files.notExists(replacementFile)) {
-+            Path globalConfigFile = configDir.resolve(GLOBAL_CONFIG_FILE_NAME);
-+            if (globalConfigFile.toFile().exists()) {
-+                Files.createFile(replacementFile);
-+                Files.writeString(replacementFile, String.format(MOVED_NOTICE, configDir.toAbsolutePath()));
-+            }
-+        }
 +        if (needsConverting(legacyConfig)) {
 +            try {
 +                if (Files.exists(configDir) && !Files.isDirectory(configDir)) {
@@ -1261,6 +1254,8 @@ index 0000000000000000000000000000000000000000..8f3426d92fd4c884080e79f523a04373
 +                if (Files.isSymbolicLink(legacyConfig)) {
 +                    Files.delete(legacyConfig);
 +                }
++                Files.createFile(replacementFile);
++                Files.writeString(replacementFile, String.format(MOVED_NOTICE, configDir.toAbsolutePath()));
 +                convert(legacyConfigBackup, configDir, worldFolder, spigotConfig);
 +            } catch (final IOException ex) {
 +                throw new RuntimeException("Could not convert '" + legacyConfig.getFileName().toString() + "' to the new configuration format", ex);

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -923,10 +923,10 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ed877d8199b883bdf08cd10e7c3c2001bb66a5f1
+index 0000000000000000000000000000000000000000..18c64590b35a26a27a884494d6905989fc45af03
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
-@@ -0,0 +1,429 @@
+@@ -0,0 +1,432 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.base.Suppliers;
@@ -1234,8 +1234,8 @@ index 0000000000000000000000000000000000000000..ed877d8199b883bdf08cd10e7c3c2001
 +
 +    public static PaperConfigurations setup(final Path legacyConfig, final Path configDir, final Path worldFolder, final File spigotConfig) throws Exception {
 +        final Path legacy = Files.isSymbolicLink(legacyConfig) ? Files.readSymbolicLink(legacyConfig) : legacyConfig;
-+        final Path replacementFile = legacy.resolveSibling(legacyConfig.getFileName() + "-README.txt");
 +        if (needsConverting(legacyConfig)) {
++            final String legacyFileName = legacyConfig.getFileName().toString();
 +            try {
 +                if (Files.exists(configDir) && !Files.isDirectory(configDir)) {
 +                    throw new RuntimeException("Paper needs to create a '" + CONFIG_DIR + "' folder in the root of your server. You already have a non-directory named '" + CONFIG_DIR + "'. Please remove it and restart the server.");
@@ -1245,7 +1245,7 @@ index 0000000000000000000000000000000000000000..ed877d8199b883bdf08cd10e7c3c2001
 +                    throw new RuntimeException("Paper needs to create a '" + BACKUP_DIR + "' directory in the '" + CONFIG_DIR + "' folder. You already have a non-directory named '" + BACKUP_DIR + "'. Please remove it and restart the server.");
 +                }
 +                createDirectoriesSymlinkAware(backupDir);
-+                final String backupFileName = legacyConfig.getFileName().toString() + ".old";
++                final String backupFileName = legacyFileName + ".old";
 +                final Path legacyConfigBackup = backupDir.resolve(backupFileName);
 +                if (Files.exists(legacyConfigBackup) && !Files.isRegularFile(legacyConfigBackup)) {
 +                    throw new RuntimeException("Paper needs to create a '" + backupFileName + "' file in the '" + BACKUP_DIR + "' folder. You already have a non-file named '" + backupFileName + "'. Please remove it and restart the server.");
@@ -1254,11 +1254,14 @@ index 0000000000000000000000000000000000000000..ed877d8199b883bdf08cd10e7c3c2001
 +                if (Files.isSymbolicLink(legacyConfig)) {
 +                    Files.delete(legacyConfig);
 +                }
-+                Files.createFile(replacementFile);
-+                Files.writeString(replacementFile, String.format(MOVED_NOTICE, configDir.toAbsolutePath()));
++                final Path replacementFile = legacy.resolveSibling(legacyFileName + "-README.txt");
++                if (Files.notExists(replacementFile)) {
++                    Files.createFile(replacementFile);
++                    Files.writeString(replacementFile, String.format(MOVED_NOTICE, configDir.toAbsolutePath()));
++                }
 +                convert(legacyConfigBackup, configDir, worldFolder, spigotConfig);
 +            } catch (final IOException ex) {
-+                throw new RuntimeException("Could not convert '" + legacyConfig.getFileName().toString() + "' to the new configuration format", ex);
++                throw new RuntimeException("Could not convert '" + legacyFileName + "' to the new configuration format", ex);
 +            }
 +        }
 +        try {

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -708,6 +708,7 @@ index 0000000000000000000000000000000000000000..84785fed0d85d78c4caf8fabe35c0e89
 +        public boolean lagCompensateBlockBreaking = true;
 +        public boolean useDimensionTypeForCustomSpawners = false;
 +        public boolean strictAdvancementDimensionCheck = false;
++        public boolean doNotCreateReadme = true;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java b/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java
@@ -923,10 +924,10 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b2e961bbd33c6ecb7f049365b7aff6c5caa262ff
+index 0000000000000000000000000000000000000000..3734d9728f88957bea55d8568b3d8913784f94d9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
-@@ -0,0 +1,431 @@
+@@ -0,0 +1,437 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.base.Suppliers;
@@ -1236,8 +1237,14 @@ index 0000000000000000000000000000000000000000..b2e961bbd33c6ecb7f049365b7aff6c5
 +        final Path legacy = Files.isSymbolicLink(legacyConfig) ? Files.readSymbolicLink(legacyConfig) : legacyConfig;
 +        final Path replacementFile = legacy.resolveSibling(legacyConfig.getFileName() + "-README.txt");
 +        if (Files.notExists(replacementFile)) {
-+            Files.createFile(replacementFile);
-+            Files.writeString(replacementFile, String.format(MOVED_NOTICE, configDir.toAbsolutePath()));
++            Path globalConfig = configDir.resolve(GLOBAL_CONFIG_FILE_NAME);
++            if (globalConfig.toFile().exists()) {
++                YamlConfiguration globalConfiguration = YamlConfiguration.loadConfiguration(globalConfig.toFile());
++                if (!globalConfiguration.getBoolean("misc.do-not-create-readme")) {
++                    Files.createFile(replacementFile);
++                    Files.writeString(replacementFile, String.format(MOVED_NOTICE, configDir.toAbsolutePath()));
++                }
++            }
 +        }
 +        if (needsConverting(legacyConfig)) {
 +            try {


### PR DESCRIPTION
Currently, Paper always creates `paper.yml-README.txt` if there is no such file in main directory.  

With this PR, Paper will only generate `paper.yml-README.txt` file config file conversion happens.

If there are any other situation I should check too, let me know.

This PR may resolve #8332 (forgot to mention, thanks for remind me!)