### PR TITLE
Expand Pose API

### DIFF
--- a/patches/api/0430-Expand-Pose-API.patch
+++ b/patches/api/0430-Expand-Pose-API.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Wed, 11 Jan 2023 20:59:02 +0200
+Subject: [PATCH] Expand Pose API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 4669037e4dc9d7bb283e0e2fb4c955bec31b916d..762cb07861ca8ff058ce8d57ea6c15df1e588bf3 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -782,6 +782,42 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+      * @param sneak true if the entity should be sneaking
+      */
+     void setSneaking(boolean sneak);
++
++    /**
++     * Sets the entity's current {@link Pose}.
++     *
++     * <p>Note: While poses affect some things like hitboxes, they do not change the entity's state
++     * (e.g. having {@link Pose#SNEAKING} does not guarantee {@link #isSneaking()} being {@code true}).
++     *
++     * <p>If applied to the {@link Player}, they might see a different pose client-side.
++     *
++     * @param pose a new {@link Pose}
++     * @see #setPose(Pose, boolean)
++     */
++    default void setPose(@NotNull Pose pose) {
++        setPose(pose, false);
++    }
++
++    /**
++     * Sets the entity's current {@link Pose}.
++     *
++     * <p>Note: While poses affect some things like hitboxes, they do not change the entity's state
++     * (e.g. having {@link Pose#SNEAKING} does not guarantee {@link #isSneaking()} being {@code true}).
++     *
++     * <p>If applied to the {@link Player}, they might see a different pose client-side.
++     *
++     * @param pose a new {@link Pose}
++     * @param fixed whether the new {@link Pose} should stay until manually changed
++     */
++    void setPose(@NotNull Pose pose, boolean fixed);
++
++    /**
++     * Checks whether the entity has a fixed {@link Pose}
++     *
++     * @see #setPose(Pose, boolean)
++     * @return whether the entity has a fixed {@link Pose}
++     */
++    boolean hasFixedPose();
+     // Paper end
+ 
+     /**

--- a/patches/server/1015-Fix-NPE-on-Boat-getStatus.patch
+++ b/patches/server/1015-Fix-NPE-on-Boat-getStatus.patch
@@ -9,7 +9,7 @@ Boat status is null until the entity is added to the world and the tick() method
 public net.minecraft.world.entity.vehicle.Boat getStatus()Lnet/minecraft/world/entity/vehicle/Boat$Status;
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
-index d7d54df20984352d84ffb9f7b7da583c34587b85..69ff732481ce6ba25bcfb27e5f9576bfa8019b8a 100644
+index d7d54df20984352d84ffb9f7b7da583c34587b85..338e5ec5a518f9542e82ad43efeaa2a8cf04af42 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
 @@ -88,6 +88,17 @@ public class CraftBoat extends CraftVehicle implements Boat {
@@ -21,7 +21,7 @@ index d7d54df20984352d84ffb9f7b7da583c34587b85..69ff732481ce6ba25bcfb27e5f9576bf
 +        if (handle.status == null) {
 +            if (handle.valid && !handle.updatingSectionStatus) {
 +                // Don't actually set the status because it would skew the old status check in the next tick
-+                return CraftBoat.boatStatusFromNms(this.getHandle().getStatus());
++                return CraftBoat.boatStatusFromNms(handle.getStatus());
 +            } else {
 +                return Status.NOT_IN_WORLD;
 +            }

--- a/patches/server/1016-Expand-Pose-API.patch
+++ b/patches/server/1016-Expand-Pose-API.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SoSeDiK <mrsosedik@gmail.com>
+Date: Wed, 11 Jan 2023 20:59:01 +0200
+Subject: [PATCH] Expand Pose API
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 0ed297f189e5d21c497ac78294db6ca664c0f2c4..e8485fb900b25e911a858678a833852731cb2ace 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -417,6 +417,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+     private UUID originWorld;
+     public boolean freezeLocked = false; // Paper - Freeze Tick Lock API
+     public boolean collidingWithWorldBorder; // Paper
++    public boolean fixedPose = false; // Paper
+ 
+     public void setOrigin(@javax.annotation.Nonnull Location location) {
+         this.origin = location.toVector();
+@@ -701,6 +702,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+     public void onClientRemoval() {}
+ 
+     public void setPose(net.minecraft.world.entity.Pose pose) {
++        if (this.fixedPose) return; // Paper
+         // CraftBukkit start
+         if (pose == this.getPose()) {
+             return;
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index 7e132298252d196a97c99b45e58a3ac9a1de7216..2dbe8b870fd39b4d22e9725912f443757ae70761 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -1227,6 +1227,20 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+     public boolean isSneaking() {
+         return this.getHandle().isShiftKeyDown();
+     }
++
++    @Override
++    public void setPose(Pose pose, boolean fixed) {
++        Preconditions.checkNotNull(pose, "Pose cannot be null");
++        final Entity handle = this.getHandle();
++        handle.fixedPose = false;
++        handle.setPose(net.minecraft.world.entity.Pose.values()[pose.ordinal()]);
++        handle.fixedPose = fixed;
++    }
++
++    @Override
++    public boolean hasFixedPose() {
++        return this.getHandle().fixedPose;
++    }
+     // Paper end
+ 
+     @Override


### PR DESCRIPTION
Adds a way to set entity's pose.
Fixed pose can be changed/reset only via another API call.
(my take on #7318 since it was closed))

Resolves #7016.