### PR TITLE
Add LivingEntity#swingHand(EquipmentSlot) convenience method

### DIFF
--- a/patches/api/0399-Add-LivingEntity-swingHand-EquipmentSlot-convenience.patch
+++ b/patches/api/0399-Add-LivingEntity-swingHand-EquipmentSlot-convenience.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Tue, 11 Oct 2022 22:35:56 +0300
+Subject: [PATCH] Add LivingEntity#swingHand(EquipmentSlot) convenience method
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 4af5e8d0cba6555f7615e4e809d9aff221c0dc4d..3dcb117664bfd170d739a4ee2af3ad30de298b25 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -985,5 +985,23 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+      * @param hurtDirection hurt direction
+      */
+     void setHurtDirection(float hurtDirection);
++
++    /**
++     * Makes this entity swing their hand.
++     *
++     * <p>This method does nothing if this entity does not
++     * have an animation for swinging their hand.
++     *
++     * @param hand hand to be swung, either {@link org.bukkit.inventory.EquipmentSlot#HAND} or {@link org.bukkit.inventory.EquipmentSlot#OFF_HAND}
++     * @throws IllegalArgumentException if invalid hand is passed
++     */
++    default void swingHand(@NotNull org.bukkit.inventory.EquipmentSlot hand) {
++        com.google.common.base.Preconditions.checkArgument(hand == org.bukkit.inventory.EquipmentSlot.HAND || hand == org.bukkit.inventory.EquipmentSlot.OFF_HAND, "EquipmentSlot was not a hand!");
++        if (hand == org.bukkit.inventory.EquipmentSlot.HAND) {
++            this.swingMainHand();
++        } else {
++            this.swingOffHand();
++        }
++    }
+     // Paper end
+ }

--- a/patches/api/0402-Add-LivingEntity-swingHand-EquipmentSlot-convenience.patch
+++ b/patches/api/0402-Add-LivingEntity-swingHand-EquipmentSlot-convenience.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#swingHand(EquipmentSlot) convenience method
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 4af5e8d0cba6555f7615e4e809d9aff221c0dc4d..3dcb117664bfd170d739a4ee2af3ad30de298b25 100644
+index 4af5e8d0cba6555f7615e4e809d9aff221c0dc4d..319e4571aca24d1e3f6c85b7435d65c0e77a5245 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -985,5 +985,23 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
@@ -23,7 +23,7 @@ index 4af5e8d0cba6555f7615e4e809d9aff221c0dc4d..3dcb117664bfd170d739a4ee2af3ad30
 +     * @throws IllegalArgumentException if invalid hand is passed
 +     */
 +    default void swingHand(@NotNull org.bukkit.inventory.EquipmentSlot hand) {
-+        com.google.common.base.Preconditions.checkArgument(hand == org.bukkit.inventory.EquipmentSlot.HAND || hand == org.bukkit.inventory.EquipmentSlot.OFF_HAND, "EquipmentSlot was not a hand!");
++        com.google.common.base.Preconditions.checkArgument(hand == org.bukkit.inventory.EquipmentSlot.HAND || hand == org.bukkit.inventory.EquipmentSlot.OFF_HAND, String.format("Expected a valid hand, got \"%s\" instead!", hand));
 +        if (hand == org.bukkit.inventory.EquipmentSlot.HAND) {
 +            this.swingMainHand();
 +        } else {


### PR DESCRIPTION
I have dozens of methods where I operate with an item from events solely based on the passed slot.
Old and ugly code (already shortened by not using brackets) would require me to do this:
```java
if (hand == EquipmentSlot.HAND) player.swingMainHand();
else if (hand == EquipmentSlot.OFF_HAND) player.swingOffHand(); // or just else considering no third hand
```
It can now be as simple as `player.swingHand(hand);` :)