### PR TITLE
Reorder bukkit damage source entity for explosion

### DIFF
--- a/patches/server/0939-Reorder-bukkit-damage-source-entity-for-explosion-to.patch
+++ b/patches/server/0939-Reorder-bukkit-damage-source-entity-for-explosion-to.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com>
+Date: Fri, 11 Nov 2022 11:49:40 +0100
+Subject: [PATCH] Reorder bukkit damage source entity for explosion to exclude
+ enderdragon part
+
+
+diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
+index 01477e7240f9e33d08d416a7d40ee10f3e5d4abf..31708d1e94b557896d42199aa0bc6ed26a4c6d8a 100644
+--- a/src/main/java/net/minecraft/world/level/Explosion.java
++++ b/src/main/java/net/minecraft/world/level/Explosion.java
+@@ -239,8 +239,6 @@ public class Explosion {
+                         double d13 = (1.0D - d7) * d12;
+ 
+                         // CraftBukkit start
+-                        CraftEventFactory.entityDamage = this.source;
+-                        entity.lastDamageCancelled = false;
+ 
+                         // Special case ender dragon only give knockback if no damage is cancelled
+                         // Thinks to note:
+@@ -252,6 +250,11 @@ public class Explosion {
+                             continue;
+                         }
+ 
++                        // Paper start - moved from above
++                        CraftEventFactory.entityDamage = this.source;
++                        entity.lastDamageCancelled = false;
++                        // Paper end
++
+                         if (entity instanceof EnderDragon) {
+                             for (EnderDragonPart entityComplexPart : ((EnderDragon) entity).subEntities) {
+                                 if (list.contains(entityComplexPart)) {


### PR DESCRIPTION
Closes #8340 
Avoid to let a damage entity source targeting a tnt primed for bukkit event that could cause conflict later
for all others non entities related damage dealt later (bc of the static field)