### PR TITLE
Properly grow plants with growth modifier

### DIFF
--- a/patches/server/0719-Fix-Spigot-growth-modifiers.patch
+++ b/patches/server/0719-Fix-Spigot-growth-modifiers.patch
@@ -12,6 +12,37 @@ Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 Co-authored-by: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com>
 
+diff --git a/src/main/java/net/minecraft/world/level/block/CactusBlock.java b/src/main/java/net/minecraft/world/level/block/CactusBlock.java
+index 0003fb51ae3a6575575e10b4c86719f3061e2577..08047eb3abad49e388c99520146e3aa8e2620da6 100644
+--- a/src/main/java/net/minecraft/world/level/block/CactusBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/CactusBlock.java
+@@ -57,15 +57,22 @@ public class CactusBlock extends Block {
+             if (i < world.paperConfig().maxGrowthHeight.cactus) { // Paper - Configurable growth height
+                 int j = (Integer) state.getValue(CactusBlock.AGE);
+ 
+-                int modifier = world.spigotConfig.cactusModifier; // Spigot - SPIGOT-7159: Better modifier resolution
+-                if (j >= 15 || (modifier != 100 && random.nextFloat() < (modifier / (100.0f * 16)))) { // Spigot - SPIGOT-7159: Better modifier resolution
++                // Paper start - fix block creating growth modifiers
++                final int ageToProgress = world.spigotConfig.computeBlockGrowingAgeProgression(
++                    random,
++                    world.spigotConfig.cactusModifier
++                );
++                if (ageToProgress > 0 && j < CactusBlock.MAX_AGE) {
++                    // Moved up from below's if, now deleted, else.
++                    world.setBlock(pos, state.setValue(CactusBlock.AGE, Math.min(CactusBlock.MAX_AGE, j + ageToProgress)), 4);
++                }
++                if (j + ageToProgress > 15) {
++                // Paper end - fix block creating growth modifiers
+                     CraftEventFactory.handleBlockGrowEvent(world, blockposition1, this.defaultBlockState()); // CraftBukkit
+                     BlockState iblockdata1 = (BlockState) state.setValue(CactusBlock.AGE, 0);
+ 
+                     world.setBlock(pos, iblockdata1, 4);
+                     world.neighborChanged(iblockdata1, blockposition1, this, pos, false);
+-                } else if (modifier == 100 || random.nextFloat() < (modifier / (100.0f * 16))) { // Spigot - SPIGOT-7159: Better modifier resolution
+-                    world.setBlock(pos, (BlockState) state.setValue(CactusBlock.AGE, j + 1), 4);
+                 }
+ 
+             }
 diff --git a/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java b/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java
 index e628b4d6683eb0bc4f83c12480ab750ecbc1599b..ead7b37122c76d43af2cdd17af7f0da8014efb26 100644
 --- a/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java
@@ -129,12 +160,22 @@ index 11ac344ef113732fa717b67c51f76692b9b247e7..62c1434018be5b5fb70f7019b3c06d4d
          this.wheatModifier = this.getAndValidateGrowth( "Wheat" );
          this.wartModifier = this.getAndValidateGrowth( "NetherWart" );
          this.vineModifier = this.getAndValidateGrowth( "Vine" );
-@@ -139,6 +143,8 @@ public class SpigotWorldConfig
+@@ -139,7 +143,18 @@ public class SpigotWorldConfig
          this.twistingVinesModifier = this.getAndValidateGrowth( "TwistingVines" );
          this.weepingVinesModifier = this.getAndValidateGrowth( "WeepingVines" );
          this.caveVinesModifier = this.getAndValidateGrowth( "CaveVines" );
 +        this.glowBerryModifier = this.getAndValidateGrowth("GlowBerry"); // Paper
 +        this.pitcherPlantModifier = this.getAndValidateGrowth("PitcherPlant"); // Paper
      }
++    // Paper start - fix block creating growth modifiers
++    public int computeBlockGrowingAgeProgression(final net.minecraft.util.RandomSource random, final int modifier) {
++        final double modifierScaled = modifier / 100D;
++        final int baseGrowth = (int) modifierScaled;
++        final double chanceOfDoubleGrowth = modifierScaled - baseGrowth;
++
++        return baseGrowth + (random.nextFloat() < chanceOfDoubleGrowth ? 1 : 0);
++    }
++    // Paper end - fix block creating growth modifiers
  
      public double itemMerge;
+     private void itemMerge()

--- a/patches/server/0759-Add-missing-structure-set-seed-configs.patch
+++ b/patches/server/0759-Add-missing-structure-set-seed-configs.patch
@@ -235,7 +235,7 @@ diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/o
 index 62c1434018be5b5fb70f7019b3c06d4d9200661d..f9b8e2bc039f1a37e47f84909c8785f3ef530284 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-@@ -368,6 +368,17 @@ public class SpigotWorldConfig
+@@ -377,6 +377,17 @@ public class SpigotWorldConfig
      public int mansionSeed;
      public int fossilSeed;
      public int portalSeed;
@@ -253,7 +253,7 @@ index 62c1434018be5b5fb70f7019b3c06d4d9200661d..f9b8e2bc039f1a37e47f84909c8785f3
      private void initWorldGenSeeds()
      {
          this.villageSeed = this.getInt( "seed-village", 10387312 );
-@@ -385,6 +396,13 @@ public class SpigotWorldConfig
+@@ -394,6 +405,13 @@ public class SpigotWorldConfig
          this.mansionSeed = this.getInt( "seed-mansion", 10387319 );
          this.fossilSeed = this.getInt( "seed-fossil", 14357921 );
          this.portalSeed = this.getInt( "seed-portal", 34222645 );


### PR DESCRIPTION
Spigots implementation of the growth modifier boils down to a plain chance for a plant to either grow immediately or to grow a single age value towards its fully grown age.

This behaviour is specifically troubling for plants like the cactus or the sugar cane, as they change an unrelated block when growing up (the free air block above their tip). This blocks validity is checked during neighbour updated which are triggered by resetting the previous tip of the plant back to [age=0].

With spigots modifier implementation, blocks at the age of zero are able to grow a new block above them however, causing the block change of the previous tip to change a block of age zero to a block of age zero, which does **not** cause a neighbour update as nothing actually changed. This means that the about block is not updated and hence may remain in an otherwise invalid state. (E.g. a cactus block next to a solid block).

This commit rewrites the existing spigot growth modifier implementation specifically for the plants that grow new blocks like the cactus or the sugar can block.

The modifier provided for the plants is separated into two distinct values. One being the remains after a floored division by 100, e.g. the original modifier without its 10^0 and 10^1 digits, the other the modifier modulo 100.
The modifier 475 would, for example, be split into a base growth of 4 and a percentage chance of an additional age progression of 75%. This way, on average, the plant would grow 4.75 times as fast as a normal plant, which would only grow a single age per random tick.

Resolves: #8544