### PR TITLE
Added PermissibleBase getters and setters

### DIFF
--- a/patches/api/0400-Added-PermissibleBase-getter-and-setter.patch
+++ b/patches/api/0400-Added-PermissibleBase-getter-and-setter.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Added PermissibleBase getter and setter
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 1d98abff1ad0116f7a2599f078aa730cb84843c1..443e63db6fc37ff5e55a09d1c0238d103f490ab6 100644
+index 1d98abff1ad0116f7a2599f078aa730cb84843c1..d0dec0999a2ffe0117b88a9bddf3b707bcd16710 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -33,6 +33,7 @@ import org.bukkit.event.player.PlayerResourcePackStatusEvent;
@@ -43,7 +43,7 @@ index 1d98abff1ad0116f7a2599f078aa730cb84843c1..443e63db6fc37ff5e55a09d1c0238d10
      /**
       * Gets the no-ticking view distance for this player.
       * <p>
-@@ -2832,4 +2833,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2832,4 +2833,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Override
      Spigot spigot();
      // Spigot end
@@ -54,12 +54,14 @@ index 1d98abff1ad0116f7a2599f078aa730cb84843c1..443e63db6fc37ff5e55a09d1c0238d10
 +     * @param base {@link PermissibleBase}
 +     * @return the old {@link PermissibleBase}
 +     */
-+    PermissibleBase setPermissibleBase(PermissibleBase base);
++    @NotNull
++    PermissibleBase setPermissibleBase(@NotNull PermissibleBase base);
 +
 +    /**
 +     * Get the player's {@link PermissibleBase}
 +     * @return the player's {@link PermissibleBase}
 +     */
++    @NotNull
 +    PermissibleBase getPermissibleBase();
 +    // Paper end
  }

--- a/patches/api/0400-Added-PermissibleBase-getter-and-setter.patch
+++ b/patches/api/0400-Added-PermissibleBase-getter-and-setter.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Badbird5907 <50347938+Badbird5907@users.noreply.github.com>
+Date: Wed, 12 Oct 2022 11:30:20 -0400
+Subject: [PATCH] Added PermissibleBase getter and setter
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 1d98abff1ad0116f7a2599f078aa730cb84843c1..443e63db6fc37ff5e55a09d1c0238d103f490ab6 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -33,6 +33,7 @@ import org.bukkit.event.player.PlayerResourcePackStatusEvent;
+ import org.bukkit.inventory.EquipmentSlot;
+ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.map.MapView;
++import org.bukkit.permissions.PermissibleBase;
+ import org.bukkit.plugin.Plugin;
+ import org.bukkit.plugin.messaging.PluginMessageRecipient;
+ import org.bukkit.scoreboard.Scoreboard;
+@@ -1965,7 +1966,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @param saturationLevel the saturation level of the player
+      */
+     public void sendHealthUpdate(final double health, final int foodLevel, final float saturationLevel);
+-    
++
+     /**
+      * Forcefully sends a health update to the player.
+      * This uses the player's current health, saturation, and food level.
+@@ -1974,7 +1975,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     public void sendHealthUpdate();
+     // Paper end
+-    
++
+     /**
+      * Gets the entity which is followed by the camera when in
+      * {@link GameMode#SPECTATOR}.
+@@ -2335,7 +2336,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @param simulationDistance the player's new simulation distance
+      */
+     public void setSimulationDistance(int simulationDistance);
+-    
++
+     /**
+      * Gets the no-ticking view distance for this player.
+      * <p>
+@@ -2832,4 +2833,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     @Override
+     Spigot spigot();
+     // Spigot end
++
++    // Paper start
++    /**
++     * Set the player's {@link PermissibleBase}
++     * @param base {@link PermissibleBase}
++     * @return the old {@link PermissibleBase}
++     */
++    PermissibleBase setPermissibleBase(PermissibleBase base);
++
++    /**
++     * Get the player's {@link PermissibleBase}
++     * @return the player's {@link PermissibleBase}
++     */
++    PermissibleBase getPermissibleBase();
++    // Paper end
+ }

--- a/patches/api/0400-Added-PermissibleBase-getter-and-setter.patch
+++ b/patches/api/0400-Added-PermissibleBase-getter-and-setter.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Added PermissibleBase getter and setter
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 1d98abff1ad0116f7a2599f078aa730cb84843c1..e5db215a400a7be9fae7fd13c6d4040f3bece296 100644
+index 1d98abff1ad0116f7a2599f078aa730cb84843c1..5fb5238df89de0a3800f3a5d29f4bb7b7c3c4310 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2832,4 +2832,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -16,15 +16,15 @@ index 1d98abff1ad0116f7a2599f078aa730cb84843c1..e5db215a400a7be9fae7fd13c6d4040f
 +    // Paper start
 +    /**
 +     * Set the player's {@link org.bukkit.permissions.PermissibleBase}
-+     * @param base {@link org.bukkit.permissions.PermissibleBase}
-+     * @return the old {@link org.bukkit.permissions.PermissibleBase}
++     * @param The value to replace the current one with.
++     * @return The previous value.
 +     */
 +    @NotNull
 +    org.bukkit.permissions.PermissibleBase setPermissibleBase(@NotNull org.bukkit.permissions.PermissibleBase base);
 +
 +    /**
 +     * Get the player's {@link org.bukkit.permissions.PermissibleBase}
-+     * @return the player's {@link org.bukkit.permissions.PermissibleBase}
++     * @return The current value.
 +     */
 +    @NotNull
 +    org.bukkit.permissions.PermissibleBase getPermissibleBase();

--- a/patches/api/0400-Added-PermissibleBase-getter-and-setter.patch
+++ b/patches/api/0400-Added-PermissibleBase-getter-and-setter.patch
@@ -5,63 +5,28 @@ Subject: [PATCH] Added PermissibleBase getter and setter
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 1d98abff1ad0116f7a2599f078aa730cb84843c1..d0dec0999a2ffe0117b88a9bddf3b707bcd16710 100644
+index 1d98abff1ad0116f7a2599f078aa730cb84843c1..e5db215a400a7be9fae7fd13c6d4040f3bece296 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -33,6 +33,7 @@ import org.bukkit.event.player.PlayerResourcePackStatusEvent;
- import org.bukkit.inventory.EquipmentSlot;
- import org.bukkit.inventory.ItemStack;
- import org.bukkit.map.MapView;
-+import org.bukkit.permissions.PermissibleBase;
- import org.bukkit.plugin.Plugin;
- import org.bukkit.plugin.messaging.PluginMessageRecipient;
- import org.bukkit.scoreboard.Scoreboard;
-@@ -1965,7 +1966,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-      * @param saturationLevel the saturation level of the player
-      */
-     public void sendHealthUpdate(final double health, final int foodLevel, final float saturationLevel);
--    
-+
-     /**
-      * Forcefully sends a health update to the player.
-      * This uses the player's current health, saturation, and food level.
-@@ -1974,7 +1975,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-      */
-     public void sendHealthUpdate();
-     // Paper end
--    
-+
-     /**
-      * Gets the entity which is followed by the camera when in
-      * {@link GameMode#SPECTATOR}.
-@@ -2335,7 +2336,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-      * @param simulationDistance the player's new simulation distance
-      */
-     public void setSimulationDistance(int simulationDistance);
--    
-+
-     /**
-      * Gets the no-ticking view distance for this player.
-      * <p>
-@@ -2832,4 +2833,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2832,4 +2832,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Override
      Spigot spigot();
      // Spigot end
 +
 +    // Paper start
 +    /**
-+     * Set the player's {@link PermissibleBase}
-+     * @param base {@link PermissibleBase}
-+     * @return the old {@link PermissibleBase}
++     * Set the player's {@link org.bukkit.permissions.PermissibleBase}
++     * @param base {@link org.bukkit.permissions.PermissibleBase}
++     * @return the old {@link org.bukkit.permissions.PermissibleBase}
 +     */
 +    @NotNull
-+    PermissibleBase setPermissibleBase(@NotNull PermissibleBase base);
++    org.bukkit.permissions.PermissibleBase setPermissibleBase(@NotNull org.bukkit.permissions.PermissibleBase base);
 +
 +    /**
-+     * Get the player's {@link PermissibleBase}
-+     * @return the player's {@link PermissibleBase}
++     * Get the player's {@link org.bukkit.permissions.PermissibleBase}
++     * @return the player's {@link org.bukkit.permissions.PermissibleBase}
 +     */
 +    @NotNull
-+    PermissibleBase getPermissibleBase();
++    org.bukkit.permissions.PermissibleBase getPermissibleBase();
 +    // Paper end
  }

--- a/patches/server/0926-Added-PermissibleBase-getter-and-setter.patch
+++ b/patches/server/0926-Added-PermissibleBase-getter-and-setter.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Badbird5907 <50347938+Badbird5907@users.noreply.github.com>
+Date: Wed, 12 Oct 2022 11:30:34 -0400
+Subject: [PATCH] Added PermissibleBase getter and setter
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+index e779dcc4982ff51e4d450265fd61bc26e8e74d3a..61fd80c691476c3eaec9ff182715913da3a0f051 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+@@ -70,7 +70,7 @@ import org.bukkit.plugin.Plugin;
+ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+     private CraftInventoryPlayer inventory;
+     private final CraftInventory enderChest;
+-    protected final PermissibleBase perm = new PermissibleBase(this);
++    protected PermissibleBase perm = new PermissibleBase(this);
+     private boolean op;
+     private GameMode mode;
+ 
+@@ -815,4 +815,14 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+         boolean success = this.getHandle().level.addFreshEntity(fireworks, SpawnReason.CUSTOM);
+         return success ? (Firework) fireworks.getBukkitEntity() : null;
+     }
++    // Paper start
++    public PermissibleBase getPermissibleBase() {
++        return this.perm;
++    }
++    public PermissibleBase setPermissibleBase(PermissibleBase base) {
++        PermissibleBase old = this.perm;
++        this.perm = base;
++        return old;
++    }
++    // Paper end
+ }

--- a/patches/server/0926-Added-PermissibleBase-getter-and-setter.patch
+++ b/patches/server/0926-Added-PermissibleBase-getter-and-setter.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Added PermissibleBase getter and setter
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index e779dcc4982ff51e4d450265fd61bc26e8e74d3a..61fd80c691476c3eaec9ff182715913da3a0f051 100644
+index e779dcc4982ff51e4d450265fd61bc26e8e74d3a..41fe37e00752d17717e0b1417faa62844a887095 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -70,7 +70,7 @@ import org.bukkit.plugin.Plugin;
@@ -13,7 +13,7 @@ index e779dcc4982ff51e4d450265fd61bc26e8e74d3a..61fd80c691476c3eaec9ff182715913d
      private CraftInventoryPlayer inventory;
      private final CraftInventory enderChest;
 -    protected final PermissibleBase perm = new PermissibleBase(this);
-+    protected PermissibleBase perm = new PermissibleBase(this);
++    protected PermissibleBase perm = new PermissibleBase(this); // Paper
      private boolean op;
      private GameMode mode;
  


### PR DESCRIPTION
Adding this API will remove the need to use reflections in plugins to get and set `PermissibleBase` on `CraftHumanEntity` to override permissions logic