### PR TITLE
Avoid resizing of ArrayList in ChunkMap#getPlayers

### DIFF
--- a/patches/server/0016-Rewrite-chunk-system.patch
+++ b/patches/server/0016-Rewrite-chunk-system.patch
@@ -12891,7 +12891,7 @@ index c905602d23cdf3af1de7ab4419f11856b07da2ba..fa1ab9974859c75075f3090e36e0de58
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 86c33f029ae56fcace51b69763202be9f8bc5f44..b550f302b1bb6ef92987c8c3431b94c3ba3a091d 100644
+index 86c33f029ae56fcace51b69763202be9f8bc5f44..2ba3bb4e5670ece798a8882801a856d82851c00a 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -50,17 +50,12 @@ public class ChunkHolder {
@@ -13148,7 +13148,7 @@ index 86c33f029ae56fcace51b69763202be9f8bc5f44..b550f302b1bb6ef92987c8c3431b94c3
  
                  if (chunk != null) {
                      int j = this.lightEngine.getMinLightSection();
-@@ -340,66 +305,34 @@ public class ChunkHolder {
+@@ -340,66 +305,32 @@ public class ChunkHolder {
      }
  
      public void broadcast(Packet<?> packet, boolean onlyOnWatchDistanceEdge) {
@@ -13178,14 +13178,12 @@ index 86c33f029ae56fcace51b69763202be9f8bc5f44..b550f302b1bb6ef92987c8c3431b94c3
 -                throw chunkStorage.debugFuturesAndCreateReportedException(new IllegalStateException("null value previously set for chunk status"), s);
 +        Object[] backingSet = players.getBackingSet();
 +        for (int i = 0, len = backingSet.length; i < len; ++i) {
-+            Object temp = backingSet[i];
-+            if (!(temp instanceof ServerPlayer)) {
++            if (!(backingSet[i] instanceof ServerPlayer player)) {
 +                continue;
              }
 -
 -            if (either == ChunkHolder.NOT_DONE_YET || either.right().isEmpty()) {
 -                return completablefuture;
-+            ServerPlayer player = (ServerPlayer)temp;
 +            if (!this.chunkMap.playerChunkManager.isChunkSent(player, this.pos.x, this.pos.z, onlyOnWatchDistanceEdge)) {
 +                continue;
              }
@@ -13235,7 +13233,7 @@ index 86c33f029ae56fcace51b69763202be9f8bc5f44..b550f302b1bb6ef92987c8c3431b94c3
      }
  
      public final ChunkPos getPos() { // Paper - final for inline
-@@ -407,207 +340,10 @@ public class ChunkHolder {
+@@ -407,207 +338,10 @@ public class ChunkHolder {
      }
  
      public final int getTicketLevel() { // Paper - final for inline
@@ -13445,7 +13443,7 @@ index 86c33f029ae56fcace51b69763202be9f8bc5f44..b550f302b1bb6ef92987c8c3431b94c3
  
      public static ChunkStatus getStatus(int level) {
          return level < 33 ? ChunkStatus.FULL : ChunkStatus.getStatusAroundFullChunk(level - 33);
-@@ -617,38 +353,14 @@ public class ChunkHolder {
+@@ -617,38 +351,14 @@ public class ChunkHolder {
          return ChunkHolder.FULL_CHUNK_STATUSES[Mth.clamp(33 - distance + 1, (int) 0, ChunkHolder.FULL_CHUNK_STATUSES.length - 1)];
      }
  
@@ -13487,7 +13485,7 @@ index 86c33f029ae56fcace51b69763202be9f8bc5f44..b550f302b1bb6ef92987c8c3431b94c3
      }
  
      @FunctionalInterface
-@@ -697,15 +409,15 @@ public class ChunkHolder {
+@@ -697,15 +407,15 @@ public class ChunkHolder {
  
      // Paper start
      public final boolean isEntityTickingReady() {
@@ -13507,7 +13505,7 @@ index 86c33f029ae56fcace51b69763202be9f8bc5f44..b550f302b1bb6ef92987c8c3431b94c3
      // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index cbd4e749574c55c6e52f42b62dd6da8cfcca97f9..eda47a2c2a26fcf3434af140e1436395b2506cb0 100644
+index cbd4e749574c55c6e52f42b62dd6da8cfcca97f9..13814643e28e36c72173d0d62b9271a7f6113f6a 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -122,10 +122,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -14419,7 +14417,7 @@ index cbd4e749574c55c6e52f42b62dd6da8cfcca97f9..eda47a2c2a26fcf3434af140e1436395
          return sectionposition;
      }
  
-@@ -1307,65 +824,40 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1307,65 +824,38 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          int k1;
          int l1;
  
@@ -14473,29 +14471,26 @@ index cbd4e749574c55c6e52f42b62dd6da8cfcca97f9..eda47a2c2a26fcf3434af140e1436395
 -        Set<ServerPlayer> set = this.playerMap.getPlayers(chunkPos.toLong());
 -        Builder<ServerPlayer> builder = ImmutableList.builder();
 -        Iterator iterator = set.iterator();
--
--        while (iterator.hasNext()) {
--            ServerPlayer entityplayer = (ServerPlayer) iterator.next();
--            SectionPos sectionposition = entityplayer.getLastSectionPos();
 +        // Paper start - per player view distance
 +        // there can be potential desync with player's last mapped section and the view distance map, so use the
 +        // view distance map here.
-+        List<ServerPlayer> ret = new java.util.ArrayList<>(4);
-+
 +        com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<ServerPlayer> players = this.playerChunkManager.broadcastMap.getObjectsInRange(chunkPos);
 +        if (players == null) {
-+            return ret;
++            return java.util.Collections.emptyList();
 +        }
+ 
+-        while (iterator.hasNext()) {
+-            ServerPlayer entityplayer = (ServerPlayer) iterator.next();
+-            SectionPos sectionposition = entityplayer.getLastSectionPos();
++        List<ServerPlayer> ret = new java.util.ArrayList<>(players.size());
  
 -            if (onlyOnWatchDistanceEdge && ChunkMap.isChunkOnRangeBorder(chunkPos.x, chunkPos.z, sectionposition.x(), sectionposition.z(), this.viewDistance) || !onlyOnWatchDistanceEdge && ChunkMap.isChunkInRange(chunkPos.x, chunkPos.z, sectionposition.x(), sectionposition.z(), this.viewDistance)) {
 -                builder.add(entityplayer);
 +        Object[] backingSet = players.getBackingSet();
 +        for (int i = 0, len = backingSet.length; i < len; ++i) {
-+            Object temp = backingSet[i];
-+            if (!(temp instanceof ServerPlayer)) {
++            if (!(backingSet[i] instanceof ServerPlayer player)) {
 +                continue;
 +            }
-+            ServerPlayer player = (ServerPlayer)temp;
 +            if (!this.playerChunkManager.isChunkSent(player, chunkPos.x, chunkPos.z, onlyOnWatchDistanceEdge)) {
 +                continue;
              }
@@ -14508,7 +14503,7 @@ index cbd4e749574c55c6e52f42b62dd6da8cfcca97f9..eda47a2c2a26fcf3434af140e1436395
      }
  
      public void addEntity(Entity entity) {
-@@ -1560,7 +1052,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1560,7 +1050,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
          @Override
          protected boolean isChunkToRemove(long pos) {
@@ -14517,7 +14512,7 @@ index cbd4e749574c55c6e52f42b62dd6da8cfcca97f9..eda47a2c2a26fcf3434af140e1436395
          }
  
          @Nullable
-@@ -1641,7 +1133,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1641,7 +1131,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              org.spigotmc.AsyncCatcher.catchOp("player tracker update"); // Spigot
              if (player != this.entity) {
                  Vec3 vec3d = player.position().subtract(this.entity.position());

--- a/patches/server/0238-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/patches/server/0238-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -8,10 +8,10 @@ Add -Ddebug.entities=true to your JVM flags to gain more information
 1.17: Needs to be reworked for new entity storage system
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index ea9f536efd4c76b421f6e02f93f16fae115840d8..d1af0aca0237ee86acd86fea3255ddeadc3db0d6 100644
+index 33e20bb8c7addbcf77b38abd837ca096880fc244..8b93af04aca46f59bed826e66ad9ee21cda38199 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -886,6 +886,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -884,6 +884,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                  } else {
                      ChunkMap.TrackedEntity playerchunkmap_entitytracker = new ChunkMap.TrackedEntity(entity, i, j, entitytypes.trackDeltas());
  
@@ -19,7 +19,7 @@ index ea9f536efd4c76b421f6e02f93f16fae115840d8..d1af0aca0237ee86acd86fea3255ddea
                      this.entityMap.put(entity.getId(), playerchunkmap_entitytracker);
                      playerchunkmap_entitytracker.updatePlayers(this.level.players());
                      if (entity instanceof ServerPlayer) {
-@@ -928,7 +929,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -926,7 +927,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          if (playerchunkmap_entitytracker1 != null) {
              playerchunkmap_entitytracker1.broadcastRemoved();
          }

--- a/patches/server/0347-Anti-Xray.patch
+++ b/patches/server/0347-Anti-Xray.patch
@@ -1044,7 +1044,7 @@ index 7825d6f0fdcfda6212cff8033ec55fb7db236154..000853110c7a89f2d0403a7a2737025a
  
      public ClientboundLevelChunkWithLightPacket(FriendlyByteBuf buf) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 67823979209f9b8a3f44cd21baca667457ef110a..e3296ca34a47f37cdb3f475fcc66c2412fd39ee0 100644
+index 9223b2c90bca5ed82ba424d936fc85b4fc1dba18..19432d3408bfa806bc415dc3f148e154eeb802fc 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -618,7 +618,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1056,7 +1056,7 @@ index 67823979209f9b8a3f44cd21baca667457ef110a..e3296ca34a47f37cdb3f475fcc66c241
          if (player.level == this.level) {
              if (newWithinViewDistance && !oldWithinViewDistance) {
                  ChunkHolder playerchunk = this.getVisibleChunkIfPresent(pos.toLong());
-@@ -1099,12 +1099,17 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1097,12 +1097,17 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
      }
  

--- a/patches/server/0349-Tracking-Range-Improvements.patch
+++ b/patches/server/0349-Tracking-Range-Improvements.patch
@@ -8,10 +8,10 @@ Sets tracking range of watermobs to animals instead of misc and simplifies code
 Also ignores Enderdragon, defaulting it to Mojang's setting
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index e3296ca34a47f37cdb3f475fcc66c2412fd39ee0..3f1bd5e0efa72e8805fcf74f20c0d46f67cfde6b 100644
+index 19432d3408bfa806bc415dc3f148e154eeb802fc..442d720783b43254d95b7fa62776f70605644ec1 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1287,6 +1287,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1285,6 +1285,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              while (iterator.hasNext()) {
                  Entity entity = (Entity) iterator.next();
                  int j = entity.getType().clientTrackingRange() * 16;

--- a/patches/server/0372-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
+++ b/patches/server/0372-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
@@ -7,10 +7,10 @@ Suspected case would be around the technique used in .stopRiding
 Stack will identify any causer of this and warn instead of crashing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 638d768393c507ff855c7b517434b61736f680d1..de5caa032685787fb04172ec5c05a022d99827c1 100644
+index 428d3a9c9c55d482bd7db8fd2784d1e55dea0528..de7e20400f7c70c84c5659d449952eb40caee163 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1020,6 +1020,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1018,6 +1018,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
      public void addEntity(Entity entity) {
          org.spigotmc.AsyncCatcher.catchOp("entity track"); // Spigot

--- a/patches/server/0386-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/patches/server/0386-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -28,10 +28,10 @@ receives a deterministic result, and should no longer require 1 tick
 delays anymore.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index de5caa032685787fb04172ec5c05a022d99827c1..46bec088294c7500c9021103587a80e29de4b54b 100644
+index de7e20400f7c70c84c5659d449952eb40caee163..93ef138cdcf2633768b0452511933ec4a14f1ceb 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1027,6 +1027,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1025,6 +1025,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                  .printStackTrace();
              return;
          }

--- a/patches/server/0412-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
+++ b/patches/server/0412-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
@@ -18,10 +18,10 @@ index 3167f5c6be39757e3cc42cbb17ab0cf13a2fe470..3768a71491ef7836b9739bdaec7a077c
      private static long encode(double value) {
          return Mth.lfloor(value * 4096.0D);
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 46bec088294c7500c9021103587a80e29de4b54b..8dce24ae70057115feff193a1307eb2437e16773 100644
+index 93ef138cdcf2633768b0452511933ec4a14f1ceb..bdf36ffc99b241c90075b40347cfb25543c49e16 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1305,9 +1305,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1303,9 +1303,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          public void updatePlayer(ServerPlayer player) {
              org.spigotmc.AsyncCatcher.catchOp("player tracker update"); // Spigot
              if (player != this.entity) {

--- a/patches/server/0416-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/patches/server/0416-Use-distance-map-to-optimise-entity-tracker.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use distance map to optimise entity tracker
 Use the distance map to find candidate players for tracking.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 50e9d29b5a0ea6d11a44c41c49d6f52bc464e6e2..2a25d552612bf94c5f54249ae3cba549ea242488 100644
+index 5b3e1d282231969918fa621dfccdc0190428495d..3b00664b8fde839cb2dfabc5c87d3dcbbc899c09 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -66,6 +66,7 @@ import net.minecraft.network.protocol.game.ClientboundSetEntityLinkPacket;
@@ -148,7 +148,7 @@ index 50e9d29b5a0ea6d11a44c41c49d6f52bc464e6e2..2a25d552612bf94c5f54249ae3cba549
  
          int i = SectionPos.blockToSectionCoord(player.getBlockX());
          int j = SectionPos.blockToSectionCoord(player.getBlockZ());
-@@ -1098,7 +1166,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1096,7 +1164,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
                      entity.tracker = playerchunkmap_entitytracker; // Paper - Fast access to tracker
                      this.entityMap.put(entity.getId(), playerchunkmap_entitytracker);
@@ -157,7 +157,7 @@ index 50e9d29b5a0ea6d11a44c41c49d6f52bc464e6e2..2a25d552612bf94c5f54249ae3cba549
                      if (entity instanceof ServerPlayer) {
                          ServerPlayer entityplayer = (ServerPlayer) entity;
  
-@@ -1142,7 +1210,37 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1140,7 +1208,37 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          entity.tracker = null; // Paper - We're no longer tracked
      }
  
@@ -195,7 +195,7 @@ index 50e9d29b5a0ea6d11a44c41c49d6f52bc464e6e2..2a25d552612bf94c5f54249ae3cba549
          List<ServerPlayer> list = Lists.newArrayList();
          List<ServerPlayer> list1 = this.level.players();
          ObjectIterator objectiterator = this.entityMap.values().iterator();
-@@ -1216,46 +1314,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1214,46 +1312,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          }));
          // Paper end
          DebugPackets.sendPoiPacketsForChunk(this.level, chunk.getPos());
@@ -243,7 +243,7 @@ index 50e9d29b5a0ea6d11a44c41c49d6f52bc464e6e2..2a25d552612bf94c5f54249ae3cba549
  
      }
  
-@@ -1310,6 +1369,42 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1308,6 +1367,42 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              this.lastSectionPos = SectionPos.of((EntityAccess) entity);
          }
  

--- a/patches/server/0729-Oprimise-map-impl-for-tracked-players.patch
+++ b/patches/server/0729-Oprimise-map-impl-for-tracked-players.patch
@@ -7,10 +7,10 @@ Reference2BooleanOpenHashMap is going to have
 better lookups than HashMap.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 3540ac6f99d724d91ff4e897f7e84ef03037f1bf..57b45ce5feaa5015b5468a0b44f354e96d7d95fc 100644
+index a49e67dffd781798085a4b912190e1f9d74dd494..1c7ec34be8e82ee67e7ea2e705c3071a1a5a870b 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1363,7 +1363,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1361,7 +1361,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          final Entity entity;
          private final int range;
          SectionPos lastSectionPos;

--- a/patches/server/0903-Workaround-for-client-lag-spikes-MC-162253.patch
+++ b/patches/server/0903-Workaround-for-client-lag-spikes-MC-162253.patch
@@ -16,10 +16,10 @@ Co-authored-by: =?UTF-8?q?Dani=C3=ABl=20Goossens?= <daniel@goossens.ch>
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 841df3f621081f6b67711cbd047e8bde498eedbf..5461bac37b6dc0575cccd6656b48b2ef18cfaa04 100644
+index bea95b155cdebb2b8e35096aafbbd0264a25b977..73daa8368066e20d251b8b6eb69c916919b48838 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1331,6 +1331,46 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1329,6 +1329,46 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
      }
  
@@ -66,7 +66,7 @@ index 841df3f621081f6b67711cbd047e8bde498eedbf..5461bac37b6dc0575cccd6656b48b2ef
      // Paper start - Anti-Xray - Bypass
      private void playerLoadedChunk(ServerPlayer player, MutableObject<java.util.Map<Object, ClientboundLevelChunkWithLightPacket>> cachedDataPackets, LevelChunk chunk) {
          if (cachedDataPackets.getValue() == null) {
-@@ -1339,6 +1379,45 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1337,6 +1377,45 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
          Boolean shouldModify = chunk.getLevel().chunkPacketBlockController.shouldModify(player, chunk);
          player.trackChunk(chunk.getPos(), (Packet) cachedDataPackets.getValue().computeIfAbsent(shouldModify, (s) -> {


### PR DESCRIPTION
Avoids resizing of ArrayList in ChunkMap#getPlayers and avoids allocations completely if no players are nearby. This method is only used once in Paper itself but I do use this method in plugins.
I also replaced the cast with instanceof pattern matching. I can revert this part if this is not wanted for some reason.