### PR TITLE
fix wrong yaw and pitch of CommandSourceStack#getBukkitLocation

### DIFF
--- a/patches/server/0298-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0298-Implement-Brigadier-Mojang-API.patch
@@ -34,7 +34,7 @@ index da6250df1c5f3385b683cffde47754bca4606f5e..3384501f83d445f45aa8233e98c7597d
      public void removeCommand(String name) {
          this.children.remove(name);
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index 3308d684fc6cd0a83e190a52693b29d30e0087cb..aadddbc16aa719677c3b6fc4969b6145b9b9ee0b 100644
+index 3308d684fc6cd0a83e190a52693b29d30e0087cb..fa258155b1cbdd8efde15ec59986d0ab56245ddd 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 @@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec2;
@@ -66,7 +66,7 @@ index 3308d684fc6cd0a83e190a52693b29d30e0087cb..aadddbc16aa719677c3b6fc4969b6145
 +        Vec3 pos = getPosition();
 +        org.bukkit.World world = getBukkitWorld();
 +        Vec2 rot = getRotation();
-+        return world != null && pos != null ? new org.bukkit.Location(world, pos.x, pos.y, pos.z, rot != null ? rot.x : 0, rot != null ? rot.y : 0) : null;
++        return world != null && pos != null ? new org.bukkit.Location(world, pos.x, pos.y, pos.z, rot != null ? rot.y : 0, rot != null ? rot.x : 0) : null;
 +    }
 +    // Paper end
 +


### PR DESCRIPTION
The method CommandSourceStack#getBukkitLocation method returns the yaw and pitch values the wrong way around. Tested this change with a small plugin reporting my yaw/pitch and the result of the method.

Closes #8408