### PR TITLE
Add AntiXray layered obfuscation mode

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -14,7 +14,7 @@ public org.spigotmc.SpigotWorldConfig getString(Ljava/lang/String;Ljava/lang/Str
 public net.minecraft.world.level.NaturalSpawner SPAWNING_CATEGORIES
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a2d2c817cdc1798cd30b3a852b3a495bcbe1b91b..ebf3d64afbb5679b97a7565a2f8e5490e4a38275 100644
+index 064a0c5b2a4b379ceec84652ff1e004d57419115..fc8a097b000e892630ddef00c350454a5f785281 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -12,6 +12,7 @@ dependencies {
@@ -1448,7 +1448,7 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2e9590c73d867c3ebb42f695df4c796a0f477452
+index 0000000000000000000000000000000000000000..4532f3a0d74feae0a1249b53e1bfbc18a8808b32
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 @@ -0,0 +1,475 @@
@@ -4002,7 +4002,7 @@ index 0000000000000000000000000000000000000000..fdc906b106a5c6fff2675d5399650f5b
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/type/EngineMode.java b/src/main/java/io/papermc/paper/configuration/type/EngineMode.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..99e90636051fa0c770ee2eafb7f0d29c8195f9ae
+index 0000000000000000000000000000000000000000..7f8b685762f59049fde88e8d1bc10e1504916010
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/type/EngineMode.java
 @@ -0,0 +1,37 @@
@@ -4013,7 +4013,7 @@ index 0000000000000000000000000000000000000000..99e90636051fa0c770ee2eafb7f0d29c
 +
 +public enum EngineMode {
 +
-+    HIDE(1, "hide ores"), OBFUSCATE(2, "obfuscate");
++    HIDE(1, "hide ores"), OBFUSCATE(2, "obfuscate"), OBFUSCATE_LAYER(3, "obfuscate layer");
 +
 +    public static final ScalarSerializer<EngineMode> SERIALIZER = new EngineModeSerializer();
 +
@@ -4576,7 +4576,7 @@ index 9afc0881f6891ef2696b6f2b37c0826f3beb0666..8873bf84c71c48297a360df9c99e511f
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 16c38195c3e4f5550122df0d65fcce8ca3a83822..1d4f6e7fcfaaee40b06f74d250d04f7a36b6458b 100644
+index 8842ac222e0dea1afb7ba4584512147bb53ccb56..7e9381fcdaafb15b22d9f79592422b165b3e2523 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -131,6 +131,19 @@ public class Main {

--- a/patches/server/0344-Anti-Xray.patch
+++ b/patches/server/0344-Anti-Xray.patch
@@ -199,10 +199,10 @@ index 0000000000000000000000000000000000000000..bd86dc2ad2f87969da4add06de2a629f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1b70024bfa2828fb12ecadf11b4d93291da28509
+index 0000000000000000000000000000000000000000..e6d5504e9eae41b8326d823affc520be2e928e7b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-@@ -0,0 +1,479 @@
+@@ -0,0 +1,671 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import io.papermc.paper.configuration.WorldConfiguration;
@@ -428,7 +428,31 @@ index 0000000000000000000000000000000000000000..1b70024bfa2828fb12ecadf11b4d9329
 +        bitStorageWriter.setBuffer(chunkPacketInfoAntiXray.getBuffer());
 +        int numberOfBlocks = presetBlockStateBits.length;
 +        // Keep the lambda expressions as simple as possible. They are used very frequently.
-+        IntSupplier random = numberOfBlocks == 1 ? (() -> 0) : new IntSupplier() {
++        LayeredIntSupplier random = numberOfBlocks == 1 ? (() -> 0) : engineMode == EngineMode.OBFUSCATE_LAYER ? new LayeredIntSupplier() {
++            // engine-mode: 3
++            private int state;
++            private int next;
++
++            {
++                while ((state = ThreadLocalRandom.current().nextInt()) == 0) ;
++            }
++
++            @Override
++            public void nextLayer() {
++                // https://en.wikipedia.org/wiki/Xorshift
++                state ^= state << 13;
++                state ^= state >>> 17;
++                state ^= state << 5;
++                // https://www.pcg-random.org/posts/bounded-rands.html
++                next = (int) ((Integer.toUnsignedLong(state) * numberOfBlocks) >>> 32);
++            }
++
++            @Override
++            public int getAsInt() {
++                return next;
++            }
++        } : new LayeredIntSupplier() {
++            // engine-mode: 2
 +            private int state;
 +
 +            {
@@ -494,6 +518,7 @@ index 0000000000000000000000000000000000000000..1b70024bfa2828fb12ecadf11b4d9329
 +
 +                    // Abuse the obfuscateLayer method to read the blocks of the first layer of the current chunk section
 +                    bitStorageWriter.setBits(0);
++                    random.nextLayer();
 +                    obfuscateLayer(-1, bitStorageReader, bitStorageWriter, solidTemp, obfuscateTemp, presetBlockStateBitsTemp, current, next, nextNext, emptyNearbyChunkSections, random);
 +                }
 +
@@ -509,6 +534,7 @@ index 0000000000000000000000000000000000000000..1b70024bfa2828fb12ecadf11b4d9329
 +                    current = next;
 +                    next = nextNext;
 +                    nextNext = temp;
++                    random.nextLayer();
 +                    obfuscateLayer(y, bitStorageReader, bitStorageWriter, solidTemp, obfuscateTemp, presetBlockStateBitsTemp, current, next, nextNext, nearbyChunkSections, random);
 +                }
 +
@@ -534,6 +560,7 @@ index 0000000000000000000000000000000000000000..1b70024bfa2828fb12ecadf11b4d9329
 +                        // There is nothing to read anymore
 +                        bitStorageReader.setBits(0);
 +                        solid[0] = true;
++                        random.nextLayer();
 +                        obfuscateLayer(15, bitStorageReader, bitStorageWriter, solid, obfuscateTemp, presetBlockStateBitsTemp, current, next, nextNext, nearbyChunkSections, random);
 +                    }
 +                } else {
@@ -546,6 +573,7 @@ index 0000000000000000000000000000000000000000..1b70024bfa2828fb12ecadf11b4d9329
 +                    current = next;
 +                    next = nextNext;
 +                    nextNext = temp;
++                    random.nextLayer();
 +                    obfuscateLayer(15, bitStorageReader, bitStorageWriter, solidTemp, obfuscateTemp, presetBlockStateBitsTemp, current, next, nextNext, nearbyChunkSections, random);
 +                }
 +
@@ -557,33 +585,190 @@ index 0000000000000000000000000000000000000000..1b70024bfa2828fb12ecadf11b4d9329
 +    }
 +
 +    private void obfuscateLayer(int y, BitStorageReader bitStorageReader, BitStorageWriter bitStorageWriter, boolean[] solid, boolean[] obfuscate, int[] presetBlockStateBits, boolean[][] current, boolean[][] next, boolean[][] nextNext, LevelChunkSection[] nearbyChunkSections, IntSupplier random) {
-+        int presetBlockState = random.getAsInt();
-+        int bits;
-+        for (int z = 0; z <= 15; z++) {
-+            for (int x = 0; x <= 15; x++) {
++        // First block of first line
++        int bits = bitStorageReader.read();
++
++        if (nextNext[0][0] = !solid[bits]) {
++            bitStorageWriter.skip();
++            next[0][1] = true;
++            next[1][0] = true;
++        } else {
++            if (current[0][0] || isTransparent(nearbyChunkSections[2], 0, y, 15) || isTransparent(nearbyChunkSections[0], 15, y, 0)) {
++                bitStorageWriter.skip();
++            } else {
++                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
++            }
++        }
++
++        if (!obfuscate[bits]) {
++            next[0][0] = true;
++        }
++
++        // First line
++        for (int x = 1; x < 15; x++) {
++            bits = bitStorageReader.read();
++
++            if (nextNext[0][x] = !solid[bits]) {
++                bitStorageWriter.skip();
++                next[0][x - 1] = true;
++                next[0][x + 1] = true;
++                next[1][x] = true;
++            } else {
++                if (current[0][x] || isTransparent(nearbyChunkSections[2], x, y, 15)) {
++                    bitStorageWriter.skip();
++                } else {
++                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
++                }
++            }
++
++            if (!obfuscate[bits]) {
++                next[0][x] = true;
++            }
++        }
++
++        // Last block of first line
++        bits = bitStorageReader.read();
++
++        if (nextNext[0][15] = !solid[bits]) {
++            bitStorageWriter.skip();
++            next[0][14] = true;
++            next[1][15] = true;
++        } else {
++            if (current[0][15] || isTransparent(nearbyChunkSections[2], 15, y, 15) || isTransparent(nearbyChunkSections[1], 0, y, 0)) {
++                bitStorageWriter.skip();
++            } else {
++                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
++            }
++        }
++
++        if (!obfuscate[bits]) {
++            next[0][15] = true;
++        }
++
++        // All inner lines
++        for (int z = 1; z < 15; z++) {
++            // First block
++            bits = bitStorageReader.read();
++
++            if (nextNext[z][0] = !solid[bits]) {
++                bitStorageWriter.skip();
++                next[z][1] = true;
++                next[z - 1][0] = true;
++                next[z + 1][0] = true;
++            } else {
++                if (current[z][0] || isTransparent(nearbyChunkSections[0], 15, y, z)) {
++                    bitStorageWriter.skip();
++                } else {
++                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
++                }
++            }
++
++            if (!obfuscate[bits]) {
++                next[z][0] = true;
++            }
++
++            // All inner blocks
++            for (int x = 1; x < 15; x++) {
 +                bits = bitStorageReader.read();
++
 +                if (nextNext[z][x] = !solid[bits]) {
 +                    bitStorageWriter.skip();
-+                    if (x > 0) next[z][x - 1] = true;
-+                    if (x < 15) next[z][x + 1] = true;
-+                    if (z > 0) next[z - 1][x] = true;
-+                    if (z < 15) next[z + 1][x] = true;
++                    next[z][x - 1] = true;
++                    next[z][x + 1] = true;
++                    next[z - 1][x] = true;
++                    next[z + 1][x] = true;
 +                } else {
-+                    // Check neighbouring chunks
-+                    boolean negX = x == 0 && isTransparent(nearbyChunkSections[0], 15, y, z);
-+                    boolean posX = x == 15 && isTransparent(nearbyChunkSections[1], 0, y, z);
-+                    boolean negZ = z == 0 && isTransparent(nearbyChunkSections[2], x, y, 15);
-+                    boolean posZ = z == 15 && isTransparent(nearbyChunkSections[3], x, y, 0);
-+                    if (current[z][x] || negX || posX || negZ || posZ) {
++                    if (current[z][x]) {
 +                        bitStorageWriter.skip();
 +                    } else {
-+                        bitStorageWriter.write(presetBlockStateBits[engineMode == EngineMode.OBFUSCATE_LAYER ? presetBlockState : random.getAsInt()]);
++                        bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
 +                    }
 +                }
++
 +                if (!obfuscate[bits]) {
 +                    next[z][x] = true;
 +                }
 +            }
++
++            // Last block
++            bits = bitStorageReader.read();
++
++            if (nextNext[z][15] = !solid[bits]) {
++                bitStorageWriter.skip();
++                next[z][14] = true;
++                next[z - 1][15] = true;
++                next[z + 1][15] = true;
++            } else {
++                if (current[z][15] || isTransparent(nearbyChunkSections[1], 0, y, z)) {
++                    bitStorageWriter.skip();
++                } else {
++                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
++                }
++            }
++
++            if (!obfuscate[bits]) {
++                next[z][15] = true;
++            }
++        }
++
++        // First block of last line
++        bits = bitStorageReader.read();
++
++        if (nextNext[15][0] = !solid[bits]) {
++            bitStorageWriter.skip();
++            next[15][1] = true;
++            next[14][0] = true;
++        } else {
++            if (current[15][0] || isTransparent(nearbyChunkSections[3], 0, y, 0) || isTransparent(nearbyChunkSections[0], 15, y, 15)) {
++                bitStorageWriter.skip();
++            } else {
++                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
++            }
++        }
++
++        if (!obfuscate[bits]) {
++            next[15][0] = true;
++        }
++
++        // Last line
++        for (int x = 1; x < 15; x++) {
++            bits = bitStorageReader.read();
++
++            if (nextNext[15][x] = !solid[bits]) {
++                bitStorageWriter.skip();
++                next[15][x - 1] = true;
++                next[15][x + 1] = true;
++                next[14][x] = true;
++            } else {
++                if (current[15][x] || isTransparent(nearbyChunkSections[3], x, y, 0)) {
++                    bitStorageWriter.skip();
++                } else {
++                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
++                }
++            }
++
++            if (!obfuscate[bits]) {
++                next[15][x] = true;
++            }
++        }
++
++        // Last block of last line
++        bits = bitStorageReader.read();
++
++        if (nextNext[15][15] = !solid[bits]) {
++            bitStorageWriter.skip();
++            next[15][14] = true;
++            next[14][15] = true;
++        } else {
++            if (current[15][15] || isTransparent(nearbyChunkSections[3], 15, y, 0) || isTransparent(nearbyChunkSections[1], 0, y, 15)) {
++                bitStorageWriter.skip();
++            } else {
++                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
++            }
++        }
++
++        if (!obfuscate[bits]) {
++            next[15][15] = true;
 +        }
 +    }
 +
@@ -679,6 +864,13 @@ index 0000000000000000000000000000000000000000..1b70024bfa2828fb12ecadf11b4d9329
 +
 +        if (blockState != null && obfuscateGlobal[GLOBAL_BLOCKSTATE_PALETTE.idFor(blockState)]) {
 +            ((ServerLevel) level).getChunkSource().blockChanged(blockPos);
++        }
++    }
++
++    @FunctionalInterface
++    private interface LayeredIntSupplier extends IntSupplier {
++        default void nextLayer() {
++
 +        }
 +    }
 +}

--- a/patches/server/0344-Anti-Xray.patch
+++ b/patches/server/0344-Anti-Xray.patch
@@ -199,10 +199,10 @@ index 0000000000000000000000000000000000000000..bd86dc2ad2f87969da4add06de2a629f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e6d5504e9eae41b8326d823affc520be2e928e7b
+index 0000000000000000000000000000000000000000..cab91880a08c6fdc545804911d295e0f24f4d983
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-@@ -0,0 +1,671 @@
+@@ -0,0 +1,670 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import io.papermc.paper.configuration.WorldConfiguration;
@@ -518,7 +518,6 @@ index 0000000000000000000000000000000000000000..e6d5504e9eae41b8326d823affc520be
 +
 +                    // Abuse the obfuscateLayer method to read the blocks of the first layer of the current chunk section
 +                    bitStorageWriter.setBits(0);
-+                    random.nextLayer();
 +                    obfuscateLayer(-1, bitStorageReader, bitStorageWriter, solidTemp, obfuscateTemp, presetBlockStateBitsTemp, current, next, nextNext, emptyNearbyChunkSections, random);
 +                }
 +
@@ -995,19 +994,6 @@ index 0000000000000000000000000000000000000000..80a2dfb266ae1221680a7b24fee2f7e2
 +        chunkPacketBlockControllerAntiXray.obfuscate(this);
 +    }
 +}
-diff --git a/src/main/java/io/papermc/paper/configuration/type/EngineMode.java b/src/main/java/io/papermc/paper/configuration/type/EngineMode.java
-index 99e90636051fa0c770ee2eafb7f0d29c8195f9ae..5d6657939595220a4cf6f1bf3ccfca3619b5bce1 100644
---- a/src/main/java/io/papermc/paper/configuration/type/EngineMode.java
-+++ b/src/main/java/io/papermc/paper/configuration/type/EngineMode.java
-@@ -5,7 +5,7 @@ import org.spongepowered.configurate.serialize.ScalarSerializer;
- 
- public enum EngineMode {
- 
--    HIDE(1, "hide ores"), OBFUSCATE(2, "obfuscate");
-+    HIDE(1, "hide ores"), OBFUSCATE(2, "obfuscate"), OBFUSCATE_LAYER(3, "obfuscate_layer");
- 
-     public static final ScalarSerializer<EngineMode> SERIALIZER = new EngineModeSerializer();
- 
 diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
 index 0ef3e9b472e35bd2572b04722781abf7d4a1094b..40a42a632540d497c1393b112731c41c6e448228 100644
 --- a/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java

--- a/patches/server/0344-Anti-Xray.patch
+++ b/patches/server/0344-Anti-Xray.patch
@@ -199,10 +199,10 @@ index 0000000000000000000000000000000000000000..bd86dc2ad2f87969da4add06de2a629f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4f3670b2bdb8b1b252e9f074a6af56a018a8c465
+index 0000000000000000000000000000000000000000..1b70024bfa2828fb12ecadf11b4d93291da28509
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-@@ -0,0 +1,636 @@
+@@ -0,0 +1,479 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import io.papermc.paper.configuration.WorldConfiguration;
@@ -557,190 +557,33 @@ index 0000000000000000000000000000000000000000..4f3670b2bdb8b1b252e9f074a6af56a0
 +    }
 +
 +    private void obfuscateLayer(int y, BitStorageReader bitStorageReader, BitStorageWriter bitStorageWriter, boolean[] solid, boolean[] obfuscate, int[] presetBlockStateBits, boolean[][] current, boolean[][] next, boolean[][] nextNext, LevelChunkSection[] nearbyChunkSections, IntSupplier random) {
-+        // First block of first line
-+        int bits = bitStorageReader.read();
-+
-+        if (nextNext[0][0] = !solid[bits]) {
-+            bitStorageWriter.skip();
-+            next[0][1] = true;
-+            next[1][0] = true;
-+        } else {
-+            if (current[0][0] || isTransparent(nearbyChunkSections[2], 0, y, 15) || isTransparent(nearbyChunkSections[0], 15, y, 0)) {
-+                bitStorageWriter.skip();
-+            } else {
-+                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
-+            }
-+        }
-+
-+        if (!obfuscate[bits]) {
-+            next[0][0] = true;
-+        }
-+
-+        // First line
-+        for (int x = 1; x < 15; x++) {
-+            bits = bitStorageReader.read();
-+
-+            if (nextNext[0][x] = !solid[bits]) {
-+                bitStorageWriter.skip();
-+                next[0][x - 1] = true;
-+                next[0][x + 1] = true;
-+                next[1][x] = true;
-+            } else {
-+                if (current[0][x] || isTransparent(nearbyChunkSections[2], x, y, 15)) {
-+                    bitStorageWriter.skip();
-+                } else {
-+                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
-+                }
-+            }
-+
-+            if (!obfuscate[bits]) {
-+                next[0][x] = true;
-+            }
-+        }
-+
-+        // Last block of first line
-+        bits = bitStorageReader.read();
-+
-+        if (nextNext[0][15] = !solid[bits]) {
-+            bitStorageWriter.skip();
-+            next[0][14] = true;
-+            next[1][15] = true;
-+        } else {
-+            if (current[0][15] || isTransparent(nearbyChunkSections[2], 15, y, 15) || isTransparent(nearbyChunkSections[1], 0, y, 0)) {
-+                bitStorageWriter.skip();
-+            } else {
-+                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
-+            }
-+        }
-+
-+        if (!obfuscate[bits]) {
-+            next[0][15] = true;
-+        }
-+
-+        // All inner lines
-+        for (int z = 1; z < 15; z++) {
-+            // First block
-+            bits = bitStorageReader.read();
-+
-+            if (nextNext[z][0] = !solid[bits]) {
-+                bitStorageWriter.skip();
-+                next[z][1] = true;
-+                next[z - 1][0] = true;
-+                next[z + 1][0] = true;
-+            } else {
-+                if (current[z][0] || isTransparent(nearbyChunkSections[0], 15, y, z)) {
-+                    bitStorageWriter.skip();
-+                } else {
-+                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
-+                }
-+            }
-+
-+            if (!obfuscate[bits]) {
-+                next[z][0] = true;
-+            }
-+
-+            // All inner blocks
-+            for (int x = 1; x < 15; x++) {
++        int presetBlockState = random.getAsInt();
++        int bits;
++        for (int z = 0; z <= 15; z++) {
++            for (int x = 0; x <= 15; x++) {
 +                bits = bitStorageReader.read();
-+
 +                if (nextNext[z][x] = !solid[bits]) {
 +                    bitStorageWriter.skip();
-+                    next[z][x - 1] = true;
-+                    next[z][x + 1] = true;
-+                    next[z - 1][x] = true;
-+                    next[z + 1][x] = true;
++                    if (x > 0) next[z][x - 1] = true;
++                    if (x < 15) next[z][x + 1] = true;
++                    if (z > 0) next[z - 1][x] = true;
++                    if (z < 15) next[z + 1][x] = true;
 +                } else {
-+                    if (current[z][x]) {
++                    // Check neighbouring chunks
++                    boolean negX = x == 0 && isTransparent(nearbyChunkSections[0], 15, y, z);
++                    boolean posX = x == 15 && isTransparent(nearbyChunkSections[1], 0, y, z);
++                    boolean negZ = z == 0 && isTransparent(nearbyChunkSections[2], x, y, 15);
++                    boolean posZ = z == 15 && isTransparent(nearbyChunkSections[3], x, y, 0);
++                    if (current[z][x] || negX || posX || negZ || posZ) {
 +                        bitStorageWriter.skip();
 +                    } else {
-+                        bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
++                        bitStorageWriter.write(presetBlockStateBits[engineMode == EngineMode.OBFUSCATE_LAYER ? presetBlockState : random.getAsInt()]);
 +                    }
 +                }
-+
 +                if (!obfuscate[bits]) {
 +                    next[z][x] = true;
 +                }
 +            }
-+
-+            // Last block
-+            bits = bitStorageReader.read();
-+
-+            if (nextNext[z][15] = !solid[bits]) {
-+                bitStorageWriter.skip();
-+                next[z][14] = true;
-+                next[z - 1][15] = true;
-+                next[z + 1][15] = true;
-+            } else {
-+                if (current[z][15] || isTransparent(nearbyChunkSections[1], 0, y, z)) {
-+                    bitStorageWriter.skip();
-+                } else {
-+                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
-+                }
-+            }
-+
-+            if (!obfuscate[bits]) {
-+                next[z][15] = true;
-+            }
-+        }
-+
-+        // First block of last line
-+        bits = bitStorageReader.read();
-+
-+        if (nextNext[15][0] = !solid[bits]) {
-+            bitStorageWriter.skip();
-+            next[15][1] = true;
-+            next[14][0] = true;
-+        } else {
-+            if (current[15][0] || isTransparent(nearbyChunkSections[3], 0, y, 0) || isTransparent(nearbyChunkSections[0], 15, y, 15)) {
-+                bitStorageWriter.skip();
-+            } else {
-+                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
-+            }
-+        }
-+
-+        if (!obfuscate[bits]) {
-+            next[15][0] = true;
-+        }
-+
-+        // Last line
-+        for (int x = 1; x < 15; x++) {
-+            bits = bitStorageReader.read();
-+
-+            if (nextNext[15][x] = !solid[bits]) {
-+                bitStorageWriter.skip();
-+                next[15][x - 1] = true;
-+                next[15][x + 1] = true;
-+                next[14][x] = true;
-+            } else {
-+                if (current[15][x] || isTransparent(nearbyChunkSections[3], x, y, 0)) {
-+                    bitStorageWriter.skip();
-+                } else {
-+                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
-+                }
-+            }
-+
-+            if (!obfuscate[bits]) {
-+                next[15][x] = true;
-+            }
-+        }
-+
-+        // Last block of last line
-+        bits = bitStorageReader.read();
-+
-+        if (nextNext[15][15] = !solid[bits]) {
-+            bitStorageWriter.skip();
-+            next[15][14] = true;
-+            next[14][15] = true;
-+        } else {
-+            if (current[15][15] || isTransparent(nearbyChunkSections[3], 15, y, 0) || isTransparent(nearbyChunkSections[1], 0, y, 15)) {
-+                bitStorageWriter.skip();
-+            } else {
-+                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
-+            }
-+        }
-+
-+        if (!obfuscate[bits]) {
-+            next[15][15] = true;
 +        }
 +    }
 +
@@ -960,6 +803,19 @@ index 0000000000000000000000000000000000000000..80a2dfb266ae1221680a7b24fee2f7e2
 +        chunkPacketBlockControllerAntiXray.obfuscate(this);
 +    }
 +}
+diff --git a/src/main/java/io/papermc/paper/configuration/type/EngineMode.java b/src/main/java/io/papermc/paper/configuration/type/EngineMode.java
+index 99e90636051fa0c770ee2eafb7f0d29c8195f9ae..5d6657939595220a4cf6f1bf3ccfca3619b5bce1 100644
+--- a/src/main/java/io/papermc/paper/configuration/type/EngineMode.java
++++ b/src/main/java/io/papermc/paper/configuration/type/EngineMode.java
+@@ -5,7 +5,7 @@ import org.spongepowered.configurate.serialize.ScalarSerializer;
+ 
+ public enum EngineMode {
+ 
+-    HIDE(1, "hide ores"), OBFUSCATE(2, "obfuscate");
++    HIDE(1, "hide ores"), OBFUSCATE(2, "obfuscate"), OBFUSCATE_LAYER(3, "obfuscate_layer");
+ 
+     public static final ScalarSerializer<EngineMode> SERIALIZER = new EngineModeSerializer();
+ 
 diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
 index 0ef3e9b472e35bd2572b04722781abf7d4a1094b..40a42a632540d497c1393b112731c41c6e448228 100644
 --- a/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java


### PR DESCRIPTION
**Changes**
* Removes code duplication from `obfuscateLayer`
* Adds a 3rd engine mode (layered obfuscation), this mode works the same as engine mode 2, but instead of randomizing every block, only randomizes blocks [per chunk layer](https://github.com/DrexHD/AntiXray/blob/1.19.3/stable/media/enginemode-3.png). This helps a lot with chunk packet compression and can reduce the network load when joining by a factor of ~2 (from very basic testing)

**Testing**
The tests have been run on a plain new paper server by joining three times in the same spot in spawn chunks. After every test, the server has been rebooted, and these results have shown to be reproducible. 
Results: [imgur](https://imgur.com/a/CmJDzcq)