### PR TITLE
Don't show particles when splash events are canceled

### DIFF
--- a/patches/server/0648-Fix-potions-splash-events.patch
+++ b/patches/server/0648-Fix-potions-splash-events.patch
@@ -1,20 +1,47 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Thu, 20 May 2021 20:40:53 -0700
-Subject: [PATCH] Fix PotionSplashEvent for water splash potions
+Subject: [PATCH] Fix potions splash events
 
+Fix PotionSplashEvent for water splash potions
 Fixes SPIGOT-6221: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-6221
+Fix splash events cancellation that still show particles/sound
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-index b5e2c391ebcca05db5c960792fcb14991aec4fe2..533aad71202f67206ff4da916b9a8574345aeba3 100644
+index b5e2c391ebcca05db5c960792fcb14991aec4fe2..1eec7926627d7956ffdd33f76247829453af3bf2 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-@@ -123,33 +123,50 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
+@@ -105,56 +105,77 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
+             Potion potionregistry = PotionUtils.getPotion(itemstack);
+             List<MobEffectInstance> list = PotionUtils.getMobEffects(itemstack);
+             boolean flag = potionregistry == Potions.WATER && list.isEmpty();
++            boolean showParticles = true; // Paper
+ 
+             if (flag) {
+-                this.applyWater();
++                showParticles = this.applyWater(); // Paper
+             } else if (true || !list.isEmpty()) { // CraftBukkit - Call event even if no effects to apply
+                 if (this.isLingering()) {
+-                    this.makeAreaOfEffectCloud(itemstack, potionregistry);
++                    showParticles = this.makeAreaOfEffectCloud(itemstack, potionregistry); // Paper
+                 } else {
+-                    this.applySplash(list, hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null);
++                    showParticles = this.applySplash(list, hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null); // Paper
+                 }
+             }
+ 
++            if (showParticles) { // Paper
+             int i = potionregistry.hasInstantEffects() ? 2007 : 2002;
+ 
+             this.level.levelEvent(i, this.blockPosition(), PotionUtils.getColor(itemstack));
++            } // Paper
+             this.discard();
          }
      }
  
+-    private void applyWater() {
 +    private static final Predicate<net.minecraft.world.entity.LivingEntity> APPLY_WATER_GET_ENTITIES_PREDICATE = ThrownPotion.WATER_SENSITIVE_OR_ON_FIRE.or(Axolotl.class::isInstance); // Paper
-     private void applyWater() {
++    private boolean applyWater() { // Paper
          AABB axisalignedbb = this.getBoundingBox().inflate(4.0D, 2.0D, 4.0D);
 -        List<net.minecraft.world.entity.LivingEntity> list = this.level.getEntitiesOfClass(net.minecraft.world.entity.LivingEntity.class, axisalignedbb, ThrownPotion.WATER_SENSITIVE_OR_ON_FIRE);
 +        // Paper start
@@ -68,9 +95,16 @@ index b5e2c391ebcca05db5c960792fcb14991aec4fe2..533aad71202f67206ff4da916b9a8574
 +            }
 +            // Paper end
          }
++        return !event.isCancelled(); // Paper
  
      }
-@@ -170,6 +187,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
+ 
+-    private void applySplash(List<MobEffectInstance> statusEffects, @Nullable Entity entity) {
++    private boolean applySplash(List<MobEffectInstance> statusEffects, @Nullable Entity entity) { // Paper
+         AABB axisalignedbb = this.getBoundingBox().inflate(4.0D, 2.0D, 4.0D);
+         List<net.minecraft.world.entity.LivingEntity> list1 = this.level.getEntitiesOfClass(net.minecraft.world.entity.LivingEntity.class, axisalignedbb);
+         Map<LivingEntity, Double> affected = new HashMap<LivingEntity, Double>(); // CraftBukkit
+@@ -170,6 +191,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
                      double d0 = this.distanceToSqr((Entity) entityliving);
  
                      if (d0 < 16.0D) {
@@ -78,3 +112,24 @@ index b5e2c391ebcca05db5c960792fcb14991aec4fe2..533aad71202f67206ff4da916b9a8574
                          double d1 = 1.0D - Math.sqrt(d0) / 4.0D;
  
                          if (entityliving == entity) {
+@@ -222,10 +244,11 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
+                 }
+             }
+         }
++        return !event.isCancelled(); // Paper
+ 
+     }
+ 
+-    private void makeAreaOfEffectCloud(ItemStack stack, Potion potion) {
++    private boolean makeAreaOfEffectCloud(ItemStack stack, Potion potion) { // Paper
+         AreaEffectCloud entityareaeffectcloud = new AreaEffectCloud(this.level, this.getX(), this.getY(), this.getZ());
+         Entity entity = this.getOwner();
+ 
+@@ -260,6 +283,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
+             entityareaeffectcloud.discard();
+         }
+         // CraftBukkit end
++        return !event.isCancelled(); // Paper
+     }
+ 
+     public boolean isLingering() {

--- a/patches/server/0818-More-Projectile-API.patch
+++ b/patches/server/0818-More-Projectile-API.patch
@@ -18,7 +18,7 @@ public net.minecraft.world.entity.projectile.Projectile leftOwner
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-index 533aad71202f67206ff4da916b9a8574345aeba3..934b9e76d9d7d4170ac9205622bc87975de73541 100644
+index 1eec7926627d7956ffdd33f76247829453af3bf2..e41f99bdef9f779b3d039bfe7a4e560e9daed9f5 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 @@ -100,6 +100,11 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
@@ -33,12 +33,12 @@ index 533aad71202f67206ff4da916b9a8574345aeba3..934b9e76d9d7d4170ac9205622bc8797
          if (!this.level.isClientSide) {
              ItemStack itemstack = this.getItem();
              Potion potionregistry = PotionUtils.getPotion(itemstack);
-@@ -112,7 +117,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
+@@ -113,7 +118,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
                  if (this.isLingering()) {
-                     this.makeAreaOfEffectCloud(itemstack, potionregistry);
+                     showParticles = this.makeAreaOfEffectCloud(itemstack, potionregistry); // Paper
                  } else {
--                    this.applySplash(list, hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null);
-+                    this.applySplash(list, hitResult != null && hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null); // Paper - nullable hitResult
+-                    showParticles = this.applySplash(list, hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null); // Paper
++                    showParticles = this.applySplash(list, hitResult != null && hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null); // Paper - nullable hitResult
                  }
              }
  


### PR DESCRIPTION
Closes #8626 
This also cancel the glass sound
and include the lingering event to avoid inconsistencies