### PR TITLE
Add No Damage Tick Utilities

### DIFF
--- a/patches/api/0407-Add-No-Damage-Tick-Utilities.patch
+++ b/patches/api/0407-Add-No-Damage-Tick-Utilities.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Fri, 18 Nov 2022 21:42:10 -0500
+Subject: [PATCH] Add No Damage Tick Utilities
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 3bd1d100d0c481ae7edaa251869640ab370aeb42..a0a36c7a44ee33e0c532587e0e40d7b861c4c922 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -405,6 +405,7 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+     /**
+      * Returns the living entity's current no damage ticks.
+      *
++     * @see LivingEntity#getExactNoDamageTicks()
+      * @return amount of no damage ticks
+      */
+     public int getNoDamageTicks();
+@@ -412,10 +413,39 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+     /**
+      * Sets the living entity's current no damage ticks.
+      *
++     * @see LivingEntity#setExactNoDamageTicks(int)
+      * @param ticks amount of no damage ticks
+      */
+     public void setNoDamageTicks(int ticks);
+ 
++    // Paper start
++    /**
++     * Gets exactly how many ticks this entity will be
++     * invulnerable with its current no damage ticks.
++     * <p>
++     * Note: The difference between this and {@link LivingEntity#getNoDamageTicks()} is that this method
++     * will correctly calculate and account for this entity's current maximum damage ticks in order get
++     * the exact value of how many ticks the current entity will be invulnerable.
++     * @return exact tick count
++     */
++    default int getExactNoDamageTicks() {
++        return Math.max(0, this.getNoDamageTicks() - (this.getMaximumNoDamageTicks() / 2));
++    }
++
++    /**
++     * Sets exactly how many ticks this entity
++     * will be invulnerable for.
++     * <p>
++     * Note: The difference between this and {@link LivingEntity#setNoDamageTicks(int)} is that this method
++     * will correctly calculate and account for this entity's current maximum damage ticks in order to make the
++     * entity invulnerable for the specified tick duration.
++     * @param ticks amount of ticks
++     */
++    default void setExactNoDamageTicks(int ticks) {
++        this.setNoDamageTicks(ticks + (this.getMaximumNoDamageTicks() / 2));
++    }
++    // Paper end
++
+     /**
+      * Gets the player identified as the killer of the living entity.
+      * <p>

--- a/patches/api/0417-Add-Exact-No-Damage-Ticks-API.patch
+++ b/patches/api/0417-Add-Exact-No-Damage-Ticks-API.patch
@@ -1,14 +1,14 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 Date: Fri, 18 Nov 2022 21:42:10 -0500
-Subject: [PATCH] Add No Damage Tick Utilities
+Subject: [PATCH] Add Exact No Damage Ticks API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 3bd1d100d0c481ae7edaa251869640ab370aeb42..a0a36c7a44ee33e0c532587e0e40d7b861c4c922 100644
+index ffca32ae2464ea5a669029079a50585ca259a4f8..e8e2284d0a841a176b883df0f4250c092e2afd3b 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -405,6 +405,7 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -467,6 +467,7 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      /**
       * Returns the living entity's current no damage ticks.
       *
@@ -16,7 +16,7 @@ index 3bd1d100d0c481ae7edaa251869640ab370aeb42..a0a36c7a44ee33e0c532587e0e40d7b8
       * @return amount of no damage ticks
       */
      public int getNoDamageTicks();
-@@ -412,10 +413,39 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -474,10 +475,35 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      /**
       * Sets the living entity's current no damage ticks.
       *
@@ -35,9 +35,7 @@ index 3bd1d100d0c481ae7edaa251869640ab370aeb42..a0a36c7a44ee33e0c532587e0e40d7b8
 +     * the exact value of how many ticks the current entity will be invulnerable.
 +     * @return exact tick count
 +     */
-+    default int getExactNoDamageTicks() {
-+        return Math.max(0, this.getNoDamageTicks() - (this.getMaximumNoDamageTicks() / 2));
-+    }
++    int getExactNoDamageTicks();
 +
 +    /**
 +     * Sets exactly how many ticks this entity
@@ -48,9 +46,7 @@ index 3bd1d100d0c481ae7edaa251869640ab370aeb42..a0a36c7a44ee33e0c532587e0e40d7b8
 +     * entity invulnerable for the specified tick duration.
 +     * @param ticks amount of ticks
 +     */
-+    default void setExactNoDamageTicks(int ticks) {
-+        this.setNoDamageTicks(ticks + (this.getMaximumNoDamageTicks() / 2));
-+    }
++    void setExactNoDamageTicks(int ticks);
 +    // Paper end
 +
      /**

--- a/patches/server/0977-Add-Exact-No-Damage-Ticks-API.patch
+++ b/patches/server/0977-Add-Exact-No-Damage-Ticks-API.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Thu, 6 Apr 2023 21:11:09 -0400
+Subject: [PATCH] Add Exact No Damage Ticks API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index aec588b41f19b2147a4e7267bafa417fbcf7abc0..cb24bfc70c7e004cc951f8c056a12a2dfc8fd941 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -418,6 +418,17 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     public void setNoDamageTicks(int ticks) {
+         this.getHandle().invulnerableTime = ticks;
+     }
++    // Paper start
++    @Override
++    public int getExactNoDamageTicks() {
++        return Math.max(0, this.getNoDamageTicks() - (this.getMaximumNoDamageTicks() / 2));
++    }
++
++    @Override
++    public void setExactNoDamageTicks(int ticks) {
++        this.setNoDamageTicks(ticks + (this.getMaximumNoDamageTicks() / 2));
++    }
++    // Paper end
+ 
+     @Override
+     public net.minecraft.world.entity.LivingEntity getHandle() {


### PR DESCRIPTION
Generally, this API is a bit misleading, 
```java
if ((float) this.invulnerableTime > (float) this.invulnerableDuration / 2.0F) { // CraftBukkit - restore use of maxNoDamageTicks
```

The invulnerability duration is only considered valid until it reaches the invulnerability duration / 2. 
Therefore, the no damage tick actions don't work as expected.
When setting it to 20 ticks, the entity will only have an actual invulnerability time frame of 10 ticks due to this invulnerability duration.

This adds new methods, which calculate the limit on top of your specified value in order to make it so when you do ``setExactNoDamageTicks(20)``, the entity will actually have 20 ticks and not 10 ticks of invulnerability. 

Old methods:
setNoDamageTicks(10)
getNoDamageTicks() -> 10
(getExactNoDamageTicks() will return 0) 
Behavior: The entity will have no invulnerability ticks

New methods:
setExactNoDamageTicks(10)
getExactNoDamageTicks() -> 10
(getNoDamageTicks() will return 20) 
Behavior: The entity will have 10 invulnerability ticks

This can probably be expanded to the invulnerability duration too, as it's currently divided by 2. But, it's not something I see useful enough and in general could be PRed by someone else.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-8572.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/449215361.zip)