### PR TITLE
Preliminary example of WorldUnloadEvent

### DIFF
--- a/patches/api/0398-Add-WorldUnloadResult.patch
+++ b/patches/api/0398-Add-WorldUnloadResult.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Wed, 28 Sep 2022 05:09:05 +0100
+Subject: [PATCH] Add WorldUnloadResult
+
+
+diff --git a/src/main/java/io/papermc/paper/world/WorldUnloadResult.java b/src/main/java/io/papermc/paper/world/WorldUnloadResult.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..5fb077e0ab5ad238763adb2a1d2a6cc95cf0f1e4
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/world/WorldUnloadResult.java
+@@ -0,0 +1,30 @@
++package io.papermc.paper.world;
++
++import net.kyori.adventure.text.Component;
++
++public class WorldUnloadResult {
++
++    public static final WorldUnloadResult SUCCESS = new WorldUnloadResult(true, Component.text("Success"));
++    public static final WorldUnloadResult NOT_LOADED = new WorldUnloadResult(false, Component.text("Cannot unload unloaded world"));
++    public static final WorldUnloadResult UNSUPPORTED = new WorldUnloadResult(false, Component.text("Unloading this world is not supported"));
++    public static final WorldUnloadResult NOT_EMPTY = new WorldUnloadResult(false, Component.text("Unable to load world with players!"));
++    public static final WorldUnloadResult PENDING_LOGIN = new WorldUnloadResult(false, Component.text("Unable to load world with pending login!"));
++    public static final WorldUnloadResult PLUGIN = new WorldUnloadResult(false, Component.text("World unload cancelled by plugin"));
++    public static final WorldUnloadResult NULL = new WorldUnloadResult(false, Component.text("Cannot unload null world"));
++
++    private final boolean success;
++    private final Component message;
++
++    public WorldUnloadResult(boolean success, Component message) {
++        this.success = success;
++        this.message = message;
++    }
++
++    public boolean isSuccess() {
++        return success;
++    }
++
++    public Component message() {
++        return message;
++    }
++}

--- a/patches/api/0398-Add-WorldUnloadResult.patch
+++ b/patches/api/0398-Add-WorldUnloadResult.patch
@@ -6,15 +6,17 @@ Subject: [PATCH] Add WorldUnloadResult
 
 diff --git a/src/main/java/io/papermc/paper/world/WorldUnloadResult.java b/src/main/java/io/papermc/paper/world/WorldUnloadResult.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5fb077e0ab5ad238763adb2a1d2a6cc95cf0f1e4
+index 0000000000000000000000000000000000000000..d8b190dfb44e3f4712f0b2e5677cb0b9893fe5ec
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/world/WorldUnloadResult.java
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,17 @@
 +package io.papermc.paper.world;
 +
 +import net.kyori.adventure.text.Component;
 +
-+public class WorldUnloadResult {
++import org.jetbrains.annotations.NotNull;
++
++public record WorldUnloadResult(boolean success, @NotNull Component message) {
 +
 +    public static final WorldUnloadResult SUCCESS = new WorldUnloadResult(true, Component.text("Success"));
 +    public static final WorldUnloadResult NOT_LOADED = new WorldUnloadResult(false, Component.text("Cannot unload unloaded world"));
@@ -24,19 +26,4 @@ index 0000000000000000000000000000000000000000..5fb077e0ab5ad238763adb2a1d2a6cc9
 +    public static final WorldUnloadResult PLUGIN = new WorldUnloadResult(false, Component.text("World unload cancelled by plugin"));
 +    public static final WorldUnloadResult NULL = new WorldUnloadResult(false, Component.text("Cannot unload null world"));
 +
-+    private final boolean success;
-+    private final Component message;
-+
-+    public WorldUnloadResult(boolean success, Component message) {
-+        this.success = success;
-+        this.message = message;
-+    }
-+
-+    public boolean isSuccess() {
-+        return success;
-+    }
-+
-+    public Component message() {
-+        return message;
-+    }
 +}

--- a/patches/server/0917-Add-WorldUnloadResult.patch
+++ b/patches/server/0917-Add-WorldUnloadResult.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Wed, 28 Sep 2022 05:09:11 +0100
+Subject: [PATCH] Add WorldUnloadResult
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 111f8276f26350a5c62a7b8577b4598978b5355d..8843c966eeeb8cc009df43cf04aae713466dbda0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1269,30 +1269,41 @@ public final class CraftServer implements Server {
+ 
+     @Override
+     public boolean unloadWorld(World world, boolean save) {
++        // Paper start
++        return unloadWorld_(world, save).isSuccess();
++    }
++
++    public io.papermc.paper.world.WorldUnloadResult unloadWorld_(World world, boolean save) {
++        // paper end
+         //Preconditions.checkState(!this.console.isIteratingOverLevels, "Cannot unload a world while worlds are being ticked"); // Paper - Cat - Temp disable. We'll see how this goes.
+         if (world == null) {
+-            return false;
++            return io.papermc.paper.world.WorldUnloadResult.NULL; // Just, why... // paper
+         }
+ 
+         ServerLevel handle = ((CraftWorld) world).getHandle();
+ 
+         if (this.console.getLevel(handle.dimension()) == null) {
+-            return false;
++            return io.papermc.paper.world.WorldUnloadResult.NOT_LOADED; // paper
+         }
+ 
+         if (handle.dimension() == net.minecraft.world.level.Level.OVERWORLD) {
+-            return false;
++            return io.papermc.paper.world.WorldUnloadResult.UNSUPPORTED; // Paper
+         }
+ 
+-        if (handle.players().size() > 0 || handle.pendingLogin.size() > 0) { // Paper
+-            return false;
++        // Paper start - replace return, and differentiante
++        if (handle.players().size() > 0) {
++            return io.papermc.paper.world.WorldUnloadResult.NOT_EMPTY;
++        }
++        if (handle.pendingLogin.size() > 0) {
++            return io.papermc.paper.world.WorldUnloadResult.PENDING_LOGIN;
+         }
++        // Paper end
+ 
+         WorldUnloadEvent e = new WorldUnloadEvent(handle.getWorld());
+         this.pluginManager.callEvent(e);
+ 
+         if (e.isCancelled()) {
+-            return false;
++            return io.papermc.paper.world.WorldUnloadResult.PLUGIN;
+         }
+ 
+         try {
+@@ -1309,7 +1320,7 @@ public final class CraftServer implements Server {
+ 
+         this.worlds.remove(world.getName().toLowerCase(java.util.Locale.ENGLISH));
+         this.console.removeLevel(handle);
+-        return true;
++        return io.papermc.paper.world.WorldUnloadResult.SUCCESS;
+     }
+ 
+     public DedicatedServer getServer() {


### PR DESCRIPTION
needs organisating, commentry, and actually exposing in the API

PR is semi hasty, I don't wanna throw a bunch of time cleaning this up without some general commentary first, iffy on not using an enum, being enums have bit us in the arse before, and mostly, people mostly only care about fail/success

Should probably add the annotation to not ignore the ret value too, as many people seem to miss that one in general