### PR TITLE
Handle legacy quirk in the console formatter

### DIFF
--- a/patches/server/0576-Add-support-for-hex-color-codes-in-console.patch
+++ b/patches/server/0576-Add-support-for-hex-color-codes-in-console.patch
@@ -65,10 +65,10 @@ index c3631efda9c7fa531a8a9f18fbee7b5f8655382b..9a3c1314d5a0aa20380662595359580b
  }
 diff --git a/src/main/java/io/papermc/paper/console/HexFormattingConverter.java b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6ee7bcf1ecbf4a2c0909e104dcaab5ab9323c09d
+index 0000000000000000000000000000000000000000..b9922b07cb105618390187d98acdf89e728e1f5a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
-@@ -0,0 +1,217 @@
+@@ -0,0 +1,213 @@
 +package io.papermc.paper.console;
 +
 +import io.papermc.paper.configuration.GlobalConfiguration;
@@ -146,28 +146,28 @@ index 0000000000000000000000000000000000000000..6ee7bcf1ecbf4a2c0909e104dcaab5ab
 +        ANSI_RESET,                                  // Reset §r
 +    };
 +    private static final String[] ANSI_ANSI_CODES = new String[]{
-+        "\u001B[0;30m",    // Black §0
-+        "\u001B[0;34m",    // Dark Blue §1
-+        "\u001B[0;32m",    // Dark Green §2
-+        "\u001B[0;36m",    // Dark Aqua §3
-+        "\u001B[0;31m",    // Dark Red §4
-+        "\u001B[0;35m",    // Dark Purple §5
-+        "\u001B[0;33m",    // Gold §6
-+        "\u001B[0;37m",    // Gray §7
-+        "\u001B[0;30;1m",  // Dark Gray §8
-+        "\u001B[0;34;1m",  // Blue §9
-+        "\u001B[0;32;1m",  // Green §a
-+        "\u001B[0;36;1m",  // Aqua §b
-+        "\u001B[0;31;1m",  // Red §c
-+        "\u001B[0;35;1m",  // Light Purple §d
-+        "\u001B[0;33;1m",  // Yellow §e
-+        "\u001B[0;37;1m",  // White §f
-+        "\u001B[5m",       // Obfuscated §k
-+        "\u001B[1m",       // Bold §l
-+        "\u001B[9m",       // Strikethrough §m
-+        "\u001B[4m",       // Underline §n
-+        "\u001B[3m",       // Italic §o
-+        ANSI_RESET,        // Reset §r
++        ANSI_RESET + "\u001B[0;30m",    // Black §0
++        ANSI_RESET + "\u001B[0;34m",    // Dark Blue §1
++        ANSI_RESET + "\u001B[0;32m",    // Dark Green §2
++        ANSI_RESET + "\u001B[0;36m",    // Dark Aqua §3
++        ANSI_RESET + "\u001B[0;31m",    // Dark Red §4
++        ANSI_RESET + "\u001B[0;35m",    // Dark Purple §5
++        ANSI_RESET + "\u001B[0;33m",    // Gold §6
++        ANSI_RESET + "\u001B[0;37m",    // Gray §7
++        ANSI_RESET + "\u001B[0;30;1m",  // Dark Gray §8
++        ANSI_RESET + "\u001B[0;34;1m",  // Blue §9
++        ANSI_RESET + "\u001B[0;32;1m",  // Green §a
++        ANSI_RESET + "\u001B[0;36;1m",  // Aqua §b
++        ANSI_RESET + "\u001B[0;31;1m",  // Red §c
++        ANSI_RESET + "\u001B[0;35;1m",  // Light Purple §d
++        ANSI_RESET + "\u001B[0;33;1m",  // Yellow §e
++        ANSI_RESET + "\u001B[0;37;1m",  // White §f
++                     "\u001B[5m",       // Obfuscated §k
++                     "\u001B[1m",       // Bold §l
++                     "\u001B[9m",       // Strikethrough §m
++                     "\u001B[4m",       // Underline §n
++                     "\u001B[3m",       // Italic §o
++        ANSI_RESET,                     // Reset §r
 +    };
 +
 +    private final boolean ansi;
@@ -207,19 +207,19 @@ index 0000000000000000000000000000000000000000..6ee7bcf1ecbf4a2c0909e104dcaab5ab
 +    private static String convertRGBColors(final String input) {
 +        return RGB_PATTERN.matcher(input).replaceAll(result -> {
 +            final int hex = Integer.decode(result.group().substring(1));
-+            return formatHexAnsi(hex, true);
++            return formatHexAnsi(hex);
 +        });
 +    }
 +
 +    private static String formatHexAnsi(final TextColor color) {
-+        return formatHexAnsi(color.value(), false);
++        return formatHexAnsi(color.value());
 +    }
 +
-+    private static String formatHexAnsi(final int color, final boolean prependReset) {
++    private static String formatHexAnsi(final int color) {
 +        final int red = color >> 16 & 0xFF;
 +        final int green = color >> 8 & 0xFF;
 +        final int blue = color & 0xFF;
-+        return String.format(prependReset ? RESET_RGB_ANSI : RGB_ANSI, red, green, blue);
++        return String.format(RESET_RGB_ANSI, red, green, blue);
 +    }
 +
 +    private static String stripRGBColors(final String input) {
@@ -244,11 +244,7 @@ index 0000000000000000000000000000000000000000..6ee7bcf1ecbf4a2c0909e104dcaab5ab
 +        while (matcher.find()) {
 +            int format = LOOKUP.indexOf(Character.toLowerCase(matcher.group().charAt(1)));
 +            if (format != -1) {
-+                String replacement = "";
-+                if (ansi) {
-+                    replacement = format < 16 ? ANSI_RESET + ansiCodes[format] : ansiCodes[format]; // handle the upstream quirk at CraftChatMessage L115
-+                }
-+                matcher.appendReplacement(buffer, replacement);
++                matcher.appendReplacement(buffer, ansi ? ansiCodes[format] : "");
 +            }
 +        }
 +        matcher.appendTail(buffer);

--- a/patches/server/0576-Add-support-for-hex-color-codes-in-console.patch
+++ b/patches/server/0576-Add-support-for-hex-color-codes-in-console.patch
@@ -65,10 +65,10 @@ index c3631efda9c7fa531a8a9f18fbee7b5f8655382b..9a3c1314d5a0aa20380662595359580b
  }
 diff --git a/src/main/java/io/papermc/paper/console/HexFormattingConverter.java b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b510d9948e78e6a392eaedc6abd8c6e70ba762cc
+index 0000000000000000000000000000000000000000..9caa8a33c6fe483af3457bf37babe83cf5ac5379
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
-@@ -0,0 +1,217 @@
+@@ -0,0 +1,216 @@
 +package io.papermc.paper.console;
 +
 +import io.papermc.paper.configuration.GlobalConfiguration;
@@ -244,10 +244,9 @@ index 0000000000000000000000000000000000000000..b510d9948e78e6a392eaedc6abd8c6e7
 +            int format = LOOKUP.indexOf(Character.toLowerCase(matcher.group().charAt(1)));
 +            if (format != -1) {
 +                String replacement = "";
-+                if (ansi && !(format >= 16 && format != 21)) { // handle the upstream quirk at CraftChatMessage L115
-+                    replacement = ANSI_RESET;
++                if (ansi) {
++                    replacement = format < 16 ? ANSI_RESET + ansiCodes[format] : ansiCodes[format]; // handle the upstream quirk at CraftChatMessage L115
 +                }
-+                replacement += ansi ? ansiCodes[format] : "";
 +                matcher.appendReplacement(buffer, replacement);
 +            }
 +        }

--- a/patches/server/0576-Add-support-for-hex-color-codes-in-console.patch
+++ b/patches/server/0576-Add-support-for-hex-color-codes-in-console.patch
@@ -65,10 +65,10 @@ index c3631efda9c7fa531a8a9f18fbee7b5f8655382b..9a3c1314d5a0aa20380662595359580b
  }
 diff --git a/src/main/java/io/papermc/paper/console/HexFormattingConverter.java b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3aeca155b63a1fdc7fe30d08147cbb0f01912f67
+index 0000000000000000000000000000000000000000..6ee7bcf1ecbf4a2c0909e104dcaab5ab9323c09d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
-@@ -0,0 +1,216 @@
+@@ -0,0 +1,217 @@
 +package io.papermc.paper.console;
 +
 +import io.papermc.paper.configuration.GlobalConfiguration;
@@ -117,6 +117,7 @@ index 0000000000000000000000000000000000000000..3aeca155b63a1fdc7fe30d08147cbb0f
 +    private static final String LOOKUP = "0123456789abcdefklmnor";
 +
 +    private static final String RGB_ANSI = "\u001B[38;2;%d;%d;%dm";
++    private static final String RESET_RGB_ANSI = ANSI_RESET + RGB_ANSI;
 +    private static final Pattern NAMED_PATTERN = Pattern.compile(COLOR_CHAR + "[0-9a-fk-orA-FK-OR]");
 +    private static final Pattern RGB_PATTERN = Pattern.compile(COLOR_CHAR + "#([0-9a-fA-F]){6}");
 +
@@ -206,19 +207,19 @@ index 0000000000000000000000000000000000000000..3aeca155b63a1fdc7fe30d08147cbb0f
 +    private static String convertRGBColors(final String input) {
 +        return RGB_PATTERN.matcher(input).replaceAll(result -> {
 +            final int hex = Integer.decode(result.group().substring(1));
-+            return ANSI_RESET + formatHexAnsi(hex);
++            return formatHexAnsi(hex, true);
 +        });
 +    }
 +
 +    private static String formatHexAnsi(final TextColor color) {
-+        return formatHexAnsi(color.value());
++        return formatHexAnsi(color.value(), false);
 +    }
 +
-+    private static String formatHexAnsi(final int color) {
++    private static String formatHexAnsi(final int color, final boolean prependReset) {
 +        final int red = color >> 16 & 0xFF;
 +        final int green = color >> 8 & 0xFF;
 +        final int blue = color & 0xFF;
-+        return String.format(RGB_ANSI, red, green, blue);
++        return String.format(prependReset ? RESET_RGB_ANSI : RGB_ANSI, red, green, blue);
 +    }
 +
 +    private static String stripRGBColors(final String input) {

--- a/patches/server/0576-Add-support-for-hex-color-codes-in-console.patch
+++ b/patches/server/0576-Add-support-for-hex-color-codes-in-console.patch
@@ -65,7 +65,7 @@ index c3631efda9c7fa531a8a9f18fbee7b5f8655382b..9a3c1314d5a0aa20380662595359580b
  }
 diff --git a/src/main/java/io/papermc/paper/console/HexFormattingConverter.java b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9caa8a33c6fe483af3457bf37babe83cf5ac5379
+index 0000000000000000000000000000000000000000..3aeca155b63a1fdc7fe30d08147cbb0f01912f67
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
 @@ -0,0 +1,216 @@
@@ -206,7 +206,7 @@ index 0000000000000000000000000000000000000000..9caa8a33c6fe483af3457bf37babe83c
 +    private static String convertRGBColors(final String input) {
 +        return RGB_PATTERN.matcher(input).replaceAll(result -> {
 +            final int hex = Integer.decode(result.group().substring(1));
-+            return formatHexAnsi(hex);
++            return ANSI_RESET + formatHexAnsi(hex);
 +        });
 +    }
 +

--- a/patches/server/0576-Add-support-for-hex-color-codes-in-console.patch
+++ b/patches/server/0576-Add-support-for-hex-color-codes-in-console.patch
@@ -65,10 +65,10 @@ index c3631efda9c7fa531a8a9f18fbee7b5f8655382b..9a3c1314d5a0aa20380662595359580b
  }
 diff --git a/src/main/java/io/papermc/paper/console/HexFormattingConverter.java b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b4d0b7ecd56ab952319946854168c1299cb0b1be
+index 0000000000000000000000000000000000000000..b510d9948e78e6a392eaedc6abd8c6e70ba762cc
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
-@@ -0,0 +1,212 @@
+@@ -0,0 +1,217 @@
 +package io.papermc.paper.console;
 +
 +import io.papermc.paper.configuration.GlobalConfiguration;
@@ -243,7 +243,12 @@ index 0000000000000000000000000000000000000000..b4d0b7ecd56ab952319946854168c129
 +        while (matcher.find()) {
 +            int format = LOOKUP.indexOf(Character.toLowerCase(matcher.group().charAt(1)));
 +            if (format != -1) {
-+                matcher.appendReplacement(buffer, ansi ? ansiCodes[format] : "");
++                String replacement = "";
++                if (ansi && !(format >= 16 && format != 21)) { // handle the upstream quirk at CraftChatMessage L115
++                    replacement = ANSI_RESET;
++                }
++                replacement += ansi ? ansiCodes[format] : "";
++                matcher.appendReplacement(buffer, replacement);
 +            }
 +        }
 +        matcher.appendTail(buffer);


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/7939

This handle correctly the needed reset ansi before each color change like bukkit do.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-8434.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/452662891.zip)