### PR TITLE
Remove CraftItemStack#setAmount null assignment

### DIFF
--- a/patches/server/0366-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/server/0366-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Raw Byte ItemStack Serialization
 Serializes using NBT which is safer for server data migrations than bukkits format.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 9c189cc0596301c16e84f7df39b983a4392583d2..cb7fd05f498448c87525eeeb012d055f90bac05e 100644
+index 9c189cc0596301c16e84f7df39b983a4392583d2..7a017d69bec0fb1e17c47d7edcfce4b1c6836693 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -434,6 +434,53 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -434,6 +434,52 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public boolean isSupportedApiVersion(String apiVersion) {
          return apiVersion != null && SUPPORTED_API.contains(apiVersion);
      }
@@ -29,8 +29,7 @@ index 9c189cc0596301c16e84f7df39b983a4392583d2..cb7fd05f498448c87525eeeb012d055f
 +
 +        CompoundTag compound = deserializeNbtFromBytes(data);
 +        int dataVersion = compound.getInt("DataVersion");
-+        Dynamic<Tag> converted = DataFixers.getDataFixer().update(References.ITEM_STACK, new Dynamic<Tag>(NbtOps.INSTANCE, compound), dataVersion, getDataVersion());
-+        return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of((CompoundTag) converted.getValue()));
++        return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of(ca.spottedleaf.dataconverter.minecraft.MCDataConverter.convertTag(ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry.ITEM_STACK, compound, dataVersion, getDataVersion())));
 +    }
 +
 +    private byte[] serializeNbtToBytes(CompoundTag compound) {

--- a/patches/server/0474-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0474-Add-methods-to-get-translation-keys.patch
@@ -46,10 +46,10 @@ index e8334e2264510f5101e80b4f130e7ae1442560d7..57decf4156f176ebcc988478c17856cb
  
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index cb7fd05f498448c87525eeeb012d055f90bac05e..30fe764640c8dad4b0f28486d00aa58a17bc7452 100644
+index 7a017d69bec0fb1e17c47d7edcfce4b1c6836693..d85526b8ddd26b2113dd8df7bf2d58ff432d86bc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -481,6 +481,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -480,6 +480,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
          Preconditions.checkArgument(dataVersion <= getDataVersion(), "Newer version! Server downgrades are not supported!");
          return compound;
      }

--- a/patches/server/0481-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0481-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -21,10 +21,10 @@ index 873206bb65b2412d3066a0f7e35fe0684e29661a..d170254265a789998be96ce1dcaf71c9
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 30fe764640c8dad4b0f28486d00aa58a17bc7452..31960587fff298e1b50c8216e47db9a0aa053b29 100644
+index d85526b8ddd26b2113dd8df7bf2d58ff432d86bc..0fc844b717a466e7ac0438bbf04371bba6a19ee2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -505,6 +505,10 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -504,6 +504,10 @@ public final class CraftMagicNumbers implements UnsafeValues {
          net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
          return nmsItemStack.getItem().getDescriptionId(nmsItemStack);
      }

--- a/patches/server/0549-Add-PaperRegistry.patch
+++ b/patches/server/0549-Add-PaperRegistry.patch
@@ -205,10 +205,10 @@ index 04137173ca7034b9dff37a68518e8b6fb0330188..9b1bde95e8303e5d4adfe92f09240df8
              // Paper start
              if (Thread.currentThread() != this.serverThread) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 7502624de2710e28ae427a7e6f38ba932f21ac1d..29a151bb161623bc2544a4ae57fe2f68577d1b5a 100644
+index 00cffc8666cc5e0694da2a3d2a2efab457781374..2ba9cac66413ddc0a830dbb2b2644ed9d40c9c99 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -515,6 +515,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -514,6 +514,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public int nextEntityId() {
          return net.minecraft.world.entity.Entity.nextEntityId();
      }

--- a/patches/server/0584-Expand-world-key-API.patch
+++ b/patches/server/0584-Expand-world-key-API.patch
@@ -67,10 +67,10 @@ index 6c2ea3e0cf385d6893faf5430b29dbe2589786b0..2dbfd750088dbf7a15fc147d9f215c19
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 29a151bb161623bc2544a4ae57fe2f68577d1b5a..f5943a84b99a794e54568a0d6d8ade7f7f9e4aa8 100644
+index 2ba9cac66413ddc0a830dbb2b2644ed9d40c9c99..4b8642d20341067ee149fbe9a23e64042127a2b2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -520,6 +520,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -519,6 +519,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public <T extends org.bukkit.Keyed> Registry<T> registryFor(Class<T> classOfT) {
          return io.papermc.paper.registry.PaperRegistry.getRegistry(classOfT);
      }

--- a/patches/server/0586-Item-Rarity-API.patch
+++ b/patches/server/0586-Item-Rarity-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Item Rarity API
 public net.minecraft.world.item.Item rarity
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index f5943a84b99a794e54568a0d6d8ade7f7f9e4aa8..be178adcf1d21787f2c673b17ba1383fc7869388 100644
+index 4b8642d20341067ee149fbe9a23e64042127a2b2..f31723187a7189cf1c9213f74f094ad196421a80 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -525,6 +525,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -524,6 +524,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public String getMainLevelName() {
          return ((net.minecraft.server.dedicated.DedicatedServer) net.minecraft.server.MinecraftServer.getServer()).getProperties().levelName;
      }

--- a/patches/server/0592-Expose-protocol-version.patch
+++ b/patches/server/0592-Expose-protocol-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index be178adcf1d21787f2c673b17ba1383fc7869388..36b80af06ba50f1a34f2c5812976308f1c525f2c 100644
+index f31723187a7189cf1c9213f74f094ad196421a80..46be2c75d68abaccc78e2120a0f45d344050c76d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -539,6 +539,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -538,6 +538,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(org.bukkit.inventory.ItemStack itemStack) {
          return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
      }

--- a/patches/server/0622-ItemStack-repair-check-API.patch
+++ b/patches/server/0622-ItemStack-repair-check-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack repair check API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 36b80af06ba50f1a34f2c5812976308f1c525f2c..fa2042a6bd12734ebdb99b5c04af7ac671f454ac 100644
+index 46be2c75d68abaccc78e2120a0f45d344050c76d..d7ebb29138352661f4fb3fb4561d96dab812b1b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -540,6 +540,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -539,6 +539,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
      }
  

--- a/patches/server/0629-Attributes-API-for-item-defaults.patch
+++ b/patches/server/0629-Attributes-API-for-item-defaults.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Attributes API for item defaults
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index fa2042a6bd12734ebdb99b5c04af7ac671f454ac..17d2acec4a2dde895019e58bdd35996d273d6ec5 100644
+index d7ebb29138352661f4fb3fb4561d96dab812b1b7..ec49b0719491f52057818a6fc2b4d3f16c7fc440 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -548,6 +548,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -547,6 +547,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftMagicNumbers.getItem(itemToBeRepaired.getType()).isValidRepairItem(CraftItemStack.asNMSCopy(itemToBeRepaired), CraftItemStack.asNMSCopy(repairMaterial));
      }
  

--- a/patches/server/0686-Get-entity-default-attributes.patch
+++ b/patches/server/0686-Get-entity-default-attributes.patch
@@ -81,10 +81,10 @@ index 0000000000000000000000000000000000000000..cf9d28ea97d93cec05c9fb768d59e283
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 17d2acec4a2dde895019e58bdd35996d273d6ec5..2dd4f67555a9207945b393e56af5672e042afaf4 100644
+index ec49b0719491f52057818a6fc2b4d3f16c7fc440..30ac1162851331526f3fc00332eded67be48e1d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -565,6 +565,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -564,6 +564,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public int getProtocolVersion() {
          return net.minecraft.SharedConstants.getCurrentVersion().getProtocolVersion();
      }

--- a/patches/server/0692-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/server/0692-Add-isCollidable-methods-to-various-places.patch
@@ -39,10 +39,10 @@ index 7b9e943b391c061782fccd2b8d705ceec8db50fe..966ac60daebb7bb211ab8096fc0c5f33
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 2dd4f67555a9207945b393e56af5672e042afaf4..f4807829a7a51a5aeab8277211a4d62cf7df2aca 100644
+index 30ac1162851331526f3fc00332eded67be48e1d4..abffb2328a0a85a6a5c664d58d2738b833b9431d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -577,6 +577,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -576,6 +576,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
          var supplier = net.minecraft.world.entity.ai.attributes.DefaultAttributes.getSupplier((net.minecraft.world.entity.EntityType<? extends net.minecraft.world.entity.LivingEntity>) net.minecraft.core.registries.BuiltInRegistries.ENTITY_TYPE.get(CraftNamespacedKey.toMinecraft(bukkitEntityKey)));
          return new io.papermc.paper.attribute.UnmodifiableAttributeMap(supplier);
      }

--- a/patches/server/0695-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0695-Add-Raw-Byte-Entity-Serialization.patch
@@ -45,11 +45,11 @@ index f1ee89047e8cd916c762b91162842e3f981856b3..726a4ae7ab928eda3ae1c1e98f342157
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index f4807829a7a51a5aeab8277211a4d62cf7df2aca..ba9ce30003eb787fe974ae53f375ae9c0591d619 100644
+index abffb2328a0a85a6a5c664d58d2738b833b9431d..90dbc63a7472b923ed4faca5ac52f9438126fa63 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -460,6 +460,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
-         return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of((CompoundTag) converted.getValue()));
+@@ -459,6 +459,29 @@ public final class CraftMagicNumbers implements UnsafeValues {
+         return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of(ca.spottedleaf.dataconverter.minecraft.MCDataConverter.convertTag(ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry.ITEM_STACK, compound, dataVersion, getDataVersion())));
      }
  
 +    @Override
@@ -69,8 +69,7 @@ index f4807829a7a51a5aeab8277211a4d62cf7df2aca..ba9ce30003eb787fe974ae53f375ae9c
 +
 +        CompoundTag compound = deserializeNbtFromBytes(data);
 +        int dataVersion = compound.getInt("DataVersion");
-+        Dynamic<Tag> converted = DataFixers.getDataFixer().update(References.ENTITY_TREE, new Dynamic<>(NbtOps.INSTANCE, compound), dataVersion, getDataVersion());
-+        compound = (CompoundTag) converted.getValue();
++        compound = ca.spottedleaf.dataconverter.minecraft.MCDataConverter.convertTag(ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry.ENTITY, compound, dataVersion, getDataVersion());
 +        if (!preserveUUID) compound.remove("UUID"); // Generate a new UUID so we don't have to worry about deserializing the same entity twice
 +        return net.minecraft.world.entity.EntityType.create(compound, ((org.bukkit.craftbukkit.CraftWorld) world).getHandle())
 +            .orElseThrow(() -> new IllegalArgumentException("An ID was not found for the data. Did you downgrade?")).getBukkitEntity();

--- a/patches/server/0884-Add-NamespacedKey-biome-methods.patch
+++ b/patches/server/0884-Add-NamespacedKey-biome-methods.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add NamespacedKey biome methods
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 45e13c9dc4a65207728cdb401511b187597fe199..17336102d37a5ab05c3b3c93fcf46961d0ffa7e2 100644
+index 73e82653e0a68560c25ae41ade4c58111cbcd276..daeaa30cdd64f5cb775304e82f2390684c02a9d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -607,6 +607,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -605,6 +605,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
          Preconditions.checkArgument(material.isBlock(), material + " is not a block");
          return getBlock(material).hasCollision;
      }

--- a/patches/server/0960-Remove-CraftItemStack-setAmount-null-assignment.patch
+++ b/patches/server/0960-Remove-CraftItemStack-setAmount-null-assignment.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Josh Roy <joshroy126@gmail.com>
+Date: Mon, 23 Jan 2023 19:19:01 -0500
+Subject: [PATCH] Remove CraftItemStack#setAmount null assignment
+
+This creates a problem with Paper's item serialization
+api where deserialized items, which are internally
+created as a CraftItemStack, will be completely lost if
+#setAmount(0) is invoked (since the underlying handle
+is set to null), while a regular Bukkit ItemStack
+simply sets the amount field to zero, retaining the
+item's data.
+
+Vanilla treats items with zero amounts the same as items
+with less than zero amounts, so this code doesn't create
+a problem with operations on the vanilla ItemStack.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+index 3e5abea2f814a0a364cf87ff4ce1b1718ba2ddac..97c5a72096ac0fd0b08a397466486014cfea4579 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+@@ -146,7 +146,7 @@ public final class CraftItemStack extends ItemStack {
+         }
+ 
+         this.handle.setCount(amount);
+-        if (amount == 0) {
++        if (false && amount == 0) { // Paper - remove CraftItemStack#setAmount null assignment
+             this.handle = null;
+         }
+     }


### PR DESCRIPTION
This creates a problem with Paper's item serialization api where deserialized items, which are internally created as a CraftItemStack, will be completely lost if #setAmount(0) is invoked (since the underlying handle is set to null), while a regular Bukkit ItemStack
simply sets the amount field to zero, retaining the item's data.

Vanilla treats items with zero amounts the same as items with less than zero amounts, so this code doesn't create a problem with operations on the vanilla ItemStack.

Also switches the item/entity serialization apis over to dataconverter rather than dfu

the following code will not add an item to an inventory prior to this patch but now works properly
```java
    final ItemStack first = new ItemStack(Material.DIAMOND_HELMET);
    ItemStack stack = Bukkit.getUnsafe().deserializeItem(Bukkit.getUnsafe().serializeItem(first));

    ItemStack clone = stack.clone();
    clone.setAmount(0);

    clone.setAmount(stack.getAmount());
    player.getInventory().addItem(clone);
```

cc @Spottedleaf 