### PR TITLE
Use pub static field for deprecated name

### DIFF
--- a/patches/api/0426-Replace-ItemFlag.HIDE_POTION_EFFECTS.patch
+++ b/patches/api/0426-Replace-ItemFlag.HIDE_POTION_EFFECTS.patch
@@ -5,23 +5,15 @@ Subject: [PATCH] Replace ItemFlag.HIDE_POTION_EFFECTS
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFlag.java b/src/main/java/org/bukkit/inventory/ItemFlag.java
-index a4c0469c565b1fea68b828280c7faf81bc6c332c..73ed2d3c4aded81a24489381db16184383e625bb 100644
+index a4c0469c565b1fea68b828280c7faf81bc6c332c..152639f55b31b81617c5c297ec8a0dd6cd795638 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFlag.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFlag.java
-@@ -28,10 +28,33 @@ public enum ItemFlag {
-     /**
-      * Setting to show/hide potion effects, book and firework information, map
-      * tooltips, patterns of banners, and enchantments of enchanted books.
-+     * @deprecated misleading name and description, use {@link #HIDE_ITEM_SPECIFICS}
+@@ -26,12 +26,35 @@ public enum ItemFlag {
       */
-+    @Deprecated // Paper
-     HIDE_POTION_EFFECTS,
+     HIDE_PLACED_ON,
      /**
-      * Setting to show/hide dyes from coloured leather armour
-      */
-     HIDE_DYE;
-+    // Paper start
-+    /**
+-     * Setting to show/hide potion effects, book and firework information, map
+-     * tooltips, patterns of banners, and enchantments of enchanted books.
 +     * Setting to show/hide item-specific information, including, but not limited to:
 +     * <ul>
 +     *     <li>Potion effects on potions, tipped arrows, and suspicious stew</li>
@@ -38,7 +30,20 @@ index a4c0469c565b1fea68b828280c7faf81bc6c332c..73ed2d3c4aded81a24489381db161843
 +     *     <li>Shulker box contents</li>
 +     *     <li>Spawner descriptions</li>
 +     * </ul>
+      */
+-    HIDE_POTION_EFFECTS,
++    HIDE_ITEM_SPECIFICS, // Paper
+     /**
+      * Setting to show/hide dyes from coloured leather armour
+      */
+     HIDE_DYE;
++    // Paper start
++    /**
++     * Setting to show/hide potion effects, book and firework information, map
++     * tooltips, patterns of banners, and enchantments of enchanted books.
++     * @deprecated misleading name and description, use {@link #HIDE_ITEM_SPECIFICS}
 +     */
-+    public static final ItemFlag HIDE_ITEM_SPECIFICS = HIDE_POTION_EFFECTS;
++    @Deprecated
++    public static final ItemFlag HIDE_POTION_EFFECTS = HIDE_ITEM_SPECIFICS;
 +    // Paper end
  }

--- a/patches/server/0957-Replace-ItemFlag.HIDE_POTION_EFFECTS.patch
+++ b/patches/server/0957-Replace-ItemFlag.HIDE_POTION_EFFECTS.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 5 Jan 2023 22:18:55 -0800
+Subject: [PATCH] Replace ItemFlag.HIDE_POTION_EFFECTS
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+index 90d7e8415f158c3176a705749f0aa36a729d3b38..07f4b7975c64bacc7d6481c66df7efae80f2af13 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -548,6 +548,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+         if (hideFlags != null) {
+             for (Object hideFlagObject : hideFlags) {
+                 String hideFlagString = (String) hideFlagObject;
++                hideFlagString = hideFlagString.equals("HIDE_POTION_EFFECTS") ? ItemFlag.HIDE_ITEM_SPECIFICS.name() : hideFlagString; // Paper
+                 try {
+                     ItemFlag hideFlatEnum = ItemFlag.valueOf(hideFlagString);
+                     this.addItemFlags(hideFlatEnum);


### PR DESCRIPTION
The undeprecated, newly named item flag should be part of the enum with the old, now-deprecated name being the public static final field. I tested this with a spigot plugin compiled to use `ItemFlag.HIDE_POTION_EFFECTS` and it worked fine without any bytecode rewriting. I assume that's because enum entries are pretty much equivalent to public static final fields. So just switching the names around shouldn't cause any ABI/API problems.