### PR TITLE
Improve PortalEvents

### DIFF
--- a/patches/api/0422-Improve-PortalEvents.patch
+++ b/patches/api/0422-Improve-PortalEvents.patch
@@ -1,0 +1,128 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 15 Dec 2022 10:33:34 -0800
+Subject: [PATCH] Improve PortalEvents
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+index 67fb9d93e808e907fa980f3004d415ae5d0a53fc..97e36c7f6e09276fbae20eaeee0965566332ca46 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityPortalEvent.java
+@@ -15,15 +15,58 @@ import org.jetbrains.annotations.Nullable;
+ public class EntityPortalEvent extends EntityTeleportEvent {
+     private static final HandlerList handlers = new HandlerList();
+     private int searchRadius = 128;
++    private final org.bukkit.PortalType type; // Paper
+ 
+     public EntityPortalEvent(@NotNull final Entity entity, @NotNull final Location from, @Nullable final Location to) {
+-        super(entity, from, to);
++        this(entity, from, to, 128); // Paper
+     }
+ 
+     public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @Nullable Location to, int searchRadius) {
+         super(entity, from, to);
+         this.searchRadius = searchRadius;
++        this.type = org.bukkit.PortalType.CUSTOM; // Paper
++    }
++
++    // Paper start
++    public EntityPortalEvent(@NotNull Entity entity, @NotNull Location from, @Nullable Location to, int searchRadius, final @NotNull org.bukkit.PortalType portalType) {
++        super(entity, from, to);
++        this.searchRadius = searchRadius;
++        this.type = portalType;
++    }
++
++    /**
++     * Get the portal type relating to this event.
++     *
++     * @return the portal type
++     */
++    public @NotNull org.bukkit.PortalType getPortalType() {
++        return this.type;
++    }
++    /**
++     * For {@link org.bukkit.PortalType#NETHER}, this is initially just the starting point
++     * for the search for a portal to teleport to. It will initially just be the {@link #getFrom()}
++     * scaled for dimension scaling and clamped to be inside the world border.
++     * <p>
++     * For {@link org.bukkit.PortalType#ENDER}, this will initially be the exact destination
++     * either, the world spawn for <i>end->any world</i> or end spawn for <i>any world->end</i>.
++     *
++     * @return starting point for search or exact destination
++     */
++    @Override
++    public @Nullable Location getTo() {
++        return super.getTo();
++    }
++
++    /**
++     * See the description of {@link #getTo()}.
++     * @param to starting point for search or exact destination
++     *           or null to cancel
++     */
++    @Override
++    public void setTo(@Nullable final Location to) {
++        super.setTo(to);
+     }
++    // Paper end
+ 
+     /**
+      * Set the Block radius to search in for available portals.
+diff --git a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
+index 57eeeafae84f83a939925820e827769749ff27ec..da753259e3c461d9fd40b7eb7d0abf7965497a47 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
+@@ -32,6 +32,53 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
+         this.canCreatePortal = canCreatePortal;
+         this.creationRadius = creationRadius;
+     }
++    // Paper start
++    /**
++     * For {@link TeleportCause#NETHER_PORTAL}, this is initially just the starting point
++     * for the search for a portal to teleport to. It will initially just be the {@link #getFrom()}
++     * scaled for dimension scaling and clamped to be inside the world border.
++     * <p>
++     * For {@link TeleportCause#END_PORTAL}, this will initially be the exact destination
++     * either, the world spawn for <i>end->any world</i> or end spawn for <i>any world->end</i>.
++     *
++     * @return starting point for search or exact destination
++     */
++    @Override
++    public @NotNull Location getTo() {
++        return super.getTo();
++    }
++
++    /**
++     * See the description of {@link #getTo()}.
++     * @param to starting point for search or exact destination
++     */
++    @Override
++    public void setTo(@NotNull final Location to) {
++        super.setTo(to);
++    }
++
++    /**
++     * No effect
++     * @return no effect
++     * @deprecated No effect
++     */
++    @Deprecated
++    @Override
++    public boolean willDismountPlayer() {
++        return super.willDismountPlayer();
++    }
++
++    /**
++     * No effect
++     * @return no effect
++     * @deprecated No effect
++     */
++    @Deprecated
++    @Override
++    public @NotNull java.util.Set<io.papermc.paper.entity.@NotNull RelativeTeleportFlag> getRelativeTeleportationFlags() {
++        return super.getRelativeTeleportationFlags();
++    }
++    // Paper end
+ 
+     /**
+      * Set the Block radius to search in for available portals.

--- a/patches/server/0950-Improve-PortalEvents.patch
+++ b/patches/server/0950-Improve-PortalEvents.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 15 Dec 2022 10:33:39 -0800
+Subject: [PATCH] Improve PortalEvents
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 7f94da8059147760cbdc2476d0e8beda4a105f40..be54a70b47433c2abaeb8632ffe55d0762f619d6 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -3533,7 +3533,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+         Location enter = bukkitEntity.getLocation();
+         Location exit = new Location(exitWorldServer.getWorld(), exitPosition.x(), exitPosition.y(), exitPosition.z());
+ 
+-        EntityPortalEvent event = new EntityPortalEvent(bukkitEntity, enter, exit, searchRadius);
++        // Paper start
++        final org.bukkit.PortalType portalType = switch (cause) {
++            case END_PORTAL -> org.bukkit.PortalType.ENDER;
++            case NETHER_PORTAL -> org.bukkit.PortalType.NETHER;
++            default -> org.bukkit.PortalType.CUSTOM;
++        };
++        EntityPortalEvent event = new EntityPortalEvent(bukkitEntity, enter, exit, searchRadius, portalType);
++        // Paper end
+         event.getEntity().getServer().getPluginManager().callEvent(event);
+         if (event.isCancelled() || event.getTo() == null || event.getTo().getWorld() == null || !entity.isAlive()) {
+             return null;


### PR DESCRIPTION
`getTo` on `PlayerPortalEvent` and `EntityPortalEvent` was very confusing, as it is **not** the destination location for the nether portal cause, but rather the starting point for the search for a matching portal in the other dimension.

Also added a way to differentiate between portal types in the EntityPortalEvent as it does not have the TeleportCause enum.