### PR TITLE
Add and remove missing or obsolete vanilla tags

### DIFF
--- a/patches/api/0261-Added-missing-vanilla-tags.patch
+++ b/patches/api/0261-Added-missing-vanilla-tags.patch
@@ -5,10 +5,23 @@ Subject: [PATCH] Added missing vanilla tags
 
 
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index 15699ee58e06880a508689f761ecfdb77d44d182..4d14135fcaceba1197132835c8c6504bac14a30e 100644
+index 15699ee58e06880a508689f761ecfdb77d44d182..0bb2f106b93db546e8f740d0dec8ddb02e76de62 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -712,6 +712,12 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -99,6 +99,12 @@ public interface Tag<T extends Keyed> extends Keyed {
+      * Vanilla block tag representing all log and bark variants that burn.
+      */
+     Tag<Material> LOGS_THAT_BURN = Bukkit.getTag(REGISTRY_BLOCKS, NamespacedKey.minecraft("logs_that_burn"), Material.class);
++    // Paper start
++    /**
++     * Vanilla block tag representing naturally occurring overworld logs.
++     */
++    Tag<Material> OVERWORLD_NATURAL_LOGS = Bukkit.getTag(REGISTRY_BLOCKS, NamespacedKey.minecraft("overworld_natural_logs"), Material.class);
++    // Paper end
+     /**
+      * Vanilla block tag representing all log and bark variants.
+      */
+@@ -712,6 +718,12 @@ public interface Tag<T extends Keyed> extends Keyed {
       * Vanilla item tag representing all chest boat items.
       */
      Tag<Material> ITEMS_CHEST_BOATS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("chest_boats"), Material.class);
@@ -21,7 +34,257 @@ index 15699ee58e06880a508689f761ecfdb77d44d182..4d14135fcaceba1197132835c8c6504b
      /**
       * Vanilla item tag representing all fish items.
       */
-@@ -839,6 +845,44 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -748,10 +760,7 @@ public interface Tag<T extends Keyed> extends Keyed {
+      * Vanilla item tag representing all stone tool materials.
+      */
+     Tag<Material> ITEMS_STONE_TOOL_MATERIALS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("stone_tool_materials"), Material.class);
+-    /**
+-     * Vanilla item tag representing all furnace materials.
+-     */
+-    Tag<Material> ITEMS_FURNACE_MATERIALS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("furnace_materials"), Material.class);
++    // Paper - remove ITEMS_FURNACE_MATERIALS (tag doesn't exist anymore)
+     /**
+      * Vanilla item tag representing all compasses.
+      */
+@@ -779,6 +788,237 @@ public interface Tag<T extends Keyed> extends Keyed {
+      * harvesting clusters (unused).
+      */
+     Tag<Material> CLUSTER_MAX_HARVESTABLES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("cluster_max_harvestables"), Material.class);
++    // Paper start - add missing item tags
++    /**
++     * @see #SOUL_FIRE_BASE_BLOCKS
++     */
++    Tag<Material> ITEMS_SOUL_FIRE_BASE_BLOCKS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("soul_fire_base_blocks"), Material.class);
++    Tag<Material> ITEMS_STONE_CRAFTING_MATERIALS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("stone_crafting_materials"), Material.class);
++    /**
++     * @see #PIGLIN_REPELLENTS
++     */
++    Tag<Material> ITEMS_PIGLIN_REPELLENTS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("piglin_repellents"), Material.class);
++    /**
++     * @see #WOODEN_FENCES
++     */
++    Tag<Material> ITEMS_WOODEN_FENCES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("wooden_fences"), Material.class);
++    /**
++     * @see #WOODEN_SLABS
++     */
++    Tag<Material> ITEMS_WOODEN_SLABS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("wooden_slabs"), Material.class);
++    /**
++     * @see #COAL_ORES
++     */
++    Tag<Material> ITEMS_COAL_ORES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("coal_ores"), Material.class);
++    /**
++     * @see #SMALL_FLOWERS
++     */
++    Tag<Material> ITEMS_SMALL_FLOWERS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("small_flowers"), Material.class);
++    /**
++     * @see #WOODEN_TRAPDOORS
++     */
++    Tag<Material> ITEMS_WOODEN_TRAPDOORS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("wooden_trapdoors"), Material.class);
++    /**
++     * @see #DAMPENS_VIBRATIONS
++     */
++    Tag<Material> ITEMS_DAMPENS_VIBRATIONS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("dampens_vibrations"), Material.class);
++    /**
++     * @see #MANGROVE_LOGS
++     */
++    Tag<Material> ITEMS_MANGROVE_LOGS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("mangrove_logs"), Material.class);
++    /**
++     * @see #JUNGLE_LOGS
++     */
++    Tag<Material> ITEMS_JUNGLE_LOGS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("jungle_logs"), Material.class);
++    /**
++     * @see #WOODEN_STAIRS
++     */
++    Tag<Material> ITEMS_WOODEN_STAIRS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("wooden_stairs"), Material.class);
++    /**
++     * @see #SIGNS
++     */
++    Tag<Material> ITEMS_SIGNS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("signs"), Material.class);
++    /**
++     * @see #SPRUCE_LOGS
++     */
++    Tag<Material> ITEMS_SPRUCE_LOGS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("spruce_logs"), Material.class);
++    /**
++     * @see #WOOL
++     */
++    Tag<Material> ITEMS_WOOL = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("wool"), Material.class);
++    /**
++     * @see #WOODEN_BUTTONS
++     */
++    Tag<Material> ITEMS_WOODEN_BUTTONS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("wooden_buttons"), Material.class);
++    /**
++     * @see #STAIRS
++     */
++    Tag<Material> ITEMS_STAIRS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("stairs"), Material.class);
++    /**
++     * @see #LOGS
++     */
++    Tag<Material> ITEMS_LOGS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("logs"), Material.class);
++    /**
++     * @see #STONE_BRICKS
++     */
++    Tag<Material> ITEMS_STONE_BRICKS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("stone_bricks"), Material.class);
++    /**
++     * @see #WOOL_CARPETS
++     */
++    Tag<Material> ITEMS_WOOL_CARPETS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("wool_carpets"), Material.class);
++    /**
++     * @see #SLABS
++     */
++    Tag<Material> ITEMS_SLABS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("slabs"), Material.class);
++    /**
++     * @see #WOODEN_DOORS
++     */
++    Tag<Material> ITEMS_WOODEN_DOORS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("wooden_doors"), Material.class);
++    /**
++     * @see #WARPED_STEMS
++     */
++    Tag<Material> ITEMS_WARPED_STEMS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("warped_stems"), Material.class);
++    /**
++     * @see #EMERALD_ORES
++     */
++    Tag<Material> ITEMS_EMERALD_ORES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("emerald_ores"), Material.class);
++    /**
++     * @see #REDSTONE_ORES
++     */
++    Tag<Material> ITEMS_REDSTONE_ORES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("redstone_ores"), Material.class);
++    /**
++     * @see #TRAPDOORS
++     */
++    Tag<Material> ITEMS_TRAPDOORS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("trapdoors"), Material.class);
++    /**
++     * @see #CRIMSON_STEMS
++     */
++    Tag<Material> ITEMS_CRIMSON_STEMS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("crimson_stems"), Material.class);
++    /**
++     * @see #BAMBOO_BLOCKS
++     */
++    Tag<Material> ITEMS_BAMBOO_BLOCKS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("bamboo_blocks"), Material.class);
++    /**
++     * @see #BUTTONS
++     */
++    Tag<Material> ITEMS_BUTTONS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("buttons"), Material.class);
++    /**
++     * @see #FLOWERS
++     */
++    Tag<Material> ITEMS_FLOWERS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("flowers"), Material.class);
++    /**
++     * @see #WART_BLOCKS
++     */
++    Tag<Material> ITEMS_WART_BLOCKS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("wart_blocks"), Material.class);
++    /**
++     * @see #TERRACOTTA
++     */
++    Tag<Material> ITEMS_TERRACOTTA = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("terracotta"), Material.class);
++    /**
++     * @see #PLANKS
++     */
++    Tag<Material> ITEMS_PLANKS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("planks"), Material.class);
++    /**
++     * @see #DARK_OAK_LOGS
++     */
++    Tag<Material> ITEMS_DARK_OAK_LOGS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("dark_oak_logs"), Material.class);
++    /**
++     * @see #RAILS
++     */
++    Tag<Material> ITEMS_RAILS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("rails"), Material.class);
++    /**
++     * @see #DIAMOND_ORES
++     */
++    Tag<Material> ITEMS_DIAMOND_ORES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("diamond_ores"), Material.class);
++    /**
++     * @see #LEAVES
++     */
++    Tag<Material> ITEMS_LEAVES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("leaves"), Material.class);
++    /**
++     * @see #WALLS
++     */
++    Tag<Material> ITEMS_WALLS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("walls"), Material.class);
++    /**
++     * @see #FENCE_GATES
++     */
++    Tag<Material> ITEMS_FENCE_GATES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("fence_gates"), Material.class);
++    /**
++     * @see #WOODEN_PRESSURE_PLATES
++     */
++    Tag<Material> ITEMS_WOODEN_PRESSURE_PLATES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("wooden_pressure_plates"), Material.class);
++    /**
++     * @see #ACACIA_LOGS
++     */
++    Tag<Material> ITEMS_ACACIA_LOGS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("acacia_logs"), Material.class);
++    /**
++     * @see #ANVIL
++     */
++    Tag<Material> ITEMS_ANVIL = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("anvil"), Material.class);
++    /**
++     * @see #CANDLES
++     */
++    Tag<Material> ITEMS_CANDLES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("candles"), Material.class);
++    /**
++     * @see #BIRCH_LOGS
++     */
++    Tag<Material> ITEMS_BIRCH_LOGS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("birch_logs"), Material.class);
++    /**
++     * @see #TALL_FLOWERS
++     */
++    Tag<Material> ITEMS_TALL_FLOWERS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("tall_flowers"), Material.class);
++    /**
++     * @see #LAPIS_ORES
++     */
++    Tag<Material> ITEMS_LAPIS_ORES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("lapis_ores"), Material.class);
++    /**
++     * @see #SAND
++     */
++    Tag<Material> ITEMS_SAND = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("sand"), Material.class);
++    /**
++     * @see #COPPER_ORES
++     */
++    Tag<Material> ITEMS_COPPER_ORES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("copper_ores"), Material.class);
++    /**
++     * @see #GOLD_ORES
++     */
++    Tag<Material> ITEMS_GOLD_ORES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("gold_ores"), Material.class);
++    /**
++     * @see #FENCES
++     */
++    Tag<Material> ITEMS_FENCES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("fences"), Material.class);
++    /**
++     * @see #LOGS_THAT_BURN
++     */
++    Tag<Material> ITEMS_LOGS_THAT_BURN = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("logs_that_burn"), Material.class);
++    /**
++     * @see #COMPLETES_FIND_TREE_TUTORIAL
++     */
++    Tag<Material> ITEMS_COMPLETES_FIND_TREE_TUTORIAL = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("completes_find_tree_tutorial"), Material.class);
++    /**
++     * @see #SAPLINGS
++     */
++    Tag<Material> ITEMS_SAPLINGS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("saplings"), Material.class);
++    /**
++     * @see #DIRT
++     */
++    Tag<Material> ITEMS_DIRT = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("dirt"), Material.class);
++    /**
++     * @see #BEDS
++     */
++    Tag<Material> ITEMS_BEDS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("beds"), Material.class);
++    /**
++     * @see #IRON_ORES
++     */
++    Tag<Material> ITEMS_IRON_ORES = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("iron_ores"), Material.class);
++    /**
++     * @see #OAK_LOGS
++     */
++    Tag<Material> ITEMS_OAK_LOGS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("oak_logs"), Material.class);
++    /**
++     * @see #DOORS
++     */
++    Tag<Material> ITEMS_DOORS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("doors"), Material.class);
++    // Paper end
+     /**
+      * Key for the built in fluid registry.
+      */
+@@ -839,6 +1079,44 @@ public interface Tag<T extends Keyed> extends Keyed {
       * Vanilla tag representing entities which can be eaten by frogs.
       */
      Tag<EntityType> ENTITY_TYPES_FROG_FOOD = Bukkit.getTag(REGISTRY_ENTITY_TYPES, NamespacedKey.minecraft("frog_food"), EntityType.class);

--- a/patches/api/0365-Add-GameEvent-tags.patch
+++ b/patches/api/0365-Add-GameEvent-tags.patch
@@ -5,25 +5,35 @@ Subject: [PATCH] Add GameEvent tags
 
 
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index 4d14135fcaceba1197132835c8c6504bac14a30e..bf05153566e8009451c25ea6b60cbe706e959493 100644
+index 0bb2f106b93db546e8f740d0dec8ddb02e76de62..35777eb635ce535d8d412747c6ca1cace25fbf96 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -882,6 +882,18 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -1116,6 +1116,28 @@ public interface Tag<T extends Keyed> extends Keyed {
       */
      @Deprecated(forRemoval = true)
      Tag<EntityType> SKELETONS = ENTITY_TYPES_SKELETONS;
 +
 +    String REGISTRY_GAME_EVENTS = "game_events";
-+
 +    /**
-+     * Tag for game events that trigger sculk sensors
++     * Tag for game events that trigger sculk sensors.
 +     */
 +    Tag<GameEvent> GAME_EVENT_VIBRATIONS = Bukkit.getTag(REGISTRY_GAME_EVENTS, NamespacedKey.minecraft("vibrations"), GameEvent.class);
-+
 +    /**
-+     * Tag for game events that are ignored if the entity is sneaking
++     * Tag for game events that are ignored if the entity is sneaking.
 +     */
 +    Tag<GameEvent> GAME_EVENT_IGNORE_VIBRATIONS_SNEAKING = Bukkit.getTag(REGISTRY_GAME_EVENTS, NamespacedKey.minecraft("ignore_vibrations_sneaking"), GameEvent.class);
++    /**
++     * Tag for game events the {@link org.bukkit.entity.Warden} can listen for.
++     */
++    Tag<GameEvent> GAME_EVENT_WARDEN_CAN_LISTEN = Bukkit.getTag(REGISTRY_GAME_EVENTS, NamespacedKey.minecraft("warden_can_listen"), GameEvent.class);
++    /**
++     * Tag for game events the {@link org.bukkit.entity.Allay} can listen for.
++     */
++    Tag<GameEvent> GAME_EVENT_ALLAY_CAN_LISTEN = Bukkit.getTag(REGISTRY_GAME_EVENTS, NamespacedKey.minecraft("allay_can_listen"), GameEvent.class);
++    /**
++     * Tag for game events the {@link org.bukkit.block.SculkShrieker} can listen for.
++     */
++    Tag<GameEvent> GAME_EVENT_SHRIEKER_CAN_LISTEN = Bukkit.getTag(REGISTRY_GAME_EVENTS, NamespacedKey.minecraft("shrieker_can_listen"), GameEvent.class);
      // Paper end
  
      /**

--- a/patches/api/0418-Mark-experimental-api-as-such.patch
+++ b/patches/api/0418-Mark-experimental-api-as-such.patch
@@ -280,10 +280,10 @@ index 56459876a7736bd3a015e0aba511313997f9ec65..e5b94299793ba7cb9071a3f3a35ddbe0
      /**
       * BlockData: {@link Directional}
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index bf05153566e8009451c25ea6b60cbe706e959493..84dbfefb2cfc10a1ac7d9712535fcaecc9af6a2d 100644
+index 35777eb635ce535d8d412747c6ca1cace25fbf96..98b8f1f57f02a9a43bdfd9d367f1f96bf389fefa 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -142,6 +142,7 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -148,6 +148,7 @@ public interface Tag<T extends Keyed> extends Keyed {
      /**
       * Vanilla block tag representing all bamboo blocks.
       */
@@ -291,7 +291,7 @@ index bf05153566e8009451c25ea6b60cbe706e959493..84dbfefb2cfc10a1ac7d9712535fcaec
      Tag<Material> BAMBOO_BLOCKS = Bukkit.getTag(REGISTRY_BLOCKS, NamespacedKey.minecraft("bamboo_blocks"), Material.class);
      /**
       * Vanilla block tag representing all banner blocks.
-@@ -312,14 +313,17 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -318,14 +319,17 @@ public interface Tag<T extends Keyed> extends Keyed {
      /**
       * Vanilla block tag representing all ceiling signs.
       */
@@ -309,7 +309,7 @@ index bf05153566e8009451c25ea6b60cbe706e959493..84dbfefb2cfc10a1ac7d9712535fcaec
      Tag<Material> ALL_HANGING_SIGNS = Bukkit.getTag(REGISTRY_BLOCKS, NamespacedKey.minecraft("all_hanging_signs"), Material.class);
      /**
       * Vanilla block tag representing all signs, regardless of type.
-@@ -745,6 +749,7 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -751,6 +755,7 @@ public interface Tag<T extends Keyed> extends Keyed {
      /**
       * Vanilla item tag representing all books that may be placed on bookshelves.
       */
@@ -317,7 +317,7 @@ index bf05153566e8009451c25ea6b60cbe706e959493..84dbfefb2cfc10a1ac7d9712535fcaec
      Tag<Material> ITEMS_BOOKSHELF_BOOKS = Bukkit.getTag(REGISTRY_ITEMS, NamespacedKey.minecraft("bookshelf_books"), Material.class);
      /**
       * Vanilla item tag representing all items that may be placed in beacons.
-@@ -765,6 +770,7 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -768,6 +773,7 @@ public interface Tag<T extends Keyed> extends Keyed {
      /**
       * Vanilla item tag representing all hanging signs.
       */

--- a/patches/server/0962-Add-test-to-check-tags-are-up-to-date.patch
+++ b/patches/server/0962-Add-test-to-check-tags-are-up-to-date.patch
@@ -1,0 +1,127 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 11 Dec 2022 14:30:11 -0800
+Subject: [PATCH] Add test to check tags are up to date
+
+
+diff --git a/src/test/java/io/papermc/paper/TagTest.java b/src/test/java/io/papermc/paper/TagTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ecbb6d16c494e233f1d3aa0cdad94ad4ed842253
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/TagTest.java
+@@ -0,0 +1,88 @@
++package io.papermc.paper;
++
++import com.google.common.collect.Sets;
++import java.lang.reflect.Field;
++import java.lang.reflect.Modifier;
++import java.util.ArrayList;
++import java.util.LinkedHashMap;
++import java.util.LinkedHashSet;
++import java.util.List;
++import java.util.Locale;
++import java.util.Map;
++import java.util.Optional;
++import java.util.Set;
++import java.util.StringJoiner;
++import java.util.function.Predicate;
++import java.util.stream.Collectors;
++import net.minecraft.core.HolderSet;
++import net.minecraft.core.Registry;
++import net.minecraft.core.registries.BuiltInRegistries;
++import net.minecraft.core.registries.Registries;
++import net.minecraft.resources.ResourceLocation;
++import net.minecraft.server.Bootstrap;
++import net.minecraft.tags.TagKey;
++import net.minecraft.world.item.Item;
++import net.minecraft.world.level.block.Block;
++import org.bukkit.Fluid;
++import org.bukkit.GameEvent;
++import org.bukkit.Material;
++import org.bukkit.NamespacedKey;
++import org.bukkit.Tag;
++import org.bukkit.craftbukkit.tag.CraftBlockTag;
++import org.bukkit.craftbukkit.tag.CraftEntityTag;
++import org.bukkit.craftbukkit.tag.CraftFluidTag;
++import org.bukkit.craftbukkit.tag.CraftItemTag;
++import org.bukkit.craftbukkit.util.CraftMagicNumbers;
++import org.bukkit.craftbukkit.util.CraftNamespacedKey;
++import org.bukkit.entity.EntityType;
++import org.bukkit.support.AbstractTestingBase;
++import org.junit.Test;
++
++import static org.junit.Assert.assertTrue;
++
++public class TagTest extends AbstractTestingBase {
++
++    @Test
++    public void ensureApiTagsUpToDate() throws ReflectiveOperationException {
++        System.setOut(Bootstrap.STDOUT);
++        final Map<Class<?>, Map<ResourceLocation, Tag<?>>> tags = new LinkedHashMap<>();
++        for (Field field : Tag.class.getFields()) {
++            if (Modifier.isStatic(field.getModifiers()) && field.getType() == Tag.class) {
++                Tag<?> tag = (Tag<?>) field.get(null);
++                tags.computeIfAbsent(tag.getClass(), t -> new LinkedHashMap<>()).put(CraftNamespacedKey.toMinecraft(tag.getKey()), tag);
++            }
++        }
++        checkTags(tags, BuiltInRegistries.BLOCK, CraftBlockTag.class, Material.class, "REGISTRY_BLOCKS", "");
++        checkTags(tags, BuiltInRegistries.ITEM, CraftItemTag.class, Material.class, "REGISTRY_ITEMS", "ITEMS_");
++        checkTags(tags, BuiltInRegistries.ENTITY_TYPE, CraftEntityTag.class, EntityType.class, "REGISTRY_ENTITY_TYPES", "ENTITY_TYPES_");
++        checkTags(tags, BuiltInRegistries.FLUID, CraftFluidTag.class, Fluid.class, "REGISTRY_FLUIDS", "FLUIDS_");
++        checkTags(tags, BuiltInRegistries.GAME_EVENT, CraftGameEventTag.class, GameEvent.class, "REGISTRY_GAME_EVENTS", "GAME_EVENT_");
++        assertTrue("Need to handle these tag types: " + tags.keySet(), tags.isEmpty());
++    }
++
++    private static void checkTags(Map<Class<?>, Map<ResourceLocation, Tag<?>>> tags, Registry<?> nmsRegistry, Class<?> cbTagClass, Class<?> apiValueClass, String registry, String prefix) {
++        Set<ResourceLocation> nmsTags = nmsRegistry.getTagNames().map(TagKey::location).collect(Collectors.toSet());
++        Set<ResourceLocation> apiTags = tags.remove(cbTagClass).keySet();
++        Set<ResourceLocation> missingApi = Sets.difference(nmsTags, apiTags);
++        Predicate<ResourceLocation> isDuplicate = ignored -> false;
++        if (nmsRegistry == BuiltInRegistries.ITEM) {
++            isDuplicate = loc -> {
++                return BuiltInRegistries.BLOCK.getTag(TagKey.create(Registries.BLOCK, loc)).isPresent();
++            };
++        }
++        Set<ResourceLocation> extraApi = Sets.difference(apiTags, nmsTags);
++        assertTrue("Missing %s\n".formatted(cbTagClass.getSimpleName()) + printMissing(missingApi, prefix, apiValueClass, registry, isDuplicate), missingApi.isEmpty());
++        assertTrue("Extra %s\n".formatted(cbTagClass.getSimpleName()) + String.join("\n", extraApi.stream().map(Object::toString).toList()), missingApi.isEmpty());
++    }
++
++    private static String printMissing(Set<ResourceLocation> missing, String prefix, Class<?> apiValueClass, String registry, Predicate<ResourceLocation> duplicateCheck) {
++        List<String> toPrint = new ArrayList<>();
++        for (ResourceLocation loc : missing) {
++            if (duplicateCheck.test(loc)) {
++                toPrint.addAll(List.of("/**", " * @see #%s".formatted(loc.getPath().toUpperCase(Locale.ENGLISH)), " */"));
++            }
++            toPrint.add("Tag<%s> %s = Bukkit.getTag(%s, NamespacedKey.minecraft(\"%s\"), %s.class);".formatted(apiValueClass.getSimpleName(), prefix + loc.getPath().toUpperCase(Locale.ENGLISH), registry, loc.getPath(), apiValueClass.getSimpleName()));
++        }
++        return String.join("\n", toPrint);
++    }
++}
+diff --git a/src/test/java/org/bukkit/support/DummyServer.java b/src/test/java/org/bukkit/support/DummyServer.java
+index 2ddceb709291d3bd713621ffa4020c02ec26bb21..c1835beeebf49fe4dc7cb197d32415585a4bfd59 100644
+--- a/src/test/java/org/bukkit/support/DummyServer.java
++++ b/src/test/java/org/bukkit/support/DummyServer.java
+@@ -116,6 +116,22 @@ public final class DummyServer implements InvocationHandler {
+                     }
+                 }
+             );
++            methods.put(
++                Server.class.getMethod("getTag", String.class, NamespacedKey.class, Class.class),
++                new MethodHandler() {
++                    @Override
++                    public Object handle(DummyServer server, Object[] args) {
++                        return switch ((String) args[0]) {
++                            case org.bukkit.Tag.REGISTRY_BLOCKS -> new org.bukkit.craftbukkit.tag.CraftBlockTag(net.minecraft.core.registries.BuiltInRegistries.BLOCK, net.minecraft.tags.TagKey.create(net.minecraft.core.registries.Registries.BLOCK, CraftNamespacedKey.toMinecraft((NamespacedKey) args[1])));
++                            case org.bukkit.Tag.REGISTRY_ITEMS -> new org.bukkit.craftbukkit.tag.CraftItemTag(net.minecraft.core.registries.BuiltInRegistries.ITEM, net.minecraft.tags.TagKey.create(net.minecraft.core.registries.Registries.ITEM, CraftNamespacedKey.toMinecraft((NamespacedKey) args[1])));
++                            case org.bukkit.Tag.REGISTRY_ENTITY_TYPES -> new org.bukkit.craftbukkit.tag.CraftEntityTag(net.minecraft.core.registries.BuiltInRegistries.ENTITY_TYPE, net.minecraft.tags.TagKey.create(net.minecraft.core.registries.Registries.ENTITY_TYPE, CraftNamespacedKey.toMinecraft((NamespacedKey) args[1])));
++                            case org.bukkit.Tag.REGISTRY_FLUIDS -> new org.bukkit.craftbukkit.tag.CraftFluidTag(net.minecraft.core.registries.BuiltInRegistries.FLUID, net.minecraft.tags.TagKey.create(net.minecraft.core.registries.Registries.FLUID, CraftNamespacedKey.toMinecraft((NamespacedKey) args[1])));
++                            case org.bukkit.Tag.REGISTRY_GAME_EVENTS -> new io.papermc.paper.CraftGameEventTag(net.minecraft.core.registries.BuiltInRegistries.GAME_EVENT, net.minecraft.tags.TagKey.create(net.minecraft.core.registries.Registries.GAME_EVENT, CraftNamespacedKey.toMinecraft((NamespacedKey) args[1])));
++                            default -> throw new IllegalArgumentException(java.util.Arrays.toString(args));
++                        };
++                    }
++                }
++            );
+             DummyServer server = new DummyServer();
+             Server instance = Proxy.getProxyClass(Server.class.getClassLoader(), Server.class).asSubclass(Server.class).getConstructor(InvocationHandler.class).newInstance(server);
+             Bukkit.setServer(instance);


### PR DESCRIPTION
Brings the Tag class up to date with current vanilla tags. Also adds a test to check that it is always up to date in the future.

Something this PR doesn't do, is address the 6 "Experimental" tags that are "null" if the datapack isn't enabled. I'm not sure what to do about that.