### PR TITLE
Improve vibration events

### DIFF
--- a/patches/api/0419-Improve-GameEvent-events.patch
+++ b/patches/api/0419-Improve-GameEvent-events.patch
@@ -1,0 +1,220 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 9 Dec 2022 21:21:50 -0800
+Subject: [PATCH] Improve GameEvent events
+
+Adds EntityReceiveGameEvent and expands BlockReceiveGameEvent
+
+diff --git a/src/main/java/io/papermc/paper/event/ReceiveGameEvent.java b/src/main/java/io/papermc/paper/event/ReceiveGameEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..81e2d7accd6705da5386e09ec786fa65859916ed
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/ReceiveGameEvent.java
+@@ -0,0 +1,49 @@
++package io.papermc.paper.event;
++
++import org.bukkit.GameEvent;
++import org.bukkit.block.data.BlockData;
++import org.bukkit.entity.Entity;
++import org.bukkit.event.Cancellable;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Common methods for {@link io.papermc.paper.event.entity.EntityReceiveGameEvent} and
++ * {@link org.bukkit.event.block.BlockReceiveGameEvent}.
++ */
++@ApiStatus.NonExtendable
++public interface ReceiveGameEvent extends Cancellable {
++
++    /**
++     * Get the underlying event.
++     *
++     * @return the event
++     */
++    @NotNull GameEvent getEvent();
++
++    /**
++     * Get the entity which triggered this event, if present.
++     *
++     * @return triggering entity or null
++     */
++    @Nullable Entity getTriggerEntity();
++
++    /**
++     * Get the block data change which triggered this event, if present.
++     *
++     * @return triggering block data or null
++     */
++    @Nullable BlockData getTriggerBlockData();
++
++    /**
++     * {@inheritDoc}
++     * <p>
++     * Cancels any action the receiver might take because of this game event
++     */
++    @Override
++    void setCancelled(boolean cancel);
++
++    @ApiStatus.Internal
++    boolean callEvent();
++}
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityReceiveGameEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityReceiveGameEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..54e18eae0c6d083e5196b706175cdd2d19f000a2
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityReceiveGameEvent.java
+@@ -0,0 +1,81 @@
++package io.papermc.paper.event.entity;
++
++import io.papermc.paper.event.ReceiveGameEvent;
++import org.bukkit.GameEvent;
++import org.bukkit.block.data.BlockData;
++import org.bukkit.entity.Entity;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when an entity receives a game event and hence might take some action.
++ * <p>
++ * Will be called cancelled if the entity's default behavior is to ignore the
++ * event.
++ */
++public class EntityReceiveGameEvent extends EntityEvent implements ReceiveGameEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++    private final GameEvent event;
++    private final Entity triggerEntity;
++    private final BlockData triggerBlockData;
++
++    private boolean cancelled;
++
++    @ApiStatus.Internal
++    public EntityReceiveGameEvent(final @NotNull Entity target, final @NotNull GameEvent event, final @Nullable Entity triggerEntity, final @Nullable BlockData triggerBlockData) {
++        super(target);
++        this.event = event;
++        this.triggerEntity = triggerEntity;
++        this.triggerBlockData = triggerBlockData;
++    }
++
++    /**
++     * {@inheritDoc}
++     * <p>
++     * Gets the entity which received the game event, not to be
++     * confused with the entity which may have caused the game event.
++     * @see #getTriggerEntity()
++     */
++    @Override
++    public @NotNull Entity getEntity() {
++        return super.getEntity();
++    }
++
++    @Override
++    public @NotNull GameEvent getEvent() {
++        return this.event;
++    }
++
++    @Override
++    public @Nullable Entity getTriggerEntity() {
++        return this.triggerEntity;
++    }
++
++    @Override
++    public @Nullable BlockData getTriggerBlockData() {
++        return this.triggerBlockData;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/block/BlockReceiveGameEvent.java b/src/main/java/org/bukkit/event/block/BlockReceiveGameEvent.java
+index e226d1306402324c2684946faa547cccb77fd138..1f5958f0c0b481def6cd67ab4d0f3e96857f4aba 100644
+--- a/src/main/java/org/bukkit/event/block/BlockReceiveGameEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockReceiveGameEvent.java
+@@ -9,29 +9,32 @@ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Nullable;
+ 
+ /**
+- * Called when a Sculk sensor receives a game event and hence might activate.
+- *
++ * Called when a block receives a game event and hence might take some action.
++ * <p>
+  * Will be called cancelled if the block's default behavior is to ignore the
+  * event.
+  */
+-public class BlockReceiveGameEvent extends BlockEvent implements Cancellable {
++public class BlockReceiveGameEvent extends BlockEvent implements io.papermc.paper.event.ReceiveGameEvent { // Paper
+ 
+     private static final HandlerList handlers = new HandlerList();
+     private final GameEvent event;
+     private final Entity entity;
++    // Paper start
++    private final org.bukkit.block.data.BlockData blockData;
++    // Paper end
+     private boolean cancelled;
+ 
+-    public BlockReceiveGameEvent(@NotNull GameEvent event, @NotNull Block block, @Nullable Entity entity) {
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public BlockReceiveGameEvent(@NotNull GameEvent event, @NotNull Block block, @Nullable Entity entity, final @Nullable org.bukkit.block.data.BlockData blockData) { // Paper
+         super(block);
+         this.event = event;
+         this.entity = entity;
++        // Paper start
++        this.blockData = blockData;
++        // Paper end
+     }
+ 
+-    /**
+-     * Get the underlying event.
+-     *
+-     * @return the event
+-     */
++    @Override // Paper - move to interface
+     @NotNull
+     public GameEvent getEvent() {
+         return event;
+@@ -41,11 +44,24 @@ public class BlockReceiveGameEvent extends BlockEvent implements Cancellable {
+      * Get the entity which triggered this event, if present.
+      *
+      * @return triggering entity or null
++     * @deprecated use {@link #getTriggerEntity()}
+      */
+     @Nullable
++    @Deprecated // Paper
+     public Entity getEntity() {
+         return entity;
+     }
++    // Paper start
++    @Override
++    public @Nullable Entity getTriggerEntity() {
++        return this.entity;
++    }
++
++    @Override
++    public @Nullable org.bukkit.block.data.BlockData getTriggerBlockData() {
++        return this.blockData;
++    }
++    // Paper end
+ 
+     @Override
+     public void setCancelled(boolean cancel) {

--- a/patches/server/0969-Improve-GameEvent-events.patch
+++ b/patches/server/0969-Improve-GameEvent-events.patch
@@ -1,0 +1,113 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 9 Dec 2022 21:21:09 -0800
+Subject: [PATCH] Improve GameEvent events
+
+Adds EntityReceiveGameEvent and makes sure each event is called in the right spot
+
+diff --git a/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java b/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java
+index 9b57d2b766f2de2d3fb4a3b5ef4df8d6756a1942..b83d3bf72e8d45d3b0aa72f78e6d253bd40e0b16 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java
++++ b/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java
+@@ -632,6 +632,12 @@ public class Allay extends PathfinderMob implements InventoryCarrier {
+         public TagKey<GameEvent> getListenableEvents() {
+             return GameEventTags.ALLAY_CAN_LISTEN;
+         }
++        // Paper start
++        @Override
++        public io.papermc.paper.event.ReceiveGameEvent createReceiveGameEvent(ServerLevel world, GameEvent event, GameEvent.Context emitter, Vec3 position) {
++            return VibrationListener.VibrationListenerConfig.createEntityEvent(event, emitter, Allay.this);
++        }
++        // Paper end
+     }
+ 
+     private class JukeboxListener implements GameEventListener {
+@@ -656,6 +662,14 @@ public class Allay extends PathfinderMob implements InventoryCarrier {
+ 
+         @Override
+         public boolean handleGameEvent(ServerLevel world, GameEvent event, GameEvent.Context emitter, Vec3 emitterPos) {
++            // Paper start
++            if (event == GameEvent.JUKEBOX_PLAY || event == GameEvent.JUKEBOX_STOP_PLAY) {
++                io.papermc.paper.event.ReceiveGameEvent entityEvent = VibrationListener.VibrationListenerConfig.createEntityEvent(event, emitter, Allay.this);
++                if (!entityEvent.callEvent()) {
++                    return false;
++                }
++            }
++            // Paper end
+             if (event == GameEvent.JUKEBOX_PLAY) {
+                 Allay.this.setJukeboxPlaying(BlockPos.containing(emitterPos), true);
+                 return true;
+diff --git a/src/main/java/net/minecraft/world/entity/monster/warden/Warden.java b/src/main/java/net/minecraft/world/entity/monster/warden/Warden.java
+index b2b63d9df3c07696f47281e9be74f1799f50b93e..e1db8c4abfe6768f5b7294da7830c077d5922d55 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/warden/Warden.java
++++ b/src/main/java/net/minecraft/world/entity/monster/warden/Warden.java
+@@ -677,4 +677,10 @@ public class Warden extends Monster implements VibrationListener.VibrationListen
+             }
+         };
+     }
++    // Paper start
++    @Override
++    public io.papermc.paper.event.ReceiveGameEvent createReceiveGameEvent(ServerLevel world, GameEvent event, GameEvent.Context emitter, Vec3 position) {
++        return VibrationListener.VibrationListenerConfig.createEntityEvent(event, emitter, this);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/SculkCatalystBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/SculkCatalystBlockEntity.java
+index 902f2b39104bf059849228829bfe93b6dbc757d4..810d57349e0383d9fbb51f669df99816677e97a6 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/SculkCatalystBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/SculkCatalystBlockEntity.java
+@@ -55,6 +55,12 @@ public class SculkCatalystBlockEntity extends BlockEntity implements GameEventLi
+                 LivingEntity entityliving = (LivingEntity) entity;
+ 
+                 if (!entityliving.wasExperienceConsumed()) {
++                    // Paper start TODO (future) add a sub event to capture more info about this happening, xp amount, amount to spread, etc.
++                    io.papermc.paper.event.ReceiveGameEvent blockEvent = net.minecraft.world.level.gameevent.vibrations.VibrationListener.VibrationListenerConfig.createBlockEvent(world, event, emitter, this.blockPosSource.getPosition(world).orElseThrow());
++                    if (!blockEvent.callEvent()) {
++                        return false;
++                    }
++                    // Paper end
+                     int i = entityliving.getExperienceReward();
+ 
+                     if (entityliving.shouldDropExperience() && i > 0) {
+diff --git a/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java b/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java
+index 103e12ec589dcbe6dbad7432b50e0644c3a37b1b..8568533811e1c6bf4cfc17683ebb623f22e95770 100644
+--- a/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java
++++ b/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationListener.java
+@@ -181,11 +181,9 @@ public class VibrationListener implements GameEventListener {
+ 
+                 // CraftBukkit start
+                 boolean defaultCancel = !this.config.shouldListen(world, this, BlockPos.containing(emitterPos), event, emitter);
+-                Entity entity = emitter.sourceEntity();
+-                BlockReceiveGameEvent event1 = new BlockReceiveGameEvent(org.bukkit.GameEvent.getByKey(CraftNamespacedKey.fromMinecraft(BuiltInRegistries.GAME_EVENT.getKey(event))), CraftBlock.at(world, BlockPos.containing(vec3d1)), (entity == null) ? null : entity.getBukkitEntity());
++                io.papermc.paper.event.ReceiveGameEvent event1 = this.config.createReceiveGameEvent(world, event, emitter, vec3d1); // Paper - TODO add special sub vibration events to control LOS check (GameEvent != Vibration)
+                 event1.setCancelled(defaultCancel);
+-                world.getCraftServer().getPluginManager().callEvent(event1);
+-                if (event1.isCancelled()) {
++                if (!event1.callEvent()) { // Paper
+                     // CraftBukkit end
+                     return false;
+                 } else if (VibrationListener.isOccluded(world, emitterPos, vec3d1)) {
+@@ -273,5 +271,23 @@ public class VibrationListener implements GameEventListener {
+         void onSignalReceive(ServerLevel world, GameEventListener listener, BlockPos pos, GameEvent event, @Nullable Entity entity, @Nullable Entity sourceEntity, float distance);
+ 
+         default void onSignalSchedule() {}
++
++        // Paper start - improve GameEvent events
++        default io.papermc.paper.event.ReceiveGameEvent createReceiveGameEvent(final ServerLevel world, final GameEvent event, final GameEvent.Context emitter, final Vec3 position) {
++            return createBlockEvent(world, event, emitter, position);
++        }
++
++        static io.papermc.paper.event.ReceiveGameEvent createBlockEvent(final ServerLevel world, final GameEvent event, final GameEvent.Context emitter, final Vec3 position) {
++            return new BlockReceiveGameEvent(convertEvent(event), CraftBlock.at(world, BlockPos.containing(position)), net.minecraft.Optionull.map(emitter.sourceEntity(), Entity::getBukkitEntity), net.minecraft.Optionull.map(emitter.affectedState(), net.minecraft.world.level.block.state.BlockState::createCraftBlockData));
++        }
++
++        static io.papermc.paper.event.ReceiveGameEvent createEntityEvent(final GameEvent event, final GameEvent.Context emitter, final Entity receiver) {
++            return new io.papermc.paper.event.entity.EntityReceiveGameEvent(receiver.getBukkitEntity(), convertEvent(event), net.minecraft.Optionull.map(emitter.sourceEntity(), Entity::getBukkitEntity), net.minecraft.Optionull.map(emitter.affectedState(), net.minecraft.world.level.block.state.BlockState::createCraftBlockData));
++        }
++
++        static org.bukkit.GameEvent convertEvent(GameEvent nms) {
++            return java.util.Objects.requireNonNull(org.bukkit.GameEvent.getByKey(CraftNamespacedKey.fromMinecraft(BuiltInRegistries.GAME_EVENT.getKey(nms))));
++        }
++        // Paper end
+     }
+ }


### PR DESCRIPTION
Adds EntityReceiveGameEvent and expands BlockReceiveGameEvent

BlockReceiveGameEvent was not called for all block listeners, and was called for entity listeners. This separates them out into two events and adds missing event calls. It also adds more api for bypassing line of sight/occlusion checks (not sure what to call that).

Still needs testing, but wanted to open this while I did that.