### PR TITLE
Mark parsed PoiChunks with data as not loaded

### DIFF
--- a/patches/server/0016-Rewrite-chunk-system.patch
+++ b/patches/server/0016-Rewrite-chunk-system.patch
@@ -4902,10 +4902,10 @@ index 0000000000000000000000000000000000000000..0b7a2b0ead4f3bc07bfd9a38c2b7cf02
 +}
 diff --git a/src/main/java/io/papermc/paper/chunk/system/poi/PoiChunk.java b/src/main/java/io/papermc/paper/chunk/system/poi/PoiChunk.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b1bdd79044c00635c836dbed327526136ca4bd4e
+index 0000000000000000000000000000000000000000..1695ef1d1ed2e067665431063fbca7f51873af32
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/chunk/system/poi/PoiChunk.java
-@@ -0,0 +1,211 @@
+@@ -0,0 +1,213 @@
 +package io.papermc.paper.chunk.system.poi;
 +
 +import com.mojang.logging.LogUtils;
@@ -5113,6 +5113,8 @@ index 0000000000000000000000000000000000000000..b1bdd79044c00635c836dbed32752613
 +            readAnything = true;
 +            ret.sections[sectionY - ret.minSection] = deserialized;
 +        }
++
++        ret.loaded = !readAnything; // Set loaded to false if we read anything to ensure proper callbacks to PoiManager are made on #load
 +
 +        return ret;
 +    }


### PR DESCRIPTION
Previously, PoiChunk#empty would create a new empty poi chunk with loaded already set to true, as no data was contained in the chunk. This allowed the poi chunk to skip expensive trips to the main thread.

However, PoiChunk#parse used #empty to create the initial PoiChunk instance that is then filled with data.
This leads to PoiChunks returned from #parse to already be marked as loaded, preventing the then needed trip to the tick thread to update things like the village distance tracker.

To fix this, this commit now marks the PoiChunks loaded state as false if the parse logic actually read and parsed any data. This allows the PoiChunk#load method to properly run its callbacks when called for the first time.

Resolves: #8401
CC: @Spottedleaf 