### PR TITLE
Fix preemtive connection dropping during shutdown process.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -53,4 +53,5 @@ Nick Hensel <nickhensel25@icloud.com>
 vytskalt <vytskalt@protonmail.com>
 TheFruxz <cedricspitzer@outlook.de>
 Kieran Wallbanks <kieran.wallbanks@gmail.com>
+Denery <dorofeevij@gmail.com>
 ```

--- a/patches/server/0949-Fix-player-kick-on-shutdown.patch
+++ b/patches/server/0949-Fix-player-kick-on-shutdown.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Denery <dorofeevij@gmail.com>
+Date: Sun, 6 Nov 2022 02:02:46 +0300
+Subject: [PATCH] Fix player kick on shutdown
+
+Fix preemptive player kick on a server shutdown.
+If you update minecraft version / upstream and something is changed in this method make sure that a server doesn't disconnect a player preemptively,
+also check if all packets are ignored during the shutdown process.
+See net.minecraft.network.Connection#channelRead0(ChannelHandlerContext, Packet) and net.minecraft.util.thread.BlockableEventLoop#executeIfPossible(Runnable)
+
+diff --git a/src/main/java/net/minecraft/network/protocol/PacketUtils.java b/src/main/java/net/minecraft/network/protocol/PacketUtils.java
+index 8bc0cb9ad5bb4e76d962ff54305e2c08e279a17b..edefab4e22ee7217e17eb036165ce58788d4c782 100644
+--- a/src/main/java/net/minecraft/network/protocol/PacketUtils.java
++++ b/src/main/java/net/minecraft/network/protocol/PacketUtils.java
+@@ -41,7 +41,7 @@ public class PacketUtils {
+ 
+     public static <T extends PacketListener> void ensureRunningOnSameThread(Packet<T> packet, T listener, BlockableEventLoop<?> engine) throws RunningOnDifferentThreadException {
+         if (!engine.isSameThread()) {
+-            engine.executeIfPossible(() -> {
++            engine.execute(() -> { // Paper - Fix preemptive player kick on a server shutdown. 
+                 packetProcessing.push(listener); // Paper - detailed watchdog information
+                 try { // Paper - detailed watchdog information
+                 if (MinecraftServer.getServer().hasStopped() || (listener instanceof ServerGamePacketListenerImpl && ((ServerGamePacketListenerImpl) listener).processedDisconnect)) return; // CraftBukkit, MC-142590


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/8460. 

The issue is caused by the `PacketUtils#ensureRunningOnSameThread()` checks in the `ServerGamePacketListenerImpl`. The implementation of `BlockableEventLoop` (which is `MinecraftServer`) inherits `BlockableEventLoop#executeIfPossible(Runnable)` method which is:
```java
    @Override
    public void executeIfPossible(Runnable runnable) {
        if (this.isStopped()) {
            throw new RejectedExecutionException("Server already shutting down");
        } else {
            super.executeIfPossible(runnable);
        }
    }
``` 
The exception is catched in the `Connection#channelRead0(ChannelHandlerContext, Packet)` method and it looks like this:
```java
           try {
                Connection.genericsFtw(packet, this.packetListener);
            } catch (RunningOnDifferentThreadException cancelledpackethandleexception) {
                ;
            } catch (RejectedExecutionException rejectedexecutionexception) { 
                // disconnects player if something is handled in the `ServerGamePacketListenerImpl`
                this.disconnect(Component.translatable("multiplayer.disconnect.server_shutdown"));
            } catch (ClassCastException classcastexception) {
                Connection.LOGGER.error("Received {} that couldn't be processed", packet.getClass(), classcastexception);
                this.disconnect(Component.translatable("multiplayer.disconnect.invalid_packet"));
            }
```
After the testing (Falling and calling `/stop` command) it worked fine and I got the `Stopping the server` disconnect reason.
```
[01:51:48 INFO]: Player107 issued server command: /stop
[01:51:48 INFO]: [Player107: Stopping the server]
[01:51:48 INFO]: Stopping server
[01:51:48 INFO]: [Paper-Test-Plugin] Disabling Paper-Test-Plugin v1.0.0-SNAPSHOT
[01:51:49 INFO]: Saving players
[01:51:50 INFO]: Player107 lost connection: Server closed
[01:51:50 INFO]: Player107 left the game
[01:51:50 INFO]: Saving worlds
```
(Paper test plugin used `Thread#sleep` in its `#onDisable()` method to make it even clear.)

The remaining questions are:
1. Why did Mojang do that check? Maybe there are cases when it is needed.
2. Should we really yeet the usage of `BlockableEventLoop#executeIfpossible(Runnable)` method? It is the only usage of this method.