### PR TITLE
Add Unmodifiable annotations to getDrops methods

### DIFF
--- a/patches/api/0398-Add-getDrops-to-BlockState-and-isPreferredTool-to-Bl.patch
+++ b/patches/api/0398-Add-getDrops-to-BlockState-and-isPreferredTool-to-Bl.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add getDrops to BlockState and isPreferredTool to BlockData
 
 
 diff --git a/src/main/java/org/bukkit/block/BlockState.java b/src/main/java/org/bukkit/block/BlockState.java
-index 10cbe71917bc32cca61748bcb0aa3395c554dbf8..5be829058c41283a5d3d14776617c98c4cdaaf8e 100644
+index 10cbe71917bc32cca61748bcb0aa3395c554dbf8..37ca7b6b0fcee8bec12026ec3715dcc47400cc11 100644
 --- a/src/main/java/org/bukkit/block/BlockState.java
 +++ b/src/main/java/org/bukkit/block/BlockState.java
 @@ -233,5 +233,34 @@ public interface BlockState extends Metadatable {
@@ -19,7 +19,7 @@ index 10cbe71917bc32cca61748bcb0aa3395c554dbf8..5be829058c41283a5d3d14776617c98c
 +     * @return an immutable list of dropped items for the block state
 +     */
 +    @NotNull
-+    java.util.Collection<org.bukkit.inventory.ItemStack> getDrops();
++    java.util.@org.jetbrains.annotations.Unmodifiable Collection<org.bukkit.inventory.ItemStack> getDrops();
 +
 +    /**
 +     * Returns an immutable list of items which would drop by destroying this block state
@@ -29,7 +29,7 @@ index 10cbe71917bc32cca61748bcb0aa3395c554dbf8..5be829058c41283a5d3d14776617c98c
 +     * @return an immutable list of dropped items for the block state
 +     */
 +    @NotNull
-+    java.util.Collection<org.bukkit.inventory.ItemStack> getDrops(@Nullable org.bukkit.inventory.ItemStack tool);
++    java.util.@org.jetbrains.annotations.Unmodifiable Collection<org.bukkit.inventory.ItemStack> getDrops(@Nullable org.bukkit.inventory.ItemStack tool);
 +
 +    /**
 +     * Returns an immutable list of items which would drop by the entity destroying this
@@ -40,7 +40,7 @@ index 10cbe71917bc32cca61748bcb0aa3395c554dbf8..5be829058c41283a5d3d14776617c98c
 +     * @return an immutable list of dropped items for the block state
 +     */
 +    @NotNull
-+    java.util.Collection<org.bukkit.inventory.ItemStack> getDrops(@NotNull org.bukkit.inventory.ItemStack tool, @Nullable org.bukkit.entity.Entity entity);
++    java.util.@org.jetbrains.annotations.Unmodifiable Collection<org.bukkit.inventory.ItemStack> getDrops(@NotNull org.bukkit.inventory.ItemStack tool, @Nullable org.bukkit.entity.Entity entity);
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/data/BlockData.java b/src/main/java/org/bukkit/block/data/BlockData.java


### PR DESCRIPTION
Was incorrectly removed [from the PR that added these methods](https://github.com/PaperMC/Paper/pull/8284).