### PR TITLE
Avoid to spam the transform event for hoglin->zoglin conversion

### DIFF
--- a/patches/server/0691-Fix-issues-with-mob-conversion.patch
+++ b/patches/server/0691-Fix-issues-with-mob-conversion.patch
@@ -26,6 +26,22 @@ index e799714e562d2653c75604b7331487e5f3c42067..badde621357a567965f0ef203e402e21
  
      }
  
+diff --git a/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java b/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java
+index 45741410a13cffe3419e34b5607b048bbcf1c3ff..5d3b3cb3a882eb5d716f678095a65b28d0967476 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java
++++ b/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java
+@@ -239,6 +239,11 @@ public class Hoglin extends Animal implements Enemy, HoglinBase {
+         if (zoglin != null) {
+             zoglin.addEffect(new MobEffectInstance(MobEffects.CONFUSION, 200, 0));
+         }
++        // Paper start - reset to prevent event spam
++        else {
++            this.timeInOverworld = 0;
++        }
++        // Paper end
+ 
+     }
+ 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/piglin/AbstractPiglin.java b/src/main/java/net/minecraft/world/entity/monster/piglin/AbstractPiglin.java
 index 5df28bd2d4e2d3c3c28bc35179e098289ecd07c5..67c012476519d93e2a4529b6cdccb0f1e53b52ad 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/piglin/AbstractPiglin.java


### PR DESCRIPTION
When the conversion start from a hoglin to a zoglin (not in the nether) and if the EntityTransformEvent is cancelled, the event spam. This behavior isn't the same for the piglin for example. It's also the only conversion which has not the transform/spawn reason defined.