### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -3435,11 +3435,11 @@ index 03bfca9d368bbe4b7c1353d52c883e756bf69bda..943d324435350d3f16fad3e21cb472a0
  
      /**
 diff --git a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
-index 92941af574945936c3714718ed3eea23697c99df..5b8a7b897d9f9d8df3705eef36388f41be4531a6 100644
+index cf13380b23b70edb73b5879397b64b24a1088729..77173e1ca3ce972632608c620aa1a2fffed27e04 100644
 --- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
 +++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
-@@ -22,15 +22,16 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
-     private static final HandlerList handlers = new HandlerList();
+@@ -23,7 +23,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+     private final String hostname;
      private final InetAddress address;
      private final boolean shouldSendChatPreviews;
 -    private String motd;
@@ -3447,35 +3447,40 @@ index 92941af574945936c3714718ed3eea23697c99df..5b8a7b897d9f9d8df3705eef36388f41
      private final int numPlayers;
      private int maxPlayers;
  
-+    @Deprecated // Paper
-     public ServerListPingEvent(@NotNull final InetAddress address, @NotNull final String motd, final boolean shouldSendChatPreviews, final int numPlayers, final int maxPlayers) {
-         super(true);
+@@ -37,7 +37,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
          Preconditions.checkArgument(numPlayers >= 0, "Cannot have negative number of players online", numPlayers);
+         this.hostname = hostname;
          this.address = address;
 -        this.motd = motd;
 +        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd); // Paper
          this.shouldSendChatPreviews = shouldSendChatPreviews;
          this.numPlayers = numPlayers;
          this.maxPlayers = maxPlayers;
-@@ -45,15 +46,61 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+@@ -58,16 +58,83 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
       * @param motd the message of the day
       * @param shouldSendChatPreviews if the server should send chat previews
       * @param maxPlayers the max number of players
-+     * @deprecated in favour of {@link #ServerListPingEvent(java.net.InetAddress, net.kyori.adventure.text.Component, boolean, int)}
++     * @deprecated in favour of {@link #ServerListPingEvent(String, java.net.InetAddress, net.kyori.adventure.text.Component, boolean, int)}
       */
 +    @Deprecated // Paper
-     protected ServerListPingEvent(@NotNull final InetAddress address, @NotNull final String motd, boolean shouldSendChatPreviews, final int maxPlayers) {
+     protected ServerListPingEvent(@NotNull final String hostname, @NotNull final InetAddress address, @NotNull final String motd, boolean shouldSendChatPreviews, final int maxPlayers) {
          super(true);
          this.numPlayers = MAGIC_PLAYER_COUNT;
+         this.hostname = hostname;
          this.address = address;
 +        this.motd = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(motd); // Paper
 +        this.shouldSendChatPreviews = shouldSendChatPreviews;
 +        this.maxPlayers = maxPlayers;
 +    }
 +    // Paper start
++    @Deprecated
 +    public ServerListPingEvent(@NotNull final InetAddress address, @NotNull final net.kyori.adventure.text.Component motd, boolean shouldSendChatPreviews, final int numPlayers, final int maxPlayers) {
++        this("", address, motd, shouldSendChatPreviews, numPlayers, maxPlayers);
++    }
++    public ServerListPingEvent(@NotNull final String hostname, @NotNull final InetAddress address, @NotNull final net.kyori.adventure.text.Component motd, boolean shouldSendChatPreviews, final int numPlayers, final int maxPlayers) {
 +        super(true);
 +        Preconditions.checkArgument(numPlayers >= 0, "Cannot have negative number of players online (%s)", numPlayers);
++        this.hostname = hostname;
 +        this.address = address;
          this.motd = motd;
          this.shouldSendChatPreviews = shouldSendChatPreviews;
@@ -3490,10 +3495,26 @@ index 92941af574945936c3714718ed3eea23697c99df..5b8a7b897d9f9d8df3705eef36388f41
 +     * @param address the address of the pinger
 +     * @param motd the message of the day
 +     * @param maxPlayers the max number of players
++     * @deprecated in favour of {@link #ServerListPingEvent(String, java.net.InetAddress, net.kyori.adventure.text.Component, boolean, int)}
 +     */
++    @Deprecated
 +    protected ServerListPingEvent(@NotNull final InetAddress address, @NotNull final net.kyori.adventure.text.Component motd, boolean shouldSendChatPreviews, final int maxPlayers) {
-+        super(true);
++        this("", address, motd, shouldSendChatPreviews, maxPlayers);
++    }
++
++    /**
++     * This constructor is intended for implementations that provide the
++     * {@link #iterator()} method, thus provided the {@link #getNumPlayers()}
++     * count.
++     *
++     * @param hostname The hostname that was used to connect to the server
++     * @param address the address of the pinger
++     * @param motd the message of the day
++     * @param maxPlayers the max number of players
++     */
++    protected ServerListPingEvent(final @NotNull String hostname, final @NotNull InetAddress address, final @NotNull net.kyori.adventure.text.Component motd, final boolean shouldSendChatPreviews, final int maxPlayers) {
 +        this.numPlayers = MAGIC_PLAYER_COUNT;
++        this.hostname = hostname;
 +        this.address = address;
 +        this.motd = motd;
 +        this.shouldSendChatPreviews = shouldSendChatPreviews;
@@ -3518,8 +3539,8 @@ index 92941af574945936c3714718ed3eea23697c99df..5b8a7b897d9f9d8df3705eef36388f41
 +    // Paper end
  
      /**
-      * Get the address the ping is coming from.
-@@ -69,19 +116,23 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+      * Gets the hostname that the player used to connect to the server, or
+@@ -94,19 +161,23 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
       * Get the message of the day message.
       *
       * @return the message of the day

--- a/patches/server/0009-Adventure.patch
+++ b/patches/server/0009-Adventure.patch
@@ -1893,7 +1893,7 @@ index 762a9392ffac3042356709dddd15bb3516048bed..3544e2dc2522e9d6305d727d56e73490
          buf.writeComponent(this.footer);
      }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 805a1773d55e2551911e5b8e69052e23f630359b..e4220f14a5ebf43dd3491fc8649c2be5238c5798 100644
+index d7ece1ae4e9c97935de96eafd6d22cded1f8aa42..77cb412656e741fdb7e002011e3a99ac304118cb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -229,6 +229,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -2237,10 +2237,10 @@ index f63ade8d99295ce9d001aae6f5228a7374e16438..93d02b5de0721e3c5903e80bbf8b3b56
              }
              // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 4fe70fee37685c3011e8212d6d47fee19da87824..bcf189d0ae917b99fff62167740ddb0012082138 100644
+index e497ac6821887c0b884b8cbdb383698404b8f198..5d2687d3f73529fd45011c011710e2386ff17c82 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -363,7 +363,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -362,7 +362,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
                          if (PlayerPreLoginEvent.getHandlerList().getRegisteredListeners().length != 0) {
                              final PlayerPreLoginEvent event = new PlayerPreLoginEvent(playerName, address, uniqueId);
                              if (asyncEvent.getResult() != PlayerPreLoginEvent.Result.ALLOWED) {
@@ -2249,7 +2249,7 @@ index 4fe70fee37685c3011e8212d6d47fee19da87824..bcf189d0ae917b99fff62167740ddb00
                              }
                              Waitable<PlayerPreLoginEvent.Result> waitable = new Waitable<PlayerPreLoginEvent.Result>() {
                                  @Override
-@@ -374,12 +374,12 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -373,12 +373,12 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
  
                              ServerLoginPacketListenerImpl.this.server.processQueue.add(waitable);
                              if (waitable.get() != PlayerPreLoginEvent.Result.ALLOWED) {
@@ -2265,20 +2265,20 @@ index 4fe70fee37685c3011e8212d6d47fee19da87824..bcf189d0ae917b99fff62167740ddb00
                              }
                          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
-index 3a587073dbe5e8a599d342c5f758d842b7b6cddb..a426adfba3fccf1815177e0b8065684c9497ef45 100644
+index ab1204dc71db31c567126fd49ab06a35703f95fc..3d187753790d31cdf1ec0351f2003128f0efce34 100644
 --- a/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
 @@ -54,7 +54,7 @@ public class ServerStatusPacketListenerImpl implements ServerStatusPacketListene
                  CraftIconCache icon = server.server.getServerIcon();
  
                  ServerListPingEvent() {
--                    super(((InetSocketAddress) ServerStatusPacketListenerImpl.this.connection.getRemoteAddress()).getAddress(), ServerStatusPacketListenerImpl.this.server.getMotd(), ServerStatusPacketListenerImpl.this.server.previewsChat(), ServerStatusPacketListenerImpl.this.server.getPlayerList().getMaxPlayers());
-+                    super(((InetSocketAddress) ServerStatusPacketListenerImpl.this.connection.getRemoteAddress()).getAddress(), ServerStatusPacketListenerImpl.this.server.server.getMotd(), ServerStatusPacketListenerImpl.this.server.previewsChat(), ServerStatusPacketListenerImpl.this.server.getPlayerList().getMaxPlayers()); // Paper - Adventure
+-                    super(connection.hostname, ((InetSocketAddress) ServerStatusPacketListenerImpl.this.connection.getRemoteAddress()).getAddress(), ServerStatusPacketListenerImpl.this.server.getMotd(), ServerStatusPacketListenerImpl.this.server.previewsChat(), ServerStatusPacketListenerImpl.this.server.getPlayerList().getMaxPlayers());
++                    super(connection.hostname, ((InetSocketAddress) ServerStatusPacketListenerImpl.this.connection.getRemoteAddress()).getAddress(), ServerStatusPacketListenerImpl.this.server.server.motd(), ServerStatusPacketListenerImpl.this.server.previewsChat(), ServerStatusPacketListenerImpl.this.server.getPlayerList().getMaxPlayers()); // Paper - Adventure
                  }
  
                  @Override
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 474843e57028ade5ef36ac5cda4924dbd95f6fe4..3710f544a491a837b973daedc2dfa51357b70b56 100644
+index efbfa3f82bd19bfe09a483306d97464e1782a0ab..8246a78e4e01ee24db88660351bc0f27a6f320aa 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -8,6 +8,7 @@ import com.mojang.logging.LogUtils;
@@ -2691,7 +2691,7 @@ index 4dd952faac05f553b28d1252296b0587369865f4..6139a06453e370865889f47644a6840f
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6d9469d577dcbb9d5b5b703cf47c8863e0b43b13..9a6820b10e4164cc38d269853b5c2a49175cb890 100644
+index 452bd97c699261623bf504ee3a177f8f4df97d11..e3d0a82387dfdcf65f1b07fd8ae2132be6e6d18f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -150,6 +150,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -3650,10 +3650,10 @@ index 984dd8d3ce4da655f3f239aa5982eccba48c6de5..2766f670f7bbe03c23552eb2ccf71d63
          return event;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
-index e2711a189bcaffc0f79d903f0696d87b0de116fe..9531a11e63b4c5beeebabc45e4a40d5d39f05c7a 100644
+index cd407b122cbe52d3b5cbf76b9b1931b640e4866f..2371f17230358806f05e284f6aca341f18e935c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
-@@ -69,6 +69,13 @@ public class CraftContainer extends AbstractContainerMenu {
+@@ -68,6 +68,13 @@ public class CraftContainer extends AbstractContainerMenu {
                  return inventory.getType();
              }
  

--- a/patches/server/0016-Rewrite-chunk-system.patch
+++ b/patches/server/0016-Rewrite-chunk-system.patch
@@ -12645,13 +12645,13 @@ index 0000000000000000000000000000000000000000..f597d65d56964297eeeed6c7e7770376
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 9b96d05094c3b83f6388d479fdca8800453ccd1d..b5b10c57401e1b27175b1960839a81382d89b73f 100644
+index 2dbaf078e99e3663bd2dbdd3548468192382fae5..463d54c6c808808d3d7fe6d5303be48844bb4444 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -89,6 +89,28 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
-     private float averageSentPackets;
+@@ -90,6 +90,28 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      private int tickCount;
      private boolean handlingFault;
+     public String hostname = ""; // CraftBukkit - add field
 +    // Paper start - add pending task queue
 +    private final Queue<Runnable> pendingTasks = new java.util.concurrent.ConcurrentLinkedQueue<>();
 +    public void execute(final Runnable run) {
@@ -12677,7 +12677,7 @@ index 9b96d05094c3b83f6388d479fdca8800453ccd1d..b5b10c57401e1b27175b1960839a8138
  
      public Connection(PacketFlow side) {
          this.receiving = side;
-@@ -247,6 +269,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -248,6 +270,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      }
  
      private void flushQueue() {
@@ -12685,7 +12685,7 @@ index 9b96d05094c3b83f6388d479fdca8800453ccd1d..b5b10c57401e1b27175b1960839a8138
          if (this.channel != null && this.channel.isOpen()) {
              Queue queue = this.queue;
  
-@@ -259,6 +282,12 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -260,6 +283,12 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
  
              }
          }
@@ -15936,7 +15936,7 @@ index 4e7db441f68019d6e5d3359605b76bc4b258e87e..22c095539425a6667b8e7f5c5f0a8ff2
          StringReader stringreader = new StringReader(packet.getCommand());
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index e7fcb402e3d4e0707a28505a9fb6642764034e23..3235d6f98794709a53208e20ef33f2164725be48 100644
+index 5f85d48fbd0ce34c21acec4849ad3efcc73c7210..e56635fe18e6264c8813834d3eb435ea6e4fffc9 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -245,7 +245,7 @@ public abstract class PlayerList {

--- a/patches/server/0088-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
+++ b/patches/server/0088-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add handshake event to allow plugins to handle client
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index eb94a7a156df1616f8093bf2f082de3754917086..9016aced079108aeae09f030a672467a953ef93f 100644
+index 5948138f3697c0cce9638524a0f481eb368da911..8284d49c8e30645d00be952c847bab7ce5753d78 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-@@ -87,9 +87,36 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
+@@ -88,9 +88,36 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
                      this.connection.disconnect(ichatmutablecomponent);
                  } else {
                      this.connection.setListener(new ServerLoginPacketListenerImpl(this.server, this.connection));

--- a/patches/server/0111-Cache-user-authenticator-threads.patch
+++ b/patches/server/0111-Cache-user-authenticator-threads.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Cache user authenticator threads
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index bcf189d0ae917b99fff62167740ddb0012082138..11031f47c019c2004bbd366ba6864d15eea4cf03 100644
+index 5d2687d3f73529fd45011c011710e2386ff17c82..9011b43dbf28f1f19809c1b45898b727d679c12f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -118,6 +118,8 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -117,6 +117,8 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
  
      }
  
@@ -17,7 +17,7 @@ index bcf189d0ae917b99fff62167740ddb0012082138..11031f47c019c2004bbd366ba6864d15
      // Spigot start
      public void initUUID()
      {
-@@ -242,8 +244,8 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -241,8 +243,8 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
                  this.connection.send(new ClientboundHelloPacket("", this.server.getKeyPair().getPublic().getEncoded(), this.nonce));
              } else {
                  // Spigot start
@@ -28,7 +28,7 @@ index bcf189d0ae917b99fff62167740ddb0012082138..11031f47c019c2004bbd366ba6864d15
                      @Override
                      public void run() {
                          try {
-@@ -254,7 +256,8 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -253,7 +255,8 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
                              server.server.getLogger().log(java.util.logging.Level.WARNING, "Exception verifying " + ServerLoginPacketListenerImpl.this.gameProfile.getName(), ex);
                          }
                      }
@@ -38,7 +38,7 @@ index bcf189d0ae917b99fff62167740ddb0012082138..11031f47c019c2004bbd366ba6864d15
                  // Spigot end
              }
  
-@@ -297,7 +300,8 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -296,7 +299,8 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
              throw new IllegalStateException("Protocol error", cryptographyexception);
          }
  
@@ -48,7 +48,7 @@ index bcf189d0ae917b99fff62167740ddb0012082138..11031f47c019c2004bbd366ba6864d15
              public void run() {
                  GameProfile gameprofile = ServerLoginPacketListenerImpl.this.gameProfile;
  
-@@ -342,10 +346,8 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -341,10 +345,8 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
  
                  return ServerLoginPacketListenerImpl.this.server.getPreventProxyConnections() && socketaddress instanceof InetSocketAddress ? ((InetSocketAddress) socketaddress).getAddress() : null;
              }

--- a/patches/server/0145-Block-player-logins-during-server-shutdown.patch
+++ b/patches/server/0145-Block-player-logins-during-server-shutdown.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Block player logins during server shutdown
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 71581c619d369d443908ed475d9a4d2d6ef07e5c..0de44db53089216f864da372238017f3ee310af9 100644
+index 9011b43dbf28f1f19809c1b45898b727d679c12f..187692ea25983195a0fe14a7dc070fd33acb0037 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -77,6 +77,12 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -76,6 +76,12 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
  
      @Override
      public void tick() {

--- a/patches/server/0155-Allow-specifying-a-custom-authentication-servers-dow.patch
+++ b/patches/server/0155-Allow-specifying-a-custom-authentication-servers-dow.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow specifying a custom "authentication servers down" kick
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 0de44db53089216f864da372238017f3ee310af9..c37a1b25638dba2b4964f73e821d989302ad415a 100644
+index 187692ea25983195a0fe14a7dc070fd33acb0037..1cbcee5b2cebe9f2c2ede3d7628ace6452a480f0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -334,7 +334,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -333,7 +333,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
                          ServerLoginPacketListenerImpl.this.gameProfile = gameprofile;
                          ServerLoginPacketListenerImpl.this.state = ServerLoginPacketListenerImpl.State.READY_TO_ACCEPT;
                      } else {

--- a/patches/server/0160-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/server/0160-Expose-client-protocol-version-and-virtual-host.patch
@@ -60,10 +60,10 @@ index 0000000000000000000000000000000000000000..a5a7624f1f372a26b982836cd31cff15
 +
 +}
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index b5b10c57401e1b27175b1960839a81382d89b73f..9f4d21b3316c1faebc043fda711b0a9d0411dfff 100644
+index 463d54c6c808808d3d7fe6d5303be48844bb4444..8774d3f1a1b0019751e515ad94c85ba2f11e80c7 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -111,6 +111,10 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -112,6 +112,10 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
          }
      }
      // Paper end - add pending task queue
@@ -75,7 +75,7 @@ index b5b10c57401e1b27175b1960839a81382d89b73f..9f4d21b3316c1faebc043fda711b0a9d
      public Connection(PacketFlow side) {
          this.receiving = side;
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index 9016aced079108aeae09f030a672467a953ef93f..4170bda451df3db43e7d57d87d1abb81934d7dad 100644
+index 8284d49c8e30645d00be952c847bab7ce5753d78..a738b79e775a0a4abed1a05e12495d85f3de14bb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 @@ -154,6 +154,10 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
@@ -90,7 +90,7 @@ index 9016aced079108aeae09f030a672467a953ef93f..4170bda451df3db43e7d57d87d1abb81
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 843764d27c490e94bcf2becdafb15e5f1a68bc92..dd86f2055af67f35a5d265b78e99b12e7b7926ad 100644
+index 87c8e494aa374b8bfb8b8432723783b00ba94763..6dd5deecd404a3b9858e63da6837caf2d5d382f0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -299,6 +299,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0164-Prevent-logins-from-being-processed-when-the-player-.patch
+++ b/patches/server/0164-Prevent-logins-from-being-processed-when-the-player-.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent logins from being processed when the player has
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index c37a1b25638dba2b4964f73e821d989302ad415a..f97552c5e62124cab00301daee2fd41069fb802c 100644
+index 1cbcee5b2cebe9f2c2ede3d7628ace6452a480f0..07784c0e6eea2a4a91f1453e937e14a4a1faedf5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -84,7 +84,11 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -83,7 +83,11 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
          }
          // Paper end
          if (this.state == ServerLoginPacketListenerImpl.State.READY_TO_ACCEPT) {

--- a/patches/server/0180-Disable-Explicit-Network-Manager-Flushing.patch
+++ b/patches/server/0180-Disable-Explicit-Network-Manager-Flushing.patch
@@ -12,10 +12,10 @@ flushing on the netty event loop, so it won't do the flush on the main thread.
 Renable flushing by passing -Dpaper.explicit-flush=true
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 9f4d21b3316c1faebc043fda711b0a9d0411dfff..7d85817a0a041c2fa257396d1508488bfc7da55b 100644
+index 8774d3f1a1b0019751e515ad94c85ba2f11e80c7..a31820cb543f3e72e461c91b3191b56b18fb33dd 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -114,6 +114,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -115,6 +115,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      // Paper start - NetworkClient implementation
      public int protocolVersion;
      public java.net.InetSocketAddress virtualHost;
@@ -23,7 +23,7 @@ index 9f4d21b3316c1faebc043fda711b0a9d0411dfff..7d85817a0a041c2fa257396d1508488b
      // Paper end
  
      public Connection(PacketFlow side) {
-@@ -309,7 +310,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -310,7 +311,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
          }
  
          if (this.channel != null) {

--- a/patches/server/0182-Ability-to-change-PlayerProfile-in-AsyncPreLoginEven.patch
+++ b/patches/server/0182-Ability-to-change-PlayerProfile-in-AsyncPreLoginEven.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ability to change PlayerProfile in AsyncPreLoginEvent
 This will allow you to change the players name or skin on login.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index f97552c5e62124cab00301daee2fd41069fb802c..9a7fe61d7de80eaf044c202e1ed13d9e4b59622a 100644
+index 07784c0e6eea2a4a91f1453e937e14a4a1faedf5..4627d2a785120c6e69fc3c82054bf0703fe5477b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -369,8 +369,16 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -368,8 +368,16 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
                          java.util.UUID uniqueId = ServerLoginPacketListenerImpl.this.gameProfile.getId();
                          final org.bukkit.craftbukkit.CraftServer server = ServerLoginPacketListenerImpl.this.server.server;
  

--- a/patches/server/0183-Player.setPlayerProfile-API.patch
+++ b/patches/server/0183-Player.setPlayerProfile-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 9a7fe61d7de80eaf044c202e1ed13d9e4b59622a..ef09f5f42a89f767060f015af27269ad496d08c7 100644
+index 4627d2a785120c6e69fc3c82054bf0703fe5477b..3a20c6e2214ad075e4cdd3fbdf0b59e1891b0f2b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -370,11 +370,11 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -369,11 +369,11 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
                          final org.bukkit.craftbukkit.CraftServer server = ServerLoginPacketListenerImpl.this.server.server;
  
                          // Paper start
@@ -24,7 +24,7 @@ index 9a7fe61d7de80eaf044c202e1ed13d9e4b59622a..ef09f5f42a89f767060f015af27269ad
                          playerName = gameProfile.getName();
                          uniqueId = gameProfile.getId();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9f959cbb6e8685dacccec1d8df68d4a8a94ab81e..aadc01662c07ab99466babc8f5ed5b3bef2c1a8e 100644
+index a08c03bb984d27ded2979353f207693fb79d4256..88f12c573ed26dbf83f61679bbee4f0fbf566a08 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -79,6 +79,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;

--- a/patches/server/0265-Configurable-connection-throttle-kick-message.patch
+++ b/patches/server/0265-Configurable-connection-throttle-kick-message.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable connection throttle kick message
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index 4170bda451df3db43e7d57d87d1abb81934d7dad..43759cdf3da0796d7969c6504ac9a6986c0f0518 100644
+index a738b79e775a0a4abed1a05e12495d85f3de14bb..34e4d00ede62be50808a2782e54da987cc62c9af 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-@@ -49,7 +49,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
+@@ -50,7 +50,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
                      synchronized (ServerHandshakePacketListenerImpl.throttleTracker) {
                          if (ServerHandshakePacketListenerImpl.throttleTracker.containsKey(address) && !"127.0.0.1".equals(address.getHostAddress()) && currentTime - ServerHandshakePacketListenerImpl.throttleTracker.get(address) < connectionThrottle) {
                              ServerHandshakePacketListenerImpl.throttleTracker.put(address, currentTime);

--- a/patches/server/0280-Restore-custom-InventoryHolder-support.patch
+++ b/patches/server/0280-Restore-custom-InventoryHolder-support.patch
@@ -157,10 +157,10 @@ index 0000000000000000000000000000000000000000..224d4b2cc45b0d02230a76caee9c8857
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
-index 9531a11e63b4c5beeebabc45e4a40d5d39f05c7a..a2eeaad280569c9ab2c02d2885611db50462bf2b 100644
+index 2371f17230358806f05e284f6aca341f18e935c5..567449faf1a5d805c44b5a2685904e919f20ade8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
-@@ -72,13 +72,13 @@ public class CraftContainer extends AbstractContainerMenu {
+@@ -71,13 +71,13 @@ public class CraftContainer extends AbstractContainerMenu {
              // Paper start
              @Override
              public net.kyori.adventure.text.Component title() {
@@ -176,7 +176,7 @@ index 9531a11e63b4c5beeebabc45e4a40d5d39f05c7a..a2eeaad280569c9ab2c02d2885611db5
              }
          }, player, id);
      }
-@@ -230,6 +230,10 @@ public class CraftContainer extends AbstractContainerMenu {
+@@ -227,6 +227,10 @@ public class CraftContainer extends AbstractContainerMenu {
              this.lastSlots = delegate.lastSlots;
              this.slots = delegate.slots;
              this.remoteSlots = delegate.remoteSlots;

--- a/patches/server/0286-Handle-Large-Packets-disconnecting-client.patch
+++ b/patches/server/0286-Handle-Large-Packets-disconnecting-client.patch
@@ -7,10 +7,10 @@ If a players inventory is too big to send in a single packet,
 split the inventory set into multiple packets instead.
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 7d85817a0a041c2fa257396d1508488bfc7da55b..870badca869aca1ad293542b345a038ddf715135 100644
+index a31820cb543f3e72e461c91b3191b56b18fb33dd..0e739c0c54eaad5ab8dddcd8294c9ccaa3697fbf 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -148,6 +148,15 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -149,6 +149,15 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      }
  
      public void exceptionCaught(ChannelHandlerContext channelhandlercontext, Throwable throwable) {

--- a/patches/server/0290-Add-PlayerConnectionCloseEvent.patch
+++ b/patches/server/0290-Add-PlayerConnectionCloseEvent.patch
@@ -34,10 +34,10 @@ how PlayerPreLoginEvent interacts with PlayerConnectionCloseEvent
 is undefined.
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 870badca869aca1ad293542b345a038ddf715135..dd9c03611e410e601ba4a7769474fada8c28c104 100644
+index 0e739c0c54eaad5ab8dddcd8294c9ccaa3697fbf..8b1c39cc7f77ca36d0341fb68de1441cc61f19e4 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -468,6 +468,26 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -469,6 +469,26 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
                      this.getPacketListener().onDisconnect(Component.translatable("multiplayer.disconnect.generic"));
                  }
                  this.queue.clear(); // Free up packet queue.

--- a/patches/server/0301-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
+++ b/patches/server/0301-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
@@ -28,10 +28,10 @@ and then catch exceptions and close if they fire.
 Part of this commit was authored by: Spottedleaf
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index dd9c03611e410e601ba4a7769474fada8c28c104..be571be69b5c3df41531b6c8c7be467afaa4dc55 100644
+index 8b1c39cc7f77ca36d0341fb68de1441cc61f19e4..593ea68037b467797aeeaee331a0349f7d57d800 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -115,6 +115,10 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -116,6 +116,10 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      public int protocolVersion;
      public java.net.InetSocketAddress virtualHost;
      private static boolean enableExplicitFlush = Boolean.getBoolean("paper.explicit-flush");
@@ -42,7 +42,7 @@ index dd9c03611e410e601ba4a7769474fada8c28c104..be571be69b5c3df41531b6c8c7be467a
      // Paper end
  
      public Connection(PacketFlow side) {
-@@ -138,6 +142,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -139,6 +143,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      }
  
      public void setProtocol(ConnectionProtocol state) {
@@ -50,7 +50,7 @@ index dd9c03611e410e601ba4a7769474fada8c28c104..be571be69b5c3df41531b6c8c7be467a
          this.channel.attr(Connection.ATTRIBUTE_PROTOCOL).set(state);
          this.channel.config().setAutoRead(true);
          Connection.LOGGER.debug("Enabled auto read");
-@@ -216,19 +221,89 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -217,19 +222,89 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
          Validate.notNull(listener, "packetListener", new Object[0]);
          this.packetListener = listener;
      }
@@ -144,7 +144,7 @@ index dd9c03611e410e601ba4a7769474fada8c28c104..be571be69b5c3df41531b6c8c7be467a
      }
  
      private void sendPacket(Packet<?> packet, @Nullable PacketSendListener callbacks) {
-@@ -256,6 +331,15 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -257,6 +332,15 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
              this.setProtocol(packetState);
          }
  
@@ -160,7 +160,7 @@ index dd9c03611e410e601ba4a7769474fada8c28c104..be571be69b5c3df41531b6c8c7be467a
          ChannelFuture channelfuture = this.channel.writeAndFlush(packet);
  
          if (callbacks != null) {
-@@ -274,28 +358,64 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -275,28 +359,64 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
  
              });
          }
@@ -235,7 +235,7 @@ index dd9c03611e410e601ba4a7769474fada8c28c104..be571be69b5c3df41531b6c8c7be467a
          } finally { // Paper start - add pending task queue
              Runnable r;
              while ((r = this.pendingTasks.poll()) != null) {
-@@ -303,6 +423,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -304,6 +424,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
              }
          } // Paper end - add pending task queue
      }
@@ -243,7 +243,7 @@ index dd9c03611e410e601ba4a7769474fada8c28c104..be571be69b5c3df41531b6c8c7be467a
  
      public void tick() {
          this.flushQueue();
-@@ -339,9 +460,22 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -340,9 +461,22 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
          return this.address;
      }
  
@@ -266,7 +266,7 @@ index dd9c03611e410e601ba4a7769474fada8c28c104..be571be69b5c3df41531b6c8c7be467a
          // Spigot End
          if (this.channel.isOpen()) {
              this.channel.close(); // We can't wait as this may be called from an event loop.
-@@ -459,7 +593,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -460,7 +594,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      public void handleDisconnection() {
          if (this.channel != null && !this.channel.isOpen()) {
              if (this.disconnectionHandled) {
@@ -275,7 +275,7 @@ index dd9c03611e410e601ba4a7769474fada8c28c104..be571be69b5c3df41531b6c8c7be467a
              } else {
                  this.disconnectionHandled = true;
                  if (this.getDisconnectedReason() != null) {
-@@ -467,7 +601,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -468,7 +602,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
                  } else if (this.getPacketListener() != null) {
                      this.getPacketListener().onDisconnect(Component.translatable("multiplayer.disconnect.generic"));
                  }

--- a/patches/server/0326-Fix-MC-158900.patch
+++ b/patches/server/0326-Fix-MC-158900.patch
@@ -7,12 +7,12 @@ The problem was we were checking isExpired() on the entry, but if it
 was expired at that point, then it would be null.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index d8c936b6b242d6ad2ca63ab98a4a111fed402241..6e585b79bf2eccc6bfc98d7cdc05efea699d4e2f 100644
+index f77bbe5ebd3fd93ec6cf92a049b585178c7583d8..d1da13e361c4898420e9d6ab8a9c48cb29ae65bf 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -612,8 +612,10 @@ public abstract class PlayerList {
          Player player = entity.getBukkitEntity();
-         PlayerLoginEvent event = new PlayerLoginEvent(player, hostname, ((java.net.InetSocketAddress) socketaddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.connection.getRawAddress()).getAddress());
+         PlayerLoginEvent event = new PlayerLoginEvent(player, loginlistener.connection.hostname, ((java.net.InetSocketAddress) socketaddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.connection.getRawAddress()).getAddress());
  
 -        if (this.getBans().isBanned(gameprofile) && !this.getBans().get(gameprofile).hasExpired()) {
 -            UserBanListEntry gameprofilebanentry = (UserBanListEntry) this.bans.get(gameprofile);

--- a/patches/server/0387-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0387-Load-Chunks-for-Login-Asynchronously.patch
@@ -25,7 +25,7 @@ index 7cc21dab89dcb50ee4034e1e39b6a27478fd983b..652d30ce735aa265db848ca73a48d7b0
      // Add env and gen to constructor, IWorldDataServer -> WorldDataServer
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, PrimaryLevelData iworlddataserver, ResourceKey<Level> resourcekey, LevelStem worlddimension, ChunkProgressListener worldloadlistener, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3008e1cce4df86150dec87cca0433676033d4f73..fdc1d1d5840ee7f12e4a72656698924c51fea05c 100644
+index b886e52e7b316df6415cdaee75242a829e491dd4..84edbb30158b8ea7771b6fb33a660d9229e6b4a5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -182,6 +182,7 @@ public class ServerPlayer extends Player {
@@ -81,10 +81,10 @@ index 3af9f2d86cf2a9566e22865689101245647d05a5..fe722106e20e199eb914a09f8dbc1409
          this.server.getProfiler().push("keepAlive");
          // Paper Start - give clients a longer time to respond to pings as per pre 1.12.2 timings
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 6fd0e5a97d0ed9155b12dac94c075e1225a22e93..c16cb8ebe28987f1630fe659dfa437264bd236e1 100644
+index 3a20c6e2214ad075e4cdd3fbdf0b59e1891b0f2b..42cdb2c70f6b906d27c4b1409df92f7459bf2c1b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -90,7 +90,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -89,7 +89,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
              }
              // Paper end
          } else if (this.state == ServerLoginPacketListenerImpl.State.DELAY_ACCEPT) {
@@ -93,7 +93,7 @@ index 6fd0e5a97d0ed9155b12dac94c075e1225a22e93..c16cb8ebe28987f1630fe659dfa43726
  
              if (entityplayer == null) {
                  this.state = ServerLoginPacketListenerImpl.State.READY_TO_ACCEPT;
-@@ -189,7 +189,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -188,7 +188,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
              }
  
              this.connection.send(new ClientboundGameProfilePacket(this.gameProfile));
@@ -103,7 +103,7 @@ index 6fd0e5a97d0ed9155b12dac94c075e1225a22e93..c16cb8ebe28987f1630fe659dfa43726
              try {
                  ServerPlayer entityplayer1 = this.server.getPlayerList().getPlayerForLogin(this.gameProfile, s); // CraftBukkit - add player reference
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 36aef2836246a33b879b3da3e988539f8615efc5..f5705346debdc940e5b5b3b54a140e3dc0228cb0 100644
+index 6cc70d6eb84fb819fb7f1b8b1ef1bbb4715315e5..1ec5facab133f265b280738afe9917592384984e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -139,6 +139,7 @@ public abstract class PlayerList {

--- a/patches/server/0398-misc-debugging-dumps.patch
+++ b/patches/server/0398-misc-debugging-dumps.patch
@@ -29,7 +29,7 @@ index 0000000000000000000000000000000000000000..2d5494d2813b773e60ddba6790b750a9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1205d5f7d2bee68f6b3cd8e2ccbcd3d056963d8e..b3231076683e5a63602ff1293765c5d76c36bfef 100644
+index c5ecf010fff3af1c9b4ebf24ca80fb6b19afccfc..7c7114193fadc6c14d6d8a87cc2d734eaa68b864 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -881,6 +881,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -58,10 +58,10 @@ index 1205d5f7d2bee68f6b3cd8e2ccbcd3d056963d8e..b3231076683e5a63602ff1293765c5d7
          this.running = false;
          if (flag) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index c16cb8ebe28987f1630fe659dfa437264bd236e1..4d501687f46722f2dcb51a8715a0be9ca4905d5f 100644
+index 42cdb2c70f6b906d27c4b1409df92f7459bf2c1b..930da83ff754bab6b6b6fff651df417baa76c46f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -203,6 +203,11 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -202,6 +202,11 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
              } catch (Exception exception) {
                  ServerLoginPacketListenerImpl.LOGGER.error("Couldn't place player in world", exception);
                  MutableComponent ichatmutablecomponent = Component.translatable("multiplayer.disconnect.invalid_player_data");
@@ -74,7 +74,7 @@ index c16cb8ebe28987f1630fe659dfa437264bd236e1..4d501687f46722f2dcb51a8715a0be9c
                  this.connection.send(new ClientboundDisconnectPacket(ichatmutablecomponent));
                  this.connection.disconnect(ichatmutablecomponent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 30199124d6c1a394fa074a221d6015c09acdd43a..9cf007fae9aa21897a06de783357f5e14f6004a0 100644
+index 86402126b13e5e6542f880cbdc978eb581d33a8a..8d4388df7e62016df262e377e5f75cc44e17e284 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1002,6 +1002,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0400-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0400-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -507,7 +507,7 @@ index f114d5dab86aa2cdd59c78406c9d82f9caededca..99fa9f1952ee7ed79b223ff210a658e4
          }
      }
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index a283cce82069bf5dfd64229d102a19dfda158daf..8f74a505087cae01520fcfaad833c73215de8036 100644
+index 593ea68037b467797aeeaee331a0349f7d57d800..bbedcdb71a326b3286805d0081e71c54a4312622 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -62,13 +62,13 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -527,7 +527,7 @@ index a283cce82069bf5dfd64229d102a19dfda158daf..8f74a505087cae01520fcfaad833c732
      });
      private final PacketFlow receiving;
      private final Queue<Connection.PacketHolder> queue = Queues.newConcurrentLinkedQueue();
-@@ -192,7 +192,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -193,7 +193,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
  
              }
          }
@@ -537,7 +537,7 @@ index a283cce82069bf5dfd64229d102a19dfda158daf..8f74a505087cae01520fcfaad833c732
  
      protected void channelRead0(ChannelHandlerContext channelhandlercontext, Packet<?> packet) {
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index abfcba1c3db090563191e8adea6d8250ae2d138e..487991163f12c1ded3f5d35a718aa89b1fb9278f 100644
+index 6fba140877e7369cdb7933ec225572c6b153e3a8..e3a62579067209c447f2fdcb76b2a11e489a376b 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -200,6 +200,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -549,7 +549,7 @@ index abfcba1c3db090563191e8adea6d8250ae2d138e..487991163f12c1ded3f5d35a718aa89b
          paperConfigurations.initializeWorldDefaultsConfiguration();
          org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash);
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c0e17bbf04723da76ea6952d9558dd4d34b00f6c..8cc266e25d25d154158b36e456804ac80a47364e 100644
+index 652d30ce735aa265db848ca73a48d7b0b143103b..35439d857801d56494cc457d116fbcbb12561bcd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -218,7 +218,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -590,10 +590,10 @@ index a24ef433d0c9d06b86fd612978cfd6d877036791..1b38326c9a709536dc4cccf9af93aede
      final MinecraftServer server;
      public volatile boolean running;
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 4d501687f46722f2dcb51a8715a0be9ca4905d5f..059cee21b636dcdda34def41309fea026aeafeb0 100644
+index 930da83ff754bab6b6b6fff651df417baa76c46f..c3027735725c68eeb1b42a42ebb8646f3a35a518 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -205,7 +205,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -204,7 +204,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
                  MutableComponent ichatmutablecomponent = Component.translatable("multiplayer.disconnect.invalid_player_data");
                  // Paper start
                  if (MinecraftServer.getServer().isDebugging()) {
@@ -625,7 +625,7 @@ index 6599f874d9f97e9ef4862039ecad7277bbc5fd91..7edd4b88eb0476f0630630bc4681e859
                              }
                         }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 941bd6c43d3de9e5c947c2b7a3f42388c3fea25a..07eeea03796cd6330a9788ef357cf307a02b4ace 100644
+index 7e1f0c9f760d6f5cfb0138542252c8469534e152..623046a5a0ba36619d43d8e55cfee3c06d09b62b 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -640,7 +640,7 @@ public class LevelChunk extends ChunkAccess {

--- a/patches/server/0472-Buffer-joins-to-world.patch
+++ b/patches/server/0472-Buffer-joins-to-world.patch
@@ -8,10 +8,10 @@ the world per tick, this attempts to reduce the impact that join floods
 has on the server
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index b8e35f493458ba9e072953dffe6b2429f1d821ec..c1a59f54f537395bebf6d78459beef3013ea67d9 100644
+index bbedcdb71a326b3286805d0081e71c54a4312622..22e2e314a4bb1b22758130d4e9065f9b87b0116e 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -425,8 +425,23 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -426,8 +426,23 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      }
      // Paper end
  

--- a/patches/server/0474-Fix-hex-colors-not-working-in-some-kick-messages.patch
+++ b/patches/server/0474-Fix-hex-colors-not-working-in-some-kick-messages.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix hex colors not working in some kick messages
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index 43759cdf3da0796d7969c6504ac9a6986c0f0518..750fef0f5b908b776a7306e54653eba497b7c50b 100644
+index 34e4d00ede62be50808a2782e54da987cc62c9af..e12c67bdfa326b3f52f6a4973063cef44359b804 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-@@ -75,12 +75,12 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
+@@ -76,12 +76,12 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
                  }
                  // CraftBukkit end
                  if (packet.getProtocolVersion() != SharedConstants.getCurrentVersion().getProtocolVersion()) {
@@ -25,10 +25,10 @@ index 43759cdf3da0796d7969c6504ac9a6986c0f0518..750fef0f5b908b776a7306e54653eba4
  
                      this.connection.send(new ClientboundLoginDisconnectPacket(ichatmutablecomponent));
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 4d501687f46722f2dcb51a8715a0be9ca4905d5f..8a2fdfb701ec663310c8f3f86607b6df1f2e01a4 100644
+index c3027735725c68eeb1b42a42ebb8646f3a35a518..8eec59b01b8366a0ee8c926d9bf77b22a8d75cb7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -108,7 +108,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -107,7 +107,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
      // CraftBukkit start
      @Deprecated
      public void disconnect(String s) {

--- a/patches/server/0508-Add-API-for-quit-reason.patch
+++ b/patches/server/0508-Add-API-for-quit-reason.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add API for quit reason
 
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index c1a59f54f537395bebf6d78459beef3013ea67d9..b8167dc1f37153deb237fbb77f89091d6a25094a 100644
+index 22e2e314a4bb1b22758130d4e9065f9b87b0116e..de1fdb93e0e3acd58429b042629df8c00bfb65ad 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -169,12 +169,15 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -170,12 +170,15 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
  
              this.handlingFault = true;
              if (this.channel.isOpen()) {
@@ -25,7 +25,7 @@ index c1a59f54f537395bebf6d78459beef3013ea67d9..b8167dc1f37153deb237fbb77f89091d
                          Connection.LOGGER.debug("Failed to sent packet", throwable);
                          ConnectionProtocol enumprotocol = this.getCurrentProtocol();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 02bb4ecdc6797d1c5bccc64cc235fe63bdc7ccd4..26caa90f9a7ffd1b8576b9de74476b681e13d429 100644
+index b39bb4b5a1612dac7d495f22e5ab3ec5fb00a058..c841cfba25d6f448fec929b3ca9653775d3e0ac9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -266,6 +266,7 @@ public class ServerPlayer extends Player {
@@ -49,7 +49,7 @@ index 3d7d23a02e4aceb95ec36fbca9d02294f08c5780..8e12c4d4b54c2f0a265dc627d7981282
              this.connection.disconnect(ichatbasecomponent);
          }));
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4d05d23f5b6967da29d5c9c91931cd79745f5dcb..8c7c0e9c972f81d458124d5b067b3c547ef87f6d 100644
+index fcd2f8514e60e1faafec787f162baf98663fb734..90559afc3533778d5cf43b04a83a0b6cd20796ac 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -607,7 +607,7 @@ public abstract class PlayerList {

--- a/patches/server/0602-Add-bypass-host-check.patch
+++ b/patches/server/0602-Add-bypass-host-check.patch
@@ -8,7 +8,7 @@ Paper.bypassHostCheck
 Seriously, fix your firewalls. -.-
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index 750fef0f5b908b776a7306e54653eba497b7c50b..53833fdd748098b662d4420a254401c0d3982e56 100644
+index e12c67bdfa326b3f52f6a4973063cef44359b804..bce2f0f66f9e5493184fd0b5d2758e136a0e05b5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 @@ -29,6 +29,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
@@ -19,7 +19,7 @@ index 750fef0f5b908b776a7306e54653eba497b7c50b..53833fdd748098b662d4420a254401c0
  
      public ServerHandshakePacketListenerImpl(MinecraftServer server, Connection connection) {
          this.server = server;
-@@ -117,7 +118,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
+@@ -118,7 +119,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
                      if (!handledByEvent && proxyLogicEnabled) {
                          // Paper end
                      // if (org.spigotmc.SpigotConfig.bungee) { // Paper - comment out, we check above!

--- a/patches/server/0617-Add-Channel-initialization-listeners.patch
+++ b/patches/server/0617-Add-Channel-initialization-listeners.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..0d7e7db9e37ef0183c32b217bd944fb4
 +    COMPRESSION_DISABLED
 +}
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index b8167dc1f37153deb237fbb77f89091d6a25094a..13213bbc9ca5ca20c3eb8a6744dc3204c8c1e423 100644
+index de1fdb93e0e3acd58429b042629df8c00bfb65ad..13d33cd159eca63c98d7239f527c444c71519634 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -596,6 +596,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -597,6 +597,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
              } else {
                  this.channel.pipeline().addBefore("encoder", "compress", new CompressionEncoder(compressionThreshold));
              }
@@ -133,7 +133,7 @@ index b8167dc1f37153deb237fbb77f89091d6a25094a..13213bbc9ca5ca20c3eb8a6744dc3204
          } else {
              if (this.channel.pipeline().get("decompress") instanceof CompressionDecoder) {
                  this.channel.pipeline().remove("decompress");
-@@ -604,6 +605,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -605,6 +606,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
              if (this.channel.pipeline().get("compress") instanceof CompressionEncoder) {
                  this.channel.pipeline().remove("compress");
              }

--- a/patches/server/0622-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/server/0622-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add raw address to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 8a2fdfb701ec663310c8f3f86607b6df1f2e01a4..fdd64b7bf24314a0d01444f0b074019b2031efdc 100644
+index 8eec59b01b8366a0ee8c926d9bf77b22a8d75cb7..fa469313d4b38bd9441b3010743e1054420bd525 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -371,12 +371,13 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -370,12 +370,13 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
          public void fireEvents() throws Exception {
                          String playerName = ServerLoginPacketListenerImpl.this.gameProfile.getName();
                          java.net.InetAddress address = ((java.net.InetSocketAddress) ServerLoginPacketListenerImpl.this.connection.getRemoteAddress()).getAddress();

--- a/patches/server/0635-Add-Unix-domain-socket-support.patch
+++ b/patches/server/0635-Add-Unix-domain-socket-support.patch
@@ -11,10 +11,10 @@ Tested-by: Mariell Hoversholm <proximyst@proximyst.com>
 Reviewed-by: Mariell Hoversholm <proximyst@proximyst.com>
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 13213bbc9ca5ca20c3eb8a6744dc3204c8c1e423..2f38d04b369b345c89f85cee32081df8baf4239f 100644
+index 13d33cd159eca63c98d7239f527c444c71519634..7bece5bd90d8f372ead5aef473f077a2a1ef9fa2 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -670,6 +670,11 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -671,6 +671,11 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      // Spigot Start
      public SocketAddress getRawAddress()
      {
@@ -27,7 +27,7 @@ index 13213bbc9ca5ca20c3eb8a6744dc3204c8c1e423..2f38d04b369b345c89f85cee32081df8
      }
      // Spigot End
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 3e600ee2d5370c2ad9c445af15f350dee21248c1..6b40e5659923d74438efaeb846732cb4efbf3f1b 100644
+index e11d90ca94e9ec34f4593cf0dde2f5853bef7ae5..7dba8ef3291987cc428cd337693c3446d01e435b 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -224,6 +224,20 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -107,10 +107,10 @@ index 83af90fb0dcb4b1a5a68f655cf66d101b472e8e7..b80aedd2002959b4026c27ce76b3ed17
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index 53833fdd748098b662d4420a254401c0d3982e56..b02cbf6bcc57167a1373925f652950e0212dfa4f 100644
+index bce2f0f66f9e5493184fd0b5d2758e136a0e05b5..446a5fb08691a45a54bed3b5e7e68842f21e60d0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-@@ -43,6 +43,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
+@@ -44,6 +44,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
                  this.connection.setProtocol(ConnectionProtocol.LOGIN);
                  // CraftBukkit start - Connection throttle
                  try {
@@ -118,7 +118,7 @@ index 53833fdd748098b662d4420a254401c0d3982e56..b02cbf6bcc57167a1373925f652950e0
                      long currentTime = System.currentTimeMillis();
                      long connectionThrottle = this.server.server.getConnectionThrottle();
                      InetAddress address = ((java.net.InetSocketAddress) this.connection.getRemoteAddress()).getAddress();
-@@ -71,6 +72,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
+@@ -72,6 +73,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
                              }
                          }
                      }
@@ -126,7 +126,7 @@ index 53833fdd748098b662d4420a254401c0d3982e56..b02cbf6bcc57167a1373925f652950e0
                  } catch (Throwable t) {
                      org.apache.logging.log4j.LogManager.getLogger().debug("Failed to check connection throttle", t);
                  }
-@@ -119,8 +121,11 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
+@@ -120,8 +122,11 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
                          // Paper end
                      // if (org.spigotmc.SpigotConfig.bungee) { // Paper - comment out, we check above!
                          if ( ( split.length == 3 || split.length == 4 ) && ( ServerHandshakePacketListenerImpl.BYPASS_HOSTCHECK || ServerHandshakePacketListenerImpl.HOST_PATTERN.matcher( split[1] ).matches() ) ) { // Paper

--- a/patches/server/0665-Fix-incorrect-message-for-outdated-client.patch
+++ b/patches/server/0665-Fix-incorrect-message-for-outdated-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix incorrect message for outdated client
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index b02cbf6bcc57167a1373925f652950e0212dfa4f..08b21f5a7a07f44f8044f56991fb6723cd8f3eea 100644
+index 446a5fb08691a45a54bed3b5e7e68842f21e60d0..e7ff7ad3bf4dd17fdd34202ec3aef8e9512bc36d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-@@ -80,7 +80,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
+@@ -81,7 +81,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL
                  if (packet.getProtocolVersion() != SharedConstants.getCurrentVersion().getProtocolVersion()) {
                      Component ichatmutablecomponent; // Paper - Fix hex colors not working in some kick messages
  

--- a/patches/server/0710-Allow-controlled-flushing-for-network-manager.patch
+++ b/patches/server/0710-Allow-controlled-flushing-for-network-manager.patch
@@ -9,10 +9,10 @@ This patch will be used to optimise out flush calls in later
 patches.
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 02cab94e208303a738adebaffe5929703d8bf0b3..af5d81778bf0dd3f227d64faeb814f2b234e7332 100644
+index 7bece5bd90d8f372ead5aef473f077a2a1ef9fa2..a71db5b49b1e6a094790d060db9f30a711581db0 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -121,6 +121,39 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -122,6 +122,39 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      public ConnectionProtocol protocol;
      // Paper end
  
@@ -52,7 +52,7 @@ index 02cab94e208303a738adebaffe5929703d8bf0b3..af5d81778bf0dd3f227d64faeb814f2b
      public Connection(PacketFlow side) {
          this.receiving = side;
      }
-@@ -286,7 +319,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -287,7 +320,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
              io.papermc.paper.util.MCUtil.isMainThread() && packet.isReady() && this.queue.isEmpty() &&
              (packet.getExtraPackets() == null || packet.getExtraPackets().isEmpty())
          ))) {
@@ -61,7 +61,7 @@ index 02cab94e208303a738adebaffe5929703d8bf0b3..af5d81778bf0dd3f227d64faeb814f2b
              return;
          }
          // write the packets to the queue, then flush - antixray hooks there already
-@@ -310,6 +343,14 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -311,6 +344,14 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      }
  
      private void sendPacket(Packet<?> packet, @Nullable PacketSendListener callbacks) {
@@ -76,7 +76,7 @@ index 02cab94e208303a738adebaffe5929703d8bf0b3..af5d81778bf0dd3f227d64faeb814f2b
          ConnectionProtocol enumprotocol = ConnectionProtocol.getProtocolForPacket(packet);
          ConnectionProtocol enumprotocol1 = this.getCurrentProtocol();
  
-@@ -320,16 +361,21 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -321,16 +362,21 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
          }
  
          if (this.channel.eventLoop().inEventLoop()) {
@@ -100,7 +100,7 @@ index 02cab94e208303a738adebaffe5929703d8bf0b3..af5d81778bf0dd3f227d64faeb814f2b
          if (packetState != currentState) {
              this.setProtocol(packetState);
          }
-@@ -343,7 +389,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -344,7 +390,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
  
          try {
              // Paper end
@@ -109,7 +109,7 @@ index 02cab94e208303a738adebaffe5929703d8bf0b3..af5d81778bf0dd3f227d64faeb814f2b
  
          if (callbacks != null) {
              channelfuture.addListener((future) -> {
-@@ -399,6 +445,10 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -400,6 +446,10 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      private boolean processQueue() {
          try { // Paper - add pending task queue
          if (this.queue.isEmpty()) return true;
@@ -120,7 +120,7 @@ index 02cab94e208303a738adebaffe5929703d8bf0b3..af5d81778bf0dd3f227d64faeb814f2b
          // If we are on main, we are safe here in that nothing else should be processing queue off main anymore
          // But if we are not on main due to login/status, the parent is synchronized on packetQueue
          java.util.Iterator<PacketHolder> iterator = this.queue.iterator();
-@@ -406,16 +456,22 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -407,16 +457,22 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
              PacketHolder queued = iterator.next(); // poll -> peek
  
              // Fix NPE (Spigot bug caused by handleDisconnection())

--- a/patches/server/0716-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0716-Detail-more-information-in-watchdog-dumps.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Detail more information in watchdog dumps
 - Dump player name, player uuid, position, and world for packet handling
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 0e8f731943af38e832200f4450fadeb80cb8ae74..6e5c483650e0c6742fa86cfcf52cfbcac7c7dbce 100644
+index a71db5b49b1e6a094790d060db9f30a711581db0..489ab7c7a66969501e60fbd44c16ba4cdc180d46 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -504,9 +504,15 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -505,9 +505,15 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
          PacketListener packetlistener = this.packetListener;
  
          if (packetlistener instanceof TickablePacketListener) {
@@ -78,7 +78,7 @@ index acfa1907bfc9c29d261cfccc00d65bad9ad1a002..d6f3869f5725c7f081efb7f486f74dbb
              });
              throw RunningOnDifferentThreadException.RUNNING_ON_DIFFERENT_THREAD;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index ced278aef7c5e883a04255974a8428743a6f5168..b8ede677ae35a30c19e7a5e2afa72319ef02c9ac 100644
+index 0577b370e0b3696d45836e6765edfdbccefd9e8b..b3c482f221dcaec62b0961e05da77d7e46e0420c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1041,7 +1041,26 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -124,7 +124,7 @@ index ced278aef7c5e883a04255974a8428743a6f5168..b8ede677ae35a30c19e7a5e2afa72319
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 27b42e8305a4aa3a3d99b73be441af9687da70a5..b1e1b8f9717d2a5a61485b843d3fde05012272ec 100644
+index dcbbf53b23a9347470986f052ecba0149d7503aa..8d342290a9ed81b20260e2e4f7262e03332464b1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -971,7 +971,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {

--- a/patches/server/0721-Add-packet-limiter-config.patch
+++ b/patches/server/0721-Add-packet-limiter-config.patch
@@ -24,10 +24,10 @@ and an action can be defined: DROP or KICK
 If interval or rate are less-than 0, the limit is ignored
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 9c0c181013d419d1a74f86b5d8cecf83b28925c6..335d9e5f11ad3469f3a0310782e41283973f5a5f 100644
+index 489ab7c7a66969501e60fbd44c16ba4cdc180d46..28e91d015cf0034cd7ca952440fd4f915c34d489 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -153,6 +153,22 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -154,6 +154,22 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
          }
      }
      // Paper end - allow controlled flushing
@@ -50,7 +50,7 @@ index 9c0c181013d419d1a74f86b5d8cecf83b28925c6..335d9e5f11ad3469f3a0310782e41283
  
      public Connection(PacketFlow side) {
          this.receiving = side;
-@@ -233,6 +249,45 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -234,6 +250,45 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
  
      protected void channelRead0(ChannelHandlerContext channelhandlercontext, Packet<?> packet) {
          if (this.channel.isOpen()) {

--- a/patches/server/0732-Optimise-non-flush-packet-sending.patch
+++ b/patches/server/0732-Optimise-non-flush-packet-sending.patch
@@ -20,7 +20,7 @@ up on this optimisation before he came along.
 Locally this patch drops the entity tracker tick by a full 1.5x.
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 335d9e5f11ad3469f3a0310782e41283973f5a5f..957fc22a6c79fd480fefc3cce9cc374d25bc8cf9 100644
+index 28e91d015cf0034cd7ca952440fd4f915c34d489..08b74302e99e596a99f142856ae33ee29a9b1b77 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -46,6 +46,8 @@ import org.slf4j.Logger;
@@ -32,7 +32,7 @@ index 335d9e5f11ad3469f3a0310782e41283973f5a5f..957fc22a6c79fd480fefc3cce9cc374d
  public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
  
      private static final float AVERAGE_PACKETS_SMOOTHING = 0.75F;
-@@ -418,9 +420,19 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -419,9 +421,19 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
          if (this.channel.eventLoop().inEventLoop()) {
              this.doSendPacket(packet, callbacks, enumprotocol, enumprotocol1, flush); // Paper
          } else {

--- a/patches/server/0735-Use-Velocity-compression-and-cipher-natives.patch
+++ b/patches/server/0735-Use-Velocity-compression-and-cipher-natives.patch
@@ -268,10 +268,10 @@ index 792883afe53d2b7989c25a81c2f9a639d5e21d20..c04379ca8a4db0f4de46ad2b3b338431
          return this.threshold;
      }
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 957fc22a6c79fd480fefc3cce9cc374d25bc8cf9..6967c90c50ea75fb9dd5da808b2c8c8ea046ecec 100644
+index 08b74302e99e596a99f142856ae33ee29a9b1b77..69b8d1276045cd6742770dcedd6246bb1713fd3b 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
-@@ -681,11 +681,28 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -682,11 +682,28 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
          return networkmanager;
      }
  
@@ -304,7 +304,7 @@ index 957fc22a6c79fd480fefc3cce9cc374d25bc8cf9..6967c90c50ea75fb9dd5da808b2c8c8e
  
      public boolean isEncrypted() {
          return this.encrypted;
-@@ -714,16 +731,17 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -715,16 +732,17 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
  
      public void setupCompression(int compressionThreshold, boolean rejectsBadPackets) {
          if (compressionThreshold >= 0) {
@@ -341,10 +341,10 @@ index b80aedd2002959b4026c27ce76b3ed17f0acfb5b..2985271132c9ae822dcb0d7a7e6f0c26
                  protected void initChannel(Channel channel) {
                      try {
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index fdd64b7bf24314a0d01444f0b074019b2031efdc..2bbf4096ec6c992a0369964efdd1375ae11b62d4 100644
+index fa469313d4b38bd9441b3010743e1054420bd525..7d7d7336eea6db6505b57198cca2b03960fb1ec0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -305,12 +305,14 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -304,12 +304,14 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
              }
  
              SecretKey secretkey = packet.getSecretKey(privatekey);

--- a/patches/server/0753-Add-config-option-for-logging-player-ip-addresses.patch
+++ b/patches/server/0753-Add-config-option-for-logging-player-ip-addresses.patch
@@ -49,10 +49,10 @@ index 2985271132c9ae822dcb0d7a7e6f0c268d1736cc..cfdbcd024de6ad0f9d4e83b2f912b36e
  
                              networkmanager.send(new ClientboundDisconnectPacket(ichatmutablecomponent), PacketSendListener.thenRun(() -> {
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 2bbf4096ec6c992a0369964efdd1375ae11b62d4..b87bd1c2d3a371e2fca1d0bff6d0985188b22584 100644
+index 7d7d7336eea6db6505b57198cca2b03960fb1ec0..e8d3f455a1a08606568079a3811e2b3ed9d666c7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -226,7 +226,10 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -225,7 +225,10 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
      }
  
      public String getUserName() {
@@ -65,7 +65,7 @@ index 2bbf4096ec6c992a0369964efdd1375ae11b62d4..b87bd1c2d3a371e2fca1d0bff6d09851
  
      @Nullable
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 456031783aa902c8fd40050aa2b8d051b996d71d..3e870218321a701b814a4dac97ff1af12142600e 100644
+index eedcccde859d39fada71122488ea019cc7405e27..279b7953638d1400072bd153dc3d0c63efdf9035 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -243,7 +243,7 @@ public abstract class PlayerList {

--- a/patches/server/0765-Fix-Spigot-growth-modifiers.patch
+++ b/patches/server/0765-Fix-Spigot-growth-modifiers.patch
@@ -7,8 +7,6 @@ Fixes kelp modifier changing growth for other crops
 Also add growth modifiers for glow berries
 Also fix above-mentioned modifiers from having the reverse effect
 
-Fixes an issue with the pumpkin speed modifier not being applied correctly
-
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 
@@ -59,19 +57,6 @@ index 4e30917fbc5c539fefc8dc391b902241f7c5ad35..b7517d1e8a5d5eb719de5eda424b7dd2
      protected BlockState getGrowIntoState(BlockState state, RandomSource random) {
          return (BlockState) state.cycle(GrowingPlantHeadBlock.AGE);
      }
-diff --git a/src/main/java/net/minecraft/world/level/block/StemBlock.java b/src/main/java/net/minecraft/world/level/block/StemBlock.java
-index 809f4927f9c27195f1cdc9138f217d475079379b..2fed3979201d944e1d96f2d8d2197ea09fb76001 100644
---- a/src/main/java/net/minecraft/world/level/block/StemBlock.java
-+++ b/src/main/java/net/minecraft/world/level/block/StemBlock.java
-@@ -52,7 +52,7 @@ public class StemBlock extends BushBlock implements BonemealableBlock {
-         if (world.getRawBrightness(pos, 0) >= 9) {
-             float f = CropBlock.getGrowthSpeed(this, world, pos);
- 
--            if (random.nextFloat() < (this == Blocks.PUMPKIN_STEM ? world.spigotConfig.pumpkinModifier : world.spigotConfig.melonModifier / (100.0f * (Math.floor((25.0F / f) + 1))))) { // Spigot - SPIGOT-7159: Better modifier resolution
-+            if (random.nextFloat() < ((this == Blocks.PUMPKIN_STEM ? world.spigotConfig.pumpkinModifier : world.spigotConfig.melonModifier) / (100.0f * (Math.floor((25.0F / f) + 1))))) { // Spigot - SPIGOT-7159: Better modifier resolution // Paper
-                 int i = (Integer) state.getValue(StemBlock.AGE);
- 
-                 if (i < 7) {
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 index 102b038e2566cba4f259a61e502ff0808c47234c..6bcc46795d1f78746192cc107c4a1f61580ec3c5 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java

--- a/patches/server/0790-Validate-usernames.patch
+++ b/patches/server/0790-Validate-usernames.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] Validate usernames
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index dd599443c7197868eaa0708b4be26f1a341ce4e4..82b55548d4652ec0c25d3dc6da628573a9c9000a 100644
+index e8d3f455a1a08606568079a3811e2b3ed9d666c7..d6fa1fb3e06a3712b1910990d5b706187c12b51a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -66,6 +66,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -65,6 +65,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+     private ServerPlayer delayedAcceptPlayer;
      @Nullable
      private ProfilePublicKey.Data profilePublicKeyData;
-     public String hostname = ""; // CraftBukkit - add field
 +    public boolean iKnowThisMayNotBeTheBestIdeaButPleaseDisableUsernameValidation = false; // Paper - username validation overriding
  
      public ServerLoginPacketListenerImpl(MinecraftServer server, Connection connection) {
          this.state = ServerLoginPacketListenerImpl.State.HELLO;
-@@ -245,10 +246,38 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -244,10 +245,38 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
          }
      }
  
@@ -56,7 +56,7 @@ index dd599443c7197868eaa0708b4be26f1a341ce4e4..82b55548d4652ec0c25d3dc6da628573
          GameProfile gameprofile = this.server.getSingleplayerProfile();
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4277f7fdd8f27e57708a8dee59bf1b9052a1ebe4..133bf27e301aa5815cc7d7e275b2b08cdc6e4392 100644
+index 870a48360dd35c190171f1302393f325f0db6692..10a4b9b2a954fc5d86ebf3f643cdc940911e7693 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -714,7 +714,7 @@ public abstract class PlayerList {

--- a/patches/server/0798-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/server/0798-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
@@ -5,15 +5,15 @@ Subject: [PATCH] Added getHostname to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 82b55548d4652ec0c25d3dc6da628573a9c9000a..62a404871650ff5caffcd9c6c83046abeefff49d 100644
+index d6fa1fb3e06a3712b1910990d5b706187c12b51a..96e33103773ae2b8807a6c0a6daac95c35c18bda 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -411,7 +411,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -410,7 +410,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
  
                          // Paper start
                          com.destroystokyo.paper.profile.PlayerProfile profile = com.destroystokyo.paper.profile.CraftPlayerProfile.asBukkitMirror(ServerLoginPacketListenerImpl.this.gameProfile);
 -                        AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, rawAddress, uniqueId, profile); // Paper - add rawAddress
-+                        AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, rawAddress, uniqueId, profile, ServerLoginPacketListenerImpl.this.hostname); // Paper - add rawAddress & hostname
++                        AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, rawAddress, uniqueId, profile, ServerLoginPacketListenerImpl.this.connection.hostname); // Paper - add rawAddress & hostname
                          server.getPluginManager().callEvent(asyncEvent);
                          profile = asyncEvent.getPlayerProfile();
                          profile.complete(true); // Paper - setPlayerProfileAPI

--- a/patches/server/0894-Remove-invalid-signature-login-stacktrace.patch
+++ b/patches/server/0894-Remove-invalid-signature-login-stacktrace.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove invalid signature login stacktrace
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 62a404871650ff5caffcd9c6c83046abeefff49d..cb761c4d87eded85a80996e6894b731381b7516c 100644
+index d3051a26f37a9022e9429b0cf949969bdc031b56..67e04be8d37af83e7a4bccfb780082e237983a60 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -167,7 +167,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -166,7 +166,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
  
                  profilepublickey = ServerLoginPacketListenerImpl.validatePublicKey(this.profilePublicKeyData, this.gameProfile.getId(), signaturevalidator, this.server.enforceSecureProfile());
              } catch (ProfilePublicKey.ValidationException profilepublickey_b) {

--- a/patches/server/0897-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0897-Add-Velocity-IP-Forwarding-Support.patch
@@ -94,18 +94,18 @@ index 0000000000000000000000000000000000000000..5de2dabbc076a9482b1d6c299f1cff74
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index cb761c4d87eded85a80996e6894b731381b7516c..18a8bf9a26c7aa2b73bc696ebb54846643262e25 100644
+index 67e04be8d37af83e7a4bccfb780082e237983a60..6f7d807f75ac3c069c47a5e698239180de1f4ea7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-@@ -67,6 +67,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -66,6 +66,7 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+     @Nullable
      private ProfilePublicKey.Data profilePublicKeyData;
-     public String hostname = ""; // CraftBukkit - add field
      public boolean iKnowThisMayNotBeTheBestIdeaButPleaseDisableUsernameValidation = false; // Paper - username validation overriding
 +    private int velocityLoginMessageId = -1; // Paper - Velocity support
  
      public ServerLoginPacketListenerImpl(MinecraftServer server, Connection connection) {
          this.state = ServerLoginPacketListenerImpl.State.HELLO;
-@@ -290,6 +291,16 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -289,6 +290,16 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
                  this.state = ServerLoginPacketListenerImpl.State.KEY;
                  this.connection.send(new ClientboundHelloPacket("", this.server.getKeyPair().getPublic().getEncoded(), this.nonce));
              } else {
@@ -122,7 +122,7 @@ index cb761c4d87eded85a80996e6894b731381b7516c..18a8bf9a26c7aa2b73bc696ebb548466
                  // Spigot start
              // Paper start - Cache authenticator threads
              authenticatorPool.execute(new Runnable() {
-@@ -403,6 +414,12 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -402,6 +413,12 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
      public class LoginHandler {
  
          public void fireEvents() throws Exception {
@@ -135,7 +135,7 @@ index cb761c4d87eded85a80996e6894b731381b7516c..18a8bf9a26c7aa2b73bc696ebb548466
                          String playerName = ServerLoginPacketListenerImpl.this.gameProfile.getName();
                          java.net.InetAddress address = ((java.net.InetSocketAddress) ServerLoginPacketListenerImpl.this.connection.getRemoteAddress()).getAddress();
                          java.net.InetAddress rawAddress = ((java.net.InetSocketAddress) connection.getRawAddress()).getAddress(); // Paper
-@@ -451,6 +468,60 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
+@@ -450,6 +467,60 @@ public class ServerLoginPacketListenerImpl implements TickablePacketListener, Se
      // Spigot end
  
      public void handleCustomQueryPacket(ServerboundCustomQueryPacket packet) {
@@ -197,7 +197,7 @@ index cb761c4d87eded85a80996e6894b731381b7516c..18a8bf9a26c7aa2b73bc696ebb548466
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 10f4e8067c21d4a0aa5f121bffe56c45c00e5d62..111f8276f26350a5c62a7b8577b4598978b5355d 100644
+index 1cec39362b6f9f23c8e6c8b45f5fd254c8e08efe..4212568bf8de6988c71f43d3e2152fa0fe51d0d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -784,7 +784,7 @@ public final class CraftServer implements Server {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
9a4de097 SPIGOT-7171: Ability to get the IP/hostname players are requesting status of

CraftBukkit Changes:
f43634ae4 SPIGOT-7170: Cannot set slots in custom smithing inventory
48f3a2258 SPIGOT-7171: Ability to get the IP/hostname players are requesting status of
30e31b4d1 SPIGOT-7177: Certain blocks don't call BlockCanBuildEvent
982364797 SPIGOT-7174: Avoid adding air to CraftMetaBundle

Spigot Changes:
6198b5ae PR-122: Add missing parentheses to pumpkin and melon growth modifier
1aec3fc1 Rebuild patches