### PR TITLE
[ci skip] Avoid loop of deprecation for horse API

### DIFF
--- a/patches/api/0311-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0311-Missing-Entity-Behavior-API.patch
@@ -8,10 +8,10 @@ Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 Co-authored-by: William Blake Galbreath <blake.galbreath@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/entity/AbstractHorse.java b/src/main/java/org/bukkit/entity/AbstractHorse.java
-index 0d88dce9978243a1f995c5fb448c5d71b01136eb..1c117ca4aebc2ff9e2f5458346fa0c090a0d7280 100644
+index 0d88dce9978243a1f995c5fb448c5d71b01136eb..8b1048c94dffd058eb9fd9144f7f59fc9bd219ad 100644
 --- a/src/main/java/org/bukkit/entity/AbstractHorse.java
 +++ b/src/main/java/org/bukkit/entity/AbstractHorse.java
-@@ -106,17 +106,72 @@ public interface AbstractHorse extends Vehicle, InventoryHolder, Tameable {
+@@ -106,17 +106,71 @@ public interface AbstractHorse extends Vehicle, InventoryHolder, Tameable {
       * Gets whether the horse is currently grazing hay.
       *
       * @return true if eating hay
@@ -47,7 +47,6 @@ index 0d88dce9978243a1f995c5fb448c5d71b01136eb..1c117ca4aebc2ff9e2f5458346fa0c09
 +     * <p>When true, the horse will lower its neck.</p>
 +     *
 +     * @param eating eating grass animation is active
-+     * @deprecated use {@link #setEatingHaystack(boolean)}
 +     */
 +    public void setEatingGrass(boolean eating);
 +


### PR DESCRIPTION
Fix the deprecation loop between setEatingGrass and setEatingHaystack methods