### PR TITLE
Fix sendBlockDamage 0 progress

### DIFF
--- a/patches/server/0928-Fix-sendBlockDamage-0-progress.patch
+++ b/patches/server/0928-Fix-sendBlockDamage-0-progress.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Spliterash <me@spliterash.ru>
+Date: Sat, 15 Oct 2022 18:49:03 +0300
+Subject: [PATCH] Fix sendBlockDamage 0 progress
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index b1136b9c39b16cbb9dfe460f88000f74ccd4f571..a7a72b7f65746c3b6dd68c00210f1526db8a05a3 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1020,7 +1020,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+ 
+         if (this.getHandle().connection == null) return;
+ 
+-        int stage = (int) (9 * progress); // There are 0 - 9 damage states
++        int stage = (int) (progress * 10) - 1; // Paper - Fix sendBlockDamage 0 progress
+         ClientboundBlockDestructionPacket packet = new ClientboundBlockDestructionPacket(destroyerIdentity, new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()), stage);  // Paper - customBlockDamage identity
+         this.getHandle().connection.send(packet);
+     }


### PR DESCRIPTION
Method Player#sendBlockDamage work wrongly. 
The javadoc says that if the progress is 0 then it means that the block has no destruction, while if you pass 0 then the player will see the destruction.
To reset the destruction, the player needs to send any number other than 0-9, this is written on wiki.vg
So I decided to handle a separate case with 0 progress