### PR TITLE
Allow preventing BlockDestroyEvent from dropping items

### DIFF
--- a/patches/api/0171-BlockDestroyEvent.patch
+++ b/patches/api/0171-BlockDestroyEvent.patch
@@ -12,10 +12,10 @@ This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java b/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..28255dc39eab5faf324d1fe556ab12daed527ff6
+index 0000000000000000000000000000000000000000..051b2ef76a914228338fa28553ad739bd2a0278c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,99 @@
 +package com.destroystokyo.paper.event.block;
 +
 +import org.bukkit.block.Block;
@@ -41,7 +41,7 @@ index 0000000000000000000000000000000000000000..28255dc39eab5faf324d1fe556ab12da
 +    private static final HandlerList handlers = new HandlerList();
 +
 +    @NotNull private final BlockData newState;
-+    private final boolean willDrop;
++    private boolean willDrop;
 +    private boolean playEffect = true;
 +
 +    private boolean cancelled = false;
@@ -65,6 +65,13 @@ index 0000000000000000000000000000000000000000..28255dc39eab5faf324d1fe556ab12da
 +     */
 +    public boolean willDrop() {
 +        return this.willDrop;
++    }
++
++    /**
++     * @param willDrop If the server is going to drop the block in question with this destroy event
++     */
++    public void setWillDrop(boolean willDrop) {
++        this.willDrop = willDrop;
 +    }
 +
 +    /**

--- a/patches/server/0302-BlockDestroyEvent.patch
+++ b/patches/server/0302-BlockDestroyEvent.patch
@@ -11,7 +11,7 @@ floating in the air.
 This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 2225921e988cdcaa4fb906b281c237972c6e7c1b..bb274ffc0f7bfd09bfcdc9bec43122cecab052e6 100644
+index 2225921e988cdcaa4fb906b281c237972c6e7c1b..d72804cd4491c60043e428c0d06e02f9ca7f9303 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -28,6 +28,7 @@ import net.minecraft.nbt.CompoundTag;
@@ -22,7 +22,7 @@ index 2225921e988cdcaa4fb906b281c237972c6e7c1b..bb274ffc0f7bfd09bfcdc9bec43122ce
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ChunkHolder;
  import net.minecraft.server.level.ServerLevel;
-@@ -578,8 +579,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -578,8 +579,21 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              return false;
          } else {
              FluidState fluid = this.getFluidState(pos);
@@ -36,6 +36,7 @@ index 2225921e988cdcaa4fb906b281c237972c6e7c1b..bb274ffc0f7bfd09bfcdc9bec43122ce
 +                    return false;
 +                }
 +                playEffect = event.playEffect();
++                drop = event.willDrop();
 +            }
 +            // Paper end
  

--- a/patches/server/0319-Optimize-Captured-TileEntity-Lookup.patch
+++ b/patches/server/0319-Optimize-Captured-TileEntity-Lookup.patch
@@ -10,10 +10,10 @@ Optimize to check if the captured list even has values in it, and also to
 just do a get call since the value can never be null.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index bb274ffc0f7bfd09bfcdc9bec43122cecab052e6..e6bfc9cdf116b2233a638eec369a80eb8536aa18 100644
+index d72804cd4491c60043e428c0d06e02f9ca7f9303..244035be96c5218a27e70c3f80ee9d7dcb4419d5 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -839,9 +839,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -840,9 +840,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Nullable
      public BlockEntity getBlockEntity(BlockPos blockposition, boolean validate) {

--- a/patches/server/0362-Avoid-hopper-searches-if-there-are-no-items.patch
+++ b/patches/server/0362-Avoid-hopper-searches-if-there-are-no-items.patch
@@ -14,10 +14,10 @@ And since minecart hoppers are used _very_ rarely near we can avoid alot of sear
 Combined, this adds up a lot.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 8e5e773fffcb17d20328903d1b1fc9d9e0aefa3e..11a02c8259a039bbe229c5626055bceef9308b5a 100644
+index 7bd8ffb6bfba7f7188532ae3788701c08e1d624a..ef4e48127168acdd614bbdcac97a98da5240928e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -965,7 +965,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -966,7 +966,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  }
              }
  

--- a/patches/server/0389-Improved-Watchdog-Support.patch
+++ b/patches/server/0389-Improved-Watchdog-Support.patch
@@ -306,10 +306,10 @@ index 6fefa619299d3202158490630d62c16aef71e831..7a4ade1a4190bf4fbb048919ae2be230
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 11a02c8259a039bbe229c5626055bceef9308b5a..c488e069a19d4bf082c94032571fcc77c0bada50 100644
+index ef4e48127168acdd614bbdcac97a98da5240928e..4c93c2ee69c2728d798a750981275f4fc6840525 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -793,6 +793,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -794,6 +794,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          try {
              tickConsumer.accept(entity);
          } catch (Throwable throwable) {

--- a/patches/server/0735-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0735-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -1051,7 +1051,7 @@ index 1a3be6f0570c7c746eafa36544debe90d7629432..c0817ef8927f00e2fd3fbf3289f8041f
  
      <T extends Entity> List<T> getEntities(EntityTypeTest<Entity, T> filter, AABB box, Predicate<? super T> predicate);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 2a4e6c6f732d9cd2567352b7fca2c284b0bb9c1b..4f484e71c93a5243d242e116e2f204ead407f598 100644
+index 4b7ed29a7a38cf7f8fb488c9c34471fafcdf2f25..a04517137ab9deff215b6f9b9ee405500af0e393 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -293,6 +293,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -1062,7 +1062,7 @@ index 2a4e6c6f732d9cd2567352b7fca2c284b0bb9c1b..4f484e71c93a5243d242e116e2f204ea
      }
  
      // Paper start
-@@ -967,26 +968,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -968,26 +969,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public List<Entity> getEntities(@Nullable Entity except, AABB box, Predicate<? super Entity> predicate) {
          this.getProfiler().incrementCounter("getEntities");
          List<Entity> list = Lists.newArrayList();
@@ -1090,7 +1090,7 @@ index 2a4e6c6f732d9cd2567352b7fca2c284b0bb9c1b..4f484e71c93a5243d242e116e2f204ea
          return list;
      }
  
-@@ -995,27 +977,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -996,27 +978,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.getProfiler().incrementCounter("getEntities");
          List<T> list = Lists.newArrayList();
  
@@ -1133,7 +1133,7 @@ index 2a4e6c6f732d9cd2567352b7fca2c284b0bb9c1b..4f484e71c93a5243d242e116e2f204ea
          return list;
      }
  
-@@ -1342,4 +1319,46 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1343,4 +1320,46 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public long nextSubTickCount() {
          return (long) (this.subTickCount++);
      }

--- a/patches/server/0737-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0737-Execute-chunk-tasks-mid-tick.patch
@@ -154,10 +154,10 @@ index 29b80d074600fa7e20b05d1fe70ac12969b954a4..7324f2ad437a15c42f84ba2deeb58861
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 4f484e71c93a5243d242e116e2f204ead407f598..7c4ec47829bb0818f489544f2b396852d42a35d3 100644
+index a04517137ab9deff215b6f9b9ee405500af0e393..90b3ca30a5ab381acde66393eb1fed5be677e5c8 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -799,6 +799,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -800,6 +800,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  // Spigot end
              } else if (this.shouldTickBlocksAt(tickingblockentity.getPos())) {
                  tickingblockentity.tick();
@@ -169,7 +169,7 @@ index 4f484e71c93a5243d242e116e2f204ead407f598..7c4ec47829bb0818f489544f2b396852
              }
          }
          this.blockEntityTickers.removeAll(toRemove);
-@@ -813,6 +818,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -814,6 +819,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public <T extends Entity> void guardEntityTick(Consumer<T> tickConsumer, T entity) {
          try {
              tickConsumer.accept(entity);

--- a/patches/server/0756-Optimise-random-block-ticking.patch
+++ b/patches/server/0756-Optimise-random-block-ticking.patch
@@ -312,10 +312,10 @@ index 69c98c2cb2fd8f149a39bbddcbfe0c5c5adc3904..5575730aa6f77a91467c394fa8465c33
  
      public BlockPos getHomePos() {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index e7487e0a21727666889cc2ec8841cca2b2c965d5..45be0dc44b98ca90b68e6ff3278e4de21934d7a2 100644
+index 8eabdd921cc976d9a1b9d3e8c315eeb22de3a968..76a2d00324a85419548005e0aa3cbd8b891b8257 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1301,10 +1301,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1302,10 +1302,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public abstract RecipeManager getRecipeManager();
  
      public BlockPos getBlockRandomPos(int x, int y, int z, int l) {

--- a/patches/server/0901-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/0901-Add-Alternate-Current-redstone-implementation.patch
@@ -2034,10 +2034,10 @@ index e5a64e70020487b15825a865623afa45b0ae59d4..684063b8433f78ef0adf0de1057ea247
  
          EntityCallbacks() {}
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index c118efaadd0e3e29f9adcd65c11ecabfc6d76216..9467ccaa1d73e1913495a46919aee530e749977d 100644
+index 30140ae5a74a511c9031b8e772e724b25e56de3d..46c45f249e71ca94044f1260a23cd7331098fb2c 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1452,4 +1452,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1453,4 +1453,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return ret;
      }
      // Paper end


### PR DESCRIPTION
Useful for overriding drops from blocks such as bamboo, which fire this event when their base is broken (moved to master as requested)