### PR TITLE
Expand on entity serialization API

### DIFF
--- a/patches/api/0312-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/api/0312-Add-Raw-Byte-Entity-Serialization.patch
@@ -3,35 +3,141 @@ From: Mariell Hoversholm <proximyst@proximyst.com>
 Date: Sun, 24 Oct 2021 16:19:26 -0400
 Subject: [PATCH] Add Raw Byte Entity Serialization
 
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
+diff --git a/src/main/java/io/papermc/paper/entity/EntitySerializationFlag.java b/src/main/java/io/papermc/paper/entity/EntitySerializationFlag.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..e29dd78c1e5114915a45b02a5276e3ef7e283400
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/entity/EntitySerializationFlag.java
+@@ -0,0 +1,38 @@
++package io.papermc.paper.entity;
++
++import org.bukkit.UnsafeValues;
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Player;
++import org.bukkit.entity.SpawnCategory;
++
++/**
++ * Represents flags for entity serialization.
++ *
++ * @see UnsafeValues#serializeEntity(Entity, EntitySerializationFlag... serializationFlags)
++ */
++public enum EntitySerializationFlag {
++
++    /**
++     * Serialize invalid (dead, unloaded, etc.) entities.
++     *
++     * @see Entity#isValid()
++     */
++    FORCE,
++    /**
++     * Serialize misc non-savable entities like lighting bolts, fishing bobbers, etc.
++     * <br>Note: players require a separate flag: {@link #PLAYER}.
++     *
++     * @see SpawnCategory#MISC
++     */
++    MISC,
++    /**
++     * Include passengers in the serialized data.
++     */
++    PASSENGERS,
++    /**
++     * Allow serializing {@link Player}s.
++     * <p>Note: deserializing player data will always fail.
++     */
++    PLAYER
++
++}
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index cbc63144e5eb35799548209f8fbee70d0c20a53d..240ac3f658ed24d3980707e146e6dfee6c9b31a0 100644
+index cbc63144e5eb35799548209f8fbee70d0c20a53d..7e6f435a060a79a45060248c26dbca7c73366240 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -167,6 +167,14 @@ public interface UnsafeValues {
+@@ -167,6 +167,74 @@ public interface UnsafeValues {
  
      ItemStack deserializeItem(byte[] data);
  
-+    byte[] serializeEntity(org.bukkit.entity.Entity entity);
++    // Paper start - Raw entity serialization API
++    /**
++     * Serializes the provided entity.
++     *
++     * @param entity entity
++     * @return serialized entity data
++     * @see #serializeEntity(org.bukkit.entity.Entity, io.papermc.paper.entity.EntitySerializationFlag...)
++     * @see #deserializeEntity(byte[], World, boolean, boolean)
++     */
++    default byte[] serializeEntity(@org.jetbrains.annotations.NotNull org.bukkit.entity.Entity entity) {
++        return serializeEntity(entity, new io.papermc.paper.entity.EntitySerializationFlag[0]);
++    }
 +
-+    default org.bukkit.entity.Entity deserializeEntity(byte[] data, World world) {
++    /**
++     * Serializes the provided entity.
++     *
++     * @param entity entity
++     * @param serializationFlags serialization flags
++     * @return serialized entity data
++     * @see #deserializeEntity(byte[], World, boolean, boolean)
++     */
++    byte[] serializeEntity(@org.jetbrains.annotations.NotNull org.bukkit.entity.Entity entity, @org.jetbrains.annotations.NotNull io.papermc.paper.entity.EntitySerializationFlag... serializationFlags);
++
++    /**
++     * Deserializes the entity from data.
++     * <br>The entity's {@link java.util.UUID} as well as passengers will not be preserved.
++     *
++     * @param data serialized entity data
++     * @param world world
++     * @return deserialized entity
++     * @see #deserializeEntity(byte[], World, boolean, boolean)
++     * @see #serializeEntity(org.bukkit.entity.Entity, io.papermc.paper.entity.EntitySerializationFlag...)
++     * @see org.bukkit.entity.Entity#spawnAt(Location, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason)
++     */
++    default org.bukkit.entity.Entity deserializeEntity(byte[] data, @org.jetbrains.annotations.NotNull World world) {
 +        return deserializeEntity(data, world, false);
 +    }
 +
-+    org.bukkit.entity.Entity deserializeEntity(byte[] data, World world, boolean preserveUUID);
++    /**
++     * Deserializes the entity from data.
++     * <br>The entity's passengers will not be preserved.
++     *
++     * @param data serialized entity data
++     * @param world world
++     * @param preserveUUID whether to preserve the entity's uuid
++     * @return deserialized entity
++     * @see #deserializeEntity(byte[], World, boolean, boolean)
++     * @see #serializeEntity(org.bukkit.entity.Entity, io.papermc.paper.entity.EntitySerializationFlag...)
++     * @see org.bukkit.entity.Entity#spawnAt(Location, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason)
++     */
++    default org.bukkit.entity.Entity deserializeEntity(byte[] data, @org.jetbrains.annotations.NotNull World world, boolean preserveUUID) {
++        return deserializeEntity(data, world, preserveUUID, false);
++    }
++
++    /**
++     * Deserializes the entity from data.
++     *
++     * @param data serialized entity data
++     * @param world world
++     * @param preserveUUID whether to preserve uuids of the entity and its passengers
++     * @param preservePassengers whether to preserve passengers
++     * @return deserialized entity
++     * @see #serializeEntity(org.bukkit.entity.Entity, io.papermc.paper.entity.EntitySerializationFlag...)
++     * @see org.bukkit.entity.Entity#spawnAt(Location, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason)
++     */
++    org.bukkit.entity.Entity deserializeEntity(byte[] data, @org.jetbrains.annotations.NotNull World world, boolean preserveUUID, boolean preservePassengers);
++    // Paper end - Raw entity serialization API
 +
      /**
       * Creates and returns the next EntityId available.
       * <p>
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 827574b3eff9b912500b092ca081e7163677695e..18fa592f9159a5377eeac8325c0b8e16f74be7b8 100644
+index 827574b3eff9b912500b092ca081e7163677695e..ab38c0eeaf7195167666e82b9e801d844d3d6c17 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -946,5 +946,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
-      */
+@@ -947,4 +947,33 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      @Deprecated
      @NotNull Set<Player> getTrackedPlayers();
+     // Paper end
 +
++    // Paper start - Raw entity serialization API
 +    /**
 +     * Spawns the entity in the world at the given {@link Location} with the default spawn reason.
 +     * <p>
@@ -39,10 +145,10 @@ index 827574b3eff9b912500b092ca081e7163677695e..18fa592f9159a5377eeac8325c0b8e16
 +     * <p>
 +     * Also, this method will fire the same events as a normal entity spawn.
 +     *
-+     * @param location The location to spawn the entity at.
-+     * @return Whether the entity was successfully spawned.
++     * @param location the location to spawn the entity at
++     * @return whether the entity was successfully spawned
 +     */
-+    public default boolean spawnAt(@NotNull Location location) {
++    default boolean spawnAt(@NotNull Location location) {
 +        return spawnAt(location, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT);
 +    }
 +
@@ -53,10 +159,10 @@ index 827574b3eff9b912500b092ca081e7163677695e..18fa592f9159a5377eeac8325c0b8e16
 +     * <p>
 +     * Also, this method will fire the same events as a normal entity spawn.
 +     *
-+     * @param location The location to spawn the entity at.
-+     * @param reason   The reason for the entity being spawned.
-+     * @return Whether the entity was successfully spawned.
++     * @param location the location to spawn the entity at
++     * @param reason   the reason for the entity being spawned
++     * @return whether the entity was successfully spawned
 +     */
-+    public boolean spawnAt(@NotNull Location location, @NotNull org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason);
-     // Paper end
++    boolean spawnAt(@NotNull Location location, @NotNull org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason);
++    // Paper end - Raw entity serialization API
  }

--- a/patches/api/0317-Entity-powdered-snow-API.patch
+++ b/patches/api/0317-Entity-powdered-snow-API.patch
@@ -5,31 +5,32 @@ Subject: [PATCH] Entity powdered snow API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 18fa592f9159a5377eeac8325c0b8e16f74be7b8..5b49ac1e3f1f03675f9aa13acd8061adb6ad5cc3 100644
+index ab38c0eeaf7195167666e82b9e801d844d3d6c17..fbd8922ee761ae3e3b5d7b54bc7f67075f697e3c 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -973,5 +973,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
-      * @return Whether the entity was successfully spawned.
+@@ -976,4 +976,13 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
-     public boolean spawnAt(@NotNull Location location, @NotNull org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason);
+     boolean spawnAt(@NotNull Location location, @NotNull org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason);
+     // Paper end - Raw entity serialization API
 +
++    // Paper start - Entity powdered snow API
 +    /**
 +     * Check if entity is inside powdered snow.
 +     *
 +     * @return true if in powdered snow.
 +     */
 +    boolean isInPowderedSnow();
-     // Paper end
++    // Paper end - Entity powdered snow API
  }
 diff --git a/src/main/java/org/bukkit/entity/Skeleton.java b/src/main/java/org/bukkit/entity/Skeleton.java
-index e0ccc090a0be507ced4d5669491311e410f60a67..472a71ca8dad0d49f0723e5fdf58bf00a55190f2 100644
+index e0ccc090a0be507ced4d5669491311e410f60a67..e58858ed85c425dd43879f95e0028b9835e0177d 100644
 --- a/src/main/java/org/bukkit/entity/Skeleton.java
 +++ b/src/main/java/org/bukkit/entity/Skeleton.java
 @@ -41,6 +41,16 @@ public interface Skeleton extends AbstractSkeleton {
       */
      void setConversionTime(int time);
  
-+    // Paper start
++    // Paper start - Entity powdered snow API
 +    /**
 +     * Gets the time the skeleton
 +     * has been inside powdered snow.
@@ -37,7 +38,7 @@ index e0ccc090a0be507ced4d5669491311e410f60a67..472a71ca8dad0d49f0723e5fdf58bf00
 +     * @return time in ticks
 +     */
 +    int inPowderedSnowTime();
-+    // Paper end
++    // Paper end - Entity powdered snow API
 +
      /**
       * A legacy enum that defines the different variances of skeleton-like

--- a/patches/api/0356-Collision-API.patch
+++ b/patches/api/0356-Collision-API.patch
@@ -5,14 +5,15 @@ Subject: [PATCH] Collision API
 
 
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index 44ee56a5956cc17194c767a0c1071a2abffe818a..43dd6c59cceba12f27e6b265acc3ad97eea37abd 100644
+index 44ee56a5956cc17194c767a0c1071a2abffe818a..7eae16bc5d60d84ce9b35c1dc507626e03ea8994 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
-@@ -493,5 +493,15 @@ public interface RegionAccessor extends Keyed { // Paper
-      * @return whether a line of sight exists between {@code from} and {@code to}
+@@ -494,4 +494,16 @@ public interface RegionAccessor extends Keyed { // Paper
       */
      public boolean lineOfSightExists(@NotNull Location from, @NotNull Location to);
+     // Paper end
 +
++    // Paper start - Collision API
 +    /**
 +     * Checks if the world collides with the given boundingbox.
 +     * This will check for any colliding hard entities (boats, shulkers) / worldborder / blocks.
@@ -22,16 +23,16 @@ index 44ee56a5956cc17194c767a0c1071a2abffe818a..43dd6c59cceba12f27e6b265acc3ad97
 +     * @return collides or not
 +     */
 +    boolean hasCollisionsIn(@NotNull org.bukkit.util.BoundingBox boundingBox);
-     // Paper end
++    // Paper end - Collision API
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 8bada7f7f0200103edc415ad003132d96ae09607..9f4498a955279b8b5c418609801fd09444a1efb5 100644
+index a176dcb592efc3bb50ebd319ac878cd75df18ff0..0105b95e841cad0121913e0baf55f36637dfbd2f 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -1023,4 +1023,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -1027,4 +1027,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      boolean isInPowderedSnow();
-     // Paper end
+     // Paper end - Entity powdered snow API
 +
 +    // Paper start - Collision API
 +    /**

--- a/patches/api/0388-Add-Entity-Body-Yaw-API.patch
+++ b/patches/api/0388-Add-Entity-Body-Yaw-API.patch
@@ -5,14 +5,15 @@ Subject: [PATCH] Add Entity Body Yaw API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 6dcaf7e9bc9afb708ab569e82f27c87833450ff1..a76e537c9b3b9519cd46894c90b750f012182be9 100644
+index 4b454d3209aa829328510122e75785f20613ba69..d7560862ef1126263b578356b9cff0146c74145c 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -1041,6 +1041,43 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
-      * @return true if in powdered snow.
+@@ -1068,4 +1068,43 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
-     boolean isInPowderedSnow();
+     boolean wouldCollideUsing(@NotNull BoundingBox boundingBox);
+     // Paper end - Collision API
 +
++    // Paper start - body yaw API
 +    /**
 +     * Gets the x-coordinate of this entity
 +     *
@@ -49,9 +50,8 @@ index 6dcaf7e9bc9afb708ab569e82f27c87833450ff1..a76e537c9b3b9519cd46894c90b750f0
 +     * @return the entity's yaw
 +     */
 +    float getYaw();
-     // Paper end
- 
-     // Paper start - Collision API
++    // Paper end - body yaw API
+ }
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
 index a2c1cc7462564411db71a1e00222ef55633b49c8..4974540e8277011e4eb00f691a5f6f96d3dde20c 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java

--- a/patches/api/0398-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/api/0398-Folia-scheduler-and-owned-region-API.patch
@@ -769,13 +769,13 @@ index 65620c67da99af7e84357fe91d90878ebe84798b..e9773ebcc76fb637ed19dce203ae0dfe
 +    // Paper end - Folia region threading API
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index a76e537c9b3b9519cd46894c90b750f012182be9..4580c7613fac4f1eeccc2be2d15497cec5868736 100644
+index d7560862ef1126263b578356b9cff0146c74145c..f40ca441dcc56055b0d571e4b63773da0650c731 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -1101,4 +1101,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -1107,4 +1107,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
-     boolean wouldCollideUsing(@NotNull BoundingBox boundingBox);
-     // Paper end - Collision API
+     float getYaw();
+     // Paper end - body yaw API
 +
 +    // Paper start - Folia schedulers
 +    /**

--- a/patches/server/0330-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/server/0330-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add Raw Byte ItemStack Serialization
 Serializes using NBT which is safer for server data migrations than bukkits format.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 7800e0a5aa381181d6a19d55f90490154de05c04..890beb473c240c084c4dd12c5dd792895117358e 100644
+index 7800e0a5aa381181d6a19d55f90490154de05c04..dec1ebf36680970f92daa8afb04823d8204a7002 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -483,6 +483,53 @@ public final class CraftMagicNumbers implements UnsafeValues {
@@ -33,7 +33,7 @@ index 7800e0a5aa381181d6a19d55f90490154de05c04..890beb473c240c084c4dd12c5dd79289
 +        return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.parse(MinecraftServer.getServer().registryAccess(), compound).orElseThrow());
 +    }
 +
-+    private byte[] serializeNbtToBytes(CompoundTag compound) {
++    private byte[] serializeNbtToBytes(net.minecraft.nbt.CompoundTag compound) {
 +        compound.putInt("DataVersion", getDataVersion());
 +        java.io.ByteArrayOutputStream outputStream = new java.io.ByteArrayOutputStream();
 +        try {

--- a/patches/server/0598-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0598-Add-Raw-Byte-Entity-Serialization.patch
@@ -6,35 +6,93 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 == AT ==
 public net.minecraft.world.entity.Entity setLevel(Lnet/minecraft/world/level/Level;)V
 
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
+
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 28c20c14fa36470a96fad88787fc01c77592d19f..13e1b47873f0a4a974bb0763679fee6e37932b5c 100644
+index 28c20c14fa36470a96fad88787fc01c77592d19f..724444ce7b844b2c04b1d91d68a4432ed22a19f5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2145,6 +2145,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
-         }
+@@ -2129,17 +2129,23 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
-+    // Paper start - Entity serialization api
-+    public boolean serializeEntity(CompoundTag compound) {
-+        List<Entity> pass = new java.util.ArrayList<>(this.getPassengers());
-+        this.passengers = ImmutableList.of();
-+        boolean result = save(compound);
-+        this.passengers = ImmutableList.copyOf(pass);
-+        return result;
+     public boolean saveAsPassenger(CompoundTag nbttagcompound, boolean includeAll) {
++        // Paper start - Raw entity serialization API
++        return this.saveAsPassenger(nbttagcompound, includeAll, false);
 +    }
-+    // Paper end - Entity serialization api
-     public boolean save(CompoundTag nbt) {
-         return this.isPassenger() ? false : this.saveAsPassenger(nbt);
++
++    public boolean saveAsPassenger(CompoundTag nbttagcompound, boolean includeAll, boolean force) {
++        // Paper end - Raw entity serialization API
+         // CraftBukkit end
+-        if (this.removalReason != null && !this.removalReason.shouldSave()) {
++        if (this.removalReason != null && !this.removalReason.shouldSave() && !force) { // Paper - Raw entity serialization API
+             return false;
+         } else {
+-            String s = this.getEncodeId();
++            String s = this.getEncodeId(force); // Paper - Raw entity serialization API
+ 
+-            if (!this.persist || s == null) { // CraftBukkit - persist flag
++            if ((!this.persist && !force) || s == null) { // CraftBukkit - persist flag // Paper - Raw entity serialization API
+                 return false;
+             } else {
+                 nbttagcompound.putString("id", s);
+-                this.saveWithoutId(nbttagcompound, includeAll); // CraftBukkit - pass on includeAll
++                this.saveWithoutId(nbttagcompound, includeAll, force); // CraftBukkit - pass on includeAll // Paper - Raw entity serialization API
+                 return true;
+             }
+         }
+@@ -2155,6 +2161,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
+ 
+     public CompoundTag saveWithoutId(CompoundTag nbttagcompound, boolean includeAll) {
++        // Paper start - Raw entity serialization API
++        return saveWithoutId(nbttagcompound, includeAll, false);
++    }
++
++    public CompoundTag saveWithoutId(CompoundTag nbttagcompound, boolean includeAll, boolean force) {
++        if (force) {
++            includeAll = true;
++        }
++        // Paper end - Raw entity serialization API
+         // CraftBukkit end
+         try {
+             // CraftBukkit start - selectively save position
+@@ -2269,7 +2284,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+                     Entity entity = (Entity) iterator.next();
+                     CompoundTag nbttagcompound1 = new CompoundTag();
+ 
+-                    if (entity.saveAsPassenger(nbttagcompound1, includeAll)) { // CraftBukkit - pass on includeAll
++                    if (entity.saveAsPassenger(nbttagcompound1, includeAll, force)) { // CraftBukkit - pass on includeAll // Paper - Raw entity serialization API
+                         nbttaglist.add(nbttagcompound1);
+                     }
+                 }
+@@ -2463,10 +2478,17 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+ 
+     @Nullable
+     public final String getEncodeId() {
++        // Paper start - Raw entity serialization API
++        return getEncodeId(false);
++    }
++
++    @Nullable
++    public final String getEncodeId(boolean force) {
++        // Paper end - Raw entity serialization API
+         EntityType<?> entitytypes = this.getType();
+         ResourceLocation minecraftkey = EntityType.getKey(entitytypes);
+ 
+-        return entitytypes.canSerialize() && minecraftkey != null ? minecraftkey.toString() : null;
++        return (entitytypes.canSerialize() || force) && minecraftkey != null ? minecraftkey.toString() : null; // Paper - Raw entity serialization API
+     }
+ 
+     // CraftBukkit start - allow excluding certain data when saving
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 7310f53747e68b918f132ee0f0a142e36537902e..6f9286e65f7ac730b808ddf9b52c344f03b4d778 100644
+index 7310f53747e68b918f132ee0f0a142e36537902e..821dd20aaaf555bfe38049f993067453e71fbfff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1085,6 +1085,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1085,6 +1085,24 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      }
      // Paper end - tracked players API
  
-+    // Paper start - raw entity serialization API
++    // Paper start - Raw entity serialization API
 +    @Override
 +    public boolean spawnAt(Location location, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason reason) {
 +        Preconditions.checkNotNull(location, "location cannot be null");
@@ -42,49 +100,94 @@ index 7310f53747e68b918f132ee0f0a142e36537902e..6f9286e65f7ac730b808ddf9b52c344f
 +        this.entity.setLevel(((CraftWorld) location.getWorld()).getHandle());
 +        this.entity.setPos(location.getX(), location.getY(), location.getZ());
 +        this.entity.setRot(location.getYaw(), location.getPitch());
-+        return !this.entity.valid && this.entity.level().addFreshEntity(this.entity, reason);
++        boolean spawned = !this.entity.valid && this.entity.level().addFreshEntity(this.entity, reason);
++        if (spawned) {
++            for (org.bukkit.entity.Entity pass : getPassengers()) {
++                pass.spawnAt(getLocation());
++            }
++        }
++        return spawned;
 +    }
-+    // Paper end - raw entity serialization API
++    // Paper end - Raw entity serialization API
 +
      // Paper start - missing entity api
      @Override
      public boolean isInvisible() {  // Paper - moved up from LivingEntity
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index cfd003e975573564a3fea9d4379842979711e841..1a46245fed7a5fca532df7e3febb22f5effca764 100644
+index e225c716d0177e7f6935a77e1b5f5cf883e1d9e7..c1570800dab144670689dc7a9d3d6ce4966b85d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -505,7 +505,33 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -505,6 +505,73 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.parse(MinecraftServer.getServer().registryAccess(), compound).orElseThrow());
      }
  
--    private byte[] serializeNbtToBytes(CompoundTag compound) {
++    // Paper start - Raw entity serialization API
 +    @Override
-+    public byte[] serializeEntity(org.bukkit.entity.Entity entity) {
++    public byte[] serializeEntity(org.bukkit.entity.Entity entity, io.papermc.paper.entity.EntitySerializationFlag... serializationFlags) {
 +        Preconditions.checkNotNull(entity, "null cannot be serialized");
-+        Preconditions.checkArgument(entity instanceof org.bukkit.craftbukkit.entity.CraftEntity, "only CraftEntities can be serialized");
++        Preconditions.checkArgument(entity instanceof org.bukkit.craftbukkit.entity.CraftEntity, "Only CraftEntities can be serialized");
++
++        java.util.Set<io.papermc.paper.entity.EntitySerializationFlag> flags = java.util.Set.of(serializationFlags);
++        boolean force = flags.contains(io.papermc.paper.entity.EntitySerializationFlag.FORCE);
++        boolean misc = flags.contains(io.papermc.paper.entity.EntitySerializationFlag.MISC);
++        Preconditions.checkArgument(entity.isValid() || force, "Cannot serialize invalid entity without the FORCE flag");
++
++        net.minecraft.world.entity.Entity nmsEntity = ((org.bukkit.craftbukkit.entity.CraftEntity) entity).getHandle();
++        if (entity instanceof org.bukkit.entity.Player) {
++            Preconditions.checkArgument(flags.contains(io.papermc.paper.entity.EntitySerializationFlag.PLAYER), "Cannot serialize Players without the PLAYER flag");
++        } else {
++            Preconditions.checkArgument(nmsEntity.getType().canSerialize() || misc, String.format("Cannot serialize misc non-savable entity (%s) without the MISC flag", entity.getType().name()));
++        }
 +
 +        net.minecraft.nbt.CompoundTag compound = new net.minecraft.nbt.CompoundTag();
-+        ((org.bukkit.craftbukkit.entity.CraftEntity) entity).getHandle().serializeEntity(compound);
++        if (flags.contains(io.papermc.paper.entity.EntitySerializationFlag.PASSENGERS)) {
++            nmsEntity.saveAsPassenger(compound, true, force || misc);
++        } else {
++            java.util.List<net.minecraft.world.entity.Entity> pass = new java.util.ArrayList<>(nmsEntity.getPassengers());
++            nmsEntity.passengers = com.google.common.collect.ImmutableList.of();
++            nmsEntity.saveAsPassenger(compound, true, force || misc);
++            nmsEntity.passengers = com.google.common.collect.ImmutableList.copyOf(pass);
++
++        }
 +        return serializeNbtToBytes(compound);
 +    }
 +
 +    @Override
-+    public org.bukkit.entity.Entity deserializeEntity(byte[] data, org.bukkit.World world, boolean preserveUUID) {
++    public org.bukkit.entity.Entity deserializeEntity(byte[] data, org.bukkit.World world, boolean preserveUUID, boolean preservePassengers) {
 +        Preconditions.checkNotNull(data, "null cannot be deserialized");
-+        Preconditions.checkArgument(data.length > 0, "cannot deserialize nothing");
++        Preconditions.checkArgument(data.length > 0, "Cannot deserialize empty data");
 +
 +        net.minecraft.nbt.CompoundTag compound = deserializeNbtFromBytes(data);
 +        int dataVersion = compound.getInt("DataVersion");
 +        compound = (net.minecraft.nbt.CompoundTag) MinecraftServer.getServer().fixerUpper.update(References.ENTITY, new Dynamic<>(NbtOps.INSTANCE, compound), dataVersion, this.getDataVersion()).getValue();
-+        if (!preserveUUID) {
-+            // Generate a new UUID so we don't have to worry about deserializing the same entity twice
-+            compound.remove("UUID");
++        if (!preservePassengers) {
++            compound.remove("Passengers");
 +        }
-+        return net.minecraft.world.entity.EntityType.create(compound, ((org.bukkit.craftbukkit.CraftWorld) world).getHandle())
-+            .orElseThrow(() -> new IllegalArgumentException("An ID was not found for the data. Did you downgrade?")).getBukkitEntity();
++        net.minecraft.world.entity.Entity nmsEntity = deserializeEntity(compound, ((org.bukkit.craftbukkit.CraftWorld) world).getHandle(), preserveUUID);
++        return nmsEntity.getBukkitEntity();
 +    }
 +
-+    private byte[] serializeNbtToBytes(net.minecraft.nbt.CompoundTag compound) {
++    private net.minecraft.world.entity.Entity deserializeEntity(net.minecraft.nbt.CompoundTag compound,  net.minecraft.server.level.ServerLevel world, boolean preserveUUID) {
++        if (!preserveUUID) {
++            // Generate a new UUID, so we don't have to worry about deserializing the same entity twice
++            compound.remove("UUID");
++        }
++        net.minecraft.world.entity.Entity nmsEntity = net.minecraft.world.entity.EntityType.create(compound, world)
++            .orElseThrow(() -> new IllegalArgumentException("An ID was not found for the data. Did you downgrade?"));
++        if (compound.contains("Passengers", Tag.TAG_LIST)) {
++            net.minecraft.nbt.ListTag passengersCompound = compound.getList("Passengers", Tag.TAG_COMPOUND);
++            for (Tag tag : passengersCompound) {
++                if (!(tag instanceof net.minecraft.nbt.CompoundTag serializedPassenger)) {
++                    continue;
++                }
++                net.minecraft.world.entity.Entity passengerEntity = deserializeEntity(serializedPassenger, world, preserveUUID);
++                passengerEntity.startRiding(nmsEntity, true);
++            }
++        }
++        return nmsEntity;
++    }
++    // Paper end - Raw entity serialization API
++
+     private byte[] serializeNbtToBytes(net.minecraft.nbt.CompoundTag compound) {
          compound.putInt("DataVersion", getDataVersion());
          java.io.ByteArrayOutputStream outputStream = new java.io.ByteArrayOutputStream();
-         try {

--- a/patches/server/0643-Entity-powdered-snow-API.patch
+++ b/patches/server/0643-Entity-powdered-snow-API.patch
@@ -7,12 +7,12 @@ Subject: [PATCH] Entity powdered snow API
 public net.minecraft.world.entity.monster.Skeleton inPowderSnowTime
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 6f9286e65f7ac730b808ddf9b52c344f03b4d778..d2648218d41439c4048901f2dbd59fe5eef57495 100644
+index 821dd20aaaf555bfe38049f993067453e71fbfff..f3f90f472311a0bbd736ab184724b13e3d0b536a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1097,6 +1097,13 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1103,6 +1103,13 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      }
-     // Paper end - raw entity serialization API
+     // Paper end - Raw entity serialization API
  
 +    // Paper start - entity powdered snow API
 +    @Override

--- a/patches/server/0992-Rewrite-dataconverter-system.patch
+++ b/patches/server/0992-Rewrite-dataconverter-system.patch
@@ -29388,7 +29388,7 @@ index 1d287dd7379e56f7fd4b425880b850cd843f5789..8ab7ca373a885fbe658013c9c6a2e38d
              return nbttagcompound;
          });
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index be56e7a7607d3119e560f38e800ad4bbfe1e7714..5a04134973dd1db7f778a57ec5f185feec370990 100644
+index afa97e79cffb6cb112ffe92cf82d8c514f899423..1122d009f4806f4494a01a84c5b19ae54efabe49 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -522,7 +522,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
@@ -29400,12 +29400,12 @@ index be56e7a7607d3119e560f38e800ad4bbfe1e7714..5a04134973dd1db7f778a57ec5f185fe
          return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.parse(MinecraftServer.getServer().registryAccess(), compound).orElseThrow());
      }
  
-@@ -543,7 +543,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -564,7 +564,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
          net.minecraft.nbt.CompoundTag compound = deserializeNbtFromBytes(data);
          int dataVersion = compound.getInt("DataVersion");
 -        compound = (net.minecraft.nbt.CompoundTag) MinecraftServer.getServer().fixerUpper.update(References.ENTITY, new Dynamic<>(NbtOps.INSTANCE, compound), dataVersion, this.getDataVersion()).getValue();
 +        compound = ca.spottedleaf.dataconverter.minecraft.MCDataConverter.convertTag(ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry.ENTITY, compound, dataVersion, this.getDataVersion());
-         if (!preserveUUID) {
-             // Generate a new UUID so we don't have to worry about deserializing the same entity twice
-             compound.remove("UUID");
+         if (!preservePassengers) {
+             compound.remove("Passengers");
+         }


### PR DESCRIPTION
Makes an entity serializable via API no matter what.
Previously you'd get an empty component (and an error later when trying to spawn the deserialized entity) in some cases:
- When the entity is marked as non-persistent.
- When the entity is a passenger.
- When the entity is not saveable (misc entities like lightning, knot, etc.).
- When the entity is "invalid" (dead, unloaded, etc.).

Now there's no problem serializing & deserializing & spawning entities in those cases.
___
Edit: see [the comment](https://github.com/PaperMC/Paper/pull/8492#issuecomment-1348574662) below for the new flags explanation