### PR TITLE
Expose isUnderWater to Entity

### DIFF
--- a/patches/api/0211-Add-entity-liquid-API.patch
+++ b/patches/api/0211-Add-entity-liquid-API.patch
@@ -5,42 +5,47 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 383844bf956e70cc8a821913d5b2560226d8e2fc..88e35a4e8d82e2e071ecd47fe8871e0f13a84e2e 100644
+index 383844bf956e70cc8a821913d5b2560226d8e2fc..63d334b93cd8e8fa9015af5529a5f9420312af34 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -760,5 +760,35 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -760,5 +760,40 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      @NotNull
      org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason();
 +
 +    /**
++     * Check if entity is underwater
++     */
++    boolean isUnderWater();
++
++    /**
 +     * Check if entity is in rain
 +     */
-+    public boolean isInRain();
++    boolean isInRain();
 +
 +    /**
 +     * Check if entity is in bubble column
 +     */
-+    public boolean isInBubbleColumn();
++    boolean isInBubbleColumn();
 +
 +    /**
 +     * Check if entity is in water or rain
 +     */
-+    public boolean isInWaterOrRain();
++    boolean isInWaterOrRain();
 +
 +    /**
 +     * Check if entity is in water or bubble column
 +     */
-+    public boolean isInWaterOrBubbleColumn();
++    boolean isInWaterOrBubbleColumn();
 +
 +    /**
 +     * Check if entity is in water or rain or bubble column
 +     */
-+    public boolean isInWaterOrRainOrBubbleColumn();
++    boolean isInWaterOrRainOrBubbleColumn();
 +
 +    /**
 +     * Check if entity is in lava
 +     */
-+    public boolean isInLava();
++    boolean isInLava();
      // Paper end
  }

--- a/patches/api/0224-Entity-isTicking.patch
+++ b/patches/api/0224-Entity-isTicking.patch
@@ -5,17 +5,17 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 88e35a4e8d82e2e071ecd47fe8871e0f13a84e2e..be83ba864e2b9df50275f0fcdb50dc57a955ebec 100644
+index 63d334b93cd8e8fa9015af5529a5f9420312af34..6ff9a29ddda50c2e073c1ab02b13d5ff0bdeb903 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -790,5 +790,10 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -795,5 +795,10 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * Check if entity is in lava
       */
-     public boolean isInLava();
+     boolean isInLava();
 +
 +    /**
 +     * Check if entity is inside a ticking chunk
 +     */
-+    public boolean isTicking();
++    boolean isTicking();
      // Paper end
  }

--- a/patches/api/0270-Expose-Tracked-Players.patch
+++ b/patches/api/0270-Expose-Tracked-Players.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index f9b2251dbb7c9fe7dccc0fd28b4c00881124b6f3..2eb98be7095495f0e99d46b92ccc16d19bbc411b 100644
+index 277dc1f3a0002f5102bc2a6be4412d179bbdb713..e3218b5c170e1916a991aa1fae6a4f4e26dc034d 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -795,5 +795,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -800,5 +800,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * Check if entity is inside a ticking chunk
       */
-     public boolean isTicking();
+     boolean isTicking();
 +
 +    /**
 +     * Returns a set of {@link Player Players} within this entity's tracking range (players that can "see" this entity).

--- a/patches/api/0338-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/api/0338-Add-Raw-Byte-Entity-Serialization.patch
@@ -24,10 +24,10 @@ index be8d5c172b0a300648f21e2163ccf0a9cd7915ee..4fcafddf3792b66c618f91e04d102f37
       * Return the translation key for the Material, so the client can translate it into the active
       * locale when using a {@link net.kyori.adventure.text.TranslatableComponent}.
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 2eb98be7095495f0e99d46b92ccc16d19bbc411b..c15235b93f43746836eb4b7e136615fbc9308369 100644
+index e3218b5c170e1916a991aa1fae6a4f4e26dc034d..570d446869022008d01ba382e85ec69fcb25f99d 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -802,5 +802,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -807,5 +807,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return players in tracking range
       */
      @NotNull Set<Player> getTrackedPlayers();

--- a/patches/api/0345-Entity-powdered-snow-API.patch
+++ b/patches/api/0345-Entity-powdered-snow-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity powdered snow API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index c15235b93f43746836eb4b7e136615fbc9308369..9d6af05deead57a2df9663d76d89ccd8b8aab6d5 100644
+index 570d446869022008d01ba382e85ec69fcb25f99d..62abbe2149bfb6cb4a38027899863a535e19e94c 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -829,5 +829,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -834,5 +834,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return Whether the entity was successfully spawned.
       */
      public boolean spawnAt(@NotNull Location location, @NotNull org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason);

--- a/patches/api/0389-Collision-API.patch
+++ b/patches/api/0389-Collision-API.patch
@@ -25,10 +25,10 @@ index 3f7e860de4e28745fcdf8d2f41f4a8c210f48909..39fa4c65e0f61450901662ff5c08d54a
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 8dd6c7bae8b5ce13e3b4d5847bb204dac5072da6..d00ce1de6f683777d6ccc10c4db1c28c571dbe75 100644
+index 9bfe62185acb2a208268a2db3aa81dad9e0eed5e..33a6b7a27dc91552799c07a7aad9b3df31ad13f7 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -924,4 +924,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -929,4 +929,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      boolean isInPowderedSnow();
      // Paper end

--- a/patches/server/0446-Add-entity-liquid-API.patch
+++ b/patches/server/0446-Add-entity-liquid-API.patch
@@ -5,34 +5,45 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 3bda8128c2956d817677e28ff87c9c5ed61c8bd2..c2282592a3e5c8e08acb30a8fe6f3a83dfe6d93d 100644
+index 3bda8128c2956d817677e28ff87c9c5ed61c8bd2..ceb7123362ba85df825a50c035a399174b6634dc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1271,5 +1271,29 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1271,5 +1271,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason() {
          return getHandle().spawnReason;
      }
 +
++    @Override
++    public boolean isUnderWater() {
++        return getHandle().isUnderWater();
++    }
++
++    @Override
 +    public boolean isInRain() {
 +        return getHandle().isInRain();
 +    }
 +
++    @Override
 +    public boolean isInBubbleColumn() {
 +        return getHandle().isInBubbleColumn();
 +    }
 +
++    @Override
 +    public boolean isInWaterOrRain() {
 +        return getHandle().isInWaterOrRain();
 +    }
 +
++    @Override
 +    public boolean isInWaterOrBubbleColumn() {
 +        return getHandle().isInWaterOrBubble();
 +    }
-+    
++
++    @Override
 +    public boolean isInWaterOrRainOrBubbleColumn() {
 +        return getHandle().isInWaterRainOrBubble();
 +    }
 +
++    @Override
 +    public boolean isInLava() {
 +        return getHandle().isInLava();
 +    }

--- a/patches/server/0487-Entity-isTicking.patch
+++ b/patches/server/0487-Entity-isTicking.patch
@@ -5,36 +5,29 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 23ec6c64579b1e682ec30ea6d4ec196ddb9ed403..353f8b46b45b152b83afb2a832cd94c8807ce858 100644
+index 23ec6c64579b1e682ec30ea6d4ec196ddb9ed403..37eb939935dc5fbaa22f89f1784bd69c0c37cfcf 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -59,6 +59,7 @@ import net.minecraft.resources.ResourceKey;
- import net.minecraft.resources.ResourceLocation;
- import net.minecraft.server.MCUtil;
- import net.minecraft.server.MinecraftServer;
-+import net.minecraft.server.level.ServerChunkCache;
- import net.minecraft.server.level.ServerLevel;
- import net.minecraft.server.level.ServerPlayer;
- import net.minecraft.server.level.TicketType;
-@@ -4167,5 +4168,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4167,5 +4167,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }
 +
 +    public boolean isTicking() {
-+        return ((ServerChunkCache) level.getChunkSource()).isPositionTicking(this);
++        return ((net.minecraft.server.level.ServerChunkCache) level.getChunkSource()).isPositionTicking(this);
 +    }
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 40e6cd06f6b0cab2718c165cb38e772e90795917..142e6be6a41500b6e3b49173b7432e63de7ad3da 100644
+index 52ccc5cb9c5512b30ce863062de85219adb801ae..0988da3d82b9f13d36ccb73f282d36bf6d1f0284 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1295,5 +1295,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1306,5 +1306,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean isInLava() {
          return getHandle().isInLava();
      }
 +
++    @Override
 +    public boolean isTicking() {
 +        return getHandle().isTicking();
 +    }

--- a/patches/server/0517-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0517-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 353f8b46b45b152b83afb2a832cd94c8807ce858..447ff449725e6f347b9efce551b71ee70a198610 100644
+index 37eb939935dc5fbaa22f89f1784bd69c0c37cfcf..508eb07ac137ca81e4f9015fe2665d992bd1cb72 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1897,6 +1897,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1896,6 +1896,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public boolean isPushable() {

--- a/patches/server/0530-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0530-MC-4-Fix-item-position-desync.patch
@@ -27,10 +27,10 @@ index 3768a71491ef7836b9739bdaec7a077c523dbacd..a57957ace1a72b3308487f180a366c38
  
      public Vec3 decode(long x, long y, long z) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 447ff449725e6f347b9efce551b71ee70a198610..8b64afcdb2f7419a0fd7cecb0d2fb364a508a161 100644
+index 508eb07ac137ca81e4f9015fe2665d992bd1cb72..83701f22e7903d0c4b9bea111dbed5d096a2ddf9 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3971,6 +3971,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3970,6 +3970,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              return;
          }
          // Paper end - rewrite chunk system

--- a/patches/server/0557-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0557-Collision-option-for-requiring-a-player-participant.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Collision option for requiring a player participant
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8b64afcdb2f7419a0fd7cecb0d2fb364a508a161..2adf73d2fe9e687d7a487bc9af531a3d42896257 100644
+index 83701f22e7903d0c4b9bea111dbed5d096a2ddf9..12a14012a53000470702ce89b883a204dc1189c8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1780,6 +1780,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1779,6 +1779,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public void push(Entity entity) {
          if (!this.isPassengerOfSameVehicle(entity)) {
              if (!entity.noPhysics && !this.noPhysics) {

--- a/patches/server/0578-Expose-Tracked-Players.patch
+++ b/patches/server/0578-Expose-Tracked-Players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 142e6be6a41500b6e3b49173b7432e63de7ad3da..b30fb13db5524dcd05a155b014b93089af05c994 100644
+index 0988da3d82b9f13d36ccb73f282d36bf6d1f0284..d34e1da89e04df311c1627f43790851c23fef0b0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1299,5 +1299,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1311,5 +1311,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean isTicking() {
          return getHandle().isTicking();
      }

--- a/patches/server/0649-Fix-dangerous-end-portal-logic.patch
+++ b/patches/server/0649-Fix-dangerous-end-portal-logic.patch
@@ -11,10 +11,10 @@ Move the tick logic into the post tick, where portaling was
 designed to happen in the first place.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2adf73d2fe9e687d7a487bc9af531a3d42896257..263f9a9b21d20733d94a5f1e176bdb5aad94b9d4 100644
+index 12a14012a53000470702ce89b883a204dc1189c8..232e9fe555b58632ee2a522b656d0927d4df0f26 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -510,6 +510,36 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -509,6 +509,36 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return chunkMap.playerEntityTrackerTrackMaps[type.ordinal()].getObjectsInRange(MCUtil.getCoordinateKey(this));
      }
      // Paper end - optimise entity tracking
@@ -51,7 +51,7 @@ index 2adf73d2fe9e687d7a487bc9af531a3d42896257..263f9a9b21d20733d94a5f1e176bdb5a
  
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
-@@ -2686,6 +2716,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2685,6 +2715,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
  
              this.processPortalCooldown();

--- a/patches/server/0682-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0682-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 263f9a9b21d20733d94a5f1e176bdb5aad94b9d4..d7dadeb5b1f021969d3e1ccfb1d3a647e54b65c0 100644
+index 232e9fe555b58632ee2a522b656d0927d4df0f26..311267d5afd70ad48ac195ebfd659d0a718cdfd7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3661,20 +3661,34 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3660,20 +3660,34 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      private Stream<Entity> getIndirectPassengersStream() {
@@ -43,7 +43,7 @@ index 263f9a9b21d20733d94a5f1e176bdb5aad94b9d4..d7dadeb5b1f021969d3e1ccfb1d3a647
          return () -> {
              return this.getIndirectPassengersStream().iterator();
          };
-@@ -3691,6 +3705,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3690,6 +3704,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      // Paper end - rewrite chunk system
  
      public boolean hasExactlyOnePlayerPassenger() {

--- a/patches/server/0692-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0692-Add-back-EntityPortalExitEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d7dadeb5b1f021969d3e1ccfb1d3a647e54b65c0..8a2d0a8dce8510fda7a9ca6c33454abc5fe015ba 100644
+index 311267d5afd70ad48ac195ebfd659d0a718cdfd7..bb535ca99a14a016c00bf7825384a831afb9ebaa 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3163,6 +3163,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3162,6 +3162,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              } else {
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
@@ -32,7 +32,7 @@ index d7dadeb5b1f021969d3e1ccfb1d3a647e54b65c0..8a2d0a8dce8510fda7a9ca6c33454abc
                  if (worldserver == this.level) {
                      // SPIGOT-6782: Just move the entity if a plugin changed the world to the one the entity is already in
                      this.moveTo(shapedetectorshape.pos.x, shapedetectorshape.pos.y, shapedetectorshape.pos.z, shapedetectorshape.yRot, shapedetectorshape.xRot);
-@@ -3182,8 +3199,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3181,8 +3198,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
                  if (entity != null) {
                      entity.restoreFrom(this);

--- a/patches/server/0703-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0703-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8a2d0a8dce8510fda7a9ca6c33454abc5fe015ba..884d055c66e1f6f47b7bcf6a7bcc3b1271292d5b 100644
+index bb535ca99a14a016c00bf7825384a831afb9ebaa..27b42e8305a4aa3a3d99b73be441af9687da70a5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1986,6 +1986,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1985,6 +1985,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
      }
  
@@ -25,10 +25,10 @@ index 8a2d0a8dce8510fda7a9ca6c33454abc5fe015ba..884d055c66e1f6f47b7bcf6a7bcc3b12
          return this.isPassenger() ? false : this.saveAsPassenger(nbt);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index b30fb13db5524dcd05a155b014b93089af05c994..a1ef4ba683b1721359fb162b5f97ceefd7207184 100644
+index d34e1da89e04df311c1627f43790851c23fef0b0..8c273a7dc38c9c5dba83c998bab3427d3112106b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1312,5 +1312,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1324,5 +1324,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          }
          return set;
      }

--- a/patches/server/0716-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0716-Detail-more-information-in-watchdog-dumps.patch
@@ -124,10 +124,10 @@ index b4b7aa2f7d602fe996ebc320ab9641866b672abe..f7841aea38707cebaaab2637454a0db8
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 884d055c66e1f6f47b7bcf6a7bcc3b1271292d5b..9d696ea3bfcd6f4159bf431043f55d199a94ec6a 100644
+index 27b42e8305a4aa3a3d99b73be441af9687da70a5..b1e1b8f9717d2a5a61485b843d3fde05012272ec 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -972,7 +972,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -971,7 +971,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return this.onGround;
      }
  
@@ -170,7 +170,7 @@ index 884d055c66e1f6f47b7bcf6a7bcc3b1271292d5b..9d696ea3bfcd6f4159bf431043f55d19
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -1145,6 +1180,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1144,6 +1179,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.level.getProfiler().pop();
              }
          }
@@ -184,7 +184,7 @@ index 884d055c66e1f6f47b7bcf6a7bcc3b1271292d5b..9d696ea3bfcd6f4159bf431043f55d19
      }
  
      protected boolean isHorizontalCollisionMinor(Vec3 adjustedMovement) {
-@@ -3973,7 +4015,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3972,7 +4014,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -194,7 +194,7 @@ index 884d055c66e1f6f47b7bcf6a7bcc3b1271292d5b..9d696ea3bfcd6f4159bf431043f55d19
      }
  
      public void setDeltaMovement(double x, double y, double z) {
-@@ -4055,7 +4099,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4054,7 +4098,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
          // Paper end - fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {

--- a/patches/server/0749-Update-head-rotation-in-missing-places.patch
+++ b/patches/server/0749-Update-head-rotation-in-missing-places.patch
@@ -8,10 +8,10 @@ This is because bukkit uses a separate head rotation field for yaw.
 This issue only applies to players.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9d696ea3bfcd6f4159bf431043f55d199a94ec6a..6b6af080e9adc0c95908460213ef392351c6530f 100644
+index b1e1b8f9717d2a5a61485b843d3fde05012272ec..1b24aa8dfa0c76b2738bbb710d2d3c1f85f23666 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1764,6 +1764,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1763,6 +1763,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          this.setXRot(Mth.clamp(pitch, -90.0F, 90.0F) % 360.0F);
          this.yRotO = this.getYRot();
          this.xRotO = this.getXRot();
@@ -19,7 +19,7 @@ index 9d696ea3bfcd6f4159bf431043f55d199a94ec6a..6b6af080e9adc0c95908460213ef3923
      }
  
      public void absMoveTo(double x, double y, double z) {
-@@ -1802,6 +1803,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1801,6 +1802,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          this.setXRot(pitch);
          this.setOldPosAndRot();
          this.reapplyPosition();

--- a/patches/server/0758-don-t-attempt-to-teleport-dead-entities.patch
+++ b/patches/server/0758-don-t-attempt-to-teleport-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] don't attempt to teleport dead entities
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c455abc1f41aa9372dec6db7a304bc26ce1b7973..ff74f075db4c401a0a8388c04f234afbe8d20c96 100644
+index 1b24aa8dfa0c76b2738bbb710d2d3c1f85f23666..97ae347604922916308c6d3e1e2e97911ddc9e35 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -780,7 +780,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -779,7 +779,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      // CraftBukkit start
      public void postTick() {
          // No clean way to break out of ticking once the entity has been copied to a new world, so instead we move the portalling later in the tick cycle

--- a/patches/server/0771-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0771-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -1215,10 +1215,10 @@ index 3e870218321a701b814a4dac97ff1af12142600e..4277f7fdd8f27e57708a8dee59bf1b90
          }
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b5fdac1a1f4a356d4eaf5ea944d3ed6582b094ee..9dbe61ef5cea1b39216551462ea79cc8658839ed 100644
+index 97ae347604922916308c6d3e1e2e97911ddc9e35..ecdb1a905b12d1d37698f7a51acbb36bffeda698 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1161,9 +1161,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1160,9 +1160,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  float f2 = this.getBlockSpeedFactor();
  
                  this.setDeltaMovement(this.getDeltaMovement().multiply((double) f2, 1.0D, (double) f2));
@@ -1266,7 +1266,7 @@ index b5fdac1a1f4a356d4eaf5ea944d3ed6582b094ee..9dbe61ef5cea1b39216551462ea79cc8
                      if (this.remainingFireTicks <= 0) {
                          this.setRemainingFireTicks(-this.getFireImmuneTicks());
                      }
-@@ -1307,32 +1342,78 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1306,32 +1341,78 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      private Vec3 collide(Vec3 movement) {
@@ -1366,7 +1366,7 @@ index b5fdac1a1f4a356d4eaf5ea944d3ed6582b094ee..9dbe61ef5cea1b39216551462ea79cc8
      }
  
      public static Vec3 collideBoundingBox(@Nullable Entity entity, Vec3 movement, AABB entityBoundingBox, Level world, List<VoxelShape> collisions) {
-@@ -2455,11 +2536,30 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2454,11 +2535,30 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              float f = this.dimensions.width * 0.8F;
              AABB axisalignedbb = AABB.ofSize(this.getEyePosition(), (double) f, 1.0E-6D, (double) f);
  

--- a/patches/server/0779-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0779-Forward-CraftEntity-in-teleport-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9dbe61ef5cea1b39216551462ea79cc8658839ed..b92924de92af850c67b72112f3747cafcaaef07b 100644
+index ecdb1a905b12d1d37698f7a51acbb36bffeda698..88df5e35020edc805f9e0371e20d6849d2dfff88 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3277,6 +3277,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3276,6 +3276,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void restoreFrom(Entity original) {
@@ -22,7 +22,7 @@ index 9dbe61ef5cea1b39216551462ea79cc8658839ed..b92924de92af850c67b72112f3747caf
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3358,10 +3365,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3357,10 +3364,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      if (worldserver.getTypeKey() == LevelStem.END) { // CraftBukkit
                          ServerLevel.makeObsidianPlatform(worldserver, this); // CraftBukkit
                      }

--- a/patches/server/0781-Entity-powdered-snow-API.patch
+++ b/patches/server/0781-Entity-powdered-snow-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity powdered snow API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index a1ef4ba683b1721359fb162b5f97ceefd7207184..385368d0c6a13f9b1b907bcc48d1fb2a845262ef 100644
+index 8c273a7dc38c9c5dba83c998bab3427d3112106b..702d0fc5ebd2d39b038dae05135f551848544818 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1322,5 +1322,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1334,5 +1334,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          entity.setRot(location.getYaw(), location.getPitch());
          return !entity.valid && entity.level.addFreshEntity(entity, reason);
      }

--- a/patches/server/0805-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0805-Freeze-Tick-Lock-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b92924de92af850c67b72112f3747cafcaaef07b..6cf2f6539ece7509efe5ae0dc66e73231718976d 100644
+index 88df5e35020edc805f9e0371e20d6849d2dfff88..95388d7d9097316df87c0ca8bba1d5730f33b378 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -397,6 +397,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -396,6 +396,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
      private UUID originWorld;
@@ -16,7 +16,7 @@ index b92924de92af850c67b72112f3747cafcaaef07b..6cf2f6539ece7509efe5ae0dc66e7323
  
      public void setOrigin(@javax.annotation.Nonnull Location location) {
          this.origin = location.toVector();
-@@ -826,7 +827,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -825,7 +826,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.setRemainingFireTicks(this.remainingFireTicks - 1);
              }
  
@@ -25,7 +25,7 @@ index b92924de92af850c67b72112f3747cafcaaef07b..6cf2f6539ece7509efe5ae0dc66e7323
                  this.setTicksFrozen(0);
                  this.level.levelEvent((Player) null, 1009, this.blockPosition, 1);
              }
-@@ -2262,6 +2263,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2261,6 +2262,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (fromNetherPortal) {
                  nbt.putBoolean("Paper.FromNetherPortal", true);
              }
@@ -35,7 +35,7 @@ index b92924de92af850c67b72112f3747cafcaaef07b..6cf2f6539ece7509efe5ae0dc66e7323
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2426,6 +2430,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2425,6 +2429,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (spawnReason == null) {
                  spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT;
              }
@@ -59,7 +59,7 @@ index 1ef11297bc9017fd3c5ac661167c58617d06200b..66a566af1dd6684bd7c0dd8b3104543e
              if (this.isInPowderSnow && this.canFreeze()) {
                  this.setTicksFrozen(Math.min(this.getTicksRequiredToFreeze(), i + 1));
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 385368d0c6a13f9b1b907bcc48d1fb2a845262ef..c4ffccddce33cf461d9b04ccbb90026544f16b7d 100644
+index 702d0fc5ebd2d39b038dae05135f551848544818..2015147126f463f11202d04ca475cc86e5ac12c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -644,6 +644,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0840-Ensure-entity-passenger-world-matches-ridden-entity.patch
+++ b/patches/server/0840-Ensure-entity-passenger-world-matches-ridden-entity.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ensure entity passenger world matches ridden entity
 Bad plugins doing this would cause some obvious problems...
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6cf2f6539ece7509efe5ae0dc66e73231718976d..869c38119d030c849cff2b66b3fd26f143933782 100644
+index 95388d7d9097316df87c0ca8bba1d5730f33b378..13a601ba8c26bac8ec943b848b9130081fd78a3f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2685,6 +2685,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2684,6 +2684,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/patches/server/0841-Guard-against-invalid-entity-positions.patch
+++ b/patches/server/0841-Guard-against-invalid-entity-positions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Guard against invalid entity positions
 Anything not finite should be blocked and logged
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 869c38119d030c849cff2b66b3fd26f143933782..445eebd06c2eb681c334bdf07c9fd6517705b128 100644
+index 13a601ba8c26bac8ec943b848b9130081fd78a3f..d92f594684c32a15c378f41a9e587c67784be005 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4198,11 +4198,33 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4197,11 +4197,33 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return this.getZ((2.0D * this.random.nextDouble() - 1.0D) * widthScale);
      }
  

--- a/patches/server/0865-Prevent-entity-loading-causing-async-lookups.patch
+++ b/patches/server/0865-Prevent-entity-loading-causing-async-lookups.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent entity loading causing async lookups
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 25618b33760a3b1f39e6bbf774c75134afe94160..8ef94c21096131c345b7505630a487bd200f3464 100644
+index d92f594684c32a15c378f41a9e587c67784be005..3dc081f73670553e764fde8dbf27ac96cfed15b7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -789,6 +789,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -788,6 +788,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
      public void baseTick() {
          this.level.getProfiler().push("entityBaseTick");

--- a/patches/server/0881-Add-various-missing-EntityDropItemEvent-calls.patch
+++ b/patches/server/0881-Add-various-missing-EntityDropItemEvent-calls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add various missing EntityDropItemEvent calls
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c2fe2722909ad25c97da90b4a94386b7c9b82244..07ed6d6e9064a1504d85ab2d1f3d8a288fd3372b 100644
+index 3dc081f73670553e764fde8dbf27ac96cfed15b7..8b87b7d78b5be77d4ad36d24b6a1ab8fc7dd1db4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2521,6 +2521,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2520,6 +2520,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              stack.setCount(0); // Paper - destroy this item - if this ever leaks due to game bugs, ensure it doesn't dupe
  
              entityitem.setDefaultPickUpDelay();

--- a/patches/server/0887-Add-EntityPortalReadyEvent.patch
+++ b/patches/server/0887-Add-EntityPortalReadyEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add EntityPortalReadyEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 07ed6d6e9064a1504d85ab2d1f3d8a288fd3372b..a80f4abf8a0c6c395f407c8bf25b44a64b0b9fe3 100644
+index 8b87b7d78b5be77d4ad36d24b6a1ab8fc7dd1db4..a1421689445b9df3f25889845c21cf37a439afe2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2868,6 +2868,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2867,6 +2867,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  if (true && !this.isPassenger() && this.portalTime++ >= i) { // CraftBukkit
                      this.level.getProfiler().push("portal");
                      this.portalTime = i;
@@ -22,7 +22,7 @@ index 07ed6d6e9064a1504d85ab2d1f3d8a288fd3372b..a80f4abf8a0c6c395f407c8bf25b44a6
                      this.setPortalCooldown();
                      // CraftBukkit start
                      if (this instanceof ServerPlayer) {
-@@ -2875,6 +2882,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2874,6 +2881,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      } else {
                          this.changeDimension(worldserver1);
                      }

--- a/patches/server/0893-Collision-API.patch
+++ b/patches/server/0893-Collision-API.patch
@@ -22,10 +22,10 @@ index 6445c2e4c97860e1c98f5263188d309cf55936f0..62bca85da6c5d9877e21fecb70237050
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 99b99fae67e53a688b3519d8a8d0cc5f3468e7e8..d4ea7d19ae16a8ccafcfe5300bb380b28fd42b75 100644
+index a1e2664c9a6cc41edf0dfb92cd2b9d77170d8fde..9368ec01e498f913bc5b7b3e77fe87659090d9b5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1357,4 +1357,19 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1369,4 +1369,19 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return getHandle().isInPowderSnow || getHandle().wasInPowderSnow; // depending on the location in the entity "tick" either could be needed.
      }
      // Paper end


### PR DESCRIPTION
There was already a fitting patch for this, so I just threw it in there, as well as cleaned it up a bit.

Differs from `Entity#isInWater` in a way that it requires eyes to be emerged as well instead of just touching the water with any body part.