### PR TITLE
[ci skip] Keep JetBrains Fleet folder away from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ work/ForgeFlower
 .idea/
 out/
 
+# JetBrains Fleet
+.fleet/
+
 # Linux temp files
 *~
 


### PR DESCRIPTION
This adds the .fleet/ folder to the ignored objects inside the .gitignore