### PR TITLE
Fix pumpkin growth modifier

### DIFF
--- a/patches/server/0765-Fix-Spigot-growth-modifiers.patch
+++ b/patches/server/0765-Fix-Spigot-growth-modifiers.patch
@@ -1,14 +1,16 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 Date: Fri, 3 Dec 2021 17:09:24 -0800
-Subject: [PATCH] Fix kelp modifier changing growth for other crops
+Subject: [PATCH] Fix Spigot growth modifiers
 
-Also add growth modifiers for twisting vines, weeping vines, cave vines,
-and glow berries
-
+Fixes kelp modifier changing growth for other crops
+Also add growth modifiers for glow berries
 Also fix above-mentioned modifiers from having the reverse effect
 
+Fixes an issue with the pumpkin speed modifier not being applied correctly
+
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
+Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java b/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java
 index 7d9056f9d841fbbdeaf1e323d818f2f1267b47e8..4940e101250874111e9c55aeb5b87b28602246f0 100644
@@ -57,6 +59,19 @@ index 4e30917fbc5c539fefc8dc391b902241f7c5ad35..b7517d1e8a5d5eb719de5eda424b7dd2
      protected BlockState getGrowIntoState(BlockState state, RandomSource random) {
          return (BlockState) state.cycle(GrowingPlantHeadBlock.AGE);
      }
+diff --git a/src/main/java/net/minecraft/world/level/block/StemBlock.java b/src/main/java/net/minecraft/world/level/block/StemBlock.java
+index 809f4927f9c27195f1cdc9138f217d475079379b..2fed3979201d944e1d96f2d8d2197ea09fb76001 100644
+--- a/src/main/java/net/minecraft/world/level/block/StemBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/StemBlock.java
+@@ -52,7 +52,7 @@ public class StemBlock extends BushBlock implements BonemealableBlock {
+         if (world.getRawBrightness(pos, 0) >= 9) {
+             float f = CropBlock.getGrowthSpeed(this, world, pos);
+ 
+-            if (random.nextFloat() < (this == Blocks.PUMPKIN_STEM ? world.spigotConfig.pumpkinModifier : world.spigotConfig.melonModifier / (100.0f * (Math.floor((25.0F / f) + 1))))) { // Spigot - SPIGOT-7159: Better modifier resolution
++            if (random.nextFloat() < ((this == Blocks.PUMPKIN_STEM ? world.spigotConfig.pumpkinModifier : world.spigotConfig.melonModifier) / (100.0f * (Math.floor((25.0F / f) + 1))))) { // Spigot - SPIGOT-7159: Better modifier resolution // Paper
+                 int i = (Integer) state.getValue(StemBlock.AGE);
+ 
+                 if (i < 7) {
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 index 102b038e2566cba4f259a61e502ff0808c47234c..6bcc46795d1f78746192cc107c4a1f61580ec3c5 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java


### PR DESCRIPTION
Had a player report an issue where pumpkins grow insanely quickly. After a quick look at the recent [upstream commit](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/spigot/commits/89741d3e9ff89cb2aa3b2e34a714a3a073b60d95) changing some stuff related to growth modifiers, I noticed they messed up their operation order, causing the division to only apply to the melon modifier (and thus causing way too large values for pumpkins).