### PR TITLE
[ci skip] Correct chat preview removal version in javadoc

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -350,7 +350,7 @@ index 0000000000000000000000000000000000000000..feece00981ebf932e64760e7a10a04ad
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/AsyncChatDecorateEvent.java b/src/main/java/io/papermc/paper/event/player/AsyncChatDecorateEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..092b5b12053315d355607ccf72e2d6b9e6befcf8
+index 0000000000000000000000000000000000000000..9a962337948810b00ceae1124962fcc7058b70ad
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/AsyncChatDecorateEvent.java
 @@ -0,0 +1,116 @@
@@ -438,7 +438,7 @@ index 0000000000000000000000000000000000000000..092b5b12053315d355607ccf72e2d6b9
 +     * If this decorating is part of a preview request/response.
 +     *
 +     * @return true if part of previewing
-+     * @deprecated chat preview was removed in 1.19.2
++     * @deprecated chat preview was removed in 1.19.3
 +     */
 +    @Deprecated(forRemoval = true)
 +    @Contract(value = "-> false", pure = true)


### PR DESCRIPTION
[As pointed out by @Fejm](https://github.com/PaperMC/Paper/commit/d8cf30dfd17ad718900b571cae4e8dbec74f1878#r92720856)