### PR TITLE
Cleanup flying fall damage API

### DIFF
--- a/patches/api/0424-Flying-Fall-Damage-API.patch
+++ b/patches/api/0424-Flying-Fall-Damage-API.patch
@@ -5,26 +5,48 @@ Subject: [PATCH] Flying Fall Damage API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b27d7414f34f1d49c56dbc33d6d23bc822adf721..b06f759b6188d87cf406072b6d7ef8266512ce50 100644
+index b27d7414f34f1d49c56dbc33d6d23bc822adf721..d5268e73ab50c577fed89b46f20ec5985089e023 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1416,6 +1416,23 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1416,6 +1416,45 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void setAllowFlight(boolean flight);
  
 +    // Paper start - flying fall damage
 +    /**
-+     * Allows you to enable fall damage while {@link #getAllowFlight()} is {@code true}
++     * Sets whether fall damage is enabled while {@link #getAllowFlight()} is {@code true}
 +     *
 +     * @param flyingFallDamage Enables fall damage when {@link #getAllowFlight()} is {@code true}
 +     */
++    default void flyingFallDamage(boolean flyingFallDamage) {
++        setFlyingFallDamage(net.kyori.adventure.util.TriState.byBoolean(flyingFallDamage));
++    }
++
++    /**
++     * Returns whether fall damage is enabled while {@link #getAllowFlight()} is {@code true}
++     *
++     * @return Whether fall damage is enabled when {@link #getAllowFlight()} is {@code true}
++     */
++    default boolean flyingFallDamage() {
++        return hasFlyingFallDamage().toBooleanOrElse(false);
++    }
++
++    /**
++     * Allows you to enable fall damage while {@link #getAllowFlight()} is {@code true}
++     *
++     * @deprecated In favour of {@link #flyingFallDamage(boolean)}
++     * @param flyingFallDamage Enables fall damage when {@link #getAllowFlight()} is {@code true}
++     */
++    @Deprecated
 +    public void setFlyingFallDamage(@NotNull net.kyori.adventure.util.TriState flyingFallDamage);
 +
 +    /**
 +     * Allows you to get if fall damage is enabled while {@link #getAllowFlight()} is {@code true}
 +     *
++     * @deprecated In favour of {@link #flyingFallDamage()}
 +     * @return A tristate of whether fall damage is enabled, not set, or disabled when {@link #getAllowFlight()} is {@code true}
 +     */
++    @Deprecated
 +    @NotNull
 +    public net.kyori.adventure.util.TriState hasFlyingFallDamage();
 +    // Paper end


### PR DESCRIPTION
Currently the flying fall damage API uses a `TriState`, but treats it like a `boolean`.
Looking at the original PR, it was a `boolean`, was changed into a `TriState` so that it can be saved to a file if it's set (and be ignored if its `UNSET`), and then saving the file was removed and it remained a `TriState` without any actual reason to be one.

This PR adds new `Player#flyingFallDamage` and `Player#flyingFallDamage(boolean)` methods that better reflect the way it works internally.
The new methods are `default` methods which use the now-deprecated `TriState` ones to avoid API breaks.