### PR TITLE
Supports custom enchantment to use the non item meta methods

### DIFF
--- a/patches/server/0068-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0068-Handle-Item-Meta-Inconsistencies.patch
@@ -69,8 +69,36 @@ index e937186aaf819a77c80beeb9e08413a1f781c13a..0e19f49ca2496b1c42d27289bcea15d2
      }
  
      public boolean isEnchanted() {
+diff --git a/src/main/java/net/minecraft/world/item/enchantment/EnchantmentHelper.java b/src/main/java/net/minecraft/world/item/enchantment/EnchantmentHelper.java
+index 22925b2f44fc510832ef07290d3109f0394f7d30..6955a1c91e9dbf06a0411c74ad5c6a3edb7dc8bc 100644
+--- a/src/main/java/net/minecraft/world/item/enchantment/EnchantmentHelper.java
++++ b/src/main/java/net/minecraft/world/item/enchantment/EnchantmentHelper.java
+@@ -59,11 +59,22 @@ public class EnchantmentHelper {
+         return Registry.ENCHANTMENT.getKey(enchantment);
+     }
+ 
++    // Paper start
++    public static int getItemCustomEnchantmentLevel(org.bukkit.enchantments.Enchantment bukkitEnchant, ItemStack stack) {
++        return getItemEnchantmentLevel(stack, () -> {
++            Enchantment enchantment = org.bukkit.craftbukkit.enchantments.CraftEnchantment.getRaw(bukkitEnchant);
++            return enchantment != null ? getEnchantmentId(enchantment) : org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(bukkitEnchant.getKey());
++        });
++    }
+     public static int getItemEnchantmentLevel(Enchantment enchantment, ItemStack stack) {
++        return getItemEnchantmentLevel(stack, () -> getEnchantmentId(enchantment));
++    }
++    private static int getItemEnchantmentLevel(ItemStack stack, java.util.function.Supplier<ResourceLocation> enchantLocation) {
++        // Paper end
+         if (stack.isEmpty()) {
+             return 0;
+         } else {
+-            ResourceLocation resourceLocation = getEnchantmentId(enchantment);
++            ResourceLocation resourceLocation = enchantLocation.get(); // Paper
+             ListTag listTag = stack.getEnchantmentTags();
+ 
+             for(int i = 0; i < listTag.size(); ++i) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 4b79b96579efbc4dd9a10e7183ed08b73b488794..c9093275d2b78b6e2f59e64efab0b4775ff0b43b 100644
+index 4b79b96579efbc4dd9a10e7183ed08b73b488794..9391bbe64fe4abf39e94ff85a4cbed903c41cacb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -6,7 +6,6 @@ import java.util.Map;
@@ -120,7 +148,7 @@ index 4b79b96579efbc4dd9a10e7183ed08b73b488794..c9093275d2b78b6e2f59e64efab0b477
              return 0;
          }
 -        return EnchantmentHelper.getItemEnchantmentLevel(CraftEnchantment.getRaw(ench), handle);
-+        return net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(CraftEnchantment.getRaw(ench), handle); // Paper
++        return net.minecraft.world.item.enchantment.EnchantmentHelper.getItemCustomEnchantmentLevel(ench, handle); // Paper
      }
  
      @Override

--- a/patches/server/0202-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0202-ItemStack-getMaxItemUseDuration.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index c9093275d2b78b6e2f59e64efab0b4775ff0b43b..ca75f84d2beeef0636fc7032297bf038d13d97e0 100644
+index 9391bbe64fe4abf39e94ff85a4cbed903c41cacb..9e868609164e0fff06cfc475cbe764f3c5b746dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -173,6 +173,13 @@ public final class CraftItemStack extends ItemStack {

--- a/patches/server/0231-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0231-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,7 +11,7 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index ca75f84d2beeef0636fc7032297bf038d13d97e0..f3abcd5949011eaef3d1ba68f4cc0751042d2834 100644
+index 9e868609164e0fff06cfc475cbe764f3c5b746dd..b7413a8d924c7afa1d9fb68b3045c0a426642a71 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -588,7 +588,7 @@ public final class CraftItemStack extends ItemStack {

--- a/patches/server/0828-More-Projectile-API.patch
+++ b/patches/server/0828-More-Projectile-API.patch
@@ -195,7 +195,7 @@ index 0db8aa840ea026d48215ac5dc80ffde5f12725b1..397e0df15a0e64e5bc522f62f3b327a5
      public net.minecraft.world.entity.projectile.ThrownPotion getHandle() {
          return (net.minecraft.world.entity.projectile.ThrownPotion) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index f3abcd5949011eaef3d1ba68f4cc0751042d2834..bfb1ad0b6e20e10fee53f94a3e6c4f8aad7aae7d 100644
+index b7413a8d924c7afa1d9fb68b3045c0a426642a71..2915967db164dc2db7db8f0ad4e7cd8c1e12e7d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -278,12 +278,20 @@ public final class CraftItemStack extends ItemStack {

--- a/patches/server/0870-Add-missing-spawn-eggs.patch
+++ b/patches/server/0870-Add-missing-spawn-eggs.patch
@@ -22,7 +22,7 @@ index ce64286ac5b836283318ac1ac0bd4afb29db9bb7..09b6475b77ebc7f43c13861aa2af26e2
          case ARMOR_STAND:
              return meta instanceof CraftMetaArmorStand ? meta : new CraftMetaArmorStand(meta);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index bfb1ad0b6e20e10fee53f94a3e6c4f8aad7aae7d..03b4f18000d455e48044eb7a15cd667acef5f14d 100644
+index 2915967db164dc2db7db8f0ad4e7cd8c1e12e7d4..210d6bbe80d12797d6c8c026addba263a1a03b5c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -428,6 +428,12 @@ public final class CraftItemStack extends ItemStack {


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/8426

Even if this "non API" is old, in any case if paper/spigot implement a proper way
to register custom enchantment, paper will need something like that.