### PR TITLE
Configurable Region Compression Format

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -440,10 +440,10 @@ index 0000000000000000000000000000000000000000..9ef6712c70fcd8912a79f3f61e351aac
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..58cdb70c0b9de45ca28811416d871099eefec2ce
+index 0000000000000000000000000000000000000000..5cfd0bd7c09aacd7313575e30cf0a171c597e2bd
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,283 @@
+@@ -0,0 +1,291 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -589,6 +589,14 @@ index 0000000000000000000000000000000000000000..58cdb70c0b9de45ca28811416d871099
 +        public boolean allowHeadlessPistons = false;
 +        @Comment("This setting controls if grindstones should be able to output overstacked items (such as cursed books).")
 +        public boolean allowGrindstoneOverstacking = false;
++        @Comment("This setting controls what compression format is used for region files.")
++        public CompressionFormat compressionFormat = CompressionFormat.ZLIB;
++
++        public enum CompressionFormat {
++            GZIP,
++            ZLIB,
++            NONE
++        }
 +    }
 +
 +    public Commands commands;

--- a/patches/server/0019-Rewrite-chunk-system.patch
+++ b/patches/server/0019-Rewrite-chunk-system.patch
@@ -15673,7 +15673,7 @@ index 0000000000000000000000000000000000000000..962d3cae6340fc11607b59355e291629
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 58cdb70c0b9de45ca28811416d871099eefec2ce..6a0560b1b0972f90b5260115e81f2baa84cfb40d 100644
+index 5cfd0bd7c09aacd7313575e30cf0a171c597e2bd..115c44d6f064049270f1fae07683da1da974b08e 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 @@ -116,21 +116,6 @@ public class GlobalConfiguration extends ConfigurationPart {
@@ -15698,7 +15698,7 @@ index 58cdb70c0b9de45ca28811416d871099eefec2ce..6a0560b1b0972f90b5260115e81f2baa
      public UnsupportedSettings unsupportedSettings;
  
      public class UnsupportedSettings extends ConfigurationPart {
-@@ -280,4 +265,43 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -288,4 +273,43 @@ public class GlobalConfiguration extends ConfigurationPart {
          public boolean disableNoteblockUpdates = false;
          public boolean disableTripwireUpdates = false;
      }

--- a/patches/server/0868-Configurable-chat-thread-limit.patch
+++ b/patches/server/0868-Configurable-chat-thread-limit.patch
@@ -22,10 +22,10 @@ is actually processed, this is honestly really just exposed for the misnomers or
 who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
 
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 6a0560b1b0972f90b5260115e81f2baa84cfb40d..4ac3fa45cd155ae8a852e26d4d4d1f16b28efdc2 100644
+index 115c44d6f064049270f1fae07683da1da974b08e..d7f541d94941a341a70dfac025a3d3601dd1aca8 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -238,13 +238,26 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -246,13 +246,26 @@ public class GlobalConfiguration extends ConfigurationPart {
      public Misc misc;
  
      public class Misc extends ConfigurationPart {

--- a/patches/server/0991-Configurable-Region-Compression-Format.patch
+++ b/patches/server/0991-Configurable-Region-Compression-Format.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Astralchroma <astralchroma@proton.me>
+Date: Thu, 27 Oct 2022 22:19:31 +0100
+Subject: [PATCH] Configurable Region Compression Format
+
+
+diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/RegionFile.java b/src/main/java/net/minecraft/world/level/chunk/storage/RegionFile.java
+index dcfe090c269d4cbcc2eb1b6f85392848bb34656c..0c5ac12b1f395bba8b7fc50baf8e825ba6488f6c 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/storage/RegionFile.java
++++ b/src/main/java/net/minecraft/world/level/chunk/storage/RegionFile.java
+@@ -425,11 +425,11 @@ public class RegionFile implements AutoCloseable {
+     // Paper end
+ 
+     public RegionFile(Path file, Path directory, boolean dsync) throws IOException {
+-        this(file, directory, RegionFileVersion.VERSION_DEFLATE, dsync);
++        this(file, directory, RegionFileVersion.getCompressionFormat(), dsync); // Paper - Configurable region compression format
+     }
+     // Paper start - add can recalc flag
+     public RegionFile(Path file, Path directory, boolean dsync, boolean canRecalcHeader) throws IOException {
+-        this(file, directory, RegionFileVersion.VERSION_DEFLATE, dsync, canRecalcHeader);
++        this(file, directory, RegionFileVersion.getCompressionFormat(), dsync, canRecalcHeader); // Paper - Configurable region compression format
+     }
+     // Paper end - add can recalc flag
+ 
+diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileVersion.java b/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileVersion.java
+index 4411e427d3b6b592f8a18e61b6c59309cf699d3f..ee27a553b426d3e1e1317bbeb39a3c2d46520e59 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileVersion.java
++++ b/src/main/java/net/minecraft/world/level/chunk/storage/RegionFileVersion.java
+@@ -30,6 +30,17 @@ public class RegionFileVersion {
+     }, (stream) -> {
+         return stream;
+     }));
++
++    // Paper Start - Configurable region compression format
++    public static RegionFileVersion getCompressionFormat() {
++        return switch (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.compressionFormat) {
++            case GZIP -> VERSION_GZIP;
++            case ZLIB -> VERSION_DEFLATE;
++            case NONE -> VERSION_NONE;
++        };
++    }
++    // Paper End
++
+     private final int id;
+     private final RegionFileVersion.StreamWrapper<InputStream> inputWrapper;
+     private final RegionFileVersion.StreamWrapper<OutputStream> outputWrapper;


### PR DESCRIPTION
Adds a configuration option to save region files without any compression, this is useful for any servers which wish to use compression at the file system level.

Minecraft already has the ability to save and load region files without compression, however the ability to save isn't used, and this adds a config option to enable that. As Minecraft supports regions saved this way, the worlds saved using this option remain compatible with an unmodified client / server.