### PR TITLE
Load Allay duplication cooldown as a long

### DIFF
--- a/patches/server/0236-Fix-NBT-type-issues.patch
+++ b/patches/server/0236-Fix-NBT-type-issues.patch
@@ -1,8 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 3 Aug 2018 00:04:54 -0400
-Subject: [PATCH] MC-135506: Experience should save as Integers
+Subject: [PATCH] Fix NBT type issues
 
+Addresses two issues:
+- MC-135506: Experience should save as Integers
+- Allay duplication cooldown is saved and exposed as a long, but loaded as an int
 
 diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 index 2fead19c1c4b04f94999887b196ceaee025edd99..2d1228670696224452cb432e0279456d8c5fe710 100644
@@ -26,3 +29,16 @@ index 2fead19c1c4b04f94999887b196ceaee025edd99..2d1228670696224452cb432e0279456d
          this.count = Math.max(nbt.getInt("Count"), 1);
          this.loadPaperNBT(nbt); // Paper
      }
+diff --git a/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java b/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java
+index 2d87b740e84435ef9bd3eee3d3e2af9f707a0826..1dcd0c494681b7665b6b86dbe20375afd8d2fad8 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java
++++ b/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java
+@@ -484,7 +484,7 @@ public class Allay extends PathfinderMob implements InventoryCarrier {
+             });
+         }
+ 
+-        this.duplicationCooldown = (long) nbt.getInt("DuplicationCooldown");
++        this.duplicationCooldown = nbt.getLong("DuplicationCooldown"); // Paper - Load as long
+         this.entityData.set(Allay.DATA_CAN_DUPLICATE, nbt.getBoolean("CanDuplicate"));
+     }
+ 


### PR DESCRIPTION
It is saved as a long, and the API exposes a long, so loading it as an int may cause some unexpected issues like overflows.

This could potentially be merged into [Aikar's MC-133506 patch](https://github.com/PaperMC/Paper/blob/master/patches/server/0237-MC-135506-Experience-should-save-as-Integers.patch).