### PR TITLE
Make CommandSyntaxException implement ComponentMessageThrowable

### DIFF
--- a/patches/server/0297-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0297-Implement-Brigadier-Mojang-API.patch
@@ -21,6 +21,31 @@ index 6dbac0f93481256dd57e76630ae9eea9d5c56849..e260462933a9f7065b2360e6bf9e4ee5
      // Paper start
      implementation("org.jline:jline-terminal-jansi:3.21.0")
      implementation("net.minecrell:terminalconsoleappender:1.3.0")
+diff --git a/src/main/java/com/mojang/brigadier/exceptions/CommandSyntaxException.java b/src/main/java/com/mojang/brigadier/exceptions/CommandSyntaxException.java
+index 3370731ee064d2693b972a0765c13dd4fd69f66a..614eba6cc55d1eb7755cac35c671cb6f6cacca13 100644
+--- a/src/main/java/com/mojang/brigadier/exceptions/CommandSyntaxException.java
++++ b/src/main/java/com/mojang/brigadier/exceptions/CommandSyntaxException.java
+@@ -5,7 +5,7 @@ package com.mojang.brigadier.exceptions;
+ 
+ import com.mojang.brigadier.Message;
+ 
+-public class CommandSyntaxException extends Exception {
++public class CommandSyntaxException extends Exception implements net.kyori.adventure.util.ComponentMessageThrowable { // Paper
+     public static final int CONTEXT_AMOUNT = 10;
+     public static boolean ENABLE_COMMAND_STACK_TRACES = true;
+     public static BuiltInExceptionProvider BUILT_IN_EXCEPTIONS = new BuiltInExceptions();
+@@ -73,4 +73,11 @@ public class CommandSyntaxException extends Exception {
+     public int getCursor() {
+         return cursor;
+     }
++
++    // Paper start
++    @Override
++    public @org.jetbrains.annotations.Nullable net.kyori.adventure.text.Component componentMessage() {
++        return io.papermc.paper.brigadier.PaperBrigadier.componentFromMessage(this.message);
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/com/mojang/brigadier/tree/CommandNode.java b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
 index da6250df1c5f3385b683cffde47754bca4606f5e..3384501f83d445f45aa8233e98c7597daa67b8ef 100644
 --- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java


### PR DESCRIPTION
This simplifies command exception handling when writing platform-agnostic code that only depends on adventure