### PR TITLE
Correctly shrink items during EntityResurrectEvent

### DIFF
--- a/patches/server/0957-Correctly-shrink-items-during-EntityResurrectEvent.patch
+++ b/patches/server/0957-Correctly-shrink-items-during-EntityResurrectEvent.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <lynxplay101@gmail.com>
+Date: Tue, 10 Jan 2023 21:06:42 +0100
+Subject: [PATCH] Correctly shrink items during EntityResurrectEvent
+
+The EntityResurrectEvent logic is supposed to locate a totem of undying
+in any of the interaction slots of the player inventory and then, if the
+called EntityResurrectEvent is not cancelled, shrink that item by 1,
+usually reducing it to zero.
+
+For this, the logic iterates over the items in the interaction slots and
+breaks out the loop if a totem of undying was found.
+However, even if no totem of undying was found, the iteration item stack
+variable remains as a refernce to the last interaction slot probed.
+
+Plugins uncancelling a EntityResurrectEvent, which is published
+pre-cancelled to listeners if no totem of undying could be found,
+would hence cause the server logic to shrink completely unrelated items
+found in, at the writing of this patch, the players off hand slot.
+
+This patch corrects this behaviour by only shrinking the item if a totem
+of undying was found and the event was called uncancelled.
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 529ea9094c0c7b6263c13b3b7a2d1e652f7bc29e..9ba8e81d117939980599caa381b1873e3600f619 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -1554,7 +1554,7 @@ public abstract class LivingEntity extends Entity {
+             this.level.getCraftServer().getPluginManager().callEvent(event);
+ 
+             if (!event.isCancelled()) {
+-                if (!itemstack1.isEmpty()) {
++                if (itemstack != null) { // Paper - only reduce item if actual totem was found
+                     itemstack1.shrink(1);
+                 }
+                 if (itemstack != null && this instanceof ServerPlayer) {

--- a/patches/server/0957-Correctly-shrink-items-during-EntityResurrectEvent.patch
+++ b/patches/server/0957-Correctly-shrink-items-during-EntityResurrectEvent.patch
@@ -22,7 +22,7 @@ This patch corrects this behaviour by only shrinking the item if a totem
 of undying was found and the event was called uncancelled.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 529ea9094c0c7b6263c13b3b7a2d1e652f7bc29e..9ba8e81d117939980599caa381b1873e3600f619 100644
+index 529ea9094c0c7b6263c13b3b7a2d1e652f7bc29e..42eb78830855d7282b7f3f1bdbe85e632d489784 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1554,7 +1554,7 @@ public abstract class LivingEntity extends Entity {
@@ -30,7 +30,7 @@ index 529ea9094c0c7b6263c13b3b7a2d1e652f7bc29e..9ba8e81d117939980599caa381b1873e
  
              if (!event.isCancelled()) {
 -                if (!itemstack1.isEmpty()) {
-+                if (itemstack != null) { // Paper - only reduce item if actual totem was found
++                if (!itemstack1.isEmpty() && itemstack != null) { // Paper - only reduce item if actual totem was found
                      itemstack1.shrink(1);
                  }
                  if (itemstack != null && this instanceof ServerPlayer) {


### PR DESCRIPTION
The EntityResurrectEvent logic is supposed to locate a totem of undying in any of the interaction slots of the player inventory and then, if the called EntityResurrectEvent is not cancelled, shrink that item by 1, usually reducing it to zero.

For this, the logic iterates over the items in the interaction slots and breaks out the loop if a totem of undying was found. However, even if no totem of undying was found, the iteration item stack variable remains as a refernce to the last interaction slot probed.

Plugins uncancelling a EntityResurrectEvent, which is published pre-cancelled to listeners if no totem of undying could be found, would hence cause the server logic to shrink completely unrelated items found in, at the writing of this patch, the players off hand slot.

This patch corrects this behaviour by only shrinking the item if a totem of undying was found and the event was called uncancelled.