### PR TITLE
[ci-skip] Rename Paper stop to Paper end.

### DIFF
--- a/patches/api/0369-More-Projectile-API.patch
+++ b/patches/api/0369-More-Projectile-API.patch
@@ -150,7 +150,7 @@ index 0d31aa0b22cf1e849572294e2cfe38b48c9210af..571712e17551f24b369044b8215b722f
 +     * @param ticks ticks to detonate on
 +     */
 +    void setTicksToDetonate(int ticks);
-+    // Paper stop
++    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/FishHook.java b/src/main/java/org/bukkit/entity/FishHook.java
 index d1b37530319f6d37ee37f62080289c1e45848bc8..e94c7e279356c510f60508b26277d4891a4258fa 100644


### PR DESCRIPTION
Uh My friend had just found `// Paper end` in the file to be modified is just mistyped to `// Paper stop`.
It seems that it is a standard for patched minecraft server and `// Paper stop` just broke this standard.
I have retyped it back.
Not intensively tested on my computer. I don't think changing a comment would break anything.