### PR TITLE
Check minecraft.commandblock permission in canUseGameMasterBlocks (Improve commandblock permission)

### DIFF
--- a/patches/server/0429-Add-permission-for-command-blocks.patch
+++ b/patches/server/0429-Add-permission-for-command-blocks.patch
@@ -4,67 +4,19 @@ Date: Sat, 16 May 2020 10:05:30 +0200
 Subject: [PATCH] Add permission for command blocks
 
 
-diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index af00442931f9f6cf878bd61137c2f29fc7c8d0b1..431ff490760f54be76847c7b370dbbb4b65de102 100644
---- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-+++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -396,7 +396,7 @@ public class ServerPlayerGameMode {
-             BlockEntity tileentity = this.level.getBlockEntity(pos);
-             Block block = iblockdata.getBlock();
- 
--            if (block instanceof GameMasterBlock && !this.player.canUseGameMasterBlocks()) {
-+            if (block instanceof GameMasterBlock && !this.player.canUseGameMasterBlocks() && !(block instanceof net.minecraft.world.level.block.CommandBlock && (this.player.isCreative() && this.player.getBukkitEntity().hasPermission("minecraft.commandblock")))) { // Paper - command block permission
-                 this.level.sendBlockUpdated(pos, iblockdata, iblockdata, 3);
-                 return false;
-             } else if (this.player.blockActionRestricted(this.level, pos, this.gameModeForPlayer)) {
-diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b7865696d9b939791b0315ab2a231e2dc5872de8..02b6cf65f6abedfd4933e4e64d254f190e061301 100644
---- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-+++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -878,7 +878,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
-         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
-         if (!this.server.isCommandBlockEnabled()) {
-             this.player.sendSystemMessage(Component.translatable("advMode.notEnabled"));
--        } else if (!this.player.canUseGameMasterBlocks()) {
-+        } else if (!this.player.canUseGameMasterBlocks() && (!this.player.isCreative() || !this.player.getBukkitEntity().hasPermission("minecraft.commandblock"))) { // Paper - command block permission
-             this.player.sendSystemMessage(Component.translatable("advMode.notAllowed"));
-         } else {
-             BaseCommandBlock commandblocklistenerabstract = null;
-@@ -945,7 +945,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
-         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
-         if (!this.server.isCommandBlockEnabled()) {
-             this.player.sendSystemMessage(Component.translatable("advMode.notEnabled"));
--        } else if (!this.player.canUseGameMasterBlocks()) {
-+        } else if (!this.player.canUseGameMasterBlocks() && (!this.player.isCreative() || !this.player.getBukkitEntity().hasPermission("minecraft.commandblock"))) { // Paper - command block permission
-             this.player.sendSystemMessage(Component.translatable("advMode.notAllowed"));
-         } else {
-             BaseCommandBlock commandblocklistenerabstract = packet.getCommandBlock(this.player.level);
-diff --git a/src/main/java/net/minecraft/world/level/BaseCommandBlock.java b/src/main/java/net/minecraft/world/level/BaseCommandBlock.java
-index da504702bc9423774b35dff792d2dbe7fc270fe3..c0195f73cd2c8721e882c681eaead65471710081 100644
---- a/src/main/java/net/minecraft/world/level/BaseCommandBlock.java
-+++ b/src/main/java/net/minecraft/world/level/BaseCommandBlock.java
-@@ -198,7 +198,7 @@ public abstract class BaseCommandBlock implements CommandSource {
+diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
+index 0960e5ecc25fad3eb46a871c2749dd176b812460..36aae55bb34502ebdf23eaf38c8a74574825d052 100644
+--- a/src/main/java/net/minecraft/world/entity/player/Player.java
++++ b/src/main/java/net/minecraft/world/entity/player/Player.java
+@@ -2247,7 +2247,7 @@ public abstract class Player extends LivingEntity {
      }
  
-     public InteractionResult usedBy(Player player) {
--        if (!player.canUseGameMasterBlocks()) {
-+        if (!player.canUseGameMasterBlocks() && (!player.isCreative() || !player.getBukkitEntity().hasPermission("minecraft.commandblock"))) { // Paper - command block permission
-             return InteractionResult.PASS;
-         } else {
-             if (player.getCommandSenderWorld().isClientSide) {
-diff --git a/src/main/java/net/minecraft/world/level/block/CommandBlock.java b/src/main/java/net/minecraft/world/level/block/CommandBlock.java
-index 061a56e3828767cd6576d5a9edde5f3498e609d0..2e7c03b00bc941b86df6a7f1b2b188c9f0aede22 100644
---- a/src/main/java/net/minecraft/world/level/block/CommandBlock.java
-+++ b/src/main/java/net/minecraft/world/level/block/CommandBlock.java
-@@ -130,7 +130,7 @@ public class CommandBlock extends BaseEntityBlock implements GameMasterBlock {
-     public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-         BlockEntity tileentity = world.getBlockEntity(pos);
+     public boolean canUseGameMasterBlocks() {
+-        return this.abilities.instabuild && this.getPermissionLevel() >= 2;
++        return this.abilities.instabuild && (this.getPermissionLevel() >= 2  || this.getBukkitEntity().hasPermission("minecraft.commandblock")); // Paper - Add permission for interacting with GameMasterBlocks
+     }
  
--        if (tileentity instanceof CommandBlockEntity && player.canUseGameMasterBlocks()) {
-+        if (tileentity instanceof CommandBlockEntity && (player.canUseGameMasterBlocks() || (player.isCreative() && player.getBukkitEntity().hasPermission("minecraft.commandblock")))) { // Paper - command block permission
-             player.openCommandBlock((CommandBlockEntity) tileentity);
-             return InteractionResult.sidedSuccess(world.isClientSide);
-         } else {
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java b/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
 index 70d3949616c63038ad3e9bd1069db5ea2fb3f3b8..8e06bc11fb28baee3407bbfe9d7b3689d6f85ff2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java


### PR DESCRIPTION
### The Problem
The existing ``minecraft.commandblock`` permission _only_ allows you to _edit_ command blocks. It looks like it was meant to also allow for breaking/placing command blocks, but in it's current state it does not.

There are also other blocks that require op level 2 or higher to break, place, and use. Currently however, there is no permission to allow this.

### The (Proposed) Solution
Upgrade the existing minecraft.commandblock permission to allow all of these things. If a player can edit command blocks, they can (presumably) create/break/modify other command blocks via commands like /setblock. 

This PR changes the ``Player.canUseGameMasterBlocks`` function to return true when the player has the minecraft.commandblock permission. It also removes all the old code (save the permission registration.) Most of the command-block-specific code seems to be broken, as you can't currently place/break command blocks with the permission.

### Things to Consider
One small side effect of this specific implementation of the change, is that minecraft.commandblock will also allow use of debug sticks while in creative mode, because this also checks ``canUseGameMasterBlocks``.

This would also cause it to override the ``minecraft.nbt.place`` permission. Whether this should be considered a significant drawback is up for discussion. My thought is that command blocks can be every bit as destructive as NBT, but maybe server owners attempting to sandbox command blocks could have issues with this?

Potentially these could all be split into different permissions, but I don't see *much* of a point when command blocks can already do all of these things on their own. If someone needs that particular behavior, it wouldn't be hard to implement as a plugin.

Only other downside I can see is that ``minecraft.commandblock`` is a bit misleading, since it would now include two other blocks, as well as the debug stick.