### PR TITLE
[ci skip] Update Build Workflow dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
                 java: [17]
             fail-fast: true
         steps:
-            - uses: actions/checkout@v2.4.0
+            - uses: actions/checkout@v2.5.0
             - name: JDK ${{ matrix.java }}
-              uses: actions/setup-java@v3.1.0
+              uses: actions/setup-java@v3.6.0
               with:
                   java-version: ${{ matrix.java }}
                   cache: 'gradle'


### PR DESCRIPTION
This PR update the version of "actions" used in the build workflow.
Based in the deprecation of save-state and set-output reported in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Tested the workflow in the rep and build fine.
![image](https://user-images.githubusercontent.com/3602279/197310517-c749f806-2bea-45e2-91d3-c66b879df0f7.png)
