### PR TITLE
Prevents nether portals from accepting portals built above the nether cei…

### DIFF
--- a/patches/server/0922-Prevents-nether-portals-from-accepting-locations-abo.patch
+++ b/patches/server/0922-Prevents-nether-portals-from-accepting-locations-abo.patch
@@ -1,0 +1,88 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Big-Crazy <dogwithhats@gmail.com>
+Date: Wed, 5 Oct 2022 21:54:57 -0400
+Subject: [PATCH] Prevents nether portals from accepting locations above the
+ nether ceiling as valid locations for generating portals / teleporting
+ entities
+
+
+diff --git a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
+index 386a73f32f2504af81107852307dcd393d4d8a11..eefd322613ba2bd3b6dcd99aec74de617c6112c6 100644
+--- a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
++++ b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
+@@ -67,6 +67,9 @@ public class PortalForcer {
+                 if (!worldborder.isWithinBounds(pos)) {
+                     return false;
+                 }
++                if (pos.getY() > level.paperConfig().environment.netherCeilingVoidDamageHeight) {
++                    return false;
++                }
+                 return lowest.getBlockState(pos).hasProperty(BlockStateProperties.HORIZONTAL_AXIS);
+             },
+             blockposition, i, Double.MAX_VALUE, PoiManager.Occupancy.ANY, true, records
+@@ -124,32 +127,36 @@ public class PortalForcer {
+             j = Math.min(i, this.level.getHeight(Heightmap.Types.MOTION_BLOCKING, blockposition_mutableblockposition1.getX(), blockposition_mutableblockposition1.getZ()));
+             boolean flag = true;
+ 
+-            if (worldborder.isWithinBounds((BlockPos) blockposition_mutableblockposition1) && worldborder.isWithinBounds((BlockPos) blockposition_mutableblockposition1.move(enumdirection, 1))) {
+-                blockposition_mutableblockposition1.move(enumdirection.getOpposite(), 1);
++            //check to see if the portal is trying to generate below nether-ceiling-void-damage-height
++            if (j < entity.level.paperConfig().environment.netherCeilingVoidDamageHeight) {
+ 
+-                for (k = j; k >= this.level.getMinBuildHeight(); --k) {
+-                    blockposition_mutableblockposition1.setY(k);
+-                    if (this.level.isEmptyBlock(blockposition_mutableblockposition1)) {
+-                        for (l = k; k > this.level.getMinBuildHeight() && this.level.isEmptyBlock(blockposition_mutableblockposition1.move(Direction.DOWN)); --k) {
+-                            ;
+-                        }
++                if (worldborder.isWithinBounds((BlockPos) blockposition_mutableblockposition1) && worldborder.isWithinBounds((BlockPos) blockposition_mutableblockposition1.move(enumdirection, 1))) {
++                    blockposition_mutableblockposition1.move(enumdirection.getOpposite(), 1);
+ 
+-                        if (k + 4 <= i) {
+-                            int i1 = l - k;
++                    for (k = j; k >= this.level.getMinBuildHeight(); --k) {
++                        blockposition_mutableblockposition1.setY(k);
++                        if (this.level.isEmptyBlock(blockposition_mutableblockposition1)) {
++                            for (l = k; k > this.level.getMinBuildHeight() && this.level.isEmptyBlock(blockposition_mutableblockposition1.move(Direction.DOWN)); --k) {
++                                ;
++                            }
+ 
+-                            if (i1 <= 0 || i1 >= 3) {
+-                                blockposition_mutableblockposition1.setY(k);
+-                                if (this.canHostFrame(blockposition_mutableblockposition1, blockposition_mutableblockposition, enumdirection, 0)) {
+-                                    double d2 = blockposition.distSqr(blockposition_mutableblockposition1);
++                            if (k + 4 <= i) {
++                                int i1 = l - k;
+ 
+-                                    if (this.canHostFrame(blockposition_mutableblockposition1, blockposition_mutableblockposition, enumdirection, -1) && this.canHostFrame(blockposition_mutableblockposition1, blockposition_mutableblockposition, enumdirection, 1) && (d0 == -1.0D || d0 > d2)) {
+-                                        d0 = d2;
+-                                        blockposition1 = blockposition_mutableblockposition1.immutable();
+-                                    }
++                                if (i1 <= 0 || i1 >= 3) {
++                                    blockposition_mutableblockposition1.setY(k);
++                                    if (this.canHostFrame(blockposition_mutableblockposition1, blockposition_mutableblockposition, enumdirection, 0)) {
++                                        double d2 = blockposition.distSqr(blockposition_mutableblockposition1);
++
++                                        if (this.canHostFrame(blockposition_mutableblockposition1, blockposition_mutableblockposition, enumdirection, -1) && this.canHostFrame(blockposition_mutableblockposition1, blockposition_mutableblockposition, enumdirection, 1) && (d0 == -1.0D || d0 > d2)) {
++                                            d0 = d2;
++                                            blockposition1 = blockposition_mutableblockposition1.immutable();
++                                        }
+ 
+-                                    if (d0 == -1.0D && (d1 == -1.0D || d1 > d2)) {
+-                                        d1 = d2;
+-                                        blockposition2 = blockposition_mutableblockposition1.immutable();
++                                        if (d0 == -1.0D && (d1 == -1.0D || d1 > d2)) {
++                                            d1 = d2;
++                                            blockposition2 = blockposition_mutableblockposition1.immutable();
++                                        }
+                                     }
+                                 }
+                             }
+@@ -158,7 +165,6 @@ public class PortalForcer {
+                 }
+             }
+         }
+-
+         if (d0 == -1.0D && d1 != -1.0D) {
+             blockposition1 = blockposition2;
+             d0 = d1;

--- a/patches/server/0923-Prevents-nether-portals-from-accepting-locations-abo.patch
+++ b/patches/server/0923-Prevents-nether-portals-from-accepting-locations-abo.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Big-Crazy <dogwithhats@gmail.com>
+Date: Fri, 7 Oct 2022 13:16:47 -0400
+Subject: [PATCH] Prevents nether portals from accepting locations above the
+ nether ceiling as valid locations for generating portals / teleporting
+ entities
+
+
+diff --git a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
+index eefd322613ba2bd3b6dcd99aec74de617c6112c6..1cebe33d6fcd3d2c7331a7a4bb5048d286daa274 100644
+--- a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
++++ b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
+@@ -126,23 +126,18 @@ public class PortalForcer {
+ 
+             j = Math.min(i, this.level.getHeight(Heightmap.Types.MOTION_BLOCKING, blockposition_mutableblockposition1.getX(), blockposition_mutableblockposition1.getZ()));
+             boolean flag = true;
+-
+             //check to see if the portal is trying to generate below nether-ceiling-void-damage-height
+             if (j < entity.level.paperConfig().environment.netherCeilingVoidDamageHeight) {
+-
+-                if (worldborder.isWithinBounds((BlockPos) blockposition_mutableblockposition1) && worldborder.isWithinBounds((BlockPos) blockposition_mutableblockposition1.move(enumdirection, 1))) {
++            if (worldborder.isWithinBounds((BlockPos) blockposition_mutableblockposition1) && worldborder.isWithinBounds((BlockPos) blockposition_mutableblockposition1.move(enumdirection, 1))) {
+                     blockposition_mutableblockposition1.move(enumdirection.getOpposite(), 1);
+-
+                     for (k = j; k >= this.level.getMinBuildHeight(); --k) {
+                         blockposition_mutableblockposition1.setY(k);
+                         if (this.level.isEmptyBlock(blockposition_mutableblockposition1)) {
+                             for (l = k; k > this.level.getMinBuildHeight() && this.level.isEmptyBlock(blockposition_mutableblockposition1.move(Direction.DOWN)); --k) {
+                                 ;
+                             }
+-
+                             if (k + 4 <= i) {
+                                 int i1 = l - k;
+-
+                                 if (i1 <= 0 || i1 >= 3) {
+                                     blockposition_mutableblockposition1.setY(k);
+                                     if (this.canHostFrame(blockposition_mutableblockposition1, blockposition_mutableblockposition, enumdirection, 0)) {


### PR DESCRIPTION
…ling as valid for teleporting entities

(hopefully) Fixes [#7208](https://github.com/PaperMC/Paper/issues/7208)

If a portal is built above the Y level specified under `nether-ceiling-void-damage-height`, entities can no longer enter the nether through that portal, even if no other options are available. Previously, it kind of just never checked this, which was simple enough to fix.

Tested by setting `nether-ceiling-void-damage-height` to 0, building a portal on the nether roof, returning to the overworld, building a portal in the proper location, setting `nether-ceiling-void-damage-height` to 128 and attempting to travel through it. 