### PR TITLE
Fix MC-252892

### DIFF
--- a/patches/server/0921-Fix-MC-252892.patch
+++ b/patches/server/0921-Fix-MC-252892.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <blake.galbreath@gmail.com>
+Date: Sat, 1 Oct 2022 22:43:24 -0500
+Subject: [PATCH] Fix MC-252892
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
+index 5a60f5dc202c44b06ca34e9a19d45cb715f74fd3..18e6ddd5082bc1729b86a55c836c007545ed7383 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
+@@ -519,7 +519,7 @@ public class ServerPlayerGameMode {
+         }
+ 
+         if (player.getCooldowns().isOnCooldown(stack.getItem())) {
+-            cancelledBlock = true;
++            cancelledBlock = stack.getItem() != net.minecraft.world.item.Items.GOAT_HORN; // Paper
+         }
+ 
+         PlayerInteractEvent event = CraftEventFactory.callPlayerInteractEvent(player, Action.RIGHT_CLICK_BLOCK, blockposition, hitResult.getDirection(), stack, cancelledBlock, hand, hitResult.getLocation()); // Paper


### PR DESCRIPTION
This bug effects _all_ cooldown items. No one's noticed until the goat horn, though, because most item cooldowns are really short. This fixes only the goat horn, but it might be desirable to remove this line of code entirely to fix all items.