### PR TITLE
Fix nothing mlg

### DIFF
--- a/patches/server/0920-Fix-nothing-mlg.patch
+++ b/patches/server/0920-Fix-nothing-mlg.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: FriwiDev <friwidev@gmail.com>
+Date: Mon, 3 Oct 2022 16:10:06 +0200
+Subject: [PATCH] Fix nothing mlg
+
+The issue here is that when jumping and sneaking right before the end of a long fall, the client will send incorrect move packets resulting in a teleport back. Due to this, this move packet (impact) of the player will not be considered for fall damage. The following move packet to the impact packet will have a positive y-value again due to the player jumping, resulting in a fall damage reset.
+
+Solution: Apply fall damage also while moving wrongly, but supply the real values the player sent to the damage calculation. This will not have any real negative effect, as the doCheckFallDamage method is meant to be called repeatedly anyway.
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 9eb921fec32afa360f3a402e978411fcf3ec618c..ab3233ad8ddd5e28fdfabe981093504c36d69d76 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1564,6 +1564,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                             }
+                             if (!this.player.noPhysics && !this.player.isSleeping() && teleportBack) { // Paper end - optimise out extra getCubes
+                                 this.internalTeleport(d3, d4, d5, f, f1, Collections.emptySet(), false); // CraftBukkit - SPIGOT-1807: Don't call teleport event, when the client thinks the player is falling, because the chunks are not loaded on the client yet.
++                                this.player.doCheckFallDamage(this.player.getY() - d6, packet.isOnGround()); // Paper - fix nothing mlg (sneaking and jumping before impact)
+                             } else {
+                                 // CraftBukkit start - fire PlayerMoveEvent
+                                 // Rest to old location first

--- a/patches/server/0920-Fix-nothing-mlg.patch
+++ b/patches/server/0920-Fix-nothing-mlg.patch
@@ -1,11 +1,13 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: FriwiDev <friwidev@gmail.com>
-Date: Mon, 3 Oct 2022 16:10:06 +0200
+Date: Mon, 3 Oct 2022 18:16:30 +0200
 Subject: [PATCH] Fix nothing mlg
 
-The issue here is that when jumping and sneaking right before the end of a long fall, the client will send incorrect move packets resulting in a teleport back. Due to this, this move packet (impact) of the player will not be considered for fall damage. The following move packet to the impact packet will have a positive y-value again due to the player jumping, resulting in a fall damage reset.
+The issue here is that when jumping and sneaking right before the end of a long fall, the client will send incorrect move packets resulting in a teleport back. Due to this, the move packet (impact) of the player will not be considered for fall damage. The following move packet to the impact packet will have a positive y-value again due to the player jumping, resulting in a fall damage reset.
 
 Solution: Apply fall damage also while moving wrongly, but supply the real values the player sent to the damage calculation. This will not have any real negative effect, as the doCheckFallDamage method is meant to be called repeatedly anyway.
+
+Mojira-ID: MC-255653
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 index 9eb921fec32afa360f3a402e978411fcf3ec618c..ab3233ad8ddd5e28fdfabe981093504c36d69d76 100644


### PR DESCRIPTION
The issue here is that when jumping and sneaking right before the end of a long fall, the client will send incorrect move packets resulting in a teleport back. Due to this, the move packet (impact) of the player will not be considered for fall damage. The following move packet to the impact packet will have a positive y-value again due to the player jumping, resulting in a fall damage reset.

Solution: Apply fall damage also while moving wrongly, but supply the real values the player sent to the damage calculation. This will not have any real negative effect, as the doCheckFallDamage method is meant to be called repeatedly anyway.

Video with demonstration:
https://www.youtube.com/watch?v=dvhoQq9wTAQ
(The explanation in the video is wrong, the behavior of the player on impact is the only relevant thing. The invalid movement packet just has to be one ahead of the "impact" packet for this to work.)

Testing: Tested before and after patch. Can reproduce without patch every second time. Did not reproduce once with patch. This does also not apply fall damage when moving wrongly in general - the onGround check and everything is still in place.