### PR TITLE
Avoid item meta usage for itemstack enchantment getter

### DIFF
--- a/patches/server/0073-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0073-Handle-Item-Meta-Inconsistencies.patch
@@ -70,10 +70,18 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..7789f3ad01df1c6fc109592ba107852c7539c982 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..c9093275d2b78b6e2f59e64efab0b4775ff0b43b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -178,28 +178,11 @@ public final class CraftItemStack extends ItemStack {
+@@ -6,7 +6,6 @@ import java.util.Map;
+ import net.minecraft.nbt.CompoundTag;
+ import net.minecraft.nbt.ListTag;
+ import net.minecraft.world.item.Item;
+-import net.minecraft.world.item.enchantment.EnchantmentHelper;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Material;
+ import org.bukkit.NamespacedKey;
+@@ -178,28 +177,11 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Validate.notNull(ench, "Cannot add null enchantment");
  
@@ -107,7 +115,15 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..7789f3ad01df1c6fc109592ba107852c
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -232,50 +215,22 @@ public final class CraftItemStack extends ItemStack {
+@@ -225,57 +207,29 @@ public final class CraftItemStack extends ItemStack {
+         if (this.handle == null) {
+             return 0;
+         }
+-        return EnchantmentHelper.getItemEnchantmentLevel(CraftEnchantment.getRaw(ench), handle);
++        return net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(CraftEnchantment.getRaw(ench), handle); // Paper
+     }
+ 
+     @Override
      public int removeEnchantment(Enchantment ench) {
          Validate.notNull(ench, "Cannot remove null enchantment");
  

--- a/patches/server/0073-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0073-Handle-Item-Meta-Inconsistencies.patch
@@ -70,18 +70,10 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..3745033afb8923ce06cbf13b55c4e96f2a89573f 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..7789f3ad01df1c6fc109592ba107852c7539c982 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -6,7 +6,6 @@ import java.util.Map;
- import net.minecraft.nbt.CompoundTag;
- import net.minecraft.nbt.ListTag;
- import net.minecraft.world.item.Item;
--import net.minecraft.world.item.enchantment.EnchantmentHelper;
- import org.apache.commons.lang.Validate;
- import org.bukkit.Material;
- import org.bukkit.NamespacedKey;
-@@ -178,28 +177,11 @@ public final class CraftItemStack extends ItemStack {
+@@ -178,28 +178,11 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Validate.notNull(ench, "Cannot add null enchantment");
  
@@ -115,25 +107,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..3745033afb8923ce06cbf13b55c4e96f
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -216,66 +198,34 @@ public final class CraftItemStack extends ItemStack {
- 
-     @Override
-     public boolean containsEnchantment(Enchantment ench) {
--        return this.getEnchantmentLevel(ench) > 0;
-+        return this.hasItemMeta() && this.getItemMeta().hasEnchant(ench); // Paper - use meta
-     }
- 
-     @Override
-     public int getEnchantmentLevel(Enchantment ench) {
--        Validate.notNull(ench, "Cannot find null enchantment");
--        if (this.handle == null) {
--            return 0;
--        }
--        return EnchantmentHelper.getItemEnchantmentLevel(CraftEnchantment.getRaw(ench), handle);
-+        return this.hasItemMeta() ? this.getItemMeta().getEnchantLevel(ench) : 0; // Paper - replace entire method with meta
-     }
- 
-     @Override
+@@ -232,50 +215,22 @@ public final class CraftItemStack extends ItemStack {
      public int removeEnchantment(Enchantment ench) {
          Validate.notNull(ench, "Cannot remove null enchantment");
  
@@ -173,10 +147,10 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..3745033afb8923ce06cbf13b55c4e96f
 -                listCopy.add(list.get(i));
 -            }
 +        // Paper start - replace entire method
-+        final ItemMeta itemMeta = this.getItemMeta();
-+        if (itemMeta == null) return 0;
-+        int level = itemMeta.getEnchantLevel(ench);
++        int level = getEnchantmentLevel(ench);
 +        if (level > 0) {
++            final ItemMeta itemMeta = this.getItemMeta();
++            if (itemMeta == null) return 0;
 +            itemMeta.removeEnchant(ench);
 +            this.setItemMeta(itemMeta);
          }

--- a/patches/server/0208-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0208-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 7789f3ad01df1c6fc109592ba107852c7539c982..a2ad53676178dc2632200bbf36ccd0e61b94172b 100644
+index 777018ba2cb5530b679b1b0a88e09ea30369f033..553dd35795b5339980aa7b5ae4e9acd9768846e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -174,6 +174,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -173,6 +173,13 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getItem().getMaxStackSize();
      }
  

--- a/patches/server/0208-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0208-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 3745033afb8923ce06cbf13b55c4e96f2a89573f..8b7d9ac312200b82b741a2c0ac26ec0710ea3cbc 100644
+index 7789f3ad01df1c6fc109592ba107852c7539c982..a2ad53676178dc2632200bbf36ccd0e61b94172b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -173,6 +173,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -174,6 +174,13 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getItem().getMaxStackSize();
      }
  

--- a/patches/server/0237-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0237-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index a2ad53676178dc2632200bbf36ccd0e61b94172b..83e7de739c4324bd4409a5ac67d20403ce09f412 100644
+index 553dd35795b5339980aa7b5ae4e9acd9768846e4..a16d6c171a62299fe4bca28dcbb1243b30268f78 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -589,7 +589,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -588,7 +588,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0237-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0237-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 8b7d9ac312200b82b741a2c0ac26ec0710ea3cbc..04aabec62f0c89e70681af3846d73659f4c81360 100644
+index a2ad53676178dc2632200bbf36ccd0e61b94172b..83e7de739c4324bd4409a5ac67d20403ce09f412 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -584,7 +584,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -589,7 +589,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0860-More-Projectile-API.patch
+++ b/patches/server/0860-More-Projectile-API.patch
@@ -195,10 +195,10 @@ index 0db8aa840ea026d48215ac5dc80ffde5f12725b1..397e0df15a0e64e5bc522f62f3b327a5
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 83e7de739c4324bd4409a5ac67d20403ce09f412..66544f00db0bea1cff00859b917306c23e6274a1 100644
+index a16d6c171a62299fe4bca28dcbb1243b30268f78..8156f8cfe924a80c9cecc0f1555d6b543bde7117 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -279,12 +279,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -278,12 +278,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0860-More-Projectile-API.patch
+++ b/patches/server/0860-More-Projectile-API.patch
@@ -195,10 +195,10 @@ index 0db8aa840ea026d48215ac5dc80ffde5f12725b1..397e0df15a0e64e5bc522f62f3b327a5
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 04aabec62f0c89e70681af3846d73659f4c81360..c7c5f18cde7a4ad4dd821e452de3068c2e2187d1 100644
+index 83e7de739c4324bd4409a5ac67d20403ce09f412..66544f00db0bea1cff00859b917306c23e6274a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -274,12 +274,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -279,12 +279,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0902-Add-missing-spawn-eggs.patch
+++ b/patches/server/0902-Add-missing-spawn-eggs.patch
@@ -22,10 +22,10 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 66544f00db0bea1cff00859b917306c23e6274a1..5e2c8d443f449c03c50740d89856483b539cea02 100644
+index 8156f8cfe924a80c9cecc0f1555d6b543bde7117..a04768f58d26a55d13a559eaf4712863283d72bb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -429,6 +429,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -428,6 +428,12 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:

--- a/patches/server/0902-Add-missing-spawn-eggs.patch
+++ b/patches/server/0902-Add-missing-spawn-eggs.patch
@@ -22,10 +22,10 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index c7c5f18cde7a4ad4dd821e452de3068c2e2187d1..f5363a753e5d24ccda946a9d65132eed28f19172 100644
+index 66544f00db0bea1cff00859b917306c23e6274a1..5e2c8d443f449c03c50740d89856483b539cea02 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -424,6 +424,12 @@ public final class CraftItemStack extends ItemStack {
+@@ -429,6 +429,12 @@ public final class CraftItemStack extends ItemStack {
              case ZOMBIE_SPAWN_EGG:
              case ZOMBIE_VILLAGER_SPAWN_EGG:
              case ZOMBIFIED_PIGLIN_SPAWN_EGG:


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/5188
Redo of my old PR without all the mess (before part II)

"Paper has fixed enchantment order inconsistencies but has also implemented the fix on getter which is useless because no write operation is done here."
This wouldn't be a problem if the item meta was fast
You should use theses methods over the meta one if you care about performance and doesn't do bulk operation on item.