### PR TITLE
Fix setEggCount method from TurtleLayEggEvent

### DIFF
--- a/patches/api/0161-Turtle-API.patch
+++ b/patches/api/0161-Turtle-API.patch
@@ -61,7 +61,7 @@ index 0000000000000000000000000000000000000000..021356d151ed638068e3e89b8cc77b37
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/TurtleLayEggEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/TurtleLayEggEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a315c5185cd465dcf63c0ababef195da76dfc786
+index 0000000000000000000000000000000000000000..bcc8dba50e3a3df0206c4827bb468bf884837b8b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/TurtleLayEggEvent.java
 @@ -0,0 +1,87 @@
@@ -129,7 +129,7 @@ index 0000000000000000000000000000000000000000..a315c5185cd465dcf63c0ababef195da
 +            cancelled = true;
 +            return;
 +        }
-+        eggCount = Math.min(eggCount, 4);
++        this.eggCount = Math.min(eggCount, 4);
 +    }
 +
 +    @Override


### PR DESCRIPTION
The old behavior only change the local variable instead of the public class field.