### PR TITLE
Fix (again) Player#getPlayerProfile no such method error

### DIFF
--- a/patches/server/0183-Player.setPlayerProfile-API.patch
+++ b/patches/server/0183-Player.setPlayerProfile-API.patch
@@ -42,7 +42,7 @@ index e7442952ef1f03969949014492a7ddc6d0796ba5..69a1852905dd4724c30ac8ab88c14251
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d2803455c9456523f8cc324e79c692595fa2420e..afa2e62732ba7b9c08fc24bc95b81b0f30d0ad05 100644
+index fb157165d46f2f2d9bbaa6f7c8199885051060a8..c9a016af654fb73bd95c1f2d5704c12dcd62241b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -81,6 +81,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -162,7 +162,7 @@ index d2803455c9456523f8cc324e79c692595fa2420e..afa2e62732ba7b9c08fc24bc95b81b0f
      public void onEntityRemove(Entity entity) {
          this.hiddenEntities.remove(entity.getUUID());
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index a679133a3de51e26eb19932ece9ade292879aefd..f5cf40baaad1b055755b6c1e18452a4afcd2dfba 100644
+index a679133a3de51e26eb19932ece9ade292879aefd..e342ea27a8a689ea080c7881711a5dcd6322c914 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 @@ -306,6 +306,12 @@ public class Commodore
@@ -170,7 +170,7 @@ index a679133a3de51e26eb19932ece9ade292879aefd..f5cf40baaad1b055755b6c1e18452a4a
                          }
  
 +                        // Paper start - Rewrite plugins
-+                        if (owner.equals("org/bukkit/OfflinePlayer") && name.equals("getPlayerProfile") && desc.equals("()Lorg/bukkit/profile/PlayerProfile;")) {
++                        if ((owner.equals("org/bukkit/OfflinePlayer") || owner.equals("org/bukkit/entity/Player")) && name.equals("getPlayerProfile") && desc.equals("()Lorg/bukkit/profile/PlayerProfile;")) {
 +                            super.visitMethodInsn(opcode, owner, name, "()Lcom/destroystokyo/paper/profile/PlayerProfile;", itf);
 +                            return;
 +                        }

--- a/patches/server/0266-Hook-into-CB-plugin-rewrites.patch
+++ b/patches/server/0266-Hook-into-CB-plugin-rewrites.patch
@@ -8,7 +8,7 @@ our own relocation. Also lets us rewrite NMS calls for when we're
 debugging in an IDE pre-relocate.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index f5cf40baaad1b055755b6c1e18452a4afcd2dfba..3c79c0ddb9bc9024a6f74d0aef273c65bc6f3228 100644
+index e342ea27a8a689ea080c7881711a5dcd6322c914..2eb62af25076b7160b0159ec382baebe5162b024 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 @@ -6,7 +6,9 @@ import java.io.FileOutputStream;
@@ -175,7 +175,7 @@ index f5cf40baaad1b055755b6c1e18452a4afcd2dfba..3c79c0ddb9bc9024a6f74d0aef273c65
 +                        {
 +                            desc = getOriginalOrRewrite(desc);
 +                        }
-                         if (owner.equals("org/bukkit/OfflinePlayer") && name.equals("getPlayerProfile") && desc.equals("()Lorg/bukkit/profile/PlayerProfile;")) {
+                         if ((owner.equals("org/bukkit/OfflinePlayer") || owner.equals("org/bukkit/entity/Player")) && name.equals("getPlayerProfile") && desc.equals("()Lorg/bukkit/profile/PlayerProfile;")) {
                              super.visitMethodInsn(opcode, owner, name, "()Lcom/destroystokyo/paper/profile/PlayerProfile;", itf);
                              return;
 @@ -401,6 +519,13 @@ public class Commodore


### PR DESCRIPTION
I thought the WHOLE reason we were able to change the return value of `Player#getPlayerProfile` but not `OfflinePlayer#getPlayerProfile` was because the "owner" would always be offline player (since that's where the method is, on the OfflinePlayer interface). But apparently you also need to check for the owner being Player.

Fixes https://github.com/PaperMC/Paper/issues/8720