### PR TITLE
Fix items never falling after being on ground

### DIFF
--- a/patches/server/0338-Fix-items-not-falling-correctly.patch
+++ b/patches/server/0338-Fix-items-not-falling-correctly.patch
@@ -28,7 +28,7 @@ index 02bd99934066b35a3f4fd59370cdabf0640ee218..477c9358a09067ace4d0fe3f519148fe
                  float f1 = 0.98F;
  
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index e2dfc4d9a16a738dd0fe91838603e1d4370afa56..65a95703bb842d5aeacb606842621198c8aab7ab 100644
+index e2dfc4d9a16a738dd0fe91838603e1d4370afa56..08bf9f85fe02a3f89640a2f3ae23089a119a394a 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -257,7 +257,7 @@ public class ActivationRange
@@ -36,7 +36,7 @@ index e2dfc4d9a16a738dd0fe91838603e1d4370afa56..65a95703bb842d5aeacb606842621198
              }
              // Add a little performance juice to active entities. Skip 1/4 if not immune.
 -        } else if ( !entity.defaultActivationState && entity.tickCount % 4 == 0 && !ActivationRange.checkEntityImmunities( entity ) )
-+        } else if ( !entity.defaultActivationState && (entity.tickCount + entity.getId()) % 4 == 3 && !ActivationRange.checkEntityImmunities( entity ) ) // Paper - Ensure checking item movement is offset from Spigot's entity activation range check
++        } else if ( !entity.defaultActivationState && (entity.tickCount + entity.getId()) % 4 == 0 && !ActivationRange.checkEntityImmunities( entity ) ) // Paper - Ensure checking item movement is offset from Spigot's entity activation range check
          {
              isActive = false;
          }

--- a/patches/server/0342-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0342-Entity-Activation-Range-2.0.patch
@@ -377,7 +377,7 @@ index 2f5f8e084c30bf654a19582e0b7baa9cde1b99b5..4f7b12d8f213d43f4ef5538b7e05809a
                              }
                          }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 65a95703bb842d5aeacb606842621198c8aab7ab..493ed4f58781c56a01a79ec4a8012528a357520d 100644
+index 08bf9f85fe02a3f89640a2f3ae23089a119a394a..f158fc8a151272428a33dc5f6e1742876edc80d5 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -1,39 +1,52 @@
@@ -740,8 +740,8 @@ index 65a95703bb842d5aeacb606842621198c8aab7ab..493ed4f58781c56a01a79ec4a8012528
 +
              }
              // Add a little performance juice to active entities. Skip 1/4 if not immune.
--        } else if ( !entity.defaultActivationState && (entity.tickCount + entity.getId()) % 4 == 3 && !ActivationRange.checkEntityImmunities( entity ) ) // Paper - Ensure checking item movement is offset from Spigot's entity activation range check
-+        } else if ( (entity.tickCount + entity.getId()) % 4 == 3 && ActivationRange.checkEntityImmunities( entity ) < 0 ) // Paper
+-        } else if ( !entity.defaultActivationState && (entity.tickCount + entity.getId()) % 4 == 0 && !ActivationRange.checkEntityImmunities( entity ) ) // Paper - Ensure checking item movement is offset from Spigot's entity activation range check
++        } else if ( (entity.tickCount + entity.getId()) % 4 == 0 && ActivationRange.checkEntityImmunities( entity ) < 0 ) // Paper
          {
              isActive = false;
          }


### PR DESCRIPTION
Fixes #8763

My previous fix changed items from always being active to only being active during ticks in which they aren't necessarily moved.

As tickCount is incremented before calling tick(), `!((tickCount + id) % 4 == c) && (tickCount + id + 1) % 4 == 0` must be true to be active (first condition) and moved based on the tick (second condition). This is not the case for c = 3 (which was chosen in the initial patch and correct in the old place), therefore I propose to just use 0 here.

I wasn't able to reproduce the mentioned issue anymore with this change.