### PR TITLE
Fixed CIS/CIM inconsistency

### DIFF
--- a/patches/server/0957-Fix-CraftItemStack-CraftItemMeta-inconsistency.patch
+++ b/patches/server/0957-Fix-CraftItemStack-CraftItemMeta-inconsistency.patch
@@ -1,0 +1,90 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Auxilor <william.favierparsons1@gmail.com>
+Date: Sun, 15 Jan 2023 19:09:56 +0000
+Subject: [PATCH] Fixed legacy compatiblity for
+ CraftItemStack#getEnchantmentLevel
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+index 3e5abea2f814a0a364cf87ff4ce1b1718ba2ddac..d54cf4e68a7a6ed729bd5bb9de9ed5b87bd33464 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+@@ -1,14 +1,12 @@
+ package org.bukkit.craftbukkit.inventory;
+ 
+-import static org.bukkit.craftbukkit.inventory.CraftMetaItem.*;
+ import com.google.common.collect.ImmutableMap;
+-import java.util.Map;
+ import net.minecraft.nbt.CompoundTag;
+ import net.minecraft.nbt.ListTag;
++import net.minecraft.resources.ResourceLocation;
+ import net.minecraft.world.item.Item;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Material;
+-import org.bukkit.NamespacedKey;
+ import org.bukkit.configuration.serialization.DelegateDeserialization;
+ import org.bukkit.craftbukkit.enchantments.CraftEnchantment;
+ import org.bukkit.craftbukkit.util.CraftLegacy;
+@@ -19,6 +17,8 @@ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.inventory.meta.ItemMeta;
+ import org.bukkit.material.MaterialData;
+ 
++import java.util.Map;
++
+ @DelegateDeserialization(ItemStack.class)
+ public final class CraftItemStack extends ItemStack {
+ 
+@@ -214,7 +214,24 @@ public final class CraftItemStack extends ItemStack {
+         if (this.handle == null) {
+             return 0;
+         }
+-        return net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(CraftEnchantment.getRaw(ench), handle); // Paper
++
++        // Paper start
++        ListTag enchantments = this.handle.getEnchantmentTags();
++
++        for (int i = 0; i < enchantments.size(); i++) {
++            CompoundTag tag = enchantments.getCompound(i);
++
++            String id = tag.getString(CraftMetaItem.ENCHANTMENTS_ID.NBT);
++
++            Enchantment enchant = Enchantment.getByKey(CraftNamespacedKey.fromStringOrNull(id));
++
++            if (ench.equals(enchant)) {
++                return 0xffff & tag.getShort(CraftMetaItem.ENCHANTMENTS_LVL.NBT);
++            }
++        }
++
++        return 0;
++        // Paper end
+     }
+ 
+     @Override
+@@ -249,8 +266,8 @@ public final class CraftItemStack extends ItemStack {
+         ImmutableMap.Builder<Enchantment, Integer> result = ImmutableMap.builder();
+ 
+         for (int i = 0; i < list.size(); i++) {
+-            String id = ((CompoundTag) list.get(i)).getString(ENCHANTMENTS_ID.NBT);
+-            int level = 0xffff & ((CompoundTag) list.get(i)).getShort(ENCHANTMENTS_LVL.NBT);
++            String id = ((CompoundTag) list.get(i)).getString(CraftMetaItem.ENCHANTMENTS_ID.NBT);
++            int level = 0xffff & ((CompoundTag) list.get(i)).getShort(CraftMetaItem.ENCHANTMENTS_LVL.NBT);
+ 
+             Enchantment enchant = Enchantment.getByKey(CraftNamespacedKey.fromStringOrNull(id));
+             if (enchant != null) {
+@@ -278,6 +295,7 @@ public final class CraftItemStack extends ItemStack {
+     public ItemMeta getItemMeta() {
+         return CraftItemStack.getItemMeta(this.handle);
+     }
++
+     // Paper start
+     public static void applyMetaToItem(net.minecraft.world.item.ItemStack itemStack, ItemMeta meta) {
+         ((org.bukkit.craftbukkit.inventory.CraftMetaItem) meta).applyToItem(itemStack.getOrCreateTag());
+@@ -286,6 +304,7 @@ public final class CraftItemStack extends ItemStack {
+     public static ItemMeta getItemMeta(net.minecraft.world.item.ItemStack item) {
+         return getItemMeta(item, CraftItemStack.getType(item));
+     }
++
+     public static ItemMeta getItemMeta(net.minecraft.world.item.ItemStack item, Material material) {
+         // Paper end
+         if (!CraftItemStack.hasItemMeta(item)) {
+


### PR DESCRIPTION
`CraftItemStack#getEnchantmentLevel` and `CraftItemMeta#getEnchantLevel` behave differently, which breaks compatibility when the Bukkit Enchantment registry doesn't match the internal NMS enchantment registry. 

I've discussed this in the discord, but I will elaborate here. I understand an objection made by mbaxter, that quote: "You are deliberately ignoring that this would be implicit acceptance of maintaining support for a previously unsupported custom enchantments setup, in perpetuity."

However, I posit three counter-arguments to this:

First is the argument of maintenance of a previously unsupported setup. While it's true that paper doesn't officially support registering custom enchantments to the API, it's also well known that many plugin developers do this. That, in itself, doesn't constitute an argument - after all, it was an unsupported method, however, the problem is the indefinite maintenance of supporting this. I argue that there is essentially zero maintenance required if this PR is merged. In order for this pull request to require maintenance in any subsequent version, Mojang would have to completely rewrite how enchantments are stored in item NBT, breaking every enchanted item that has ever been made. It would be the first change to this system since enchantments were added to the game, and I would argue that it's fair to say that this will not happen. It's not worth worrying about future changes to a system that in all likelihood will not change.

Next, I want to mention the net benefit this would give to server owners and plugin developers. There are many plugins that register custom enchantments to the API, whether it be to apply a glow effect to items, or to have full custom enchantment systems. While I understand that the natural reply to this would be 'Just use PDC', this wouldn't add a glow to items, and it would break cross-plugin compatibility where plugins can naturally integrate with each other's custom enchantments simply by doing `Enchantment.getByKey(NamespacedKey.minecraft(String));` (as they have done since 1.13, over 4 years ago). It would break years of existing compatibility between plugins, and would (and currently does) cause a headache to server owners.

And on a more API-centric note, because of how it is written currently, ItemStack#getEnchantmentLevel does not function the same as ItemMeta#getEnchantLevel. Calling the method on ItemMeta works as intended, returning the level of whatever enchantment is on the item. However, calling it on ItemStack (or specifically CraftItemStack) returns the level of whatever enchantment is on the item, if and only if the enchantment is also registered via NMS into the Registry, and if the enchantment is either an instance of `EnchantmentWrapper` or `CraftEnchantment`. I understand a reasonable objection to this would be 'Why not register into NMS if it's such a problem?' but this causes many problems with natural generation, client incompatibility, et cetera.

I completely understand why you may object to this on the grounds of principle. However, the maintenance requirements are slim to none, it would improve the developer experience and fix plugin incompatibilities that have been generated by updating the CraftItemStack code, it would fix API inconsistency, and most importantly, it would ease the lives of thousands of server owners that have seemingly bizarre bugs caused by this.

PS: In order to completely remove the chance of there any maintenance obligation whatsoever, this change could simply be
```java
return getEnchantments(this.handle).getOrDefault(ench, 0);
```
however you could argue that this would have (albeit microscopic) performance implications where the loop isn't returned from as soon as the enchantment is found. In order to sidestep this potential issue, I've submitted a more optimised version in this PR.