### PR TITLE
Improve some logging and errors

### DIFF
--- a/patches/server/0947-Improve-logging-and-errors.patch
+++ b/patches/server/0947-Improve-logging-and-errors.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 14 Dec 2022 15:52:11 -0800
+Subject: [PATCH] Improve logging and errors
+
+
+diff --git a/src/main/java/net/minecraft/server/packs/PathPackResources.java b/src/main/java/net/minecraft/server/packs/PathPackResources.java
+index 0232c29d96e1021a9f5a9678996993dc55fe7254..8ad8ad1189d7cdb58caaa39c482d32685afa3f9a 100644
+--- a/src/main/java/net/minecraft/server/packs/PathPackResources.java
++++ b/src/main/java/net/minecraft/server/packs/PathPackResources.java
+@@ -105,6 +105,12 @@ public class PathPackResources extends AbstractPackResources {
+         try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(path)) {
+             for(Path path2 : directoryStream) {
+                 String string = path2.getFileName().toString();
++                // Paper start
++                if (!Files.isDirectory(path2)) {
++                    LOGGER.error("Invalid directory entry: {} in {}.", string, this.root, new java.nio.file.NotDirectoryException(string));
++                    continue;
++                }
++                // Paper end
+                 if (string.equals(string.toLowerCase(Locale.ROOT))) {
+                     set.add(string);
+                 } else {
+diff --git a/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java b/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java
+index 6a083e269b828ef53f943cae56b029f2e0021ef1..110503062b3043cffa082a1cda6b8d57152869aa 100644
+--- a/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java
++++ b/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java
+@@ -44,6 +44,7 @@ import org.bukkit.material.MaterialData;
+  */
+ @Deprecated
+ public final class CraftLegacy {
++    private static final org.slf4j.Logger LOGGER = com.mojang.logging.LogUtils.getLogger(); // Paper
+ 
+     private static final Map<Byte, Material> SPAWN_EGGS = new HashMap<>();
+     private static final Set<String> whitelistedStates = new HashSet<>(Arrays.asList("explode", "check_decay", "decayable", "facing"));
+@@ -255,7 +256,7 @@ public final class CraftLegacy {
+     }
+ 
+     static {
+-        System.err.println("Initializing Legacy Material Support. Unless you have legacy plugins and/or data this is a bug!");
++        LOGGER.warn("Initializing Legacy Material Support. Unless you have legacy plugins and/or data this is a bug!"); // Paper - doesn't need to be an error
+         if (MinecraftServer.getServer() != null && MinecraftServer.getServer().isDebugging()) {
+             new Exception().printStackTrace();
+         }


### PR DESCRIPTION
Previously, if you had a file inside the root `data/` folder of a datapack, it was ignored. Now it just assumes they are all directories and so loading a datapack with that spits out about 50 stacktraces. Just need to log the error less and earlier.

Also changes the legacy mats to a warning not an error. We get too many "reports" of an error because it was error in the logs.


Do we have any other patches that either remove bad logged errors or any other place we want to change this stuff? I feel like we have more, but I just can't remember them.