### PR TITLE
Limit pet look distance

### DIFF
--- a/patches/server/0952-Limit-pet-look-distance.patch
+++ b/patches/server/0952-Limit-pet-look-distance.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Tue, 6 Dec 2022 18:45:54 +0100
+Subject: [PATCH] Limit pet look distance
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java
+index 7dc8cc93e8da37e1096c3263c1c8fc55bbf60401..fed2291d24d6014bd30b3d3491d555694c4e99f2 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java
++++ b/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java
+@@ -89,7 +89,7 @@ public class FollowOwnerGoal extends Goal {
+ 
+     @Override
+     public void tick() {
+-        this.tamable.getLookControl().setLookAt(this.owner, 10.0F, (float) this.tamable.getMaxHeadXRot());
++        if (this.tamable.distanceToSqr(this.owner) <= 16 * 16) this.tamable.getLookControl().setLookAt(this.owner, 10.0F, (float) this.tamable.getMaxHeadXRot()); // Paper
+         if (--this.timeToRecalcPath <= 0) {
+             this.timeToRecalcPath = this.adjustedTickDelay(10);
+             if (!this.tamable.isLeashed() && !this.tamable.isPassenger()) {


### PR DESCRIPTION
Cats are nearsighted, so it doesn't exactly make sense to have them be able to look at their owner who is very far away.