### PR TITLE
Don't clone Location in PreCreatureSpawnEvent

### DIFF
--- a/patches/api/0082-PreCreatureSpawnEvent.patch
+++ b/patches/api/0082-PreCreatureSpawnEvent.patch
@@ -48,7 +48,7 @@ index 0000000000000000000000000000000000000000..3ad231aa3206c8cfd5ec995249584ceb
 +    private boolean shouldAbortSpawn;
 +
 +    public PreCreatureSpawnEvent(@NotNull Location location, @NotNull EntityType type, @NotNull CreatureSpawnEvent.SpawnReason reason) {
-+        this.location = Preconditions.checkNotNull(location, "Location may not be null").clone();
++        this.location = Preconditions.checkNotNull(location, "Location may not be null");
 +        this.type = Preconditions.checkNotNull(type, "Type may not be null");
 +        this.reason = Preconditions.checkNotNull(reason, "Reason may not be null");
 +    }


### PR DESCRIPTION
A new Location object is already created every time this event is called.  Micro opt but it's in a hot path 

<img width="659" alt="PreCreatureSpawnEvent" src="https://user-images.githubusercontent.com/111554242/212557936-de6a451a-2d8c-48c7-897f-4b4f65e92371.png">