### PR TITLE
Deprecate Player sendMultiBlockChange

### DIFF
--- a/patches/api/0355-Multi-Block-Change-API.patch
+++ b/patches/api/0355-Multi-Block-Change-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Multi Block Change API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b5519cf329485a2ec72586e66a8a88617c09312e..82d9cfadb00da9b7c2034938780354a573801728 100644
+index b5519cf329485a2ec72586e66a8a88617c09312e..70a3493153388ef025481ebca7bbb01b96012180 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -624,6 +624,27 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -624,6 +624,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendBlockDamage(@NotNull Location loc, float progress);
  
@@ -18,7 +18,9 @@ index b5519cf329485a2ec72586e66a8a88617c09312e..82d9cfadb00da9b7c2034938780354a5
 +     * chunk section that a block change occurs. This will not actually change the world in any way.
 +     *
 +     * @param blockChanges A map of the locations you want to change to their new block data
++     * @deprecated in favor of {@link #sendBlockChanges(java.util.Collection, boolean)}
 +     */
++    @Deprecated
 +    public default void sendMultiBlockChange(@NotNull java.util.Map<Location, BlockData> blockChanges) {
 +        sendMultiBlockChange(blockChanges, false);
 +    }
@@ -29,7 +31,9 @@ index b5519cf329485a2ec72586e66a8a88617c09312e..82d9cfadb00da9b7c2034938780354a5
 +     *
 +     * @param blockChanges A map of the locations you want to change to their new block data
 +     * @param suppressLightUpdates Whether to suppress light updates or not
++     * @deprecated in favor of {@link #sendBlockChanges(java.util.Collection, boolean)}
 +     */
++    @Deprecated
 +    public void sendMultiBlockChange(@NotNull java.util.Map<Location, BlockData> blockChanges, boolean suppressLightUpdates);
 +    // Paper end
 +

--- a/patches/api/0385-More-Teleport-API.patch
+++ b/patches/api/0385-More-Teleport-API.patch
@@ -76,7 +76,7 @@ index 0000000000000000000000000000000000000000..0426ee8bd71142b6f933a479c0f2e5ef
 +
 +}
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index f9ca4b90f92f57288654d7006613531b139dcddc..8dd6c7bae8b5ce13e3b4d5847bb204dac5072da6 100644
+index b878509ff536f2d728c800a0ae6cd36802570b31..9bfe62185acb2a208268a2db3aa81dad9e0eed5e 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -122,10 +122,77 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
@@ -159,10 +159,10 @@ index f9ca4b90f92f57288654d7006613531b139dcddc..8dd6c7bae8b5ce13e3b4d5847bb204da
       * Teleports this entity to the given location. If this entity is riding a
       * vehicle, it will be dismounted prior to teleportation.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 82d9cfadb00da9b7c2034938780354a573801728..8bac7b0b762a75a6535b50351850192a9568b578 100644
+index 70a3493153388ef025481ebca7bbb01b96012180..0efc0253bd23799bc26d3077ce4bac0044ae4b4a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2732,6 +2732,71 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2736,6 +2736,71 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      String getClientBrandName();
      // Paper end
  

--- a/patches/api/0387-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0387-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8bac7b0b762a75a6535b50351850192a9568b578..cde9dfaba913e18d2efc6003d5209ba3cfb02945 100644
+index 0efc0253bd23799bc26d3077ce4bac0044ae4b4a..ae6a245505dd16fc02ced747f2cd983cc4ca030c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2594,6 +2594,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2598,6 +2598,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException If the level is negative or greater than {@code 4} (i.e. not within {@code [0, 4]}).
       */
      void sendOpLevel(byte level);

--- a/patches/api/0399-Elder-Guardian-appearance-API.patch
+++ b/patches/api/0399-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 1d98abff1ad0116f7a2599f078aa730cb84843c1..ecb8b4cf48c7d6151ffec92bc6855d1fc57a2b51 100644
+index f849f0ad4268de0c25d9a2934d828d388480a899..2ef34c4d96e76c6a570908e26dbed5197b1f1784 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2828,6 +2828,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2832,6 +2832,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
      // Paper end - Teleport API
  

--- a/patches/server/0801-Multi-Block-Change-API-Implementation.patch
+++ b/patches/server/0801-Multi-Block-Change-API-Implementation.patch
@@ -5,14 +5,15 @@ Subject: [PATCH] Multi Block Change API Implementation
 
 
 diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundSectionBlocksUpdatePacket.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundSectionBlocksUpdatePacket.java
-index 285da70a15f6e4c868747af9d40ac30bd4e42ef4..a0aeac9c29300a0cf6bad55133019e8c29f6cc1c 100644
+index 285da70a15f6e4c868747af9d40ac30bd4e42ef4..1ff41ebf5722db0e72f3a68bed7bad0b5b1642a3 100644
 --- a/src/main/java/net/minecraft/network/protocol/game/ClientboundSectionBlocksUpdatePacket.java
 +++ b/src/main/java/net/minecraft/network/protocol/game/ClientboundSectionBlocksUpdatePacket.java
-@@ -63,6 +63,15 @@ public class ClientboundSectionBlocksUpdatePacket implements Packet<ClientGamePa
+@@ -63,6 +63,16 @@ public class ClientboundSectionBlocksUpdatePacket implements Packet<ClientGamePa
  
      }
  
 +    // Paper start
++    @Deprecated
 +    public ClientboundSectionBlocksUpdatePacket(SectionPos sectionPos, it.unimi.dsi.fastutil.shorts.Short2ObjectMap<BlockState> blockChanges, boolean suppressLightUpdates) {
 +        this.sectionPos = sectionPos;
 +        this.positions = blockChanges.keySet().toShortArray();
@@ -25,15 +26,16 @@ index 285da70a15f6e4c868747af9d40ac30bd4e42ef4..a0aeac9c29300a0cf6bad55133019e8c
      public void write(FriendlyByteBuf buf) {
          buf.writeLong(this.sectionPos.asLong());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9b9fe738a20bfd2c9f954539362d35d7c83e8eb1..2dc1f092576a2432563224d895729ad7c4cfc3bd 100644
+index 9b9fe738a20bfd2c9f954539362d35d7c83e8eb1..d55a195101fbab2853d42d70b15612bc6ea9a1b3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -923,6 +923,35 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -923,6 +923,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
 +    // Paper start
 +    @Override
++    @Deprecated
 +    public void sendMultiBlockChange(Map<Location, BlockData> blockChanges, boolean suppressLightUpdates) {
 +        if (this.getHandle().connection == null) return;
 +

--- a/patches/server/0884-More-Teleport-API.patch
+++ b/patches/server/0884-More-Teleport-API.patch
@@ -69,10 +69,10 @@ index 2015147126f463f11202d04ca475cc86e5ac12c2..a1e2664c9a6cc41edf0dfb92cd2b9d77
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2dc1f092576a2432563224d895729ad7c4cfc3bd..3834952589a0becf88a4fdc328ca4f3e6c5b1aa6 100644
+index d55a195101fbab2853d42d70b15612bc6ea9a1b3..0411671c5a545935e12273da979b163beee17a40 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1178,13 +1178,92 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1179,13 +1179,92 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setRotation(float yaw, float pitch) {
@@ -166,7 +166,7 @@ index 2dc1f092576a2432563224d895729ad7c4cfc3bd..3834952589a0becf88a4fdc328ca4f3e
          location.checkFinite();
  
          ServerPlayer entity = this.getHandle();
-@@ -1197,7 +1276,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1198,7 +1277,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
             return false;
          }
  
@@ -175,7 +175,7 @@ index 2dc1f092576a2432563224d895729ad7c4cfc3bd..3834952589a0becf88a4fdc328ca4f3e
              return false;
          }
  
-@@ -1215,7 +1294,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1216,7 +1295,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          // If this player is riding another entity, we must dismount before teleporting.
@@ -184,7 +184,7 @@ index 2dc1f092576a2432563224d895729ad7c4cfc3bd..3834952589a0becf88a4fdc328ca4f3e
  
          // SPIGOT-5509: Wakeup, similar to riding
          if (this.isSleeping()) {
-@@ -1237,7 +1316,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1238,7 +1317,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Check if the fromWorld and toWorld are the same.
          if (fromWorld == toWorld) {

--- a/patches/server/0903-Add-custom-destroyerIdentity-to-sendBlockDamage.patch
+++ b/patches/server/0903-Add-custom-destroyerIdentity-to-sendBlockDamage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add custom destroyerIdentity to sendBlockDamage
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 781c0e10b523c55989f368b4507137343dcffdab..968aa80b57a31d89852c6f4bc0ec5ed4a98c6530 100644
+index bcbf6b5117329aa44662fbff7344d5aca715b69b..880ecbc05d9640bb00b0322a23b8abdb3f1e183d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1008,13 +1008,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1009,13 +1009,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void sendBlockDamage(Location loc, float progress) {

--- a/patches/server/0924-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0924-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 968aa80b57a31d89852c6f4bc0ec5ed4a98c6530..b1136b9c39b16cbb9dfe460f88000f74ccd4f571 100644
+index 880ecbc05d9640bb00b0322a23b8abdb3f1e183d..fb9b65ec26ec232827bcd358508c3163d9908bd0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2932,6 +2932,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2933,6 +2933,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  


### PR DESCRIPTION
A similar method player.sendBlockChanges was added by upstream which essentially performs the same function as player.sendMultiBlockChange that I PR'd awhile ago to Paper at https://github.com/PaperMC/Paper/pull/7333.

This PR deprecates my original method in favor of upstreams.