### PR TITLE
Add stacktrace deobfuscation in more places

### DIFF
--- a/patches/api/0020-Add-exception-reporting-event.patch
+++ b/patches/api/0020-Add-exception-reporting-event.patch
@@ -211,12 +211,13 @@ index 0000000000000000000000000000000000000000..c06ea3942447d4824b83ff839cb449fb
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/exception/ServerInternalException.java b/src/main/java/com/destroystokyo/paper/exception/ServerInternalException.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e762ed0dbad51625e65fef2e1898679108459a36
+index 0000000000000000000000000000000000000000..2c3effca7c9d6c904cbe248d312b74e2cd360acf
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/exception/ServerInternalException.java
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,36 @@
 +package com.destroystokyo.paper.exception;
 +
++import java.util.logging.Level;
 +import org.bukkit.Bukkit;
 +import com.destroystokyo.paper.event.server.ServerExceptionEvent;
 +
@@ -246,7 +247,7 @@ index 0000000000000000000000000000000000000000..e762ed0dbad51625e65fef2e18986791
 +            Bukkit.getPluginManager().callEvent(new ServerExceptionEvent(new ServerInternalException(cause)));
 +            ;
 +        } catch (Throwable t) {
-+            t.printStackTrace(); // Don't want to rethrow!
++            Bukkit.getLogger().log(Level.WARNING, "Exception posting ServerExceptionEvent", t); // Don't want to rethrow!
 +        }
 +    }
 +}

--- a/patches/server/0008-MC-Utils.patch
+++ b/patches/server/0008-MC-Utils.patch
@@ -4975,7 +4975,7 @@ index 0000000000000000000000000000000000000000..c59fca05484c30b28e883f5b5dde0362
 +}
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b310d51b7fe3e8cef0a450674725969fe1ce78a4
+index 0000000000000000000000000000000000000000..9db975e84609956b2206076e30f17a350adb77d6
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -0,0 +1,511 @@
@@ -5292,7 +5292,7 @@ index 0000000000000000000000000000000000000000..b310d51b7fe3e8cef0a450674725969f
 +    public static void ensureMain(String reason, Runnable run) {
 +        if (!isMainThread()) {
 +            if (reason != null) {
-+                new IllegalStateException("Asynchronous " + reason + "!").printStackTrace();
++                MinecraftServer.LOGGER.warn("Asynchronous " + reason + "!", new IllegalStateException());
 +            }
 +            getProcessQueue().add(run);
 +            return;
@@ -5317,7 +5317,7 @@ index 0000000000000000000000000000000000000000..b310d51b7fe3e8cef0a450674725969f
 +    public static <T> T ensureMain(String reason, Supplier<T> run) {
 +        if (!isMainThread()) {
 +            if (reason != null) {
-+                new IllegalStateException("Asynchronous " + reason + "! Blocking thread until it returns ").printStackTrace();
++                MinecraftServer.LOGGER.warn("Asynchronous " + reason + "! Blocking thread until it returns ", new IllegalStateException());
 +            }
 +            Waitable<T> wait = new Waitable<T>() {
 +                @Override
@@ -5329,7 +5329,7 @@ index 0000000000000000000000000000000000000000..b310d51b7fe3e8cef0a450674725969f
 +            try {
 +                return wait.get();
 +            } catch (InterruptedException | ExecutionException e) {
-+                e.printStackTrace();
++                MinecraftServer.LOGGER.warn("Encountered exception", e);
 +            }
 +            return null;
 +        }
@@ -6627,7 +6627,7 @@ index 9fdfeab462e5f5c5e09c5fee2dfe1fca89330086..18d56618a1e8ff5ba408523f620333db
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ad34d8af3e5bba7ec4f41a10c423ed1262c58f6d..2bad9717ec4ec16309856a83d8e19735ae1fcbec 100644
+index 9001040060383cff5a51028d652315467c7d51ec..e283e8383a52c74cebd16fa7642a5e3993b2ed1a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -260,6 +260,7 @@ public abstract class LivingEntity extends Entity {
@@ -6639,7 +6639,7 @@ index ad34d8af3e5bba7ec4f41a10c423ed1262c58f6d..2bad9717ec4ec16309856a83d8e19735
      @Override
      public float getBukkitYaw() {
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 77c6f4ff7131b7317a0c0193ead21eabe38517cb..738c54ce0a0fb7fee6b584a6d96a8b74931222e5 100644
+index 9eaf96ca2300a839e4990d1447a3d8903d0c2b02..2a0f65134c8ffdbcce3af606db02693eaa4ee471 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -242,6 +242,7 @@ public abstract class Mob extends LivingEntity {

--- a/patches/server/0372-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
+++ b/patches/server/0372-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
@@ -7,18 +7,17 @@ Suspected case would be around the technique used in .stopRiding
 Stack will identify any causer of this and warn instead of crashing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 428d3a9c9c55d482bd7db8fd2784d1e55dea0528..de7e20400f7c70c84c5659d449952eb40caee163 100644
+index 428d3a9c9c55d482bd7db8fd2784d1e55dea0528..68d072d3b84fb19aae9c20151c342c81131038ca 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1018,6 +1018,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1018,6 +1018,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
      public void addEntity(Entity entity) {
          org.spigotmc.AsyncCatcher.catchOp("entity track"); // Spigot
 +        // Paper start - ignore and warn about illegal addEntity calls instead of crashing server
 +        if (!entity.valid || entity.level != this.level || this.entityMap.containsKey(entity.getId())) {
-+            new Throwable("[ERROR] Illegal PlayerChunkMap::addEntity for world " + this.level.getWorld().getName()
-+                + ": " + entity  + (this.entityMap.containsKey(entity.getId()) ? " ALREADY CONTAINED (This would have crashed your server)" : ""))
-+                .printStackTrace();
++            LOGGER.error("Illegal ChunkMap::addEntity for world " + this.level.getWorld().getName()
++                + ": " + entity  + (this.entityMap.containsKey(entity.getId()) ? " ALREADY CONTAINED (This would have crashed your server)" : ""), new Throwable());
 +            return;
 +        }
 +        // Paper end

--- a/patches/server/0386-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/patches/server/0386-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -28,11 +28,11 @@ receives a deterministic result, and should no longer require 1 tick
 delays anymore.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index de7e20400f7c70c84c5659d449952eb40caee163..93ef138cdcf2633768b0452511933ec4a14f1ceb 100644
+index 68d072d3b84fb19aae9c20151c342c81131038ca..6d539b0fe7a0d72a24896a0000ba813bbf0dcfd2 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1025,6 +1025,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
-                 .printStackTrace();
+@@ -1024,6 +1024,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+                 + ": " + entity  + (this.entityMap.containsKey(entity.getId()) ? " ALREADY CONTAINED (This would have crashed your server)" : ""), new Throwable());
              return;
          }
 +        if (entity instanceof ServerPlayer && ((ServerPlayer) entity).supressTrackerForLogin) return; // Delay adding to tracker until after list packets

--- a/patches/server/0400-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0400-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -536,37 +536,6 @@ index a283cce82069bf5dfd64229d102a19dfda158daf..8f74a505087cae01520fcfaad833c732
      }
  
      protected void channelRead0(ChannelHandlerContext channelhandlercontext, Packet<?> packet) {
-diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 99f56658c70f99592fb40c9df0ce3e47053d1bd5..b39da428cb9b67eda8a722e8c88b6fce4d7544fa 100644
---- a/src/main/java/net/minecraft/server/MCUtil.java
-+++ b/src/main/java/net/minecraft/server/MCUtil.java
-@@ -332,7 +332,7 @@ public final class MCUtil {
-     public static void ensureMain(String reason, Runnable run) {
-         if (!isMainThread()) {
-             if (reason != null) {
--                new IllegalStateException("Asynchronous " + reason + "!").printStackTrace();
-+                io.papermc.paper.util.TraceUtil.printStackTrace(new IllegalStateException("Asynchronous " + reason + "!"));
-             }
-             getProcessQueue().add(run);
-             return;
-@@ -357,7 +357,7 @@ public final class MCUtil {
-     public static <T> T ensureMain(String reason, Supplier<T> run) {
-         if (!isMainThread()) {
-             if (reason != null) {
--                new IllegalStateException("Asynchronous " + reason + "! Blocking thread until it returns ").printStackTrace();
-+                io.papermc.paper.util.TraceUtil.printStackTrace(new IllegalStateException("Asynchronous " + reason + "! Blocking thread until it returns "));
-             }
-             Waitable<T> wait = new Waitable<T>() {
-                 @Override
-@@ -369,7 +369,7 @@ public final class MCUtil {
-             try {
-                 return wait.get();
-             } catch (InterruptedException | ExecutionException e) {
--                e.printStackTrace();
-+                io.papermc.paper.util.TraceUtil.printStackTrace(e);
-             }
-             return null;
-         }
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 index abfcba1c3db090563191e8adea6d8250ae2d138e..487991163f12c1ded3f5d35a718aa89b1fb9278f 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
@@ -579,22 +548,6 @@ index abfcba1c3db090563191e8adea6d8250ae2d138e..487991163f12c1ded3f5d35a718aa89b
          paperConfigurations.initializeGlobalConfiguration();
          paperConfigurations.initializeWorldDefaultsConfiguration();
          org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash);
-diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 93ef138cdcf2633768b0452511933ec4a14f1ceb..c5822b4ecb16f1f20c39a296755ee656973a0f7c 100644
---- a/src/main/java/net/minecraft/server/level/ChunkMap.java
-+++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1020,9 +1020,9 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
-         org.spigotmc.AsyncCatcher.catchOp("entity track"); // Spigot
-         // Paper start - ignore and warn about illegal addEntity calls instead of crashing server
-         if (!entity.valid || entity.level != this.level || this.entityMap.containsKey(entity.getId())) {
--            new Throwable("[ERROR] Illegal PlayerChunkMap::addEntity for world " + this.level.getWorld().getName()
-+            io.papermc.paper.util.TraceUtil.dumpTraceForThread("[ERROR] Illegal PlayerChunkMap::addEntity for world " + this.level.getWorld().getName()
-                 + ": " + entity  + (this.entityMap.containsKey(entity.getId()) ? " ALREADY CONTAINED (This would have crashed your server)" : ""))
--                .printStackTrace();
-+                ;
-             return;
-         }
-         if (entity instanceof ServerPlayer && ((ServerPlayer) entity).supressTrackerForLogin) return; // Delay adding to tracker until after list packets
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
 index c0e17bbf04723da76ea6952d9558dd4d34b00f6c..8cc266e25d25d154158b36e456804ac80a47364e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java

--- a/patches/server/0400-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0400-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -537,7 +537,7 @@ index a283cce82069bf5dfd64229d102a19dfda158daf..8f74a505087cae01520fcfaad833c732
  
      protected void channelRead0(ChannelHandlerContext channelhandlercontext, Packet<?> packet) {
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 99f56658c70f99592fb40c9df0ce3e47053d1bd5..45c1bc8d8675282bd8eef44ae8a5db25620a94e9 100644
+index 99f56658c70f99592fb40c9df0ce3e47053d1bd5..b39da428cb9b67eda8a722e8c88b6fce4d7544fa 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -332,7 +332,7 @@ public final class MCUtil {
@@ -558,6 +558,15 @@ index 99f56658c70f99592fb40c9df0ce3e47053d1bd5..45c1bc8d8675282bd8eef44ae8a5db25
              }
              Waitable<T> wait = new Waitable<T>() {
                  @Override
+@@ -369,7 +369,7 @@ public final class MCUtil {
+             try {
+                 return wait.get();
+             } catch (InterruptedException | ExecutionException e) {
+-                e.printStackTrace();
++                io.papermc.paper.util.TraceUtil.printStackTrace(e);
+             }
+             return null;
+         }
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 index abfcba1c3db090563191e8adea6d8250ae2d138e..487991163f12c1ded3f5d35a718aa89b1fb9278f 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java

--- a/patches/server/0400-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0400-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -456,10 +456,10 @@ index 0000000000000000000000000000000000000000..eb910d4abf91488fa7cf1f5d47e0ee91
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/util/TraceUtil.java b/src/main/java/io/papermc/paper/util/TraceUtil.java
-index 2d5494d2813b773e60ddba6790b750a9a08f21f8..7695bf44503f161523ea612ef8a884ae574a2e21 100644
+index 2d5494d2813b773e60ddba6790b750a9a08f21f8..0b210bdf7c1f5962afbd44195af6f84f625635e3 100644
 --- a/src/main/java/io/papermc/paper/util/TraceUtil.java
 +++ b/src/main/java/io/papermc/paper/util/TraceUtil.java
-@@ -6,13 +6,15 @@ public final class TraceUtil {
+@@ -6,13 +6,20 @@ public final class TraceUtil {
  
      public static void dumpTraceForThread(Thread thread, String reason) {
          Bukkit.getLogger().warning(thread.getName() + ": " + reason);
@@ -475,6 +475,11 @@ index 2d5494d2813b773e60ddba6790b750a9a08f21f8..7695bf44503f161523ea612ef8a884ae
 +        final Throwable throwable = new Throwable(reason);
 +        StacktraceDeobfuscator.INSTANCE.deobfuscateThrowable(throwable);
 +        throwable.printStackTrace();
++    }
++
++    public static void printStackTrace(Throwable thr) {
++        StacktraceDeobfuscator.INSTANCE.deobfuscateThrowable(thr);
++        thr.printStackTrace();
      }
  }
 diff --git a/src/main/java/net/minecraft/CrashReport.java b/src/main/java/net/minecraft/CrashReport.java
@@ -502,7 +507,7 @@ index f114d5dab86aa2cdd59c78406c9d82f9caededca..99fa9f1952ee7ed79b223ff210a658e4
          }
      }
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index a283cce82069bf5dfd64229d102a19dfda158daf..b8e35f493458ba9e072953dffe6b2429f1d821ec 100644
+index a283cce82069bf5dfd64229d102a19dfda158daf..8f74a505087cae01520fcfaad833c73215de8036 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -62,13 +62,13 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -522,6 +527,37 @@ index a283cce82069bf5dfd64229d102a19dfda158daf..b8e35f493458ba9e072953dffe6b2429
      });
      private final PacketFlow receiving;
      private final Queue<Connection.PacketHolder> queue = Queues.newConcurrentLinkedQueue();
+@@ -192,7 +192,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+ 
+             }
+         }
+-        if (net.minecraft.server.MinecraftServer.getServer().isDebugging()) throwable.printStackTrace(); // Spigot
++        if (net.minecraft.server.MinecraftServer.getServer().isDebugging()) io.papermc.paper.util.TraceUtil.printStackTrace(throwable); // Spigot // Paper
+     }
+ 
+     protected void channelRead0(ChannelHandlerContext channelhandlercontext, Packet<?> packet) {
+diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
+index 99f56658c70f99592fb40c9df0ce3e47053d1bd5..45c1bc8d8675282bd8eef44ae8a5db25620a94e9 100644
+--- a/src/main/java/net/minecraft/server/MCUtil.java
++++ b/src/main/java/net/minecraft/server/MCUtil.java
+@@ -332,7 +332,7 @@ public final class MCUtil {
+     public static void ensureMain(String reason, Runnable run) {
+         if (!isMainThread()) {
+             if (reason != null) {
+-                new IllegalStateException("Asynchronous " + reason + "!").printStackTrace();
++                io.papermc.paper.util.TraceUtil.printStackTrace(new IllegalStateException("Asynchronous " + reason + "!"));
+             }
+             getProcessQueue().add(run);
+             return;
+@@ -357,7 +357,7 @@ public final class MCUtil {
+     public static <T> T ensureMain(String reason, Supplier<T> run) {
+         if (!isMainThread()) {
+             if (reason != null) {
+-                new IllegalStateException("Asynchronous " + reason + "! Blocking thread until it returns ").printStackTrace();
++                io.papermc.paper.util.TraceUtil.printStackTrace(new IllegalStateException("Asynchronous " + reason + "! Blocking thread until it returns "));
+             }
+             Waitable<T> wait = new Waitable<T>() {
+                 @Override
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 index abfcba1c3db090563191e8adea6d8250ae2d138e..487991163f12c1ded3f5d35a718aa89b1fb9278f 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
@@ -534,6 +570,46 @@ index abfcba1c3db090563191e8adea6d8250ae2d138e..487991163f12c1ded3f5d35a718aa89b
          paperConfigurations.initializeGlobalConfiguration();
          paperConfigurations.initializeWorldDefaultsConfiguration();
          org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash);
+diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
+index 93ef138cdcf2633768b0452511933ec4a14f1ceb..c5822b4ecb16f1f20c39a296755ee656973a0f7c 100644
+--- a/src/main/java/net/minecraft/server/level/ChunkMap.java
++++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
+@@ -1020,9 +1020,9 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+         org.spigotmc.AsyncCatcher.catchOp("entity track"); // Spigot
+         // Paper start - ignore and warn about illegal addEntity calls instead of crashing server
+         if (!entity.valid || entity.level != this.level || this.entityMap.containsKey(entity.getId())) {
+-            new Throwable("[ERROR] Illegal PlayerChunkMap::addEntity for world " + this.level.getWorld().getName()
++            io.papermc.paper.util.TraceUtil.dumpTraceForThread("[ERROR] Illegal PlayerChunkMap::addEntity for world " + this.level.getWorld().getName()
+                 + ": " + entity  + (this.entityMap.containsKey(entity.getId()) ? " ALREADY CONTAINED (This would have crashed your server)" : ""))
+-                .printStackTrace();
++                ;
+             return;
+         }
+         if (entity instanceof ServerPlayer && ((ServerPlayer) entity).supressTrackerForLogin) return; // Delay adding to tracker until after list packets
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index c0e17bbf04723da76ea6952d9558dd4d34b00f6c..8cc266e25d25d154158b36e456804ac80a47364e 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -218,7 +218,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
+     public final UUID uuid;
+     public boolean hasPhysicsEvent = true; // Paper
+     public static Throwable getAddToWorldStackTrace(Entity entity) {
+-        return new Throwable(entity + " Added to world at " + new java.util.Date());
++        final Throwable thr = new Throwable(entity + " Added to world at " + new java.util.Date());
++        io.papermc.paper.util.StacktraceDeobfuscator.INSTANCE.deobfuscateThrowable(thr);
++        return thr;
+     }
+ 
+     @Override public LevelChunk getChunkIfLoaded(int x, int z) { // Paper - this was added in world too but keeping here for NMS ABI
+@@ -1289,7 +1291,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+         if (entity.isRemoved()) {
+             // Paper start
+             if (DEBUG_ENTITIES) {
+-                new Throwable("Tried to add entity " + entity + " but it was marked as removed already").printStackTrace(); // CraftBukkit
++                io.papermc.paper.util.TraceUtil.dumpTraceForThread("Tried to add entity " + entity + " but it was marked as removed already"); // CraftBukkit
+                 getAddToWorldStackTrace(entity).printStackTrace();
+             }
+             // Paper end
 diff --git a/src/main/java/net/minecraft/server/network/ServerConnectionListener.java b/src/main/java/net/minecraft/server/network/ServerConnectionListener.java
 index a24ef433d0c9d06b86fd612978cfd6d877036791..1b38326c9a709536dc4cccf9af93aede98a1a782 100644
 --- a/src/main/java/net/minecraft/server/network/ServerConnectionListener.java
@@ -551,6 +627,54 @@ index a24ef433d0c9d06b86fd612978cfd6d877036791..1b38326c9a709536dc4cccf9af93aede
      });
      final MinecraftServer server;
      public volatile boolean running;
+diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
+index 4d501687f46722f2dcb51a8715a0be9ca4905d5f..059cee21b636dcdda34def41309fea026aeafeb0 100644
+--- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
+@@ -205,7 +205,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+                 MutableComponent ichatmutablecomponent = Component.translatable("multiplayer.disconnect.invalid_player_data");
+                 // Paper start
+                 if (MinecraftServer.getServer().isDebugging()) {
+-                    exception.printStackTrace();
++                    io.papermc.paper.util.TraceUtil.printStackTrace(exception);
+                 }
+                 // Paper end
+ 
+diff --git a/src/main/java/net/minecraft/server/players/OldUsersConverter.java b/src/main/java/net/minecraft/server/players/OldUsersConverter.java
+index 6599f874d9f97e9ef4862039ecad7277bbc5fd91..7edd4b88eb0476f0630630bc4681e859bd145b2b 100644
+--- a/src/main/java/net/minecraft/server/players/OldUsersConverter.java
++++ b/src/main/java/net/minecraft/server/players/OldUsersConverter.java
+@@ -364,7 +364,7 @@ public class OldUsersConverter {
+                         try {
+                             root = NbtIo.readCompressed(new java.io.FileInputStream(file5));
+                         } catch (Exception exception) {
+-                            exception.printStackTrace();
++                            io.papermc.paper.util.TraceUtil.printStackTrace(exception); // Paper
+                             ServerInternalException.reportInternalException(exception); // Paper
+                         }
+ 
+@@ -378,7 +378,7 @@ public class OldUsersConverter {
+                             try {
+                                 NbtIo.writeCompressed(root, new java.io.FileOutputStream(file2));
+                             } catch (Exception exception) {
+-                                exception.printStackTrace();
++                                io.papermc.paper.util.TraceUtil.printStackTrace(exception); // Paper
+                                 ServerInternalException.reportInternalException(exception); // Paper
+                             }
+                        }
+diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
+index 941bd6c43d3de9e5c947c2b7a3f42388c3fea25a..07eeea03796cd6330a9788ef357cf307a02b4ace 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
++++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
+@@ -640,7 +640,7 @@ public class LevelChunk extends ChunkAccess {
+                     + " (" + getBlockState(blockposition) + ") where there was no entity tile!\n" +
+                     "Chunk coordinates: " + (this.chunkPos.x * 16) + "," + (this.chunkPos.z * 16) +
+                     "\nWorld: " + level.getLevel().dimension().location());
+-            e.printStackTrace();
++            io.papermc.paper.util.TraceUtil.printStackTrace(e);
+             ServerInternalException.reportInternalException(e);
+             // Paper end
+             // CraftBukkit end
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
 index 3c1992e212a6d6f1db4d5b807b38d71913619fc0..9c1aff17aabd062640e3f451a2ef8c50a7c62f10 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java

--- a/patches/server/0412-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
+++ b/patches/server/0412-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
@@ -18,10 +18,10 @@ index 3167f5c6be39757e3cc42cbb17ab0cf13a2fe470..3768a71491ef7836b9739bdaec7a077c
      private static long encode(double value) {
          return Mth.lfloor(value * 4096.0D);
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 93ef138cdcf2633768b0452511933ec4a14f1ceb..bdf36ffc99b241c90075b40347cfb25543c49e16 100644
+index 6d539b0fe7a0d72a24896a0000ba813bbf0dcfd2..b56bba0614545cf2dc51bc0670250e464a7b52d5 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1303,9 +1303,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1302,9 +1302,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          public void updatePlayer(ServerPlayer player) {
              org.spigotmc.AsyncCatcher.catchOp("player tracker update"); // Spigot
              if (player != this.entity) {

--- a/patches/server/0416-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/patches/server/0416-Use-distance-map-to-optimise-entity-tracker.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use distance map to optimise entity tracker
 Use the distance map to find candidate players for tracking.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 5b3e1d282231969918fa621dfccdc0190428495d..3b00664b8fde839cb2dfabc5c87d3dcbbc899c09 100644
+index a25ef2f2362b6f9b0cc8bfb33b6da66dc0f59347..e75b72d7bb51e50b46e639fbff4d9a01533f50c8 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -66,6 +66,7 @@ import net.minecraft.network.protocol.game.ClientboundSetEntityLinkPacket;
@@ -148,7 +148,7 @@ index 5b3e1d282231969918fa621dfccdc0190428495d..3b00664b8fde839cb2dfabc5c87d3dcb
  
          int i = SectionPos.blockToSectionCoord(player.getBlockX());
          int j = SectionPos.blockToSectionCoord(player.getBlockZ());
-@@ -1096,7 +1164,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1095,7 +1163,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
                      entity.tracker = playerchunkmap_entitytracker; // Paper - Fast access to tracker
                      this.entityMap.put(entity.getId(), playerchunkmap_entitytracker);
@@ -157,7 +157,7 @@ index 5b3e1d282231969918fa621dfccdc0190428495d..3b00664b8fde839cb2dfabc5c87d3dcb
                      if (entity instanceof ServerPlayer) {
                          ServerPlayer entityplayer = (ServerPlayer) entity;
  
-@@ -1140,7 +1208,37 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1139,7 +1207,37 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          entity.tracker = null; // Paper - We're no longer tracked
      }
  
@@ -195,7 +195,7 @@ index 5b3e1d282231969918fa621dfccdc0190428495d..3b00664b8fde839cb2dfabc5c87d3dcb
          List<ServerPlayer> list = Lists.newArrayList();
          List<ServerPlayer> list1 = this.level.players();
          ObjectIterator objectiterator = this.entityMap.values().iterator();
-@@ -1214,46 +1312,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1213,46 +1311,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          }));
          // Paper end
          DebugPackets.sendPoiPacketsForChunk(this.level, chunk.getPos());
@@ -243,7 +243,7 @@ index 5b3e1d282231969918fa621dfccdc0190428495d..3b00664b8fde839cb2dfabc5c87d3dcb
  
      }
  
-@@ -1308,6 +1367,42 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1307,6 +1366,42 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              this.lastSectionPos = SectionPos.of((EntityAccess) entity);
          }
  
@@ -287,7 +287,7 @@ index 5b3e1d282231969918fa621dfccdc0190428495d..3b00664b8fde839cb2dfabc5c87d3dcb
              return object instanceof ChunkMap.TrackedEntity ? ((ChunkMap.TrackedEntity) object).entity.getId() == this.entity.getId() : false;
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ae76b3404e4251e7705269b2e57068154eb11fb8..c8ca2835c4fbad85a9680d0cc1da2fdc9a5324b6 100644
+index 32623f90a5bc4fb6fe99897c682ef4f55f056dea..6a86125c6f6daa0a443601db4fea19531225ad33 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -57,6 +57,7 @@ import net.minecraft.network.syncher.EntityDataSerializers;

--- a/patches/server/0437-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0437-incremental-chunk-and-player-saving.patch
@@ -73,10 +73,10 @@ index 44766ea7e5dd8f8411b52cf259187d7557cc0c23..fa7801158b68eaa12d6322c9c0def9de
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c0e17bbf04723da76ea6952d9558dd4d34b00f6c..fc3e5068473e1586024e87fee3eeeb6cf5124923 100644
+index 8cc266e25d25d154158b36e456804ac80a47364e..7ef0eaa6fffae02c3c27313f05eab5ae1558e948 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1120,6 +1120,37 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1122,6 +1122,37 @@ public class ServerLevel extends Level implements WorldGenLevel {
          return !this.server.isUnderSpawnProtection(this, pos, player) && this.getWorldBorder().isWithinBounds(pos);
      }
  

--- a/patches/server/0467-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0467-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SpawnChangeEvent not firing for all use-cases
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index fc3e5068473e1586024e87fee3eeeb6cf5124923..e18ee5ec984cb8d8aaa8a40714fc9a0381b04317 100644
+index 7ef0eaa6fffae02c3c27313f05eab5ae1558e948..6e9e9ec7a8f8f1213681c25f4fb44c7a1cf3d715 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1890,6 +1890,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1892,6 +1892,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          //ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(new BlockPosition(this.worldData.a(), 0, this.worldData.c()));
  
          this.levelData.setSpawn(pos, angle);

--- a/patches/server/0484-Extend-block-drop-capture-to-capture-all-items-added.patch
+++ b/patches/server/0484-Extend-block-drop-capture-to-capture-all-items-added.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Extend block drop capture to capture all items added to the
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index e18ee5ec984cb8d8aaa8a40714fc9a0381b04317..da8a708d24611bd0580ae0132cac277a6580b0ea 100644
+index 6e9e9ec7a8f8f1213681c25f4fb44c7a1cf3d715..7fb15c373f5d212aee1d1607768c814b06092097 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1327,6 +1327,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1329,6 +1329,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // WorldServer.LOGGER.warn("Tried to add entity {} but it was marked as removed already", EntityTypes.getKey(entity.getType())); // CraftBukkit
              return false;
          } else {

--- a/patches/server/0552-Remove-stale-POIs.patch
+++ b/patches/server/0552-Remove-stale-POIs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove stale POIs
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index da8a708d24611bd0580ae0132cac277a6580b0ea..944719180fff8ac34682330ecf456fa90a4e95f2 100644
+index 7fb15c373f5d212aee1d1607768c814b06092097..dc308e26913ffc8ae6be022eeaa411a205b10149 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1955,6 +1955,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1957,6 +1957,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
              });
              optional1.ifPresent((holder) -> {
                  this.getServer().execute(() -> {

--- a/patches/server/0569-EntityMoveEvent.patch
+++ b/patches/server/0569-EntityMoveEvent.patch
@@ -17,7 +17,7 @@ index be7cfe5ce05b51786790a7eaf3cdac9acf9ff566..2bd90398b85c34efcad4e1779a4fbbf0
  
              this.profiler.push(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 944719180fff8ac34682330ecf456fa90a4e95f2..8ccc21373bb52a80d76c62cf875963da8d25b247 100644
+index dc308e26913ffc8ae6be022eeaa411a205b10149..6a218e39001259a737c1e823b95f87faae532464 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -217,6 +217,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -26,8 +26,8 @@ index 944719180fff8ac34682330ecf456fa90a4e95f2..8ccc21373bb52a80d76c62cf875963da
      public boolean hasPhysicsEvent = true; // Paper
 +    public boolean hasEntityMoveEvent = false; // Paper
      public static Throwable getAddToWorldStackTrace(Entity entity) {
-         return new Throwable(entity + " Added to world at " + new java.util.Date());
-     }
+         final Throwable thr = new Throwable(entity + " Added to world at " + new java.util.Date());
+         io.papermc.paper.util.StacktraceDeobfuscator.INSTANCE.deobfuscateThrowable(thr);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 index 0896cbe04be6a5471088c321296506415fccbed6..cc930b8a22b3e3540b9fb24c6eaa329895c075cb 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java

--- a/patches/server/0570-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/patches/server/0570-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] added option to disable pathfinding updates on block changes
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 8ccc21373bb52a80d76c62cf875963da8d25b247..961d24e1e0d5ee8429ab558893a356d175b31d39 100644
+index 6a218e39001259a737c1e823b95f87faae532464..017bf2c25e777194ed2229ac275f8f11e7804fb6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1529,6 +1529,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1531,6 +1531,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          }
  
          this.getChunkSource().blockChanged(pos);
@@ -16,7 +16,7 @@ index 8ccc21373bb52a80d76c62cf875963da8d25b247..961d24e1e0d5ee8429ab558893a356d1
          VoxelShape voxelshape = oldState.getCollisionShape(this, pos);
          VoxelShape voxelshape1 = newState.getCollisionShape(this, pos);
  
-@@ -1570,6 +1571,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1572,6 +1573,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              }
  
          }

--- a/patches/server/0638-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0638-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add cause to Weather/ThunderChangeEvents
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 961d24e1e0d5ee8429ab558893a356d175b31d39..81f47264c48a7838d6045b062cbc884cd703ed5d 100644
+index 017bf2c25e777194ed2229ac275f8f11e7804fb6..d58af846320f18db9f30a18ceaded050c0986049 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -528,8 +528,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -530,8 +530,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
          this.serverLevelData.setClearWeatherTime(clearDuration);
          this.serverLevelData.setRainTime(rainDuration);
          this.serverLevelData.setThunderTime(rainDuration);
@@ -19,7 +19,7 @@ index 961d24e1e0d5ee8429ab558893a356d175b31d39..81f47264c48a7838d6045b062cbc884c
      }
  
      @Override
-@@ -924,8 +924,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -926,8 +926,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  this.serverLevelData.setThunderTime(j);
                  this.serverLevelData.setRainTime(k);
                  this.serverLevelData.setClearWeatherTime(i);
@@ -30,7 +30,7 @@ index 961d24e1e0d5ee8429ab558893a356d175b31d39..81f47264c48a7838d6045b062cbc884c
              }
  
              this.oThunderLevel = this.thunderLevel;
-@@ -991,14 +991,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -993,14 +993,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
      private void resetWeatherCycle() {
          // CraftBukkit start

--- a/patches/server/0660-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0660-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -8,10 +8,10 @@ ticket level 33 (yes getChunkIfLoaded will actually perform a chunk
 load in that case).
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 81f47264c48a7838d6045b062cbc884cd703ed5d..619105bd19d5aa78efc6527371646ee79caf2015 100644
+index d58af846320f18db9f30a18ceaded050c0986049..6b1124ee45b40b49fdbf7e5d3b0349986112afc4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -223,7 +223,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -225,7 +225,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      }
  
      @Override public LevelChunk getChunkIfLoaded(int x, int z) { // Paper - this was added in world too but keeping here for NMS ABI
@@ -20,7 +20,7 @@ index 81f47264c48a7838d6045b062cbc884cd703ed5d..619105bd19d5aa78efc6527371646ee7
      }
  
      @Override
-@@ -1476,7 +1476,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1478,7 +1478,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          for (int l1 = j; l1 <= i1; ++l1) {
              for (int i2 = l; i2 <= k1; ++i2) {

--- a/patches/server/0693-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0693-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 619105bd19d5aa78efc6527371646ee79caf2015..401ae035ac48791b3a7c20b6e3ed19baca1eda42 100644
+index 6b1124ee45b40b49fdbf7e5d3b0349986112afc4..0070f82f7725f584a177464cc8dc543b7a5c78e1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -813,6 +813,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -815,6 +815,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
      }
  
      protected BlockPos findLightningTargetAround(BlockPos pos) {
@@ -20,7 +20,7 @@ index 619105bd19d5aa78efc6527371646ee79caf2015..401ae035ac48791b3a7c20b6e3ed19ba
          BlockPos blockposition1 = this.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, pos);
          Optional<BlockPos> optional = this.findLightningRod(blockposition1);
  
-@@ -827,6 +832,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -829,6 +834,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              if (!list.isEmpty()) {
                  return ((LivingEntity) list.get(this.random.nextInt(list.size()))).blockPosition();
              } else {

--- a/patches/server/0705-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
+++ b/patches/server/0705-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
@@ -9,10 +9,10 @@ chunk through it. This should also be OK from a leak prevention/
 state desync POV because the TE is getting unloaded anyways.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 401ae035ac48791b3a7c20b6e3ed19baca1eda42..4fa19370e05600391e60b9b416f343834362cbac 100644
+index 0070f82f7725f584a177464cc8dc543b7a5c78e1..ff2f7b933929e4b8ac4710e5eaa2bd3667f19bbe 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1373,9 +1373,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1375,9 +1375,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
          // Spigot Start
          for (net.minecraft.world.level.block.entity.BlockEntity tileentity : chunk.getBlockEntities().values()) {
              if (tileentity instanceof net.minecraft.world.Container) {

--- a/patches/server/0713-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0713-Execute-chunk-tasks-mid-tick.patch
@@ -126,7 +126,7 @@ index cfcb3ba96569f3eb24d1035d770c50085f60b772..89ecb5c6c25246d0c71b14cc089386d4
                  }
                  // Paper start - optimise chunk tick iteration
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4fa19370e05600391e60b9b416f343834362cbac..b4b7aa2f7d602fe996ebc320ab9641866b672abe 100644
+index ff2f7b933929e4b8ac4710e5eaa2bd3667f19bbe..ced278aef7c5e883a04255974a8428743a6f5168 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -212,6 +212,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -137,7 +137,7 @@ index 4fa19370e05600391e60b9b416f343834362cbac..b4b7aa2f7d602fe996ebc320ab964186
  
      // CraftBukkit start
      public final LevelStorageSource.LevelStorageAccess convertable;
-@@ -1024,6 +1025,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1026,6 +1027,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          if (fluid1.is(fluid)) {
              fluid1.tick(this, pos);
          }
@@ -145,7 +145,7 @@ index 4fa19370e05600391e60b9b416f343834362cbac..b4b7aa2f7d602fe996ebc320ab964186
  
      }
  
-@@ -1033,6 +1035,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1035,6 +1037,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          if (iblockdata.is(block)) {
              iblockdata.tick(this, pos, this.random);
          }

--- a/patches/server/0716-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0716-Detail-more-information-in-watchdog-dumps.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Detail more information in watchdog dumps
 - Dump player name, player uuid, position, and world for packet handling
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 13ab14b1fb3acfd245fbab35f84f5c30c97ed855..9c0c181013d419d1a74f86b5d8cecf83b28925c6 100644
+index 0e8f731943af38e832200f4450fadeb80cb8ae74..6e5c483650e0c6742fa86cfcf52cfbcac7c7dbce 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -504,9 +504,15 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -78,10 +78,10 @@ index acfa1907bfc9c29d261cfccc00d65bad9ad1a002..d6f3869f5725c7f081efb7f486f74dbb
              });
              throw RunningOnDifferentThreadException.RUNNING_ON_DIFFERENT_THREAD;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index b4b7aa2f7d602fe996ebc320ab9641866b672abe..f7841aea38707cebaaab2637454a0db8f93065b4 100644
+index ced278aef7c5e883a04255974a8428743a6f5168..b8ede677ae35a30c19e7a5e2afa72319ef02c9ac 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1039,7 +1039,26 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1041,7 +1041,26 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
      }
  
@@ -108,7 +108,7 @@ index b4b7aa2f7d602fe996ebc320ab9641866b672abe..f7841aea38707cebaaab2637454a0db8
          ++TimingHistory.entityTicks; // Paper - timings
          // Spigot start
          co.aikar.timings.Timing timer; // Paper
-@@ -1079,7 +1098,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1081,7 +1100,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
              this.tickPassenger(entity, entity1);
          }
          // } finally { timer.stopTiming(); } // Paper - timings - move up

--- a/patches/server/0729-Oprimise-map-impl-for-tracked-players.patch
+++ b/patches/server/0729-Oprimise-map-impl-for-tracked-players.patch
@@ -7,10 +7,10 @@ Reference2BooleanOpenHashMap is going to have
 better lookups than HashMap.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index a49e67dffd781798085a4b912190e1f9d74dd494..1c7ec34be8e82ee67e7ea2e705c3071a1a5a870b 100644
+index 6ff62d07b5db18d920786d62255ead9f74cc7d80..3c8d435ede28ded94db2a745dbd145cb4c3fe29a 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1361,7 +1361,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1360,7 +1360,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          final Entity entity;
          private final int range;
          SectionPos lastSectionPos;

--- a/patches/server/0731-Optimise-random-block-ticking.patch
+++ b/patches/server/0731-Optimise-random-block-ticking.patch
@@ -90,10 +90,10 @@ index 0000000000000000000000000000000000000000..7d93652c1abbb6aee6eb7c26cf35d4d0
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f7841aea38707cebaaab2637454a0db8f93065b4..4f32dff7ec2fc55b085b13464667707454413dac 100644
+index b8ede677ae35a30c19e7a5e2afa72319ef02c9ac..60d354bce53b5101dc986d0c35d82ac9dbbbd016 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -703,6 +703,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -705,6 +705,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
              entityplayer.stopSleepInBed(false, false);
          });
      }
@@ -104,7 +104,7 @@ index f7841aea38707cebaaab2637454a0db8f93065b4..4f32dff7ec2fc55b085b134646677074
  
      public void tickChunk(LevelChunk chunk, int randomTickSpeed) {
          ChunkPos chunkcoordintpair = chunk.getPos();
-@@ -712,10 +716,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -714,10 +718,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
          ProfilerFiller gameprofilerfiller = this.getProfiler();
  
          gameprofilerfiller.push("thunder");
@@ -117,7 +117,7 @@ index f7841aea38707cebaaab2637454a0db8f93065b4..4f32dff7ec2fc55b085b134646677074
              if (this.isRainingAt(blockposition)) {
                  DifficultyInstance difficultydamagescaler = this.getCurrentDifficultyAt(blockposition);
                  boolean flag1 = this.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING) && this.random.nextDouble() < (double) difficultydamagescaler.getEffectiveDifficulty() * this.paperConfig().entities.spawning.skeletonHorseThunderSpawnChance.or(0.01D) && !this.getBlockState(blockposition.below()).is(Blocks.LIGHTNING_ROD); // Paper
-@@ -739,64 +743,75 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -741,64 +745,75 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          gameprofilerfiller.popPush("iceandsnow");
          if (!this.paperConfig().environment.disableIceAndSnow && this.random.nextInt(16) == 0) { // Paper - Disable ice and snow

--- a/patches/server/0733-Optimise-nearby-player-lookups.patch
+++ b/patches/server/0733-Optimise-nearby-player-lookups.patch
@@ -9,7 +9,7 @@ since the penalty of a map lookup could outweigh the benefits of
 searching less players (as it basically did in the outside range patch).
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 1fb298ff60b59a7074fb9d7a79709f05887ce32c..94d52a21d40a31cd6e8251f79ffc885de16e48f4 100644
+index dcb1318a3e676598f3b64279da77aa1170a94c42..10a5762e3d5540e24839f82ea875b4daeb9f0603 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -93,6 +93,12 @@ public class ChunkHolder {
@@ -39,7 +39,7 @@ index 1fb298ff60b59a7074fb9d7a79709f05887ce32c..94d52a21d40a31cd6e8251f79ffc885d
      // Paper end
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 57b45ce5feaa5015b5468a0b44f354e96d7d95fc..841df3f621081f6b67711cbd047e8bde498eedbf 100644
+index 134274a7e36f14d855f659df37e0ba24d93fdad7..2a7cdaabbb772520ced0eb1dcd827bd93ebbc59b 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -152,6 +152,12 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -104,10 +104,10 @@ index 57b45ce5feaa5015b5468a0b44f354e96d7d95fc..841df3f621081f6b67711cbd047e8bde
  
      protected ChunkGenerator generator() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4f32dff7ec2fc55b085b13464667707454413dac..3fda64e9d530b85ddcfe4277f64286fc3356512f 100644
+index 60d354bce53b5101dc986d0c35d82ac9dbbbd016..2112b7aef36054c9854c13cc5e9fb4c05bf18c6e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -440,6 +440,84 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -442,6 +442,84 @@ public class ServerLevel extends Level implements WorldGenLevel {
      // Paper end
      public final ReferenceOpenHashSet<ServerPlayer> pendingLogin = new ReferenceOpenHashSet<>(); // Paper
  
@@ -192,7 +192,7 @@ index 4f32dff7ec2fc55b085b13464667707454413dac..3fda64e9d530b85ddcfe4277f64286fc
      // Add env and gen to constructor, IWorldDataServer -> WorldDataServer
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, PrimaryLevelData iworlddataserver, ResourceKey<Level> resourcekey, LevelStem worlddimension, ChunkProgressListener worldloadlistener, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider) {
          // Holder holder = worlddimension.typeHolder(); // CraftBukkit - decompile error
-@@ -543,6 +621,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -545,6 +623,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
      }
  
      public void tick(BooleanSupplier shouldKeepTicking) {
@@ -322,7 +322,7 @@ index e0b6f7da138776be2892821b32a099c2d0e45038..df83b6f0e217eec4c9e9707be0030c12
  
      private static Boolean isValidSpawnPostitionForType(ServerLevel world, MobCategory group, StructureManager structureAccessor, ChunkGenerator chunkGenerator, MobSpawnSettings.SpawnerData spawnEntry, BlockPos.MutableBlockPos pos, double squaredDistance) { // Paper
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index b0f53c99a89b900ffe49bdd277329829b44775d4..05499ae9fc331471db6e763a2adb46b5da8522d3 100644
+index 07eeea03796cd6330a9788ef357cf307a02b4ace..258d00692fa50e0932747a7a2f0ddae5ab659040 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -269,6 +269,98 @@ public class LevelChunk extends ChunkAccess {

--- a/patches/server/0739-Fix-merchant-inventory-not-closing-on-entity-removal.patch
+++ b/patches/server/0739-Fix-merchant-inventory-not-closing-on-entity-removal.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix merchant inventory not closing on entity removal
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 3fda64e9d530b85ddcfe4277f64286fc3356512f..6388ed56f71f065ab811acf3fb264083fdb5b09a 100644
+index 2112b7aef36054c9854c13cc5e9fb4c05bf18c6e..8085c73a405166fd2a70db60f53c37b4b2798ef7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2606,6 +2606,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2608,6 +2608,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // Spigot end
              // Spigot Start
              if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder && (!(entity instanceof ServerPlayer) || entity.getRemovalReason() != Entity.RemovalReason.KILLED)) { // SPIGOT-6876: closeInventory clears death message

--- a/patches/server/0859-Don-t-tick-markers.patch
+++ b/patches/server/0859-Don-t-tick-markers.patch
@@ -22,10 +22,10 @@ index 68f99e93ed3e843b4001a7a27620f88a48b85e67..0dc96c39151ec4dbeec3947cb17606f5
                  }
              });
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 6388ed56f71f065ab811acf3fb264083fdb5b09a..ae204baabbadafe4572d476be085a80c867d5fba 100644
+index 8085c73a405166fd2a70db60f53c37b4b2798ef7..b8f766d181ada1e7c13c4cf5c3f3ebcaad37e865 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2516,6 +2516,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2518,6 +2518,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          }
  
          public void onTickingStart(Entity entity) {

--- a/patches/server/0868-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/0868-Add-Alternate-Current-redstone-implementation.patch
@@ -2008,7 +2008,7 @@ index 0000000000000000000000000000000000000000..33cd90c30c22200a4e1ae64f40a0bf78
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index ae204baabbadafe4572d476be085a80c867d5fba..09aae0e2c958506d93dc6bb3e655f3036c362c41 100644
+index b8f766d181ada1e7c13c4cf5c3f3ebcaad37e865..359c70e99f40ed8ae67000d18d54966ff6804562 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -219,6 +219,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -2017,9 +2017,9 @@ index ae204baabbadafe4572d476be085a80c867d5fba..09aae0e2c958506d93dc6bb3e655f303
      public boolean hasEntityMoveEvent = false; // Paper
 +    private final alternate.current.wire.WireHandler wireHandler = new alternate.current.wire.WireHandler(this); // Paper - optimize redstone (Alternate Current)
      public static Throwable getAddToWorldStackTrace(Entity entity) {
-         return new Throwable(entity + " Added to world at " + new java.util.Date());
-     }
-@@ -2505,6 +2506,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
+         final Throwable thr = new Throwable(entity + " Added to world at " + new java.util.Date());
+         io.papermc.paper.util.StacktraceDeobfuscator.INSTANCE.deobfuscateThrowable(thr);
+@@ -2507,6 +2508,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
          // Paper end - rewrite chunk system
      }
  

--- a/patches/server/0876-Prevent-empty-items-from-being-added-to-world.patch
+++ b/patches/server/0876-Prevent-empty-items-from-being-added-to-world.patch
@@ -7,10 +7,10 @@ The previous solution caused a bunch of bandaid fixes inorder to resolve edge ca
 Just simply prevent them from being added to the world instead.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 09aae0e2c958506d93dc6bb3e655f3036c362c41..b396e9b35f315db37ba070ad4baeec1f098d0cb8 100644
+index 359c70e99f40ed8ae67000d18d54966ff6804562..a57e5319e41231aa65d0d05c91a2ed97d97b535c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1464,6 +1464,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1466,6 +1466,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // WorldServer.LOGGER.warn("Tried to add entity {} but it was marked as removed already", EntityTypes.getKey(entity.getType())); // CraftBukkit
              return false;
          } else {

--- a/patches/server/0903-Workaround-for-client-lag-spikes-MC-162253.patch
+++ b/patches/server/0903-Workaround-for-client-lag-spikes-MC-162253.patch
@@ -16,10 +16,10 @@ Co-authored-by: =?UTF-8?q?Dani=C3=ABl=20Goossens?= <daniel@goossens.ch>
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index bea95b155cdebb2b8e35096aafbbd0264a25b977..73daa8368066e20d251b8b6eb69c916919b48838 100644
+index 57b8a657cd8a1b525ec95bca1cad89591d81ff46..971405224418fee037030a4c465b5f4bb9cd2c3b 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1329,6 +1329,46 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1328,6 +1328,46 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
      }
  
@@ -66,7 +66,7 @@ index bea95b155cdebb2b8e35096aafbbd0264a25b977..73daa8368066e20d251b8b6eb69c9169
      // Paper start - Anti-Xray - Bypass
      private void playerLoadedChunk(ServerPlayer player, MutableObject<java.util.Map<Object, ClientboundLevelChunkWithLightPacket>> cachedDataPackets, LevelChunk chunk) {
          if (cachedDataPackets.getValue() == null) {
-@@ -1337,6 +1377,45 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1336,6 +1376,45 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
          Boolean shouldModify = chunk.getLevel().chunkPacketBlockController.shouldModify(player, chunk);
          player.trackChunk(chunk.getPos(), (Packet) cachedDataPackets.getValue().computeIfAbsent(shouldModify, (s) -> {

--- a/patches/server/0921-Remove-unnecessary-onTrackingStart-during-navigation.patch
+++ b/patches/server/0921-Remove-unnecessary-onTrackingStart-during-navigation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove unnecessary onTrackingStart during navigation warning
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index b396e9b35f315db37ba070ad4baeec1f098d0cb8..f1a27e0ea0569438032ff6c5a777a35be4e501ef 100644
+index a57e5319e41231aa65d0d05c91a2ed97d97b535c..f1a1c58fd70610c7fe29d5890cdf161346f34cb9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2552,7 +2552,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2554,7 +2554,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              if (entity instanceof Mob) {
                  Mob entityinsentient = (Mob) entity;
  
@@ -17,7 +17,7 @@ index b396e9b35f315db37ba070ad4baeec1f098d0cb8..f1a27e0ea0569438032ff6c5a777a35b
                      String s = "onTrackingStart called during navigation iteration";
  
                      Util.logAndPauseIfInIde("onTrackingStart called during navigation iteration", new IllegalStateException("onTrackingStart called during navigation iteration"));
-@@ -2637,7 +2637,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2639,7 +2639,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              if (entity instanceof Mob) {
                  Mob entityinsentient = (Mob) entity;
  


### PR DESCRIPTION
Now covers some ServerExceptionEvents and others I noticed in logs from users

for some of these could probably edit the original patch to use a logger instead but this works