### PR TITLE
don't warn about offline mode

### DIFF
--- a/patches/server/0957-don-t-warn-about-offline-mode.patch
+++ b/patches/server/0957-don-t-warn-about-offline-mode.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: NonSwag <mrminecraft00@gmail.com>
+Date: Mon, 2 Jan 2023 10:35:23 +0100
+Subject: [PATCH] don't warn about offline mode
+
+
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index 51b3db0b6c2cede95b584268e035c0fb36d38094..95d5c4ab5610d3b5b4cc7ce1fbe6a75031888c5b 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.server.dedicated;
+ 
++import com.destroystokyo.paper.PaperConfig;
+ import com.google.common.collect.Lists;
+ import com.mojang.authlib.GameProfile;
+ import com.mojang.datafixers.DataFixer;
+@@ -19,6 +20,8 @@ import java.util.Locale;
+ import java.util.Optional;
+ import java.util.function.BooleanSupplier;
+ import javax.annotation.Nullable;
++
++import io.papermc.paper.configuration.GlobalConfiguration;
+ import net.minecraft.DefaultUncaughtExceptionHandler;
+ import net.minecraft.DefaultUncaughtExceptionHandlerWithName;
+ import net.minecraft.SharedConstants;
+@@ -274,7 +277,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.STARTUP);
+         // CraftBukkit end
+ 
+-        if (!this.usesAuthentication()) {
++        if (!this.usesAuthentication() && (!GlobalConfiguration.get().proxies.velocity.enabled || !GlobalConfiguration.get().proxies.velocity.onlineMode)) { // paper - don't print this warning when velocity is active and in online mode
+             DedicatedServer.LOGGER.warn("**** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");
+             DedicatedServer.LOGGER.warn("The server will make no attempt to authenticate usernames. Beware.");
+             // Spigot start

--- a/patches/server/0958-added-warning.patch
+++ b/patches/server/0958-added-warning.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: NonSwag <mrminecraft00@gmail.com>
+Date: Mon, 2 Jan 2023 12:45:44 +0100
+Subject: [PATCH] added warning
+
+
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index 95d5c4ab5610d3b5b4cc7ce1fbe6a75031888c5b..7a29ee44f26fb8534d680ab3b867ec3773b04554 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -289,7 +289,11 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+             }
+             // Spigot end
+             DedicatedServer.LOGGER.warn("To change this, set \"online-mode\" to \"true\" in the server.properties file.");
++        // Paper start
++        } else if (!this.usesAuthentication()) {
++            DedicatedServer.LOGGER.warn("The server is currently configured to use Velocity and therefore not verifying player connections");
+         }
++        // Paper end
+ 
+ 
+         if (!OldUsersConverter.serverReadyAfterUserconversion(this)) {


### PR DESCRIPTION
Me and many other users of paper are very annoyed by the warning when starting our servers in offline mode
we all are aware of the possible consequences and therefore using velocity in online mode
the message is very useless with a server behind velocity because players can't exploit this without knowing the security key
This patch will not print the warning when velocity is enabled and set to online