### PR TITLE
Fix campfire recipes not always outputting full result

### DIFF
--- a/patches/server/0470-Fix-item-locations-dropped-from-campfires.patch
+++ b/patches/server/0470-Fix-item-locations-dropped-from-campfires.patch
@@ -4,21 +4,25 @@ Date: Sat, 3 Oct 2020 20:32:25 -0500
 Subject: [PATCH] Fix item locations dropped from campfires
 
 Fixes #4259 by not flooring the blockposition among other weirdness
+Vanilla Issue: MC-267622
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
-index c4cf6abf0a962794ddbb4d7a691406054062ffee..24e2063db933bfbc8fc1f34edb8106ae4d7c633c 100644
+index c4cf6abf0a962794ddbb4d7a691406054062ffee..f706c787f7608f7440a5f5e05e7e9c4cb582368c 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
-@@ -82,7 +82,11 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
+@@ -82,7 +82,14 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
                          result = blockCookEvent.getResult();
                          itemstack1 = CraftItemStack.asNMSCopy(result);
                          // CraftBukkit end
 -                        Containers.dropItemStack(world, (double) pos.getX(), (double) pos.getY(), (double) pos.getZ(), itemstack1);
-+                    // Paper start
-+                    net.minecraft.world.entity.item.ItemEntity droppedItem = new net.minecraft.world.entity.item.ItemEntity(world, pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, itemstack1.split(world.random.nextInt(21) + 10));
-+                    droppedItem.setDeltaMovement(world.random.nextGaussian() * 0.05D, world.random.nextGaussian() * 0.05D + 0.2D, world.random.nextGaussian() * 0.05D);
-+                    world.addFreshEntity(droppedItem);
-+                    // Paper end
++                        // Paper start
++                        double deviation = 0.05F * RandomSource.GAUSSIAN_SPREAD_FACTOR;
++                        while (!itemstack1.isEmpty()) {
++                            net.minecraft.world.entity.item.ItemEntity droppedItem = new net.minecraft.world.entity.item.ItemEntity(world, pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, itemstack1.split(world.random.nextInt(21) + 10));
++                            droppedItem.setDeltaMovement(world.random.triangle(0.0D, deviation), world.random.triangle(0.2D, deviation), world.random.triangle(0.0D, deviation));
++                            world.addFreshEntity(droppedItem);
++                        }
++                        // Paper end
                          campfire.items.set(i, ItemStack.EMPTY);
                          world.sendBlockUpdated(pos, state, state, 3);
                          world.gameEvent(GameEvent.BLOCK_CHANGE, pos, GameEvent.Context.of(state));

--- a/patches/server/0720-Add-more-Campfire-API.patch
+++ b/patches/server/0720-Add-more-Campfire-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add more Campfire API
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
-index 04b2697ee857e714b1202d02d093b0c60f079a6f..d80855b22dc10dbf697578d5f78664ed7b6ac572 100644
+index f776289eea00bd741ad55bb9bc338dd2c05c8b39..18d3cb828f85e17ec27dbb5b33c6f17fff178a1d 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
 @@ -42,6 +42,7 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
@@ -34,7 +34,7 @@ index 04b2697ee857e714b1202d02d093b0c60f079a6f..d80855b22dc10dbf697578d5f78664ed
  
                  if (campfire.cookingProgress[i] >= campfire.cookingTime[i]) {
                      SimpleContainer inventorysubcontainer = new SimpleContainer(new ItemStack[]{itemstack});
-@@ -168,6 +172,16 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
+@@ -171,6 +175,16 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
              System.arraycopy(aint, 0, this.cookingTime, 0, Math.min(this.cookingTime.length, aint.length));
          }
  
@@ -51,7 +51,7 @@ index 04b2697ee857e714b1202d02d093b0c60f079a6f..d80855b22dc10dbf697578d5f78664ed
      }
  
      @Override
-@@ -176,6 +190,13 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
+@@ -179,6 +193,13 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
          ContainerHelper.saveAllItems(nbt, this.items, true);
          nbt.putIntArray("CookingTimes", this.cookingProgress);
          nbt.putIntArray("CookingTotalTimes", this.cookingTime);


### PR DESCRIPTION
[This fix](https://github.com/PaperMC/Paper/pull/4611) did not include the while(notEmpty) look to drop all of the result stack. If you try to create a recipe with an output stack greater than 10, it might not produce all of it.