### PR TITLE
Fix treasure map config for loot tables

### DIFF
--- a/patches/server/0118-Configurable-Cartographer-Treasure-Maps.patch
+++ b/patches/server/0118-Configurable-Cartographer-Treasure-Maps.patch
@@ -23,7 +23,7 @@ index 155301c03e6553de8aed55e87ece40e8f5f3f495..44a237426739fad0096b2f5108f1d25b
                      ItemStack itemStack = MapItem.create(serverLevel, blockPos.getX(), blockPos.getZ(), (byte)2, true, true);
                      MapItem.renderBiomePreviewMap(serverLevel, itemStack);
 diff --git a/src/main/java/net/minecraft/world/level/storage/loot/functions/ExplorationMapFunction.java b/src/main/java/net/minecraft/world/level/storage/loot/functions/ExplorationMapFunction.java
-index 5762bb0725a0e206a24d3056d9330af45afea1bd..a4806eb60d5dde1f1bd11d9501f3cc4f1805311d 100644
+index 5762bb0725a0e206a24d3056d9330af45afea1bd..9d40469f92db025e760ed1603018fcb1f43dace5 100644
 --- a/src/main/java/net/minecraft/world/level/storage/loot/functions/ExplorationMapFunction.java
 +++ b/src/main/java/net/minecraft/world/level/storage/loot/functions/ExplorationMapFunction.java
 @@ -68,7 +68,16 @@ public class ExplorationMapFunction extends LootItemConditionalFunction {
@@ -40,7 +40,7 @@ index 5762bb0725a0e206a24d3056d9330af45afea1bd..a4806eb60d5dde1f1bd11d9501f3cc4f
 +                    return stack;
 +                }
 +                // Paper end
-+                BlockPos blockPos = serverLevel.findNearestMapStructure(this.destination, new BlockPos(vec3), this.searchRadius, serverLevel.paperConfig().environment.treasureMaps.findAlreadyDiscoveredLootTable.or(this.skipKnownStructures)); // Paper
++                BlockPos blockPos = serverLevel.findNearestMapStructure(this.destination, new BlockPos(vec3), this.searchRadius, !serverLevel.paperConfig().environment.treasureMaps.findAlreadyDiscoveredLootTable.or(!this.skipKnownStructures)); // Paper
                  if (blockPos != null) {
                      ItemStack itemStack = MapItem.create(serverLevel, blockPos.getX(), blockPos.getZ(), this.zoom, true, true);
                      MapItem.renderBiomePreviewMap(serverLevel, itemStack);


### PR DESCRIPTION
Fixes a boolean invert issue. The config option of treasure maps in the inverse of the boolean skipExistingStructures when searching for structures. 