### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0213-Add-PrepareResultEvent-PrepareGrindstoneEvent.patch
+++ b/patches/api/0213-Add-PrepareResultEvent-PrepareGrindstoneEvent.patch
@@ -11,14 +11,12 @@ Grindstone is a backwards compat from a previous PrepareGrindstoneEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..449e8c06f8434b59d49a76481fa60c5c49e80579
+index 0000000000000000000000000000000000000000..a89d189e1175e980e5af8476f539f0a025e8903b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,26 @@
 +package com.destroystokyo.paper.event.inventory;
 +
-+import org.bukkit.event.HandlerList;
-+import org.bukkit.event.inventory.InventoryEvent;
 +import org.bukkit.inventory.GrindstoneInventory;
 +import org.bukkit.inventory.InventoryView;
 +import org.bukkit.inventory.ItemStack;
@@ -27,7 +25,7 @@ index 0000000000000000000000000000000000000000..449e8c06f8434b59d49a76481fa60c5c
 +
 +/**
 + * Called when an item is put in a slot for grinding in a Grindstone
-+ * @see com.destroystokyo.paper.event.inventory.PrepareResultEvent
++ * @deprecated use {@link org.bukkit.event.inventory.PrepareGrindstoneEvent}
 + */
 +@Deprecated
 +public class PrepareGrindstoneEvent extends PrepareResultEvent {
@@ -45,15 +43,13 @@ index 0000000000000000000000000000000000000000..449e8c06f8434b59d49a76481fa60c5c
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/inventory/PrepareResultEvent.java b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareResultEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..045ce9ec3c9134aced5f5235b760ac85599d16c6
+index 0000000000000000000000000000000000000000..25e5f0354b3b65c656d6c173ec108825f1e8b1be
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareResultEvent.java
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,37 @@
 +package com.destroystokyo.paper.event.inventory;
 +
-+import org.bukkit.event.HandlerList;
-+import org.bukkit.event.inventory.InventoryEvent;
-+import org.bukkit.event.inventory.InventoryType;
++import org.bukkit.event.inventory.PrepareInventoryResultEvent;
 +import org.bukkit.inventory.InventoryView;
 +import org.bukkit.inventory.ItemStack;
 +import org.jetbrains.annotations.NotNull;
@@ -62,14 +58,11 @@ index 0000000000000000000000000000000000000000..045ce9ec3c9134aced5f5235b760ac85
 +/**
 + * Called when an item is put in an inventory containing a result slot
 + */
-+public class PrepareResultEvent extends InventoryEvent {
++public class PrepareResultEvent extends PrepareInventoryResultEvent {
 +
-+    private static final HandlerList handlers = new HandlerList();
-+    private ItemStack result;
-+
++    // HandlerList on PrepareInventoryResultEvent to ensure api compat
 +    public PrepareResultEvent(@NotNull InventoryView inventory, @Nullable ItemStack result) {
-+        super(inventory);
-+        this.result = result;
++        super(inventory, result);
 +    }
 +
 +    /**
@@ -79,133 +72,125 @@ index 0000000000000000000000000000000000000000..045ce9ec3c9134aced5f5235b760ac85
 +     */
 +    @Nullable
 +    public ItemStack getResult() {
-+        return result;
++        return super.getResult();
 +    }
 +
++    /**
++     * Set result item, may be null.
++     *
++     * @param result result item
++     */
 +    public void setResult(@Nullable ItemStack result) {
-+        this.result = result;
-+    }
-+
-+    @NotNull
-+    @Override
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
++        super.setResult(result);
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java b/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java
-index 77109a07f07aa6985106dc1a9ad5218f6c7f360f..f1f6f4ab4f81a3f21e757fef4a30b00e94371f8d 100644
+index 6782024735a885ba0b1b4dba4a576740c1410366..8695715c10d81b06c088ff0c8d401875d26879b5 100644
 --- a/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java
 +++ b/src/main/java/org/bukkit/event/inventory/PrepareAnvilEvent.java
-@@ -1,5 +1,6 @@
- package org.bukkit.event.inventory;
- 
-+import com.destroystokyo.paper.event.inventory.PrepareResultEvent;
- import org.bukkit.event.HandlerList;
- import org.bukkit.inventory.AnvilInventory;
- import org.bukkit.inventory.InventoryView;
-@@ -10,14 +11,16 @@ import org.jetbrains.annotations.Nullable;
+@@ -10,9 +10,9 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Called when an item is put in a slot for repair by an anvil.
   */
--public class PrepareAnvilEvent extends InventoryEvent {
-+// Paper start - extend PrepareResultEvent
-+public class PrepareAnvilEvent extends PrepareResultEvent {
+-public class PrepareAnvilEvent extends PrepareInventoryResultEvent {
++public class PrepareAnvilEvent extends com.destroystokyo.paper.event.inventory.PrepareResultEvent {
  
 -    private static final HandlerList handlers = new HandlerList();
--    private ItemStack result;
-+    //private static final HandlerList handlers = new HandlerList();
-+    //private ItemStack result;
++    // Paper - move HandlerList to PrepareInventoryResultEvent
  
      public PrepareAnvilEvent(@NotNull InventoryView inventory, @Nullable ItemStack result) {
--        super(inventory);
--        this.result = result;
-+        super(inventory, result);
-+        //this.result = result;
-+        // Paper end
+         super(inventory, result);
+@@ -24,14 +24,5 @@ public class PrepareAnvilEvent extends PrepareInventoryResultEvent {
+         return (AnvilInventory) super.getInventory();
      }
  
-     @NotNull
-@@ -33,13 +36,14 @@ public class PrepareAnvilEvent extends InventoryEvent {
-      */
-     @Nullable
-     public ItemStack getResult() {
--        return result;
-+        return super.getResult(); // Paper
-     }
- 
-     public void setResult(@Nullable ItemStack result) {
--        this.result = result;
-+        super.setResult(result); // Paper
-     }
- 
-+    /* // Paper - comment out
-     @NotNull
-     @Override
-     public HandlerList getHandlers() {
-@@ -50,4 +54,5 @@ public class PrepareAnvilEvent extends InventoryEvent {
-     public static HandlerList getHandlerList() {
-         return handlers;
-     }
-+    */ // Paper
+-    @NotNull
+-    @Override
+-    public HandlerList getHandlers() {
+-        return handlers;
+-    }
+-
+-    @NotNull
+-    public static HandlerList getHandlerList() {
+-        return handlers;
+-    }
++    // Paper - move HandlerList to PrepareInventoryResultEvent
  }
+diff --git a/src/main/java/org/bukkit/event/inventory/PrepareGrindstoneEvent.java b/src/main/java/org/bukkit/event/inventory/PrepareGrindstoneEvent.java
+index fb172479ce28edbf969b9492236e30fb04395bf9..a7e03600099b8d6a117b8f5455fee24eed03e3a3 100644
+--- a/src/main/java/org/bukkit/event/inventory/PrepareGrindstoneEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/PrepareGrindstoneEvent.java
+@@ -10,9 +10,9 @@ import org.jetbrains.annotations.Nullable;
+ /**
+  * Called when an item is put in a slot for repair or unenchanting in a grindstone.
+  */
+-public class PrepareGrindstoneEvent extends PrepareInventoryResultEvent {
++public class PrepareGrindstoneEvent extends com.destroystokyo.paper.event.inventory.PrepareGrindstoneEvent { // Paper
+ 
+-    private static final HandlerList handlers = new HandlerList();
++    // Paper - move HandlerList to PrepareInventoryResultEvent
+ 
+     public PrepareGrindstoneEvent(@NotNull InventoryView inventory, @Nullable ItemStack result) {
+         super(inventory, result);
+@@ -24,14 +24,5 @@ public class PrepareGrindstoneEvent extends PrepareInventoryResultEvent {
+         return (GrindstoneInventory) super.getInventory();
+     }
+ 
+-    @NotNull
+-    @Override
+-    public HandlerList getHandlers() {
+-        return handlers;
+-    }
+-
+-    @NotNull
+-    public static HandlerList getHandlerList() {
+-        return handlers;
+-    }
++    // Paper - move HandlerList to PrepareInventoryResultEvent
+ }
+diff --git a/src/main/java/org/bukkit/event/inventory/PrepareInventoryResultEvent.java b/src/main/java/org/bukkit/event/inventory/PrepareInventoryResultEvent.java
+index b543bc17fb9354d1939c67c1fb6c92d88fdbe4ec..656ffd4cf7851d6862cc9b675502efa03f4eb94c 100644
+--- a/src/main/java/org/bukkit/event/inventory/PrepareInventoryResultEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/PrepareInventoryResultEvent.java
+@@ -8,7 +8,9 @@ import org.jetbrains.annotations.Nullable;
+ 
+ /**
+  * Called when an item is put in a slot and the result is calculated.
++ * @deprecated use {@link com.destroystokyo.paper.event.inventory.PrepareResultEvent}
+  */
++@Deprecated // Paper
+ public class PrepareInventoryResultEvent extends InventoryEvent {
+ 
+     private static final HandlerList handlers = new HandlerList();
 diff --git a/src/main/java/org/bukkit/event/inventory/PrepareSmithingEvent.java b/src/main/java/org/bukkit/event/inventory/PrepareSmithingEvent.java
-index 99af1540324c4d68c5890ac40b591c5cbdd2e870..0bc0ca4f96c800e9c46c61710f44446691d8b93f 100644
+index 901774e03f8789dddff4e7695ac599ff69cc97a5..8d7924fa81e9b53514fa534f0572fd7effef73c4 100644
 --- a/src/main/java/org/bukkit/event/inventory/PrepareSmithingEvent.java
 +++ b/src/main/java/org/bukkit/event/inventory/PrepareSmithingEvent.java
-@@ -1,5 +1,6 @@
- package org.bukkit.event.inventory;
- 
-+import com.destroystokyo.paper.event.inventory.PrepareResultEvent;
- import org.bukkit.event.HandlerList;
- import org.bukkit.inventory.InventoryView;
- import org.bukkit.inventory.ItemStack;
-@@ -10,14 +11,16 @@ import org.jetbrains.annotations.Nullable;
+@@ -10,9 +10,9 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Called when an item is put in a slot for upgrade by a Smithing Table.
   */
--public class PrepareSmithingEvent extends InventoryEvent {
-+// Paper start - extend PrepareResultEvent
-+public class PrepareSmithingEvent extends PrepareResultEvent {
+-public class PrepareSmithingEvent extends PrepareInventoryResultEvent {
++public class PrepareSmithingEvent extends com.destroystokyo.paper.event.inventory.PrepareResultEvent {
  
 -    private static final HandlerList handlers = new HandlerList();
--    private ItemStack result;
-+    //private static final HandlerList handlers = new HandlerList();
-+    //private ItemStack result;
++    // Paper - move HandlerList ot PrepareInventoryResultEvent
  
      public PrepareSmithingEvent(@NotNull InventoryView inventory, @Nullable ItemStack result) {
--        super(inventory);
--        this.result = result;
-+        super(inventory, result);
-+        //this.result = result;
-+        // Paper end
+         super(inventory, result);
+@@ -24,14 +24,5 @@ public class PrepareSmithingEvent extends PrepareInventoryResultEvent {
+         return (SmithingInventory) super.getInventory();
      }
  
-     @NotNull
-@@ -33,13 +36,14 @@ public class PrepareSmithingEvent extends InventoryEvent {
-      */
-     @Nullable
-     public ItemStack getResult() {
--        return result;
-+        return super.getResult(); // Paper
-     }
- 
-     public void setResult(@Nullable ItemStack result) {
--        this.result = result;
-+        super.setResult(result); // Paper
-     }
- 
-+    /* // Paper - comment out
-     @NotNull
-     @Override
-     public HandlerList getHandlers() {
-@@ -50,4 +54,5 @@ public class PrepareSmithingEvent extends InventoryEvent {
-     public static HandlerList getHandlerList() {
-         return handlers;
-     }
-+    */ // Paper
+-    @NotNull
+-    @Override
+-    public HandlerList getHandlers() {
+-        return handlers;
+-    }
+-
+-    @NotNull
+-    public static HandlerList getHandlerList() {
+-        return handlers;
+-    }
++    // Paper - move HandlerList to PrepareInventoryResultEvent
  }

--- a/patches/api/0270-Add-missing-effects.patch
+++ b/patches/api/0270-Add-missing-effects.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add missing effects
 
 
 diff --git a/src/main/java/org/bukkit/Effect.java b/src/main/java/org/bukkit/Effect.java
-index bf752c5a71bcafe740be281cb6ef5a756c839534..3f2fb26455f6a71e43281098a2291ccf25635348 100644
+index 879d637691683ca862045402f74b751a892bf3ff..e6573b8bd45e0d3ae4f46d64996fa67f13d29f2b 100644
 --- a/src/main/java/org/bukkit/Effect.java
 +++ b/src/main/java/org/bukkit/Effect.java
-@@ -307,7 +307,100 @@ public enum Effect {
+@@ -337,7 +337,100 @@ public enum Effect {
       * block.
       */
      OXIDISED_COPPER_SCRAPE(3005, Type.VISUAL),
@@ -109,7 +109,7 @@ index bf752c5a71bcafe740be281cb6ef5a756c839534..3f2fb26455f6a71e43281098a2291ccf
  
      private final int id;
      private final Type type;
-@@ -367,10 +460,22 @@ public enum Effect {
+@@ -397,10 +490,22 @@ public enum Effect {
  
      static {
          for (Effect effect : values()) {

--- a/patches/api/0387-More-Teleport-API.patch
+++ b/patches/api/0387-More-Teleport-API.patch
@@ -235,7 +235,7 @@ index 82d9cfadb00da9b7c2034938780354a573801728..8bac7b0b762a75a6535b50351850192a
      @Override
      Spigot spigot();
 diff --git a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
-index 553d7740489fe729166c8ca8ef8c7834db3663ad..5b9c750cc3fdbb21c0e16f9df7740cb1f916170a 100644
+index 113e620ce38bb8ff97cf24e309af59b717774b36..149725da2468cf2e8cf3877f78b4a9b749ec1e51 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
 @@ -13,8 +13,14 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
@@ -271,7 +271,7 @@ index 553d7740489fe729166c8ca8ef8c7834db3663ad..5b9c750cc3fdbb21c0e16f9df7740cb1
      /**
       * Gets the cause of this teleportation event
       *
-@@ -80,6 +97,30 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
+@@ -84,6 +101,30 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
          UNKNOWN;
      }
  

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -67,7 +67,7 @@ index 40d1dcd4a0870cf002ee6d0309ce667f49a89d35..a2d2c817cdc1798cd30b3a852b3a495b
      exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index daec3479f451b322934000dc2942cdd6aff122ac..68aafbe2ff05ad2c48b8f3ed23d779680bca574a 100644
+index 3790fd4f33a1fcd7d1430032af146cc724fcde61..16c38195c3e4f5550122df0d65fcce8ca3a83822 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -192,7 +192,7 @@ public class Main {
@@ -78,7 +78,7 @@ index daec3479f451b322934000dc2942cdd6aff122ac..68aafbe2ff05ad2c48b8f3ed23d77968
 +                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -7);
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 index 93046379d0cefd5d3236fc59e698809acdc18f80..774556a62eb240da42e84db4502e2ed43495be17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java

--- a/patches/server/0009-Adventure.patch
+++ b/patches/server/0009-Adventure.patch
@@ -2070,7 +2070,7 @@ index 48972d64710fb0d3821e7c1a0722a1d203c47e07..6a8c67dc668c775809227b455b2dd522
          // CraftBukkit end
          this.chatVisibility = packet.chatVisibility();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3e37ce53e31b0c4e362ff7eefb3662d7d1aabea4..91a0b7923b5a39a7de5d7899002ec4cd4a987a47 100644
+index 478d40c7cc0374cddb76486b6bd148a846a16813..f4502ebedb31b101faa6c99c4fa51fb5b4fdf3f0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -185,6 +185,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
@@ -2702,7 +2702,7 @@ index f4455d8a45fbd687a21a46a4c2850f9a3e6432c5..e91305263fcf6929fe62e5e8da467217
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index a857f9e20d2fe0f495df884e81489e89a64bea54..e2cf043fb35ae8474bf1f6ba2cc2505566973cfe 100644
+index 1d4f6e7fcfaaee40b06f74d250d04f7a36b6458b..f7b2211d04bb6b4a11ad7499c6e3a0e945e6d9da 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -19,6 +19,12 @@ public class Main {
@@ -3662,10 +3662,10 @@ index d2be98416529aea3bdbedd0ea7131bd8de2a0162..6c316c969e87d9da047cd80c15d5579f
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2eb41a4a7cca5a3635451a9910bbdc826c987a02..e303445b64ce59158567a2ab7388e7fe3627e055 100644
+index 92ce3bae7116157b66ed657fe3dc9d4f709bab11..3b520b1301eb0225cdcbb271c8032726c59d3990 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -820,9 +820,9 @@ public class CraftEventFactory {
+@@ -821,9 +821,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -3677,7 +3677,7 @@ index 2eb41a4a7cca5a3635451a9910bbdc826c987a02..e303445b64ce59158567a2ab7388e7fe
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          org.bukkit.World world = entity.getWorld();
-@@ -847,7 +847,7 @@ public class CraftEventFactory {
+@@ -848,7 +848,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/patches/server/0025-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0025-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Show 'Paper' in client crashes, server lists, and Mojang
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 11fd961b2b522920ceb5cde7dbf5cc197044836a..7e313778c44c2b06543c95b5687c2dd841b5216a 100644
+index e9f4ffec4b659f3300daa0138f6e955a8d97786d..e2e66fd4bd34e0ceaab350214a50ddbb1dc76184 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1433,7 +1433,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -19,7 +19,7 @@ index 11fd961b2b522920ceb5cde7dbf5cc197044836a..7e313778c44c2b06543c95b5687c2dd8
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1e8f5b6b74c469a77238b2798fe1d0897a7c6fb3..8ab757b46191811dd49e34e96199ccb38ef5cb2b 100644
+index 5b6653bb3ed90ca1b200ae13ed71e834c07b5d27..445c73c27b2e87fbbc3d5f57098b0c6b618d002e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -259,7 +259,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -32,11 +32,11 @@ index 1e8f5b6b74c469a77238b2798fe1d0897a7c6fb3..8ab757b46191811dd49e34e96199ccb3
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 44b30d0f297af5eb4ace4160a0c601ff824632f6..76487bb730f7915f4eac4b3f2394e02436e527cd 100644
+index c6b04971733b2a26f287e0fa7bf74316c8cc48f2..0be441eef296ebf301d086edaf8dc3d0e107a025 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -223,12 +223,25 @@ public class Main {
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -7);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");
 -                        System.err.println("*** Please download a new build as per instructions from https://www.spigotmc.org/go/outdated-spigot ***");

--- a/patches/server/0109-Add-EntityZapEvent.patch
+++ b/patches/server/0109-Add-EntityZapEvent.patch
@@ -28,10 +28,10 @@ index 18ba4b9d9b68088afd48d1f12cec6b155ea84159..dfc67cd0ef52939be5e5a9952cfcdb4d
                  entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
                  entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e303445b64ce59158567a2ab7388e7fe3627e055..04510bb66453a42badf268548aed45d3a3d6ad9d 100644
+index 3b520b1301eb0225cdcbb271c8032726c59d3990..d8ebe20844136f2a5b395669dcfdd7f6bbc6fff3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1157,6 +1157,14 @@ public class CraftEventFactory {
+@@ -1158,6 +1158,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index baa5cc93ec210032fcbe493d473396964288933f..c12493cc369f632c4aa9535cde9b8629
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 04510bb66453a42badf268548aed45d3a3d6ad9d..35d7dbd3d7cb445a631b4105ae61a4808cc1759a 100644
+index d8ebe20844136f2a5b395669dcfdd7f6bbc6fff3..71364663b577dedd62993808d764b4e4a91322d5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1116,6 +1116,17 @@ public class CraftEventFactory {
+@@ -1117,6 +1117,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0114-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0114-Add-ProjectileCollideEvent.patch
@@ -87,10 +87,10 @@ index 88181c59e604ba3b132b9e695cef5eaf5b836029..94d09b05737679b133ec462815b010b1
  
          this.checkInsideBlocks();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 35d7dbd3d7cb445a631b4105ae61a4808cc1759a..03637eb7237a4caeb01bc84bda65a8c6513b2014 100644
+index 71364663b577dedd62993808d764b4e4a91322d5..90da45df46e344ffae6eda1efe9ed571b345acf9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1260,6 +1260,16 @@ public class CraftEventFactory {
+@@ -1261,6 +1261,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/patches/server/0151-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0151-Fix-this-stupid-bullshit.patch
@@ -31,12 +31,12 @@ index b5aa358638b9d0638dfe47f7ebac04cca1dd80b9..0d3a8f576c037886ccdd6068ce953c4c
              Bootstrap.isBootstrapped = true;
              if (BuiltInRegistries.REGISTRY.keySet().isEmpty()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index be564acab5459313bd7c76c0f128f7e4b620fcdc..d4f6d7fee1012adaef516f283ef8d12b5804af46 100644
+index 75f5a3eb8730af1fea5bedbe168dcffacdbc85ad..22bb84601865960459040d7cb51d0c8d96695b3c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -241,10 +241,12 @@ public class Main {
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -7);
                      if (buildDate.before(deadline.getTime())) {
 -                        System.err.println("*** Error, this build is outdated ***");
 +                        // Paper start - This is some stupid bullshit

--- a/patches/server/0176-Add-ArmorStand-Item-Meta.patch
+++ b/patches/server/0176-Add-ArmorStand-Item-Meta.patch
@@ -274,10 +274,10 @@ index 4d687fa31f4d889ac755c178b9afd2b927c78ee2..01ceb8de8411193fa407bf19bbd25a4b
                          CraftMetaCompass.LODESTONE_POS.NBT,
                          CraftMetaCompass.LODESTONE_TRACKED.NBT,
 diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
-index 257eac95179207f77ac9d5e7a5a499ceedb12d0b..13144f8d1dc0a2ca640d138e6c7930c1736ec4a0 100644
+index 851cacdae78b3772daca7fd05ff5f946dcfd3c2e..fe8bf637055f542151c4888b0fc8671d5b3cf67c 100644
 --- a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
 +++ b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
-@@ -324,6 +324,7 @@ public class ItemMetaTest extends AbstractTestingBase {
+@@ -341,6 +341,7 @@ public class ItemMetaTest extends AbstractTestingBase {
                      final CraftMetaArmorStand meta = (CraftMetaArmorStand) cleanStack.getItemMeta();
                      meta.entityTag = new CompoundTag();
                      meta.entityTag.putBoolean("Small", true);

--- a/patches/server/0217-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0217-InventoryCloseEvent-Reason-API.patch
@@ -75,7 +75,7 @@ index 0e64cb9969453832c5d08b112cafb9ef835f9a2a..cd392d316f35ac488c49ad8c34c0273b
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d1adb186bf9c79b99967da9c7d9aa20ba85c64e2..a646264c34592f3a7512e94399ba15490381095d 100644
+index 217961627f32d19e1b4ebe56d7132613fa613fe4..6c74c37f396459d25672b6ad7574393d8cc7c292 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -217,6 +217,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -173,7 +173,7 @@ index 7ea4a2d4e691e0a0a4d9ef3189a29a4a4ca4374b..883b6245f44f3fb82d7678e1092177ca
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3259d4ecad831f68a742517d2e85a1062035712b..aae49c0a8a6672b0b2753c88a61df5f1c9436699 100644
+index b09643ee16b049d9fab2ea36ca76837cac580149..ff910a539a119a45e06fc2934f034a83395f9843 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1160,7 +1160,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -186,10 +186,10 @@ index 3259d4ecad831f68a742517d2e85a1062035712b..aae49c0a8a6672b0b2753c88a61df5f1
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 03637eb7237a4caeb01bc84bda65a8c6513b2014..d2129225afbf617dbaeeeb2e783eea5ff33792db 100644
+index 90da45df46e344ffae6eda1efe9ed571b345acf9..21ca981fba9d93f83d12c38f12ed276cc3c3548f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1229,7 +1229,7 @@ public class CraftEventFactory {
+@@ -1230,7 +1230,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -198,7 +198,7 @@ index 03637eb7237a4caeb01bc84bda65a8c6513b2014..d2129225afbf617dbaeeeb2e783eea5f
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1395,8 +1395,18 @@ public class CraftEventFactory {
+@@ -1396,8 +1396,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0228-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0228-Vanished-players-don-t-have-rights.patch
@@ -88,10 +88,10 @@ index d2e07f39097aee880e14c7b6c6df90e825a724d3..808a025548fd390ef4d657c53eb9bf73
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d2129225afbf617dbaeeeb2e783eea5ff33792db..99b5db683591b42cf6c88dcd6b9a4aa0cf769ce4 100644
+index 21ca981fba9d93f83d12c38f12ed276cc3c3548f..b653121dc16ce4ab3f32456e0c8690e022aa263c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1265,6 +1265,14 @@ public class CraftEventFactory {
+@@ -1266,6 +1266,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0231-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0231-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -24,10 +24,10 @@ index 846c89f7502b6f9a288b2fb7b6a7ba55b6fe1a38..7f6d331cf832f57857519b6e9801c3b4
  
      static boolean hasItemMeta(net.minecraft.world.item.ItemStack item) {
 diff --git a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
-index 13144f8d1dc0a2ca640d138e6c7930c1736ec4a0..5239cc38e02051d662518f103534d44e3d22d6b9 100644
+index fe8bf637055f542151c4888b0fc8671d5b3cf67c..7ce2782359be9aea3f2209138c3f82725b27515e 100644
 --- a/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
 +++ b/src/test/java/org/bukkit/craftbukkit/inventory/ItemMetaTest.java
-@@ -99,6 +99,34 @@ public class ItemMetaTest extends AbstractTestingBase {
+@@ -101,6 +101,34 @@ public class ItemMetaTest extends AbstractTestingBase {
          assertThat(itemMeta.hasConflictingEnchant(null), is(false));
      }
  

--- a/patches/server/0255-Improve-death-events.patch
+++ b/patches/server/0255-Improve-death-events.patch
@@ -23,7 +23,7 @@ public net.minecraft.world.entity.LivingEntity getDeathSound()Lnet/minecraft/sou
 public net.minecraft.world.entity.LivingEntity getSoundVolume()F
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b3fa1f28405ddebdd616bcc31db42d73697f2d79..05e72945da26295fbc5f0d243ba48a8649244b3b 100644
+index cd392d316f35ac488c49ad8c34c0273bbccc6a1c..db02d7938c79995b8acc4184c1be2fe39cbf479c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -235,6 +235,10 @@ public class ServerPlayer extends Player {
@@ -314,7 +314,7 @@ index f70f75867a8f03d42f240a0d007d2221269f2fdb..e463ae13ce6f65675c2b6d553ecf91db
          this.gameEvent(GameEvent.ENTITY_DIE);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8c528f32ef3a5e97ff14bd299a1f6e93b1a8a9af..15da4358e46547fa979dd5023ec6eb5d1358bcb5 100644
+index 1b5d713ea7f184b90ad050d758cbdfc5ca76a5b5..9ba067e28a6c533b5e611a31dd6d4b3e83656b93 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2155,7 +2155,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -334,10 +334,10 @@ index 8c528f32ef3a5e97ff14bd299a1f6e93b1a8a9af..15da4358e46547fa979dd5023ec6eb5d
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 99b5db683591b42cf6c88dcd6b9a4aa0cf769ce4..2dfade8cc1e5e7e774d876d1e60c692aca0ef739 100644
+index b653121dc16ce4ab3f32456e0c8690e022aa263c..2d55260f4c753bfdd9f7fca69f1a9a1df0d28d1c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -806,9 +806,16 @@ public class CraftEventFactory {
+@@ -807,9 +807,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -354,7 +354,7 @@ index 99b5db683591b42cf6c88dcd6b9a4aa0cf769ce4..2dfade8cc1e5e7e774d876d1e60c692a
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -825,8 +832,15 @@ public class CraftEventFactory {
+@@ -826,8 +833,15 @@ public class CraftEventFactory {
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
@@ -370,7 +370,7 @@ index 99b5db683591b42cf6c88dcd6b9a4aa0cf769ce4..2dfade8cc1e5e7e774d876d1e60c692a
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -843,6 +857,31 @@ public class CraftEventFactory {
+@@ -844,6 +858,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0312-Mob-Spawner-API-Enhancements.patch
+++ b/patches/server/0312-Mob-Spawner-API-Enhancements.patch
@@ -69,10 +69,10 @@ index 6ba97a0b4f2cb15d5435657c8e8f5c71c6fee3db..c5a117308f051c20b81818ad91e0ca40
          nbt.putShort("MaxNearbyEntities", (short) this.maxNearbyEntities);
          nbt.putShort("RequiredPlayerRange", (short) this.requiredPlayerRange);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftCreatureSpawner.java b/src/main/java/org/bukkit/craftbukkit/block/CraftCreatureSpawner.java
-index 590d77470e979b331917aaa8cbc30a6513e385db..6887b479488e8d25c6170c29ce7955df927cba68 100644
+index e8f888b9e37454d9863fbaf0f0c3dc982d582f1e..95b01ddddb1ba90da495927099147e775fb4f7aa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftCreatureSpawner.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftCreatureSpawner.java
-@@ -116,4 +116,28 @@ public class CraftCreatureSpawner extends CraftBlockEntityState<SpawnerBlockEnti
+@@ -129,4 +129,28 @@ public class CraftCreatureSpawner extends CraftBlockEntityState<SpawnerBlockEnti
      public void setSpawnRange(int spawnRange) {
          this.getSnapshot().getSpawner().spawnRange = spawnRange;
      }

--- a/patches/server/0358-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/patches/server/0358-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2dfade8cc1e5e7e774d876d1e60c692aca0ef739..b35dd78b08b15842e87182de9afef6c49c249366 100644
+index 2d55260f4c753bfdd9f7fca69f1a9a1df0d28d1c..417ae46d36690f7f7c72fb85331f8d5ff21ab937 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -348,13 +348,18 @@ public class CraftEventFactory {
+@@ -349,13 +349,18 @@ public class CraftEventFactory {
          }
  
          org.bukkit.inventory.ItemStack item;

--- a/patches/server/0390-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0390-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -135,10 +135,10 @@ index e463ae13ce6f65675c2b6d553ecf91db5a047dbc..7ff1e7e4d493770bfdbc0ad5e8f10387
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b35dd78b08b15842e87182de9afef6c49c249366..120e21edad328f382b5edc030f546e3b9a80916b 100644
+index 417ae46d36690f7f7c72fb85331f8d5ff21ab937..7069b447c12c170683dee7052327a55c29af83c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -809,6 +809,11 @@ public class CraftEventFactory {
+@@ -810,6 +810,11 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
@@ -150,7 +150,7 @@ index b35dd78b08b15842e87182de9afef6c49c249366..120e21edad328f382b5edc030f546e3b
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
          populateFields(victim, event); // Paper - make cancellable
-@@ -822,11 +827,13 @@ public class CraftEventFactory {
+@@ -823,11 +828,13 @@ public class CraftEventFactory {
          playDeathSound(victim, event);
          // Paper end
          victim.expToDrop = event.getDroppedExp();

--- a/patches/server/0401-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0401-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 120e21edad328f382b5edc030f546e3b9a80916b..2fd5e1b4f20c28ebed0b480cc866ed05cb739462 100644
+index 7069b447c12c170683dee7052327a55c29af83c4..a8d9ad5eba330c23d2cc745242977f4fb1b4c674 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -630,16 +630,30 @@ public class CraftEventFactory {
+@@ -631,16 +631,30 @@ public class CraftEventFactory {
              net.minecraft.world.entity.ExperienceOrb xp = (net.minecraft.world.entity.ExperienceOrb) entity;
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/patches/server/0402-ExperienceOrbMergeEvent.patch
+++ b/patches/server/0402-ExperienceOrbMergeEvent.patch
@@ -9,10 +9,10 @@ Plugins can cancel this if they want to ensure experience orbs do not lose impor
 metadata such as spawn reason, or conditionally move data from source to target.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2fd5e1b4f20c28ebed0b480cc866ed05cb739462..571eb0eea3bf7b0cf567cdf571699e729402fda0 100644
+index a8d9ad5eba330c23d2cc745242977f4fb1b4c674..4610d7d329c9c8bf3cbe8c203fe8c89413717df2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -640,7 +640,7 @@ public class CraftEventFactory {
+@@ -641,7 +641,7 @@ public class CraftEventFactory {
                      if (e instanceof net.minecraft.world.entity.ExperienceOrb) {
                          net.minecraft.world.entity.ExperienceOrb loopItem = (net.minecraft.world.entity.ExperienceOrb) e;
                          // Paper start

--- a/patches/server/0446-Add-PrepareResultEvent.patch
+++ b/patches/server/0446-Add-PrepareResultEvent.patch
@@ -32,7 +32,7 @@ index 74447bd2ff36c5360db52d2a56fe3fbe56aee7d2..7733b5271307849e3e56c6089649c4ca
  
      private void setupResultSlot(ItemStack map, ItemStack item, ItemStack oldResult) {
 diff --git a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
-index 9010656b7f013d50872017a298368ec8a3016e9c..00e2148419517c94def76f0a75562cc0093ea3ed 100644
+index e3c3d202a9852adf32d5e94c9011c3799668419b..d610bd1468d506416fe61bf93d6be3bd0dc042a9 100644
 --- a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
 @@ -159,6 +159,7 @@ public class GrindstoneMenu extends AbstractContainerMenu {
@@ -94,10 +94,10 @@ index 78c1bd1c709ef29ccfa75fa87d8af1217cc57b59..4ee54e3a61588e5574e3f7ba06a73bbd
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 571eb0eea3bf7b0cf567cdf571699e729402fda0..88fb677231e13d714e20ae55c08443212b0512a9 100644
+index 4610d7d329c9c8bf3cbe8c203fe8c89413717df2..1c3419d6b7cdc13485e2667c9bc55bd28d607094 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1584,19 +1584,44 @@ public class CraftEventFactory {
+@@ -1585,26 +1585,53 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -107,10 +107,23 @@ index 571eb0eea3bf7b0cf567cdf571699e729402fda0..88fb677231e13d714e20ae55c0844321
 +    // Paper start - disable this method, handled below
 +    public static void callPrepareAnvilEvent(InventoryView view, ItemStack item) { // Paper - verify nothing uses return - handled below in PrepareResult
 +        PrepareAnvilEvent event = new PrepareAnvilEvent(view, CraftItemStack.asCraftMirror(item)); // Paper - remove clone
-+        //event.getView().getPlayer().getServer().getPluginManager().callEvent(event); // disable event
++        //event.getView().getPlayer().getServer().getPluginManager().callEvent(event); // Paper - disable event
          event.getInventory().setItem(2, event.getResult());
 -        return event;
 +        //return event; // Paper
+     }
++    // Paper end
+ 
+-    public static PrepareGrindstoneEvent callPrepareGrindstoneEvent(InventoryView view, ItemStack item) {
+-        PrepareGrindstoneEvent event = new PrepareGrindstoneEvent(view, CraftItemStack.asCraftMirror(item).clone());
+-        event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
++    // Paper start - disable this method, handled below
++    public static void callPrepareGrindstoneEvent(InventoryView view, ItemStack item) {
++        PrepareGrindstoneEvent event = new PrepareGrindstoneEvent(view, CraftItemStack.asCraftMirror(item)); // Paper - remove clone
++        // event.getView().getPlayer().getServer().getPluginManager().callEvent(event); // Paper - disable event
+         event.getInventory().setItem(2, event.getResult());
+-        return event;
++        // return event; // Paper
      }
 +    // Paper end
  
@@ -136,7 +149,7 @@ index 571eb0eea3bf7b0cf567cdf571699e729402fda0..88fb677231e13d714e20ae55c0844321
 +        if (view.getTopInventory() instanceof org.bukkit.inventory.AnvilInventory) {
 +            event = new PrepareAnvilEvent(view, result);
 +        } else if (view.getTopInventory() instanceof org.bukkit.inventory.GrindstoneInventory) {
-+            event = new com.destroystokyo.paper.event.inventory.PrepareGrindstoneEvent(view, result);
++            event = new PrepareGrindstoneEvent(view, result);
 +        } else if (view.getTopInventory() instanceof org.bukkit.inventory.SmithingInventory) {
 +            event = new PrepareSmithingEvent(view, result);
 +        } else {

--- a/patches/server/0522-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/patches/server/0522-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 88fb677231e13d714e20ae55c08443212b0512a9..672b1000daf839d69a06cb3daf9f6dbb86b2cbdc 100644
+index 1c3419d6b7cdc13485e2667c9bc55bd28d607094..9dfbf59fd781e649579dd7082e8ea0ffaa7885d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -264,6 +264,10 @@ public class CraftEventFactory {
+@@ -265,6 +265,10 @@ public class CraftEventFactory {
                          return BedEnterResult.TOO_FAR_AWAY;
                      case NOT_SAFE:
                          return BedEnterResult.NOT_SAFE;

--- a/patches/server/0534-Fix-interact-event-not-being-called-in-adventure.patch
+++ b/patches/server/0534-Fix-interact-event-not-being-called-in-adventure.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix interact event not being called in adventure
 Call PlayerInteractEvent when left-clicking on a block in adventure mode
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index dbe3cab9dfd86081aab876488fda576810ce2105..a21117908a8e1ccbb23fa79cfcc7a6d956ba6a51 100644
+index fd5d2c17471229df9f9f0fb21a9407657231c9af..ee3966cd5df09fda88a269105de8fe11736b55b3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1847,7 +1847,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -20,7 +20,7 @@ index dbe3cab9dfd86081aab876488fda576810ce2105..a21117908a8e1ccbb23fa79cfcc7a6d9
                          }
 @@ -2473,7 +2473,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          // SPIGOT-5607: Only call interact event if no block or entity is being clicked. Use bukkit ray trace method, because it handles blocks and entities at the same time
-         org.bukkit.util.RayTraceResult result = this.player.level.getWorld().rayTrace(origin, origin.getDirection(), d3, org.bukkit.FluidCollisionMode.NEVER, false, 0.1, entity -> entity != this.player.getBukkitEntity());
+         org.bukkit.util.RayTraceResult result = this.player.level.getWorld().rayTrace(origin, origin.getDirection(), d3, org.bukkit.FluidCollisionMode.NEVER, false, 0.1, entity -> entity != this.player.getBukkitEntity() && this.player.getBukkitEntity().canSee(entity));
  
 -        if (result == null) {
 +        if (result == null || this.player.gameMode.getGameModeForPlayer() == GameType.ADVENTURE) { // Paper - call PlayerInteractEvent when left-clicking on a block in adventure mode

--- a/patches/server/0542-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0542-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 1415ad60163f6584619cc7caa61f1848d6ebaa93..801c4c120e98584bcf218a4ef9bd66d7
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 672b1000daf839d69a06cb3daf9f6dbb86b2cbdc..13f97a07ccc1686b6660f60db4af5428f3247e3e 100644
+index 9dfbf59fd781e649579dd7082e8ea0ffaa7885d3..b98ba88d5bf423cee6d88133f021e748171a37c6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1858,4 +1858,12 @@ public class CraftEventFactory {
+@@ -1868,4 +1868,12 @@ public class CraftEventFactory {
          EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
      }

--- a/patches/server/0547-Implement-API-to-expose-exact-interaction-point.patch
+++ b/patches/server/0547-Implement-API-to-expose-exact-interaction-point.patch
@@ -18,7 +18,7 @@ index b0096fe5399397d4c5e170daa892aef017108c2f..645a226c2e3f6dcf1c25187d006d4250
          this.interactResult = event.useItemInHand() == Event.Result.DENY;
          this.interactPosition = blockposition.immutable();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 13f97a07ccc1686b6660f60db4af5428f3247e3e..3a2dfd81f25c50ea7388bc68d37d59999187c645 100644
+index b98ba88d5bf423cee6d88133f021e748171a37c6..3b7c3e15db25c04d818eef4ab6562649597d39f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -56,7 +56,9 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
@@ -31,7 +31,7 @@ index 13f97a07ccc1686b6660f60db4af5428f3247e3e..3a2dfd81f25c50ea7388bc68d37d5999
  import org.bukkit.Material;
  import org.bukkit.NamespacedKey;
  import org.bukkit.Server;
-@@ -473,7 +475,13 @@ public class CraftEventFactory {
+@@ -474,7 +476,13 @@ public class CraftEventFactory {
          return CraftEventFactory.callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand);
      }
  
@@ -45,7 +45,7 @@ index 13f97a07ccc1686b6660f60db4af5428f3247e3e..3a2dfd81f25c50ea7388bc68d37d5999
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
  
-@@ -499,7 +507,10 @@ public class CraftEventFactory {
+@@ -500,7 +508,10 @@ public class CraftEventFactory {
              itemInHand = null;
          }
  

--- a/patches/server/0558-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0558-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 85c5319837295bd2f85baebfe8d6660b267f1d5f..8f55d0753fa26924235c943595f0d1a0
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 3a2dfd81f25c50ea7388bc68d37d59999187c645..8c4211306b16031c58e407381965d0fe5223e1a8 100644
+index 3b7c3e15db25c04d818eef4ab6562649597d39f4..638f05ab3c3986b26339867f71c179b30a4e5f6b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1876,5 +1876,11 @@ public class CraftEventFactory {
+@@ -1886,5 +1886,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0562-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0562-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index 88c7e494051bc3d2c134167318f3eb84abaa2125..6672ca0e82048c23405845a8f5df49ac
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8c4211306b16031c58e407381965d0fe5223e1a8..e29fef212f7db7e1d4ec3e3f43758c9866389765 100644
+index 638f05ab3c3986b26339867f71c179b30a4e5f6b..a0cc7dc09bfb74e0101e53c5c53dcf9438541ee0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1517,8 +1517,10 @@ public class CraftEventFactory {
+@@ -1518,8 +1518,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0568-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/patches/server/0568-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow adding items to BlockDropItemEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e29fef212f7db7e1d4ec3e3f43758c9866389765..8f248352fa17d96a5d64d0ad52e4de61beee0a62 100644
+index a0cc7dc09bfb74e0101e53c5c53dcf9438541ee0..5927968003b6ff55bd524244338c236892d4ca88 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -399,13 +399,30 @@ public class CraftEventFactory {
+@@ -400,13 +400,30 @@ public class CraftEventFactory {
      }
  
      public static void handleBlockDropItemEvent(Block block, BlockState state, ServerPlayer player, List<ItemEntity> items) {

--- a/patches/server/0582-Prevent-grindstones-from-overstacking-items.patch
+++ b/patches/server/0582-Prevent-grindstones-from-overstacking-items.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent grindstones from overstacking items
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
-index 00e2148419517c94def76f0a75562cc0093ea3ed..08e9cc68fa88e4ca42fa26c1425f101e72c094cb 100644
+index d610bd1468d506416fe61bf93d6be3bd0dc042a9..233e8626280a8b93dcb8621a1405e8c308c6836b 100644
 --- a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
 @@ -198,13 +198,13 @@ public class GrindstoneMenu extends AbstractContainerMenu {
@@ -14,7 +14,7 @@ index 00e2148419517c94def76f0a75562cc0093ea3ed..08e9cc68fa88e4ca42fa26c1425f101e
                  if (!itemstack2.isDamageableItem()) {
 -                    if (!ItemStack.matches(itemstack, itemstack1)) {
 +                    if (!ItemStack.matches(itemstack, itemstack1) || (itemstack2.getMaxStackSize() == 1 && !io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.allowGrindstoneOverstacking)) { // Paper - add max stack size check & config value
-                         this.resultSlots.setItem(0, ItemStack.EMPTY);
+                         org.bukkit.craftbukkit.event.CraftEventFactory.callPrepareGrindstoneEvent(this.getBukkitView(), ItemStack.EMPTY); // CraftBukkit
                          this.broadcastChanges();
                          return;
                      }

--- a/patches/server/0692-Add-critical-damage-API.patch
+++ b/patches/server/0692-Add-critical-damage-API.patch
@@ -72,10 +72,10 @@ index 61d4a58ab25ce3bdf7ced426d2f92bc75ef02f7d..dcd3c5b4d3982f02214f8e0306eab37e
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8f248352fa17d96a5d64d0ad52e4de61beee0a62..debaeb0ccf78c6a65efa13c8158d1ef4d90bdedd 100644
+index 5927968003b6ff55bd524244338c236892d4ca88..e3b44666564cf40f015daff6ad1109bd5983fcfa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -969,7 +969,7 @@ public class CraftEventFactory {
+@@ -970,7 +970,7 @@ public class CraftEventFactory {
                  } else {
                      damageCause = DamageCause.ENTITY_EXPLOSION;
                  }
@@ -84,7 +84,7 @@ index 8f248352fa17d96a5d64d0ad52e4de61beee0a62..debaeb0ccf78c6a65efa13c8158d1ef4
              }
              event.setCancelled(cancelled);
  
-@@ -998,7 +998,7 @@ public class CraftEventFactory {
+@@ -999,7 +999,7 @@ public class CraftEventFactory {
                  cause = DamageCause.SONIC_BOOM;
              }
  
@@ -93,7 +93,7 @@ index 8f248352fa17d96a5d64d0ad52e4de61beee0a62..debaeb0ccf78c6a65efa13c8158d1ef4
          } else if (source == DamageSource.OUT_OF_WORLD) {
              EntityDamageEvent event = new EntityDamageByBlockEvent(null, entity.getBukkitEntity(), DamageCause.VOID, modifiers, modifierFunctions);
              event.setCancelled(cancelled);
-@@ -1068,7 +1068,7 @@ public class CraftEventFactory {
+@@ -1069,7 +1069,7 @@ public class CraftEventFactory {
              } else {
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager.getHandle(), source.msgId));
              }
@@ -102,7 +102,7 @@ index 8f248352fa17d96a5d64d0ad52e4de61beee0a62..debaeb0ccf78c6a65efa13c8158d1ef4
              event.setCancelled(cancelled);
              CraftEventFactory.callEvent(event);
              if (!event.isCancelled()) {
-@@ -1113,20 +1113,28 @@ public class CraftEventFactory {
+@@ -1114,20 +1114,28 @@ public class CraftEventFactory {
          }
  
          if (cause != null) {

--- a/patches/server/0909-Correctly-handle-interactions-with-items-on-cooldown.patch
+++ b/patches/server/0909-Correctly-handle-interactions-with-items-on-cooldown.patch
@@ -30,10 +30,10 @@ index 13031576c20bda3bb12c926f6cd938fa5fb105f2..58b093bb1de78ee3b3b2ea364aa50474
          this.interactResult = event.useItemInHand() == Event.Result.DENY;
          this.interactPosition = blockposition.immutable();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index debaeb0ccf78c6a65efa13c8158d1ef4d90bdedd..ae59a1259db4c4cef6f0cd128850229a63491845 100644
+index e3b44666564cf40f015daff6ad1109bd5983fcfa..dd063e8b0df7505a96cd25dc5c797c0c04dfdfd0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -498,6 +498,12 @@ public class CraftEventFactory {
+@@ -499,6 +499,12 @@ public class CraftEventFactory {
      }
  
      public static PlayerInteractEvent callPlayerInteractEvent(net.minecraft.world.entity.player.Player who, Action action, BlockPos position, Direction direction, ItemStack itemstack, boolean cancelledBlock, InteractionHand hand, Vec3 hitVec) {
@@ -46,7 +46,7 @@ index debaeb0ccf78c6a65efa13c8158d1ef4d90bdedd..ae59a1259db4c4cef6f0cd128850229a
          // Paper end
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
-@@ -531,6 +537,11 @@ public class CraftEventFactory {
+@@ -532,6 +538,11 @@ public class CraftEventFactory {
          if (cancelledBlock) {
              event.setUseInteractedBlock(Event.Result.DENY);
          }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
f50ad1f8 PR-798: Add PrepareGrindstoneEvent and refactor related events to use PrepareInventoryResultEvent 0cac7963 SPIGOT-7204: Add TeleportCause#DISMOUNT
b4dd47b0 SPIGOT-7202: Deprecate removed door effects

CraftBukkit Changes:
ab1586c2f PR-1123: Add PrepareGrindstoneEvent
b402824ea SPIGOT-7204: Add TeleportCause#DISMOUNT
06a6a1012 PR-1121: Add unit test for spawn egg meta c18668be3 SPIGOT-7192: Call PlayerInteractEvent with Action.LEFT_CLICK_AIR if the entity interacted is hidden to the player 47124f639 Increase outdated build delay
645993470 SPIGOT-7201: Spawner ItemMeta not working as expected