### PR TITLE
Detect headless JREs

### DIFF
--- a/patches/server/0929-Detect-headless-JREs.patch
+++ b/patches/server/0929-Detect-headless-JREs.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sat, 22 Oct 2022 14:47:45 +0200
+Subject: [PATCH] Detect headless JREs
+
+Crashes caused by the missing AWT dependency come up in the support channels fairly often.
+This patch detects the missing dependency and stops the server with a clear error message,
+containing a link to instructions on how to install a non-headless JRE.
+
+diff --git a/src/main/java/io/papermc/paper/util/ServerEnvironment.java b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
+index 6bd0afddbcc461149dfe9a5c7a86fff6ea13a5f1..025731a189cff83576648232a91de69922241123 100644
+--- a/src/main/java/io/papermc/paper/util/ServerEnvironment.java
++++ b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
+@@ -37,4 +37,14 @@ public class ServerEnvironment {
+     public static boolean userIsRootOrAdmin() {
+         return RUNNING_AS_ROOT_OR_ADMIN;
+     }
++
++    public static boolean isMissingAWTDependency() {
++        try {
++            new java.awt.Color(0);
++        } catch (UnsatisfiedLinkError e) {
++            return true;
++        }
++
++        return false;
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
+index 5962f7a2b185d7d54a0f9e341a4fdf6e6f1c1ec5..88ef769abfa163f923258d1f83d47b28c491eaca 100644
+--- a/src/main/java/net/minecraft/server/Main.java
++++ b/src/main/java/net/minecraft/server/Main.java
+@@ -155,6 +155,15 @@ public class Main {
+                 return;
+             }
+ 
++            // Paper start - Warn on headless
++            if (io.papermc.paper.util.ServerEnvironment.isMissingAWTDependency()) {
++                Main.LOGGER.error("You are using a headless JRE distribution.");
++                Main.LOGGER.error("This distribution is missing certain graphic libraries that the Minecraft server needs to function.");
++                Main.LOGGER.error("For instructions on how to install the non-headless JRE, see https://docs.papermc.io/misc/java-install");
++                return;
++            }
++            // Paper end
++
+             org.spigotmc.SpigotConfig.disabledAdvancements = spigotConfiguration.getStringList("advancements.disabled"); // Paper - fix SPIGOT-5885, must be set early in init
+             // Paper start - fix SPIGOT-5824
+             File file;


### PR DESCRIPTION
Crashes caused by the missing AWT dependency come up in the support channels fairly often.
This patch detects the missing dependency and stops the server with a clear error message,
containing a link to instructions on how to install a non-headless JRE.
This should clarify what the issue is for most users, instead of just crashing with [a vague UnsatisfiedLinkError](https://paste.gg/p/Pencil/022db02be70840539e429532960806f9).