### PR TITLE
Fix desync of honeycomb when the event is canceled

### DIFF
--- a/patches/server/0888-Fire-EntityChangeBlockEvent-in-more-places.patch
+++ b/patches/server/0888-Fire-EntityChangeBlockEvent-in-more-places.patch
@@ -111,15 +111,18 @@ index e0c3aa1285709a40ff0ea8c1d74d43d2b341aecc..f4fc8ff3981555e4b560289248a9b02a
                  Block.pushEntitiesUp(iblockdata, iblockdata1, world, blockposition);
                  world.setBlock(blockposition, iblockdata1, 2);
 diff --git a/src/main/java/net/minecraft/world/item/HoneycombItem.java b/src/main/java/net/minecraft/world/item/HoneycombItem.java
-index 68a8d3b16d49c10fc9834f32009095d35c9c55a8..1f8b7b50c6aa24778d87821ae2ff4d019d176082 100644
+index 68a8d3b16d49c10fc9834f32009095d35c9c55a8..f0b720eafc538f97d788f89bd2f2e9da0ff84a19 100644
 --- a/src/main/java/net/minecraft/world/item/HoneycombItem.java
 +++ b/src/main/java/net/minecraft/world/item/HoneycombItem.java
-@@ -37,6 +37,11 @@ public class HoneycombItem extends Item {
+@@ -37,6 +37,14 @@ public class HoneycombItem extends Item {
          return getWaxed(blockState).map((state) -> {
              Player player = context.getPlayer();
              ItemStack itemStack = context.getItemInHand();
 +            // Paper start - EntityChangeBlockEvent
 +            if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, blockPos, state).isCancelled()) {
++                if (!player.isCreative()) {
++                    player.containerMenu.sendAllDataToRemote();
++                }
 +                return InteractionResult.PASS;
 +            }
 +            // Paper end


### PR DESCRIPTION
When the EntityChangeBlockEvent is canceled for the waxed copper, the honeycomb (in survival) will shrink only clientside but not serverside.