### PR TITLE
Don't call lock check event if the block entity doesn't exist

### DIFF
--- a/patches/server/0948-Add-BlockLockCheckEvent.patch
+++ b/patches/server/0948-Add-BlockLockCheckEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add BlockLockCheckEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java
-index a782994e2e53f2c4212c2d59ce740ebf00a826b0..3444c1a2e7f1dd938e42cdf0668e43be273b9116 100644
+index a782994e2e53f2c4212c2d59ce740ebf00a826b0..3d37c9a57c01c5035770e20873a801bf2f591cc5 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java
 @@ -69,17 +69,44 @@ public abstract class BaseContainerBlockEntity extends BlockEntity implements Co
@@ -22,7 +22,7 @@ index a782994e2e53f2c4212c2d59ce740ebf00a826b0..3444c1a2e7f1dd938e42cdf0668e43be
 +        return canUnlock(player, lock, containerName, null);
 +    }
 +    public static boolean canUnlock(Player player, LockCode lock, Component containerName, @Nullable BlockEntity blockEntity) {
-+        if (player instanceof net.minecraft.server.level.ServerPlayer serverPlayer && blockEntity != null && blockEntity.getLevel() != null) {
++        if (player instanceof net.minecraft.server.level.ServerPlayer serverPlayer && blockEntity != null && blockEntity.getLevel() != null && blockEntity.getLevel().getBlockEntity(blockEntity.getBlockPos()) == blockEntity) {
 +            final org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(blockEntity.getLevel(), blockEntity.getBlockPos());
 +            net.kyori.adventure.text.Component lockedMessage = net.kyori.adventure.text.Component.translatable("container.isLocked", io.papermc.paper.adventure.PaperAdventure.asAdventure(containerName));
 +            net.kyori.adventure.sound.Sound lockedSound = net.kyori.adventure.sound.Sound.sound(org.bukkit.Sound.BLOCK_CHEST_LOCKED, net.kyori.adventure.sound.Sound.Source.BLOCK, 1.0F, 1.0F);


### PR DESCRIPTION
I think it's fine to use reference equality to check if the block entity does exist in the world at that location. I did some testing and it worked, bypassing the event if that block entity wasn't the same one in the world. But I don't know if there is some state the world could be in where they'd be different.

Fixes https://github.com/PaperMC/Paper/issues/8685