### PR TITLE
Fix BlockDispenseEvent being called when nothing actually happens

### DIFF
--- a/patches/server/0884-Fix-inconsistencies-in-dispense-events-regarding-sta.patch
+++ b/patches/server/0884-Fix-inconsistencies-in-dispense-events-regarding-sta.patch
@@ -86,7 +86,7 @@ index 90e1914599b43c8bf813596b3b428d8be3bac1b5..6df0db8b4cdab23494ea34236949ece4
      }
  
 diff --git a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
-index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41cce9222e 100644
+index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..415d387f8cfa3ae99b1c809233c86c18b76ad1e2 100644
 --- a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
 +++ b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
 @@ -217,7 +217,7 @@ public interface DispenseItemBehavior {
@@ -237,13 +237,13 @@ index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41
                  }
  
                  if (event.isCancelled()) {
-+                    // stack.grow(1); // Paper - shrink below (this was actually missing and should be here, added it commented out just for less confusion)
++                    // stack.grow(1); // Paper - shrink below (this was actually missing and should be here, added it commented out to be consistent)
                      return stack;
                  }
  
 +                boolean shrink = true; // Paper
                  if (!event.getItem().equals(craftItem)) {
-+                    shrink = false; // Paper - shrink below (this was actually missing and should be here, added it commented out just for less confusion)
++                    shrink = false; // Paper - shrink below
                      // Chain to handler for new item
                      ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
                      DispenseItemBehavior idispensebehavior = (DispenseItemBehavior) DispenserBlock.DISPENSER_REGISTRY.get(eventStack.getItem());
@@ -333,15 +333,7 @@ index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41
  
                      BlockDispenseEvent event = new BlockDispenseEvent(block, craftItem.clone(), new org.bukkit.util.Vector(x, y, z));
                      if (!DispenserBlock.eventFired) {
-@@ -631,6 +641,7 @@ public interface DispenseItemBehavior {
-                         return stack;
-                     }
- 
-+                    boolean shrink = true; // Paper
-                     if (!event.getItem().equals(craftItem)) {
-                         // Chain to handler for new item
-                         ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
-@@ -694,7 +705,7 @@ public interface DispenseItemBehavior {
+@@ -694,7 +704,7 @@ public interface DispenseItemBehavior {
  
                          // CraftBukkit start
                          org.bukkit.block.Block bukkitBlock = CraftBlock.at(worldserver, pointer.pos());
@@ -350,17 +342,16 @@ index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41
  
                          BlockDispenseEvent event = new BlockDispenseEvent(bukkitBlock, craftItem.clone(), new org.bukkit.util.Vector(blockposition.getX(), blockposition.getY(), blockposition.getZ()));
                          if (!DispenserBlock.eventFired) {
-@@ -752,7 +763,9 @@ public interface DispenseItemBehavior {
-                     return stack;
-                 }
+@@ -741,7 +751,7 @@ public interface DispenseItemBehavior {
  
-+                boolean shrink = true; // Paper
-                 if (!event.getItem().equals(craftItem)) {
-+                    shrink = false; // Paper - shrink below (this was actually missing and should be here, added it commented out just for less confusion)
-                     // Chain to handler for new item
-                     ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
-                     DispenseItemBehavior idispensebehavior = (DispenseItemBehavior) DispenserBlock.DISPENSER_REGISTRY.get(eventStack.getItem());
-@@ -802,7 +815,7 @@ public interface DispenseItemBehavior {
+                 // CraftBukkit start
+                 org.bukkit.block.Block bukkitBlock = CraftBlock.at(worldserver, pointer.pos());
+-                CraftItemStack craftItem = CraftItemStack.asCraftMirror(stack);
++                CraftItemStack craftItem = CraftItemStack.asCraftMirror(stack); // Paper - ignore stack size on damageable items
+ 
+                 BlockDispenseEvent event = new BlockDispenseEvent(bukkitBlock, craftItem.clone(), new org.bukkit.util.Vector(0, 0, 0));
+                 if (!DispenserBlock.eventFired) {
+@@ -802,7 +812,7 @@ public interface DispenseItemBehavior {
                  BlockPos blockposition = pointer.pos().relative((Direction) pointer.state().getValue(DispenserBlock.FACING));
                  // CraftBukkit start
                  org.bukkit.block.Block block = CraftBlock.at(worldserver, pointer.pos());
@@ -369,15 +360,7 @@ index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41
  
                  BlockDispenseEvent event = new BlockDispenseEvent(block, craftItem.clone(), new org.bukkit.util.Vector(0, 0, 0));
                  if (!DispenserBlock.eventFired) {
-@@ -813,6 +826,7 @@ public interface DispenseItemBehavior {
-                     return stack;
-                 }
- 
-+                boolean shrink = true; // Paper
-                 if (!event.getItem().equals(craftItem)) {
-                     // Chain to handler for new item
-                     ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
-@@ -868,7 +882,7 @@ public interface DispenseItemBehavior {
+@@ -868,7 +878,7 @@ public interface DispenseItemBehavior {
                  // CraftBukkit start
                  // EntityTNTPrimed entitytntprimed = new EntityTNTPrimed(worldserver, (double) blockposition.getX() + 0.5D, (double) blockposition.getY(), (double) blockposition.getZ() + 0.5D, (EntityLiving) null);
  
@@ -386,7 +369,7 @@ index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41
                  org.bukkit.block.Block block = CraftBlock.at(worldserver, pointer.pos());
                  CraftItemStack craftItem = CraftItemStack.asCraftMirror(itemstack1);
  
-@@ -878,12 +892,13 @@ public interface DispenseItemBehavior {
+@@ -878,12 +888,13 @@ public interface DispenseItemBehavior {
                  }
  
                  if (event.isCancelled()) {
@@ -402,7 +385,7 @@ index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41
                      // Chain to handler for new item
                      ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
                      DispenseItemBehavior idispensebehavior = (DispenseItemBehavior) DispenserBlock.DISPENSER_REGISTRY.get(eventStack.getItem());
-@@ -899,7 +914,7 @@ public interface DispenseItemBehavior {
+@@ -899,7 +910,7 @@ public interface DispenseItemBehavior {
                  worldserver.addFreshEntity(entitytntprimed);
                  worldserver.playSound((Player) null, entitytntprimed.getX(), entitytntprimed.getY(), entitytntprimed.getZ(), SoundEvents.TNT_PRIMED, SoundSource.BLOCKS, 1.0F, 1.0F);
                  worldserver.gameEvent((Entity) null, GameEvent.ENTITY_PLACE, blockposition);
@@ -411,7 +394,7 @@ index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41
                  return stack;
              }
          });
-@@ -926,7 +941,7 @@ public interface DispenseItemBehavior {
+@@ -926,7 +937,7 @@ public interface DispenseItemBehavior {
  
                  // CraftBukkit start
                  org.bukkit.block.Block bukkitBlock = CraftBlock.at(worldserver, pointer.pos());
@@ -420,19 +403,7 @@ index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41
  
                  BlockDispenseEvent event = new BlockDispenseEvent(bukkitBlock, craftItem.clone(), new org.bukkit.util.Vector(blockposition.getX(), blockposition.getY(), blockposition.getZ()));
                  if (!DispenserBlock.eventFired) {
-@@ -934,9 +949,11 @@ public interface DispenseItemBehavior {
-                 }
- 
-                 if (event.isCancelled()) {
-+                    // stack.grow(1); // Paper - shrink below (this was actually missing and should be here, added it commented out just for less confusion)
-                     return stack;
-                 }
- 
-+                boolean shrink = true; // Paper
-                 if (!event.getItem().equals(craftItem)) {
-                     // Chain to handler for new item
-                     ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
-@@ -975,7 +992,7 @@ public interface DispenseItemBehavior {
+@@ -975,7 +986,7 @@ public interface DispenseItemBehavior {
  
                  // CraftBukkit start
                  org.bukkit.block.Block bukkitBlock = CraftBlock.at(worldserver, pointer.pos());
@@ -441,15 +412,7 @@ index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41
  
                  BlockDispenseEvent event = new BlockDispenseEvent(bukkitBlock, craftItem.clone(), new org.bukkit.util.Vector(blockposition.getX(), blockposition.getY(), blockposition.getZ()));
                  if (!DispenserBlock.eventFired) {
-@@ -986,6 +1003,7 @@ public interface DispenseItemBehavior {
-                     return stack;
-                 }
- 
-+                boolean shrink = true; // Paper
-                 if (!event.getItem().equals(craftItem)) {
-                     // Chain to handler for new item
-                     ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
-@@ -1048,7 +1066,7 @@ public interface DispenseItemBehavior {
+@@ -1048,7 +1059,7 @@ public interface DispenseItemBehavior {
  
                  // CraftBukkit start
                  org.bukkit.block.Block bukkitBlock = CraftBlock.at(worldserver, pointer.pos());
@@ -458,14 +421,19 @@ index b65d0c2ac5b4f7eb3da85b693c354463c6f49694..dd017c33ff89a516022378160410bc41
  
                  BlockDispenseEvent event = new BlockDispenseEvent(bukkitBlock, craftItem.clone(), new org.bukkit.util.Vector(blockposition.getX(), blockposition.getY(), blockposition.getZ()));
                  if (!DispenserBlock.eventFired) {
-@@ -1059,6 +1077,7 @@ public interface DispenseItemBehavior {
-                     return stack;
-                 }
+diff --git a/src/main/java/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java
+index e17090003988ad2c890d48666c2234b14d511345..45d356c1ed888b4d749379ceaa8a95d7d7c876d5 100644
+--- a/src/main/java/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java
++++ b/src/main/java/net/minecraft/core/dispenser/ShearsDispenseItemBehavior.java
+@@ -37,7 +37,7 @@ public class ShearsDispenseItemBehavior extends OptionalDispenseItemBehavior {
+         ServerLevel worldserver = pointer.level();
+         // CraftBukkit start
+         org.bukkit.block.Block bukkitBlock = CraftBlock.at(worldserver, pointer.pos());
+-        CraftItemStack craftItem = CraftItemStack.asCraftMirror(stack);
++        CraftItemStack craftItem = CraftItemStack.asCraftMirror(stack); // Paper - ignore stack size on damageable items
  
-+                boolean shrink = true; // Paper
-                 if (!event.getItem().equals(craftItem)) {
-                     // Chain to handler for new item
-                     ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
+         BlockDispenseEvent event = new BlockDispenseEvent(bukkitBlock, craftItem.clone(), new org.bukkit.util.Vector(0, 0, 0));
+         if (!DispenserBlock.eventFired) {
 diff --git a/src/main/java/net/minecraft/core/dispenser/ShulkerBoxDispenseBehavior.java b/src/main/java/net/minecraft/core/dispenser/ShulkerBoxDispenseBehavior.java
 index f84987c36a16df19286d6f1badfb1ffb9cc7e770..6f2adf2334e35e8a617a4ced0c1af2abf32bbd8d 100644
 --- a/src/main/java/net/minecraft/core/dispenser/ShulkerBoxDispenseBehavior.java

--- a/patches/server/0948-Call-missing-BlockDispenseEvent.patch
+++ b/patches/server/0948-Call-missing-BlockDispenseEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Call missing BlockDispenseEvent
 
 
 diff --git a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
-index dd017c33ff89a516022378160410bc41cce9222e..105bb94b844c5ee85b53aca95360e7b2caf374cc 100644
+index 415d387f8cfa3ae99b1c809233c86c18b76ad1e2..0286740aabe04e6e78ad6efd003a1e1a1ab6a460 100644
 --- a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
 +++ b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
-@@ -1114,6 +1114,13 @@ public interface DispenseItemBehavior {
+@@ -1106,6 +1106,13 @@ public interface DispenseItemBehavior {
                  this.setSuccess(true);
                  if (iblockdata.is(Blocks.RESPAWN_ANCHOR)) {
                      if ((Integer) iblockdata.getValue(RespawnAnchorBlock.CHARGE) != 4) {
@@ -22,7 +22,7 @@ index dd017c33ff89a516022378160410bc41cce9222e..105bb94b844c5ee85b53aca95360e7b2
                          RespawnAnchorBlock.charge((Entity) null, worldserver, blockposition, iblockdata);
                          stack.shrink(1);
                      } else {
-@@ -1136,6 +1143,13 @@ public interface DispenseItemBehavior {
+@@ -1128,6 +1135,13 @@ public interface DispenseItemBehavior {
                  Optional<BlockState> optional = HoneycombItem.getWaxed(iblockdata);
  
                  if (optional.isPresent()) {
@@ -36,7 +36,7 @@ index dd017c33ff89a516022378160410bc41cce9222e..105bb94b844c5ee85b53aca95360e7b2
                      worldserver.setBlockAndUpdate(blockposition, (BlockState) optional.get());
                      worldserver.levelEvent(3003, blockposition, 0);
                      stack.shrink(1);
-@@ -1161,6 +1175,12 @@ public interface DispenseItemBehavior {
+@@ -1153,6 +1167,12 @@ public interface DispenseItemBehavior {
                      if (!worldserver.getBlockState(blockposition1).is(BlockTags.CONVERTABLE_TO_MUD)) {
                          return this.defaultDispenseItemBehavior.dispense(pointer, stack);
                      } else {
@@ -50,7 +50,7 @@ index dd017c33ff89a516022378160410bc41cce9222e..105bb94b844c5ee85b53aca95360e7b2
                              for (int k = 0; k < 5; ++k) {
                                  worldserver.sendParticles(ParticleTypes.SPLASH, (double) blockposition.getX() + worldserver.random.nextDouble(), (double) (blockposition.getY() + 1), (double) blockposition.getZ() + worldserver.random.nextDouble(), 1, 0.0D, 0.0D, 0.0D, 1.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 864ff2d3c8e2e2bef744e8048ba0cdbb42787268..c62396041c1546f3136ab6de3b174983f49287b3 100644
+index d55e1611028a836a34dd85f08c4463f1ec15662e..eeed64faf94e55b247ae13eba67336a48834bba6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -2098,6 +2098,32 @@ public class CraftEventFactory {

--- a/patches/server/0948-Call-missing-BlockDispenseEvent.patch
+++ b/patches/server/0948-Call-missing-BlockDispenseEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Call missing BlockDispenseEvent
 
 
 diff --git a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
-index 415d387f8cfa3ae99b1c809233c86c18b76ad1e2..0286740aabe04e6e78ad6efd003a1e1a1ab6a460 100644
+index 415d387f8cfa3ae99b1c809233c86c18b76ad1e2..7092dcc5c5d25b352cf47b031d6c7039c4c27561 100644
 --- a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
 +++ b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
 @@ -1106,6 +1106,13 @@ public interface DispenseItemBehavior {
@@ -13,7 +13,7 @@ index 415d387f8cfa3ae99b1c809233c86c18b76ad1e2..0286740aabe04e6e78ad6efd003a1e1a
                  if (iblockdata.is(Blocks.RESPAWN_ANCHOR)) {
                      if ((Integer) iblockdata.getValue(RespawnAnchorBlock.CHARGE) != 4) {
 +                        // Paper start
-+                        ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(pointer, blockposition, stack, this);
++                        ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(pointer, blockposition, stack, this).result();
 +                        if (result != null) {
 +                            this.setSuccess(false);
 +                            return result;
@@ -27,7 +27,7 @@ index 415d387f8cfa3ae99b1c809233c86c18b76ad1e2..0286740aabe04e6e78ad6efd003a1e1a
  
                  if (optional.isPresent()) {
 +                    // Paper start
-+                    ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(pointer, blockposition, stack, this);
++                    ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(pointer, blockposition, stack, this).result();
 +                    if (result != null) {
 +                        this.setSuccess(false);
 +                        return result;
@@ -41,7 +41,7 @@ index 415d387f8cfa3ae99b1c809233c86c18b76ad1e2..0286740aabe04e6e78ad6efd003a1e1a
                          return this.defaultDispenseItemBehavior.dispense(pointer, stack);
                      } else {
 +                        // Paper start
-+                        ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(pointer, blockposition1, stack, this);
++                        ItemStack result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(pointer, blockposition1, stack, this).result();
 +                        if (result != null) {
 +                            return result;
 +                        }
@@ -50,36 +50,40 @@ index 415d387f8cfa3ae99b1c809233c86c18b76ad1e2..0286740aabe04e6e78ad6efd003a1e1a
                              for (int k = 0; k < 5; ++k) {
                                  worldserver.sendParticles(ParticleTypes.SPLASH, (double) blockposition.getX() + worldserver.random.nextDouble(), (double) (blockposition.getY() + 1), (double) blockposition.getZ() + worldserver.random.nextDouble(), 1, 0.0D, 0.0D, 0.0D, 1.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d55e1611028a836a34dd85f08c4463f1ec15662e..eeed64faf94e55b247ae13eba67336a48834bba6 100644
+index d55e1611028a836a34dd85f08c4463f1ec15662e..6a1a2af8793d47d8b46f0d654eb98e168bba88d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2098,6 +2098,32 @@ public class CraftEventFactory {
+@@ -2098,6 +2098,36 @@ public class CraftEventFactory {
      }
      // Paper end
  
 +    // Paper start - missing BlockDispenseEvent calls
-+    @Nullable
-+    public static ItemStack handleBlockDispenseEvent(net.minecraft.core.dispenser.BlockSource pointer, BlockPos to, ItemStack itemStack, net.minecraft.core.dispenser.DispenseItemBehavior instance) {
-+        org.bukkit.block.Block bukkitBlock = pointer.level().getWorld().getBlockAt(pointer.pos().getX(), pointer.pos().getY(), pointer.pos().getZ());
-+        CraftItemStack craftItem = CraftItemStack.asCraftMirror(itemStack.copyWithCount(1));
++    public static DispenseResult handleBlockDispenseEvent(final net.minecraft.core.dispenser.BlockSource pointer, final BlockPos to, final ItemStack itemStack, final net.minecraft.core.dispenser.DispenseItemBehavior instance) {
++        return handleBlockDispenseEvent(pointer, to, itemStack, CraftVector.toBukkit(to), instance);
++    }
++    public static DispenseResult handleBlockDispenseEvent(final net.minecraft.core.dispenser.BlockSource pointer, final BlockPos to, final ItemStack itemStack, final Vector velocity, final net.minecraft.core.dispenser.DispenseItemBehavior instance) {
++        final Block bukkitBlock = CraftBlock.at(pointer.level(), pointer.pos());
++        final CraftItemStack craftItem = CraftItemStack.asCraftMirror(itemStack.getMaxDamage() > 0 ? itemStack : itemStack.copyWithCount(1)); // ignore stack size on damageable items
 +
-+        org.bukkit.event.block.BlockDispenseEvent event = new org.bukkit.event.block.BlockDispenseEvent(bukkitBlock, craftItem.clone(), new org.bukkit.util.Vector(to.getX(), to.getY(), to.getZ()));
++        final org.bukkit.event.block.BlockDispenseEvent event = new org.bukkit.event.block.BlockDispenseEvent(bukkitBlock, craftItem.clone(), new org.bukkit.util.Vector(to.getX(), to.getY(), to.getZ()));
 +        if (!net.minecraft.world.level.block.DispenserBlock.eventFired) {
 +            if (!event.callEvent()) {
-+                return itemStack;
++                return new DispenseResult(true, itemStack);
 +            }
 +        }
 +
 +        if (!event.getItem().equals(craftItem)) {
 +            // Chain to handler for new item
-+            ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
-+            net.minecraft.core.dispenser.DispenseItemBehavior idispensebehavior = net.minecraft.world.level.block.DispenserBlock.DISPENSER_REGISTRY.get(eventStack.getItem());
-+            if (idispensebehavior != net.minecraft.core.dispenser.DispenseItemBehavior.NOOP && idispensebehavior != instance) {
-+                idispensebehavior.dispense(pointer, eventStack);
-+                return itemStack;
++            final ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
++            final net.minecraft.core.dispenser.DispenseItemBehavior newDispenseBehavior = net.minecraft.world.level.block.DispenserBlock.DISPENSER_REGISTRY.get(eventStack.getItem());
++            if (newDispenseBehavior != net.minecraft.core.dispenser.DispenseItemBehavior.NOOP && newDispenseBehavior != instance) {
++                newDispenseBehavior.dispense(pointer, eventStack);
++                return new DispenseResult(false, itemStack);
 +            }
 +        }
-+        return null;
++        return new DispenseResult(false, null);
++    }
++    public record DispenseResult(boolean cancelled, @Nullable ItemStack result) {
 +    }
 +    // Paper end - missing BlockDispenseEvent calls
 +

--- a/patches/server/0967-Only-capture-actual-tree-growth.patch
+++ b/patches/server/0967-Only-capture-actual-tree-growth.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only capture actual tree growth
 
 
 diff --git a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
-index 105bb94b844c5ee85b53aca95360e7b2caf374cc..e6ac20a38f31bb0cd6b8840b2518f6992ef7f518 100644
+index 0286740aabe04e6e78ad6efd003a1e1a1ab6a460..f42a86549e389ec53962f7a5e7a625f351cd4724 100644
 --- a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
 +++ b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
-@@ -866,6 +866,7 @@ public interface DispenseItemBehavior {
+@@ -862,6 +862,7 @@ public interface DispenseItemBehavior {
                      if (!fertilizeEvent.isCancelled()) {
                          for (org.bukkit.block.BlockState blockstate : blocks) {
                              blockstate.update(true);

--- a/patches/server/1058-Fix-BlockDispenseEvent-being-called-when-nothing-act.patch
+++ b/patches/server/1058-Fix-BlockDispenseEvent-being-called-when-nothing-act.patch
@@ -1,0 +1,156 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Mon, 12 Dec 2022 10:02:26 -0800
+Subject: [PATCH] Fix BlockDispenseEvent being called when nothing actually
+ happens
+
+
+diff --git a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
+index 1fdac66011e6d4d1e1213997bdbd72887dae8e6b..596c8607bec897106ca69848bf5801e7f015e629 100644
+--- a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
++++ b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
+@@ -749,29 +749,7 @@ public interface DispenseItemBehavior {
+             protected ItemStack execute(BlockSource pointer, ItemStack stack) {
+                 ServerLevel worldserver = pointer.level();
+ 
+-                // CraftBukkit start
+-                org.bukkit.block.Block bukkitBlock = CraftBlock.at(worldserver, pointer.pos());
+-                CraftItemStack craftItem = CraftItemStack.asCraftMirror(stack); // Paper - ignore stack size on damageable items
+-
+-                BlockDispenseEvent event = new BlockDispenseEvent(bukkitBlock, craftItem.clone(), new org.bukkit.util.Vector(0, 0, 0));
+-                if (!DispenserBlock.eventFired) {
+-                    worldserver.getCraftServer().getPluginManager().callEvent(event);
+-                }
+-
+-                if (event.isCancelled()) {
+-                    return stack;
+-                }
+-
+-                if (!event.getItem().equals(craftItem)) {
+-                    // Chain to handler for new item
+-                    ItemStack eventStack = CraftItemStack.asNMSCopy(event.getItem());
+-                    DispenseItemBehavior idispensebehavior = (DispenseItemBehavior) DispenserBlock.DISPENSER_REGISTRY.get(eventStack.getItem());
+-                    if (idispensebehavior != DispenseItemBehavior.NOOP && idispensebehavior != this) {
+-                        idispensebehavior.dispense(pointer, eventStack);
+-                        return stack;
+-                    }
+-                }
+-                // CraftBukkit end
++                // Paper - move into specific cases
+ 
+                 this.setSuccess(true);
+                 Direction enumdirection = (Direction) pointer.state().getValue(DispenserBlock.FACING);
+@@ -779,6 +757,10 @@ public interface DispenseItemBehavior {
+                 BlockState iblockdata = worldserver.getBlockState(blockposition);
+ 
+                 if (BaseFireBlock.canBePlacedAt(worldserver, blockposition, enumdirection)) {
++                    // Paper start - call dispense event
++                    final net.minecraft.world.item.ItemStack result = this.handleFlintAndSteelEvent(pointer, stack, blockposition);
++                    if (result != null) return result;
++                    // Paper end - call dispense event
+                     // CraftBukkit start - Ignition by dispensing flint and steel
+                     if (!org.bukkit.craftbukkit.event.CraftEventFactory.callBlockIgniteEvent(worldserver, blockposition, pointer.pos()).isCancelled()) {
+                         worldserver.setBlockAndUpdate(blockposition, BaseFireBlock.getState(worldserver, blockposition));
+@@ -786,6 +768,12 @@ public interface DispenseItemBehavior {
+                     }
+                     // CraftBukkit end
+                 } else if (!CampfireBlock.canLight(iblockdata) && !CandleBlock.canLight(iblockdata) && !CandleCakeBlock.canLight(iblockdata)) {
++                    // Paper start - call dispense event
++                    if (iblockdata.getBlock() instanceof TntBlock) {
++                        final net.minecraft.world.item.ItemStack result = this.handleFlintAndSteelEvent(pointer, stack, blockposition);
++                        if (result != null) return result;
++                    }
++                    // Paper end - call dispense event
+                     if (iblockdata.getBlock() instanceof TntBlock && org.bukkit.craftbukkit.event.CraftEventFactory.callTNTPrimeEvent(worldserver, blockposition, org.bukkit.event.block.TNTPrimeEvent.PrimeCause.DISPENSER, null, pointer.pos())) { // CraftBukkit - TNTPrimeEvent
+                         TntBlock.explode(worldserver, blockposition);
+                         worldserver.removeBlock(blockposition, false);
+@@ -793,6 +781,10 @@ public interface DispenseItemBehavior {
+                         this.setSuccess(false);
+                     }
+                 } else {
++                    // Paper start - call dispense event
++                    final net.minecraft.world.item.ItemStack result = this.handleFlintAndSteelEvent(pointer, stack, blockposition);
++                    if (result != null) return result;
++                    // Paper end - call dispense event
+                     worldserver.setBlockAndUpdate(blockposition, (BlockState) iblockdata.setValue(BlockStateProperties.LIT, true));
+                     worldserver.gameEvent((Entity) null, GameEvent.BLOCK_CHANGE, blockposition);
+                 }
+@@ -803,6 +795,18 @@ public interface DispenseItemBehavior {
+ 
+                 return stack;
+             }
++
++            @javax.annotation.Nullable
++            private net.minecraft.world.item.ItemStack handleFlintAndSteelEvent(final BlockSource pointer, final ItemStack stack, final BlockPos blockposition) {
++                final org.bukkit.craftbukkit.event.CraftEventFactory.DispenseResult result = org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockDispenseEvent(pointer, blockposition, stack, new org.bukkit.util.Vector(0, 0, 0), this);
++                if (result.result() != null) {
++                    this.setSuccess(false);
++                }
++                if (result.cancelled()) {
++                    return java.util.Objects.requireNonNull(result.result(), "if cancelled, must have a result stack set");
++                }
++                return null;
++            }
+         });
+         DispenserBlock.registerBehavior(Items.BONE_MEAL, new OptionalDispenseItemBehavior() {
+             @Override
+@@ -810,6 +814,9 @@ public interface DispenseItemBehavior {
+                 this.setSuccess(true);
+                 ServerLevel worldserver = pointer.level();
+                 BlockPos blockposition = pointer.pos().relative((Direction) pointer.state().getValue(DispenserBlock.FACING));
++                // Paper start
++                final BlockState blockState = worldserver.getBlockState(blockposition);
++                if (BoneMealItem.canGrowCrop(worldserver, blockposition, blockState) || BoneMealItem.canGrowWaterPlant(worldserver, blockposition, blockState)) { // Paper - check if it will succeed first
+                 // CraftBukkit start
+                 org.bukkit.block.Block block = CraftBlock.at(worldserver, pointer.pos());
+                 CraftItemStack craftItem = CraftItemStack.asCraftMirror(stack.copyWithCount(1)); // Paper - single item in event
+@@ -832,6 +839,7 @@ public interface DispenseItemBehavior {
+                         return stack;
+                     }
+                 }
++                } // Paper
+ 
+                 worldserver.captureTreeGeneration = true;
+                 // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/item/BoneMealItem.java b/src/main/java/net/minecraft/world/item/BoneMealItem.java
+index 4bc5c7a68f5d2122864d30eee97d2550a73398f9..b6ed42a487034132e474e2bfb1b0bd72b4231b85 100644
+--- a/src/main/java/net/minecraft/world/item/BoneMealItem.java
++++ b/src/main/java/net/minecraft/world/item/BoneMealItem.java
+@@ -67,15 +67,17 @@ public class BoneMealItem extends Item {
+             }
+         }
+     }
++    // Paper start - separate out canGrowCrop check
++    public static boolean canGrowCrop(Level world, BlockPos pos, BlockState state) {
++        return state.getBlock() instanceof BonemealableBlock bonemealableBlock && bonemealableBlock.isValidBonemealTarget(world, pos, state);
++    }
++    // Paper end
+ 
+     public static boolean growCrop(ItemStack stack, Level world, BlockPos pos) {
+         BlockState iblockdata = world.getBlockState(pos);
+         Block block = iblockdata.getBlock();
+ 
+-        if (block instanceof BonemealableBlock) {
+-            BonemealableBlock iblockfragileplantelement = (BonemealableBlock) block;
+-
+-            if (iblockfragileplantelement.isValidBonemealTarget(world, pos, iblockdata)) {
++        if (canGrowCrop(world, pos, iblockdata) && block instanceof final BonemealableBlock iblockfragileplantelement) {{ // Paper - separate out check into separate method above
+                 if (world instanceof ServerLevel) {
+                     if (iblockfragileplantelement.isBonemealSuccess(world, world.random, pos, iblockdata)) {
+                         iblockfragileplantelement.performBonemeal((ServerLevel) world, world.random, pos, iblockdata);
+@@ -91,8 +93,14 @@ public class BoneMealItem extends Item {
+         return false;
+     }
+ 
++    // Paper start - separate out canGrowWaterPlant check
++    public static boolean canGrowWaterPlant(Level world, BlockPos blockPos, BlockState blockState) {
++        return blockState.is(Blocks.WATER) && world.getFluidState(blockPos).getAmount() == 8;
++    }
++    // Paper end
++
+     public static boolean growWaterPlant(ItemStack stack, Level world, BlockPos blockPos, @Nullable Direction facing) {
+-        if (world.getBlockState(blockPos).is(Blocks.WATER) && world.getFluidState(blockPos).getAmount() == 8) {
++        if (canGrowWaterPlant(world, blockPos, world.getBlockState(blockPos))) { // Paper - separate out check into separate method above
+             if (!(world instanceof ServerLevel)) {
+                 return true;
+             } else {


### PR DESCRIPTION
The BlockDispenseEvent was incorrectly called in two specific situations, when bonemealing an invalid location, like a solid block or when trying to use flint & steel in an incorrect way. This doesn't match up with the rest of the calls of BlockDispenseEvent in which something always happens, and in other cases where something *might* happen, that logic is checked before calling the event.