### PR TITLE
Fix metrics reporting unknown paper version

### DIFF
--- a/patches/server/0011-Paper-Metrics.patch
+++ b/patches/server/0011-Paper-Metrics.patch
@@ -15,10 +15,10 @@ decisions on behalf of the project.
 
 diff --git a/src/main/java/com/destroystokyo/paper/Metrics.java b/src/main/java/com/destroystokyo/paper/Metrics.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5a19e30a9b7e65a70f68a429b8ca741f788a303b
+index 0000000000000000000000000000000000000000..6aaed8e8bf8c721fc834da5c76ac72a4c3e92458
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/Metrics.java
-@@ -0,0 +1,670 @@
+@@ -0,0 +1,678 @@
 +package com.destroystokyo.paper;
 +
 +import net.minecraft.server.MinecraftServer;
@@ -619,7 +619,15 @@ index 0000000000000000000000000000000000000000..5a19e30a9b7e65a70f68a429b8ca741f
 +
 +                metrics.addCustomChart(new Metrics.SingleLineChart("players", () -> Bukkit.getOnlinePlayers().size()));
 +                metrics.addCustomChart(new Metrics.SimplePie("online_mode", () -> Bukkit.getOnlineMode() ? "online" : "offline"));
-+                metrics.addCustomChart(new Metrics.SimplePie("paper_version", () -> (Metrics.class.getPackage().getImplementationVersion() != null) ? Metrics.class.getPackage().getImplementationVersion() : "unknown"));
++                final String paperVersion;
++                final String implVersion = org.bukkit.craftbukkit.Main.class.getPackage().getImplementationVersion();
++                if (implVersion != null) {
++                    final String buildOrHash = implVersion.substring(implVersion.lastIndexOf('-') + 1);
++                    paperVersion = "git-Paper-%s-%s".formatted(Bukkit.getServer().getMinecraftVersion(), buildOrHash);
++                } else {
++                    paperVersion = "unknown";
++                }
++                metrics.addCustomChart(new Metrics.SimplePie("paper_version", () -> paperVersion));
 +
 +                metrics.addCustomChart(new Metrics.DrilldownPie("java_version", () -> {
 +                    Map<String, Map<String, Integer>> map = new HashMap<>();


### PR DESCRIPTION
https://bstats.org/plugin/server-implementation/Paper/580#paper_version was reporting "unknown" for a long while ever since spigot's classloading changes.

This changes it to `1.19.3-R0.2-SNAPSHOT_git-Paper-<build/hash>`. I'm not sure this is great? But we need some way to add the mc version number in there since paper's build number resets with each major version update.