### PR TITLE
Strip coordinates from lodestone compasses

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -1435,10 +1435,10 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a1bd848bbf924267e74e61dabdb840628712b1ad
+index 0000000000000000000000000000000000000000..7e995bb83a06e302fd70a8e6f079e3ac55c60473
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,467 @@
+@@ -0,0 +1,468 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1515,6 +1515,7 @@ index 0000000000000000000000000000000000000000..a1bd848bbf924267e74e61dabdb84062
 +            public class Items extends ConfigurationPart {
 +                public boolean hideItemmeta = false;
 +                public boolean hideDurability = false;
++                public boolean hideItemmetaWithVisualEffects = false;
 +            }
 +        }
 +
@@ -4490,7 +4491,7 @@ index a96cb7a5f7c94cd9a46b31cf8ec90b544221557b..7c35d86eac0d69ba4be48faf364fd6dc
          for ( Method method : clazz.getDeclaredMethods() )
          {
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index bd0bf398f900302187f3436119c754592d575416..d139cbcf0b159372f229bef6ae49b45a74c163ad 100644
+index b17fc2d59a488e59532059e204a9fdc76e15b938..3b7724a8ad8b9df0bbbca7fd2f8328e9885c5a73 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -58,8 +58,14 @@ public class SpigotWorldConfig

--- a/patches/server/0762-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0762-Hide-unnecessary-itemmeta-from-clients.patch
@@ -33,7 +33,7 @@ index f9e2392e705a0168b9dc359313e68cbca08b2d3a..2db7071d80a2d288d864ae32f250435d
                              }
                          }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8a393cc4165c2aec51dcb26f7447dcc796528241..1ef11297bc9017fd3c5ac661167c58617d06200b 100644
+index 8a393cc4165c2aec51dcb26f7447dcc796528241..8bf7d54cbdbc1dc2ec0482855d7f531b2dc648be 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3139,7 +3139,7 @@ public abstract class LivingEntity extends Entity {
@@ -45,7 +45,7 @@ index 8a393cc4165c2aec51dcb26f7447dcc796528241..1ef11297bc9017fd3c5ac661167c5861
              // Paper end
              switch (enumitemslot.getType()) {
                  case HAND:
-@@ -3153,6 +3153,59 @@ public abstract class LivingEntity extends Entity {
+@@ -3153,6 +3153,70 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  
@@ -63,12 +63,12 @@ index 8a393cc4165c2aec51dcb26f7447dcc796528241..1ef11297bc9017fd3c5ac661167c5861
 +            }
 +        }
 +
++        final CompoundTag tag = copy.getTag();
 +        if (level.paperConfig().anticheat.obfuscation.items.hideItemmeta) {
 +            // Some resource packs show different textures when there is more than one item. Since this shouldn't provide a big advantage,
 +            // we'll tell the client if there's one or (more than) two items.
 +            copy.setCount(copy.getCount() > 1 ? 2 : 1);
 +            // We can't just strip out display, leather helmets still use the display.color tag.
-+            final CompoundTag tag = copy.getTag();
 +            if (tag != null) {
 +                if (tag.get("display") instanceof CompoundTag displayTag) {
 +                    displayTag.remove("Lore");
@@ -98,6 +98,17 @@ index 8a393cc4165c2aec51dcb26f7447dcc796528241..1ef11297bc9017fd3c5ac661167c5861
 +                tag.remove("generation");
 +            }
 +        }
++
++        if (level.paperConfig().anticheat.obfuscation.items.hideItemmetaWithVisualEffects && tag != null) {
++            // Lodestone compasses
++            tag.remove("LodestonePos");
++            if (tag.contains("LodestoneDimension")) {
++                // The client shows the glint if either the position or the dimension is present, so we just wipe
++                // the position and fake the dimension
++                tag.putString("LodestoneDimension", "paper:paper");
++            }
++        }
++
 +        return copy;
 +    }
 +    // Paper end

--- a/patches/server/0801-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0801-Freeze-Tick-Lock-API.patch
@@ -46,10 +46,10 @@ index 305a70f4b4646fa6cb8f36af367222a2b7fa39d4..476668fe955841f61cf12d032b0d3bd1
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1ef11297bc9017fd3c5ac661167c58617d06200b..66a566af1dd6684bd7c0dd8b3104543e20b64295 100644
+index 8bf7d54cbdbc1dc2ec0482855d7f531b2dc648be..30013439192c9d32d3e1ebba5aec81140392d152 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3379,7 +3379,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3390,7 +3390,7 @@ public abstract class LivingEntity extends Entity {
          boolean flag1 = this.getType().is(EntityTypeTags.FREEZE_HURTS_EXTRA_TYPES);
          int i;
  

--- a/patches/server/0853-Add-PlayerStopUsingItemEvent.patch
+++ b/patches/server/0853-Add-PlayerStopUsingItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerStopUsingItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9cefacd1db700402d6a7eef18be123c2e037716e..0a2ff3b8412b7e3ccca26d1e32d9d5bc7d5c2ee2 100644
+index 38a07f42c339d57f96ec4ff502c810f8367a5c11..2dc3c151192d755e5e518ada9e79c9eb378423c7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3938,6 +3938,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3949,6 +3949,7 @@ public abstract class LivingEntity extends Entity {
  
      public void releaseUsingItem() {
          if (!this.useItem.isEmpty()) {


### PR DESCRIPTION
Stops the coordinates of a lodestone compass from being sent to other players, preventing possible base leaks.

Since the other client doesn't know the position, it'll show the compass in the 'spinning' state, similar to what happens when you use a compass in the nether, as shown in the gif below. Without hide itemmeta enabled the compass just points to the same location as on the screen of the user holding the compass.

[Click to view gif, it's too large for GH to proxy](https://i.noah.pm/xWg6hF.gif)

Another possible solution would be to make the compass point in the general direction of the location, similar to what craftbukkit does for far-away sounds, but this would not only require re-sending the compass quite often, but it would also allow users to triangulate the position the compass is pointing towards.