### PR TITLE
Correctly mark pseudo inventories as not creatable

### DIFF
--- a/patches/api/0420-Correctly-mark-pseudo-inventories-as-not-creatable.patch
+++ b/patches/api/0420-Correctly-mark-pseudo-inventories-as-not-creatable.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 14 Dec 2022 20:01:19 -0800
+Subject: [PATCH] Correctly mark pseudo inventories as not creatable
+
+Fixes an NPE when the server tries to find an inventory creator
+instance based on the InventoryType. Now it throws an
+IllegalArgumentException like other un-creatable inventories
+
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
+index 8d7ad84c2bdafa8c8a385fe31acb887a883194ff..b6bf5669ef5e4e0f1048db6e9448f1d7774f6198 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
+@@ -133,12 +133,12 @@ public enum InventoryType {
+     /**
+      * Pseudo composter inventory with 0 or 1 slots of undefined type.
+      */
+-    COMPOSTER(1, "Composter"),
++    COMPOSTER(1, "Composter", false), // Paper - prevent NPE on inv creation
+     /**
+      * Pseudo chiseled bookshelf inventory, with 6 slots of undefined type.
+      */
+     @org.jetbrains.annotations.ApiStatus.Experimental // Paper
+-    CHISELED_BOOKSHELF(6, "Chiseled Bookshelf"),
++    CHISELED_BOOKSHELF(6, "Chiseled Bookshelf", false), // Paper - prevent NPE on inv creation
+     ;
+ 
+     private final int size;


### PR DESCRIPTION
Fixes an NPE when the server tries to find an inventory creator instance based on the InventoryType. Now it throws an IllegalArgumentException like other un-creatable inventories.

I think this is the correct solution, not to add inventory creator instances to the CraftInventoryCreator but I could be wrong. The chiseled bookshelf is a tile entity which technically would be easy to add one for.