### PR TITLE
Add Player#sendEquipmentChange(Map) API

### DIFF
--- a/patches/api/0427-Add-Player-sendEquipmentChange-Map-API.patch
+++ b/patches/api/0427-Add-Player-sendEquipmentChange-Map-API.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aya <31237389+tal5@users.noreply.github.com>
+Date: Fri, 20 Jan 2023 13:49:35 +0000
+Subject: [PATCH] Add Player#sendEquipmentChange(Map) API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index de960716478477ce199526b8f860cfafa1541ee9..e98acbb96bfe226f929c3d24be24d0e5ae80e83d 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -657,6 +657,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     public void sendMultiBlockChange(@NotNull java.util.Map<Location, BlockData> blockChanges, boolean suppressLightUpdates);
+     // Paper end
+ 
++    // Paper start
+     /**
+      * Send the equipment change of an entity. This fakes the equipment change
+      * of an entity for a user. This will not actually change the inventory of
+@@ -666,7 +667,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @param slot The slot of the spoofed equipment change
+      * @param item The ItemStack to display for the player
+      */
+-    public void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull EquipmentSlot slot, @NotNull ItemStack item);
++    default void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull EquipmentSlot slot, @NotNull ItemStack item) {
++        this.sendEquipmentChange(entity, java.util.Map.of(slot, item));
++    };
++
++    /**
++     * Send an equipment change for an entity. This fakes the equipment change
++     * of an entity for a user. This will not actually change the inventory of
++     * the specified entity in any way.
++     *
++     * @param entity The entity that the player will see the change for
++     * @param equipmentChanges A map of slots to the items they will be changed to
++     */
++    void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull java.util.Map<EquipmentSlot, ItemStack> equipmentChanges);
++    // Paper end
+ 
+     // Paper start
+     /**

--- a/patches/api/0427-Add-Player-sendEquipmentChange-Map-API.patch
+++ b/patches/api/0427-Add-Player-sendEquipmentChange-Map-API.patch
@@ -5,22 +5,15 @@ Subject: [PATCH] Add Player#sendEquipmentChange(Map) API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index de960716478477ce199526b8f860cfafa1541ee9..e98acbb96bfe226f929c3d24be24d0e5ae80e83d 100644
+index de960716478477ce199526b8f860cfafa1541ee9..10232a4568c026aa66229f55733078c32d1c71eb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -657,6 +657,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-     public void sendMultiBlockChange(@NotNull java.util.Map<Location, BlockData> blockChanges, boolean suppressLightUpdates);
-     // Paper end
- 
-+    // Paper start
-     /**
-      * Send the equipment change of an entity. This fakes the equipment change
-      * of an entity for a user. This will not actually change the inventory of
-@@ -666,7 +667,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -666,7 +666,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param slot The slot of the spoofed equipment change
       * @param item The ItemStack to display for the player
       */
 -    public void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull EquipmentSlot slot, @NotNull ItemStack item);
++    // Paper start
 +    default void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull EquipmentSlot slot, @NotNull ItemStack item) {
 +        this.sendEquipmentChange(entity, java.util.Map.of(slot, item));
 +    };

--- a/patches/api/0427-Add-Player-sendEquipmentChange-Map-API.patch
+++ b/patches/api/0427-Add-Player-sendEquipmentChange-Map-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add Player#sendEquipmentChange(Map) API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index de960716478477ce199526b8f860cfafa1541ee9..8e9497f3998fd555bfdb0ef51d48b85a4b606d08 100644
+index de960716478477ce199526b8f860cfafa1541ee9..eb2fd6f0e09e50eeacfe4ceccf8fdede55c135a3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -666,7 +666,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -24,9 +24,9 @@ index de960716478477ce199526b8f860cfafa1541ee9..8e9497f3998fd555bfdb0ef51d48b85a
 +     * the specified entity in any way.
 +     *
 +     * @param entity The entity that the player will see the change for
-+     * @param equipmentChanges A map of slots to the items they will be changed to
++     * @param equipmentChanges A map of slots to the items they will be changed to, cannot contain null values.
 +     */
-+    void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull java.util.Map<@NotNull EquipmentSlot, @NotNull ItemStack> equipmentChanges);
++    void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull java.util.Map<EquipmentSlot, ItemStack> equipmentChanges);
 +    // Paper end
  
      // Paper start

--- a/patches/api/0427-Add-Player-sendEquipmentChange-Map-API.patch
+++ b/patches/api/0427-Add-Player-sendEquipmentChange-Map-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add Player#sendEquipmentChange(Map) API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index de960716478477ce199526b8f860cfafa1541ee9..10232a4568c026aa66229f55733078c32d1c71eb 100644
+index de960716478477ce199526b8f860cfafa1541ee9..8e9497f3998fd555bfdb0ef51d48b85a4b606d08 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -666,7 +666,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -26,7 +26,7 @@ index de960716478477ce199526b8f860cfafa1541ee9..10232a4568c026aa66229f55733078c3
 +     * @param entity The entity that the player will see the change for
 +     * @param equipmentChanges A map of slots to the items they will be changed to
 +     */
-+    void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull java.util.Map<EquipmentSlot, ItemStack> equipmentChanges);
++    void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull java.util.Map<@NotNull EquipmentSlot, @NotNull ItemStack> equipmentChanges);
 +    // Paper end
  
      // Paper start

--- a/patches/server/0958-Add-Player-sendEquipmentChange-Map-API.patch
+++ b/patches/server/0958-Add-Player-sendEquipmentChange-Map-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player#sendEquipmentChange(Map) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b32f44beab2c9790ee2da8403e362e8b3ecc6175..c025047c365fbdbaaa9daf2ab4aa787ffcfb4e38 100644
+index b32f44beab2c9790ee2da8403e362e8b3ecc6175..7b795a8f23a617d1d80f72f3262e11a1c9f806be 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1055,17 +1055,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1055,17 +1055,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.sendSignChange0(components, loc, dyeColor, hasGlowingText); // Paper
      }
  
@@ -29,6 +29,7 @@ index b32f44beab2c9790ee2da8403e362e8b3ecc6175..c025047c365fbdbaaa9daf2ab4aa787f
 +        List<Pair<net.minecraft.world.entity.EquipmentSlot, net.minecraft.world.item.ItemStack>> equipment = new ArrayList<>(equipmentChanges.size());
 +        for (Map.Entry<EquipmentSlot, ItemStack> entry : equipmentChanges.entrySet()) {
 +            Preconditions.checkNotNull(entry.getKey(), "EquipmentSlot key must not be null");
++            Preconditions.checkNotNull(entry.getValue(), "ItemStack value must not be null");
 +            equipment.add(new Pair<>(CraftEquipmentSlot.getNMS(entry.getKey()), CraftItemStack.asNMSCopy(entry.getValue())));
 +        }
 +        // Paper end

--- a/patches/server/0958-Add-Player-sendEquipmentChange-Map-API.patch
+++ b/patches/server/0958-Add-Player-sendEquipmentChange-Map-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player#sendEquipmentChange(Map) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b32f44beab2c9790ee2da8403e362e8b3ecc6175..c2823d1340ed7f7d5c5ec672b09bea267bb60ef7 100644
+index b32f44beab2c9790ee2da8403e362e8b3ecc6175..c025047c365fbdbaaa9daf2ab4aa787ffcfb4e38 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1055,17 +1055,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1055,17 +1055,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.sendSignChange0(components, loc, dyeColor, hasGlowingText); // Paper
      }
  
@@ -28,6 +28,7 @@ index b32f44beab2c9790ee2da8403e362e8b3ecc6175..c2823d1340ed7f7d5c5ec672b09bea26
 -        );
 +        List<Pair<net.minecraft.world.entity.EquipmentSlot, net.minecraft.world.item.ItemStack>> equipment = new ArrayList<>(equipmentChanges.size());
 +        for (Map.Entry<EquipmentSlot, ItemStack> entry : equipmentChanges.entrySet()) {
++            Preconditions.checkNotNull(entry.getKey(), "EquipmentSlot key must not be null");
 +            equipment.add(new Pair<>(CraftEquipmentSlot.getNMS(entry.getKey()), CraftItemStack.asNMSCopy(entry.getValue())));
 +        }
 +        // Paper end

--- a/patches/server/0958-Add-Player-sendEquipmentChange-Map-API.patch
+++ b/patches/server/0958-Add-Player-sendEquipmentChange-Map-API.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aya <31237389+tal5@users.noreply.github.com>
+Date: Fri, 20 Jan 2023 13:49:59 +0000
+Subject: [PATCH] Add Player#sendEquipmentChange(Map) API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index b32f44beab2c9790ee2da8403e362e8b3ecc6175..3043da912195d468baa2a0b7b995169e003a7760 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1055,20 +1055,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         this.sendSignChange0(components, loc, dyeColor, hasGlowingText); // Paper
+     }
+ 
++    // Paper start
+     @Override
+-    public void sendEquipmentChange(LivingEntity entity, EquipmentSlot slot, ItemStack item) {
++    public void sendEquipmentChange(LivingEntity entity, Map<EquipmentSlot, ItemStack> equipmentChanges) {
+         Preconditions.checkArgument(entity != null, "entity must not be null");
+-        Preconditions.checkArgument(slot != null, "slot must not be null");
+-        Preconditions.checkArgument(item != null, "item must not be null");
++        Preconditions.checkNotNull(equipmentChanges, "equipmentChanges must not be null");
+ 
+         if (this.getHandle().connection == null) return;
+ 
+-        List<Pair<net.minecraft.world.entity.EquipmentSlot, net.minecraft.world.item.ItemStack>> equipment = Arrays.asList(
+-                new Pair<>(CraftEquipmentSlot.getNMS(slot), CraftItemStack.asNMSCopy(item))
+-        );
++        List<Pair<net.minecraft.world.entity.EquipmentSlot, net.minecraft.world.item.ItemStack>> equipment = new ArrayList<>(equipmentChanges.size());
++        for (Map.Entry<EquipmentSlot, ItemStack> entry : equipmentChanges.entrySet()) {
++            equipment.add(new Pair<>(CraftEquipmentSlot.getNMS(entry.getKey()), CraftItemStack.asNMSCopy(entry.getValue())));
++        }
+ 
+         this.getHandle().connection.send(new ClientboundSetEquipmentPacket(entity.getEntityId(), equipment));
+     }
++    // Paper end
+ 
+     @Override
+     public WorldBorder getWorldBorder() {

--- a/patches/server/0958-Add-Player-sendEquipmentChange-Map-API.patch
+++ b/patches/server/0958-Add-Player-sendEquipmentChange-Map-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player#sendEquipmentChange(Map) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b32f44beab2c9790ee2da8403e362e8b3ecc6175..3043da912195d468baa2a0b7b995169e003a7760 100644
+index b32f44beab2c9790ee2da8403e362e8b3ecc6175..c2823d1340ed7f7d5c5ec672b09bea267bb60ef7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1055,20 +1055,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1055,17 +1055,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.sendSignChange0(components, loc, dyeColor, hasGlowingText); // Paper
      }
  
@@ -30,10 +30,7 @@ index b32f44beab2c9790ee2da8403e362e8b3ecc6175..3043da912195d468baa2a0b7b995169e
 +        for (Map.Entry<EquipmentSlot, ItemStack> entry : equipmentChanges.entrySet()) {
 +            equipment.add(new Pair<>(CraftEquipmentSlot.getNMS(entry.getKey()), CraftItemStack.asNMSCopy(entry.getValue())));
 +        }
++        // Paper end
  
          this.getHandle().connection.send(new ClientboundSetEquipmentPacket(entity.getEntityId(), equipment));
      }
-+    // Paper end
- 
-     @Override
-     public WorldBorder getWorldBorder() {


### PR DESCRIPTION
Adds `Player#sendEquipmentChange(LivingEntity, Map<EquipementSlot, ItemStack>)`, this is useful as the current method only changes one slot, but the underlaying packet takes a list of pairs, which means using the existing method you might need to send 6 packets when it can be done in one.