### PR TITLE
Fix nullability check

### DIFF
--- a/patches/server/0606-More-World-API.patch
+++ b/patches/server/0606-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9055b7821ba2a52e20bf6422cae2edfefc1872b1..7beaea21edf0b832bc1115d90f5893c75a8da912 100644
+index 9055b7821ba2a52e20bf6422cae2edfefc1872b1..efc2fa39175d6981ebbc5b204baeef4298eb0e5c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2034,6 +2034,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2034,6 +2034,69 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return new CraftStructureSearchResult(CraftStructure.minecraftToBukkit(found.getSecond().value(), this.getHandle().registryAccess()), new Location(this, found.getFirst().getX(), found.getFirst().getY(), found.getFirst().getZ()));
      }
  
@@ -21,8 +21,12 @@ index 9055b7821ba2a52e20bf6422cae2edfefc1872b1..7beaea21edf0b832bc1115d90f5893c7
 +    @Override
 +    public Location locateNearestBiome(Location origin, Biome biome, int radius, int step) {
 +        BlockPos originPos = new BlockPos(origin.getX(), origin.getY(), origin.getZ());
-+        BlockPos nearest = getHandle().findClosestBiome3d( holder -> holder.is(CraftNamespacedKey.toMinecraft(biome.getKey())), originPos, radius, step, step).getFirst();
-+        return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
++        Pair<BlockPos, Holder<net.minecraft.world.level.biome.Biome>> pair = getHandle().findClosestBiome3d(holder -> holder.is(CraftNamespacedKey.toMinecraft(biome.getKey())), originPos, radius, step, step);
++        if (pair == null) {
++            return null;
++        }
++        BlockPos nearest = pair.getFirst();
++        return new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
 +    }
 +
 +    @Override

--- a/patches/server/0877-Warn-on-plugins-accessing-faraway-chunks.patch
+++ b/patches/server/0877-Warn-on-plugins-accessing-faraway-chunks.patch
@@ -18,7 +18,7 @@ index bb411f4efc550ed7872f0252373be81bd8e99b76..3cbf801b2e5420c0e870f73788deb550
  
      private static boolean isOutsideSpawnableHeight(int y) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 37a204d35979fb51cab9c228515e35c4b1049ab1..c5eb25b191cbb496be2a761d0b6eec9776319687 100644
+index 01ccb54fb94fc5c03865b12bde63a2cb5a46e0f5..f8d321e925bf2708e51590542325c1bdc67d5964 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -312,9 +312,24 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -86,7 +86,7 @@ index 37a204d35979fb51cab9c228515e35c4b1049ab1..c5eb25b191cbb496be2a761d0b6eec97
          // Transient load for this tick
          return this.world.getChunk(x >> 4, z >> 4).getHeight(CraftHeightMap.toNMS(heightMap), x, z);
      }
-@@ -2314,6 +2334,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2318,6 +2338,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot end
      // Paper start
      public java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent) {


### PR DESCRIPTION
Prevents NPE when `World#locateNearestBiome` fails to find a biome:
```java
[16:54:39 WARN]: [Paper-Test-Plugin] Task #2 for Paper-Test-Plugin v1.0.0-SNAPSHOT generated an exception
java.lang.NullPointerException: Cannot invoke "com.mojang.datafixers.util.Pair.getFirst()" because "pair" is null
        at org.bukkit.craftbukkit.CraftWorld.locateNearestBiome(CraftWorld.java:2166) ~[main/:?]
        at org.bukkit.craftbukkit.CraftWorld.locateNearestBiome(CraftWorld.java:2159) ~[main/:?]
        at io.papermc.paper.testplugin.TestPlugin.lambda$onChat$0(TestPlugin.java:22) ~[test-plugin-1.0.0-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:101) ~[main/:?]
        at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[main/:?]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1473) ~[main/:?]
        at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:440) ~[main/:?]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1397) ~[main/:?]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1173) ~[main/:?]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[main/:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```