### PR TITLE
[ci skip] Allow .git to be a regular file

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 import java.util.Locale
 
-if (!file(".git").isDirectory) {
+if (!file(".git").exists()) {
     val errorText = """
         
         =====================[ ERROR ]=====================


### PR DESCRIPTION
https://github.com/PaperMC/Paper/pull/8578 added a check to prevent trying to build Paper from a downloaded ZIP snapshot of the repo instead of an actual clone. This breaks building a Paperweight fork using submodules because `.git` is then a file (with `gitdir: ../../.git/modules/work/Paper` inside) instead of a directory.

This PR replaces the directory check by a simple exists check, which still prevents building from a ZIP, but now allows building from a submodule too.