### PR TITLE
Add missing isFuel Material entries

### DIFF
--- a/patches/api/0430-Add-missing-isFuel-Material-entries.patch
+++ b/patches/api/0430-Add-missing-isFuel-Material-entries.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 12 Feb 2023 10:52:22 -0800
+Subject: [PATCH] Add missing isFuel Material entries
+
+
+diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
+index e5b94299793ba7cb9071a3f3a35ddbe08b0b9906..ee471fbd7c2138cd330b2c64da4e77b3414ec913 100644
+--- a/src/main/java/org/bukkit/Material.java
++++ b/src/main/java/org/bukkit/Material.java
+@@ -7467,6 +7467,7 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+             case ACACIA_DOOR:
+             case ACACIA_FENCE:
+             case ACACIA_FENCE_GATE:
++            case ACACIA_HANGING_SIGN: // Paper
+             case ACACIA_LOG:
+             case ACACIA_PLANKS:
+             case ACACIA_PRESSURE_PLATE:
+@@ -7478,9 +7479,27 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+             case ACACIA_WOOD:
+             case AZALEA:
+             case BAMBOO:
++            // Paper start - add missing fuels
++            case BAMBOO_BLOCK:
++            case BAMBOO_BUTTON:
++            case BAMBOO_CHEST_RAFT:
++            case BAMBOO_DOOR:
++            case BAMBOO_FENCE:
++            case BAMBOO_FENCE_GATE:
++            case BAMBOO_HANGING_SIGN:
++            // Paper end
+             case BAMBOO_MOSAIC:
+             case BAMBOO_MOSAIC_SLAB:
+             case BAMBOO_MOSAIC_STAIRS:
++            // Paper start - add missing fuels
++            case BAMBOO_PLANKS:
++            case BAMBOO_PRESSURE_PLATE:
++            case BAMBOO_RAFT:
++            case BAMBOO_SIGN:
++            case BAMBOO_SLAB:
++            case BAMBOO_STAIRS:
++            case BAMBOO_TRAPDOOR:
++            // Paper end
+             case BARREL:
+             case BIRCH_BOAT:
+             case BIRCH_BUTTON:
+@@ -7488,6 +7507,7 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+             case BIRCH_DOOR:
+             case BIRCH_FENCE:
+             case BIRCH_FENCE_GATE:
++            case BIRCH_HANGING_SIGN: // Paper
+             case BIRCH_LOG:
+             case BIRCH_PLANKS:
+             case BIRCH_PRESSURE_PLATE:
+@@ -7528,6 +7548,7 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+             case DARK_OAK_DOOR:
+             case DARK_OAK_FENCE:
+             case DARK_OAK_FENCE_GATE:
++            case DARK_OAK_HANGING_SIGN: // Paper
+             case DARK_OAK_LOG:
+             case DARK_OAK_PLANKS:
+             case DARK_OAK_PRESSURE_PLATE:
+@@ -7556,6 +7577,7 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+             case JUNGLE_DOOR:
+             case JUNGLE_FENCE:
+             case JUNGLE_FENCE_GATE:
++            case JUNGLE_HANGING_SIGN: // Paper
+             case JUNGLE_LOG:
+             case JUNGLE_PLANKS:
+             case JUNGLE_PRESSURE_PLATE:
+@@ -7587,6 +7609,7 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+             case MANGROVE_DOOR:
+             case MANGROVE_FENCE:
+             case MANGROVE_FENCE_GATE:
++            case MANGROVE_HANGING_SIGN: // Paper
+             case MANGROVE_LOG:
+             case MANGROVE_PLANKS:
+             case MANGROVE_PRESSURE_PLATE:
+@@ -7604,6 +7627,7 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+             case OAK_DOOR:
+             case OAK_FENCE:
+             case OAK_FENCE_GATE:
++            case OAK_HANGING_SIGN: // Paper
+             case OAK_LOG:
+             case OAK_PLANKS:
+             case OAK_PRESSURE_PLATE:
+@@ -7633,6 +7657,7 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+             case SPRUCE_DOOR:
+             case SPRUCE_FENCE:
+             case SPRUCE_FENCE_GATE:
++            case SPRUCE_HANGING_SIGN: // Paper
+             case SPRUCE_LOG:
+             case SPRUCE_PLANKS:
+             case SPRUCE_PRESSURE_PLATE:
+@@ -7645,6 +7670,7 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+             case STICK:
+             case STRIPPED_ACACIA_LOG:
+             case STRIPPED_ACACIA_WOOD:
++            case STRIPPED_BAMBOO_BLOCK: // Paper
+             case STRIPPED_BIRCH_LOG:
+             case STRIPPED_BIRCH_WOOD:
+             case STRIPPED_DARK_OAK_LOG:

--- a/patches/server/0961-Add-missing-isFuel-Material-entries.patch
+++ b/patches/server/0961-Add-missing-isFuel-Material-entries.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 12 Feb 2023 10:52:35 -0800
+Subject: [PATCH] Add missing isFuel Material entries
+
+
+diff --git a/src/test/java/org/bukkit/support/AbstractTestingBase.java b/src/test/java/org/bukkit/support/AbstractTestingBase.java
+index 084c48ffabac2cd753609add745203e8a55bc09e..f1be92753106abedc3617257517bbb66d02923b1 100644
+--- a/src/test/java/org/bukkit/support/AbstractTestingBase.java
++++ b/src/test/java/org/bukkit/support/AbstractTestingBase.java
+@@ -44,7 +44,12 @@ public abstract class AbstractTestingBase {
+         SharedConstants.tryDetectVersion();
+         Bootstrap.bootStrap();
+         // Set up resource manager
+-        MultiPackResourceManager resourceManager = new MultiPackResourceManager(PackType.SERVER_DATA, Collections.singletonList(new ServerPacksSource().getVanillaPack()));
++        // Paper start - make sure to actually load the packs you add API for
++        final List<net.minecraft.server.packs.PackResources> packs = new java.util.ArrayList<>();
++        // don't worry about closing them, the only pack types should be VanillaPackResources (empty close) and PackPackResources (also empty close)
++        new ServerPacksSource().loadPacks(pack -> packs.add(pack.open()));
++        final MultiPackResourceManager resourceManager = new MultiPackResourceManager(PackType.SERVER_DATA, packs);
++        // Paper end
+         // add tags and loot tables for unit tests
+         LayeredRegistryAccess<RegistryLayer> layers = RegistryLayer.createRegistryAccess();
+         layers = WorldLoader.loadAndReplaceLayer(resourceManager, layers, RegistryLayer.WORLDGEN, RegistryDataLoader.WORLDGEN_REGISTRIES);


### PR DESCRIPTION
The isFuel method in Material was missing the new experimental blocks. Other Material isX methods seem to be correct.