### PR TITLE
Add LivingEntity knockback API

### DIFF
--- a/patches/api/0403-Add-entity-knockback-API.patch
+++ b/patches/api/0403-Add-entity-knockback-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 319e4571aca24d1e3f6c85b7435d65c0e77a5245..dba1729a693a6883f94896fcf16b162abe83b1fe 100644
+index 319e4571aca24d1e3f6c85b7435d65c0e77a5245..c9a44e8024f903da83181ee752c971bab22c8895 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -1003,5 +1003,17 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
@@ -19,7 +19,7 @@ index 319e4571aca24d1e3f6c85b7435d65c0e77a5245..dba1729a693a6883f94896fcf16b162a
 +     *
 +     * The direction specified in this method will be the direction of the source of the knockback,
 +     * so the entity will be pushed in the opposite direction.
-+     * @param strength The strength of the knockback. Must be greater than or equal to 0.
++     * @param strength The strength of the knockback. Must be greater than 0.
 +     * @param directionX The relative x position of the knockback source direction
 +     * @param directionZ The relative z position of the knockback source direction
 +     */

--- a/patches/api/0403-Add-entity-knockback-API.patch
+++ b/patches/api/0403-Add-entity-knockback-API.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Sun, 16 Oct 2022 12:10:00 -0700
+Subject: [PATCH] Add entity knockback API
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 319e4571aca24d1e3f6c85b7435d65c0e77a5245..296dbc0360f380820ec5f2b569353251a11f8547 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -1003,5 +1003,16 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+             this.swingOffHand();
+         }
+     }
++
++    /**
++     * Knocks back this entity from a specific direction with a specified strength.
++     *
++     * The direction specified in this method will be the direction of the source of the knockback,
++     * so the entity will be pushed in the opposite direction.
++     * @param strength The strength of the knockback. If the entity hsa knockback resistance, this will be reduced.
++     * @param directionX The relative x position of the knockback source direction
++     * @param directionZ The relative z position of the knockback source direction
++     */
++    void knockback(double strength, double directionX, double directionZ);
+     // Paper end
+ }

--- a/patches/api/0403-Add-entity-knockback-API.patch
+++ b/patches/api/0403-Add-entity-knockback-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 319e4571aca24d1e3f6c85b7435d65c0e77a5245..15d2626c6571c99e7ef125eb785a20ddab4616cd 100644
+index 319e4571aca24d1e3f6c85b7435d65c0e77a5245..dba1729a693a6883f94896fcf16b162abe83b1fe 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -1003,5 +1003,17 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
@@ -19,7 +19,7 @@ index 319e4571aca24d1e3f6c85b7435d65c0e77a5245..15d2626c6571c99e7ef125eb785a20dd
 +     *
 +     * The direction specified in this method will be the direction of the source of the knockback,
 +     * so the entity will be pushed in the opposite direction.
-+     * @param strength The strength of the knockback.
++     * @param strength The strength of the knockback. Must be greater than or equal to 0.
 +     * @param directionX The relative x position of the knockback source direction
 +     * @param directionZ The relative z position of the knockback source direction
 +     */

--- a/patches/api/0403-Add-entity-knockback-API.patch
+++ b/patches/api/0403-Add-entity-knockback-API.patch
@@ -5,20 +5,21 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 319e4571aca24d1e3f6c85b7435d65c0e77a5245..296dbc0360f380820ec5f2b569353251a11f8547 100644
+index 319e4571aca24d1e3f6c85b7435d65c0e77a5245..15d2626c6571c99e7ef125eb785a20ddab4616cd 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1003,5 +1003,16 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1003,5 +1003,17 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
              this.swingOffHand();
          }
      }
 +
 +    /**
-+     * Knocks back this entity from a specific direction with a specified strength.
++     * Knocks back this entity from a specific direction with a specified strength. Mechanics such
++     * as knockback resistance will be factored in.
 +     *
 +     * The direction specified in this method will be the direction of the source of the knockback,
 +     * so the entity will be pushed in the opposite direction.
-+     * @param strength The strength of the knockback. If the entity hsa knockback resistance, this will be reduced.
++     * @param strength The strength of the knockback.
 +     * @param directionX The relative x position of the knockback source direction
 +     * @param directionZ The relative z position of the knockback source direction
 +     */

--- a/patches/server/0928-Add-entity-knockback-API.patch
+++ b/patches/server/0928-Add-entity-knockback-API.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Sun, 16 Oct 2022 12:10:17 -0700
+Subject: [PATCH] Add entity knockback API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index e807ef287136e7b3931197e45434a3f618cf3054..152b07ad1d1027d5dd5cd861a687229c04853c66 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -977,5 +977,10 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         }
+         throw new IllegalArgumentException(entityCategory + " is an unrecognized entity category");
+     }
++
++    @Override
++    public void knockback(double strength, double directionX, double directionZ) {
++        getHandle().knockback(strength, directionX, directionZ);
++    };
+     // Paper end
+ }

--- a/patches/server/0928-Add-entity-knockback-API.patch
+++ b/patches/server/0928-Add-entity-knockback-API.patch
@@ -5,16 +5,17 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index e807ef287136e7b3931197e45434a3f618cf3054..152b07ad1d1027d5dd5cd861a687229c04853c66 100644
+index e807ef287136e7b3931197e45434a3f618cf3054..a8b1cb9a5d46fd840a83d47cb8d885b24d2c8917 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -977,5 +977,10 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -977,5 +977,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          }
          throw new IllegalArgumentException(entityCategory + " is an unrecognized entity category");
      }
 +
 +    @Override
 +    public void knockback(double strength, double directionX, double directionZ) {
++        Preconditions.checkArgument(strength >= 0, "Knockback strength must be >= 0");
 +        getHandle().knockback(strength, directionX, directionZ);
 +    };
      // Paper end

--- a/patches/server/0928-Add-entity-knockback-API.patch
+++ b/patches/server/0928-Add-entity-knockback-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index e807ef287136e7b3931197e45434a3f618cf3054..a8b1cb9a5d46fd840a83d47cb8d885b24d2c8917 100644
+index e807ef287136e7b3931197e45434a3f618cf3054..06559a620b36f744c3d9fa2754e3c3eabead4752 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -977,5 +977,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
@@ -15,7 +15,7 @@ index e807ef287136e7b3931197e45434a3f618cf3054..a8b1cb9a5d46fd840a83d47cb8d885b2
 +
 +    @Override
 +    public void knockback(double strength, double directionX, double directionZ) {
-+        Preconditions.checkArgument(strength >= 0, "Knockback strength must be >= 0");
++        Preconditions.checkArgument(strength > 0, "Knockback strength must be > 0");
 +        getHandle().knockback(strength, directionX, directionZ);
 +    };
      // Paper end


### PR DESCRIPTION
This pull request adds a knockback method on LivingEntity to knock back the entity from a specific position and a specific knockback.

Currently, knocking back an entity can be done with setting the velocity, but this method does not take in vanilla knockback mechanics into consideration such as knockback resistance. Copying the knockback method from the NMS LivingEntity works, but it causes a lot of code duplication, and won't update if the built-in vanilla knockback dynamics change. The knockback method added by this pull request will expose the built-in knockback method from the NMS LivingEntity to allow simulating vanilla knockback mechanics.