### PR TITLE
add config for velocity secret key file

### DIFF
--- a/patches/server/0957-add-config-for-velocity-secret-key-file.patch
+++ b/patches/server/0957-add-config-for-velocity-secret-key-file.patch
@@ -1,0 +1,96 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gabriel Fontes <hi@m7.rs>
+Date: Mon, 2 Jan 2023 17:32:38 -0300
+Subject: [PATCH] add config for velocity secret key file
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java b/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java
+index c4934979b1ed85bfc4f8d9e6f8848b2beaad95c3..6703468b0c0547502aee8c788d77a624c41d56e1 100644
+--- a/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java
++++ b/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java
+@@ -4,6 +4,7 @@ import io.papermc.paper.configuration.GlobalConfiguration;
+ import com.google.common.net.InetAddresses;
+ import com.mojang.authlib.GameProfile;
+ import com.mojang.authlib.properties.Property;
++import java.io.IOException;
+ import java.net.InetAddress;
+ import java.security.InvalidKeyException;
+ import java.security.MessageDigest;
+@@ -33,12 +34,12 @@ public class VelocityProxy {
+ 
+         try {
+             final Mac mac = Mac.getInstance("HmacSHA256");
+-            mac.init(new SecretKeySpec(GlobalConfiguration.get().proxies.velocity.secret.getBytes(java.nio.charset.StandardCharsets.UTF_8), "HmacSHA256"));
++            mac.init(new SecretKeySpec(GlobalConfiguration.get().proxies.velocity.getSecret().getBytes(java.nio.charset.StandardCharsets.UTF_8), "HmacSHA256"));
+             final byte[] mySignature = mac.doFinal(data);
+             if (!MessageDigest.isEqual(signature, mySignature)) {
+                 return false;
+             }
+-        } catch (final InvalidKeyException | NoSuchAlgorithmException e) {
++        } catch (final InvalidKeyException | IOException | NoSuchAlgorithmException e) {
+             throw new AssertionError(e);
+         }
+ 
+diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+index 8d442c5a498ecf288a0cc0c54889c6e2fda849ce..948b0751b355bdbaaa8d21133c11beade1fa19cf 100644
+--- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
++++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+@@ -13,6 +13,9 @@ import org.spongepowered.configurate.objectmapping.meta.Comment;
+ import org.spongepowered.configurate.objectmapping.meta.Required;
+ import org.spongepowered.configurate.objectmapping.meta.Setting;
+ 
++import java.io.IOException;
++import java.nio.file.Files;
++import java.nio.file.Path;
+ import java.util.List;
+ import java.util.Map;
+ import java.util.Objects;
+@@ -84,6 +87,16 @@ public class GlobalConfiguration extends ConfigurationPart {
+             public boolean enabled = false;
+             public boolean onlineMode = false;
+             public String secret = "";
++            public String secretFile = "";
++            public String getSecret() throws IOException {
++                if (!this.secret.isEmpty()) {
++                    return this.secret;
++                } else if (!this.secretFile.isEmpty()) {
++                    return String.join("", Files.readAllLines(Path.of(this.secretFile)));
++                } else {
++                    return "";
++                }
++            }
+         }
+         public boolean proxyProtocol = false;
+         public boolean isProxyOnlineMode() {
+diff --git a/src/main/java/io/papermc/paper/configuration/constraint/Constraints.java b/src/main/java/io/papermc/paper/configuration/constraint/Constraints.java
+index b470332f542c30c42355adb711ff148e8e1dd7a1..f8814c428d7f8a2aec736c0655ba5b24721348b2 100644
+--- a/src/main/java/io/papermc/paper/configuration/constraint/Constraints.java
++++ b/src/main/java/io/papermc/paper/configuration/constraint/Constraints.java
+@@ -8,6 +8,7 @@ import org.slf4j.Logger;
+ import org.spongepowered.configurate.objectmapping.meta.Constraint;
+ import org.spongepowered.configurate.serialize.SerializationException;
+ 
++import java.io.IOException;
+ import java.lang.annotation.Documented;
+ import java.lang.annotation.ElementType;
+ import java.lang.annotation.Retention;
+@@ -26,9 +27,16 @@ public final class Constraints {
+ 
+         @Override
+         public void validate(final GlobalConfiguration.Proxies.@Nullable Velocity value) throws SerializationException {
+-            if (value != null && value.enabled && value.secret.isEmpty()) {
+-                LOGGER.error("Velocity is enabled, but no secret key was specified. A secret key is required. Disabling velocity...");
+-                value.enabled = false;
++            if (!value.secret.isEmpty()) {
++                LOGGER.warn("You are currently using proxies.velocity.secret. Consider using the safer proxies.velocity.secret-file option instead.");
++            }
++            try {
++                if (value != null && value.enabled && value.getSecret().isEmpty()) {
++                    LOGGER.error("Velocity is enabled, but no secret key was specified. A secret key is required. Disabling velocity...");
++                    value.enabled = false;
++                }
++            } catch (final IOException e) {
++                throw new SerializationException(e);
+             }
+         }
+     }


### PR DESCRIPTION
Adds a `proxies.velocity.secret-file` option, making it possible to specify a file containing the velocity secret file instead of including it in the yml. Similarly to https://github.com/PaperMC/Velocity/pull/712.

Should work nicely, here's a couple of questions:
- Should I bump the config version to 29?
- Should we somehow deprecate the previous option? For now, I've added a log warning for it.

Fixes https://github.com/PaperMC/Paper/issues/6332