### PR TITLE
Expose pre-collision moving velocity to VehicleBlockCollisionEvent

### DIFF
--- a/patches/api/0425-Expose-pre-collision-moving-velocity-to-VehicleBlock.patch
+++ b/patches/api/0425-Expose-pre-collision-moving-velocity-to-VehicleBlock.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Tue, 11 Oct 2022 23:30:32 +0300
+Subject: [PATCH] Expose pre-collision moving velocity to
+ VehicleBlockCollisionEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleBlockCollisionEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleBlockCollisionEvent.java
+index 7ff9aec7ed341c01feddb8d71170b177e1fde47b..d2b33f4105ae32a884e714a8936e3d91e23a00a0 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleBlockCollisionEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleBlockCollisionEvent.java
+@@ -11,11 +11,20 @@ import org.jetbrains.annotations.NotNull;
+ public class VehicleBlockCollisionEvent extends VehicleCollisionEvent {
+     // private static final HandlerList handlers = new HandlerList(); // Paper - move HandlerList to VehicleCollisionEvent
+     private final Block block;
++    private final org.bukkit.util.Vector velocity; // Paper
+ 
++    // Paper start - Add pre-collision velocity
++    @Deprecated
+     public VehicleBlockCollisionEvent(@NotNull final Vehicle vehicle, @NotNull final Block block) {
++        this(vehicle, block, vehicle.getVelocity());
++    }
++
++    public VehicleBlockCollisionEvent(@NotNull final Vehicle vehicle, @NotNull final Block block, @NotNull final org.bukkit.util.Vector velocity) { // Paper - Added velocity
+         super(vehicle);
+         this.block = block;
++        this.velocity = velocity;
+     }
++    // Paper end
+ 
+     /**
+      * Gets the block the vehicle collided with
+@@ -26,4 +35,16 @@ public class VehicleBlockCollisionEvent extends VehicleCollisionEvent {
+     public Block getBlock() {
+         return block;
+     }
++
++    // Paper start
++    /**
++     * Gets velocity at which the vehicle collided with the block
++     *
++     * @return pre-collision moving velocity
++     */
++    @NotNull
++    public org.bukkit.util.Vector getVelocity() {
++        return velocity;
++    }
++    // Paper end
+ }

--- a/patches/server/0955-Expose-pre-collision-moving-velocity-to-VehicleBlock.patch
+++ b/patches/server/0955-Expose-pre-collision-moving-velocity-to-VehicleBlock.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Tue, 11 Oct 2022 23:30:32 +0300
+Subject: [PATCH] Expose pre-collision moving velocity to
+ VehicleBlockCollisionEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 7555b04dcf274bb624b89f2eb9ff80da0056de4e..1eaab1f6923e6aa34b643293347348e5cc19af3c 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -1103,7 +1103,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+                     }
+ 
+                     if (!bl.getType().isAir()) {
+-                        VehicleBlockCollisionEvent event = new VehicleBlockCollisionEvent(vehicle, bl);
++                        VehicleBlockCollisionEvent event = new VehicleBlockCollisionEvent(vehicle, bl, org.bukkit.craftbukkit.util.CraftVector.toBukkit(moveVector)); // Paper - Expose pre-collision velocity
+                         this.level.getCraftServer().getPluginManager().callEvent(event);
+                     }
+                 }


### PR DESCRIPTION
Upon firing `VehicleBlockCollisionEvent` the collision already happened (for example, a minecart would already be stopped), and before there was no easy way to know the velocity at which this happened; you'd have to track that yourself.

Now you can use this API to implement features like bouncing from slime blocks depending on the speed you hit them :)