### PR TITLE
Deprecate ProjectileCollideEvent

### DIFF
--- a/patches/api/0045-Add-ProjectileCollideEvent.patch
+++ b/patches/api/0045-Add-ProjectileCollideEvent.patch
@@ -3,13 +3,14 @@ From: Techcable <Techcable@outlook.com>
 Date: Fri, 16 Dec 2016 21:25:39 -0600
 Subject: [PATCH] Add ProjectileCollideEvent
 
+Now deprecated and replaced with ProjectileHitEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..453663893021768ae21d4980ce17ffba55d9e129
+index 0000000000000000000000000000000000000000..6ae2bc3d952d34f298220738856024e0b6594199
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,69 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Entity;
@@ -20,10 +21,12 @@ index 0000000000000000000000000000000000000000..453663893021768ae21d4980ce17ffba
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Called when an projectile collides with an entity
++ * Called when a projectile collides with an entity
 + * <p>
 + * This event is called <b>before</b> {@link org.bukkit.event.entity.EntityDamageByEntityEvent}, and cancelling it will allow the projectile to continue flying
++ * @deprecated Deprecated, use {@link org.bukkit.event.entity.ProjectileHitEvent} and check if there is a hit entity
 + */
++@Deprecated
 +public class ProjectileCollideEvent extends EntityEvent implements Cancellable {
 +    @NotNull private final Entity collidedWith;
 +

--- a/patches/server/0114-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0114-Add-ProjectileCollideEvent.patch
@@ -3,98 +3,18 @@ From: Techcable <Techcable@outlook.com>
 Date: Fri, 16 Dec 2016 21:25:39 -0600
 Subject: [PATCH] Add ProjectileCollideEvent
 
+Deprecated now and replaced with ProjectileHitEvent
 
-diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-index cfd202d32048abcd3e961d9f7f08c1bc6282e601..f268fc2914996698490b84c4a30bac819c581d05 100644
---- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-+++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-@@ -227,6 +227,17 @@ public abstract class AbstractArrow extends Projectile {
-                     }
-                 }
- 
-+                // Paper start - Call ProjectileCollideEvent
-+                // TODO: flag - noclip - call cancelled?
-+                if (object instanceof EntityHitResult) {
-+                    com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileCollideEvent(this, (EntityHitResult)object);
-+                    if (event.isCancelled()) {
-+                        object = null;
-+                        movingobjectpositionentity = null;
-+                    }
-+                }
-+                // Paper end
-+
-                 if (object != null && !flag) {
-                     this.preOnHit((HitResult) object); // CraftBukkit - projectile hit event
-                     this.hasImpulse = true;
-diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java
-index edc9f3450b56e0c5c12387b6fd51b9628732c372..6dbbd129d05ad52008fb7b70cb1dc3b8818701ad 100644
---- a/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java
-+++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java
-@@ -12,6 +12,7 @@ import net.minecraft.world.entity.Entity;
- import net.minecraft.world.entity.EntityType;
- import net.minecraft.world.entity.LivingEntity;
- import net.minecraft.world.level.Level;
-+import net.minecraft.world.phys.EntityHitResult;
- import net.minecraft.world.phys.HitResult;
- import net.minecraft.world.phys.Vec3;
- import org.bukkit.craftbukkit.event.CraftEventFactory; // CraftBukkit
-@@ -83,7 +84,16 @@ public abstract class AbstractHurtingProjectile extends Projectile {
- 
-             HitResult movingobjectposition = ProjectileUtil.getHitResult(this, this::canHitEntity);
- 
--            if (movingobjectposition.getType() != HitResult.Type.MISS) {
-+            // Paper start - Call ProjectileCollideEvent
-+            if (movingobjectposition instanceof EntityHitResult) {
-+                com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = CraftEventFactory.callProjectileCollideEvent(this, (EntityHitResult)movingobjectposition);
-+                if (event.isCancelled()) {
-+                    movingobjectposition = null;
-+                }
-+            }
-+            // Paper end
-+
-+            if (movingobjectposition != null && movingobjectposition.getType() != HitResult.Type.MISS) { // Paper - add null check in case cancelled
-                 this.preOnHit(movingobjectposition); // CraftBukkit - projectile hit event
- 
-                 // CraftBukkit start - Fire ProjectileHitEvent
-diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrowableProjectile.java b/src/main/java/net/minecraft/world/entity/projectile/ThrowableProjectile.java
-index 88181c59e604ba3b132b9e695cef5eaf5b836029..94d09b05737679b133ec462815b010b19c01b4fa 100644
---- a/src/main/java/net/minecraft/world/entity/projectile/ThrowableProjectile.java
-+++ b/src/main/java/net/minecraft/world/entity/projectile/ThrowableProjectile.java
-@@ -10,6 +10,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
- import net.minecraft.world.level.block.entity.TheEndGatewayBlockEntity;
- import net.minecraft.world.level.block.state.BlockState;
- import net.minecraft.world.phys.BlockHitResult;
-+import net.minecraft.world.phys.EntityHitResult;
- import net.minecraft.world.phys.HitResult;
- import net.minecraft.world.phys.Vec3;
- 
-@@ -66,7 +67,17 @@ public abstract class ThrowableProjectile extends Projectile {
-         }
- 
-         if (movingobjectposition.getType() != HitResult.Type.MISS && !flag) {
-+            // Paper start - Call ProjectileCollideEvent
-+            if (movingobjectposition instanceof EntityHitResult) {
-+                com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileCollideEvent(this, (EntityHitResult)movingobjectposition);
-+                if (event.isCancelled()) {
-+                    movingobjectposition = null;
-+                }
-+            }
-+            if (movingobjectposition != null) {
-+            // Paper end
-             this.preOnHit(movingobjectposition); // CraftBukkit - projectile hit event
-+            } // Paper
-         }
- 
-         this.checkInsideBlocks();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 71364663b577dedd62993808d764b4e4a91322d5..90da45df46e344ffae6eda1efe9ed571b345acf9 100644
+index 71364663b577dedd62993808d764b4e4a91322d5..24814f91088b835e398d4d5fa1c895a3b1cdb086 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1261,6 +1261,16 @@ public class CraftEventFactory {
+@@ -1261,6 +1261,17 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  
 +    // Paper start
++    @Deprecated
 +    public static com.destroystokyo.paper.event.entity.ProjectileCollideEvent callProjectileCollideEvent(Entity entity, EntityHitResult position) {
 +        Projectile projectile = (Projectile) entity.getBukkitEntity();
 +        org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
@@ -107,3 +27,19 @@ index 71364663b577dedd62993808d764b4e4a91322d5..90da45df46e344ffae6eda1efe9ed571
      public static ProjectileLaunchEvent callProjectileLaunchEvent(Entity entity) {
          Projectile bukkitEntity = (Projectile) entity.getBukkitEntity();
          ProjectileLaunchEvent event = new ProjectileLaunchEvent(bukkitEntity);
+@@ -1285,8 +1296,15 @@ public class CraftEventFactory {
+         if (position.getType() == HitResult.Type.ENTITY) {
+             hitEntity = ((EntityHitResult) position).getEntity().getBukkitEntity();
+         }
++        // Paper start - legacy event
++        boolean cancelled = false;
++        if (hitEntity != null && position instanceof EntityHitResult entityHitResult) {
++            cancelled = callProjectileCollideEvent(entity, entityHitResult).isCancelled();
++        }
++        // Paper end
+ 
+         ProjectileHitEvent event = new ProjectileHitEvent((Projectile) entity.getBukkitEntity(), hitEntity, hitBlock, hitFace);
++        event.setCancelled(cancelled); // Paper - propagate legacy event cancellation to modern event
+         entity.level.getCraftServer().getPluginManager().callEvent(event);
+         return event;
+     }

--- a/patches/server/0217-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0217-InventoryCloseEvent-Reason-API.patch
@@ -186,7 +186,7 @@ index bc8738811465d61e41580c5718d85c34e11b609b..5057a65e1f9b4f5646db83b4311636c9
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 90da45df46e344ffae6eda1efe9ed571b345acf9..21ca981fba9d93f83d12c38f12ed276cc3c3548f 100644
+index 2dce08e8680562a19f86909bfe21d91753f9455d..97edf72d799f73d5e6a4bd7bee9fd20dabcb3533 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1230,7 +1230,7 @@ public class CraftEventFactory {
@@ -198,7 +198,7 @@ index 90da45df46e344ffae6eda1efe9ed571b345acf9..21ca981fba9d93f83d12c38f12ed276c
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1396,8 +1396,18 @@ public class CraftEventFactory {
+@@ -1404,8 +1404,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0228-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0228-Vanished-players-don-t-have-rights.patch
@@ -88,10 +88,10 @@ index d2e07f39097aee880e14c7b6c6df90e825a724d3..808a025548fd390ef4d657c53eb9bf73
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 21ca981fba9d93f83d12c38f12ed276cc3c3548f..b653121dc16ce4ab3f32456e0c8690e022aa263c 100644
+index fab613b7c4ee48c3f0eac1405bca7bd53da19060..67d820fb9aa00a3275cc3e23461864b496d738aa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1266,6 +1266,14 @@ public class CraftEventFactory {
+@@ -1267,6 +1267,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0445-Add-PrepareResultEvent.patch
+++ b/patches/server/0445-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index 78c1bd1c709ef29ccfa75fa87d8af1217cc57b59..4ee54e3a61588e5574e3f7ba06a73bbd
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4610d7d329c9c8bf3cbe8c203fe8c89413717df2..1c3419d6b7cdc13485e2667c9bc55bd28d607094 100644
+index 985a5c5f01d54674f7bcb77e07f8890e81113418..856242121e5102dbc88080e8a611ae64348ba86e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1585,26 +1585,53 @@ public class CraftEventFactory {
+@@ -1593,26 +1593,53 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0540-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0540-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 1415ad60163f6584619cc7caa61f1848d6ebaa93..801c4c120e98584bcf218a4ef9bd66d7
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 9dfbf59fd781e649579dd7082e8ea0ffaa7885d3..b98ba88d5bf423cee6d88133f021e748171a37c6 100644
+index 0656f9ec67a51c1ad41de7bfe80a9f67da36dea2..b2c29d6c8affd823e8d9882b72cb5661da57c746 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1868,4 +1868,12 @@ public class CraftEventFactory {
+@@ -1876,4 +1876,12 @@ public class CraftEventFactory {
          EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
      }

--- a/patches/server/0552-Remove-ProjectileHitEvent-call-when-fireballs-dead.patch
+++ b/patches/server/0552-Remove-ProjectileHitEvent-call-when-fireballs-dead.patch
@@ -7,10 +7,10 @@ The duplicate ProjectileHitEvent in EntityFireball was removed. The
 event was always called before the duplicate call.
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java
-index 6dbbd129d05ad52008fb7b70cb1dc3b8818701ad..d73c10167c9100615cd5180f5e5d09b00f7bdc2a 100644
+index edc9f3450b56e0c5c12387b6fd51b9628732c372..97231f7328f0eebffcacdae5469027be8aeec3ae 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractHurtingProjectile.java
-@@ -98,7 +98,7 @@ public abstract class AbstractHurtingProjectile extends Projectile {
+@@ -88,7 +88,7 @@ public abstract class AbstractHurtingProjectile extends Projectile {
  
                  // CraftBukkit start - Fire ProjectileHitEvent
                  if (this.isRemoved()) {

--- a/patches/server/0556-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0556-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 85c5319837295bd2f85baebfe8d6660b267f1d5f..8f55d0753fa26924235c943595f0d1a0
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 3b7c3e15db25c04d818eef4ab6562649597d39f4..638f05ab3c3986b26339867f71c179b30a4e5f6b 100644
+index 36fa211c9ae970624dfc461d9a1b6bcd9e33d22e..9851859fc3c1ff87edc1d52aa8e6806d0d1494a0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1886,5 +1886,11 @@ public class CraftEventFactory {
+@@ -1894,5 +1894,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0560-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0560-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index 88c7e494051bc3d2c134167318f3eb84abaa2125..6672ca0e82048c23405845a8f5df49ac
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 638f05ab3c3986b26339867f71c179b30a4e5f6b..a0cc7dc09bfb74e0101e53c5c53dcf9438541ee0 100644
+index 9851859fc3c1ff87edc1d52aa8e6806d0d1494a0..fcdc34d42076758543b5c5e75ea634e6b0ab767b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1518,8 +1518,10 @@ public class CraftEventFactory {
+@@ -1526,8 +1526,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0690-Add-critical-damage-API.patch
+++ b/patches/server/0690-Add-critical-damage-API.patch
@@ -60,10 +60,10 @@ index 3d5e5d41a2d8c1de0d318eeac0652b115aa0ded8..95019b6ba1bc3bff42e15e5bed4ca7c5
                                      }
                                      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-index 61d4a58ab25ce3bdf7ced426d2f92bc75ef02f7d..dcd3c5b4d3982f02214f8e0306eab37ebbf15299 100644
+index 724bf984fdc65e8468a1b0826332aef87e67a35f..740f08e5fadf9b8d277af05cc9734ceb54f54abb 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-@@ -383,6 +383,7 @@ public abstract class AbstractArrow extends Projectile {
+@@ -372,6 +372,7 @@ public abstract class AbstractArrow extends Projectile {
              }
          }
  
@@ -72,7 +72,7 @@ index 61d4a58ab25ce3bdf7ced426d2f92bc75ef02f7d..dcd3c5b4d3982f02214f8e0306eab37e
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5927968003b6ff55bd524244338c236892d4ca88..e3b44666564cf40f015daff6ad1109bd5983fcfa 100644
+index 97f97a00063e1e4012ec825c165d1dddd7c898f8..31d0227cfb5ceede53830fad43167ee561841618 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -970,7 +970,7 @@ public class CraftEventFactory {

--- a/patches/server/0814-Fix-cancelling-ProjectileHitEvent-for-piercing-arrow.patch
+++ b/patches/server/0814-Fix-cancelling-ProjectileHitEvent-for-piercing-arrow.patch
@@ -15,10 +15,10 @@ piercing arrows to avoid duplicate damage being applied.
 protected net.minecraft.world.entity.projectile.Projectile hitCancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-index dcd3c5b4d3982f02214f8e0306eab37ebbf15299..e7ef36dac559d03d127cf45373a7e0dc935b80a8 100644
+index 740f08e5fadf9b8d277af05cc9734ceb54f54abb..09a4c0d30898bbdc05e32b6f1d4b0436a5e4af53 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-@@ -301,6 +301,19 @@ public abstract class AbstractArrow extends Projectile {
+@@ -290,6 +290,19 @@ public abstract class AbstractArrow extends Projectile {
          }
      }
  


### PR DESCRIPTION
replaced by ProjectileHitEvent
propagated the cancellation of the legacy event
to the modern one

Replaces https://github.com/PaperMC/Paper/pull/4959