### PR TITLE
[ci skip] Update checkout action in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
                 java: [17]
             fail-fast: true
         steps:
-            - uses: actions/checkout@v2.5.0
+            - uses: actions/checkout@v3
             - name: JDK ${{ matrix.java }}
               uses: actions/setup-java@v3.6.0
               with:


### PR DESCRIPTION
This is a continuation of https://github.com/PaperMC/Paper/pull/8489 because not sure why... the docs about checkout show the last version 2.5 but the examples show 3.. and in v3 the depreaction things are fixed... sorry for not notice this in the last PR...