### PR TITLE
Bedrock pattern fix

### DIFF
--- a/patches/server/0330-Flat-bedrock-generator-settings.patch
+++ b/patches/server/0330-Flat-bedrock-generator-settings.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Flat bedrock generator settings
 Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/data/worldgen/SurfaceRuleData.java b/src/main/java/net/minecraft/data/worldgen/SurfaceRuleData.java
-index 06e1774dfbb667aca69bc30c9675ed472cb5728c..2f9ba60c0196c3722fbf5a44fbbcf22a85d438db 100644
+index 06e1774dfbb667aca69bc30c9675ed472cb5728c..1d5bc86516df3781aea894c3afd340421ba51a17 100644
 --- a/src/main/java/net/minecraft/data/worldgen/SurfaceRuleData.java
 +++ b/src/main/java/net/minecraft/data/worldgen/SurfaceRuleData.java
 @@ -53,6 +53,66 @@ public class SurfaceRuleData {
@@ -62,7 +62,7 @@ index 06e1774dfbb667aca69bc30c9675ed472cb5728c..2f9ba60c0196c3722fbf5a44fbbcf22a
 +                        return false;
 +                    } else {
 +                        double d = net.minecraft.util.Mth.map((double) y, (double) i, (double) j, 1.0D, 0.0D);
-+                        net.minecraft.util.RandomSource randomSource = positionalRandomFactory.at(this.context.blockX, i, this.context.blockZ);
++                        net.minecraft.util.RandomSource randomSource = positionalRandomFactory.at(this.context.blockX, y, this.context.blockZ);
 +                        return (double) randomSource.nextFloat() < d;
 +                    }
 +                }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41451155/196005443-2e75b64f-14e5-4a5a-be39-5b2c8fa09047.png)
![image](https://user-images.githubusercontent.com/41451155/196005448-71589f9d-eafd-4d3f-990c-2994f1ea1325.png)

Paper uses a fixed number for bedrock in the same column.
Vanilla uses the y coord of the bedrock block.