### PR TITLE
Fix entity types not appearing in timings

### DIFF
--- a/patches/server/0012-Timings-v2.patch
+++ b/patches/server/0012-Timings-v2.patch
@@ -1309,7 +1309,7 @@ index f4502ebedb31b101faa6c99c4fa51fb5b4fdf3f0..e4435962a60cf9c6d833183bd244a275
      }
      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 5481a029a4a710eb20a4689633d5a4ec509d49d8..b1cd261b42a2c2de5f5a1aa844ecabc986afe00d 100644
+index 8c1937ff71b8b4dad85e20b55dcf2a0cc06ce2df..257b13703166bf953c73c83db8982b412ca96565 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1,5 +1,6 @@
@@ -1369,7 +1369,7 @@ index 742897a534dac2bbbacaca0f6c8196e8d2bc03dd..23b22543c3d164e3fdf2f262f3e01246
  
      protected boolean isHorizontalCollisionMinor(Vec3 adjustedMovement) {
 diff --git a/src/main/java/net/minecraft/world/entity/EntityType.java b/src/main/java/net/minecraft/world/entity/EntityType.java
-index 092d563dd1fa8577818aaaa8e81db92c67a77587..e0620a295d49e42bcc8ee397c6d53143eab15103 100644
+index 092d563dd1fa8577818aaaa8e81db92c67a77587..a2c4267f0001b276d848377e4dbcc407ee8d1ff9 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityType.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityType.java
 @@ -315,6 +315,15 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
@@ -1401,6 +1401,15 @@ index 092d563dd1fa8577818aaaa8e81db92c67a77587..e0620a295d49e42bcc8ee397c6d53143
      public boolean trackDeltas() {
          return this != EntityType.PLAYER && this != EntityType.LLAMA_SPIT && this != EntityType.WITHER && this != EntityType.BAT && this != EntityType.ITEM_FRAME && this != EntityType.GLOW_ITEM_FRAME && this != EntityType.LEASH_KNOT && this != EntityType.PAINTING && this != EntityType.END_CRYSTAL && this != EntityType.EVOKER_FANGS;
      }
+@@ -740,7 +755,7 @@ public class EntityType<T extends Entity> implements FeatureElement, EntityTypeT
+                 Util.fetchChoiceType(References.ENTITY_TREE, id);
+             }
+ 
+-            return new EntityType<>(this.factory, this.category, this.serialize, this.summon, this.fireImmune, this.canSpawnFarFromPlayer, this.immuneTo, this.dimensions, this.clientTrackingRange, this.updateInterval, this.requiredFeatures);
++            return new EntityType<>(this.factory, this.category, this.serialize, this.summon, this.fireImmune, this.canSpawnFarFromPlayer, this.immuneTo, this.dimensions, this.clientTrackingRange, this.updateInterval, this.requiredFeatures, id); // Paper - add id
+         }
+     }
+ 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 index f29b109fdef494927f5f894ac962c50c33b1f0b6..c6ce813f7ea6c4dcbd45e9d8c55f56c29dc3ea53 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java


### PR DESCRIPTION
This was inadvertently dropped from the timings patch while being updated for 1.19.3, causing all entities to appear as "custom" in timings reports