### PR TITLE
Add projectile hit simulation API

### DIFF
--- a/patches/api/0371-More-Projectile-API.patch
+++ b/patches/api/0371-More-Projectile-API.patch
@@ -178,10 +178,10 @@ index d1b37530319f6d37ee37f62080289c1e45848bc8..e94c7e279356c510f60508b26277d489
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Projectile.java b/src/main/java/org/bukkit/entity/Projectile.java
-index a523fca4baab447181ef91df67fa69b24e010149..34c5037682a78644c925733078b92ef505b706dc 100644
+index a523fca4baab447181ef91df67fa69b24e010149..278eefa43c5e5810a95b9e2871017124bb85faa9 100644
 --- a/src/main/java/org/bukkit/entity/Projectile.java
 +++ b/src/main/java/org/bukkit/entity/Projectile.java
-@@ -43,4 +43,61 @@ public interface Projectile extends Entity {
+@@ -43,4 +43,63 @@ public interface Projectile extends Entity {
       */
      @Deprecated(forRemoval = true) // Paper
      public void setBounce(boolean doesBounce);
@@ -229,6 +229,7 @@ index a523fca4baab447181ef91df67fa69b24e010149..34c5037682a78644c925733078b92ef5
 +    /**
 +     * Makes this projectile hit a specific entity.
 +     * This uses the current position of the projectile for the hit point.
++     * Using this method will result in {@link org.bukkit.event.entity.ProjectileHitEvent} being called.
 +     * @param entity the entity to hit
 +     * @see #hitEntity(Entity, org.bukkit.util.Vector)
 +     */
@@ -236,6 +237,7 @@ index a523fca4baab447181ef91df67fa69b24e010149..34c5037682a78644c925733078b92ef5
 +
 +    /**
 +     * Makes this projectile hit a specific entity from a specific point.
++     * Using this method will result in {@link org.bukkit.event.entity.ProjectileHitEvent} being called.
 +     * @param entity the entity to hit
 +     * @param vector the direction to hit from
 +     * @see #hitEntity(Entity)

--- a/patches/api/0371-More-Projectile-API.patch
+++ b/patches/api/0371-More-Projectile-API.patch
@@ -178,10 +178,10 @@ index d1b37530319f6d37ee37f62080289c1e45848bc8..e94c7e279356c510f60508b26277d489
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Projectile.java b/src/main/java/org/bukkit/entity/Projectile.java
-index a523fca4baab447181ef91df67fa69b24e010149..6935f8806ca1ed87fa761e73bc0f6c41ab60453e 100644
+index a523fca4baab447181ef91df67fa69b24e010149..34c5037682a78644c925733078b92ef505b706dc 100644
 --- a/src/main/java/org/bukkit/entity/Projectile.java
 +++ b/src/main/java/org/bukkit/entity/Projectile.java
-@@ -43,4 +43,45 @@ public interface Projectile extends Entity {
+@@ -43,4 +43,61 @@ public interface Projectile extends Entity {
       */
      @Deprecated(forRemoval = true) // Paper
      public void setBounce(boolean doesBounce);
@@ -225,6 +225,22 @@ index a523fca4baab447181ef91df67fa69b24e010149..6935f8806ca1ed87fa761e73bc0f6c41
 +     * @param beenShot has been in shot into the world
 +     */
 +    void setHasBeenShot(boolean beenShot);
++
++    /**
++     * Makes this projectile hit a specific entity.
++     * This uses the current position of the projectile for the hit point.
++     * @param entity the entity to hit
++     * @see #hitEntity(Entity, org.bukkit.util.Vector)
++     */
++    void hitEntity(@org.jetbrains.annotations.NotNull Entity entity);
++
++    /**
++     * Makes this projectile hit a specific entity from a specific point.
++     * @param entity the entity to hit
++     * @param vector the direction to hit from
++     * @see #hitEntity(Entity)
++     */
++    void hitEntity(@org.jetbrains.annotations.NotNull Entity entity, @org.jetbrains.annotations.NotNull org.bukkit.util.Vector vector);
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/ShulkerBullet.java b/src/main/java/org/bukkit/entity/ShulkerBullet.java

--- a/patches/api/0371-More-Projectile-API.patch
+++ b/patches/api/0371-More-Projectile-API.patch
@@ -178,10 +178,10 @@ index d1b37530319f6d37ee37f62080289c1e45848bc8..e94c7e279356c510f60508b26277d489
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Projectile.java b/src/main/java/org/bukkit/entity/Projectile.java
-index a523fca4baab447181ef91df67fa69b24e010149..278eefa43c5e5810a95b9e2871017124bb85faa9 100644
+index a523fca4baab447181ef91df67fa69b24e010149..d97904540ff5cf103604862a5a1a3a41f56dfe33 100644
 --- a/src/main/java/org/bukkit/entity/Projectile.java
 +++ b/src/main/java/org/bukkit/entity/Projectile.java
-@@ -43,4 +43,63 @@ public interface Projectile extends Entity {
+@@ -43,4 +43,80 @@ public interface Projectile extends Entity {
       */
      @Deprecated(forRemoval = true) // Paper
      public void setBounce(boolean doesBounce);
@@ -227,11 +227,27 @@ index a523fca4baab447181ef91df67fa69b24e010149..278eefa43c5e5810a95b9e2871017124
 +    void setHasBeenShot(boolean beenShot);
 +
 +    /**
++     * Gets whether this projectile can hit an entity.
++     * <p>
++     * This method returns true under the following conditions:
++     * <p>
++     * - The shooter can see the entity ({@link Player#canSee(Entity)}) <p>
++     * - The entity is alive and not a spectator <p>
++     * - The projectile has left the hitbox of the shooter ({@link #hasLeftShooter()})<p>
++     * - If this is an arrow with piercing, it has not pierced the entity already
++     *
++     * @param entity the entity to check if this projectile can hit
++     * @return true if this projectile can damage the entity, false otherwise
++     */
++    boolean canHitEntity(@org.jetbrains.annotations.NotNull Entity entity);
++
++    /**
 +     * Makes this projectile hit a specific entity.
 +     * This uses the current position of the projectile for the hit point.
 +     * Using this method will result in {@link org.bukkit.event.entity.ProjectileHitEvent} being called.
 +     * @param entity the entity to hit
 +     * @see #hitEntity(Entity, org.bukkit.util.Vector)
++     * @see #canHitEntity(Entity) 
 +     */
 +    void hitEntity(@org.jetbrains.annotations.NotNull Entity entity);
 +
@@ -241,6 +257,7 @@ index a523fca4baab447181ef91df67fa69b24e010149..278eefa43c5e5810a95b9e2871017124
 +     * @param entity the entity to hit
 +     * @param vector the direction to hit from
 +     * @see #hitEntity(Entity)
++     * @see #canHitEntity(Entity) 
 +     */
 +    void hitEntity(@org.jetbrains.annotations.NotNull Entity entity, @org.jetbrains.annotations.NotNull org.bukkit.util.Vector vector);
 +    // Paper end

--- a/patches/server/0812-Fix-cancelling-ProjectileHitEvent-for-piercing-arrow.patch
+++ b/patches/server/0812-Fix-cancelling-ProjectileHitEvent-for-piercing-arrow.patch
@@ -15,7 +15,7 @@ piercing arrows to avoid duplicate damage being applied.
 protected net.minecraft.world.entity.projectile.Projectile hitCancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-index 8c08e07ba78e2ed042d79b692221008f59e92593..9788e477ff1446ad2ea3669922cc7dfc09900ce8 100644
+index 740f08e5fadf9b8d277af05cc9734ceb54f54abb..09a4c0d30898bbdc05e32b6f1d4b0436a5e4af53 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 @@ -290,6 +290,19 @@ public abstract class AbstractArrow extends Projectile {
@@ -24,7 +24,7 @@ index 8c08e07ba78e2ed042d79b692221008f59e92593..9788e477ff1446ad2ea3669922cc7dfc
  
 +    // Paper start
 +    @Override
-+    protected void preOnHit(HitResult hitResult) {
++    public void preOnHit(HitResult hitResult) {
 +        super.preOnHit(hitResult);
 +        if (hitResult instanceof EntityHitResult entityHitResult && this.hitCancelled && this.getPierceLevel() > 0) {
 +            if (this.piercingIgnoreEntityIds == null) {

--- a/patches/server/0813-More-Projectile-API.patch
+++ b/patches/server/0813-More-Projectile-API.patch
@@ -14,6 +14,7 @@ public net.minecraft.world.entity.projectile.AbstractArrow soundEvent
 public net.minecraft.world.entity.projectile.ThrownTrident dealtDamage
 public net.minecraft.world.entity.projectile.Projectile hasBeenShot
 public net.minecraft.world.entity.projectile.Projectile leftOwner
+public net.minecraft.world.entity.projectile.Projectile preOnHit(Lnet/minecraft/world/phys/HitResult;)V
 
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
@@ -43,10 +44,10 @@ index 740ff3fed9c8d637527fda8544eba2b9d7d7280a..1f1519c1b33d16eba59546c86f20a099
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java b/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java
-index 40e5b19bc8fa3de3b3d54da0762aee5bd7bb8d7b..825fdc6162797ade8e76e1ca3a863ed5fb48f936 100644
+index 40e5b19bc8fa3de3b3d54da0762aee5bd7bb8d7b..9ee9d357b1c6ddebca788e2bdd6592cc2cd8c46c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java
-@@ -21,5 +21,31 @@ public abstract class AbstractProjectile extends CraftEntity implements Projecti
+@@ -21,5 +21,41 @@ public abstract class AbstractProjectile extends CraftEntity implements Projecti
      public void setBounce(boolean doesBounce) {
          this.doesBounce = doesBounce;
      }
@@ -69,6 +70,16 @@ index 40e5b19bc8fa3de3b3d54da0762aee5bd7bb8d7b..825fdc6162797ade8e76e1ca3a863ed5
 +    @Override
 +    public void setHasBeenShot(boolean beenShot) {
 +        this.getHandle().hasBeenShot = beenShot;
++    }
++
++    @Override
++    public void hitEntity(org.bukkit.entity.Entity entity) {
++        this.getHandle().preOnHit(new net.minecraft.world.phys.EntityHitResult(((CraftEntity) entity).getHandle()));
++    }
++
++    @Override
++    public void hitEntity(org.bukkit.entity.Entity entity, org.bukkit.util.Vector vector) {
++        this.getHandle().preOnHit(new net.minecraft.world.phys.EntityHitResult(((CraftEntity) entity).getHandle(), new net.minecraft.world.phys.Vec3(vector.getX(), vector.getY(), vector.getZ())));
 +    }
 +
 +    @Override

--- a/patches/server/0813-More-Projectile-API.patch
+++ b/patches/server/0813-More-Projectile-API.patch
@@ -15,6 +15,7 @@ public net.minecraft.world.entity.projectile.ThrownTrident dealtDamage
 public net.minecraft.world.entity.projectile.Projectile hasBeenShot
 public net.minecraft.world.entity.projectile.Projectile leftOwner
 public net.minecraft.world.entity.projectile.Projectile preOnHit(Lnet/minecraft/world/phys/HitResult;)V
+public net.minecraft.world.entity.projectile.Projectile canHitEntity(Lnet/minecraft/world/entity/Entity;)Z
 
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
@@ -44,10 +45,10 @@ index 740ff3fed9c8d637527fda8544eba2b9d7d7280a..1f1519c1b33d16eba59546c86f20a099
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java b/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java
-index 40e5b19bc8fa3de3b3d54da0762aee5bd7bb8d7b..9ee9d357b1c6ddebca788e2bdd6592cc2cd8c46c 100644
+index 40e5b19bc8fa3de3b3d54da0762aee5bd7bb8d7b..1c8d63e462f3ed3d5286659ae0d1ec04d8b55177 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java
-@@ -21,5 +21,41 @@ public abstract class AbstractProjectile extends CraftEntity implements Projecti
+@@ -21,5 +21,46 @@ public abstract class AbstractProjectile extends CraftEntity implements Projecti
      public void setBounce(boolean doesBounce) {
          this.doesBounce = doesBounce;
      }
@@ -70,6 +71,11 @@ index 40e5b19bc8fa3de3b3d54da0762aee5bd7bb8d7b..9ee9d357b1c6ddebca788e2bdd6592cc
 +    @Override
 +    public void setHasBeenShot(boolean beenShot) {
 +        this.getHandle().hasBeenShot = beenShot;
++    }
++
++    @Override
++    public boolean canHitEntity(org.bukkit.entity.Entity entity) {
++        return this.getHandle().canHitEntity(((CraftEntity) entity).getHandle());
 +    }
 +
 +    @Override


### PR DESCRIPTION
This adds API to force a projectile to hit a provided entity. Example usage could be if you have a player disguised as another entity, you could simulate an arrow colliding with the (fake) entity hitbox. 

Simply teleporting projectiles does not suffice - it is buggy both visually and physically (they can become stuck in your hitbox), and you have to edit the velocity to force it to hit the entity which is not great for preserving damage.

I edited the existing "More Projectile API" patch, I wasn't sure whether I should make a new patch or not.