### PR TITLE
Fix chunksnapshot biome getter

### DIFF
--- a/patches/api/0054-Fix-upstream-javadocs.patch
+++ b/patches/api/0054-Fix-upstream-javadocs.patch
@@ -18,6 +18,19 @@ index d3d8c5ac59cee2ec24e91223e0c994016a4f9752..82757d3013e01a6bfbb685929955d3e7
       *
       * @return an array containing all previous players
       */
+diff --git a/src/main/java/org/bukkit/ChunkSnapshot.java b/src/main/java/org/bukkit/ChunkSnapshot.java
+index fb3e166ec48b8c0ebb7d541eaa1761b03a140610..cab63d678e56df0a090ee793d56def88b8c68079 100644
+--- a/src/main/java/org/bukkit/ChunkSnapshot.java
++++ b/src/main/java/org/bukkit/ChunkSnapshot.java
+@@ -136,7 +136,7 @@ public interface ChunkSnapshot {
+      * Get raw biome temperature at given coordinates
+      *
+      * @param x X-coordinate (0-15)
+-     * @param y Y-coordinate (0-15)
++     * @param y Y-coordinate (world minHeight (inclusive) - world maxHeight (exclusive))
+      * @param z Z-coordinate (0-15)
+      * @return temperature at given coordinate
+      */
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
 index a8d3addae5b0ed261d6a27052ad4e54970de597c..3485db7548e93242f99977a236eb3bcebedfb964 100644
 --- a/src/main/java/org/bukkit/Server.java

--- a/patches/server/0946-Fix-chunk-snapshot-biome-getter.patch
+++ b/patches/server/0946-Fix-chunk-snapshot-biome-getter.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com>
+Date: Sat, 10 Dec 2022 13:01:52 +0100
+Subject: [PATCH] Fix chunk snapshot biome getter
+
+Fixes SPIGOT-7188: https://hub.spigotmc.org/jira/browse/SPIGOT-7188
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunkSnapshot.java b/src/main/java/org/bukkit/craftbukkit/CraftChunkSnapshot.java
+index 75193684a71d694736087d1a368b8fb6a8c8363b..f39cf8e90d955c83471363e7dc5097c04894785b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftChunkSnapshot.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftChunkSnapshot.java
+@@ -135,7 +135,7 @@ public class CraftChunkSnapshot implements ChunkSnapshot {
+         Preconditions.checkState(this.biome != null, "ChunkSnapshot created without biome. Please call getSnapshot with includeBiome=true");
+         this.validateChunkCoordinates(x, y, z);
+ 
+-        PalettedContainerRO<Holder<net.minecraft.world.level.biome.Biome>> biome = this.biome[this.getSectionIndex(y >> 2)];
++        PalettedContainerRO<Holder<net.minecraft.world.level.biome.Biome>> biome = this.biome[this.getSectionIndex(y)]; // Paper
+         return CraftBlock.biomeBaseToBiome(biomeRegistry, biome.get(x >> 2, (y & 0xF) >> 2, z >> 2));
+     }
+ 
+@@ -149,7 +149,7 @@ public class CraftChunkSnapshot implements ChunkSnapshot {
+         Preconditions.checkState(this.biome != null, "ChunkSnapshot created without biome. Please call getSnapshot with includeBiome=true");
+         this.validateChunkCoordinates(x, y, z);
+ 
+-        PalettedContainerRO<Holder<net.minecraft.world.level.biome.Biome>> biome = this.biome[this.getSectionIndex(y >> 2)];
++        PalettedContainerRO<Holder<net.minecraft.world.level.biome.Biome>> biome = this.biome[this.getSectionIndex(y)]; // Paper
+         return biome.get(x >> 2, (y & 0xF) >> 2, z >> 2).value().getTemperature(new BlockPos((this.x << 4) | x, y, (this.z << 4) | z));
+     }
+ 


### PR DESCRIPTION
The chunk section is found using the y absolute position but a (wrong) biome relative position has been passed.
This result that the biome getter can only retrieve data from -16 to 79 pos for the full range (-64 -> 320 by default), so the biome is found from a shifted chunk section (from 3 to 8, ignoring the others 18 sections).
Fixes SPIGOT-7188: https://hub.spigotmc.org/jira/browse/SPIGOT-7188
I have also correct some related javadoc