### PR TITLE
Add a consumer parameter to ProjectileSource#launchProjectile

### DIFF
--- a/patches/api/0394-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
+++ b/patches/api/0394-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Mon, 19 Sep 2022 14:04:13 -0700
+Subject: [PATCH] Add a consumer parameter to ProjectileSource#launchProjectile
+
+
+diff --git a/src/main/java/org/bukkit/projectiles/ProjectileSource.java b/src/main/java/org/bukkit/projectiles/ProjectileSource.java
+index eabd8b926ec1c934cd7e77b7cc6adfae16771021..6cb28e65b82198b19f159f8e8334208f7f62d394 100644
+--- a/src/main/java/org/bukkit/projectiles/ProjectileSource.java
++++ b/src/main/java/org/bukkit/projectiles/ProjectileSource.java
+@@ -31,4 +31,24 @@ public interface ProjectileSource {
+      */
+     @NotNull
+     public <T extends Projectile> T launchProjectile(@NotNull Class<? extends T> projectile, @Nullable Vector velocity);
++    
++    // Paper start
++    /**
++     * Launches a {@link Projectile} from the ProjectileSource with an
++     * initial velocity, with the supplied function run before the
++     * entity is added to the world.
++     * <br>
++     * Note that when the function is run, the entity will not be actually in
++     * the world. Any operation involving such as teleporting the entity is undefined
++     * until after this function returns.
++     *
++     * @param <T> a projectile subclass
++     * @param projectile class of the projectile to launch
++     * @param velocity the velocity with which to launch
++     * @param function the function to be run before the entity is spawned
++     * @return the launched projectile
++     */
++    @NotNull
++    public <T extends Projectile> T launchProjectile(@NotNull Class<? extends T> projectile, @Nullable Vector velocity, @Nullable org.bukkit.util.Consumer<T> function);
++    // Paper end
+ }

--- a/patches/server/0943-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
+++ b/patches/server/0943-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Mon, 19 Sep 2022 14:16:10 -0700
+Subject: [PATCH] Add a consumer parameter to ProjectileSource#launchProjectile
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index 1994dd3c272395a27474ec1b37a924a24fc50fd6..e807ef287136e7b3931197e45434a3f618cf3054 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -482,8 +482,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     }
+ 
+     @Override
+-    @SuppressWarnings("unchecked")
+     public <T extends Projectile> T launchProjectile(Class<? extends T> projectile, Vector velocity) {
++        // Paper start - launchProjectile consumer
++        return this.launchProjectile(projectile, velocity, null);
++    }
++
++    @Override
++    @SuppressWarnings("unchecked")
++    public <T extends Projectile> T launchProjectile(Class<? extends T> projectile, Vector velocity, org.bukkit.util.Consumer<T> function) {
++        // Paper end - launchProjectile consumer
+         Preconditions.checkState(!this.getHandle().generation, "Cannot launch projectile during world generation");
+ 
+         net.minecraft.world.level.Level world = ((CraftWorld) getWorld()).getHandle();
+@@ -566,6 +573,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         if (velocity != null) {
+             ((T) launch.getBukkitEntity()).setVelocity(velocity);
+         }
++        // Paper start - launchProjectile consumer
++        if (function != null) {
++            function.accept((T) launch.getBukkitEntity());
++        }
++        // Paper end - launchProjectile consumer
+ 
+         world.addFreshEntity(launch);
+         return (T) launch.getBukkitEntity();
+diff --git a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
+index 388647c2ef814270942f4e6c6eb57a3abaf84212..2afb7af0a90959edd3b0ead2fe4d9018b5560aa4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
++++ b/src/main/java/org/bukkit/craftbukkit/projectiles/CraftBlockProjectileSource.java
+@@ -57,6 +57,13 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
+ 
+     @Override
+     public <T extends Projectile> T launchProjectile(Class<? extends T> projectile, Vector velocity) {
++        // Paper start - launchProjectile consumer
++        return this.launchProjectile(projectile, velocity, null);
++    }
++
++    @Override
++    public <T extends Projectile> T launchProjectile(Class<? extends T> projectile, Vector velocity, org.bukkit.util.Consumer<T> function) {
++        // Paper end - launchProjectile consumer
+         Validate.isTrue(this.getBlock().getType() == Material.DISPENSER, "Block is no longer dispenser");
+         // Copied from BlockDispenser.dispense()
+         BlockSourceImpl isourceblock = new BlockSourceImpl((ServerLevel) this.dispenserBlock.getLevel(), this.dispenserBlock.getBlockPos());
+@@ -147,6 +154,11 @@ public class CraftBlockProjectileSource implements BlockProjectileSource {
+         if (velocity != null) {
+             ((T) launch.getBukkitEntity()).setVelocity(velocity);
+         }
++        // Paper start
++        if (function != null) {
++            function.accept((T) launch.getBukkitEntity());
++        }
++        // Paper end
+ 
+         world.addFreshEntity(launch);
+         return (T) launch.getBukkitEntity();


### PR DESCRIPTION
Similar to the consumer parameter in RegionAccessor#spawnEntity, this pull request adds a method override with a consumer parameter to ProjectileSource#launchProjectile.

Previously, it was not possible to use the API to modify a projectile from launchProjectile before it is added to the world. A workaround to this is to modify the entity immediately after calling launchProjectile, but this had a short delay, and the client would see the incorrect projectile for a short duration.
This also causes modified explosion radius fireballs to explode with the wrong explosion radius if it explodes immediately after spawning, such as spawning inside a wall.
This pull request adds another method override with a function to be called before the entity is added to the world, which allows projectiles to be modified before being added to the world, fixing the above issues.

