### PR TITLE
Make PlayerPurchaseEvent respect result item

### DIFF
--- a/patches/server/0958-Make-PlayerTradeEvent-respect-result-item.patch
+++ b/patches/server/0958-Make-PlayerTradeEvent-respect-result-item.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: fr3qu3ncy <kilicbatuhan1205@gmail.com>
+Date: Sun, 1 Jan 2023 23:34:10 +0100
+Subject: [PATCH] Make PlayerTradeEvent respect result item
+
+
+diff --git a/src/main/java/net/minecraft/world/inventory/MerchantResultSlot.java b/src/main/java/net/minecraft/world/inventory/MerchantResultSlot.java
+index 7acf5ab9339e0134819aab5f270e99e927cc7a62..b11486583870d1c89d9339768c29aeda482720f3 100644
+--- a/src/main/java/net/minecraft/world/inventory/MerchantResultSlot.java
++++ b/src/main/java/net/minecraft/world/inventory/MerchantResultSlot.java
+@@ -64,6 +64,9 @@ public class MerchantResultSlot extends Slot {
+                     return;
+                 }
+                 merchantOffer = org.bukkit.craftbukkit.inventory.CraftMerchantRecipe.fromBukkit(event.getTrade()).toMinecraft();
++                stack.setItem(merchantOffer.result.getItem());
++                stack.setTag(merchantOffer.result.getTag());
++                stack.setCount(merchantOffer.result.getCount());
+             }
+         }
+         this.checkTakeAchievements(stack);


### PR DESCRIPTION
When modifying a trade using setTrade() in PlayerPurchaseEvent or PlayerTradeEvent, the result item of that new trade is completely ignored. With this change, you can easily manipulate villager trading from within these events, because it sets the clicked item (which is the result item in MerchantResultSlot) to the new result item.