### PR TITLE
Fix explosion yield with new gamerules

### DIFF
--- a/patches/server/0948-Fix-explosion-yield-with-new-gamerules.patch
+++ b/patches/server/0948-Fix-explosion-yield-with-new-gamerules.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 14 Dec 2022 17:46:27 -0800
+Subject: [PATCH] Fix explosion yield with new gamerules
+
+
+diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
+index e7ce14ab0732034107e735787354a6fb0ec90f54..122880ca3cfe6528e10e6df4c3200d6c66421c8b 100644
+--- a/src/main/java/net/minecraft/world/level/Explosion.java
++++ b/src/main/java/net/minecraft/world/level/Explosion.java
+@@ -327,13 +327,13 @@ public class Explosion {
+             float yield;
+ 
+             if (explode != null) {
+-                EntityExplodeEvent event = new EntityExplodeEvent(explode, location, blockList, this.blockInteraction == Explosion.BlockInteraction.DESTROY ? 1.0F / this.radius : 1.0F);
++                EntityExplodeEvent event = new EntityExplodeEvent(explode, location, blockList, this.blockInteraction == Explosion.BlockInteraction.DESTROY_WITH_DECAY ? 1.0F / this.radius : 1.0F); // Paper - fix explosion yield with new gamerules
+                 this.level.getCraftServer().getPluginManager().callEvent(event);
+                 cancelled = event.isCancelled();
+                 bukkitBlocks = event.blockList();
+                 yield = event.getYield();
+             } else {
+-                BlockExplodeEvent event = new BlockExplodeEvent(location.getBlock(), blockList, this.blockInteraction == Explosion.BlockInteraction.DESTROY ? 1.0F / this.radius : 1.0F);
++                BlockExplodeEvent event = new BlockExplodeEvent(location.getBlock(), blockList, this.blockInteraction == Explosion.BlockInteraction.DESTROY_WITH_DECAY ? 1.0F / this.radius : 1.0F); // Paper - fix explosion yield with new gamerules
+                 this.level.getCraftServer().getPluginManager().callEvent(event);
+                 cancelled = event.isCancelled();
+                 bukkitBlocks = event.blockList();


### PR DESCRIPTION
New explosion block damage types (because of new gamerules) need to be taken into account.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-8674.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/476783845.zip)