### PR TITLE
remove duplicate animate packet for records

### DIFF
--- a/patches/server/0972-remove-duplicate-animate-packet-for-records.patch
+++ b/patches/server/0972-remove-duplicate-animate-packet-for-records.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 1 Dec 2022 12:42:18 -0800
+Subject: [PATCH] remove duplicate animate packet for records
+
+
+diff --git a/src/main/java/net/minecraft/world/item/RecordItem.java b/src/main/java/net/minecraft/world/item/RecordItem.java
+index af6d00adfe9b528f9854fbed174f7ae1f44522a6..a088111762fd36d4e6a8303e964b06c610590b44 100644
+--- a/src/main/java/net/minecraft/world/item/RecordItem.java
++++ b/src/main/java/net/minecraft/world/item/RecordItem.java
+@@ -46,7 +46,7 @@ public class RecordItem extends Item {
+             ItemStack itemstack = context.getItemInHand();
+ 
+             if (!world.isClientSide) {
+-                if (true) return InteractionResult.SUCCESS; // CraftBukkit - handled in ItemStack
++                if (true) return InteractionResult.sidedSuccess(world.isClientSide); // CraftBukkit - handled in ItemStack // Paper - fix duplicate animate packet
+                 Player entityhuman = context.getPlayer();
+                 BlockEntity tileentity = world.getBlockEntity(blockposition);
+ 


### PR DESCRIPTION
Returning SUCCESS here will send an animate packet to all players tracking the "using" player which will be a duplicate packet because the server has already sent one in response to the serverbound arm swing packet. Verified the duplicate packet behavior on 1.19 using pakkit and a vanilla server vs a 1.19 paper server.