### PR TITLE
fix ArmorStandMeta not applying false flags

### DIFF
--- a/patches/server/0176-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0176-Add-ArmorStand-Item-Meta.patch
@@ -13,7 +13,7 @@ starting point for future additions in this area.
 Fixes GH-559
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
-index 4017933f2244fca32cf9d39444f3a4f550e8af01..06bd5e6dd7ca6e6a44dca6ff133233b53c8ae22d 100644
+index 4017933f2244fca32cf9d39444f3a4f550e8af01..e721517ce7b52a1aa10d039aa9f309eb69db4733 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
 @@ -8,9 +8,22 @@ import org.bukkit.Material;
@@ -131,7 +131,7 @@ index 4017933f2244fca32cf9d39444f3a4f550e8af01..06bd5e6dd7ca6e6a44dca6ff133233b5
  
      boolean isArmorStandEmpty() {
 -        return !(this.entityTag != null);
-+        return !(this.isInvisible() || this.hasNoBasePlate() || this.shouldShowArms() || this.isSmall() || this.isMarker() || this.entityTag != null);
++        return !(this.invisible != null || this.noBasePlate != null || this.showArms != null || this.small != null || this.marker != null || this.entityTag != null); // Paper
      }
  
      @Override

--- a/patches/server/0176-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0176-Add-ArmorStand-Item-Meta.patch
@@ -13,7 +13,7 @@ starting point for future additions in this area.
 Fixes GH-559
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
-index 4017933f2244fca32cf9d39444f3a4f550e8af01..0c40a4a18cfc6f4ed6473a475f307f5c75ab56c5 100644
+index 4017933f2244fca32cf9d39444f3a4f550e8af01..06bd5e6dd7ca6e6a44dca6ff133233b53c8ae22d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
 @@ -8,9 +8,22 @@ import org.bukkit.Material;
@@ -31,11 +31,11 @@ index 4017933f2244fca32cf9d39444f3a4f550e8af01..0c40a4a18cfc6f4ed6473a475f307f5c
 +    static final ItemMetaKey SMALL = new ItemMetaKey("Small", "small");
 +    static final ItemMetaKey MARKER = new ItemMetaKey("Marker", "marker");
 +
-+    private boolean invisible;
-+    private boolean noBasePlate;
-+    private boolean showArms;
-+    private boolean small;
-+    private boolean marker;
++    private Boolean invisible = null;
++    private Boolean noBasePlate = null;
++    private Boolean showArms = null;
++    private Boolean small = null;
++    private Boolean marker = null;
 +    // Paper end
      CompoundTag entityTag;
  
@@ -103,23 +103,23 @@ index 4017933f2244fca32cf9d39444f3a4f550e8af01..0c40a4a18cfc6f4ed6473a475f307f5c
 +            this.entityTag = new CompoundTag();
 +        }
 +
-+        if (isInvisible()) {
++        if (this.invisible != null) {
 +            this.entityTag.putBoolean(INVISIBLE.NBT, this.invisible);
 +        }
 +
-+        if (hasNoBasePlate()) {
++        if (this.noBasePlate != null) {
 +            this.entityTag.putBoolean(NO_BASE_PLATE.NBT, this.noBasePlate);
 +        }
 +
-+        if (shouldShowArms()) {
++        if (this.showArms != null) {
 +            this.entityTag.putBoolean(SHOW_ARMS.NBT, this.showArms);
 +        }
 +
-+        if (isSmall()) {
++        if (this.small != null) {
 +            this.entityTag.putBoolean(SMALL.NBT, this.small);
 +        }
 +
-+        if (isMarker()) {
++        if (this.marker != null) {
 +            this.entityTag.putBoolean(MARKER.NBT, this.marker);
 +        }
 +        // Paper end
@@ -173,23 +173,23 @@ index 4017933f2244fca32cf9d39444f3a4f550e8af01..0c40a4a18cfc6f4ed6473a475f307f5c
          super.serialize(builder);
  
 +        // Paper start
-+        if (this.isInvisible()) {
++        if (invisible != null) {
 +            builder.put(INVISIBLE.BUKKIT, invisible);
 +        }
 +
-+        if (this.hasNoBasePlate()) {
++        if (noBasePlate != null) {
 +            builder.put(NO_BASE_PLATE.BUKKIT, noBasePlate);
 +        }
 +
-+        if (this.shouldShowArms()) {
++        if (showArms != null) {
 +            builder.put(SHOW_ARMS.BUKKIT, showArms);
 +        }
 +
-+        if (this.isSmall()) {
++        if (small != null) {
 +            builder.put(SMALL.BUKKIT, small);
 +        }
 +
-+        if (this.isMarker()) {
++        if (marker != null) {
 +            builder.put(MARKER.BUKKIT, marker);
 +        }
 +        // Paper end
@@ -205,27 +205,27 @@ index 4017933f2244fca32cf9d39444f3a4f550e8af01..0c40a4a18cfc6f4ed6473a475f307f5c
 +    // Paper start
 +    @Override
 +    public boolean isInvisible() {
-+        return invisible;
++        return invisible != null && invisible;
 +    }
 +
 +    @Override
 +    public boolean hasNoBasePlate() {
-+        return noBasePlate;
++        return noBasePlate != null && noBasePlate;
 +    }
 +
 +    @Override
 +    public boolean shouldShowArms() {
-+        return showArms;
++        return showArms != null && showArms;
 +    }
 +
 +    @Override
 +    public boolean isSmall() {
-+        return small;
++        return small != null && small;
 +    }
 +
 +    @Override
 +    public boolean isMarker() {
-+        return marker;
++        return marker != null && marker;
 +    }
 +
 +    @Override


### PR DESCRIPTION
Currently, trying to set one of ArmorStandMeta's flags (invisible, small, etc.) to false with the API does nothing. This PR fixes that.

One issue with this solution is that explicitly setting flags to false now saves the flags to item, which is technically useless data, so perhaps something like this for the flag handlers in `#applyToItem` might be better:
```java
if (this.bool != null) {
  if (this.bool) {
    this.entityTag.putBoolean(BOOL.NBT, this.bool);
  else {
    this.entityTag.remove(BOOL.NBT);
  }
}
```
But I'm not sure if that might cause issues with compatibility.