### PR TITLE
Exempt players in creative/spectator from nether ceiling damage

### DIFF
--- a/patches/server/0033-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0033-Configurable-top-of-nether-void-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable top of nether void damage
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ab2671c21f2f44973fb2507b178ac8e1e03bc8dc..4b5ec8921a86adf919e87ec9d7b2e58705478022 100644
+index ab2671c21f2f44973fb2507b178ac8e1e03bc8dc..ce5f30b761ddaa2b3b241903d75770d0c5050d92 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -705,7 +705,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -705,7 +705,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void checkOutOfWorld() {
@@ -16,7 +16,8 @@ index ab2671c21f2f44973fb2507b178ac8e1e03bc8dc..4b5ec8921a86adf919e87ec9d7b2e587
 +        // Paper start - Configurable nether ceiling damage
 +        if (this.getY() < (double) (this.level.getMinBuildHeight() - 64) || (this.level.getWorld().getEnvironment() == org.bukkit.World.Environment.NETHER
 +            && level.paperConfig().environment.netherCeilingVoidDamageHeight > 0
-+            && this.getY() >= this.level.paperConfig().environment.netherCeilingVoidDamageHeight)) {
++            && this.getY() >= this.level.paperConfig().environment.netherCeilingVoidDamageHeight
++            && (!(this instanceof Player player) || !player.getAbilities().invulnerable))) {
 +            // Paper end
              this.outOfWorld();
          }

--- a/patches/server/0056-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0056-Add-configurable-portal-search-radius.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4b5ec8921a86adf919e87ec9d7b2e58705478022..71d539341c2ae8c64befc54ef974daa06a859fa5 100644
+index ce5f30b761ddaa2b3b241903d75770d0c5050d92..5723bddfe94f4b064ba25911dab474cad11eac17 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3003,7 +3003,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3004,7 +3004,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  double d0 = DimensionType.getTeleportationScale(this.level.dimensionType(), destination.dimensionType());
                  BlockPos blockposition = worldborder.clampToBounds(this.getX() * d0, this.getY(), this.getZ() * d0);
                  // CraftBukkit start

--- a/patches/server/0061-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/patches/server/0061-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 71d539341c2ae8c64befc54ef974daa06a859fa5..e28ccb5651a793775166d51859620882ee54b641 100644
+index 5723bddfe94f4b064ba25911dab474cad11eac17..551365ae91c5e595ff00eb9f26bd91e99491233e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2641,6 +2641,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2642,6 +2642,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
      @Nullable
      public Team getTeam() {

--- a/patches/server/0127-Don-t-allow-entities-to-ride-themselves-572.patch
+++ b/patches/server/0127-Don-t-allow-entities-to-ride-themselves-572.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't allow entities to ride themselves - #572
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 77652939ccb3191c29b919170a06ef451b3fd74f..b4d96dfc68788a4eae2197a0f2615de213d5ca8b 100644
+index 3cc3ee1a997992ea53445a656d0ab9fb9e0ae9e8..d43a6fa8c25382bef7127f1106e3bde0341472b0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2385,6 +2385,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2386,6 +2386,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/patches/server/0146-Entity-fromMobSpawner.patch
+++ b/patches/server/0146-Entity-fromMobSpawner.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6e1b53317c4107f907e551a9baeaf64909f6de87..65a22c154807c416a63fbf68dad72175b51a52d4 100644
+index 8e9530e5c37bbab8d9ad016f25ce1da6623e3b8e..5c54729fbf8fa0a58260fcb1f52f9b95bab4aadf 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -380,6 +380,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -16,7 +16,7 @@ index 6e1b53317c4107f907e551a9baeaf64909f6de87..65a22c154807c416a63fbf68dad72175
      @javax.annotation.Nullable
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
-@@ -2020,6 +2021,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2021,6 +2022,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  }
                  nbt.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -27,7 +27,7 @@ index 6e1b53317c4107f907e551a9baeaf64909f6de87..65a22c154807c416a63fbf68dad72175
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2159,6 +2164,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2160,6 +2165,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.originWorld = originWorld;
                  origin = new org.bukkit.util.Vector(originTag.getDouble(0), originTag.getDouble(1), originTag.getDouble(2));
              }

--- a/patches/server/0221-add-more-information-to-Entity.toString.patch
+++ b/patches/server/0221-add-more-information-to-Entity.toString.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add more information to Entity.toString()
 UUID, ticks lived, valid, dead
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 65a22c154807c416a63fbf68dad72175b51a52d4..2e988d59404c52cd9c290b96d21f886573cda0fa 100644
+index 5c54729fbf8fa0a58260fcb1f52f9b95bab4aadf..38031c5d034333cbeaba3f3e271d7b3bc2c2b0da 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2968,7 +2968,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2969,7 +2969,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public String toString() {
          String s = this.level == null ? "~NULL~" : this.level.toString();
  

--- a/patches/server/0287-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0287-force-entity-dismount-during-teleportation.patch
@@ -41,10 +41,10 @@ index 32aba4c822742d6a2ebbc25b169ffb665e9413f7..135e61ffa69a56e7c5edcd9e2066334a
  
          if (entity1 != entity && this.connection != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0e632f9eabd0d55a4eaacff54abaf637660528dd..e6fa82b942ec176288aaca080e3d9c8df6a16ac0 100644
+index 304aac869261548681956fa7137578d73384a789..9257d639b41b1c66f64cc2d1f7ce534cc8354c93 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2381,11 +2381,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2382,11 +2382,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void removeVehicle() {
@@ -62,7 +62,7 @@ index 0e632f9eabd0d55a4eaacff54abaf637660528dd..e6fa82b942ec176288aaca080e3d9c8d
          }
  
      }
-@@ -2448,7 +2453,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2449,7 +2454,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return true; // CraftBukkit
      }
  
@@ -74,7 +74,7 @@ index 0e632f9eabd0d55a4eaacff54abaf637660528dd..e6fa82b942ec176288aaca080e3d9c8d
          if (entity.getVehicle() == this) {
              throw new IllegalStateException("Use x.stopRiding(y), not y.removePassenger(x)");
          } else {
-@@ -2458,7 +2466,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2459,7 +2467,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (this.getBukkitEntity() instanceof Vehicle && entity.getBukkitEntity() instanceof LivingEntity) {
                  VehicleExitEvent event = new VehicleExitEvent(
                          (Vehicle) this.getBukkitEntity(),
@@ -83,7 +83,7 @@ index 0e632f9eabd0d55a4eaacff54abaf637660528dd..e6fa82b942ec176288aaca080e3d9c8d
                  );
                  // Suppress during worldgen
                  if (this.valid) {
-@@ -2472,7 +2480,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2473,7 +2481,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
              // CraftBukkit end
              // Spigot start

--- a/patches/server/0305-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0305-Entity-getEntitySpawnReason.patch
@@ -35,7 +35,7 @@ index 45cd4ac70bf322a3bb256579f795db46b9beb7a0..80b6eb1e010559c02c9e7624a5c131d1
              });
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e6fa82b942ec176288aaca080e3d9c8df6a16ac0..fa128e7f8089339f932e19edf95a8d5c0cc14046 100644
+index 9257d639b41b1c66f64cc2d1f7ce534cc8354c93..91cac068ed56ded6e786698fbbfb00fc3670fdd0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -74,6 +74,8 @@ import net.minecraft.world.InteractionHand;
@@ -55,7 +55,7 @@ index e6fa82b942ec176288aaca080e3d9c8df6a16ac0..fa128e7f8089339f932e19edf95a8d5c
  
      public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
      private CraftEntity bukkitEntity;
-@@ -2023,6 +2026,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2024,6 +2027,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  }
                  nbt.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -65,7 +65,7 @@ index e6fa82b942ec176288aaca080e3d9c8df6a16ac0..fa128e7f8089339f932e19edf95a8d5c
              // Save entity's from mob spawner status
              if (spawnedViaMobSpawner) {
                  nbt.putBoolean("Paper.FromMobSpawner", true);
-@@ -2168,6 +2174,26 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2169,6 +2175,26 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0345-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0345-Entity-Activation-Range-2.0.patch
@@ -108,7 +108,7 @@ index faee1edda215fa72f5b7e1bdbbeb01004d019b0d..4a06da72c8b769c683e9eb03817bd938
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fa128e7f8089339f932e19edf95a8d5c0cc14046..c5b1d2e4b577a3f4ad352dc6a8436c04411efa8b 100644
+index 91cac068ed56ded6e786698fbbfb00fc3670fdd0..993108ff719f29b819ccb2da338977c9d2b32219 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -384,6 +384,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -120,7 +120,7 @@ index fa128e7f8089339f932e19edf95a8d5c0cc14046..c5b1d2e4b577a3f4ad352dc6a8436c04
      protected int numCollisions = 0; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      @javax.annotation.Nullable
-@@ -909,6 +911,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -910,6 +912,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          } else {
              this.wasOnFire = this.isOnFire();
              if (movementType == MoverType.PISTON) {
@@ -129,7 +129,7 @@ index fa128e7f8089339f932e19edf95a8d5c0cc14046..c5b1d2e4b577a3f4ad352dc6a8436c04
                  movement = this.limitPistonMovement(movement);
                  if (movement.equals(Vec3.ZERO)) {
                      return;
-@@ -921,6 +925,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -922,6 +926,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }

--- a/patches/server/0350-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0350-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c5b1d2e4b577a3f4ad352dc6a8436c04411efa8b..1b546c979d7ebe5f77fe7ad7fc422d94e8181aac 100644
+index 993108ff719f29b819ccb2da338977c9d2b32219..1d933c0302c1ca4752c837b7da802f752a53b437 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3175,6 +3175,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3176,6 +3176,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (flag1) {
                  blockposition1 = ServerLevel.END_SPAWN_POINT;
              } else {

--- a/patches/server/0358-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0358-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1b546c979d7ebe5f77fe7ad7fc422d94e8181aac..904015183bbaa3ac3976e3d81a7968ebb18c0c41 100644
+index 1d933c0302c1ca4752c837b7da802f752a53b437..6aa075103b599980d2ee6ba1f898b6cbf59754cd 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -386,6 +386,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -16,7 +16,7 @@ index 1b546c979d7ebe5f77fe7ad7fc422d94e8181aac..904015183bbaa3ac3976e3d81a7968eb
      protected int numCollisions = 0; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      @javax.annotation.Nullable
-@@ -2044,6 +2045,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2045,6 +2046,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (spawnedViaMobSpawner) {
                  nbt.putBoolean("Paper.FromMobSpawner", true);
              }
@@ -26,7 +26,7 @@ index 1b546c979d7ebe5f77fe7ad7fc422d94e8181aac..904015183bbaa3ac3976e3d81a7968eb
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2185,6 +2189,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2186,6 +2190,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0388-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/patches/server/0388-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -7,10 +7,10 @@ The code following this has better support for null worlds to move
 them back to the world spawn.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7326d892f40447b716c93efe2f01fbbb67d6b942..457471f4e5621b312714dcbad733c23d528131d7 100644
+index 89e3a1421d3658a42bca24e6c3ed76d207b6c3ea..cbf5995e7fdea520080501368d968e7f9ad749c8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2162,9 +2162,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2163,9 +2163,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      bworld = server.getWorld(worldName);
                  }
  

--- a/patches/server/0392-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0392-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,10 +16,10 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 457471f4e5621b312714dcbad733c23d528131d7..ae76b3404e4251e7705269b2e57068154eb11fb8 100644
+index cbf5995e7fdea520080501368d968e7f9ad749c8..7778f8b1e439e47bbe7658239f1727083fc13342 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2292,11 +2292,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2293,11 +2293,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          } else {
              // CraftBukkit start - Capture drops for death event
              if (this instanceof net.minecraft.world.entity.LivingEntity && !((net.minecraft.world.entity.LivingEntity) this).forceDrops) {
@@ -34,7 +34,7 @@ index 457471f4e5621b312714dcbad733c23d528131d7..ae76b3404e4251e7705269b2e5706815
  
              entityitem.setDefaultPickUpDelay();
              // CraftBukkit start
-@@ -3060,6 +3061,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3061,6 +3062,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      @Nullable
      public Entity teleportTo(ServerLevel worldserver, PositionImpl location) {
          // CraftBukkit end
@@ -47,7 +47,7 @@ index 457471f4e5621b312714dcbad733c23d528131d7..ae76b3404e4251e7705269b2e5706815
          if (this.level instanceof ServerLevel && !this.isRemoved()) {
              this.level.getProfiler().push("changeDimension");
              // CraftBukkit start
-@@ -3086,6 +3093,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3087,6 +3094,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  // CraftBukkit end
  
                  this.level.getProfiler().popPush("reloading");
@@ -59,7 +59,7 @@ index 457471f4e5621b312714dcbad733c23d528131d7..ae76b3404e4251e7705269b2e5706815
                  Entity entity = this.getType().create(worldserver);
  
                  if (entity != null) {
-@@ -3099,10 +3111,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3100,10 +3112,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index 457471f4e5621b312714dcbad733c23d528131d7..ae76b3404e4251e7705269b2e5706815
                      // CraftBukkit end
                  }
  
-@@ -3223,7 +3231,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3224,7 +3232,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public boolean canChangeDimensions() {

--- a/patches/server/0430-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0430-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c8ca2835c4fbad85a9680d0cc1da2fdc9a5324b6..544d59be3722cd13e0590a5b03059da0fd5ce364 100644
+index 326928fec8c0a1b8892091e02be7ddf73b92ff26..8f7cdc52f5c1888a69e714f948fdc46412b2ab50 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -713,8 +713,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -19,7 +19,7 @@ index c8ca2835c4fbad85a9680d0cc1da2fdc9a5324b6..544d59be3722cd13e0590a5b03059da0
      }
  
      protected AABB makeBoundingBox() {
-@@ -3945,6 +3945,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3946,6 +3946,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public final void setPosRaw(double x, double y, double z) {
@@ -31,7 +31,7 @@ index c8ca2835c4fbad85a9680d0cc1da2fdc9a5324b6..544d59be3722cd13e0590a5b03059da0
          // Paper start - rewrite chunk system
          if (this.updatingSectionStatus) {
              LOGGER.error("Refusing to update position for entity " + this + " to position " + new Vec3(x, y, z) + " since it is processing a section status update", new Throwable());
-@@ -3968,6 +3973,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3969,6 +3974,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              this.levelCallback.onMove();
          }
  

--- a/patches/server/0481-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0481-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -31,7 +31,7 @@ index da6a0171bd63ac68635de1c23fc9eafa732503bd..214771e661ca3303af167fda3b623d83
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 544d59be3722cd13e0590a5b03059da0fd5ce364..9325d4b5cbcf3785985567deeb9f13e56a4124d0 100644
+index 8f7cdc52f5c1888a69e714f948fdc46412b2ab50..f7db3233c3f63f3383930f80ebeba6d8b48e05bc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -158,6 +158,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -42,7 +42,7 @@ index 544d59be3722cd13e0590a5b03059da0fd5ce364..9325d4b5cbcf3785985567deeb9f13e5
      static boolean isLevelAtLeast(CompoundTag tag, int level) {
          return tag.contains("Bukkit.updateLevel") && tag.getInt("Bukkit.updateLevel") >= level;
      }
-@@ -1716,6 +1717,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1717,6 +1718,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void moveTo(double x, double y, double z, float yaw, float pitch) {

--- a/patches/server/0485-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0485-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9325d4b5cbcf3785985567deeb9f13e56a4124d0..71b75dd2127c80b782973fdd34be461357042e7d 100644
+index f7db3233c3f63f3383930f80ebeba6d8b48e05bc..4be4326103311fc73e2539cb655b44f7feb20f2a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4162,4 +4162,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4163,4 +4163,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0487-Entity-isTicking.patch
+++ b/patches/server/0487-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 71b75dd2127c80b782973fdd34be461357042e7d..a3f3de0c231619702fff29062b1fb47f335783c6 100644
+index 4be4326103311fc73e2539cb655b44f7feb20f2a..742ff6a0585b1ac58bcbc15224a07f78838a9f1d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -59,6 +59,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index 71b75dd2127c80b782973fdd34be461357042e7d..a3f3de0c231619702fff29062b1fb47f
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -4167,5 +4168,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4168,5 +4169,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0517-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0517-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a3f3de0c231619702fff29062b1fb47f335783c6..0e8a5c3fbbafa90f0975733a534aace646e73fde 100644
+index 742ff6a0585b1ac58bcbc15224a07f78838a9f1d..3f29f53c23055036f75926f263030ff91a2d9452 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1897,6 +1897,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1898,6 +1898,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public boolean isPushable() {

--- a/patches/server/0530-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0530-MC-4-Fix-item-position-desync.patch
@@ -27,10 +27,10 @@ index 3768a71491ef7836b9739bdaec7a077c523dbacd..a57957ace1a72b3308487f180a366c38
  
      public Vec3 decode(long x, long y, long z) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0e8a5c3fbbafa90f0975733a534aace646e73fde..45931b056abab7c38bc7c6713192be4b62a7e6e4 100644
+index 3f29f53c23055036f75926f263030ff91a2d9452..c8657fbba5294c55d09163e87fa59e9fdca3e6ce 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3971,6 +3971,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3972,6 +3972,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              return;
          }
          // Paper end - rewrite chunk system

--- a/patches/server/0557-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0557-Collision-option-for-requiring-a-player-participant.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Collision option for requiring a player participant
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 45931b056abab7c38bc7c6713192be4b62a7e6e4..9b1892a4bb385ab888cf0c11f9a7a84921755803 100644
+index c8657fbba5294c55d09163e87fa59e9fdca3e6ce..e7f57353e121ba964a9f8f5d6e095ec82aceafa4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1780,6 +1780,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1781,6 +1781,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public void push(Entity entity) {
          if (!this.isPassengerOfSameVehicle(entity)) {
              if (!entity.noPhysics && !this.noPhysics) {

--- a/patches/server/0649-Fix-dangerous-end-portal-logic.patch
+++ b/patches/server/0649-Fix-dangerous-end-portal-logic.patch
@@ -11,7 +11,7 @@ Move the tick logic into the post tick, where portaling was
 designed to happen in the first place.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9b1892a4bb385ab888cf0c11f9a7a84921755803..dafe29f3e2b4e7a51d4232c60fd27645e5f20335 100644
+index e7f57353e121ba964a9f8f5d6e095ec82aceafa4..f7397e1deaa714781541075ebbf5d61223e2fb17 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -510,6 +510,36 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -51,7 +51,7 @@ index 9b1892a4bb385ab888cf0c11f9a7a84921755803..dafe29f3e2b4e7a51d4232c60fd27645
  
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
-@@ -2686,6 +2716,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2687,6 +2717,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
  
              this.processPortalCooldown();

--- a/patches/server/0682-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0682-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index dafe29f3e2b4e7a51d4232c60fd27645e5f20335..517ee85a7425d89e4197887eb6b385bc64ecedd3 100644
+index f7397e1deaa714781541075ebbf5d61223e2fb17..bce565c170c37f8009303bda9c5eb7c2a83ef795 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3661,20 +3661,34 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3662,20 +3662,34 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      private Stream<Entity> getIndirectPassengersStream() {
@@ -43,7 +43,7 @@ index dafe29f3e2b4e7a51d4232c60fd27645e5f20335..517ee85a7425d89e4197887eb6b385bc
          return () -> {
              return this.getIndirectPassengersStream().iterator();
          };
-@@ -3691,6 +3705,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3692,6 +3706,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      // Paper end - rewrite chunk system
  
      public boolean hasExactlyOnePlayerPassenger() {

--- a/patches/server/0692-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0692-Add-back-EntityPortalExitEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 517ee85a7425d89e4197887eb6b385bc64ecedd3..07ba08de35bac64eeac2657e15dcc60d1dce3cca 100644
+index bce565c170c37f8009303bda9c5eb7c2a83ef795..ad51baf7d9e22f7181f718a332b3ae23d7e4d1b5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3163,6 +3163,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3164,6 +3164,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              } else {
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
@@ -32,7 +32,7 @@ index 517ee85a7425d89e4197887eb6b385bc64ecedd3..07ba08de35bac64eeac2657e15dcc60d
                  if (worldserver == this.level) {
                      // SPIGOT-6782: Just move the entity if a plugin changed the world to the one the entity is already in
                      this.moveTo(shapedetectorshape.pos.x, shapedetectorshape.pos.y, shapedetectorshape.pos.z, shapedetectorshape.yRot, shapedetectorshape.xRot);
-@@ -3182,8 +3199,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3183,8 +3200,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
                  if (entity != null) {
                      entity.restoreFrom(this);

--- a/patches/server/0703-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0703-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 07ba08de35bac64eeac2657e15dcc60d1dce3cca..bdfa91daf69e71e8c2e1e820f14360c567bdeb87 100644
+index ad51baf7d9e22f7181f718a332b3ae23d7e4d1b5..fac8512645c8845855b709471c098cd568970b75 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1986,6 +1986,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1987,6 +1987,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
      }
  

--- a/patches/server/0716-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0716-Detail-more-information-in-watchdog-dumps.patch
@@ -124,10 +124,10 @@ index b4b7aa2f7d602fe996ebc320ab9641866b672abe..f7841aea38707cebaaab2637454a0db8
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index bdfa91daf69e71e8c2e1e820f14360c567bdeb87..5e211f1df6739433437930116d134326abbf558d 100644
+index fac8512645c8845855b709471c098cd568970b75..95f9fe6d958b9bdd1e544120a8a7165b44aaa2a8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -972,7 +972,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -973,7 +973,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return this.onGround;
      }
  
@@ -170,7 +170,7 @@ index bdfa91daf69e71e8c2e1e820f14360c567bdeb87..5e211f1df6739433437930116d134326
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -1145,6 +1180,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1146,6 +1181,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.level.getProfiler().pop();
              }
          }
@@ -184,7 +184,7 @@ index bdfa91daf69e71e8c2e1e820f14360c567bdeb87..5e211f1df6739433437930116d134326
      }
  
      protected boolean isHorizontalCollisionMinor(Vec3 adjustedMovement) {
-@@ -3973,7 +4015,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3974,7 +4016,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -194,7 +194,7 @@ index bdfa91daf69e71e8c2e1e820f14360c567bdeb87..5e211f1df6739433437930116d134326
      }
  
      public void setDeltaMovement(double x, double y, double z) {
-@@ -4055,7 +4099,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4056,7 +4100,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
          // Paper end - fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {

--- a/patches/server/0749-Update-head-rotation-in-missing-places.patch
+++ b/patches/server/0749-Update-head-rotation-in-missing-places.patch
@@ -8,10 +8,10 @@ This is because bukkit uses a separate head rotation field for yaw.
 This issue only applies to players.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5e211f1df6739433437930116d134326abbf558d..c455abc1f41aa9372dec6db7a304bc26ce1b7973 100644
+index 95f9fe6d958b9bdd1e544120a8a7165b44aaa2a8..dff601f09007b15ea1fd6a12412c5153613546dc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1764,6 +1764,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1765,6 +1765,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          this.setXRot(Mth.clamp(pitch, -90.0F, 90.0F) % 360.0F);
          this.yRotO = this.getYRot();
          this.xRotO = this.getXRot();
@@ -19,7 +19,7 @@ index 5e211f1df6739433437930116d134326abbf558d..c455abc1f41aa9372dec6db7a304bc26
      }
  
      public void absMoveTo(double x, double y, double z) {
-@@ -1802,6 +1803,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1803,6 +1804,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          this.setXRot(pitch);
          this.setOldPosAndRot();
          this.reapplyPosition();

--- a/patches/server/0771-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0771-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -1215,10 +1215,10 @@ index 3e870218321a701b814a4dac97ff1af12142600e..4277f7fdd8f27e57708a8dee59bf1b90
          }
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ff74f075db4c401a0a8388c04f234afbe8d20c96..c0dd7405b4e26f7bfcfcced164675b124ca1cc4d 100644
+index b0f512681fc67986a87b75170c140119ef4b9ec0..10c1da2d76d48c30eab310a38227f31d1f75168f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1161,9 +1161,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1162,9 +1162,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  float f2 = this.getBlockSpeedFactor();
  
                  this.setDeltaMovement(this.getDeltaMovement().multiply((double) f2, 1.0D, (double) f2));
@@ -1266,7 +1266,7 @@ index ff74f075db4c401a0a8388c04f234afbe8d20c96..c0dd7405b4e26f7bfcfcced164675b12
                      if (this.remainingFireTicks <= 0) {
                          this.setRemainingFireTicks(-this.getFireImmuneTicks());
                      }
-@@ -1307,32 +1342,78 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1308,32 +1343,78 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      private Vec3 collide(Vec3 movement) {
@@ -1366,7 +1366,7 @@ index ff74f075db4c401a0a8388c04f234afbe8d20c96..c0dd7405b4e26f7bfcfcced164675b12
      }
  
      public static Vec3 collideBoundingBox(@Nullable Entity entity, Vec3 movement, AABB entityBoundingBox, Level world, List<VoxelShape> collisions) {
-@@ -2455,11 +2536,30 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2456,11 +2537,30 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              float f = this.dimensions.width * 0.8F;
              AABB axisalignedbb = AABB.ofSize(this.getEyePosition(), (double) f, 1.0E-6D, (double) f);
  

--- a/patches/server/0779-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0779-Forward-CraftEntity-in-teleport-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c0dd7405b4e26f7bfcfcced164675b124ca1cc4d..8958c95105394601ca91b4318b598e45ced9e706 100644
+index 10c1da2d76d48c30eab310a38227f31d1f75168f..210b58b78e7ebe8dd24bc0e289bd5b33e7a8bda0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3277,6 +3277,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3278,6 +3278,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void restoreFrom(Entity original) {
@@ -22,7 +22,7 @@ index c0dd7405b4e26f7bfcfcced164675b124ca1cc4d..8958c95105394601ca91b4318b598e45
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3358,10 +3365,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3359,10 +3366,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      if (worldserver.getTypeKey() == LevelStem.END) { // CraftBukkit
                          ServerLevel.makeObsidianPlatform(worldserver, this); // CraftBukkit
                      }

--- a/patches/server/0805-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0805-Freeze-Tick-Lock-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8958c95105394601ca91b4318b598e45ced9e706..fd536e670036a365f6d0e8c168ef4b5fdf597615 100644
+index 210b58b78e7ebe8dd24bc0e289bd5b33e7a8bda0..f8bf2fc17d2a5b762437ca2fbe2fe0a05f521d2d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -397,6 +397,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -25,7 +25,7 @@ index 8958c95105394601ca91b4318b598e45ced9e706..fd536e670036a365f6d0e8c168ef4b5f
                  this.setTicksFrozen(0);
                  this.level.levelEvent((Player) null, 1009, this.blockPosition, 1);
              }
-@@ -2262,6 +2263,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2263,6 +2264,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (fromNetherPortal) {
                  nbt.putBoolean("Paper.FromNetherPortal", true);
              }
@@ -35,7 +35,7 @@ index 8958c95105394601ca91b4318b598e45ced9e706..fd536e670036a365f6d0e8c168ef4b5f
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2426,6 +2430,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2427,6 +2431,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (spawnReason == null) {
                  spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT;
              }

--- a/patches/server/0840-Ensure-entity-passenger-world-matches-ridden-entity.patch
+++ b/patches/server/0840-Ensure-entity-passenger-world-matches-ridden-entity.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ensure entity passenger world matches ridden entity
 Bad plugins doing this would cause some obvious problems...
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fd536e670036a365f6d0e8c168ef4b5fdf597615..4aa46029c42dc8a87a354fe6215ce78c59879bf2 100644
+index f8bf2fc17d2a5b762437ca2fbe2fe0a05f521d2d..8d80717589046271119552726e3b4bbd403dac65 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2685,6 +2685,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2686,6 +2686,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/patches/server/0841-Guard-against-invalid-entity-positions.patch
+++ b/patches/server/0841-Guard-against-invalid-entity-positions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Guard against invalid entity positions
 Anything not finite should be blocked and logged
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4aa46029c42dc8a87a354fe6215ce78c59879bf2..25618b33760a3b1f39e6bbf774c75134afe94160 100644
+index 8d80717589046271119552726e3b4bbd403dac65..7f104aa35dce81d2299cb7b4a3e560e67105da4a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4198,11 +4198,33 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4199,11 +4199,33 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return this.getZ((2.0D * this.random.nextDouble() - 1.0D) * widthScale);
      }
  

--- a/patches/server/0881-Add-various-missing-EntityDropItemEvent-calls.patch
+++ b/patches/server/0881-Add-various-missing-EntityDropItemEvent-calls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add various missing EntityDropItemEvent calls
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8ef94c21096131c345b7505630a487bd200f3464..125ba0e3dc05e763a09318a4735d14546df6294f 100644
+index f7eb87eb4e2a3fe0d07d61543a7cf23a30699222..870e628f8039ce0ee4bc850ce82cfb3b3fb3db65 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2521,6 +2521,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2522,6 +2522,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              stack.setCount(0); // Paper - destroy this item - if this ever leaks due to game bugs, ensure it doesn't dupe
  
              entityitem.setDefaultPickUpDelay();

--- a/patches/server/0887-Add-EntityPortalReadyEvent.patch
+++ b/patches/server/0887-Add-EntityPortalReadyEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add EntityPortalReadyEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 125ba0e3dc05e763a09318a4735d14546df6294f..008bd65d838819431a0823c6ac5925774bd155a1 100644
+index 870e628f8039ce0ee4bc850ce82cfb3b3fb3db65..756b8e68c6b7c21c1ef78b68da9e41db4828c7c9 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2868,6 +2868,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2869,6 +2869,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  if (true && !this.isPassenger() && this.portalTime++ >= i) { // CraftBukkit
                      this.level.getProfiler().push("portal");
                      this.portalTime = i;
@@ -22,7 +22,7 @@ index 125ba0e3dc05e763a09318a4735d14546df6294f..008bd65d838819431a0823c6ac592577
                      this.setPortalCooldown();
                      // CraftBukkit start
                      if (this instanceof ServerPlayer) {
-@@ -2875,6 +2882,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2876,6 +2883,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      } else {
                          this.changeDimension(worldserver1);
                      }


### PR DESCRIPTION
Makes it so that players in creative or spectator mode don't receive damage from the nether ceiling when that option is configured.