### PR TITLE
[ci skip] Fix PiglinBarterEvent JavaDoc

### DIFF
--- a/patches/api/0055-Fix-upstream-javadocs.patch
+++ b/patches/api/0055-Fix-upstream-javadocs.patch
@@ -214,6 +214,20 @@ index d51d2ec1d04d9ea8a25a70d0d856f2355ebfcb4a..7ecff9fcee19fc94be784474fea620e5
           */
          EATING,
          /**
+diff --git a/src/main/java/org/bukkit/event/entity/PiglinBarterEvent.java b/src/main/java/org/bukkit/event/entity/PiglinBarterEvent.java
+index c17ff41a688b2cbd877cda25d4ec033ac8ef5524..bd67b7cba78b9bbdd82a5a40048e658a979e3108 100644
+--- a/src/main/java/org/bukkit/event/entity/PiglinBarterEvent.java
++++ b/src/main/java/org/bukkit/event/entity/PiglinBarterEvent.java
+@@ -10,8 +10,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Stores all data related to the bartering interaction with a piglin.
+  *
+- * This event can be triggered by a piglin picking up an item that's on its
+- * bartering list.
++ * Called when a piglin completes a barter.
+  */
+ public class PiglinBarterEvent extends EntityEvent implements Cancellable {
+ 
 diff --git a/src/main/java/org/bukkit/inventory/EntityEquipment.java b/src/main/java/org/bukkit/inventory/EntityEquipment.java
 index d5b50a4a954fed35d37f03f1a277cc173ca106df..a91fa5386afd7a1137adb921ad5adb798604772f 100644
 --- a/src/main/java/org/bukkit/inventory/EntityEquipment.java

--- a/patches/api/0428-Win-Screen-API.patch
+++ b/patches/api/0428-Win-Screen-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Win Screen API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index de960716478477ce199526b8f860cfafa1541ee9..204bdc65e8d8bbfe462a0b5180c55beae8cb181d 100644
+index eb2fd6f0e09e50eeacfe4ceccf8fdede55c135a3..c68df5e5cc63b26da8623cf27e257ef07a61897d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -822,6 +822,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -836,6 +836,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  

--- a/patches/server/0959-Win-Screen-API.patch
+++ b/patches/server/0959-Win-Screen-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Win Screen API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b32f44beab2c9790ee2da8403e362e8b3ecc6175..2687f9e2764343c4a0d582ab65ff45b04a470057 100644
+index 7b795a8f23a617d1d80f72f3262e11a1c9f806be..7c43de6ad6bd7259c6bcb2a55e312e8abfcf546b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1162,6 +1162,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1166,6 +1166,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  


### PR DESCRIPTION
Currently `PiglinBarterEvent` is documented as `can be triggered by a piglin picking up an item that's on its bartering list.`, but it's fired when the barter is complete, right before the items are dropped.
I went with the generic `Called when X` format most events use, let me know if it should include anything else.