### PR TITLE
Add missing Fluid type

### DIFF
--- a/patches/api/0414-Add-missing-Fluid-type.patch
+++ b/patches/api/0414-Add-missing-Fluid-type.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 4 Dec 2022 10:07:16 -0800
+Subject: [PATCH] Add missing Fluid type
+
+
+diff --git a/src/main/java/org/bukkit/Fluid.java b/src/main/java/org/bukkit/Fluid.java
+index 4cc974689a229e73ddbf2c353ac0fe23da03a5b2..7202b44a65e8699cf64329e441e83d4dd1779c19 100644
+--- a/src/main/java/org/bukkit/Fluid.java
++++ b/src/main/java/org/bukkit/Fluid.java
+@@ -8,6 +8,12 @@ import org.jetbrains.annotations.NotNull;
+  */
+ public enum Fluid implements Keyed {
+ 
++    // Paper start
++    /**
++     * No fluid.
++     */
++    EMPTY,
++    // Paper end
+     /**
+      * Stationary water.
+      */


### PR DESCRIPTION
If you used a datapack to create a fluid tag containing the fluid `minecraft:empty`, you would have a random "null" in the bukkit set of tagged items. Also the CraftMagicNumbers map FLUID_MATERIALS map was mapping nms Fluids.EMPTY to null, probably an unexpected thing.

You will definitely need this to finally add FluidState API.