### PR TITLE
Fix chunk loading/sending when the rate is set to 1.0

### DIFF
--- a/patches/server/0016-Rewrite-chunk-system.patch
+++ b/patches/server/0016-Rewrite-chunk-system.patch
@@ -1309,7 +1309,7 @@ index 0000000000000000000000000000000000000000..99f49b5625cf51d6c97640553cf5c420
 +}
 diff --git a/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java b/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0b060183429f4c72ec767075538477b4302bbf0d
+index 0000000000000000000000000000000000000000..f4cbedd9cd3557be5384261d04d3f9cb5be30b4d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java
 @@ -0,0 +1,1128 @@
@@ -1698,15 +1698,15 @@ index 0000000000000000000000000000000000000000..0b060183429f4c72ec767075538477b4
 +    protected int getMaxChunkLoads() {
 +        double config = GlobalConfiguration.get().chunkLoading.playerMaxConcurrentLoads;
 +        double max = GlobalConfiguration.get().chunkLoading.globalMaxConcurrentLoads;
-+        return (int)Math.ceil(Math.min(config * MinecraftServer.getServer().getPlayerCount(), max <= 1.0 ? Double.MAX_VALUE : max));
++        return (int)Math.ceil(Math.min(config * MinecraftServer.getServer().getPlayerCount(), max < 1.0 ? Double.MAX_VALUE : max));
 +    }
 +
 +    protected long getTargetSendPerPlayerAddend() {
-+        return GlobalConfiguration.get().chunkLoading.targetPlayerChunkSendRate <= 1.0 ? 0L : (long)Math.round(1.0e9 / GlobalConfiguration.get().chunkLoading.targetPlayerChunkSendRate);
++        return GlobalConfiguration.get().chunkLoading.targetPlayerChunkSendRate < 1.0e-3 ? 0L : (long)Math.round(1.0e9 / GlobalConfiguration.get().chunkLoading.targetPlayerChunkSendRate);
 +    }
 +
 +    protected long getMaxSendAddend() {
-+        return GlobalConfiguration.get().chunkLoading.globalMaxChunkSendRate <= 1.0 ? 0L : (long)Math.round(1.0e9 / GlobalConfiguration.get().chunkLoading.globalMaxChunkSendRate);
++        return GlobalConfiguration.get().chunkLoading.globalMaxChunkSendRate < 1.0e-3 ? 0L : (long)Math.round(1.0e9 / GlobalConfiguration.get().chunkLoading.globalMaxChunkSendRate);
 +    }
 +
 +    public void onChunkPlayerTickReady(final int chunkX, final int chunkZ) {


### PR DESCRIPTION
Fixes #6616.

This allows the following `paper-global.yml` configuration values:
* `global-max-concurrent-loads` can be set to 1.0 and higher
  (previously could only be set to strictly higher than 1.0)
* `target-player-chunk-send-rate` and `global-max-chunk-send-rate` can be set to 10<sup>-3</sup> (1 chunk per 1000 seconds, a value that is safe and lower than anyone could ever need) and higher
  (previously could only be set to strictly higher than 1.0)