### PR TITLE
Fix chunk sending when the computed time overflows

### DIFF
--- a/patches/server/0016-Rewrite-chunk-system.patch
+++ b/patches/server/0016-Rewrite-chunk-system.patch
@@ -1309,7 +1309,7 @@ index 0000000000000000000000000000000000000000..99f49b5625cf51d6c97640553cf5c420
 +}
 diff --git a/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java b/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0b060183429f4c72ec767075538477b4302bbf0d
+index 0000000000000000000000000000000000000000..e77972c4c264100ffdd824bfa2dac58dbbc6d678
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java
 @@ -0,0 +1,1128 @@
@@ -1404,7 +1404,7 @@ index 0000000000000000000000000000000000000000..0b060183429f4c72ec767075538477b4
 +
 +        final int priorityCompare = Double.compare(holder1 == null ? Double.MAX_VALUE : holder1.priority, holder2 == null ? Double.MAX_VALUE : holder2.priority);
 +
-+        final int lastLoadTimeCompare = Long.compare(p1.lastChunkLoad, p2.lastChunkLoad);
++        final int lastLoadTimeCompare = Long.compare(p1.lastChunkLoad - p2.lastChunkLoad, 0);
 +
 +        if ((holder1 == null || holder2 == null || lastLoadTimeCompare == 0 || holder1.priority < 0.0 || holder2.priority < 0.0) && priorityCompare != 0) {
 +            return priorityCompare;
@@ -1429,7 +1429,7 @@ index 0000000000000000000000000000000000000000..0b060183429f4c72ec767075538477b4
 +            return 0;
 +        }
 +
-+        final int timeCompare = Long.compare(p1.nextChunkSendTarget, p2.nextChunkSendTarget);
++        final int timeCompare = Long.compare(p1.nextChunkSendTarget - p2.nextChunkSendTarget, 0);
 +        if (timeCompare != 0) {
 +            return timeCompare;
 +        }
@@ -1835,14 +1835,14 @@ index 0000000000000000000000000000000000000000..0b060183429f4c72ec767075538477b4
 +    private static long nextChunkSend;
 +    private void trySendChunks() {
 +        final long time = System.nanoTime();
-+        if (time < nextChunkSend) {
++        if (nextChunkSend - time > 0) {
 +            return;
 +        }
 +        // drain entries from wait queue
 +        while (!this.chunkSendWaitQueue.isEmpty()) {
 +            final PlayerLoaderData data = this.chunkSendWaitQueue.first();
 +
-+            if (data.nextChunkSendTarget > time) {
++            if (data.nextChunkSendTarget - time > 0) {
 +                break;
 +            }
 +
@@ -1914,7 +1914,7 @@ index 0000000000000000000000000000000000000000..0b060183429f4c72ec767075538477b4
 +            });
 +
 +            nextChunkSend = this.getMaxSendAddend() + time;
-+            if (time < nextChunkSend) {
++            if (nextChunkSend - time > 0) {
 +                break;
 +            }
 +        }


### PR DESCRIPTION
When `System.nanoTime()` wraps around the long limit, the chunk sending can get stuck for 292 years (if the planned next time is just below `Long.MAX_VALUE` and the current time is just above `Long.MIN_VALUE`). This is fixed by using subtractions instead of direct comparisons.