### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0024-Add-methods-for-working-with-arrows-stuck-in-living-.patch
+++ b/patches/api/0024-Add-methods-for-working-with-arrows-stuck-in-living-.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods for working with arrows stuck in living entities
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 5077ec367a5cba88957c6115be27742974f7deec..b41133f23d25f90fc0993499056c4eeaf003a701 100644
+index 9f876af2324ebb1f299fbebc8c66d551df7463f0..ba64745a77821ecb8626aca4c8df264c93835270 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -612,4 +612,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -620,4 +620,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @return Whether the entity is invisible
       */
      public boolean isInvisible();

--- a/patches/api/0110-Make-shield-blocking-delay-configurable.patch
+++ b/patches/api/0110-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index bfc90a3569abc717f37c064e3068c55ef323edab..588ad09a764236cf858a4e6689cf4ee5246e6f08 100644
+index 08ce9cb5a44f62dc3138c45aab947a52a24d3e37..dbe8511d97bfd6361177f66ae638af0c3be19a04 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -635,5 +635,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -643,5 +643,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param arrows Number of arrows to stick in this entity
       */
      void setArrowsStuck(int arrows);

--- a/patches/api/0117-LivingEntity-Hand-Raised-Item-Use-API.patch
+++ b/patches/api/0117-LivingEntity-Hand-Raised-Item-Use-API.patch
@@ -20,10 +20,10 @@ index bd9222b9b5e7ec1f3aebe37838775f345e868150..34c2ae10e2a230ef88a756cf2024edcd
      public ItemStack getItemInUse();
  
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 588ad09a764236cf858a4e6689cf4ee5246e6f08..1dd9f7ac1f26c253b8181519aa1873784bc54a07 100644
+index dbe8511d97bfd6361177f66ae638af0c3be19a04..06896b9690a939ade2167da1a19239df2dcdba8f 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -649,5 +649,42 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -657,5 +657,42 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param delay Delay in ticks
       */
      void setShieldBlockingDelay(int delay);

--- a/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0176-Fix-Spigot-annotation-mistakes.patch
@@ -490,10 +490,10 @@ index 5408a8c123942a56ef11597ae6cdb77e14f741e3..29bb84145be18ef9162abdfc8820f2b3
  public class PlayerShowEntityEvent extends PlayerEvent {
  
 diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
-index 4c9a64ace0d0f9f83d31ea75dabdf4666d48461a..e70e6949a9d5a5a37f0c92e139071d4060548e96 100644
+index 6cb2bf60fb970b646451c02faf71a14a80e6a56b..7cf8ffb5a29d1cf382064b3aca0353a53b89fa9e 100644
 --- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
 +++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
-@@ -515,7 +515,9 @@ public abstract class ChunkGenerator {
+@@ -514,7 +514,9 @@ public abstract class ChunkGenerator {
           * @param y the y location in the chunk from minHeight (inclusive) - maxHeight (exclusive)
           * @param z the z location in the chunk from 0-15 inclusive
           * @param material the type to set the block to
@@ -503,7 +503,7 @@ index 4c9a64ace0d0f9f83d31ea75dabdf4666d48461a..e70e6949a9d5a5a37f0c92e139071d40
          public void setBlock(int x, int y, int z, @NotNull MaterialData material);
  
          /**
-@@ -559,7 +561,9 @@ public abstract class ChunkGenerator {
+@@ -558,7 +560,9 @@ public abstract class ChunkGenerator {
           * @param yMax maximum y location (exclusive) in the chunk to set
           * @param zMax maximum z location (exclusive) in the chunk to set
           * @param material the type to set the blocks to
@@ -513,7 +513,7 @@ index 4c9a64ace0d0f9f83d31ea75dabdf4666d48461a..e70e6949a9d5a5a37f0c92e139071d40
          public void setRegion(int xMin, int yMin, int zMin, int xMax, int yMax, int zMax, @NotNull MaterialData material);
  
          /**
-@@ -600,8 +604,10 @@ public abstract class ChunkGenerator {
+@@ -599,8 +603,10 @@ public abstract class ChunkGenerator {
           * @param y the y location in the chunk from minHeight (inclusive) - maxHeight (exclusive)
           * @param z the z location in the chunk from 0-15 inclusive
           * @return the type and data of the block or the MaterialData for air if x, y or z are outside the chunk's bounds

--- a/patches/api/0188-Entity-Jump-API.patch
+++ b/patches/api/0188-Entity-Jump-API.patch
@@ -57,10 +57,10 @@ index 0000000000000000000000000000000000000000..f0067c2e953d18e1a33536980071ba3f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index f479e8c26e88520a47f7beeec753b3af9978bde1..c11de6fbaa6fce8b341ac6c4d9478c18481cc0ef 100644
+index 356e516790c4e38d8dac6a106f824787a0ee19ba..33e58114c98a75c14f576db29fe0b658fcec6e15 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -801,5 +801,25 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -809,5 +809,25 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      @NotNull
      org.bukkit.inventory.EquipmentSlot getHandRaised();

--- a/patches/api/0219-Add-playPickupItemAnimation-to-LivingEntity.patch
+++ b/patches/api/0219-Add-playPickupItemAnimation-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add playPickupItemAnimation to LivingEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index c11de6fbaa6fce8b341ac6c4d9478c18481cc0ef..37bb2f8c0eba7713793ef51a16f7ca5981e39747 100644
+index 33e58114c98a75c14f576db29fe0b658fcec6e15..5192d2472bece141b0990d48a3373a6fb4e1fea6 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -821,5 +821,28 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -829,5 +829,28 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param jumping entity jump state
       */
      void setJumping(boolean jumping);

--- a/patches/api/0235-Add-LivingEntity-clearActiveItem.patch
+++ b/patches/api/0235-Add-LivingEntity-clearActiveItem.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#clearActiveItem
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 37bb2f8c0eba7713793ef51a16f7ca5981e39747..607696debd78e143b5a1de6e90a9b6d15dc98e96 100644
+index 5192d2472bece141b0990d48a3373a6fb4e1fea6..aa1b76a0633e223fbae0897cb0690fdd7e9f4c40 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -772,6 +772,13 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -780,6 +780,13 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      @NotNull
      org.bukkit.inventory.ItemStack getActiveItem();
  

--- a/patches/api/0241-Expose-LivingEntity-hurt-direction.patch
+++ b/patches/api/0241-Expose-LivingEntity-hurt-direction.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose LivingEntity hurt direction
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 607696debd78e143b5a1de6e90a9b6d15dc98e96..087a9c54bc11d5d87aa90bf9d8e66fdac2c44457 100644
+index aa1b76a0633e223fbae0897cb0690fdd7e9f4c40..a8ccf7f0a74a8295bbb921e24eed626c15104b8c 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -851,5 +851,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -859,5 +859,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param quantity quantity of item
       */
      void playPickupItemAnimation(@NotNull Item item, int quantity);

--- a/patches/api/0312-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0312-Missing-Entity-Behavior-API.patch
@@ -564,10 +564,10 @@ index 627e3c1a96ae3331f5aa2dd7803dd2a31c7204be..3c447d2300c866ae605eeca97bd869f4
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Warden.java b/src/main/java/org/bukkit/entity/Warden.java
-index 25bbecc89b01faa4905def014d07a616e39df992..5cd34abcc42aa2582dee6770ff1563b1b7b0ee21 100644
+index 3794db8867b53f3b3735ad82fdd8765a26df2bfb..efaa45f41bc1dc8df6665c55b4e5ade343d60d4c 100644
 --- a/src/main/java/org/bukkit/entity/Warden.java
 +++ b/src/main/java/org/bukkit/entity/Warden.java
-@@ -18,6 +18,18 @@ public interface Warden extends Monster {
+@@ -30,6 +30,18 @@ public interface Warden extends Monster {
       */
      int getAnger(@NotNull Entity entity);
  

--- a/patches/api/0342-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0342-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -61,10 +61,10 @@ index 16f631fdde4b63e0ed3162486dba684697bdffa7..a7e1d81a8a5e14f556d6b462dfba7f2e
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
-index e70e6949a9d5a5a37f0c92e139071d4060548e96..ef756dcd55146af71649658eadc45b70d3ba057f 100644
+index 7cf8ffb5a29d1cf382064b3aca0353a53b89fa9e..ab972330f6219fae8d1d443b36dd9b04df22d777 100644
 --- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
 +++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
-@@ -454,6 +454,22 @@ public abstract class ChunkGenerator {
+@@ -453,6 +453,22 @@ public abstract class ChunkGenerator {
          return false;
      }
  

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -67,10 +67,10 @@ index d10ff4a52c22033e2adb2a4e7f2cee98a13ea6c5..5d8a84341ab5be52b5c37737e3f82590
      exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 96df36c550cfdb63db773ab998a212c7eacc724a..eca7833e722a876be29806c92b18b6b58aab5725 100644
+index 79cc8fc158d7fa2010581e72bb3f70fa347174a9..0b3eebd669d9d7a8876ffa8743874703dd14b6a9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -190,7 +190,7 @@ public class Main {
+@@ -192,7 +192,7 @@ public class Main {
                  }
  
                  if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
@@ -78,7 +78,7 @@ index 96df36c550cfdb63db773ab998a212c7eacc724a..eca7833e722a876be29806c92b18b6b5
 +                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -7);
+                     deadline.add(Calendar.DAY_OF_YEAR, -28);
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 index 93046379d0cefd5d3236fc59e698809acdc18f80..774556a62eb240da42e84db4502e2ed43495be17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -4168,10 +4168,10 @@ index 0000000000000000000000000000000000000000..70cc7b45e7355f6c8476a74a070f1266
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 853e7c2019f5147e9681e95a82eaef0825b6341e..a48a12a31a3d09a9373b688dcc093035f8f8a300 100644
+index 23e60283a6c99dde5fbb142da678f6569d163c97..4dd3af1416cbdad330365a19ad664079f3598c15 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -110,6 +110,11 @@ public class Main {
+@@ -114,6 +114,11 @@ public class Main {
              DedicatedServerSettings dedicatedserversettings = new DedicatedServerSettings(optionset); // CraftBukkit - CLI argument support
  
              dedicatedserversettings.forceSave();
@@ -4183,7 +4183,7 @@ index 853e7c2019f5147e9681e95a82eaef0825b6341e..a48a12a31a3d09a9373b688dcc093035
              Path path1 = Paths.get("eula.txt");
              Eula eula = new Eula(path1);
  
-@@ -133,7 +138,7 @@ public class Main {
+@@ -150,7 +155,7 @@ public class Main {
              }
  
              File file = (File) optionset.valueOf("universe"); // CraftBukkit
@@ -4193,7 +4193,7 @@ index 853e7c2019f5147e9681e95a82eaef0825b6341e..a48a12a31a3d09a9373b688dcc093035
              String s = (String) Optional.ofNullable((String) optionset.valueOf("world")).orElse(dedicatedserversettings.getProperties().levelName);
              LevelStorageSource convertable = LevelStorageSource.createDefault(file.toPath());
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 15ecb1769a0604eed348b0cd31b86ce2010cbda0..8d65c989aef5ec92873a504f5b331dfe7d8b4bff 100644
+index ec2d172cb8fb19b7d0c83b6bb948df66dce320f7..cd9f94b98f9b7072ed7ca1becd779132dfc1dd12 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -281,6 +281,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -4266,7 +4266,7 @@ index 7d965247833c91dc824e6cc56e8b0fe5f3413d1d..08ae7a96e93c0d8547f560b3f7538045
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 3f4dbd3503bc3224a2f483563af25a76cc0b68f9..1a23437b9fa17846fd28163ae930d21a6bb00138 100644
+index 0029d8e349ee0766aae3ab53fb374759b1f28e72..bbdde701a16480b0b4b29e8fb6b5b5d987db0ce3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -227,7 +227,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -4307,7 +4307,7 @@ index c1194f459414dc6ca9626ab8cec48cb48cdd926b..649df119b24dc8c390f45e9f813cf8c3
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b2a06ca1240e20693ee993928509dd50992b6f6f..3620b8a76b5c13d33ec32e4a0d7fc7fa7290f220 100644
+index 57814d847551122a4d700c397cde62d32b840950..7c3d02a8a3bac227692ad2349981bc8c6c600341 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -872,6 +872,7 @@ public final class CraftServer implements Server {
@@ -4319,10 +4319,10 @@ index b2a06ca1240e20693ee993928509dd50992b6f6f..3620b8a76b5c13d33ec32e4a0d7fc7fa
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index eca7833e722a876be29806c92b18b6b58aab5725..e8d71985f2e96574081e4f609d62a3b8bded8249 100644
+index 0b3eebd669d9d7a8876ffa8743874703dd14b6a9..d3a5641e84d5b761ebd932a79869a288e2044f4e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -129,6 +129,19 @@ public class Main {
+@@ -131,6 +131,19 @@ public class Main {
                          .defaultsTo(new File("spigot.yml"))
                          .describedAs("Yml file");
                  // Spigot End

--- a/patches/server/0009-Adventure.patch
+++ b/patches/server/0009-Adventure.patch
@@ -2048,7 +2048,7 @@ index 84564ca128d2dfc79c0b5a13b699cf6fc80bdea7..9ab4588e4e512176b881ad4c252e400f
          // CraftBukkit end
          this.chatVisibility = packet.chatVisibility();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index bc253a8140f6775d038b2b0bfa185de99b3010d8..a258c965a4a0352f9d77def6748b176f3bdab106 100644
+index a768fe68db9cf1fedc2e4a2ef7b58fd2673be078..77f169e6d2d9899316c6a38dd7ef8de24d9b6414 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -188,6 +188,8 @@ import org.apache.commons.lang3.StringUtils;
@@ -2198,7 +2198,7 @@ index bc253a8140f6775d038b2b0bfa185de99b3010d8..a258c965a4a0352f9d77def6748b176f
          }, this.server);
          return completablefuture;
      }
-@@ -3092,30 +3110,30 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3086,30 +3104,30 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  return;
              }
  
@@ -2722,7 +2722,7 @@ index 6d9469d577dcbb9d5b5b703cf47c8863e0b43b13..9a6820b10e4164cc38d269853b5c2a49
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index e8d71985f2e96574081e4f609d62a3b8bded8249..681b58e6de48cccac82c7b6833f6fcea46d83dde 100644
+index d3a5641e84d5b761ebd932a79869a288e2044f4e..ef0d91e72e4ffb829b976da44a5cfe4eedc8703a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -19,6 +19,12 @@ public class Main {

--- a/patches/server/0019-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0019-Asynchronous-chunk-IO-and-loading.patch
@@ -2266,10 +2266,10 @@ index a5e438a834826161c52ca9db57d234d9ff80a591..b8bc1b9b8e8a33df90a963f9f9769292
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index a48a12a31a3d09a9373b688dcc093035f8f8a300..0c59ca1a22449893adcfa851198f057ce69bb7e3 100644
+index 4dd3af1416cbdad330365a19ad664079f3598c15..45db9f1b1d19319e7f92bd4e61be9ea9b06dd5e5 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -245,6 +245,7 @@ public class Main {
+@@ -262,6 +262,7 @@ public class Main {
  
              convertable_conversionsession.saveDataTag(iregistrycustom_dimension, savedata);
              */
@@ -2767,7 +2767,7 @@ index dfa08dbf025ed702a864280a540e0169b9f33cbd..10fa6cec911950f72407ae7f45c8cf48
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index cdc24defe649644ceade1c6cfcfe20c29ca936c1..5072d4dc1f7f77c61e3cc72c1101cb95f6596ce7 100644
+index 79c6ab332f0cc7e48dc3d84d936c9e964db19611..ca7fe80e0af3502aad492519ad19dade70f8bbe0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -784,6 +784,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic

--- a/patches/server/0021-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0021-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -66,10 +66,10 @@ index eb5c7e15366ee5902d8c754a1e9daec50d26fb17..37fefdf0d96cd2b6e23b6e69ee5a8db1
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 681b58e6de48cccac82c7b6833f6fcea46d83dde..f64a690ed3173f78ed60b0262c0c868d97a803d5 100644
+index ef0d91e72e4ffb829b976da44a5cfe4eedc8703a..0572703c3820d7febeb9da9e0636044209138078 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -147,6 +147,12 @@ public class Main {
+@@ -149,6 +149,12 @@ public class Main {
                          .ofType(File.class)
                          .defaultsTo(new File("paper.yml"))
                          .describedAs("Yml file");

--- a/patches/server/0029-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0029-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -32,11 +32,11 @@ index 37fefdf0d96cd2b6e23b6e69ee5a8db16f0e51da..fc22de3e1bb4e01fc2c43ffd9ecd0a8c
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index f64a690ed3173f78ed60b0262c0c868d97a803d5..ce104a63cd56f3343a0f58b0d7bcd47d885beb7f 100644
+index 0572703c3820d7febeb9da9e0636044209138078..43b8af609fb89cfe23fcab3f741f6dca41888b69 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -221,12 +221,25 @@ public class Main {
-                     deadline.add(Calendar.DAY_OF_YEAR, -7);
+@@ -223,12 +223,25 @@ public class Main {
+                     deadline.add(Calendar.DAY_OF_YEAR, -28);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");
 -                        System.err.println("*** Please download a new build as per instructions from https://www.spigotmc.org/go/outdated-spigot ***");

--- a/patches/server/0067-Add-methods-for-working-with-arrows-stuck-in-living-.patch
+++ b/patches/server/0067-Add-methods-for-working-with-arrows-stuck-in-living-.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods for working with arrows stuck in living entities
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 1d3cd79634366718cd354cd2f55c6fc974ad3525..b65d44780c7e6e1e2e8724df838d1aa54edcc30a 100644
+index 13906f0dfd7169b2110c83b7cb51c4979668cb13..652f0e3429efba1326f0e4cae7096a6cfe4b2c85 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -717,4 +717,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -722,4 +722,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().persistentInvisibility = invisible;
          this.getHandle().setSharedFlag(5, invisible);
      }

--- a/patches/server/0087-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0087-Add-PlayerUseUnknownEntityEvent.patch
@@ -20,10 +20,10 @@ index 8834ed411a7db86b4d2b88183a1315317107d719..c45b5ab6776f3ac79f856c3a6467c510
      static final ServerboundInteractPacket.Action ATTACK_ACTION = new ServerboundInteractPacket.Action() {
          @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e4f1b7fca8046df11f7e212c316385f82ce45322..1161ed7ba2a32a42fb092f3f76af0bba958c44ae 100644
+index 6c0eac7f4fbf57ae1a777de651ef93f577dc9c3a..972f31be7c91aaaa3e959527ca28c706b9ab3028 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2642,8 +2642,37 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2636,8 +2636,37 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  });
              }
          }

--- a/patches/server/0105-Add-server-name-parameter.patch
+++ b/patches/server/0105-Add-server-name-parameter.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add server-name parameter
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index ce104a63cd56f3343a0f58b0d7bcd47d885beb7f..04e7295ab4ec7e417ebb272f5f1b26721dfbb476 100644
+index 43b8af609fb89cfe23fcab3f741f6dca41888b69..d5f3b44f950ffba5b2680bd2ca5826aae3df2aca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -154,6 +154,14 @@ public class Main {
+@@ -156,6 +156,14 @@ public class Main {
                          .defaultsTo(new File[] {})
                          .describedAs("Jar file");
                  // Paper end

--- a/patches/server/0127-Properly-fix-item-duplication-bug.patch
+++ b/patches/server/0127-Properly-fix-item-duplication-bug.patch
@@ -19,10 +19,10 @@ index 4d8dfe375f5b3b9e5cfc12a6af0b87ae78f9b764..5d214b7dd4f6d7feff0a1904ce6573cf
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c8f9223f750ec0825c45288d52df149f94748d5d..98f168c72ae9c7636ab07a14daf8b7afb1b3feec 100644
+index bfbd6a23a39cf96371ebabbe4a79036acfd3f4b2..846ca6e4437cc827584459511c3e119b35f9ba72 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3281,7 +3281,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3275,7 +3275,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      }
  
      public final boolean isDisconnected() {

--- a/patches/server/0139-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0139-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 98f168c72ae9c7636ab07a14daf8b7afb1b3feec..f3360ebf43d973606682fe85bc3240a84a0f0123 100644
+index 846ca6e4437cc827584459511c3e119b35f9ba72..db2db8156338eae296f085a60a91a29fe02ab050 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2462,6 +2462,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2456,6 +2456,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          switch (packet.getAction()) {
              case PRESS_SHIFT_KEY:
                  this.player.setShiftKeyDown(true);

--- a/patches/server/0141-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0141-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -262,7 +262,7 @@ index 6109763453327f49a15c677a3af8f2de959b58cc..8da0beff6a7937130ecd99dd46880da0
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 04e7295ab4ec7e417ebb272f5f1b26721dfbb476..a2fda01d1995c655ae562436b49a1be90129e7bb 100644
+index d5f3b44f950ffba5b2680bd2ca5826aae3df2aca..773fe0f425053a450c7b14faf016a35f1d0d266f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,7 +12,7 @@ import java.util.logging.Level;
@@ -274,7 +274,7 @@ index 04e7295ab4ec7e417ebb272f5f1b26721dfbb476..a2fda01d1995c655ae562436b49a1be9
  
  public class Main {
      public static boolean useJline = true;
-@@ -200,6 +200,8 @@ public class Main {
+@@ -202,6 +202,8 @@ public class Main {
              }
  
              try {
@@ -283,7 +283,7 @@ index 04e7295ab4ec7e417ebb272f5f1b26721dfbb476..a2fda01d1995c655ae562436b49a1be9
                  // This trick bypasses Maven Shade's clever rewriting of our getProperty call when using String literals
                  String jline_UnsupportedTerminal = new String(new char[]{'j', 'l', 'i', 'n', 'e', '.', 'U', 'n', 's', 'u', 'p', 'p', 'o', 'r', 't', 'e', 'd', 'T', 'e', 'r', 'm', 'i', 'n', 'a', 'l'});
                  String jline_terminal = new String(new char[]{'j', 'l', 'i', 'n', 'e', '.', 't', 'e', 'r', 'm', 'i', 'n', 'a', 'l'});
-@@ -217,9 +219,18 @@ public class Main {
+@@ -219,9 +221,18 @@ public class Main {
                      // This ensures the terminal literal will always match the jline implementation
                      System.setProperty(jline.TerminalFactory.JLINE_TERMINAL, jline.UnsupportedTerminal.class.getName());
                  }
@@ -302,7 +302,7 @@ index 04e7295ab4ec7e417ebb272f5f1b26721dfbb476..a2fda01d1995c655ae562436b49a1be9
                  }
  
                  if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
-@@ -247,7 +258,7 @@ public class Main {
+@@ -249,7 +260,7 @@ public class Main {
                      System.out.println("Unable to read system info");
                  }
                  // Paper end

--- a/patches/server/0148-Basic-PlayerProfile-API.patch
+++ b/patches/server/0148-Basic-PlayerProfile-API.patch
@@ -555,7 +555,7 @@ index 0000000000000000000000000000000000000000..7ac27392a8647ef7d0dc78efe78703e9
 +    @NotNull GameProfile buildGameProfile();
 +}
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 3023bf9d1e7ead3afedc7f72a85ee65f6cf2016c..98cd851cdc67ecd9296ec5a8e56141638e108109 100644
+index 5eb6ce20ee17d87db0f6c2dcee96d6d0891d6c50..3e8867c317f7018780f44b62d0bd40fc9fa9ce9f 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -1,5 +1,7 @@
@@ -586,10 +586,10 @@ index 3023bf9d1e7ead3afedc7f72a85ee65f6cf2016c..98cd851cdc67ecd9296ec5a8e5614163
       * Calculates distance between 2 entities
       * @param e1
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 0c59ca1a22449893adcfa851198f057ce69bb7e3..8fda43173012ed3134ed1f114143ceaad66cae4a 100644
+index 45db9f1b1d19319e7f92bd4e61be9ea9b06dd5e5..151b13e257c09fc5c4bbccfc388b15ad76133909 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -138,7 +138,7 @@ public class Main {
+@@ -155,7 +155,7 @@ public class Main {
              }
  
              File file = (File) optionset.valueOf("universe"); // CraftBukkit

--- a/patches/server/0157-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0157-Fix-this-stupid-bullshit.patch
@@ -31,12 +31,12 @@ index e359919de57f97d18667df1b2f1bf54a19a49c2f..c5822637e48fad4ca4e8cf210431b5ea
              Bootstrap.isBootstrapped = true;
              if (Registry.REGISTRY.keySet().isEmpty()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index a2fda01d1995c655ae562436b49a1be90129e7bb..2febe4c031cbd03a9d61dae64fbfa9312e5b752c 100644
+index 773fe0f425053a450c7b14faf016a35f1d0d266f..fdbb6ab345833d8163b7d365d03b641d8a09d008 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -239,10 +239,12 @@ public class Main {
+@@ -241,10 +241,12 @@ public class Main {
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -7);
+                     deadline.add(Calendar.DAY_OF_YEAR, -28);
                      if (buildDate.before(deadline.getTime())) {
 -                        System.err.println("*** Error, this build is outdated ***");
 +                        // Paper start - This is some stupid bullshit

--- a/patches/server/0165-handle-ServerboundKeepAlivePacket-async.patch
+++ b/patches/server/0165-handle-ServerboundKeepAlivePacket-async.patch
@@ -15,10 +15,10 @@ also adding some additional logging in order to help work out what is causing
 random disconnections for clients.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b44fd3e73d2d15736ac2bbcc7d99ae44c7459d4b..c6330fa43f205c28f3a494269933482c14f75afb 100644
+index fddef0ba2ff963a242e457c4888dc801d1ea6920..95c0f5e429a0dd5075264d91c80f0016e7d330c5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3240,14 +3240,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3234,14 +3234,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      @Override
      public void handleKeepAlive(ServerboundKeepAlivePacket packet) {

--- a/patches/server/0197-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
+++ b/patches/server/0197-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix exploit that allowed colored signs to be created
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9d66ce602f2c71107659774d5a8a1e19071de214..9b7e1b11c499fe78869487e2ba056043e1e10fff 100644
+index 40a289c81bffc679d7c77052d4dbea25832d0acf..1dd0c9629d16bfaaebec61cbadf720d14902069d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3254,9 +3254,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3248,9 +3248,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  FilteredText filteredtext = (FilteredText) signText.get(i);
  
                  if (this.player.isTextFilteringEnabled()) {

--- a/patches/server/0214-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0214-Make-shield-blocking-delay-configurable.patch
@@ -35,10 +35,10 @@ index 18d29125c19db2ffc3550a843ee9c3974b619f89..6e1484555eeceacf5a082ad16f1e7539
          return this.isShiftKeyDown();
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 6455a81fea0de79173419587171b5ed025c30592..bbb7d6bcdc280236a583056cf9ccfc7b8de37706 100644
+index 0bb285e50d7e327ad811d2d41a241928c5246774..268bbe892a70a829733bea8bf2a8b0f14ac70ad5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -739,5 +739,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -744,5 +744,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void setArrowsStuck(int arrows) {
          getHandle().setArrowCount(arrows);
      }

--- a/patches/server/0219-LivingEntity-Hand-Raised-Item-Use-API.patch
+++ b/patches/server/0219-LivingEntity-Hand-Raised-Item-Use-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] LivingEntity Hand Raised/Item Use API
 How long an entity has raised hands to charge an attack or use an item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index bbb7d6bcdc280236a583056cf9ccfc7b8de37706..5c517025576461b426b4a73eea4369f00aeeee41 100644
+index 268bbe892a70a829733bea8bf2a8b0f14ac70ad5..4d4d42fa1bb813b7f977770bfb93e4bc5ba8c2db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -749,5 +749,30 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -754,5 +754,30 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void setShieldBlockingDelay(int delay) {
          getHandle().setShieldBlockingDelay(delay);
      }

--- a/patches/server/0223-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0223-InventoryCloseEvent-Reason-API.patch
@@ -75,7 +75,7 @@ index a214916ff80885af262165d5936b8bdf2056cbed..4b9af6ef008a297438bfc583025d235d
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9b7e1b11c499fe78869487e2ba056043e1e10fff..68d46505791e0c29b22fa266c70c996b0f10713c 100644
+index 1dd0c9629d16bfaaebec61cbadf720d14902069d..1e6f3ea047c7cf94ee420c8c4eb3fe2f31d9b374 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -219,6 +219,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -86,7 +86,7 @@ index 9b7e1b11c499fe78869487e2ba056043e1e10fff..68d46505791e0c29b22fa266c70c996b
  import org.bukkit.event.inventory.InventoryCreativeEvent;
  import org.bukkit.event.inventory.InventoryType.SlotType;
  import org.bukkit.event.inventory.SmithItemEvent;
-@@ -2780,10 +2781,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2774,10 +2775,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      @Override
      public void handleContainerClose(ServerboundContainerClosePacket packet) {

--- a/patches/server/0225-Refresh-player-inventory-when-cancelling-PlayerInter.patch
+++ b/patches/server/0225-Refresh-player-inventory-when-cancelling-PlayerInter.patch
@@ -16,10 +16,10 @@ Refresh the player inventory when PlayerInteractEntityEvent is
 cancelled to avoid this problem.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 68d46505791e0c29b22fa266c70c996b0f10713c..38d9abe5f34c17b66c8eaf40fac87fc16786f095 100644
+index 1e6f3ea047c7cf94ee420c8c4eb3fe2f31d9b374..60b29af5e48bed0b1d3749de8313e07b9d82e623 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2665,6 +2665,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2659,6 +2659,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                          }
  
                          if (event.isCancelled()) {

--- a/patches/server/0306-Limit-Client-Sign-length-more.patch
+++ b/patches/server/0306-Limit-Client-Sign-length-more.patch
@@ -22,7 +22,7 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1454d5c070bb004d75523d69eaa3d0d382944198..db3b208e560ae2c8a59bfb474f7b2266d108068f 100644
+index c45910b192bcc6171a2ae98a525fdc7008c2185f..74d77d3dd5a7f05242d2105c8cfbe10b1a054a1f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -296,6 +296,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -33,7 +33,7 @@ index 1454d5c070bb004d75523d69eaa3d0d382944198..db3b208e560ae2c8a59bfb474f7b2266
  
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
          this.lastChatTimeStamp = new AtomicReference(Instant.EPOCH);
-@@ -3294,7 +3295,19 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3288,7 +3289,19 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      @Override
      public void handleSignUpdate(ServerboundSignUpdatePacket packet) {

--- a/patches/server/0313-Update-entity-Metadata-for-all-tracked-players.patch
+++ b/patches/server/0313-Update-entity-Metadata-for-all-tracked-players.patch
@@ -22,10 +22,10 @@ index d6f34adbdf45bbef4a39e629dd7cb6d7fcb5db0f..7881176a900daa3306c691454f688c1f
          this.broadcast.accept(packet);
          if (this.entity instanceof ServerPlayer) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index db3b208e560ae2c8a59bfb474f7b2266d108068f..75cd936e28c3c933c53513093634a9d071a7f94b 100644
+index 74d77d3dd5a7f05242d2105c8cfbe10b1a054a1f..a93297667485c27721b3ef45042ea0d2466d0a61 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2730,7 +2730,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2724,7 +2724,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
                          if (event.isCancelled() || ServerGamePacketListenerImpl.this.player.getInventory().getSelected() == null || ServerGamePacketListenerImpl.this.player.getInventory().getSelected().getItem() != origItem) {
                              // Refresh the current entity metadata

--- a/patches/server/0336-Dont-send-unnecessary-sign-update.patch
+++ b/patches/server/0336-Dont-send-unnecessary-sign-update.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Dont send unnecessary sign update
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0b31a2e2d3bde184c9e1ef9d4ff08e94da0a6960..9d3a88ed093c5eda7a11133ebc97226c544fbd18 100644
+index 133d76c6a011d4c3f7ad037e535e8faa27f89874..ccd3ed84db4be3ee7b5d34de59a727c0c0ea677e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3339,6 +3339,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3333,6 +3333,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
              if (!tileentitysign.isEditable() || !this.player.getUUID().equals(tileentitysign.getPlayerWhoMayEdit())) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Player {} just tried to change non-editable sign", this.player.getName().getString());

--- a/patches/server/0357-Anti-Xray.patch
+++ b/patches/server/0357-Anti-Xray.patch
@@ -1529,7 +1529,7 @@ index 864e591b10360b0f12fe5c5a650da372555ebd10..f26a08f81495dde6205b34254d159b04
      // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index cf48c93d89da53e0ec771e5c2c8582e30b35e3f5..518dfbb7dbd4221937636cf46d27109de6f431a4 100644
+index dfdcc01c7cb2864d9b5f572c0cafedf16063edd8..d9c2e7e18e1ede37d92cecb8ddb32dae1472bd1c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 @@ -54,7 +54,7 @@ public class CraftChunk implements Chunk {
@@ -1541,15 +1541,6 @@ index cf48c93d89da53e0ec771e5c2c8582e30b35e3f5..518dfbb7dbd4221937636cf46d27109d
      private static final byte[] emptyLight = new byte[2048];
  
      public CraftChunk(net.minecraft.world.level.chunk.LevelChunk chunk) {
-@@ -392,7 +392,7 @@ public class CraftChunk implements Chunk {
-             empty[i] = true;
- 
-             if (biome != null) {
--                biome[i] = new PalettedContainer<>(iregistry.asHolderIdMap(), iregistry.getHolderOrThrow(Biomes.PLAINS), PalettedContainer.Strategy.SECTION_BIOMES);
-+                biome[i] = new PalettedContainer<>(iregistry.asHolderIdMap(), iregistry.getHolderOrThrow(Biomes.PLAINS), PalettedContainer.Strategy.SECTION_BIOMES, null); // Paper - Anti-Xray - Add preset biomes
-             }
-         }
- 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 index e8c11b59dc50fd9c5bbf073b66d0cd9c504d7c25..8cc2a35486e8c6433e722ddc5e776c3332e7c7fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java

--- a/patches/server/0366-Remove-garbage-Java-version-check.patch
+++ b/patches/server/0366-Remove-garbage-Java-version-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove garbage Java version check
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 2febe4c031cbd03a9d61dae64fbfa9312e5b752c..3472114c373d7b884d8ae24906e30daa039d0742 100644
+index fdbb6ab345833d8163b7d365d03b641d8a09d008..08e74f41516a545a2371a7418d995ab288831834 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -194,10 +194,6 @@ public class Main {
+@@ -196,10 +196,6 @@ public class Main {
                  System.err.println("Unsupported Java detected (" + javaVersion + "). This version of Minecraft requires at least Java 17. Check your Java version with the command 'java -version'.");
                  return;
              }

--- a/patches/server/0368-Entity-Jump-API.patch
+++ b/patches/server/0368-Entity-Jump-API.patch
@@ -48,10 +48,10 @@ index f747aa85beab98fbecdbe15b188be6614478bac6..a0eee7dc73bd4a96d9a1aa9555093820
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index fb0e0c629d16bc97efc3e91f7ba6fe9e87fc950b..be1540b0a5f95f8a85f91d5fe398cd2cf8832ec4 100644
+index ebebbd2536b9641b5b01d0e3fc060f89861eecdb..9887c98e3bc1c940f787328bfa2f6fcc22cbce1f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -824,5 +824,19 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -829,5 +829,19 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public org.bukkit.inventory.EquipmentSlot getHandRaised() {
          return getHandle().getUsedItemHand() == net.minecraft.world.InteractionHand.MAIN_HAND ? org.bukkit.inventory.EquipmentSlot.HAND : org.bukkit.inventory.EquipmentSlot.OFF_HAND;
      }

--- a/patches/server/0389-Improved-Watchdog-Support.patch
+++ b/patches/server/0389-Improved-Watchdog-Support.patch
@@ -343,7 +343,7 @@ index a35501ea43bf3589b346b1e684c318b44ca57977..4016b31bd020e00c0e79328646f9b541
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 3472114c373d7b884d8ae24906e30daa039d0742..987bc4577190d827718b5144656aaddf22599cab 100644
+index 08e74f41516a545a2371a7418d995ab288831834..cce6886bb3973eed8f0c7ca7b1189547324fd4e2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,6 +12,8 @@ import java.util.logging.Level;
@@ -355,7 +355,7 @@ index 3472114c373d7b884d8ae24906e30daa039d0742..987bc4577190d827718b5144656aaddf
  import net.minecrell.terminalconsole.TerminalConsoleAppender; // Paper
  
  public class Main {
-@@ -167,6 +169,36 @@ public class Main {
+@@ -169,6 +171,36 @@ public class Main {
  
          OptionSet options = null;
  
@@ -392,7 +392,7 @@ index 3472114c373d7b884d8ae24906e30daa039d0742..987bc4577190d827718b5144656aaddf
          try {
              options = parser.parse(args);
          } catch (joptsimple.OptionException ex) {
-@@ -262,8 +294,64 @@ public class Main {
+@@ -264,8 +296,64 @@ public class Main {
              } catch (Throwable t) {
                  t.printStackTrace();
              }

--- a/patches/server/0441-Add-and-implement-PlayerRecipeBookClickEvent.patch
+++ b/patches/server/0441-Add-and-implement-PlayerRecipeBookClickEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add and implement PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0885f265cadb1ebc1f6bdfcd2a39502b0617f185..2da61f9cc0f930538348bc185063c3d7dfeeb3b2 100644
+index fd2358003a400ec5229721c22160d9c80ad67858..b00c66e68cb457ddedcde2ed7b0be791ffd78718 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3230,9 +3230,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3224,9 +3224,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              if (!this.player.containerMenu.stillValid(this.player)) {
                  ServerGamePacketListenerImpl.LOGGER.debug("Player {} interacted with invalid menu {}", this.player, this.player.containerMenu);
              } else {

--- a/patches/server/0445-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0445-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -89,10 +89,10 @@ index 29a03760f092a004a47e75120841d80e696b6c3d..be7d2275548936beade4aba02dc5b14f
  
                  playerlist.sendPlayerPermissionLevel(this);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 02635061fe59156a1c94ad3bf05d2fc534a8cf29..487003209da9fce5c365be041a7b9643404bce8e 100644
+index 2cce979398f1e15811356941f89d15ca4463ebd5..d7118172a9f587716f24cd2aa5deb1566bef2daf 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3500,7 +3500,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3494,7 +3494,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      public void handleChangeDifficulty(ServerboundChangeDifficultyPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
          if (this.player.hasPermissions(2) || this.isSingleplayerOwner()) {

--- a/patches/server/0470-Fix-SPIGOT-5824-Bukkit-world-container-is-not-used.patch
+++ b/patches/server/0470-Fix-SPIGOT-5824-Bukkit-world-container-is-not-used.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SPIGOT-5824 Bukkit world-container is not used
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 8fda43173012ed3134ed1f114143ceaad66cae4a..3e1b589031d46126bdd6b6f63d7a133304fb9574 100644
+index 151b13e257c09fc5c4bbccfc388b15ad76133909..3f7dde4fe1fdce3638d1db5e96a546b9fae90269 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -137,8 +137,17 @@ public class Main {
+@@ -154,8 +154,17 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0471-Fix-SPIGOT-5885-Unable-to-disable-advancements.patch
+++ b/patches/server/0471-Fix-SPIGOT-5885-Unable-to-disable-advancements.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SPIGOT-5885 Unable to disable advancements
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 3e1b589031d46126bdd6b6f63d7a133304fb9574..8bbc3a1e7f848047ff915d5bdf08d376e71c4025 100644
+index 3f7dde4fe1fdce3638d1db5e96a546b9fae90269..13ef3bb2b84fac9a1be72b09e7e3c022fa08221a 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -137,6 +137,7 @@ public class Main {
+@@ -154,6 +154,7 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0477-Brand-support.patch
+++ b/patches/server/0477-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 487003209da9fce5c365be041a7b9643404bce8e..ecd3d2cb0a4da4360c420f8c733a5898c54ba72e 100644
+index d7118172a9f587716f24cd2aa5deb1566bef2daf..c4b36f8eab6f73bccfe92a5d4b66ef44306a5e36 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -298,6 +298,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -17,7 +17,7 @@ index 487003209da9fce5c365be041a7b9643404bce8e..ecd3d2cb0a4da4360c420f8c733a5898
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
          this.lastChatTimeStamp = new AtomicReference(Instant.EPOCH);
          this.lastSeenMessagesValidator = new LastSeenMessagesValidator();
-@@ -3455,6 +3457,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3449,6 +3451,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      private static final ResourceLocation CUSTOM_REGISTER = new ResourceLocation("register");
      private static final ResourceLocation CUSTOM_UNREGISTER = new ResourceLocation("unregister");
  
@@ -26,7 +26,7 @@ index 487003209da9fce5c365be041a7b9643404bce8e..ecd3d2cb0a4da4360c420f8c733a5898
      @Override
      public void handleCustomPayload(ServerboundCustomPayloadPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
-@@ -3482,6 +3486,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3476,6 +3480,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              try {
                  byte[] data = new byte[packet.data.readableBytes()];
                  packet.data.readBytes(data);
@@ -42,7 +42,7 @@ index 487003209da9fce5c365be041a7b9643404bce8e..ecd3d2cb0a4da4360c420f8c733a5898
                  this.cserver.getMessenger().dispatchIncomingMessage(this.player.getBukkitEntity(), packet.identifier.toString(), data);
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
-@@ -3491,6 +3504,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3485,6 +3498,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      }
  

--- a/patches/server/0479-Add-playPickupItemAnimation-to-LivingEntity.patch
+++ b/patches/server/0479-Add-playPickupItemAnimation-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add playPickupItemAnimation to LivingEntity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 639d376bf382409410e26385134d36fd6e3b5f0c..537d1a6dcf8add34e8dac8aee2fa50c50ce7e5d0 100644
+index a9e7ef578c89905ff23beb85f0114f984eaaaaa7..594db7ab7c78f4f7f17781f339431bf5f133b8bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -838,5 +838,10 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -843,5 +843,10 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
              ((Mob) getHandle()).getJumpControl().jump();
          }
      }

--- a/patches/server/0529-Add-LivingEntity-clearActiveItem.patch
+++ b/patches/server/0529-Add-LivingEntity-clearActiveItem.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#clearActiveItem
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 537d1a6dcf8add34e8dac8aee2fa50c50ce7e5d0..24ffc967391c9ba175f41396a90007ecdc32f55c 100644
+index 594db7ab7c78f4f7f17781f339431bf5f133b8bf..6e2e217d965ea6b8601e5ba0f8a44b817ee6654d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -805,6 +805,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -810,6 +810,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          return getHandle().getUseItem().asBukkitMirror();
      }
  

--- a/patches/server/0537-Limit-recipe-packets.patch
+++ b/patches/server/0537-Limit-recipe-packets.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Limit recipe packets
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a6820c2262dd2198b772eae491c40ee379ec2da7..38bc886317dec183bb276d1a81b4b0a001350312 100644
+index bae8cb6dea250a389c02efe8667c5a898ff49909..bdab60032896ad24add7d2efb49db07a1793670a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -263,6 +263,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -24,7 +24,7 @@ index a6820c2262dd2198b772eae491c40ee379ec2da7..38bc886317dec183bb276d1a81b4b0a0
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -3249,6 +3251,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3243,6 +3245,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      @Override
      public void handlePlaceRecipe(ServerboundPlaceRecipePacket packet) {

--- a/patches/server/0541-Expose-LivingEntity-hurt-direction.patch
+++ b/patches/server/0541-Expose-LivingEntity-hurt-direction.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose LivingEntity hurt direction
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 24ffc967391c9ba175f41396a90007ecdc32f55c..0293d6fd1bb29f75fa1fa1cdfa36b3f679c1bc45 100644
+index 6e2e217d965ea6b8601e5ba0f8a44b817ee6654d..a0b46e05dc9c384b3dd70de00d89911c492ef493 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -850,5 +850,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -855,5 +855,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void playPickupItemAnimation(org.bukkit.entity.Item item, int quantity) {
          getHandle().take(((CraftItem) item).getHandle(), quantity);
      }

--- a/patches/server/0554-Fix-interact-event-not-being-called-in-adventure.patch
+++ b/patches/server/0554-Fix-interact-event-not-being-called-in-adventure.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix interact event not being called in adventure
 Call PlayerInteractEvent when left-clicking on a block in adventure mode
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 38bc886317dec183bb276d1a81b4b0a001350312..2ad4df9895728185d6e5db2e8525ed3b08a518a1 100644
+index bdab60032896ad24add7d2efb49db07a1793670a..0840813bf89eb5d51f9dae02d5100ea9ba3de928 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1852,7 +1852,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -18,12 +18,12 @@ index 38bc886317dec183bb276d1a81b4b0a001350312..2ad4df9895728185d6e5db2e8525ed3b
                              this.player.swing(enumhand, true);
                          }
                      }
-@@ -2612,7 +2612,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
-         Vec3 vec3d1 = vec3d.add((double) f7 * d3, (double) f6 * d3, (double) f8 * d3);
-         HitResult movingobjectposition = this.player.level.clip(new ClipContext(vec3d, vec3d1, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, this.player));
+@@ -2606,7 +2606,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+         // SPIGOT-5607: Only call interact event if no block or entity is being clicked. Use bukkit ray trace method, because it handles blocks and entities at the same time
+         org.bukkit.util.RayTraceResult result = this.player.level.getWorld().rayTrace(origin, origin.getDirection(), d3, org.bukkit.FluidCollisionMode.NEVER, false, 0.1, entity -> entity != this.player.getBukkitEntity());
  
--        if (movingobjectposition == null || movingobjectposition.getType() != HitResult.Type.BLOCK) {
-+        if (movingobjectposition == null || movingobjectposition.getType() != HitResult.Type.BLOCK || this.player.gameMode.getGameModeForPlayer() == GameType.ADVENTURE) { // Paper - call PlayerInteractEvent when left-clicking on a block in adventure mode
+-        if (result == null) {
++        if (result == null || this.player.gameMode.getGameModeForPlayer() == GameType.ADVENTURE) { // Paper - call PlayerInteractEvent when left-clicking on a block in adventure mode
              CraftEventFactory.callPlayerInteractEvent(this.player, Action.LEFT_CLICK_AIR, this.player.getInventory().getSelected(), InteractionHand.MAIN_HAND);
          }
  

--- a/patches/server/0632-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/server/0632-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add RespawnFlags to PlayerRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 35b906d74a4cc03a5878cedff2ee9e694bb03ad4..1a987fe9bbfe4e59e6a10a0ef94e1b18ed874a9a 100644
+index a65ca51125de3935e610f9f5fdb047268d0c0102..c78d2aa1d4c2066716e274a26496ddd8eaf1be0a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2896,7 +2896,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2890,7 +2890,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              case PERFORM_RESPAWN:
                  if (this.player.wonGame) {
                      this.player.wonGame = false;

--- a/patches/server/0644-Add-environment-variable-to-disable-server-gui.patch
+++ b/patches/server/0644-Add-environment-variable-to-disable-server-gui.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add environment variable to disable server gui
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 8bbc3a1e7f848047ff915d5bdf08d376e71c4025..ce4aed84d751a48dcd2a8409190db4a22d78f77b 100644
+index 13ef3bb2b84fac9a1be72b09e7e3c022fa08221a..2f82002c52af7304ff6b2d6fe8f094314daf0bba 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -267,6 +267,7 @@ public class Main {
+@@ -284,6 +284,7 @@ public class Main {
                  */
                  boolean flag1 = !optionset.has("nogui") && !optionset.nonOptionArguments().contains("nogui");
  

--- a/patches/server/0645-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0645-additions-to-PlayerGameModeChangeEvent.patch
@@ -126,10 +126,10 @@ index 32746dfbc2fdfc150583676b1bf0762398b76d75..1ad1f958a9b6e1bc21f1c505aa7ea549
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1a987fe9bbfe4e59e6a10a0ef94e1b18ed874a9a..66d5b3d44fb56aa6142f730e4742bb8f04f4d1c8 100644
+index c78d2aa1d4c2066716e274a26496ddd8eaf1be0a..a10d09f2129a3e3a8dd72f32494e80bce14905b9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2905,7 +2905,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2899,7 +2899,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
                      this.player = this.server.getPlayerList().respawn(this.player, false);
                      if (this.server.isHardcore()) {

--- a/patches/server/0647-More-Enchantment-API.patch
+++ b/patches/server/0647-More-Enchantment-API.patch
@@ -64,10 +64,10 @@ index 31a22f26070059e5379730c1940ff1c5fb109be1..873185fd4d4c994130f2e7c271b3e03c
  
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 6555db49ff57bba13a7eb3c0bf7ecb66d7828dce..8fe1f5deddfee329c020d93c990dc686fe2b458e 100644
+index a0ed78ffbfe8a236da273f796a016fe06875e10a..c33e33d2eba4630113a4399a0883af4b24ad943a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -867,5 +867,21 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -872,5 +872,21 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void setHurtDirection(float hurtDirection) {
          getHandle().hurtDir = hurtDirection;
      }

--- a/patches/server/0649-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0649-Fix-and-optimise-world-force-upgrading.patch
@@ -244,7 +244,7 @@ index 0000000000000000000000000000000000000000..95cac7edae8ac64811fc6a2f6b97dd4a
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index ce4aed84d751a48dcd2a8409190db4a22d78f77b..0a843e0afbcb1af8e2641515eb244b791b819b8c 100644
+index 2f82002c52af7304ff6b2d6fe8f094314daf0bba..5962f7a2b185d7d54a0f9e341a4fdf6e6f1c1ec5 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
 @@ -16,6 +16,7 @@ import java.util.Objects;
@@ -255,7 +255,7 @@ index ce4aed84d751a48dcd2a8409190db4a22d78f77b..0a843e0afbcb1af8e2641515eb244b79
  import joptsimple.NonOptionArgumentSpec;
  import joptsimple.OptionParser;
  import joptsimple.OptionSet;
-@@ -297,6 +298,15 @@ public class Main {
+@@ -314,6 +315,15 @@ public class Main {
  
      }
  

--- a/patches/server/0657-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0657-Add-PlayerKickEvent-causes.patch
@@ -57,7 +57,7 @@ index 65637a33ba171a4b598f70cd943d24b0ee44a69f..57a9146bf2dee7a60aab16716e25348f
          }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index da9001a29b2ec2f715336c8187e6c918dd32db5e..b87d5dda2ac847cdc4c83b713568d9e9a37d0c8f 100644
+index 0b9365e60b36550e356cd2e43bad63951d2e315d..7fe9e406a865abb256e02a697c0412c856d4c987 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -369,7 +369,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -294,7 +294,7 @@ index da9001a29b2ec2f715336c8187e6c918dd32db5e..b87d5dda2ac847cdc4c83b713568d9e9
      }
  
      @Override
-@@ -2739,7 +2749,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2733,7 +2743,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              }
  
              if (i > 4096) {
@@ -303,7 +303,7 @@ index da9001a29b2ec2f715336c8187e6c918dd32db5e..b87d5dda2ac847cdc4c83b713568d9e9
              }
  
          }
-@@ -2754,7 +2764,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2748,7 +2758,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          // Spigot Start
          if ( entity == this.player && !this.player.isSpectator() )
          {
@@ -312,7 +312,7 @@ index da9001a29b2ec2f715336c8187e6c918dd32db5e..b87d5dda2ac847cdc4c83b713568d9e9
              return;
          }
          // Spigot End
-@@ -2852,7 +2862,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2846,7 +2856,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                              }
                              // CraftBukkit end
                          } else {
@@ -321,7 +321,7 @@ index da9001a29b2ec2f715336c8187e6c918dd32db5e..b87d5dda2ac847cdc4c83b713568d9e9
                              ServerGamePacketListenerImpl.LOGGER.warn("Player {} tried to attack an invalid entity", ServerGamePacketListenerImpl.this.player.getName().getString());
                          }
                      }
-@@ -3260,7 +3270,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3254,7 +3264,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          // Paper start
          if (!org.bukkit.Bukkit.isPrimaryThread()) {
              if (recipeSpamPackets.addAndGet(io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamIncrement) > io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamLimit) {
@@ -330,7 +330,7 @@ index da9001a29b2ec2f715336c8187e6c918dd32db5e..b87d5dda2ac847cdc4c83b713568d9e9
                  return;
              }
          }
-@@ -3463,7 +3473,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3457,7 +3467,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          } else if (!this.isSingleplayerOwner()) {
              // Paper start - This needs to be handled on the main thread for plugins
              server.submit(() -> {
@@ -339,7 +339,7 @@ index da9001a29b2ec2f715336c8187e6c918dd32db5e..b87d5dda2ac847cdc4c83b713568d9e9
              });
              // Paper end
          }
-@@ -3509,7 +3519,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3503,7 +3513,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  }
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t register custom payload", ex);
@@ -348,7 +348,7 @@ index da9001a29b2ec2f715336c8187e6c918dd32db5e..b87d5dda2ac847cdc4c83b713568d9e9
              }
          } else if (packet.identifier.equals(CUSTOM_UNREGISTER)) {
              try {
-@@ -3519,7 +3529,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3513,7 +3523,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  }
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t unregister custom payload", ex);
@@ -357,7 +357,7 @@ index da9001a29b2ec2f715336c8187e6c918dd32db5e..b87d5dda2ac847cdc4c83b713568d9e9
              }
          } else {
              try {
-@@ -3537,7 +3547,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3531,7 +3541,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  this.cserver.getMessenger().dispatchIncomingMessage(this.player.getBukkitEntity(), packet.identifier.toString(), data);
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);

--- a/patches/server/0673-Missing-Entity-Behavior-API.patch
+++ b/patches/server/0673-Missing-Entity-Behavior-API.patch
@@ -557,10 +557,10 @@ index 8a0a905f6701c6e94cbbf15793788350958fb728..2a74e6ecb4f57bc6879b37f7bc067541
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java
-index 024107a70cc517224b98581389db5cbf1977a1a3..4bec74bd45e3abc0fd0f2e07ed5ad9003b6aea33 100644
+index 7ece945d1a4fa29c7b98532788076483037f4bda..963928fc8e29b8abc2026c0b0183ebb07f0de4d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftWarden.java
-@@ -34,6 +34,13 @@ public class CraftWarden extends CraftMonster implements org.bukkit.entity.Warde
+@@ -43,6 +43,13 @@ public class CraftWarden extends CraftMonster implements org.bukkit.entity.Warde
          return this.getHandle().getAngerManagement().getActiveAnger(((CraftEntity) entity).getHandle());
      }
  

--- a/patches/server/0678-Adds-PlayerArmSwingEvent.patch
+++ b/patches/server/0678-Adds-PlayerArmSwingEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Adds PlayerArmSwingEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6d3929916da5ea45c5f9f3d0d11b3bd4db9660ef..47043ebc5054a03ac56d171dc0c8c54bff0230c3 100644
+index 4e969e37c3ba9ada9ee770a599e52873ada78cdc..74f1221e51e8b0875c4242c9ec2f635aa0827bea 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2633,7 +2633,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2627,7 +2627,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          }
  
          // Arm swing animation

--- a/patches/server/0793-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0793-Hide-unnecessary-itemmeta-from-clients.patch
@@ -18,10 +18,10 @@ index 319dfa82dff1fe188a52bed5aa2d39575853b793..919758363c7b703cb200582768e68c97
                  }
              }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f63ff3240b477e86e45bd7572ab0dda308bab5f3..583f61adf2122ff94be79814a04616a42a827f75 100644
+index 97f1b8585c0fa6f1abbec0a0172157c61b6d0614..3e8284838eecb3c71410dcaf684cf8727265d2b6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2818,8 +2818,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2812,8 +2812,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                              }
                              // Paper end
                              // SPIGOT-7136 - Allays

--- a/patches/server/0879-Prevent-tile-entity-copies-loading-chunks.patch
+++ b/patches/server/0879-Prevent-tile-entity-copies-loading-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent tile entity copies loading chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index faf63674f8c1ebc5f8dea1a937811f0d9e9d1d96..99efa1950b56d719f210cad5989b5535e2d3c934 100644
+index 7cc9e225115f4c6ac6fc5f8bee46bf949a9245dd..143370d7395d1bed22420e515be288688b0faf63 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3413,7 +3413,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3407,7 +3407,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  BlockPos blockposition = BlockEntity.getPosFromTag(nbttagcompound);
  
                  if (this.player.level.isLoaded(blockposition)) {

--- a/patches/server/0882-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0882-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -18,10 +18,10 @@ index 20670bc075c387ee0422eb1014207e26105efccd..bdd6560fe85950b0a857a949cb38c044
  
              if (dedicatedserverproperties.enableQuery) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 99efa1950b56d719f210cad5989b5535e2d3c934..a7285b0e6c256d475c43b38a6d78f2f1f4bd17f5 100644
+index 143370d7395d1bed22420e515be288688b0faf63..8e7d7d9f1f228bd0f71abfe46a3cef1f1a72a7ed 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3009,7 +3009,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3003,7 +3003,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                      this.player = this.server.getPlayerList().respawn(this.player, false);
                      if (this.server.isHardcore()) {
                          this.player.setGameMode(GameType.SPECTATOR, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.HARDCORE_DEATH, null); // Paper

--- a/patches/server/0893-Do-not-accept-invalid-client-settings.patch
+++ b/patches/server/0893-Do-not-accept-invalid-client-settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Do not accept invalid client settings
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a7285b0e6c256d475c43b38a6d78f2f1f4bd17f5..603e404e75d39279fa5c4222ec5373271dd1ae64 100644
+index 8e7d7d9f1f228bd0f71abfe46a3cef1f1a72a7ed..6123e1151dad07fbfeb726d338a2268d9707c07d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3592,6 +3592,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3586,6 +3586,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      @Override
      public void handleClientInformation(ServerboundClientInformationPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
2683d766 PR-787: Add LivingEntity#canBreatheUnderwater()
dea11a5f SPIGOT-7128: ChunkGenerator#shouldGenerateBedrock doesn't work
ecc290fd PR-755: Add more Warden methods

CraftBukkit Changes:
5901d580a PR-1101: Implement LivingEntity#canBreatheUnderwater()
dd0a21830 SPIGOT-5607: PlayerInteractEvent Left-Click Bug
990d077dc SPIGOT-7131: Chunk snapshot returned by World#getEmptyChunkSnapshot(int,int,boolean,boolean) thinks every block has PLAINS biome
6c8a09611 SPIGOT-5761: initSettings is not a recognized option
a73b35878 Increase outdated build delay
370eeceff PR-1060: Add more Warden methods

Spigot Changes:
e53686f7 Rebuild patches