### PR TITLE
Fix OfflinePlayer#getPlayerProfile returning deprecated type

### DIFF
--- a/patches/server/0183-Player.setPlayerProfile-API.patch
+++ b/patches/server/0183-Player.setPlayerProfile-API.patch
@@ -26,6 +26,21 @@ index bb5c4ecd43aa344dfe9cca8ab7c2ebf9760e94cf..203786383387765d1f5a2d2ccce79d79
                          gameProfile = com.destroystokyo.paper.profile.CraftPlayerProfile.asAuthlibCopy(profile);
                          playerName = gameProfile.getName();
                          uniqueId = gameProfile.getId();
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+index e7442952ef1f03969949014492a7ddc6d0796ba5..69a1852905dd4724c30ac8ab88c14251eee2c371 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+@@ -76,8 +76,8 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
+     }
+ 
+     @Override
+-    public PlayerProfile getPlayerProfile() {
+-        return new CraftPlayerProfile(this.profile);
++    public com.destroystokyo.paper.profile.PlayerProfile getPlayerProfile() { // Paper
++        return new com.destroystokyo.paper.profile.CraftPlayerProfile(this.profile); // Paper
+     }
+ 
+     public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 index d2803455c9456523f8cc324e79c692595fa2420e..afa2e62732ba7b9c08fc24bc95b81b0f30d0ad05 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -146,3 +161,20 @@ index d2803455c9456523f8cc324e79c692595fa2420e..afa2e62732ba7b9c08fc24bc95b81b0f
  
      public void onEntityRemove(Entity entity) {
          this.hiddenEntities.remove(entity.getUUID());
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
+index a679133a3de51e26eb19932ece9ade292879aefd..f5cf40baaad1b055755b6c1e18452a4afcd2dfba 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
+@@ -306,6 +306,12 @@ public class Commodore
+                             return;
+                         }
+ 
++                        // Paper start - Rewrite plugins
++                        if (owner.equals("org/bukkit/OfflinePlayer") && name.equals("getPlayerProfile") && desc.equals("()Lorg/bukkit/profile/PlayerProfile;")) {
++                            super.visitMethodInsn(opcode, owner, name, "()Lcom/destroystokyo/paper/profile/PlayerProfile;", itf);
++                            return;
++                        }
++                        // Paper end
+                         if ( modern )
+                         {
+                             if ( owner.equals( "org/bukkit/Material" ) )

--- a/patches/server/0266-Hook-into-CB-plugin-rewrites.patch
+++ b/patches/server/0266-Hook-into-CB-plugin-rewrites.patch
@@ -8,7 +8,7 @@ our own relocation. Also lets us rewrite NMS calls for when we're
 debugging in an IDE pre-relocate.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index a679133a3de51e26eb19932ece9ade292879aefd..2c537a80951ddf98d3135ca19a34a238484c2d88 100644
+index f5cf40baaad1b055755b6c1e18452a4afcd2dfba..3c79c0ddb9bc9024a6f74d0aef273c65bc6f3228 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 @@ -6,7 +6,9 @@ import java.io.FileOutputStream;
@@ -166,22 +166,19 @@ index a679133a3de51e26eb19932ece9ade292879aefd..2c537a80951ddf98d3135ca19a34a238
                          if ( owner.equals( "org/bukkit/block/Biome" ) )
                          {
                              switch ( name )
-@@ -306,6 +419,14 @@ public class Commodore
-                             return;
+@@ -307,6 +420,11 @@ public class Commodore
                          }
  
-+                        // Paper start - Rewrite plugins
+                         // Paper start - Rewrite plugins
 +                        owner = getOriginalOrRewrite( owner) ;
 +                        if (desc != null)
 +                        {
 +                            desc = getOriginalOrRewrite(desc);
 +                        }
-+                        // Paper end
-+
-                         if ( modern )
-                         {
-                             if ( owner.equals( "org/bukkit/Material" ) )
-@@ -395,6 +516,13 @@ public class Commodore
+                         if (owner.equals("org/bukkit/OfflinePlayer") && name.equals("getPlayerProfile") && desc.equals("()Lorg/bukkit/profile/PlayerProfile;")) {
+                             super.visitMethodInsn(opcode, owner, name, "()Lcom/destroystokyo/paper/profile/PlayerProfile;", itf);
+                             return;
+@@ -401,6 +519,13 @@ public class Commodore
                      @Override
                      public void visitLdcInsn(Object value)
                      {

--- a/patches/server/0688-Add-more-advancement-API.patch
+++ b/patches/server/0688-Add-more-advancement-API.patch
@@ -189,7 +189,7 @@ index 4aa8cda2bf72627b153e636a408fb3971caf2309..e29d7c6e1cef10a76c8630855fada11c
  
      private final DisplayInfo handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index cf73d333ae625ea1bdc32d5f79daf408937bb13b..6fdecd4bed469fffc04d37e3563fb9c7c393761b 100644
+index 1c430959289b99eb8ebf1627dcbed8893dc88886..0d150f5ea05b8ecb83cef738ae8ad036d6a2de87 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 @@ -54,6 +54,7 @@ public class Commodore
@@ -200,9 +200,9 @@ index cf73d333ae625ea1bdc32d5f79daf408937bb13b..6fdecd4bed469fffc04d37e3563fb9c7
      private static final Map<String, String> SEARCH_AND_REMOVE = initReplacementsMap();
      private static Map<String, String> initReplacementsMap()
      {
-@@ -433,6 +434,11 @@ public class Commodore
-                         {
-                             desc = getOriginalOrRewrite(desc);
+@@ -437,6 +438,11 @@ public class Commodore
+                             super.visitMethodInsn(opcode, owner, name, "()Lcom/destroystokyo/paper/profile/PlayerProfile;", itf);
+                             return;
                          }
 +                        if (owner.equals("org/bukkit/advancement/Advancement") && name.equals("getDisplay") && desc.endsWith(")Lorg/bukkit/advancement/AdvancementDisplay;")) {
 +                            super.visitTypeInsn(Opcodes.CHECKCAST, CB_PACKAGE + "/advancement/CraftAdvancement");
@@ -210,8 +210,8 @@ index cf73d333ae625ea1bdc32d5f79daf408937bb13b..6fdecd4bed469fffc04d37e3563fb9c7
 +                            return;
 +                        }
                          // Paper end
- 
                          if ( modern )
+                         {
 diff --git a/src/test/java/io/papermc/paper/advancement/AdvancementFrameTest.java b/src/test/java/io/papermc/paper/advancement/AdvancementFrameTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..4d043e0e43ef8bb75788e195f95b5a50a51a2a48

--- a/patches/server/0897-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
+++ b/patches/server/0897-Mitigate-effects-of-WorldCreator-keepSpawnLoaded-ret.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Mitigate effects of WorldCreator#keepSpawnLoaded ret type
 TODO: Remove in 1.21?
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index 6fdecd4bed469fffc04d37e3563fb9c7c393761b..1ea5be29f3f06042d7cc278ce82790e4e439a81f 100644
+index 0d150f5ea05b8ecb83cef738ae8ad036d6a2de87..27883f91870422384af4a0348804b5dd53aa3483 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-@@ -439,6 +439,12 @@ public class Commodore
+@@ -443,6 +443,12 @@ public class Commodore
                              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, CB_PACKAGE + "/advancement/CraftAdvancement", "getDisplay0", desc, false);
                              return;
                          }
@@ -21,5 +21,5 @@ index 6fdecd4bed469fffc04d37e3563fb9c7c393761b..1ea5be29f3f06042d7cc278ce82790e4
 +                            return;
 +                        }
                          // Paper end
- 
                          if ( modern )
+                         {


### PR DESCRIPTION
OfflinePlayer has a method, getPlayerProfile, that returns the deprecated bukkit PlayerProfile type. This changes that to use our interface which is a subtype of bukkit's. Additionally, to maintain API compatibility, this rewrites plugins still expecting the old type.