### PR TITLE
Allow preventing BlockDestroyEvent from dropping items

### DIFF
--- a/patches/api/0170-BlockDestroyEvent.patch
+++ b/patches/api/0170-BlockDestroyEvent.patch
@@ -12,10 +12,10 @@ This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java b/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..28255dc39eab5faf324d1fe556ab12daed527ff6
+index 0000000000000000000000000000000000000000..051b2ef76a914228338fa28553ad739bd2a0278c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,99 @@
 +package com.destroystokyo.paper.event.block;
 +
 +import org.bukkit.block.Block;
@@ -41,7 +41,7 @@ index 0000000000000000000000000000000000000000..28255dc39eab5faf324d1fe556ab12da
 +    private static final HandlerList handlers = new HandlerList();
 +
 +    @NotNull private final BlockData newState;
-+    private final boolean willDrop;
++    private boolean willDrop;
 +    private boolean playEffect = true;
 +
 +    private boolean cancelled = false;
@@ -65,6 +65,13 @@ index 0000000000000000000000000000000000000000..28255dc39eab5faf324d1fe556ab12da
 +     */
 +    public boolean willDrop() {
 +        return this.willDrop;
++    }
++
++    /**
++     * @param willDrop If the server is going to drop the block in question with this destroy event
++     */
++    public void setWillDrop(boolean willDrop) {
++        this.willDrop = willDrop;
 +    }
 +
 +    /**

--- a/patches/server/0297-BlockDestroyEvent.patch
+++ b/patches/server/0297-BlockDestroyEvent.patch
@@ -11,7 +11,7 @@ floating in the air.
 This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index dc2235824853a0d7ccbff51dd26a71e97fe90ba7..a00b4c84cc27678c07d0195a90f38dc458a11862 100644
+index dc2235824853a0d7ccbff51dd26a71e97fe90ba7..ae3c10214414ad78637f537c72e3cebb29fd5420 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -29,6 +29,7 @@ import net.minecraft.nbt.CompoundTag;
@@ -22,7 +22,7 @@ index dc2235824853a0d7ccbff51dd26a71e97fe90ba7..a00b4c84cc27678c07d0195a90f38dc4
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ChunkHolder;
  import net.minecraft.server.level.ServerLevel;
-@@ -563,8 +564,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -563,8 +564,21 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              return false;
          } else {
              FluidState fluid = this.getFluidState(pos);
@@ -36,6 +36,7 @@ index dc2235824853a0d7ccbff51dd26a71e97fe90ba7..a00b4c84cc27678c07d0195a90f38dc4
 +                    return false;
 +                }
 +                playEffect = event.playEffect();
++                drop = event.willDrop();
 +            }
 +            // Paper end
  

--- a/patches/server/0315-Optimize-Captured-TileEntity-Lookup.patch
+++ b/patches/server/0315-Optimize-Captured-TileEntity-Lookup.patch
@@ -10,10 +10,10 @@ Optimize to check if the captured list even has values in it, and also to
 just do a get call since the value can never be null.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index a00b4c84cc27678c07d0195a90f38dc458a11862..dab1b7491fff4da9f606d041536adb649bfccd9a 100644
+index ae3c10214414ad78637f537c72e3cebb29fd5420..afa1e786c80b009ad865fe24fe853cc8051e39ed 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -874,9 +874,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -875,9 +875,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Nullable
      public BlockEntity getBlockEntity(BlockPos blockposition, boolean validate) {

--- a/patches/server/0361-Avoid-hopper-searches-if-there-are-no-items.patch
+++ b/patches/server/0361-Avoid-hopper-searches-if-there-are-no-items.patch
@@ -14,10 +14,10 @@ And since minecart hoppers are used _very_ rarely near we can avoid alot of sear
 Combined, this adds up a lot.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index bfbd1922d77602628e57326b3251459f45b1aed9..334fd625829c8e5e9c434b184f6d0084b2d6ccc8 100644
+index dee4c8186a35b70f90b30cc736b2e4f0d4993a50..60bd7929eadaa0d23c04f02c93bdc4a7eea55c45 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -986,7 +986,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -987,7 +987,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  }
              }
  

--- a/patches/server/0388-Improved-Watchdog-Support.patch
+++ b/patches/server/0388-Improved-Watchdog-Support.patch
@@ -299,10 +299,10 @@ index 6fefa619299d3202158490630d62c16aef71e831..7a4ade1a4190bf4fbb048919ae2be230
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 334fd625829c8e5e9c434b184f6d0084b2d6ccc8..e4c2bd0131a54495fbd1930ad046225118e33186 100644
+index 60bd7929eadaa0d23c04f02c93bdc4a7eea55c45..2fa9df5c326ab257bbaa2baa4a0dc7c4bf9db77b 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -832,6 +832,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -833,6 +833,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          try {
              tickConsumer.accept(entity);
          } catch (Throwable throwable) {

--- a/patches/server/0679-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0679-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -21,7 +21,7 @@ index 958949d972fd7b8ae61041bfe15c21d4d19d9573..384222f321f1678803d62187b76bf3de
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index c3ae2b4b5b4eb14d24f2c15a7e8ace8ebee84c1a..c293531a6913b365c3bf804d6d0bfae24378dc43 100644
+index 914d6cc2024695f3d8693f29919201d85048168f..e584cd432db36b458627de9e9b87bf33ea31c279 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -189,6 +189,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -38,7 +38,7 @@ index c3ae2b4b5b4eb14d24f2c15a7e8ace8ebee84c1a..c293531a6913b365c3bf804d6d0bfae2
      public abstract ResourceKey<LevelStem> getTypeKey();
  
      protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, Holder<DimensionType> holder, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.concurrent.Executor executor) { // Paper - Async-Anti-Xray - Pass executor
-@@ -1366,7 +1373,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1367,7 +1374,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
          for (int l1 = j; l1 <= l; ++l1) {
              for (int i2 = k; i2 <= i1; ++i2) {

--- a/patches/server/0740-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0740-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -1051,7 +1051,7 @@ index 1a3be6f0570c7c746eafa36544debe90d7629432..c0817ef8927f00e2fd3fbf3289f8041f
  
      <T extends Entity> List<T> getEntities(EntityTypeTest<Entity, T> filter, AABB box, Predicate<? super T> predicate);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index c293531a6913b365c3bf804d6d0bfae24378dc43..944519c4433710610ac5015d3d3de380d9ec39c9 100644
+index e584cd432db36b458627de9e9b87bf33ea31c279..66214419f54d20448cc2b6e7f89743fa4cfbf237 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -278,6 +278,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -1062,7 +1062,7 @@ index c293531a6913b365c3bf804d6d0bfae24378dc43..944519c4433710610ac5015d3d3de380
      }
  
      // Paper start
-@@ -988,26 +989,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -989,26 +990,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public List<Entity> getEntities(@Nullable Entity except, AABB box, Predicate<? super Entity> predicate) {
          this.getProfiler().incrementCounter("getEntities");
          List<Entity> list = Lists.newArrayList();
@@ -1090,7 +1090,7 @@ index c293531a6913b365c3bf804d6d0bfae24378dc43..944519c4433710610ac5015d3d3de380
          return list;
      }
  
-@@ -1016,27 +998,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1017,27 +999,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.getProfiler().incrementCounter("getEntities");
          List<T> list = Lists.newArrayList();
  
@@ -1133,7 +1133,7 @@ index c293531a6913b365c3bf804d6d0bfae24378dc43..944519c4433710610ac5015d3d3de380
          return list;
      }
  
-@@ -1389,4 +1366,46 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1390,4 +1367,46 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public long nextSubTickCount() {
          return (long) (this.subTickCount++);
      }

--- a/patches/server/0742-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0742-Execute-chunk-tasks-mid-tick.patch
@@ -157,10 +157,10 @@ index 848601bf0a5af305a0eef48d5870afc0fcce3af0..8fc78a0405359e6031e66e988f3ddbf9
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 944519c4433710610ac5015d3d3de380d9ec39c9..06035b728a66a63582c34c85096bada1588bfaa6 100644
+index 66214419f54d20448cc2b6e7f89743fa4cfbf237..babd6502dceba3b893bd62076b79db3e08331789 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -838,6 +838,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -839,6 +839,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  // Spigot end
              } else if (this.shouldTickBlocksAt(ChunkPos.asLong(tickingblockentity.getPos()))) {
                  tickingblockentity.tick();
@@ -172,7 +172,7 @@ index 944519c4433710610ac5015d3d3de380d9ec39c9..06035b728a66a63582c34c85096bada1
              }
          }
          this.blockEntityTickers.removeAll(toRemove);
-@@ -852,6 +857,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -853,6 +858,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public <T extends Entity> void guardEntityTick(Consumer<T> tickConsumer, T entity) {
          try {
              tickConsumer.accept(entity);

--- a/patches/server/0763-Optimise-random-block-ticking.patch
+++ b/patches/server/0763-Optimise-random-block-ticking.patch
@@ -293,10 +293,10 @@ index 1b0be28ebfd7ec2f978b5d87f6d26e4d5913fb06..ac17fd4454730db831cf9b781963062d
  
      public BlockPos getHomePos() {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 843c36a8272ea5affe0a4f3baa9e15823ad74059..67cb2f94f1f2f2b8ae82d65e19b7f173157076b9 100644
+index 08306392af562ea418df88424a385ee6cca5f152..56977a681d31f6524f81891676ae2beeeb18b4db 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1318,10 +1318,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1319,10 +1319,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public abstract RecipeManager getRecipeManager();
  
      public BlockPos getBlockRandomPos(int x, int y, int z, int l) {

--- a/patches/server/0904-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/0904-Add-Alternate-Current-redstone-implementation.patch
@@ -1980,10 +1980,10 @@ index 62ec40de8ed8acb293ef21c8d2c624060d51cfe8..98209532ad3e692d7e459640123f78bb
  
          EntityCallbacks() {}
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 160c0f37aa3aaf7598f852acf9bd444f79444c97..fee8996f35b38fd79946cdfd677763e0201eb57d 100644
+index 756c56f441b7a9afb99aa559d2786d3a6077e843..72aa8a90e3d32cdb7b01f0b9654c11a13da98739 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1499,4 +1499,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1500,4 +1500,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return ret;
      }
      // Paper end


### PR DESCRIPTION
Useful for overriding drops from blocks such as bamboo, which fire this event when their base is broken.