### PR TITLE
Add the non-flammable wood item tag

### DIFF
--- a/patches/api/0261-Added-missing-vanilla-tags.patch
+++ b/patches/api/0261-Added-missing-vanilla-tags.patch
@@ -1,14 +1,27 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Sun, 3 Jan 2021 20:03:40 -0800
-Subject: [PATCH] Added Vanilla Entity Tags
+Subject: [PATCH] Added missing vanilla tags
 
 
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index 15699ee58e06880a508689f761ecfdb77d44d182..be5bb4210a11154013e2fc80653bf467ebdaf15f 100644
+index 15699ee58e06880a508689f761ecfdb77d44d182..4d14135fcaceba1197132835c8c6504bac14a30e 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -839,6 +839,44 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -712,6 +712,12 @@ public interface Tag<T extends Keyed> extends Keyed {
+      * Vanilla item tag representing all chest boat items.
+      */
+     Tag<Material> ITEMS_CHEST_BOATS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("chest_boats"), Material.class);
++    // Paper start
++    /**
++     * Vanilla item tag representing all non-flammable wood items.
++     */
++    Tag<Material> ITEMS_NON_FLAMMABLE_WOOD = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("non_flammable_wood"), Material.class);
++    // Paper end
+     /**
+      * Vanilla item tag representing all fish items.
+      */
+@@ -839,6 +845,44 @@ public interface Tag<T extends Keyed> extends Keyed {
       * Vanilla tag representing entities which can be eaten by frogs.
       */
      Tag<EntityType> ENTITY_TYPES_FROG_FOOD = Bukkit.getTag(REGISTRY_ENTITY_TYPES, NamespacedKey.minecraft("frog_food"), EntityType.class);

--- a/patches/api/0365-Add-GameEvent-tags.patch
+++ b/patches/api/0365-Add-GameEvent-tags.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add GameEvent tags
 
 
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index be5bb4210a11154013e2fc80653bf467ebdaf15f..d34f0481b3f27591f089dce5673dbe2feae358f5 100644
+index 4d14135fcaceba1197132835c8c6504bac14a30e..bf05153566e8009451c25ea6b60cbe706e959493 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -876,6 +876,18 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -882,6 +882,18 @@ public interface Tag<T extends Keyed> extends Keyed {
       */
      @Deprecated(forRemoval = true)
      Tag<EntityType> SKELETONS = ENTITY_TYPES_SKELETONS;

--- a/patches/api/0418-Mark-experimental-api-as-such.patch
+++ b/patches/api/0418-Mark-experimental-api-as-such.patch
@@ -280,7 +280,7 @@ index 56459876a7736bd3a015e0aba511313997f9ec65..e5b94299793ba7cb9071a3f3a35ddbe0
      /**
       * BlockData: {@link Directional}
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index d34f0481b3f27591f089dce5673dbe2feae358f5..a8530852fd7fddedbc2a4199399e8f5301d842b1 100644
+index bf05153566e8009451c25ea6b60cbe706e959493..84dbfefb2cfc10a1ac7d9712535fcaecc9af6a2d 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
 @@ -142,6 +142,7 @@ public interface Tag<T extends Keyed> extends Keyed {
@@ -309,7 +309,7 @@ index d34f0481b3f27591f089dce5673dbe2feae358f5..a8530852fd7fddedbc2a4199399e8f53
      Tag<Material> ALL_HANGING_SIGNS = Bukkit.getTag(REGISTRY_BLOCKS, NamespacedKey.minecraft("all_hanging_signs"), Material.class);
      /**
       * Vanilla block tag representing all signs, regardless of type.
-@@ -739,6 +743,7 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -745,6 +749,7 @@ public interface Tag<T extends Keyed> extends Keyed {
      /**
       * Vanilla item tag representing all books that may be placed on bookshelves.
       */
@@ -317,7 +317,7 @@ index d34f0481b3f27591f089dce5673dbe2feae358f5..a8530852fd7fddedbc2a4199399e8f53
      Tag<Material> ITEMS_BOOKSHELF_BOOKS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("bookshelf_books"), Material.class);
      /**
       * Vanilla item tag representing all items that may be placed in beacons.
-@@ -759,6 +764,7 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -765,6 +770,7 @@ public interface Tag<T extends Keyed> extends Keyed {
      /**
       * Vanilla item tag representing all hanging signs.
       */


### PR DESCRIPTION
Vanilla removed the Block non-flammable wood tag, but not the item.