### PR TITLE
Fix MapLike Codec missing key 'selector'

### DIFF
--- a/patches/server/0946-Fix-MapLike-Codec-missing-key-selector.patch
+++ b/patches/server/0946-Fix-MapLike-Codec-missing-key-selector.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 9 Dec 2022 12:11:39 -0800
+Subject: [PATCH] Fix MapLike Codec missing key 'selector'
+
+
+diff --git a/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java b/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java
+index f25d523ae5a5228bca376c4911a92608f4c82df8..286a3cd9309736cc3baad9963d75acfe96d3a8ca 100644
+--- a/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java
++++ b/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java
+@@ -97,7 +97,7 @@ public class VibrationListener implements GameEventListener {
+                 return vibrationlistener.listenerRange;
+             }), VibrationInfo.CODEC.optionalFieldOf("event").forGetter((vibrationlistener) -> {
+                 return Optional.ofNullable(vibrationlistener.currentVibration);
+-            }), VibrationSelector.CODEC.fieldOf("selector").forGetter((vibrationlistener) -> {
++            }), VibrationSelector.CODEC.optionalFieldOf("selector", new VibrationSelector()).forGetter((vibrationlistener) -> { // Paper - fix MapLike spam for missing "selector" in 1.19.2
+                 return vibrationlistener.selectionStrategy;
+             }), ExtraCodecs.NON_NEGATIVE_INT.fieldOf("event_delay").orElse(0).forGetter((vibrationlistener) -> {
+                 return vibrationlistener.travelTimeInTicks;

--- a/patches/server/0948-Fix-MapLike-Codec-missing-key-selector.patch
+++ b/patches/server/0948-Fix-MapLike-Codec-missing-key-selector.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix MapLike Codec missing key 'selector'
 
 
 diff --git a/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java b/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java
-index f25d523ae5a5228bca376c4911a92608f4c82df8..286a3cd9309736cc3baad9963d75acfe96d3a8ca 100644
+index f25d523ae5a5228bca376c4911a92608f4c82df8..3288837a406539c4a22464524ffb2e727c6ad32b 100644
 --- a/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java
 +++ b/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java
 @@ -97,7 +97,7 @@ public class VibrationListener implements GameEventListener {
@@ -13,7 +13,7 @@ index f25d523ae5a5228bca376c4911a92608f4c82df8..286a3cd9309736cc3baad9963d75acfe
              }), VibrationInfo.CODEC.optionalFieldOf("event").forGetter((vibrationlistener) -> {
                  return Optional.ofNullable(vibrationlistener.currentVibration);
 -            }), VibrationSelector.CODEC.fieldOf("selector").forGetter((vibrationlistener) -> {
-+            }), VibrationSelector.CODEC.optionalFieldOf("selector", new VibrationSelector()).forGetter((vibrationlistener) -> { // Paper - fix MapLike spam for missing "selector" in 1.19.2
++            }), Codec.optionalField("selector", VibrationSelector.CODEC).xmap(o -> o.orElseGet(VibrationSelector::new), Optional::of).forGetter((vibrationlistener) -> { // Paper - fix MapLike spam for missing "selector" in 1.19.2
                  return vibrationlistener.selectionStrategy;
              }), ExtraCodecs.NON_NEGATIVE_INT.fieldOf("event_delay").orElse(0).forGetter((vibrationlistener) -> {
                  return vibrationlistener.travelTimeInTicks;


### PR DESCRIPTION
Tested by placing a sculk shrieker and sculk sensor down in a 1.19.2 world, then upgrading the world to 1.19.3

I verified that upgrading the world without this change did log the error, and with this change, no error was logged.

`new VibrationSelector()` is the default value for newly created VibrationListeners so it should work as the default here.