### PR TITLE
Persist paper lootable on entities

### DIFF
--- a/patches/server/0094-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0094-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -502,7 +502,7 @@ index c070fd1b224aeeaa9ebb054105a0f73285956da1..0c0060cdc35e0d8d3098a0ade8080f91
  
      public CraftEntity getBukkitEntity() {
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java
-index 9347faecdaa3ef8c375fe8b0a89fc3385b6823bd..b8fb7b5a347298ada16bc8b818edf1863e3f6040 100644
+index 9347faecdaa3ef8c375fe8b0a89fc3385b6823bd..cc74eeb45913fab03e85969957215d2811252a83 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java
 @@ -32,6 +32,20 @@ public abstract class AbstractMinecartContainer extends AbstractMinecart impleme
@@ -530,7 +530,7 @@ index 9347faecdaa3ef8c375fe8b0a89fc3385b6823bd..b8fb7b5a347298ada16bc8b818edf186
      @Override
      protected void addAdditionalSaveData(CompoundTag nbt) {
          super.addAdditionalSaveData(nbt);
-+        this.lootableData.loadNbt(nbt); // Paper
++        this.lootableData.saveNbt(nbt); // Paper
          this.addChestVehicleSaveData(nbt);
      }
  
@@ -542,14 +542,14 @@ index 9347faecdaa3ef8c375fe8b0a89fc3385b6823bd..b8fb7b5a347298ada16bc8b818edf186
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java b/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java
-index e1c4289ff790c691fdae8f7653414a60eb196dc2..a9fb2d5e95d5caa71b794eda0f2749ff795ed4e7 100644
+index e1c4289ff790c691fdae8f7653414a60eb196dc2..a99e2586962952332dd9904ef5bb50a0d3083266 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java
 @@ -65,12 +65,14 @@ public class ChestBoat extends Boat implements HasCustomInventoryScreen, Contain
      @Override
      protected void addAdditionalSaveData(CompoundTag nbt) {
          super.addAdditionalSaveData(nbt);
-+        this.lootableData.loadNbt(nbt); // Paper
++        this.lootableData.saveNbt(nbt); // Paper
          this.addChestVehicleSaveData(nbt);
      }
  


### PR DESCRIPTION
With the recent bugfix that enabled papers custom lootable options to effect minecarts with chests, a new bug surfanced.

The logic on both chest boats and minecarts that was responsible for persisting the lootables (specifically the replenishment times) to the entities nbt were calling to PaperLootableInventoryData#loadNbt method, resulting in no data being actually persisted.

This commit fixes said issue by properly calling the saveNbt method instead, writing the paper lootable data into the compound tag.

See: #8580
Resolves: #8758