### PR TITLE
Deprecate and replace methods using deprecated StructureType

### DIFF
--- a/patches/api/0426-Deprecate-and-replace-methods-with-old-StructureType.patch
+++ b/patches/api/0426-Deprecate-and-replace-methods-with-old-StructureType.patch
@@ -1,0 +1,159 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 10 Dec 2022 17:52:45 -0800
+Subject: [PATCH] Deprecate and replace methods with old StructureType
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index f380a518bc444bfdfbbedf38805c7684e53a5629..f78b5fd3c3347d28da58777bff88903d2eb140f6 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -915,7 +915,9 @@ public final class Bukkit {
+      *
+      * @see World#locateNearestStructure(org.bukkit.Location,
+      *      org.bukkit.StructureType, int, boolean)
++     * @deprecated use {@link #createExplorerMap(World, Location, org.bukkit.generator.structure.StructureType, org.bukkit.map.MapCursor.Type)}
+      */
++    @Deprecated // Paper
+     @NotNull
+     public static ItemStack createExplorerMap(@NotNull World world, @NotNull Location location, @NotNull StructureType structureType) {
+         return server.createExplorerMap(world, location, structureType);
+@@ -924,9 +926,6 @@ public final class Bukkit {
+     /**
+      * Create a new explorer map targeting the closest nearby structure of a
+      * given {@link StructureType}.
+-     * <br>
+-     * This method uses implementation default values for radius and
+-     * findUnexplored (usually 100, true).
+      *
+      * @param world the world the map will belong to
+      * @param location the origin location to find the nearest structure
+@@ -938,11 +937,54 @@ public final class Bukkit {
+      *
+      * @see World#locateNearestStructure(org.bukkit.Location,
+      *      org.bukkit.StructureType, int, boolean)
++     * @deprecated use {@link #createExplorerMap(World, Location, org.bukkit.generator.structure.StructureType, org.bukkit.map.MapCursor.Type, int, boolean)}
+      */
++    @Deprecated // Paper
+     @NotNull
+     public static ItemStack createExplorerMap(@NotNull World world, @NotNull Location location, @NotNull StructureType structureType, int radius, boolean findUnexplored) {
+         return server.createExplorerMap(world, location, structureType, radius, findUnexplored);
+     }
++    // Paper start
++    /**
++     * Create a new explorer map targeting the closest nearby structure of a
++     * given {@link org.bukkit.generator.structure.StructureType}.
++     * <br>
++     * This method uses implementation default values for radius and
++     * findUnexplored (usually 100, true).
++     *
++     * @param world the world the map will belong to
++     * @param location the origin location to find the nearest structure
++     * @param structureType the type of structure to find
++     * @param mapIcon the map icon to use on the map
++     * @return a newly created item stack or null if it can't find a location
++     *
++     * @see World#locateNearestStructure(org.bukkit.Location,
++     *      org.bukkit.generator.structure.StructureType, int, boolean)
++     */
++    public static @Nullable ItemStack createExplorerMap(@NotNull World world, @NotNull Location location, @NotNull org.bukkit.generator.structure.StructureType structureType, @NotNull org.bukkit.map.MapCursor.Type mapIcon) {
++        return server.createExplorerMap(world, location, structureType, mapIcon);
++    }
++
++    /**
++     * Create a new explorer map targeting the closest nearby structure of a
++     * given {@link org.bukkit.generator.structure.StructureType}.
++     *
++     * @param world the world the map will belong to
++     * @param location the origin location to find the nearest structure
++     * @param structureType the type of structure to find
++     * @param mapIcon the map icon to use on the map
++     * @param radius radius to search, see World#locateNearestStructure for more
++     *               information
++     * @param findUnexplored whether to find unexplored structures
++     * @return the newly created item stack or null if it can't find a location
++     *
++     * @see World#locateNearestStructure(org.bukkit.Location,
++     *      org.bukkit.generator.structure.StructureType, int, boolean)
++     */
++    public static @Nullable ItemStack createExplorerMap(@NotNull World world, @NotNull Location location, @NotNull org.bukkit.generator.structure.StructureType structureType, @NotNull org.bukkit.map.MapCursor.Type mapIcon, int radius, boolean findUnexplored) {
++        return server.createExplorerMap(world, location, structureType, mapIcon, radius, findUnexplored);
++    }
++    // Paper end
+ 
+     /**
+      * Reloads the server, refreshing settings and plugin information.
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 68206cf0178c26c0f528a1e14a5fb4e9ad410369..8d8fe04e6b09d2a5b1cc05002073df5c58cdcb96 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -775,16 +775,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      *
+      * @see World#locateNearestStructure(org.bukkit.Location,
+      *      org.bukkit.StructureType, int, boolean)
++     * @deprecated use {@link #createExplorerMap(World, Location, org.bukkit.generator.structure.StructureType, org.bukkit.map.MapCursor.Type)}
+      */
++    @Deprecated // Paper
+     @NotNull
+     public ItemStack createExplorerMap(@NotNull World world, @NotNull Location location, @NotNull StructureType structureType);
+ 
+     /**
+      * Create a new explorer map targeting the closest nearby structure of a
+      * given {@link StructureType}.
+-     * <br>
+-     * This method uses implementation default values for radius and
+-     * findUnexplored (usually 100, true).
+      *
+      * @param world the world the map will belong to
+      * @param location the origin location to find the nearest structure
+@@ -796,9 +795,50 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      *
+      * @see World#locateNearestStructure(org.bukkit.Location,
+      *      org.bukkit.StructureType, int, boolean)
++     * @deprecated use {@link #createExplorerMap(World, Location, org.bukkit.generator.structure.StructureType, org.bukkit.map.MapCursor.Type, int, boolean)}
+      */
++    @Deprecated // Paper
+     @NotNull
+     public ItemStack createExplorerMap(@NotNull World world, @NotNull Location location, @NotNull StructureType structureType, int radius, boolean findUnexplored);
++    // Paper start
++    /**
++     * Create a new explorer map targeting the closest nearby structure of a
++     * given {@link org.bukkit.generator.structure.StructureType}.
++     * <br>
++     * This method uses implementation default values for radius and
++     * findUnexplored (usually 100, true).
++     *
++     * @param world the world the map will belong to
++     * @param location the origin location to find the nearest structure
++     * @param structureType the type of structure to find
++     * @param mapIcon the map icon to use on the map
++     * @return a newly created item stack or null if it can't find a location
++     *
++     * @see World#locateNearestStructure(org.bukkit.Location,
++     *      org.bukkit.generator.structure.StructureType, int, boolean)
++     */
++    default @Nullable ItemStack createExplorerMap(@NotNull World world, @NotNull Location location, @NotNull org.bukkit.generator.structure.StructureType structureType, @NotNull org.bukkit.map.MapCursor.Type mapIcon) {
++        return this.createExplorerMap(world, location, structureType, mapIcon, 100, true);
++    }
++
++    /**
++     * Create a new explorer map targeting the closest nearby structure of a
++     * given {@link org.bukkit.generator.structure.StructureType}.
++     *
++     * @param world the world the map will belong to
++     * @param location the origin location to find the nearest structure
++     * @param structureType the type of structure to find
++     * @param mapIcon the map icon to use on the map
++     * @param radius radius to search, see World#locateNearestStructure for more
++     *               information
++     * @param findUnexplored whether to find unexplored structures
++     * @return the newly created item stack or null if it can't find a location
++     *
++     * @see World#locateNearestStructure(org.bukkit.Location,
++     *      org.bukkit.generator.structure.StructureType, int, boolean)
++     */
++    @Nullable ItemStack createExplorerMap(@NotNull World world, @NotNull Location location, @NotNull org.bukkit.generator.structure.StructureType structureType, @NotNull org.bukkit.map.MapCursor.Type mapIcon, int radius, boolean findUnexplored);
++    // Paper end
+ 
+     /**
+      * Reloads the server, refreshing settings and plugin information.

--- a/patches/server/1004-Deprecate-and-replace-methods-with-old-StructureType.patch
+++ b/patches/server/1004-Deprecate-and-replace-methods-with-old-StructureType.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 10 Dec 2022 17:52:38 -0800
+Subject: [PATCH] Deprecate and replace methods with old StructureType
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 249d76acac9a91cd46f0b8a477511974a75d6f4a..ec4b73321205b472f19fa5bd4ad95893020d1340 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1872,6 +1872,11 @@ public final class CraftServer implements Server {
+ 
+         ServerLevel worldServer = ((CraftWorld) world).getHandle();
+         Location structureLocation = world.locateNearestStructure(location, structureType, radius, findUnexplored);
++        // Paper start - don't throw NPE
++        if (structureLocation == null) {
++            throw new IllegalStateException("Could not find a structure for " + structureType);
++        }
++        // Paper end
+         BlockPos structurePosition = CraftLocation.toBlockPosition(structureLocation);
+ 
+         // Create map with trackPlayer = true, unlimitedTracking = true
+@@ -1882,6 +1887,31 @@ public final class CraftServer implements Server {
+ 
+         return CraftItemStack.asBukkitCopy(stack);
+     }
++    // Paper start - copied from above (uses un-deprecated StructureType type)
++    @Override
++    public ItemStack createExplorerMap(World world, Location location, org.bukkit.generator.structure.StructureType structureType, org.bukkit.map.MapCursor.Type mapIcon, int radius, boolean findUnexplored) {
++        Preconditions.checkArgument(world != null, "World cannot be null");
++        Preconditions.checkArgument(location != null, "Location cannot be null");
++        Preconditions.checkArgument(structureType != null, "StructureType cannot be null");
++        Preconditions.checkArgument(mapIcon != null, "mapIcon cannot be null");
++
++        ServerLevel worldServer = ((CraftWorld) world).getHandle();
++        final org.bukkit.util.StructureSearchResult structureSearchResult = world.locateNearestStructure(location, structureType, radius, findUnexplored);
++        if (structureSearchResult == null) {
++            return null;
++        }
++        Location structureLocation = structureSearchResult.getLocation();
++        BlockPos structurePosition = new BlockPos(structureLocation.getBlockX(), structureLocation.getBlockY(), structureLocation.getBlockZ());
++
++        // Create map with showIcons = true, unlimitedTracking = true
++        net.minecraft.world.item.ItemStack stack = MapItem.create(worldServer, structurePosition.getX(), structurePosition.getZ(), MapView.Scale.NORMAL.getValue(), true, true);
++        MapItem.renderBiomePreviewMap(worldServer, stack);
++        // "+" map ID taken from VillagerTrades$TreasureMapForEmeralds
++        MapItem.getSavedData(stack, worldServer).addTargetDecoration(stack, structurePosition, "+", MapDecoration.Type.byIcon(mapIcon.getValue()));
++
++        return CraftItemStack.asBukkitCopy(stack);
++    }
++    // Paper end
+ 
+     @Override
+     public void shutdown() {


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/9477

Well this change certainly got more complicated. In order to deprecate and add replacements for the methods on Server/Bukkit that used the deprecated StructureType, I had to completely switch to mockito for testing. Otherwise there's a static initializer loop created. Apparently the default heap sizes then weren't enough for the tests, so I bumped those up (this seems weird, maybe I did something wrong with mockito).