### PR TITLE
Elder Guardian appearance API

### DIFF
--- a/patches/api/0399-Elder-Guardian-appearance-API.patch
+++ b/patches/api/0399-Elder-Guardian-appearance-API.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Tue, 11 Oct 2022 20:38:47 +0300
+Subject: [PATCH] Elder Guardian appearance API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 1d98abff1ad0116f7a2599f078aa730cb84843c1..ecb8b4cf48c7d6151ffec92bc6855d1fc57a2b51 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -2828,6 +2828,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
+     // Paper end - Teleport API
+ 
++    // Paper start
++    /**
++     * Displays elder guardian effect with a sound
++     *
++     * @see #showElderGuardian(boolean)
++     */
++    default void showElderGuardian() {
++        showElderGuardian(false);
++    }
++
++    /**
++     * Displays elder guardian effect and optionally plays a sound
++     *
++     * @param silent whether sound should be silenced
++     */
++    void showElderGuardian(boolean silent);
++    // Paper end
++
+     @NotNull
+     @Override
+     Spigot spigot();

--- a/patches/server/0925-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0925-Elder-Guardian-appearance-API.patch
@@ -15,7 +15,7 @@ index 968aa80b57a31d89852c6f4bc0ec5ed4a98c6530..4712a034ea43a6dada15d68e8657c485
 +    // Paper start
 +    @Override
 +    public void showElderGuardian(boolean silent) {
-+        getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
++        if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
 +    }
 +    // Paper end
 +

--- a/patches/server/0925-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0925-Elder-Guardian-appearance-API.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Tue, 11 Oct 2022 20:38:47 +0300
+Subject: [PATCH] Elder Guardian appearance API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 968aa80b57a31d89852c6f4bc0ec5ed4a98c6530..4712a034ea43a6dada15d68e8657c48519b3eac0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -2932,6 +2932,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+     // Paper end
+ 
++    // Paper start
++    @Override
++    public void showElderGuardian(boolean silent) {
++        getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
++    }
++    // Paper end
++
+     public Player.Spigot spigot()
+     {
+         return this.spigot;


### PR DESCRIPTION
Allows sending elder guardian effect to the player, optionally without a sound.

Note: float value in this packet acts like a boolean, and thus it's a boolean in API too (>= 0.5 < 1.5 plays the same sound, otherwise silent).

P.S. In the server patch, the upper `// Paper` block has `// Paper start - brand support` heading, so that's why a new block was made.