### PR TITLE
Avoid/deprecate usages of RecipeChoice#getItemStack()

### DIFF
--- a/patches/api/0169-Add-ItemStack-Recipe-API-helper-methods.patch
+++ b/patches/api/0169-Add-ItemStack-Recipe-API-helper-methods.patch
@@ -3,7 +3,10 @@ From: Aikar <aikar@aikar.co>
 Date: Tue, 28 Jan 2014 19:13:57 -0500
 Subject: [PATCH] Add ItemStack Recipe API helper methods
 
-Allows using ExactChoice Recipes with easier methodss
+Allows using ExactChoice Recipes with easier methods
+
+Redirects some of upstream's APIs to these new methods to avoid
+usage of magic values and the deprecated RecipeChoice#getItemStack
 
 diff --git a/src/main/java/org/bukkit/inventory/ShapedRecipe.java b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
 index ad2ab6e97ccf6900d19f8bfbe08181d4c7743a99..ecf8cd763ae600c11be6385ea6240e4d2c08abc9 100644
@@ -24,7 +27,7 @@ index ad2ab6e97ccf6900d19f8bfbe08181d4c7743a99..ecf8cd763ae600c11be6385ea6240e4d
       * Get a copy of the ingredients map.
       *
 diff --git a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
-index 75b47c608d0a902e4ea5f03c395667f47dec8980..ff5a0e378a7c1e0f89d81144629251dc61af6355 100644
+index 75b47c608d0a902e4ea5f03c395667f47dec8980..7485da0de3712619b8d89d0b21f60fe20dafad6b 100644
 --- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
 +++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
 @@ -142,6 +142,40 @@ public class ShapelessRecipe implements Recipe, Keyed {
@@ -55,8 +58,8 @@ index 75b47c608d0a902e4ea5f03c395667f47dec8980..ff5a0e378a7c1e0f89d81144629251dc
 +    public ShapelessRecipe removeIngredient(int count, @NotNull ItemStack item) {
 +        Iterator<RecipeChoice> iterator = ingredients.iterator();
 +        while (count > 0 && iterator.hasNext()) {
-+            ItemStack stack = iterator.next().getItemStack();
-+            if (stack.equals(item)) {
++            RecipeChoice choice = iterator.next();
++            if (choice.test(item)) {
 +                iterator.remove();
 +                count--;
 +            }
@@ -68,3 +71,21 @@ index 75b47c608d0a902e4ea5f03c395667f47dec8980..ff5a0e378a7c1e0f89d81144629251dc
      /**
       * Removes an ingredient from the list.
       *
+@@ -165,7 +199,7 @@ public class ShapelessRecipe implements Recipe, Keyed {
+      */
+     @NotNull
+     public ShapelessRecipe removeIngredient(@NotNull Material ingredient) {
+-        return removeIngredient(ingredient, 0);
++        return removeIngredient(new ItemStack(ingredient)); // Paper - avoid using deprecated methods (magic values; RecipeChoice#getItemStack)
+     }
+ 
+     /**
+@@ -192,7 +226,7 @@ public class ShapelessRecipe implements Recipe, Keyed {
+      */
+     @NotNull
+     public ShapelessRecipe removeIngredient(int count, @NotNull Material ingredient) {
+-        return removeIngredient(count, ingredient, 0);
++        return removeIngredient(count, new ItemStack(ingredient)); // Paper - avoid using deprecated methods (magic values; RecipeChoice#getItemStack)
+     }
+ 
+     /**

--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -524,6 +524,20 @@ index 6cb2bf60fb970b646451c02faf71a14a80e6a56b..7cf8ffb5a29d1cf382064b3aca0353a5
          public MaterialData getTypeAndData(int x, int y, int z);
  
          /**
+diff --git a/src/main/java/org/bukkit/inventory/CookingRecipe.java b/src/main/java/org/bukkit/inventory/CookingRecipe.java
+index 6f251252aa96f202139103c657a81c71a0ffbfaf..e95ee930c4791c441c9b54b2c284f3da343eb376 100644
+--- a/src/main/java/org/bukkit/inventory/CookingRecipe.java
++++ b/src/main/java/org/bukkit/inventory/CookingRecipe.java
+@@ -66,7 +66,9 @@ public abstract class CookingRecipe<T extends CookingRecipe> implements Recipe,
+      * Get the input material.
+      *
+      * @return The input material.
++     * @deprecated Use {@link #getInputChoice()} instead for more complete data.
+      */
++    @Deprecated // Paper
+     @NotNull
+     public ItemStack getInput() {
+         return this.ingredient.getItemStack();
 diff --git a/src/main/java/org/bukkit/inventory/CraftingInventory.java b/src/main/java/org/bukkit/inventory/CraftingInventory.java
 index df81bac9ecff697f98941e5c8490e10391e90090..a32977ba3ba60a1c9aee6e469d5d6cd1887c55a2 100644
 --- a/src/main/java/org/bukkit/inventory/CraftingInventory.java
@@ -716,7 +730,7 @@ index 5461f7fa75f5a065bb333b4a113640b5fe1e3825..c4d657727e508cb941320730a9d3aa54
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ShapedRecipe.java b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
-index ecf8cd763ae600c11be6385ea6240e4d2c08abc9..40e9040fec4e7d39aa1b0d75d183cf97aff44438 100644
+index ecf8cd763ae600c11be6385ea6240e4d2c08abc9..161e408bf90de7ca8c3ea418543d25ecccc35c48 100644
 --- a/src/main/java/org/bukkit/inventory/ShapedRecipe.java
 +++ b/src/main/java/org/bukkit/inventory/ShapedRecipe.java
 @@ -95,8 +95,10 @@ public class ShapedRecipe implements Recipe, Keyed {
@@ -730,8 +744,18 @@ index ecf8cd763ae600c11be6385ea6240e4d2c08abc9..40e9040fec4e7d39aa1b0d75d183cf97
      public ShapedRecipe setIngredient(char key, @NotNull MaterialData ingredient) {
          return setIngredient(key, ingredient.getItemType(), ingredient.getData());
      }
+@@ -155,7 +157,9 @@ public class ShapedRecipe implements Recipe, Keyed {
+      * Get a copy of the ingredients map.
+      *
+      * @return The mapping of character to ingredients.
++     * @deprecated Use {@link #getChoiceMap()} instead for more complete data.
+      */
++    @Deprecated // Paper
+     @NotNull
+     public Map<Character, ItemStack> getIngredientMap() {
+         HashMap<Character, ItemStack> result = new HashMap<Character, ItemStack>();
 diff --git a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
-index ff5a0e378a7c1e0f89d81144629251dc61af6355..c6dba5bbca302237bb4abd2b7ef17c1281d74a29 100644
+index 7485da0de3712619b8d89d0b21f60fe20dafad6b..3c8423192f069f3c7690eee4e3080b3dc2e7acf8 100644
 --- a/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
 +++ b/src/main/java/org/bukkit/inventory/ShapelessRecipe.java
 @@ -54,8 +54,10 @@ public class ShapelessRecipe implements Recipe, Keyed {
@@ -778,6 +802,30 @@ index ff5a0e378a7c1e0f89d81144629251dc61af6355..c6dba5bbca302237bb4abd2b7ef17c12
      public ShapelessRecipe removeIngredient(int count, @NotNull MaterialData ingredient) {
          return removeIngredient(count, ingredient.getItemType(), ingredient.getData());
      }
+@@ -299,7 +307,9 @@ public class ShapelessRecipe implements Recipe, Keyed {
+      * Get the list of ingredients used for this recipe.
+      *
+      * @return The input list
++     * @deprecated Use {@link #getChoiceList()} instead for more complete data.
+      */
++    @Deprecated // Paper
+     @NotNull
+     public List<ItemStack> getIngredientList() {
+         ArrayList<ItemStack> result = new ArrayList<ItemStack>(ingredients.size());
+diff --git a/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java b/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java
+index d8ef781d6b025790ce9d2a9782e6ef2a47cc8e62..09806e5f7f01028baad2985406c3c1a43be459f8 100644
+--- a/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java
++++ b/src/main/java/org/bukkit/inventory/StonecuttingRecipe.java
+@@ -57,7 +57,9 @@ public class StonecuttingRecipe implements Recipe, Keyed {
+      * Get the input material.
+      *
+      * @return The input material.
++     * @deprecated Use {@link #getInputChoice()} instead for more complete data.
+      */
++    @Deprecated // Paper
+     @NotNull
+     public ItemStack getInput() {
+         return this.ingredient.getItemStack();
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 index 35009498aafd1bd36c493085127135fc8a5c36ec..1beedb446a9dd554d05d1d94dba8598e4b69eba6 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java


### PR DESCRIPTION
Replaces some internal usages of this method with the more proper `RecipeChoice#test(ItemStack)`. Every other method that utilizes `RecipeChoice#getItemStack()` has been deprecated with a message suggesting the modern equivalent that should be used instead.