### PR TITLE
Fix rogue armswing detection

### DIFF
--- a/patches/server/0942-Fix-rouge-armswing-detection.patch
+++ b/patches/server/0942-Fix-rouge-armswing-detection.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Wed, 23 Nov 2022 13:19:25 -0500
+Subject: [PATCH] Fix rouge armswing detection
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index d31a345edfffe39f127073fc3aec8b3489bae79c..90780fbe7da58ef9076c258dd8ac265cc6cd6a33 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -2750,9 +2750,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+         double d2 = this.player.getZ();
+         Location origin = new Location(this.player.level.getWorld(), d0, d1, d2, f2, f1);
+ 
+-        double d3 = player.gameMode.getGameModeForPlayer() == GameType.CREATIVE ? 5.0D : 4.5D;
++        double d3 = player.gameMode.getGameModeForPlayer() == GameType.CREATIVE ? 5.0D : 3.0D; // Paper
+         // SPIGOT-5607: Only call interact event if no block or entity is being clicked. Use bukkit ray trace method, because it handles blocks and entities at the same time
+-        org.bukkit.util.RayTraceResult result = this.player.level.getWorld().rayTrace(origin, origin.getDirection(), d3, org.bukkit.FluidCollisionMode.NEVER, false, 0.1, entity -> entity != this.player.getBukkitEntity());
++        org.bukkit.util.RayTraceResult result = this.player.level.getWorld().rayTrace(origin, origin.getDirection(), d3, org.bukkit.FluidCollisionMode.NEVER, false, 0, entity -> entity != this.player.getBukkitEntity()); // Paper
+ 
+         if (result == null || this.player.gameMode.getGameModeForPlayer() == GameType.ADVENTURE) { // Paper - call PlayerInteractEvent when left-clicking on a block in adventure mode
+             CraftEventFactory.callPlayerInteractEvent(this.player, Action.LEFT_CLICK_AIR, this.player.getInventory().getSelected(), InteractionHand.MAIN_HAND);


### PR DESCRIPTION
Fix https://github.com/PaperMC/Paper/issues/8540

The range for survival is actually 3 blocks.
This also fixes the issue where if you look "nearby" an entity it will incorrectly assume you
are attacking that entity.

TODO: Properly have check for blocks/entities separate 
