### PR TITLE
Add ItemStack#hoverName API

### DIFF
--- a/patches/api/0427-Add-ItemStack-hoverName-API.patch
+++ b/patches/api/0427-Add-ItemStack-hoverName-API.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Sun, 15 Jan 2023 15:32:50 -0800
+Subject: [PATCH] Add ItemStack#hoverName API
+
+
+diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
+index 40edff7c93b6bf75de81102326667135b9344666..4e9d0d55afaab4613ba274ac48de53d773a22b41 100644
+--- a/src/main/java/org/bukkit/inventory/ItemFactory.java
++++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
+@@ -195,6 +195,15 @@ public interface ItemFactory {
+     @NotNull
+     net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack);
+ 
++    /**
++     * Get the hover name of the {@link ItemStack}.
++     *
++     * @param itemStack the {@link ItemStack}
++     * @return hover name of the {@link ItemStack}
++     */
++    @NotNull
++    net.kyori.adventure.text.Component hoverName(@NotNull ItemStack itemStack);
++
+     /**
+      * Gets the Display name as seen in the Client.
+      * Currently the server only supports the English language. To override this,
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index 870c0ddd101094a3bce1ebf5ec4d42c51053db84..4a412f50fdf8847af1473dac05210553c9a118b8 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -681,6 +681,16 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+         return Bukkit.getServer().getItemFactory().displayName(this);
+     }
+ 
++    /**
++     * Get the hover name of the {@link ItemStack}.
++     * This will be the displayed name when hovering over the item.
++     *
++     * @return hover name of the {@link ItemStack}
++     */
++    public @NotNull net.kyori.adventure.text.Component hoverName() {
++        return Bukkit.getServer().getItemFactory().hoverName(this);
++    }
++
+     /**
+      * Minecraft updates are converting simple item stacks into more complex NBT oriented Item Stacks.
+      *

--- a/patches/server/0957-Add-ItemStack-hoverName-API.patch
+++ b/patches/server/0957-Add-ItemStack-hoverName-API.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Sun, 15 Jan 2023 15:33:07 -0800
+Subject: [PATCH] Add ItemStack#hoverName API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+index f8d7e13c6ea7f2bc19d1d30bb82c54a4daeca45f..a85cae285a76a4fdafd54831c268b7b21bd3d7f0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+@@ -437,6 +437,10 @@ public final class CraftItemFactory implements ItemFactory {
+     public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component displayName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
+         return io.papermc.paper.adventure.PaperAdventure.asAdventure(CraftItemStack.asNMSCopy(itemStack).getDisplayName());
+     }
++    @Override
++    public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component hoverName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(CraftItemStack.asNMSCopy(itemStack).getHoverName());
++    }
+ 
+     // Paper start
+     @Override


### PR DESCRIPTION
Currently, ItemStack#displayName will return the item's display name but with brackets added and with a hover event added. This pull request adds a method named "hoverName" that will return the item's display name exactly how it looks when hovering over the item (just the name, without brackets or hover events). The displayName method actually internally calls the NMS getHoverName method to apply the brackets and events to, so this pull request helps expose the hovername of the item.