### PR TITLE
Fixes potential issues arising from optimizing getPlayerByUUID

### DIFF
--- a/patches/server/0338-Optimise-EntityGetter-getPlayerByUUID.patch
+++ b/patches/server/0338-Optimise-EntityGetter-getPlayerByUUID.patch
@@ -1,15 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Sat, 11 Jan 2020 21:50:56 -0800
-Subject: [PATCH] Optimise IEntityAccess#getPlayerByUUID
+Subject: [PATCH] Optimise EntityGetter#getPlayerByUUID
 
-Use the world entity map instead of iterating over all players
+Use the PlayerList map instead of iterating over all players
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 0c5065ac62d8a708f70282e765277866834169bc..878123befd7580082cf85222fa3a331baf41156c 100644
+index 72d3af43afd1b71d92a4d0673795835c6a3a07d0..c38229f3844328e8e5a0d84e64a0867bafadc5dc 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -423,6 +423,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -423,6 +423,15 @@ public class ServerLevel extends Level implements WorldGenLevel {
      }
      // Paper end - rewrite chunk system
  
@@ -17,7 +17,8 @@ index 0c5065ac62d8a708f70282e765277866834169bc..878123befd7580082cf85222fa3a331b
 +    @Nullable
 +    @Override
 +    public Player getPlayerByUUID(UUID uuid) {
-+        return this.getServer().getPlayerList().getPlayer(uuid);
++        final Player player = this.getServer().getPlayerList().getPlayer(uuid);
++        return player != null && player.level == this ? player : null;
 +    }
 +    // Paper end
 +

--- a/patches/server/0344-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0344-Entity-Activation-Range-2.0.patch
@@ -18,7 +18,7 @@ public net.minecraft.world.entity.Entity isInsidePortal
 public net.minecraft.world.entity.LivingEntity jumping
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c2fe17a2bd52a7235614e59ce4a521f4ce786049..e35f32f67e88eaef0ba01e884b1a61f63e80aeb4 100644
+index c38229f3844328e8e5a0d84e64a0867bafadc5dc..9b321475a9b944f8af58f2e2b2b22c81a8757a2e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2,7 +2,6 @@ package net.minecraft.server.level;
@@ -29,7 +29,7 @@ index c2fe17a2bd52a7235614e59ce4a521f4ce786049..e35f32f67e88eaef0ba01e884b1a61f6
  import com.google.common.collect.Lists;
  import com.mojang.datafixers.DataFixer;
  import com.mojang.datafixers.util.Pair;
-@@ -1026,17 +1025,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1027,17 +1026,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
          ++TimingHistory.entityTicks; // Paper - timings
          // Spigot start
          co.aikar.timings.Timing timer; // Paper
@@ -51,7 +51,7 @@ index c2fe17a2bd52a7235614e59ce4a521f4ce786049..e35f32f67e88eaef0ba01e884b1a61f6
          try {
          // Paper end - timings
          entity.setOldPosAndRot();
-@@ -1047,9 +1046,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1048,9 +1047,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
              return Registry.ENTITY_TYPE.getKey(entity.getType()).toString();
          });
          gameprofilerfiller.incrementCounter("tickNonPassenger");
@@ -65,7 +65,7 @@ index c2fe17a2bd52a7235614e59ce4a521f4ce786049..e35f32f67e88eaef0ba01e884b1a61f6
          Iterator iterator = entity.getPassengers().iterator();
  
          while (iterator.hasNext()) {
-@@ -1057,13 +1060,18 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1058,13 +1061,18 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
              this.tickPassenger(entity, entity1);
          }
@@ -85,7 +85,7 @@ index c2fe17a2bd52a7235614e59ce4a521f4ce786049..e35f32f67e88eaef0ba01e884b1a61f6
                  passenger.setOldPosAndRot();
                  ++passenger.tickCount;
                  ProfilerFiller gameprofilerfiller = this.getProfiler();
-@@ -1072,8 +1080,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1073,8 +1081,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
                      return Registry.ENTITY_TYPE.getKey(passenger.getType()).toString();
                  });
                  gameprofilerfiller.incrementCounter("tickPassenger");
@@ -103,7 +103,7 @@ index c2fe17a2bd52a7235614e59ce4a521f4ce786049..e35f32f67e88eaef0ba01e884b1a61f6
                  gameprofilerfiller.pop();
                  Iterator iterator = passenger.getPassengers().iterator();
  
-@@ -1083,6 +1100,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1084,6 +1101,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                      this.tickPassenger(passenger, entity2);
                  }
  

--- a/patches/server/0346-Anti-Xray.patch
+++ b/patches/server/0346-Anti-Xray.patch
@@ -1044,7 +1044,7 @@ index 7825d6f0fdcfda6212cff8033ec55fb7db236154..000853110c7a89f2d0403a7a2737025a
  
      public ClientboundLevelChunkWithLightPacket(FriendlyByteBuf buf) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index d97e017289783cd8795e055616dd5931bb6147cd..7c4eded1135e50f2ffea069de7bcd77bd80d0ac1 100644
+index 48cc42222c5c7fb91e440028f847c51dc5517fce..63d480e7c50bed3d5b00b09f789522ff9ea18776 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -618,7 +618,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1079,10 +1079,10 @@ index d97e017289783cd8795e055616dd5931bb6147cd..7c4eded1135e50f2ffea069de7bcd77b
          List<Entity> list = Lists.newArrayList();
          List<Entity> list1 = Lists.newArrayList();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 1433ece7d85de61271ec619b68e09ecfd46b3f24..7aaa8e7bfc2a949346dc760a5ff1231f80d410d5 100644
+index 9b321475a9b944f8af58f2e2b2b22c81a8757a2e..1133928654269d3b9b794513b39526fe0accc3c3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -434,7 +434,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -435,7 +435,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, PrimaryLevelData iworlddataserver, ResourceKey<Level> resourcekey, LevelStem worlddimension, ChunkProgressListener worldloadlistener, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider) {
          // Holder holder = worlddimension.typeHolder(); // CraftBukkit - decompile error
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error
@@ -1178,7 +1178,7 @@ index 41e61e6c128f22224665af3f07cd11d69a43062b..54e57791f6220325d05939decae46dc4
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 0493be4a898962ef80aa6ae6fb61f0a755540ab8..fb42b212805c8ea9ae5be8b2a515a37ecda28535 100644
+index 3a613d3fb6240a504724ba42b9aadaa0881b3ac1..afc443f36b26e9493fa0a530891b2edd7f3f6703 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -93,7 +93,7 @@ public class LevelChunk extends ChunkAccess {
@@ -1457,7 +1457,7 @@ index 9a2bf744abd8916d492e901be889223591bac3fd..a27fce0f1af9776a713bf1b5277869ed
      int getSerializedSize();
  
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
-index f4bf0ecde863f1795d764d8cc8d6525af02356ea..3c61be19c65b2da9283b2aba2b4e66f84bac6e1c 100644
+index 648719a58e62105064ac6b51c6f5e7867ff0b7a9..89c367f542aee35ba9f596d678bfeb5412c1697d 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 @@ -69,7 +69,7 @@ import org.slf4j.Logger;

--- a/patches/server/0371-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
+++ b/patches/server/0371-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
@@ -7,7 +7,7 @@ Suspected case would be around the technique used in .stopRiding
 Stack will identify any causer of this and warn instead of crashing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 7b6a35026978485b676ea92324d3290ad9da3705..160147561c03f18d955467ba48e4e368d26c2ca5 100644
+index 6250615dbdb58e8d4e3937b2152b41751122dd56..9fbdb834559df0da45ea4a61eb3963fa8e371af3 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1018,6 +1018,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -25,10 +25,10 @@ index 7b6a35026978485b676ea92324d3290ad9da3705..160147561c03f18d955467ba48e4e368
              EntityType<?> entitytypes = entity.getType();
              int i = entitytypes.clientTrackingRange() * 16;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 9abe233a02b6e5fdeda7a602223188897df5a2e4..7cc21dab89dcb50ee4034e1e39b6a27478fd983b 100644
+index d30885b0b85d78a312c142460e5d342fdbeada79..ceab806cf008f8c9306283c86a92164176f8f1c5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2344,7 +2344,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2345,7 +2345,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          public void onTrackingStart(Entity entity) {
              org.spigotmc.AsyncCatcher.catchOp("entity register"); // Spigot
@@ -37,7 +37,7 @@ index 9abe233a02b6e5fdeda7a602223188897df5a2e4..7cc21dab89dcb50ee4034e1e39b6a274
              if (entity instanceof ServerPlayer) {
                  ServerPlayer entityplayer = (ServerPlayer) entity;
  
-@@ -2378,6 +2378,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2379,6 +2379,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
              entity.updateDynamicGameEventListener(DynamicGameEventListener::add);
              entity.valid = true; // CraftBukkit

--- a/patches/server/0386-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0386-Load-Chunks-for-Login-Asynchronously.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Load Chunks for Login Asynchronously
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 7cc21dab89dcb50ee4034e1e39b6a27478fd983b..652d30ce735aa265db848ca73a48d7b0b143103b 100644
+index ceab806cf008f8c9306283c86a92164176f8f1c5..d18337c4c123819e4d5f55b65985e548da492627 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -170,6 +170,7 @@ import org.bukkit.event.world.GenericGameEvent;
@@ -16,8 +16,8 @@ index 7cc21dab89dcb50ee4034e1e39b6a27478fd983b..652d30ce735aa265db848ca73a48d7b0
  
  public class ServerLevel extends Level implements WorldGenLevel {
  
-@@ -435,6 +436,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
-         return this.getServer().getPlayerList().getPlayer(uuid);
+@@ -436,6 +437,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+         return player != null && player.level == this ? player : null;
      }
      // Paper end
 +    public final ReferenceOpenHashSet<ServerPlayer> pendingLogin = new ReferenceOpenHashSet<>(); // Paper
@@ -25,7 +25,7 @@ index 7cc21dab89dcb50ee4034e1e39b6a27478fd983b..652d30ce735aa265db848ca73a48d7b0
      // Add env and gen to constructor, IWorldDataServer -> WorldDataServer
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, PrimaryLevelData iworlddataserver, ResourceKey<Level> resourcekey, LevelStem worlddimension, ChunkProgressListener worldloadlistener, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b886e52e7b316df6415cdaee75242a829e491dd4..84edbb30158b8ea7771b6fb33a660d9229e6b4a5 100644
+index 8660fc4bc748131d9bc3088afb5bb9af073300f8..7ad1d2cd3b2d4b1f9b21f0de5ddbf2626aea0310 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -182,6 +182,7 @@ public class ServerPlayer extends Player {
@@ -57,7 +57,7 @@ index 97d1ff2af23bac14e67bca5896843325aaa5bfc1..e9bc61590d33dc341074371859ceec54
      public static final TicketType<ChunkPos> UNKNOWN = TicketType.create("unknown", Comparator.comparingLong(ChunkPos::toLong), 1);
      public static final TicketType<Unit> PLUGIN = TicketType.create("plugin", (a, b) -> 0); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3af9f2d86cf2a9566e22865689101245647d05a5..fe722106e20e199eb914a09f8dbc1409e27f1d69 100644
+index c40da6e0f5da3a6663aba74720c530713b94650b..2a75c77ac51b620098f5cc49a8a6bebafdfc06a1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -346,6 +346,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic

--- a/patches/server/0399-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0399-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -461,7 +461,7 @@ index 30a58229aa6dac5039511d0c0df5f2912ea7de9f..abe37c7c3c6f5ab73afd738ec78f06d7
          this.exception = cause;
          this.systemReport.setDetail("CraftBukkit Information", new org.bukkit.craftbukkit.CraftCrashReport()); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/CrashReportCategory.java b/src/main/java/net/minecraft/CrashReportCategory.java
-index f114d5dab86aa2cdd59c78406c9d82f9caededca..99fa9f1952ee7ed79b223ff210a658e4b119b3e4 100644
+index 65231daec99d36d9ad3c1ca8561b6dbc49efde10..6df4d02020a14d17d9c5b1971bb5640b35411c45 100644
 --- a/src/main/java/net/minecraft/CrashReportCategory.java
 +++ b/src/main/java/net/minecraft/CrashReportCategory.java
 @@ -104,6 +104,7 @@ public class CrashReportCategory {
@@ -515,7 +515,7 @@ index 6fba140877e7369cdb7933ec225572c6b153e3a8..e3a62579067209c447f2fdcb76b2a11e
          paperConfigurations.initializeWorldDefaultsConfiguration();
          org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash);
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 652d30ce735aa265db848ca73a48d7b0b143103b..35439d857801d56494cc457d116fbcbb12561bcd 100644
+index d18337c4c123819e4d5f55b65985e548da492627..6cdd0c13189f372dcf562c4190f4c6155b33dd13 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -218,7 +218,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -529,7 +529,7 @@ index 652d30ce735aa265db848ca73a48d7b0b143103b..35439d857801d56494cc457d116fbcbb
      }
  
      @Override public LevelChunk getChunkIfLoaded(int x, int z) { // Paper - this was added in world too but keeping here for NMS ABI
-@@ -1289,7 +1291,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1290,7 +1292,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          if (entity.isRemoved()) {
              // Paper start
              if (DEBUG_ENTITIES) {
@@ -591,7 +591,7 @@ index 6599f874d9f97e9ef4862039ecad7277bbc5fd91..7edd4b88eb0476f0630630bc4681e859
                              }
                         }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 7e1f0c9f760d6f5cfb0138542252c8469534e152..623046a5a0ba36619d43d8e55cfee3c06d09b62b 100644
+index b2d06181ad76b1db2abb1ddca075f4ec6dab55dc..aa3adc628178962ce89df0e372c925e8f4801606 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -640,7 +640,7 @@ public class LevelChunk extends ChunkAccess {

--- a/patches/server/0436-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0436-incremental-chunk-and-player-saving.patch
@@ -53,7 +53,7 @@ index dda33bd52d9c527c37f67b829010c27dba4b667a..e42b12839faab0c040495b00368b107b
          // Paper start - move executeAll() into full server tick timing
          try (co.aikar.timings.Timing ignored = MinecraftTimings.processTasksTimer.startTiming()) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 67bcda3e1d343b59dd1842f5eb982a71859d4d7b..a05e8d136dfeb41fb6008cba4d3b4abcddbd9557 100644
+index 324a99ea21bccdf27c15248ae2811048efaa2595..998c333c0b7064e9077c2b30d6b36623ffc419c7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -601,6 +601,15 @@ public class ServerChunkCache extends ChunkSource {
@@ -73,10 +73,10 @@ index 67bcda3e1d343b59dd1842f5eb982a71859d4d7b..a05e8d136dfeb41fb6008cba4d3b4abc
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 35439d857801d56494cc457d116fbcbb12561bcd..8c233252583ffbc05c20fe3e6704dc5404b209f3 100644
+index 6cdd0c13189f372dcf562c4190f4c6155b33dd13..5537903d6e1233489d31127f3af3d99c40258eb4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1122,6 +1122,37 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1123,6 +1123,37 @@ public class ServerLevel extends Level implements WorldGenLevel {
          return !this.server.isUnderSpawnProtection(this, pos, player) && this.getWorldBorder().isWithinBounds(pos);
      }
  
@@ -115,7 +115,7 @@ index 35439d857801d56494cc457d116fbcbb12561bcd..8c233252583ffbc05c20fe3e6704dc54
          // Paper start - rewrite chunk system - add close param
          this.save(progressListener, flush, savingDisabled, false);
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index d8c77533a44e316693535ea66fe6ae7f4994de5f..b39bb4b5a1612dac7d495f22e5ab3ec5fb00a058 100644
+index c32f09e993ef25876373a34d148b0452ea03bcf0..b41fddf5225b9d7cccf73b91dd0c14897c990346 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -179,6 +179,7 @@ import org.bukkit.inventory.MainHand;

--- a/patches/server/0466-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0466-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SpawnChangeEvent not firing for all use-cases
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 8c233252583ffbc05c20fe3e6704dc5404b209f3..31a624cd60afa29741576ae35209acab5f48e912 100644
+index 5537903d6e1233489d31127f3af3d99c40258eb4..12534be05aa56930cde39e6fef90d402b5eb7c4e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1892,6 +1892,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1893,6 +1893,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          //ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(new BlockPosition(this.worldData.a(), 0, this.worldData.c()));
  
          this.levelData.setSpawn(pos, angle);
@@ -17,7 +17,7 @@ index 8c233252583ffbc05c20fe3e6704dc5404b209f3..31a624cd60afa29741576ae35209acab
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig().spawn.keepSpawnLoadedRange * 16, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fabd0ef0bef97bc7f14d6fae18028cca0709d3a6..37c7eb9357d897e1d5aefd355460d6fe76762d9d 100644
+index 643b682db12560fc3409ede861a4e0aea8fc5360..ca768eea4f4ad7196f6f595516683b28372de71a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -263,11 +263,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0483-Extend-block-drop-capture-to-capture-all-items-added.patch
+++ b/patches/server/0483-Extend-block-drop-capture-to-capture-all-items-added.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Extend block drop capture to capture all items added to the
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 31a624cd60afa29741576ae35209acab5f48e912..03232cda01646a6bc8493f9b3abdd70c9ce3ec67 100644
+index 12534be05aa56930cde39e6fef90d402b5eb7c4e..894d49d505b43b48013b7b404056a4bfe65b09c8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1329,6 +1329,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1330,6 +1330,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // WorldServer.LOGGER.warn("Tried to add entity {} but it was marked as removed already", EntityTypes.getKey(entity.getType())); // CraftBukkit
              return false;
          } else {

--- a/patches/server/0551-Remove-stale-POIs.patch
+++ b/patches/server/0551-Remove-stale-POIs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove stale POIs
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 03232cda01646a6bc8493f9b3abdd70c9ce3ec67..0a0727b5c6900bd7299a0caf1e1125d809880423 100644
+index 894d49d505b43b48013b7b404056a4bfe65b09c8..1bb87c81c57a8d28712ff82b8211b7cc2e32c2a6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1957,6 +1957,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1958,6 +1958,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
              });
              optional1.ifPresent((holder) -> {
                  this.getServer().execute(() -> {

--- a/patches/server/0569-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/patches/server/0569-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] added option to disable pathfinding updates on block changes
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 44dc48d663e384161cd2a2b3de5464ee4b068dbf..88b2e618f4e140a099b9711498b699e54ed83dc9 100644
+index 38b2b6b1a3068abd6432d866fe582935d144fb89..dc3c519542e40a9645fd21cc91bbebc5e1285e3a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1531,6 +1531,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1532,6 +1532,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          }
  
          this.getChunkSource().blockChanged(pos);
@@ -16,7 +16,7 @@ index 44dc48d663e384161cd2a2b3de5464ee4b068dbf..88b2e618f4e140a099b9711498b699e5
          VoxelShape voxelshape = oldState.getCollisionShape(this, pos);
          VoxelShape voxelshape1 = newState.getCollisionShape(this, pos);
  
-@@ -1572,6 +1573,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1573,6 +1574,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              }
  
          }

--- a/patches/server/0636-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0636-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add cause to Weather/ThunderChangeEvents
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 88b2e618f4e140a099b9711498b699e54ed83dc9..c44139052e080b39be81a3b2a4e0ebc086fe30a6 100644
+index dc3c519542e40a9645fd21cc91bbebc5e1285e3a..8a18b41bba88c8fd75bc08576a8f01b7967dbda5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -530,8 +530,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -531,8 +531,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
          this.serverLevelData.setClearWeatherTime(clearDuration);
          this.serverLevelData.setRainTime(rainDuration);
          this.serverLevelData.setThunderTime(rainDuration);
@@ -19,7 +19,7 @@ index 88b2e618f4e140a099b9711498b699e54ed83dc9..c44139052e080b39be81a3b2a4e0ebc0
      }
  
      @Override
-@@ -926,8 +926,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -927,8 +927,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  this.serverLevelData.setThunderTime(j);
                  this.serverLevelData.setRainTime(k);
                  this.serverLevelData.setClearWeatherTime(i);
@@ -30,7 +30,7 @@ index 88b2e618f4e140a099b9711498b699e54ed83dc9..c44139052e080b39be81a3b2a4e0ebc0
              }
  
              this.oThunderLevel = this.thunderLevel;
-@@ -993,14 +993,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -994,14 +994,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
      private void resetWeatherCycle() {
          // CraftBukkit start
@@ -48,7 +48,7 @@ index 88b2e618f4e140a099b9711498b699e54ed83dc9..c44139052e080b39be81a3b2a4e0ebc0
          // If we stop due to everyone sleeping we should reset the weather duration to some other random value.
          // Not that everyone ever manages to get the whole server to sleep at the same time....
 diff --git a/src/main/java/net/minecraft/world/level/storage/PrimaryLevelData.java b/src/main/java/net/minecraft/world/level/storage/PrimaryLevelData.java
-index 401787a5b55384b9ab7755e822b3b881dc45ac45..e537a8df45c31efa80cb898cbef9c3a09fac3bf9 100644
+index a85e81d3128b7cb45d3b611728dcc5b3c3105f6d..e37d687c9c5b8482fe053e18c7dd38a174800b19 100644
 --- a/src/main/java/net/minecraft/world/level/storage/PrimaryLevelData.java
 +++ b/src/main/java/net/minecraft/world/level/storage/PrimaryLevelData.java
 @@ -351,6 +351,11 @@ public class PrimaryLevelData implements ServerLevelData, WorldData {

--- a/patches/server/0658-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0658-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -8,7 +8,7 @@ ticket level 33 (yes getChunkIfLoaded will actually perform a chunk
 load in that case).
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c44139052e080b39be81a3b2a4e0ebc086fe30a6..304002cab34cdbb000f22d18ee94ffe233ac2b8e 100644
+index 8a18b41bba88c8fd75bc08576a8f01b7967dbda5..acc378462a9e24cfa51d89f67b8252aeb2198bf1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -225,7 +225,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -20,7 +20,7 @@ index c44139052e080b39be81a3b2a4e0ebc086fe30a6..304002cab34cdbb000f22d18ee94ffe2
      }
  
      @Override
-@@ -1478,7 +1478,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1479,7 +1479,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          for (int l1 = j; l1 <= i1; ++l1) {
              for (int i2 = l; i2 <= k1; ++i2) {

--- a/patches/server/0691-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0691-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 public net.minecraft.server.level.ServerLevel findLightningRod(Lnet/minecraft/core/BlockPos;)Ljava/util/Optional;
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 0fcee6adcb99f142bd35d57a65026fc7175c8168..b1f0d64d8d40e7f9b2b0e7702e70853cd70387ac 100644
+index acc378462a9e24cfa51d89f67b8252aeb2198bf1..b20391fce0cb6f1f92c329962a9798c5d4caf82c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -815,6 +815,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -816,6 +816,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
      }
  
      protected BlockPos findLightningTargetAround(BlockPos pos) {
@@ -22,7 +22,7 @@ index 0fcee6adcb99f142bd35d57a65026fc7175c8168..b1f0d64d8d40e7f9b2b0e7702e70853c
          BlockPos blockposition1 = this.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, pos);
          Optional<BlockPos> optional = this.findLightningRod(blockposition1);
  
-@@ -829,6 +834,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -830,6 +835,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              if (!list.isEmpty()) {
                  return ((LivingEntity) list.get(this.random.nextInt(list.size()))).blockPosition();
              } else {

--- a/patches/server/0703-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
+++ b/patches/server/0703-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
@@ -9,10 +9,10 @@ chunk through it. This should also be OK from a leak prevention/
 state desync POV because the TE is getting unloaded anyways.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 7d35d948e395258c77301c3dfee572545d3e52ff..34c587232c6bb9876de68f4bf07d11b3d794f0b7 100644
+index b20391fce0cb6f1f92c329962a9798c5d4caf82c..c5867232ed6f630d76dad9d111022b37ca781b94 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1375,9 +1375,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1376,9 +1376,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
          // Spigot Start
          for (net.minecraft.world.level.block.entity.BlockEntity tileentity : chunk.getBlockEntities().values()) {
              if (tileentity instanceof net.minecraft.world.Container) {
@@ -51,7 +51,7 @@ index e212f7a2f20fb5b8af18f3f11aef189d7d533160..eac88fdb3c9184e9c0d3500c62fbc349
      public void doCloseContainer() {
          this.containerMenu.removed(this);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 5451b1d61ae2ee4fa461c2a334bfe8f794868030..9b131f0a827413e9f5d6d0f7491c5481576cb8b1 100644
+index 860636642707e09f76d01ee566b5ceab6512159f..4b2495aed39450eb148627a0787848fd7c35f1f9 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -506,6 +506,11 @@ public abstract class Player extends LivingEntity {

--- a/patches/server/0711-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0711-Execute-chunk-tasks-mid-tick.patch
@@ -106,7 +106,7 @@ index 1203076f688a16af17b7e55d913c9248e3f0fec7..ee6dc7d149f96c9a63e627e765b8d3a0
 +    // Paper end - execute chunk tasks mid tick
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 4e73960a77165a959e989249fd25a7c5376e50bb..44ea29c42d660cc92481a78990b5cdb7a23ef2a9 100644
+index ef9ae57072e1b558c1a4a81b71196832ce974505..2aba72cd7a87b8b999cfbc7a2e7a58ea95717c19 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -748,6 +748,7 @@ public class ServerChunkCache extends ChunkSource {
@@ -126,7 +126,7 @@ index 4e73960a77165a959e989249fd25a7c5376e50bb..44ea29c42d660cc92481a78990b5cdb7
                  }
                  // Paper start - optimise chunk tick iteration
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 34c587232c6bb9876de68f4bf07d11b3d794f0b7..0577b370e0b3696d45836e6765edfdbccefd9e8b 100644
+index c5867232ed6f630d76dad9d111022b37ca781b94..205a9dc093b6c79cbd91a82f705d087719ad8681 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -212,6 +212,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -137,7 +137,7 @@ index 34c587232c6bb9876de68f4bf07d11b3d794f0b7..0577b370e0b3696d45836e6765edfdbc
  
      // CraftBukkit start
      public final LevelStorageSource.LevelStorageAccess convertable;
-@@ -1026,6 +1027,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1027,6 +1028,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          if (fluid1.is(fluid)) {
              fluid1.tick(this, pos);
          }
@@ -145,7 +145,7 @@ index 34c587232c6bb9876de68f4bf07d11b3d794f0b7..0577b370e0b3696d45836e6765edfdbc
  
      }
  
-@@ -1035,6 +1037,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1036,6 +1038,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          if (iblockdata.is(block)) {
              iblockdata.tick(this, pos, this.random);
          }

--- a/patches/server/0714-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0714-Detail-more-information-in-watchdog-dumps.patch
@@ -78,10 +78,10 @@ index acfa1907bfc9c29d261cfccc00d65bad9ad1a002..d6f3869f5725c7f081efb7f486f74dbb
              });
              throw RunningOnDifferentThreadException.RUNNING_ON_DIFFERENT_THREAD;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 0577b370e0b3696d45836e6765edfdbccefd9e8b..b3c482f221dcaec62b0961e05da77d7e46e0420c 100644
+index 205a9dc093b6c79cbd91a82f705d087719ad8681..eaaf69434b152fbfa099bf0cfa3190bc1b565e5d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1041,7 +1041,26 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1042,7 +1042,26 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
      }
  
@@ -108,7 +108,7 @@ index 0577b370e0b3696d45836e6765edfdbccefd9e8b..b3c482f221dcaec62b0961e05da77d7e
          ++TimingHistory.entityTicks; // Paper - timings
          // Spigot start
          co.aikar.timings.Timing timer; // Paper
-@@ -1081,7 +1100,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1082,7 +1101,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
              this.tickPassenger(entity, entity1);
          }
          // } finally { timer.stopTiming(); } // Paper - timings - move up

--- a/patches/server/0729-Optimise-random-block-ticking.patch
+++ b/patches/server/0729-Optimise-random-block-ticking.patch
@@ -90,10 +90,10 @@ index 0000000000000000000000000000000000000000..7d93652c1abbb6aee6eb7c26cf35d4d0
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index b3c482f221dcaec62b0961e05da77d7e46e0420c..195c50c7ba10b784c372046d956b54fccf684812 100644
+index eaaf69434b152fbfa099bf0cfa3190bc1b565e5d..1a790b84a96c975af8ae14a35b271fdcbee89d18 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -705,6 +705,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -706,6 +706,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
              entityplayer.stopSleepInBed(false, false);
          });
      }
@@ -104,7 +104,7 @@ index b3c482f221dcaec62b0961e05da77d7e46e0420c..195c50c7ba10b784c372046d956b54fc
  
      public void tickChunk(LevelChunk chunk, int randomTickSpeed) {
          ChunkPos chunkcoordintpair = chunk.getPos();
-@@ -714,10 +718,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -715,10 +719,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
          ProfilerFiller gameprofilerfiller = this.getProfiler();
  
          gameprofilerfiller.push("thunder");
@@ -117,7 +117,7 @@ index b3c482f221dcaec62b0961e05da77d7e46e0420c..195c50c7ba10b784c372046d956b54fc
              if (this.isRainingAt(blockposition)) {
                  DifficultyInstance difficultydamagescaler = this.getCurrentDifficultyAt(blockposition);
                  boolean flag1 = this.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING) && this.random.nextDouble() < (double) difficultydamagescaler.getEffectiveDifficulty() * this.paperConfig().entities.spawning.skeletonHorseThunderSpawnChance.or(0.01D) && !this.getBlockState(blockposition.below()).is(Blocks.LIGHTNING_ROD); // Paper
-@@ -741,64 +745,75 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -742,64 +746,75 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          gameprofilerfiller.popPush("iceandsnow");
          if (!this.paperConfig().environment.disableIceAndSnow && this.random.nextInt(16) == 0) { // Paper - Disable ice and snow

--- a/patches/server/0731-Optimise-nearby-player-lookups.patch
+++ b/patches/server/0731-Optimise-nearby-player-lookups.patch
@@ -39,7 +39,7 @@ index e11ec87e8007979a1c6932b414bcd70c10db746c..bc46479fd0622a90fd98ac88f92b2840
      // Paper end
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index b93d98b8ce576508b051a904e83cb4d19b87017b..b9143dd8454eb3b1d628188ea11c73dec4fac949 100644
+index 315fec3941d71ee29c8f2fdc864c227bde54a0ca..882820653800e0fe9e16441cb4edcd119aa2c44d 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -152,6 +152,12 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -104,10 +104,10 @@ index b93d98b8ce576508b051a904e83cb4d19b87017b..b9143dd8454eb3b1d628188ea11c73de
  
      protected ChunkGenerator generator() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 195c50c7ba10b784c372046d956b54fccf684812..48c5a62ea9c0441fa14300aff4dab44cc26090c5 100644
+index 1a790b84a96c975af8ae14a35b271fdcbee89d18..502da788bace6c078fc3c58c077367581521cc1d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -442,6 +442,84 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -443,6 +443,84 @@ public class ServerLevel extends Level implements WorldGenLevel {
      // Paper end
      public final ReferenceOpenHashSet<ServerPlayer> pendingLogin = new ReferenceOpenHashSet<>(); // Paper
  
@@ -192,7 +192,7 @@ index 195c50c7ba10b784c372046d956b54fccf684812..48c5a62ea9c0441fa14300aff4dab44c
      // Add env and gen to constructor, IWorldDataServer -> WorldDataServer
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, PrimaryLevelData iworlddataserver, ResourceKey<Level> resourcekey, LevelStem worlddimension, ChunkProgressListener worldloadlistener, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider) {
          // Holder holder = worlddimension.typeHolder(); // CraftBukkit - decompile error
-@@ -545,6 +623,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -546,6 +624,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
      }
  
      public void tick(BooleanSupplier shouldKeepTicking) {
@@ -208,7 +208,7 @@ index 195c50c7ba10b784c372046d956b54fccf684812..48c5a62ea9c0441fa14300aff4dab44c
  
          this.handlingTick = true;
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index b9685fa96bb59b4b080ffd0ac53e4c5581aaeb8b..fffa6ba329b38433a1df51df339df652d3fda828 100644
+index 147ec41ae4a3b9e9ad495ab4309c9f7306122749..cf40ebd06c52a7a00e6f704a29ae9d2b5186d35a 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -808,7 +808,12 @@ public abstract class Mob extends LivingEntity {
@@ -300,7 +300,7 @@ index b5fd3a9b58fb56db92d579d307edc99bbe344c79..09c2d318330e03d0230a82b30985bba3
      public abstract ResourceKey<LevelStem> getTypeKey();
  
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index edd32b6d5a96a6fffe641a23c27921e6dcf37a54..272bdc088f440cf94850dff6e626331b4b5d6539 100644
+index 21941af701eab308f87ca64b2801c55444814acb..7c7408b9686c8ff945c30892d45914c60f6c5e4a 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -259,7 +259,7 @@ public final class NaturalSpawner {
@@ -322,7 +322,7 @@ index edd32b6d5a96a6fffe641a23c27921e6dcf37a54..272bdc088f440cf94850dff6e626331b
  
      private static Boolean isValidSpawnPostitionForType(ServerLevel world, MobCategory group, StructureManager structureAccessor, ChunkGenerator chunkGenerator, MobSpawnSettings.SpawnerData spawnEntry, BlockPos.MutableBlockPos pos, double squaredDistance) { // Paper
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 623046a5a0ba36619d43d8e55cfee3c06d09b62b..7350b73f4af4ae347532dc579ab151447c298e09 100644
+index aa3adc628178962ce89df0e372c925e8f4801606..5e54cf312160e537d2fe6e6fedc618160359330e 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -269,6 +269,98 @@ public class LevelChunk extends ChunkAccess {

--- a/patches/server/0737-Fix-merchant-inventory-not-closing-on-entity-removal.patch
+++ b/patches/server/0737-Fix-merchant-inventory-not-closing-on-entity-removal.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix merchant inventory not closing on entity removal
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 48c5a62ea9c0441fa14300aff4dab44cc26090c5..cf24d93a7c84938ead0390f0a7876bc3fd5b1855 100644
+index 502da788bace6c078fc3c58c077367581521cc1d..ffe42e757d11978d861a70b69f9050014f7f8ea8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2608,6 +2608,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2609,6 +2609,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // Spigot end
              // Spigot Start
              if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder && (!(entity instanceof ServerPlayer) || entity.getRemovalReason() != Entity.RemovalReason.KILLED)) { // SPIGOT-6876: closeInventory clears death message

--- a/patches/server/0855-Don-t-tick-markers.patch
+++ b/patches/server/0855-Don-t-tick-markers.patch
@@ -22,10 +22,10 @@ index 68f99e93ed3e843b4001a7a27620f88a48b85e67..0dc96c39151ec4dbeec3947cb17606f5
                  }
              });
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index cf24d93a7c84938ead0390f0a7876bc3fd5b1855..352b74e2705af3b6d31bb2caf83b4553929e070c 100644
+index ffe42e757d11978d861a70b69f9050014f7f8ea8..979f6e925c2b0300ebddefc98a15b170a455d952 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2518,6 +2518,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2519,6 +2519,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          }
  
          public void onTickingStart(Entity entity) {
@@ -34,7 +34,7 @@ index cf24d93a7c84938ead0390f0a7876bc3fd5b1855..352b74e2705af3b6d31bb2caf83b4553
          }
  
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index b1ed97618d08d7691d24f89e9e9b0ed0f2bddd09..40b382c2e0e33fe5c24a51b211cd2f9557a60c5e 100644
+index 417296e8d2efb2b70809ff91b61451bd8e788df3..1b42c98956342832c37f0aa266f85271daa4ba5b 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -212,7 +212,7 @@ public class ActivationRange

--- a/patches/server/0864-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/0864-Add-Alternate-Current-redstone-implementation.patch
@@ -2008,7 +2008,7 @@ index 0000000000000000000000000000000000000000..33cd90c30c22200a4e1ae64f40a0bf78
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 352b74e2705af3b6d31bb2caf83b4553929e070c..9f9e9ffb7c33540f5cb3c58a255227b7e524b5af 100644
+index 979f6e925c2b0300ebddefc98a15b170a455d952..ba52939ac3a6a467c76632874dfb32def0012f86 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -219,6 +219,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -2019,7 +2019,7 @@ index 352b74e2705af3b6d31bb2caf83b4553929e070c..9f9e9ffb7c33540f5cb3c58a255227b7
      public static Throwable getAddToWorldStackTrace(Entity entity) {
          final Throwable thr = new Throwable(entity + " Added to world at " + new java.util.Date());
          io.papermc.paper.util.StacktraceDeobfuscator.INSTANCE.deobfuscateThrowable(thr);
-@@ -2507,6 +2508,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2508,6 +2509,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
          // Paper end - rewrite chunk system
      }
  

--- a/patches/server/0872-Prevent-empty-items-from-being-added-to-world.patch
+++ b/patches/server/0872-Prevent-empty-items-from-being-added-to-world.patch
@@ -7,10 +7,10 @@ The previous solution caused a bunch of bandaid fixes inorder to resolve edge ca
 Just simply prevent them from being added to the world instead.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 9f9e9ffb7c33540f5cb3c58a255227b7e524b5af..1e79eaf5ac647840ef97f728d5d29aaf3b401a86 100644
+index ba52939ac3a6a467c76632874dfb32def0012f86..2b4565dfaff3ee4ea3a49d3195b1336eac5b5b68 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1466,6 +1466,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1467,6 +1467,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // WorldServer.LOGGER.warn("Tried to add entity {} but it was marked as removed already", EntityTypes.getKey(entity.getType())); // CraftBukkit
              return false;
          } else {

--- a/patches/server/0917-Remove-unnecessary-onTrackingStart-during-navigation.patch
+++ b/patches/server/0917-Remove-unnecessary-onTrackingStart-during-navigation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove unnecessary onTrackingStart during navigation warning
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 1e79eaf5ac647840ef97f728d5d29aaf3b401a86..8b3e703ebb497b9166bd211b4247a78891b61aeb 100644
+index 2b4565dfaff3ee4ea3a49d3195b1336eac5b5b68..cc291b58292d33613a639650a6c55293603bb6e5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2554,7 +2554,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2555,7 +2555,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              if (entity instanceof Mob) {
                  Mob entityinsentient = (Mob) entity;
  
@@ -17,7 +17,7 @@ index 1e79eaf5ac647840ef97f728d5d29aaf3b401a86..8b3e703ebb497b9166bd211b4247a788
                      String s = "onTrackingStart called during navigation iteration";
  
                      Util.logAndPauseIfInIde("onTrackingStart called during navigation iteration", new IllegalStateException("onTrackingStart called during navigation iteration"));
-@@ -2639,7 +2639,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2640,7 +2640,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              if (entity instanceof Mob) {
                  Mob entityinsentient = (Mob) entity;
  

--- a/patches/server/0944-check-global-player-list-where-appropriate.patch
+++ b/patches/server/0944-check-global-player-list-where-appropriate.patch
@@ -1,0 +1,109 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 22 Nov 2022 13:16:01 -0800
+Subject: [PATCH] check global player list where appropriate
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index cc291b58292d33613a639650a6c55293603bb6e5..79aa3374fd47cd57d2e0810bb5afebbdb38a1892 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -2677,4 +2677,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
+             entity.updateDynamicGameEventListener(DynamicGameEventListener::move);
+         }
+     }
++
++    // Paper start
++    @Override
++    @Nullable
++    public Player getGlobalPlayerByUUID(UUID uuid) {
++        return this.server.getPlayerList().getPlayer(uuid);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 3bfa0c6a0d82ed980b3289051892a6d1745ebb69..529d4805d841beec9aaff57b0184d8313fad01c3 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -3584,7 +3584,7 @@ public abstract class LivingEntity extends Entity {
+     }
+ 
+     public void onItemPickup(ItemEntity item) {
+-        net.minecraft.world.entity.player.Player entityhuman = item.getThrower() != null ? this.level.getPlayerByUUID(item.getThrower()) : null;
++        net.minecraft.world.entity.player.Player entityhuman = item.getThrower() != null ? this.level.getGlobalPlayerByUUID(item.getThrower()) : null; // Paper - check all players
+ 
+         if (entityhuman instanceof ServerPlayer) {
+             CriteriaTriggers.THROWN_ITEM_PICKED_UP_BY_ENTITY.trigger((ServerPlayer) entityhuman, item.getItem(), this);
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Animal.java b/src/main/java/net/minecraft/world/entity/animal/Animal.java
+index 6216513805add7c8f52e1ed6c77e2d26786b3ab5..3c4d142e982c34a23bdb5da1f51c8dcacc0532c1 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Animal.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Animal.java
+@@ -210,7 +210,7 @@ public abstract class Animal extends AgeableMob {
+         if (this.loveCause == null) {
+             return null;
+         } else {
+-            Player entityhuman = this.level.getPlayerByUUID(this.loveCause);
++            Player entityhuman = this.level.getGlobalPlayerByUUID(this.loveCause); // Paper - check all players
+ 
+             return entityhuman instanceof ServerPlayer ? (ServerPlayer) entityhuman : null;
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
+index fcc5444a1268931a0fd2df1e6bbbc17cfd5a61e0..da877bfb87c34f83991dd0957f6042c7543edb3e 100644
+--- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
++++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
+@@ -98,7 +98,7 @@ public class ItemEntity extends Entity {
+         Level world = this.level;
+ 
+         Objects.requireNonNull(this.level);
+-        return (Entity) Util.mapNullable(uuid, world::getPlayerByUUID);
++        return (Entity) Util.mapNullable(uuid, world::getGlobalPlayerByUUID); // Paper - check all players
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/world/entity/monster/ZombieVillager.java b/src/main/java/net/minecraft/world/entity/monster/ZombieVillager.java
+index fb0a77b4cf1ba47c73c00993bd9b7454240fe5d6..d1f7d912ad274cf90a912e44d63b39f9387a694b 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/ZombieVillager.java
++++ b/src/main/java/net/minecraft/world/entity/monster/ZombieVillager.java
+@@ -268,7 +268,7 @@ public class ZombieVillager extends Zombie implements VillagerDataHolder {
+         entityvillager.finalizeSpawn(world, world.getCurrentDifficultyAt(entityvillager.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
+         entityvillager.refreshBrain(world);
+         if (this.conversionStarter != null) {
+-            Player entityhuman = world.getPlayerByUUID(this.conversionStarter);
++            Player entityhuman = world.getGlobalPlayerByUUID(this.conversionStarter); // Paper - check all players
+ 
+             if (entityhuman instanceof ServerPlayer) {
+                 CriteriaTriggers.CURED_ZOMBIE_VILLAGER.trigger((ServerPlayer) entityhuman, this, entityvillager);
+diff --git a/src/main/java/net/minecraft/world/level/EntityGetter.java b/src/main/java/net/minecraft/world/level/EntityGetter.java
+index 87beea39636b641dc5b46c2755a00285b7671ac5..6e55f383f48e9a304b0acd541728394615dc6478 100644
+--- a/src/main/java/net/minecraft/world/level/EntityGetter.java
++++ b/src/main/java/net/minecraft/world/level/EntityGetter.java
+@@ -243,4 +243,11 @@ public interface EntityGetter {
+ 
+         return null;
+     }
++
++    // Paper start
++    @Nullable
++    default Player getGlobalPlayerByUUID(UUID uuid) {
++        return this.getPlayerByUUID(uuid);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/SculkShriekerBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/SculkShriekerBlockEntity.java
+index ec0eba674c940ee1d743cd32f9c2b690868757e0..5c4cf21fc64ad5cfc3896ac7e13d814dd44be6f4 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/SculkShriekerBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/SculkShriekerBlockEntity.java
+@@ -100,6 +100,13 @@ public class SculkShriekerBlockEntity extends BlockEntity implements VibrationLi
+ 
+     @Nullable
+     public static ServerPlayer tryGetPlayer(@Nullable Entity entity) {
++        // Paper start - ensure level is the same for sculk events
++        final ServerPlayer player = tryGetPlayer0(entity);
++        return player != null && player.level == entity.level ? player : null;
++    }
++    @Nullable
++    private static ServerPlayer tryGetPlayer0(@Nullable Entity entity) {
++        // Paper end
+         if (entity instanceof ServerPlayer serverPlayer) {
+             return serverPlayer;
+         } else {


### PR DESCRIPTION
Vanilla's getPlayerByUUID only can return player's in the level, but due to an optimization by paper, this changed to return any player with the UUID across all levels. This can lead to unexpected side effects for sculk events and tamable animal owners. 

This PR adds a level check to paper's optimization and replaces some uses of getPlayerByUUID with a getGlobalPlayerByUUID where you do want to return any matching player on the whole server.