### PR TITLE
Add Position methods to pathfinder api

### DIFF
--- a/patches/api/0151-Mob-Pathfinding-API.patch
+++ b/patches/api/0151-Mob-Pathfinding-API.patch
@@ -13,12 +13,13 @@ You can use EntityPathfindEvent to cancel new pathfinds from overriding your cur
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..43f062257472a06e9e64c2feef6c3b1012aee00e
+index 0000000000000000000000000000000000000000..3174a858d63f72bf151f737d485476aa1cdf423c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
-@@ -0,0 +1,212 @@
+@@ -0,0 +1,272 @@
 +package com.destroystokyo.paper.entity;
 +
++import io.papermc.paper.math.Position;
 +import org.bukkit.Location;
 +import org.bukkit.entity.LivingEntity;
 +import org.bukkit.entity.Mob;
@@ -26,6 +27,7 @@ index 0000000000000000000000000000000000000000..43f062257472a06e9e64c2feef6c3b10
 +import java.util.List;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
++import org.jetbrains.annotations.Unmodifiable;
 +
 +/**
 + * Handles pathfinding operations for an Entity
@@ -61,17 +63,28 @@ index 0000000000000000000000000000000000000000..43f062257472a06e9e64c2feef6c3b10
 +     * as the current target. Useful for calculating what would happen before setting it.
 +     * @param loc Location to navigate to
 +     * @return The closest Location the Entity can get to for this navigation, or null if no path could be calculated
++     * @see #findPath(Position)
 +     */
-+    @Nullable PathResult findPath(@NotNull Location loc);
++    default @Nullable PathResult findPath(@NotNull Location loc) {
++        return this.findPath((Position) loc);
++    }
++
++    /**
++     * Calculates a destination for the Entity to navigate to, but does not set it
++     * as the current target. Useful for calculating what would happen before setting it.
++     * @param position Position to navigate to
++     * @return The closest Location the Entity can get to for this navigation, or null if no path could be calculated
++     */
++    @Nullable PathResult findPath(@NotNull Position position);
 +
 +    /**
 +     * Calculates a destination for the Entity to navigate to to reach the target entity,
 +     * but does not set it as the current target.
 +     * Useful for calculating what would happen before setting it.
-+     *
++     * <p>
 +     * The behavior of this PathResult is subject to the games pathfinding rules, and may
 +     * result in the pathfinding automatically updating to follow the target Entity.
-+     *
++     * <p>
 +     * However, this behavior is not guaranteed, and is subject to the games behavior.
 +     *
 +     * @param target the Entity to navigate to
@@ -84,9 +97,10 @@ index 0000000000000000000000000000000000000000..43f062257472a06e9e64c2feef6c3b10
 +     * as the current target.
 +     * @param loc Location to navigate to
 +     * @return If the pathfinding was successfully started
++     * @see #moveTo(Position)
 +     */
 +    default boolean moveTo(@NotNull Location loc) {
-+        return moveTo(loc, 1);
++        return this.moveTo((Position) loc, 1);
 +    }
 +
 +    /**
@@ -95,19 +109,41 @@ index 0000000000000000000000000000000000000000..43f062257472a06e9e64c2feef6c3b10
 +     * @param loc Location to navigate to
 +     * @param speed Speed multiplier to navigate at, where 1 is 'normal'
 +     * @return If the pathfinding was successfully started
++     * @see #moveTo(Position, double)
 +     */
 +    default boolean moveTo(@NotNull Location loc, double speed) {
-+        PathResult path = findPath(loc);
-+        return path != null && moveTo(path, speed);
++        return this.moveTo((Position) loc, speed);
++    }
++
++    /**
++     * Calculates a destination for the Entity to navigate to, and sets it with default speed
++     * as the current target.
++     * @param position Position to navigate to
++     * @return If the pathfinding was successfully started
++     */
++    default boolean moveTo(@NotNull Position position) {
++        return this.moveTo(position, 1);
++    }
++
++    /**
++     * Calculates a destination for the Entity to navigate to, with desired speed
++     * as the current target.
++     * @param position Position to navigate to
++     * @param speed Speed multiplier to navigate at, where 1 is 'normal'
++     * @return If the pathfinding was successfully started
++     */
++    default boolean moveTo(@NotNull Position position, double speed) {
++        final PathResult path = this.findPath(position);
++        return path != null && this.moveTo(path, speed);
 +    }
 +
 +    /**
 +     * Calculates a destination for the Entity to navigate to to reach the target entity,
 +     * and sets it with default speed.
-+     *
++     * <p>
 +     * The behavior of this PathResult is subject to the games pathfinding rules, and may
 +     * result in the pathfinding automatically updating to follow the target Entity.
-+     *
++     * <p>
 +     * However, this behavior is not guaranteed, and is subject to the games behavior.
 +     *
 +     * @param target the Entity to navigate to
@@ -120,10 +156,10 @@ index 0000000000000000000000000000000000000000..43f062257472a06e9e64c2feef6c3b10
 +    /**
 +     * Calculates a destination for the Entity to navigate to to reach the target entity,
 +     * and sets it with specified speed.
-+     *
++     * <p>
 +     * The behavior of this PathResult is subject to the games pathfinding rules, and may
 +     * result in the pathfinding automatically updating to follow the target Entity.
-+     *
++     * <p>
 +     * However, this behavior is not guaranteed, and is subject to the games behavior.
 +     *
 +     * @param target the Entity to navigate to
@@ -208,9 +244,19 @@ index 0000000000000000000000000000000000000000..43f062257472a06e9e64c2feef6c3b10
 +         *
 +         * Will return points the entity has already moved past, see {@link #getNextPointIndex()}
 +         * @return List of points
++         * @deprecated use {@link #getPathPoints()}
 +         */
 +        @NotNull
++        @Deprecated(forRemoval = true)
 +        List<Location> getPoints();
++
++        /**
++         * All currently calculated points to follow along the path to reach the destination location
++         * <p>
++         * Will return points the entity has already moved past, see {@link #getNextPointIndex()}
++         * @return immutable list of points
++         */
++         @NotNull @Unmodifiable List<Position> getPathPoints();
 +
 +        /**
 +         * @return Returns the index of the current point along the points returned in {@link #getPoints()} the entity
@@ -220,13 +266,27 @@ index 0000000000000000000000000000000000000000..43f062257472a06e9e64c2feef6c3b10
 +
 +        /**
 +         * @return The next location in the path points the entity is trying to reach, or null if there is no next point
++         * @deprecated use {@link #getNextPathPoint()}
 +         */
++        @Deprecated(forRemoval = true)
 +        @Nullable Location getNextPoint();
++
++        /**
++         * @return The next location in the path points the entity is trying to reach, or null if there is no next point
++         */
++        @Nullable Position getNextPathPoint();
++
++        /**
++         * @return The closest point the path can get to the target location
++         * @deprecated use {@link #getFinalPathPoint()}
++         */
++        @Deprecated(forRemoval = true)
++        @Nullable Location getFinalPoint();
 +
 +        /**
 +         * @return The closest point the path can get to the target location
 +         */
-+        @Nullable Location getFinalPoint();
++        @Nullable Position getFinalPathPoint();
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java

--- a/patches/server/0257-Mob-Pathfinding-API.patch
+++ b/patches/server/0257-Mob-Pathfinding-API.patch
@@ -12,25 +12,30 @@ public net.minecraft.world.level.pathfinder.Path nodes
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java b/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2d799fec40afe7dade649a294761d272c83157f0
+index 0000000000000000000000000000000000000000..c0c59c534ddcf5d16d5a55a05956130b525c235b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
-@@ -0,0 +1,143 @@
+@@ -0,0 +1,168 @@
 +package com.destroystokyo.paper.entity;
 +
++import io.papermc.paper.math.Position;
++import java.lang.ref.WeakReference;
 +import org.apache.commons.lang.Validate;
 +import org.bukkit.Location;
++import org.bukkit.World;
 +import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 +import org.bukkit.entity.LivingEntity;
 +import org.bukkit.entity.Mob;
-+import javax.annotation.Nonnull;
-+import javax.annotation.Nullable;
 +import net.minecraft.world.level.pathfinder.Node;
 +import net.minecraft.world.level.pathfinder.Path;
 +import java.util.ArrayList;
 +import java.util.List;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.checker.nullness.qual.Nullable;
++import org.checkerframework.framework.qual.DefaultQualifier;
 +
-+public class PaperPathfinder implements com.destroystokyo.paper.entity.Pathfinder {
++@DefaultQualifier(NonNull.class)
++public class PaperPathfinder implements Pathfinder {
 +
 +    private net.minecraft.world.entity.Mob entity;
 +
@@ -57,31 +62,28 @@ index 0000000000000000000000000000000000000000..2d799fec40afe7dade649a294761d272
 +        return entity.getNavigation().getPath() != null;
 +    }
 +
-+    @Nullable
 +    @Override
 +    public PathResult getCurrentPath() {
-+        Path path = entity.getNavigation().getPath();
-+        return path != null ? new PaperPathResult(path) : null;
++        final @Nullable Path path = entity.getNavigation().getPath();
++        return path != null ? new PaperPathResult(path, this.entity.level.getWorld()) : null;
 +    }
 +
-+    @Nullable
 +    @Override
-+    public PathResult findPath(Location loc) {
-+        Validate.notNull(loc, "Location can not be null");
-+        Path path = entity.getNavigation().createPath(loc.getX(), loc.getY(), loc.getZ(), 0);
-+        return path != null ? new PaperPathResult(path) : null;
++    public PathResult findPath(final Position position) {
++        Validate.notNull(position, "Position cannot be null");
++        final @Nullable Path path = entity.getNavigation().createPath(position.x(), position.y(), position.z(), 0);
++        return path != null ? new PaperPathResult(path, this.entity.level.getWorld()) : null;
 +    }
 +
-+    @Nullable
 +    @Override
 +    public PathResult findPath(LivingEntity target) {
 +        Validate.notNull(target, "Target can not be null");
-+        Path path = entity.getNavigation().createPath(((CraftLivingEntity) target).getHandle(), 0);
-+        return path != null ? new PaperPathResult(path) : null;
++        final @Nullable Path path = entity.getNavigation().createPath(((CraftLivingEntity) target).getHandle(), 0);
++        return path != null ? new PaperPathResult(path, this.entity.level.getWorld()) : null;
 +    }
 +
 +    @Override
-+    public boolean moveTo(@Nonnull PathResult path, double speed) {
++    public boolean moveTo(PathResult path, double speed) {
 +        Validate.notNull(path, "PathResult can not be null");
 +        Path pathEntity = ((PaperPathResult) path).path;
 +        return entity.getNavigation().moveTo(pathEntity, speed);
@@ -117,18 +119,26 @@ index 0000000000000000000000000000000000000000..2d799fec40afe7dade649a294761d272
 +        entity.getNavigation().pathFinder.nodeEvaluator.setCanFloat(canFloat);
 +    }
 +
-+    public class PaperPathResult implements com.destroystokyo.paper.entity.PaperPathfinder.PathResult {
++    public static class PaperPathResult implements PaperPathfinder.PathResult {
 +
 +        private final Path path;
-+        PaperPathResult(Path path) {
++        private final WeakReference<World> world;
++        PaperPathResult(Path path, World world) {
 +            this.path = path;
++            this.world = new WeakReference<>(world);
 +        }
 +
 +        @Nullable
 +        @Override
 +        public Location getFinalPoint() {
-+            Node point = path.getEndNode();
++            final @Nullable Node point = path.getEndNode();
 +            return point != null ? toLoc(point) : null;
++        }
++
++        @Override
++        public Position getFinalPathPoint() {
++            final @Nullable Node point = this.path.getEndNode();
++            return point != null ? this.toPos(point) : null;
 +        }
 +
 +        @Override
@@ -138,6 +148,11 @@ index 0000000000000000000000000000000000000000..2d799fec40afe7dade649a294761d272
 +                points.add(toLoc(point));
 +            }
 +            return points;
++        }
++
++        @Override
++        public List<Position> getPathPoints() {
++            return this.path.nodes.stream().map(this::toPos).toList();
 +        }
 +
 +        @Override
@@ -153,10 +168,20 @@ index 0000000000000000000000000000000000000000..2d799fec40afe7dade649a294761d272
 +            }
 +            return toLoc(path.nodes.get(path.getNextNodeIndex()));
 +        }
-+    }
 +
-+    private Location toLoc(Node point) {
-+        return new Location(entity.level.getWorld(), point.x, point.y, point.z);
++        @Override
++        public Position getNextPathPoint() {
++            return this.path.hasNext() ? this.toPos(this.path.getNextNode()) : null;
++        }
++
++        @Deprecated
++        private Location toLoc(Node point) {
++            return new Location(this.world.get(), point.x, point.y, point.z);
++        }
++        
++        private Position toPos(final Node point) {
++            return Position.block(point.x, point.y, point.z);
++        }
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/level/pathfinder/Path.java b/src/main/java/net/minecraft/world/level/pathfinder/Path.java


### PR DESCRIPTION
Deprecates methods that return location, but left methods with Location parameters as undeprecated because Location implements Position, and would therefore require a cast to not use the deprecated methods (if you still used a Location).

Also made PaperPath a static class instead of inner class. This will be useful later for a certain memory key which PaperPath is the type we would use for it (can't use it if its an inner class in PaperPathfinder).