### PR TITLE
Fix jigsaw block kicking user

### DIFF
--- a/patches/server/0917-fix-Jigsaw-block-kicking-user.patch
+++ b/patches/server/0917-fix-Jigsaw-block-kicking-user.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Legitimoose <legitimoose@gmail.com>
+Date: Wed, 28 Sep 2022 22:45:49 -0700
+Subject: [PATCH] fix Jigsaw block kicking user
+
+
+diff --git a/src/main/java/net/minecraft/world/level/levelgen/structure/pools/StructureTemplatePool.java b/src/main/java/net/minecraft/world/level/levelgen/structure/pools/StructureTemplatePool.java
+index de7435f6596e200c8511224a0479c2ad499b2a97..bcf9eb1096b09748bcabba05bc9ffac494d3c611 100644
+--- a/src/main/java/net/minecraft/world/level/levelgen/structure/pools/StructureTemplatePool.java
++++ b/src/main/java/net/minecraft/world/level/levelgen/structure/pools/StructureTemplatePool.java
+@@ -89,7 +89,13 @@ public class StructureTemplatePool {
+     }
+ 
+     public StructurePoolElement getRandomTemplate(RandomSource random) {
++        //Paper start - Prevent random.nextInt throwing an IllegalArgumentException
++        if (this.templates.size() == 0) {
++            return EmptyPoolElement.INSTANCE;
++        } else {
+         return this.templates.get(random.nextInt(this.templates.size()));
++        }
++        // Paper end
+     }
+ 
+     public List<StructurePoolElement> getShuffledTemplates(RandomSource random) {


### PR DESCRIPTION
Fixes #8102 

Adds a tiny check to prevent an IllegalArgumentException when calling ``random.nextInt(0)``.  Previously this kicked players who clicked "Generate" in a structure block attempting to load "minecraft:empty".