### PR TITLE
Deprecate duplicate API for arrow stuck count

### DIFF
--- a/patches/api/0025-Add-methods-for-working-with-arrows-stuck-in-living-.patch
+++ b/patches/api/0025-Add-methods-for-working-with-arrows-stuck-in-living-.patch
@@ -3,12 +3,42 @@ From: mrapple <tony@oc.tc>
 Date: Sun, 25 Nov 2012 13:47:27 -0600
 Subject: [PATCH] Add methods for working with arrows stuck in living entities
 
+Upstream added methods for this so the original methods
+are now deprecated
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 2b816f0e6bdb912ceeff82c0043272b3970fe243..f00502b59f15c3a92ce18e7d1aa4e546fd45b16a 100644
+index 2b816f0e6bdb912ceeff82c0043272b3970fe243..9977bb3cb5a66c84db816f8e4597db1c053f77c8 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -689,4 +689,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -215,12 +215,26 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+      */
+     public int getArrowsInBody();
+ 
++    // Paper start
++    /**
++     * Set the amount of arrows in the entity's body.
++     * <p>
++     * Does not fire the {@link org.bukkit.event.entity.ArrowBodyCountChangeEvent}.
++     *
++     * @param count amount of arrows in entity's body
++     */
++    default void setArrowsInBody(final int count) {
++        this.setArrowsInBody(count, false);
++    }
++    // Paper end
++
+     /**
+      * Set the amount of arrows in the entity's body.
+      *
+      * @param count amount of arrows in entity's body
++     * @param fireEvent whether to fire the {@link org.bukkit.event.entity.ArrowBodyCountChangeEvent} event
+      */
+-    public void setArrowsInBody(int count);
++    void setArrowsInBody(int count, boolean fireEvent); // Paper
+ 
+     /**
+      * Returns the living entity's current maximum no damage ticks.
+@@ -689,4 +703,24 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @return Whether the entity is invisible
       */
      public boolean isInvisible();
@@ -17,14 +47,19 @@ index 2b816f0e6bdb912ceeff82c0043272b3970fe243..f00502b59f15c3a92ce18e7d1aa4e546
 +    /**
 +     * Get the number of arrows stuck in this entity
 +     * @return Number of arrows stuck
++     * @deprecated use {@link #getArrowsInBody()}
 +     */
++    @Deprecated
 +    int getArrowsStuck();
 +
 +    /**
 +     * Set the number of arrows stuck in this entity
 +     *
 +     * @param arrows Number of arrows to stick in this entity
++     * @deprecated use {@link #setArrowsInBody(int, boolean)}. <b>This method previously fired {@link org.bukkit.event.entity.ArrowBodyCountChangeEvent} so if
++     * you want to retain exact functionality, pass {@code true} for {@code fireEvent}.</b>
 +     */
++    @Deprecated
 +    void setArrowsStuck(int arrows);
 +    // Paper end
  }

--- a/patches/api/0068-LivingEntity-setKiller.patch
+++ b/patches/api/0068-LivingEntity-setKiller.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] LivingEntity#setKiller
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index f00502b59f15c3a92ce18e7d1aa4e546fd45b16a..036936671d816fc553ad2fdf8324609ab610b7f5 100644
+index 069711e792f92c2afa9dc661a2b14c55ffa54114..3489c719089e5cc0cc4710e8a06417c02dd76767 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -281,6 +281,15 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -295,6 +295,15 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      @Nullable
      public Player getKiller();
  

--- a/patches/api/0111-Make-shield-blocking-delay-configurable.patch
+++ b/patches/api/0111-Make-shield-blocking-delay-configurable.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 036936671d816fc553ad2fdf8324609ab610b7f5..75629874849e4cdcf0465b653f27baaca5247fea 100644
+index 3489c719089e5cc0cc4710e8a06417c02dd76767..81d89daf9691b5338b53bb7b0749ad802f5d026f 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -712,5 +712,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
-      * @param arrows Number of arrows to stick in this entity
+@@ -731,5 +731,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
+     @Deprecated
      void setArrowsStuck(int arrows);
 +
 +    /**

--- a/patches/api/0118-LivingEntity-Hand-Raised-Item-Use-API.patch
+++ b/patches/api/0118-LivingEntity-Hand-Raised-Item-Use-API.patch
@@ -20,10 +20,10 @@ index 13b74e942012169611f2791f8b4493d04710e4c0..9c711d0b2c2f7b0c0603847590e8a1a9
      public ItemStack getItemInUse();
  
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 75629874849e4cdcf0465b653f27baaca5247fea..c80e75b72ac863db19e3d234e349876dd8797924 100644
+index 81d89daf9691b5338b53bb7b0749ad802f5d026f..8241a89ac92845a2a8c2398dbeb76529abebd37c 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -726,5 +726,42 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -745,5 +745,42 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param delay Delay in ticks
       */
      void setShieldBlockingDelay(int delay);

--- a/patches/api/0188-Entity-Jump-API.patch
+++ b/patches/api/0188-Entity-Jump-API.patch
@@ -57,10 +57,10 @@ index 0000000000000000000000000000000000000000..f0067c2e953d18e1a33536980071ba3f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 98484c748db12dbdcdbe456befa30ad87864420b..3618a138a602fde4d3f045e9982dd95c0376b30d 100644
+index affe38b8c04f71ff6ef60dced1a5e829324429af..eacb21bea254a104cc0ef2288e2f9886dc09d888 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -926,5 +926,25 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -945,5 +945,25 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      @NotNull
      org.bukkit.inventory.EquipmentSlot getHandRaised();

--- a/patches/api/0219-Add-playPickupItemAnimation-to-LivingEntity.patch
+++ b/patches/api/0219-Add-playPickupItemAnimation-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add playPickupItemAnimation to LivingEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 3618a138a602fde4d3f045e9982dd95c0376b30d..4b2bbeebe724682a53850f92872169d7cfbeb552 100644
+index eacb21bea254a104cc0ef2288e2f9886dc09d888..1e510a40f48fdf1337cdd0cc8ec8bc378dab94da 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -946,5 +946,28 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -965,5 +965,28 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param jumping entity jump state
       */
      void setJumping(boolean jumping);

--- a/patches/api/0235-Add-LivingEntity-clearActiveItem.patch
+++ b/patches/api/0235-Add-LivingEntity-clearActiveItem.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#clearActiveItem
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 4b2bbeebe724682a53850f92872169d7cfbeb552..f52c7d2ac653dde284de8d83ebe034afa2cde90a 100644
+index 1e510a40f48fdf1337cdd0cc8ec8bc378dab94da..194159adbab5e6ee86a07a9a67a3ca40e103f535 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -897,6 +897,13 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -916,6 +916,13 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      @NotNull
      org.bukkit.inventory.ItemStack getActiveItem();
  

--- a/patches/api/0241-Expose-LivingEntity-hurt-direction.patch
+++ b/patches/api/0241-Expose-LivingEntity-hurt-direction.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose LivingEntity hurt direction
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index f52c7d2ac653dde284de8d83ebe034afa2cde90a..f44f510b3194c9716ec59caa195f83dde2b2773a 100644
+index 194159adbab5e6ee86a07a9a67a3ca40e103f535..53a8d79788f2d9d4b46e6aece1d76863dd5fb727 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -976,5 +976,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -995,5 +995,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param quantity quantity of item
       */
      void playPickupItemAnimation(@NotNull Item item, int quantity);

--- a/patches/api/0310-Add-more-line-of-sight-methods.patch
+++ b/patches/api/0310-Add-more-line-of-sight-methods.patch
@@ -23,10 +23,10 @@ index aa534b1a9a1fb84a2fbd4b372f313bb4b63325fa..43b53c21af01e0f496c8aaacff82dfdf
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index f44f510b3194c9716ec59caa195f83dde2b2773a..21ca1df6b484390a644d1f0894ebcac0080ff570 100644
+index 53a8d79788f2d9d4b46e6aece1d76863dd5fb727..a38606c07d681b210124949001c9439835d6d3c9 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -532,6 +532,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -546,6 +546,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
      public boolean hasLineOfSight(@NotNull Entity other);
  

--- a/patches/api/0317-Stinger-API.patch
+++ b/patches/api/0317-Stinger-API.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Stinger API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 21ca1df6b484390a644d1f0894ebcac0080ff570..6f7483a86b713b7b85e595f55b167e1547bc4b8e 100644
+index 9ab91154c74b5a3001cf4d5df1b4ae1e26508b60..27187efdbcf1cf20a53175f1177c16dc40acab3c 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -385,6 +385,36 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -399,6 +399,36 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       */
-     public void setArrowsInBody(int count);
+     void setArrowsInBody(int count, boolean fireEvent); // Paper
  
 +    // Paper Start - Bee Stinger API
 +    /**

--- a/patches/api/0404-Add-LivingEntity-swingHand-EquipmentSlot-convenience.patch
+++ b/patches/api/0404-Add-LivingEntity-swingHand-EquipmentSlot-convenience.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#swingHand(EquipmentSlot) convenience method
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 6f7483a86b713b7b85e595f55b167e1547bc4b8e..475fdef28596cf8454da58d04d4c4153719a4a68 100644
+index 6512d2bf94adfc32046ddae25a7c2906db7b1441..15c803ad038585bf3c37e4504d53177d31850acf 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1033,5 +1033,23 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1052,5 +1052,23 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param hurtDirection hurt direction
       */
      void setHurtDirection(float hurtDirection);

--- a/patches/api/0405-Add-entity-knockback-API.patch
+++ b/patches/api/0405-Add-entity-knockback-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 475fdef28596cf8454da58d04d4c4153719a4a68..1999cd1b1aaa23589da4e11cf80139b8e7a2a539 100644
+index 15c803ad038585bf3c37e4504d53177d31850acf..b18a833019c81b8e46535a1b4c42ba3987a97c90 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1051,5 +1051,17 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1070,5 +1070,17 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
              this.swingOffHand();
          }
      }

--- a/patches/api/0412-ItemStack-damage-API.patch
+++ b/patches/api/0412-ItemStack-damage-API.patch
@@ -8,10 +8,10 @@ to simulate damage done to an itemstack and all
 the logic associated with damaging them
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index 1999cd1b1aaa23589da4e11cf80139b8e7a2a539..c27aaec51ae4de593da4443e1e8a773e1b59aafa 100644
+index b18a833019c81b8e46535a1b4c42ba3987a97c90..717c7419d872286e38b6919503ab0e6537c55387 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
-@@ -1063,5 +1063,48 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+@@ -1082,5 +1082,48 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
       * @param directionZ The relative z position of the knockback source direction
       */
      void knockback(double strength, double directionX, double directionZ);

--- a/patches/server/0062-Add-methods-for-working-with-arrows-stuck-in-living-.patch
+++ b/patches/server/0062-Add-methods-for-working-with-arrows-stuck-in-living-.patch
@@ -3,12 +3,31 @@ From: mrapple <tony@oc.tc>
 Date: Sun, 25 Nov 2012 13:43:39 -0600
 Subject: [PATCH] Add methods for working with arrows stuck in living entities
 
+Upstream added methods for this, original methods are now
+deprecated
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index c2407224e8bc5e872e153de14090d60e66bb07bc..4f4ee7071183e7eef918741e38c2bc2e522c72df 100644
+index c2407224e8bc5e872e153de14090d60e66bb07bc..3fae28c52f2aac63ac6a4e8eb6af2d7226e6bec6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -764,4 +764,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -266,9 +266,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     }
+ 
+     @Override
+-    public void setArrowsInBody(int count) {
++    public void setArrowsInBody(final int count, final boolean fireEvent) { // Paper
+         Preconditions.checkArgument(count >= 0, "New arrow amount must be >= 0");
++        if (!fireEvent) { // Paper
+         this.getHandle().getEntityData().set(net.minecraft.world.entity.LivingEntity.DATA_ARROW_COUNT_ID, count);
++        // Paper start
++        } else {
++            this.getHandle().setArrowCount(count);
++        }
++        // Paper end
+     }
+ 
+     @Override
+@@ -764,4 +770,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().persistentInvisibility = invisible;
          this.getHandle().setSharedFlag(5, invisible);
      }
@@ -16,12 +35,12 @@ index c2407224e8bc5e872e153de14090d60e66bb07bc..4f4ee7071183e7eef918741e38c2bc2e
 +    // Paper start
 +    @Override
 +    public int getArrowsStuck() {
-+        return getHandle().getArrowCount();
++        return this.getHandle().getArrowCount();
 +    }
 +
 +    @Override
-+    public void setArrowsStuck(int arrows) {
-+        getHandle().setArrowCount(arrows);
++    public void setArrowsStuck(final int arrows) {
++        this.getHandle().setArrowCount(arrows);
 +    }
 +    // Paper end
  }

--- a/patches/server/0152-LivingEntity-setKiller.patch
+++ b/patches/server/0152-LivingEntity-setKiller.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] LivingEntity#setKiller
 public net.minecraft.world.entity.LivingEntity lastHurtByPlayerTime
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 4f4ee7071183e7eef918741e38c2bc2e522c72df..a08fd99fb97d8c880c855e6af2a99afcfa8098b5 100644
+index 3fae28c52f2aac63ac6a4e8eb6af2d7226e6bec6..cae153b184af9ef87ca2f335692b396800f00cf2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -347,6 +347,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -353,6 +353,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          return this.getHandle().lastHurtByPlayer == null ? null : (Player) this.getHandle().lastHurtByPlayer.getBukkitEntity();
      }
  

--- a/patches/server/0208-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0208-Make-shield-blocking-delay-configurable.patch
@@ -35,12 +35,12 @@ index 6d599fb38607cf841eef6d48bcaad81b378f667e..4ebdf94833062cde6882f09f1d687806
          return this.isShiftKeyDown();
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index a08fd99fb97d8c880c855e6af2a99afcfa8098b5..80efb900e37069f4ff39c35d39456959ca24bfe8 100644
+index cae153b184af9ef87ca2f335692b396800f00cf2..b9657abde59bdf3b2a464466f1a251a2c5f226e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -785,5 +785,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
-     public void setArrowsStuck(int arrows) {
-         getHandle().setArrowCount(arrows);
+@@ -791,5 +791,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     public void setArrowsStuck(final int arrows) {
+         this.getHandle().setArrowCount(arrows);
      }
 +
 +    @Override

--- a/patches/server/0213-LivingEntity-Hand-Raised-Item-Use-API.patch
+++ b/patches/server/0213-LivingEntity-Hand-Raised-Item-Use-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] LivingEntity Hand Raised/Item Use API
 How long an entity has raised hands to charge an attack or use an item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 80efb900e37069f4ff39c35d39456959ca24bfe8..04829ced2048b07aa4b2dcf98a601d1fdd9431fb 100644
+index b9657abde59bdf3b2a464466f1a251a2c5f226e1..235e360df71b796a39d6c85530157097fd0c7b79 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -795,5 +795,30 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -801,5 +801,30 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void setShieldBlockingDelay(int delay) {
          getHandle().setShieldBlockingDelay(delay);
      }

--- a/patches/server/0355-Entity-Jump-API.patch
+++ b/patches/server/0355-Entity-Jump-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index dbc412d7ea8c7e22557e4e03520ec89994a42e26..8b7a9a607b3919543a47a14147bfbfad250d4b46 100644
+index b448a7b6318311ce3542e49a2f1670ccac77c215..9621438358c85cf66c756f0d53bcd89f4f0ec933 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3264,8 +3264,10 @@ public abstract class LivingEntity extends Entity {
@@ -34,7 +34,7 @@ index e98849c103e7409f70e73a30c6713c644155b284..2db5d8a937c841718e7b568c215109c3
          }
  
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Ravager.java b/src/main/java/net/minecraft/world/entity/monster/Ravager.java
-index 8517fd004727b083545082a5de26b11cb2a93623..23cd2e1faf0d7b59885e194fc0f0adc558e4921b 100644
+index 01dfe3e29ea55b9e839a4db027fdd6a1dbb5ca23..6a0b4f86e5157494a917cf5efecb730081bae628 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Ravager.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Ravager.java
 @@ -177,7 +177,9 @@ public class Ravager extends Raider {
@@ -48,10 +48,10 @@ index 8517fd004727b083545082a5de26b11cb2a93623..23cd2e1faf0d7b59885e194fc0f0adc5
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 0bdb8a887ac159c58ec39d4aaa56cef404eaa6b2..194c6a9accc21bfb2f446b2a2c3a8a4ee7c3a479 100644
+index 0541d68f6fc758ce5915fe906f7a44814c33b2d6..c7cc9408f961aa804af9548d8c8fee46631421cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -881,5 +881,19 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -887,5 +887,19 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public org.bukkit.inventory.EquipmentSlot getHandRaised() {
          return getHandle().getUsedItemHand() == net.minecraft.world.InteractionHand.MAIN_HAND ? org.bukkit.inventory.EquipmentSlot.HAND : org.bukkit.inventory.EquipmentSlot.OFF_HAND;
      }

--- a/patches/server/0402-Fix-PotionEffect-ignores-icon-flag.patch
+++ b/patches/server/0402-Fix-PotionEffect-ignores-icon-flag.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix PotionEffect ignores icon flag
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 194c6a9accc21bfb2f446b2a2c3a8a4ee7c3a479..57e839a5582d3d0219fcf670afbb3e4b36dcd19c 100644
+index c7cc9408f961aa804af9548d8c8fee46631421cf..b543619e50196f82e55dd7e648e5f8c580658dbe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -425,7 +425,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -431,7 +431,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
  
      @Override
      public boolean addPotionEffect(PotionEffect effect, boolean force) {

--- a/patches/server/0460-Add-playPickupItemAnimation-to-LivingEntity.patch
+++ b/patches/server/0460-Add-playPickupItemAnimation-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add playPickupItemAnimation to LivingEntity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 57e839a5582d3d0219fcf670afbb3e4b36dcd19c..c5657b6f8c7a9f6605d22bed0a5faec288eb8d6d 100644
+index b543619e50196f82e55dd7e648e5f8c580658dbe..ec57e0323f7b38828dd989244905025f973028f3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -895,5 +895,10 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -901,5 +901,10 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
              ((Mob) getHandle()).getJumpControl().jump();
          }
      }

--- a/patches/server/0507-Add-LivingEntity-clearActiveItem.patch
+++ b/patches/server/0507-Add-LivingEntity-clearActiveItem.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#clearActiveItem
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index c5657b6f8c7a9f6605d22bed0a5faec288eb8d6d..c789cefb61270c7e52ddea7efd433fa6c0e63fda 100644
+index ec57e0323f7b38828dd989244905025f973028f3..8409087a5977a6ba0cd948c51f3f7ae59a041f5c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -862,6 +862,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -868,6 +868,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          return getHandle().getUseItem().asBukkitMirror();
      }
  

--- a/patches/server/0519-Expose-LivingEntity-hurt-direction.patch
+++ b/patches/server/0519-Expose-LivingEntity-hurt-direction.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose LivingEntity hurt direction
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index c789cefb61270c7e52ddea7efd433fa6c0e63fda..8c15517e3602f815819c44136adec3c09d70a71b 100644
+index 8409087a5977a6ba0cd948c51f3f7ae59a041f5c..dfc5317ab5c50c240a4f0806aba6cec7852092cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -907,5 +907,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -913,5 +913,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void playPickupItemAnimation(org.bukkit.entity.Item item, int quantity) {
          getHandle().take(((CraftItem) item).getHandle(), quantity);
      }

--- a/patches/server/0567-living-entity-allow-attribute-registration.patch
+++ b/patches/server/0567-living-entity-allow-attribute-registration.patch
@@ -41,10 +41,10 @@ index 233e372ba5d785352c9ac12dac37395bac63315c..0e61caa5c9f21788fbeaa90ed75d23e1
          return BuiltInRegistries.ATTRIBUTE.get(CraftNamespacedKey.toMinecraft(attribute.getKey()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 8c15517e3602f815819c44136adec3c09d70a71b..3f349f3ac972c90412cd20a30ccb55598c8cf7ba 100644
+index dfc5317ab5c50c240a4f0806aba6cec7852092cf..fb74a06e73765a82d936975f4070093e35e2dade 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -699,6 +699,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -705,6 +705,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          return this.getHandle().craftAttributes.getAttribute(attribute);
      }
  

--- a/patches/server/0622-More-Enchantment-API.patch
+++ b/patches/server/0622-More-Enchantment-API.patch
@@ -66,10 +66,10 @@ index 57decf4156f176ebcc988478c17856cbc555c5e4..3d0ce0803e1da8a2681a3cb41096ac94
  
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 3f349f3ac972c90412cd20a30ccb55598c8cf7ba..f4a219ba563aa153ae26128fe4e49ddc03fecc44 100644
+index fb74a06e73765a82d936975f4070093e35e2dade..3c6d64601afdf1c23756c1419e450228a2e7a362 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -924,5 +924,21 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -930,5 +930,21 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void setHurtDirection(float hurtDirection) {
          getHandle().hurtDir = hurtDirection;
      }

--- a/patches/server/0643-Line-Of-Sight-Changes.patch
+++ b/patches/server/0643-Line-Of-Sight-Changes.patch
@@ -40,7 +40,7 @@ index 6c627e3f2c34557e11232fb0c5fa4f1718018ef5..e5684294b2d71c4496a47e72afe41b8a
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index f4a219ba563aa153ae26128fe4e49ddc03fecc44..ba8b98f1a4b4c8865385033307dc0e7486d597be 100644
+index 3c6d64601afdf1c23756c1419e450228a2e7a362..9a0af16ffe32c096fb4190692875bfccfa6b769b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -29,6 +29,9 @@ import net.minecraft.world.entity.projectile.ThrownEgg;
@@ -53,7 +53,7 @@ index f4a219ba563aa153ae26128fe4e49ddc03fecc44..ba8b98f1a4b4c8865385033307dc0e74
  import org.apache.commons.lang.Validate;
  import org.bukkit.FluidCollisionMode;
  import org.bukkit.Location;
-@@ -570,6 +573,18 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -576,6 +579,18 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          return this.getHandle().hasLineOfSight(((CraftEntity) other).getHandle());
      }
  

--- a/patches/server/0660-Stinger-API.patch
+++ b/patches/server/0660-Stinger-API.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Stinger API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index ba8b98f1a4b4c8865385033307dc0e7486d597be..244123cd98171dcd8ea9e34b32d5ba8c2bd6b7f8 100644
+index 9a0af16ffe32c096fb4190692875bfccfa6b769b..f7d20efecfee6aaae2e323d543739308c4bb371c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -334,7 +334,28 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
-         Preconditions.checkArgument(count >= 0, "New arrow amount must be >= 0");
-         this.getHandle().getEntityData().set(net.minecraft.world.entity.LivingEntity.DATA_ARROW_COUNT_ID, count);
+@@ -340,7 +340,28 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         }
+         // Paper end
      }
 +    // Paper Start - Bee Stinger API
 +    @Override

--- a/patches/server/0893-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
+++ b/patches/server/0893-Add-a-consumer-parameter-to-ProjectileSource-launchP.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add a consumer parameter to ProjectileSource#launchProjectile
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 244123cd98171dcd8ea9e34b32d5ba8c2bd6b7f8..a4d916fcb12da37f9b75e844346578c160abea96 100644
+index f7d20efecfee6aaae2e323d543739308c4bb371c..65f8d9b6a4ecffdf50b88c6924402bdf0668a8f2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -493,8 +493,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -499,8 +499,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      }
  
      @Override
@@ -25,7 +25,7 @@ index 244123cd98171dcd8ea9e34b32d5ba8c2bd6b7f8..a4d916fcb12da37f9b75e844346578c1
          Preconditions.checkState(!this.getHandle().generation, "Cannot launch projectile during world generation");
  
          net.minecraft.world.level.Level world = ((CraftWorld) getWorld()).getHandle();
-@@ -577,6 +584,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -583,6 +590,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          if (velocity != null) {
              ((T) launch.getBukkitEntity()).setVelocity(velocity);
          }

--- a/patches/server/0909-Add-entity-knockback-API.patch
+++ b/patches/server/0909-Add-entity-knockback-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity knockback API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index a4d916fcb12da37f9b75e844346578c160abea96..3076831b3d26c6dd3bf0c0d0618151ce6ad0df82 100644
+index 65f8d9b6a4ecffdf50b88c6924402bdf0668a8f2..2785c42b9b0a9e22ad544f8a4eb6cb77eaad0db6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -988,5 +988,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -994,5 +994,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          }
          throw new IllegalArgumentException(entityCategory + " is an unrecognized entity category");
      }

--- a/patches/server/0929-ItemStack-damage-API.patch
+++ b/patches/server/0929-ItemStack-damage-API.patch
@@ -11,10 +11,10 @@ the logic associated with damaging them
 public net.minecraft.world.entity.LivingEntity entityEventForEquipmentBreak(Lnet/minecraft/world/entity/EquipmentSlot;)B
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 3076831b3d26c6dd3bf0c0d0618151ce6ad0df82..fe9f52176d87944ac5743dced8cf4d0576089d06 100644
+index 2785c42b9b0a9e22ad544f8a4eb6cb77eaad0db6..7a7647fbe7dc4167c4e90fbd63e03a23e9b2729c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -989,6 +989,53 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -995,6 +995,53 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          throw new IllegalArgumentException(entityCategory + " is an unrecognized entity category");
      }
  

--- a/patches/server/0930-Friction-API.patch
+++ b/patches/server/0930-Friction-API.patch
@@ -132,10 +132,10 @@ index fea44ba6a6584b4a510af6a58cab07eecec6b68b..ecec5e17807a760769fc0ea79c2a0161
      public int getHealth() {
          return item.health;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index fe9f52176d87944ac5743dced8cf4d0576089d06..09da9d3c85e36c2a78663f58a97963dbc795a367 100644
+index 7a7647fbe7dc4167c4e90fbd63e03a23e9b2729c..f2a7a10df4c283ef3d7e44121c074156556c9cf2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1036,6 +1036,18 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1042,6 +1042,18 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          });
      }
  


### PR DESCRIPTION
Paper had API for getting/setting the stuck arrow count in LivingEntity, but at some point upstream added it and we failed to deprecate ours. In addition, the behavior was slightly different, our method always fired the `ArrowBodyCountChangeEvent` whereas upstream's did not. So I added a method overload to upstream's method with a boolean to fire the event or not.