### PR TITLE
Properly close section storage managed files

### DIFF
--- a/patches/server/0019-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0019-Asynchronous-chunk-IO-and-loading.patch
@@ -2767,7 +2767,7 @@ index dfa08dbf025ed702a864280a540e0169b9f33cbd..10fa6cec911950f72407ae7f45c8cf48
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 79c6ab332f0cc7e48dc3d84d936c9e964db19611..ca7fe80e0af3502aad492519ad19dade70f8bbe0 100644
+index 4e7db441f68019d6e5d3359605b76bc4b258e87e..22c095539425a6667b8e7f5c5f0a8ff2e87adfb5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -784,6 +784,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -3384,7 +3384,7 @@ index 8ba1c073387fa21a20bd42a873ec3cc314eae64e..6fa0bc18ab05b9fb05521f46c5dadb69
  
          while (objectiterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/SectionStorage.java b/src/main/java/net/minecraft/world/level/chunk/storage/SectionStorage.java
-index 8a4750dd8f604062c4ea452f7b97b05a0c8d583a..678bd36581ead3a225e3a6e24b78e5db4e42657b 100644
+index 8a4750dd8f604062c4ea452f7b97b05a0c8d583a..4dcfffe2e1c5263c3d1bd096d57d090c1e4b0523 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/SectionStorage.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/SectionStorage.java
 @@ -34,10 +34,10 @@ import net.minecraft.world.level.ChunkPos;
@@ -3476,12 +3476,13 @@ index 8a4750dd8f604062c4ea452f7b97b05a0c8d583a..678bd36581ead3a225e3a6e24b78e5db
      private static long getKey(ChunkPos chunkPos, int y) {
          return SectionPos.asLong(chunkPos.x, y, chunkPos.z);
      }
-@@ -233,6 +254,23 @@ public class SectionStorage<R> implements AutoCloseable {
+@@ -233,6 +254,24 @@ public class SectionStorage<R> implements AutoCloseable {
  
      @Override
      public void close() throws IOException {
 -        this.worker.close();
-+        //this.worker.close(); // Paper - nuke I/O worker
++        //this.worker.close(); // Paper - nuke I/O worker - don't call the worker
++        super.close(); // Paper - nuke I/O worker - call super.close method which is responsible for closing used files.
 +    }
 +
 +    // Paper start - get data function


### PR DESCRIPTION
While nuking the mojang IO worker in the async chunk transition, the SectionStorage's close method was missing the super call to its parent RegionFileStorage which in turn is responsible for closing the region files in use by the section storage. This would manifest in opened files for an unloaded world.

This commit adapts the SectionStorage#close method to properly call its parent's close method, closing any open files.

Resolves: #7504 

-------------------------------------------

Testing this change is as easy as loading and unloading a world while monitoring the opened files. The following code can be used to test the changes:
```java
@EventHandler
public void on(final PlayerDropItemEvent event) {
    event.setCancelled(true);
    
    final World world = Bukkit.getWorld("test");
    if (world == null) {
        final WorldCreator worldCreator = new WorldCreator("test");
        worldCreator.keepSpawnLoaded(TriState.FALSE);

        final World created = Bukkit.createWorld(worldCreator);
        event.getPlayer().teleportAsync(created.getSpawnLocation());
    } else {
        event.getPlayer().teleport(Bukkit.getWorlds().get(0).getSpawnLocation());
        Bukkit.unloadWorld(world, true);
    }
}
```
and a simple
```bash
 watch -n0.1 lsof run/test/poi/r.0.0.mca
```
call in the paper server.