### PR TITLE
Take in account waterlogged block for the event

### DIFF
--- a/patches/server/0821-Fix-new-block-data-for-EntityChangeBlockEvent.patch
+++ b/patches/server/0821-Fix-new-block-data-for-EntityChangeBlockEvent.patch
@@ -18,6 +18,32 @@ index cc44e975aef8e9dabfbc740dd5a0db3a55c5831e..80aa539f7c6a6ee44338de084cdcdf5f
                          this.level.levelEvent(2001, blockposition1, Block.getId(Blocks.GRASS_BLOCK.defaultBlockState()));
                          this.level.setBlock(blockposition1, Blocks.DIRT.defaultBlockState(), 2);
                      }
+diff --git a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
+index b781c849737225c00f1dd8d45a6d08cebc000263..08a432f76a72ad628b8febe393196286182fbe07 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
++++ b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
+@@ -372,7 +372,7 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob
+ 
+                                 if (WitherBoss.canDestroy(iblockdata)) {
+                                     // CraftBukkit start
+-                                    if (CraftEventFactory.callEntityChangeBlockEvent(this, blockposition, Blocks.AIR.defaultBlockState()).isCancelled()) {
++                                    if (CraftEventFactory.callEntityChangeBlockEvent(this, blockposition, iblockdata.getFluidState().createLegacyBlock()).isCancelled()) { // Paper
+                                         continue;
+                                     }
+                                     // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Ravager.java b/src/main/java/net/minecraft/world/entity/monster/Ravager.java
+index 6a0b4f86e5157494a917cf5efecb730081bae628..40443f7d0c9f5697f529bfbbd16695c00bbd7322 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Ravager.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Ravager.java
+@@ -171,7 +171,7 @@ public class Ravager extends Raider {
+                     BlockState iblockdata = this.level.getBlockState(blockposition);
+                     Block block = iblockdata.getBlock();
+ 
+-                    if (block instanceof LeavesBlock && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(this, blockposition, net.minecraft.world.level.block.Blocks.AIR.defaultBlockState()).isCancelled()) { // CraftBukkit
++                    if (block instanceof LeavesBlock && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(this, blockposition, iblockdata.getFluidState().createLegacyBlock()).isCancelled()) { // CraftBukkit // Paper
+                         flag = this.level.destroyBlock(blockposition, true, this) || flag;
+                     }
+                 }
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Silverfish.java b/src/main/java/net/minecraft/world/entity/monster/Silverfish.java
 index 2dcda3b03796655da443e1b3dd68c6f6bca20d21..37d3b670a93c26b87ffc5c93ad7828f45b4b0217 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Silverfish.java
@@ -35,3 +61,16 @@ index 2dcda3b03796655da443e1b3dd68c6f6bca20d21..37d3b670a93c26b87ffc5c93ad7828f4
                                      continue;
                                  }
                                  // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/level/block/PointedDripstoneBlock.java b/src/main/java/net/minecraft/world/level/block/PointedDripstoneBlock.java
+index 24524b673f78da1ce138b72d6d879c2e690f19ea..01da5a5684692b3ed2e06834d6f926706925f643 100644
+--- a/src/main/java/net/minecraft/world/level/block/PointedDripstoneBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/PointedDripstoneBlock.java
+@@ -131,7 +131,7 @@ public class PointedDripstoneBlock extends Block implements Fallable, SimpleWate
+ 
+         if (!world.isClientSide && projectile.mayInteract(world, blockposition) && projectile instanceof ThrownTrident && projectile.getDeltaMovement().length() > 0.6D) {
+             // CraftBukkit start
+-            if (CraftEventFactory.callEntityChangeBlockEvent(projectile, blockposition, Blocks.AIR.defaultBlockState()).isCancelled()) {
++            if (CraftEventFactory.callEntityChangeBlockEvent(projectile, blockposition, state.getFluidState().createLegacyBlock()).isCancelled()) { // Paper
+                 return;
+             }
+             // CraftBukkit end


### PR DESCRIPTION
There's some inconsistencies between the EntityChangeBlockEvent and the BlockDestroyEvent. The destroy event has always the right final type but the change block event has always air even for watterlogged blocks. This fix this behavior only for possible case to avoid a bigger patch. I have maybe missed some of them.