### PR TITLE
Fully deserialise persistent anger post async load

### DIFF
--- a/patches/server/0861-Prevent-entity-loading-causing-async-lookups.patch
+++ b/patches/server/0861-Prevent-entity-loading-causing-async-lookups.patch
@@ -17,10 +17,10 @@ index d81ee5367205ba96eb23f885ec648a27f2cf62f8..7bb45ae3ed51975972e013aaf66acc35
          if (this.isPassenger() && this.getVehicle().isRemoved()) {
              this.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/NeutralMob.java b/src/main/java/net/minecraft/world/entity/NeutralMob.java
-index dedf76de5d6f46b9626ca4a98cfffe125b90dd0c..78632fd681049fbd49d0030c23ed204dbc515a44 100644
+index dedf76de5d6f46b9626ca4a98cfffe125b90dd0c..7dac62b6370dae3ad6d098857c3136d5acf2bd74 100644
 --- a/src/main/java/net/minecraft/world/entity/NeutralMob.java
 +++ b/src/main/java/net/minecraft/world/entity/NeutralMob.java
-@@ -42,18 +42,7 @@ public interface NeutralMob {
+@@ -42,18 +42,11 @@ public interface NeutralMob {
                  UUID uuid = nbt.getUUID("AngryAt");
  
                  this.setPersistentAngerTarget(uuid);
@@ -37,10 +37,14 @@ index dedf76de5d6f46b9626ca4a98cfffe125b90dd0c..78632fd681049fbd49d0030c23ed204d
 -
 -                }
 +                // Paper - Moved diff to separate method
++                // If this entity already survived its first tick, e.g. is loaded and ticked in sync, actively
++                // tick the initial persistent anger.
++                // If not, let the first tick on the baseTick call the method later down the line.
++                if (this instanceof Entity entity && !entity.firstTick) this.tickInitialPersistentAnger(world);
              }
          }
      }
-@@ -127,4 +116,26 @@ public interface NeutralMob {
+@@ -127,4 +120,26 @@ public interface NeutralMob {
  
      @Nullable
      LivingEntity getTarget();


### PR DESCRIPTION
The modified patch prevents entity loading off the main thread when entities are initially loaded.

However, the initial loading of an entity is not the only time the Entity#readAdditionalSaveData method is called. Commands like /data also invoke the method (through Entity#load) to update an entities data without completely re-creating it.

This however breaks with the current patch, as the patch moves parts of the entity lookup for persistent anger deserialisation into the first tick of an entity (which obviously is only called once and hence not re-run when an already ticking entity is modified as laid out above).

This change actively runs the now split logic for deserialisation again if the entity has already ticked its first tick. This way, initial deserialisation is still split into one off thread and the first tick parts, but following main thread deserialisations can happen completely inside Entity#readAdditionalSaveData is called.

Resolves: #8556 