### PR TITLE
Fix collision between AABB and a dot

### DIFF
--- a/patches/server/0746-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0746-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -975,7 +975,7 @@ index 0000000000000000000000000000000000000000..a87f6380b2c387fb0cdd40d5087b5c93
 +}
 diff --git a/src/main/java/io/papermc/paper/voxel/AABBVoxelShape.java b/src/main/java/io/papermc/paper/voxel/AABBVoxelShape.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d67a40e7be030142443680c89e1763fc9ecdfe0a
+index 0000000000000000000000000000000000000000..3d2fa2466fe40e0b9d7749498684587a11dfa80a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/voxel/AABBVoxelShape.java
 @@ -0,0 +1,200 @@
@@ -1159,7 +1159,7 @@ index 0000000000000000000000000000000000000000..d67a40e7be030142443680c89e1763fc
 +
 +    @Override
 +    public double collide(Direction.Axis enumdirection_enumaxis, AABB axisalignedbb, double d0) {
-+        if (CollisionUtil.isEmpty(this.aabb) || CollisionUtil.isEmpty(axisalignedbb)) {
++        if (CollisionUtil.isEmpty(this.aabb)) {
 +            return d0;
 +        }
 +        switch (enumdirection_enumaxis.ordinal()) {


### PR DESCRIPTION
Closes #8038 
Vanilla doesn't check if the target box is empty (a dot) only if the source box is empty to then fallback to the default max distance (-2 here) but paper do. But even if the marker has an empty box, the distance must still be calculated between where the marker has been default placed (one block above) and the top of the block (where the dot will collide) which is -1