### PR TITLE
Make a chunk accessible before entities are asked to interact with it during loading

### DIFF
--- a/patches/server/0016-Rewrite-chunk-system.patch
+++ b/patches/server/0016-Rewrite-chunk-system.patch
@@ -9000,7 +9000,7 @@ index 0000000000000000000000000000000000000000..396d72c00e47cf1669ae20dc839c1c96
 +}
 diff --git a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dd9c1d68a2bc42467b4566953aaed028bddf0f74
+index 0000000000000000000000000000000000000000..f3f20666ab31a733e4fe73b085215db72359fc2a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
 @@ -0,0 +1,2071 @@
@@ -10312,8 +10312,8 @@ index 0000000000000000000000000000000000000000..dd9c1d68a2bc42467b4566953aaed028
 +                    if (!currState.isOrAfter(ChunkHolder.FullChunkStatus.BORDER) && nextState.isOrAfter(ChunkHolder.FullChunkStatus.BORDER)) {
 +                        nextState = this.updateCurrentState(ChunkHolder.FullChunkStatus.BORDER);
 +                        holderManager.ensureInAutosave(this);
-+                        this.changeEntityChunkStatus(ChunkHolder.FullChunkStatus.BORDER);
 +                        chunk.onChunkLoad(this);
++                        this.changeEntityChunkStatus(ChunkHolder.FullChunkStatus.BORDER);
 +                        this.onFullChunkLoadChange(true, changedFullStatus);
 +                        this.completeFullStatusConsumers(ChunkHolder.FullChunkStatus.BORDER, chunk);
 +                    }


### PR DESCRIPTION
While digging into issue  #8481 it seems that the order between chunk.onChunkLoad() causing ServerChunkCache#addLoadedChunk() making the chunk accesible and changeEntityChunkStatus() instruction entites to interact with the chunk is wrong. 

I m not sure if there are any non-obvious bad effects from delaying the updates to the entities until after the onChunkLoad() calls. I did some test runs and went through the code as far as I could and nothing obvious was found.