### PR TITLE
Add TeleportFlags

### DIFF
--- a/patches/api/0375-More-Teleport-API.patch
+++ b/patches/api/0375-More-Teleport-API.patch
@@ -35,51 +35,100 @@ index 0000000000000000000000000000000000000000..7713a5b7e06da185685f18e79eae2c97
 +     */
 +    EYES;
 +}
-diff --git a/src/main/java/io/papermc/paper/entity/RelativeTeleportFlag.java b/src/main/java/io/papermc/paper/entity/RelativeTeleportFlag.java
+diff --git a/src/main/java/io/papermc/paper/entity/TeleportFlag.java b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0426ee8bd71142b6f933a479c0f2e5ef6043147d
+index 0000000000000000000000000000000000000000..61bf11978a712be805afb34506a4171ed1972777
 --- /dev/null
-+++ b/src/main/java/io/papermc/paper/entity/RelativeTeleportFlag.java
-@@ -0,0 +1,34 @@
++++ b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
+@@ -0,0 +1,83 @@
 +package io.papermc.paper.entity;
 +
 +import org.bukkit.Location;
 +import org.bukkit.event.player.PlayerTeleportEvent;
++import org.jetbrains.annotations.ApiStatus;
 +
 +/**
-+ * Represents coordinates in a teleportation that should be handled relatively.
++ * Represents a flag that can be set on teleportation that may
++ * slightly modify the behavior.
 + *
-+ * @see org.bukkit.entity.Player#teleport(Location, PlayerTeleportEvent.TeleportCause, boolean, boolean, RelativeTeleportFlag...)
++ * @see EntityStateFlag
++ * @see RelativeTeleportFlag
 + */
-+@org.jetbrains.annotations.ApiStatus.Experimental
-+public enum RelativeTeleportFlag {
++@ApiStatus.Experimental
++public sealed interface TeleportFlag permits TeleportFlag.EntityStateFlag, TeleportFlag.RelativeTeleportFlag {
++
 +    /**
-+     * Represents the player's X coordinate
++     * Note: These flags only work on {@link org.bukkit.entity.Player} entities.
++     * <p>
++     * Represents coordinates in a teleportation that should be handled relatively.
++     * <p>
++     * Coordinates of the location that the client should handle as relative teleportation
++     * Relative teleportation flags are only used client side, and cause the player to not lose velocity in that
++     * specific coordinate. The location of the teleportation will not change.
++     *
++     * @see org.bukkit.entity.Player#teleport(Location, PlayerTeleportEvent.TeleportCause, TeleportFlag...)
 +     */
-+    X,
++    @org.jetbrains.annotations.ApiStatus.Experimental
++    enum RelativeTeleportFlag implements TeleportFlag {
++        /**
++         * Represents the player's X coordinate
++         */
++        X,
++        /**
++         * Represents the player's Y coordinate
++         */
++        Y,
++        /**
++         * Represents the player's Z coordinate
++         */
++        Z,
++        /**
++         * Represents the player's yaw
++         */
++        YAW,
++        /**
++         * Represents the player's pitch
++         */
++        PITCH;
++    }
++
 +    /**
-+     * Represents the player's Y coordinate
++     * Represents flags that effect the entity's state on
++     * teleportation.
 +     */
-+    Y,
-+    /**
-+     * Represents the player's Z coordinate
-+     */
-+    Z,
-+    /**
-+     * Represents the player's yaw
-+     */
-+    YAW,
-+    /**
-+     * Represents the player's pitch
-+     */
-+    PITCH;
++    @ApiStatus.Experimental
++    enum EntityStateFlag implements TeleportFlag {
++        /**
++         * If all passengers should not be required to be removed prior to teleportation.
++         *
++         * Note
++         * Teleporting to a different world with ignorePassengers to true while the entity has entities riding it
++         * will cause this teleportation to return false and not occur.
++         */
++        IGNORE_PASSENGERS,
++        /**
++         * If the entity should not be dismounted if they are riding another entity.
++         *
++         * Note:
++         * Teleporting to a different world with dismount to false while this entity is riding another entity will
++         * cause this teleportation to return false and not occur.
++         */
++        IGNORE_DISMOUNT,
++        /**
++         * Indicates that a player should not have their current open inventory closed when teleporting.
++         *
++         * Note:
++         * This option will be ignored when teleported to a different world.
++         */
++        IGNORE_OPEN_INVENTORY;
++    }
 +
 +}
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index b878509ff536f2d728c800a0ae6cd36802570b31..9bfe62185acb2a208268a2db3aa81dad9e0eed5e 100644
+index b878509ff536f2d728c800a0ae6cd36802570b31..ec2adecad37c321b7852c34020dc1c61bef5dd8d 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -122,10 +122,77 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -122,10 +122,34 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       *
       * @param yaw the yaw
       * @param pitch the pitch
@@ -90,79 +139,36 @@ index b878509ff536f2d728c800a0ae6cd36802570b31..9bfe62185acb2a208268a2db3aa81dad
 +    // Paper start - Teleport API
 +    /**
 +     * Teleports this entity to the given location.
-+     * <p>
-+     * Note: Teleporting to a different world with ignorePassengers to true while the entity has entities riding it
-+     * will cause this teleportation to return false and not occur.
 +     *
 +     * @param location New location to teleport this entity to
-+     * @param ignorePassengers If all passengers should not be required to be removed prior to teleportation
++     * @param teleportFlags Flags to be used in this teleportation
 +     * @return <code>true</code> if the teleport was successful
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Experimental
-+    default boolean teleport(@NotNull Location location, boolean ignorePassengers) {
-+        return this.teleport(location, TeleportCause.PLUGIN, ignorePassengers);
++    default boolean teleport(@NotNull Location location, @NotNull io.papermc.paper.entity.TeleportFlag @NotNull... teleportFlags) {
++        return this.teleport(location, TeleportCause.PLUGIN, teleportFlags);
 +    }
 +
 +    /**
 +     * Teleports this entity to the given location.
-+     * <p>
-+     * Note: Teleporting to a different world with ignorePassengers to true while the entity has entities riding it
-+     * will cause this teleportation to return false and not occur.
 +     *
 +     * @param location New location to teleport this entity to
 +     * @param cause The cause of this teleportation
-+     * @param ignorePassengers If all passengers should not be required to be removed prior to teleportation
++     * @param teleportFlags Flags to be used in this teleportation
 +     * @return <code>true</code> if the teleport was successful
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Experimental
-+    default boolean teleport(@NotNull Location location, @NotNull TeleportCause cause, boolean ignorePassengers) {
-+        return this.teleport(location, cause, ignorePassengers, true);
-+    }
-+
-+    /**
-+     * Teleports this entity to the given location.
-+     * <p>
-+     * Note: Teleporting to a different world with ignorePassengers to true while the entity has entities riding it
-+     * will cause this teleportation to return false and not occur.
-+     * Note: Teleporting to a different world with dismount to false while this entity is riding another entity will
-+     * cause this teleportation to return false and not occur.
-+     *
-+     * @param location New location to teleport this entity to
-+     * @param ignorePassengers If all passengers should not be required to be removed prior to teleportation
-+     * @param dismount If the entity should be dismounted if they are riding another entity
-+     * @return <code>true</code> if the teleport was successful
-+     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
-+    default boolean teleport(@NotNull Location location, boolean ignorePassengers, boolean dismount) {
-+        return this.teleport(location, TeleportCause.PLUGIN, ignorePassengers, dismount);
-+    }
-+
-+    /**
-+     * Teleports this entity to the given location.
-+     * <p>
-+     * Note: Teleporting to a different world with ignorePassengers to true while the entity has entities riding it
-+     * will cause this teleportation to return false and not occur.
-+     * Note: Teleporting to a different world with dismount to false while this entity is riding another entity will
-+     * cause this teleportation to return false and not occur.
-+     *
-+     * @param location New location to teleport this entity to
-+     * @param cause The cause of this teleportation
-+     * @param ignorePassengers If all passengers should not be required to be removed prior to teleportation
-+     * @param dismount If the entity should be dismounted if they are riding another entity
-+     * @return <code>true</code> if the teleport was successful
-+     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
-+    boolean teleport(@NotNull Location location, @NotNull TeleportCause cause, boolean ignorePassengers, boolean dismount);
++    boolean teleport(@NotNull Location location, @NotNull TeleportCause cause, @NotNull io.papermc.paper.entity.TeleportFlag @NotNull... teleportFlags);
 +    // Paper end - Teleport API
 +
      /**
       * Teleports this entity to the given location. If this entity is riding a
       * vehicle, it will be dismounted prior to teleportation.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 17ad43c24dc2e18f5cde0ac0bfae1de9fe415964..6fbdcf6e5df2e613db022d38fc1e170578ef5e8a 100644
+index 17ad43c24dc2e18f5cde0ac0bfae1de9fe415964..02979f3bce2d771120a39287cdfcb12c5487a23f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2757,6 +2757,71 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2757,6 +2757,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      String getClientBrandName();
      // Paper end
  
@@ -175,28 +181,6 @@ index 17ad43c24dc2e18f5cde0ac0bfae1de9fe415964..6fbdcf6e5df2e613db022d38fc1e1705
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Experimental
 +    void setRotation(float yaw, float pitch);
-+
-+    /**
-+     * Teleports this entity to the given location.
-+     * <p>
-+     * Note: Teleporting to a different world with ignorePassengers to true while the entity has entities riding it
-+     * will cause this teleportation to return false and not occur.
-+     * Note: Teleporting to a different world with dismount to false while this entity is riding another entity will
-+     * cause this teleportation to return false and not occur.
-+     *
-+     * <p>
-+     * Relative teleportation flags are only used client side, and cause the player to not lose velocity in that
-+     * specific coordinate. The location of the teleportation will not change.
-+     *
-+     * @param location New location to teleport this entity to
-+     * @param cause The cause of this teleportation
-+     * @param ignorePassengers If all passengers should not be required to be removed prior to teleportation
-+     * @param dismount If the entity should be dismounted if they are riding another entity
-+     * @param teleportFlags Coordinates of the location that the client should handle as relative teleportation
-+     * @return <code>true</code> if the teleport was successful
-+     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
-+    boolean teleport(@NotNull Location location, @NotNull org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause, boolean ignorePassengers, boolean dismount, @NotNull io.papermc.paper.entity.RelativeTeleportFlag @NotNull... teleportFlags);
 +
 +    /**
 +     * Causes the player to look towards the given position.
@@ -212,12 +196,12 @@ index 17ad43c24dc2e18f5cde0ac0bfae1de9fe415964..6fbdcf6e5df2e613db022d38fc1e1705
 +    /**
 +     * Causes the player to look towards the given location.
 +     *
-+     * @param location Location to look at
++     * @param position Position to look at in the player's current world
 +     * @param playerAnchor What part of player should face the location
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Experimental
-+    default void lookAt(@NotNull Location location, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor) {
-+        this.lookAt(location.getX(), location.getY(), location.getZ(), playerAnchor);
++    default void lookAt(@NotNull io.papermc.paper.math.Position position, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor) {
++        this.lookAt(position.x(), position.y(), position.z(), playerAnchor);
 +    }
 +
 +    /**
@@ -235,7 +219,7 @@ index 17ad43c24dc2e18f5cde0ac0bfae1de9fe415964..6fbdcf6e5df2e613db022d38fc1e1705
      @Override
      Spigot spigot();
 diff --git a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
-index 113e620ce38bb8ff97cf24e309af59b717774b36..149725da2468cf2e8cf3877f78b4a9b749ec1e51 100644
+index 113e620ce38bb8ff97cf24e309af59b717774b36..89f2f4b05c1732960bb844d3e26ec7c4e757246d 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
 @@ -13,8 +13,14 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
@@ -244,7 +228,7 @@ index 113e620ce38bb8ff97cf24e309af59b717774b36..149725da2468cf2e8cf3877f78b4a9b7
  
 +    // Paper start - Teleport API
 +    private boolean dismounted = true;
-+    private final java.util.Set<io.papermc.paper.entity.RelativeTeleportFlag> teleportFlagSet;
++    private final java.util.Set<io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag> teleportFlagSet;
 +    // Paper end
 +
      public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to) {
@@ -259,7 +243,7 @@ index 113e620ce38bb8ff97cf24e309af59b717774b36..149725da2468cf2e8cf3877f78b4a9b7
  
 +    // Paper start - Teleport API
 +    @org.jetbrains.annotations.ApiStatus.Experimental
-+    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to, @NotNull final TeleportCause cause, boolean dismounted, @NotNull java.util.Set<io.papermc.paper.entity.@NotNull RelativeTeleportFlag> teleportFlagSet) {
++    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to, @NotNull final TeleportCause cause, boolean dismounted, @NotNull java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull RelativeTeleportFlag> teleportFlagSet) {
 +        super(player, from, to);
 +
 +        this.dismounted = dismounted;
@@ -294,7 +278,7 @@ index 113e620ce38bb8ff97cf24e309af59b717774b36..149725da2468cf2e8cf3877f78b4a9b7
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Experimental
 +    @NotNull
-+    public java.util.Set<io.papermc.paper.entity.@NotNull RelativeTeleportFlag> getRelativeTeleportationFlags() {
++    public java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull RelativeTeleportFlag> getRelativeTeleportationFlags() {
 +        return this.teleportFlagSet;
 +    }
 +    // Paper end

--- a/patches/api/0375-More-Teleport-API.patch
+++ b/patches/api/0375-More-Teleport-API.patch
@@ -37,7 +37,7 @@ index 0000000000000000000000000000000000000000..7713a5b7e06da185685f18e79eae2c97
 +}
 diff --git a/src/main/java/io/papermc/paper/entity/TeleportFlag.java b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..61bf11978a712be805afb34506a4171ed1972777
+index 0000000000000000000000000000000000000000..4a9143ef4e4b9e822dd65702d4aa8e70c14124e4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
 @@ -0,0 +1,83 @@
@@ -51,11 +51,11 @@ index 0000000000000000000000000000000000000000..61bf11978a712be805afb34506a4171e
 + * Represents a flag that can be set on teleportation that may
 + * slightly modify the behavior.
 + *
-+ * @see EntityStateFlag
-+ * @see RelativeTeleportFlag
++ * @see EntityState
++ * @see Relative
 + */
 +@ApiStatus.Experimental
-+public sealed interface TeleportFlag permits TeleportFlag.EntityStateFlag, TeleportFlag.RelativeTeleportFlag {
++public sealed interface TeleportFlag permits TeleportFlag.EntityState, TeleportFlag.Relative {
 +
 +    /**
 +     * Note: These flags only work on {@link org.bukkit.entity.Player} entities.
@@ -68,8 +68,8 @@ index 0000000000000000000000000000000000000000..61bf11978a712be805afb34506a4171e
 +     *
 +     * @see org.bukkit.entity.Player#teleport(Location, PlayerTeleportEvent.TeleportCause, TeleportFlag...)
 +     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
-+    enum RelativeTeleportFlag implements TeleportFlag {
++    @ApiStatus.Experimental
++    enum Relative implements TeleportFlag {
 +        /**
 +         * Represents the player's X coordinate
 +         */
@@ -97,30 +97,30 @@ index 0000000000000000000000000000000000000000..61bf11978a712be805afb34506a4171e
 +     * teleportation.
 +     */
 +    @ApiStatus.Experimental
-+    enum EntityStateFlag implements TeleportFlag {
++    enum EntityState implements TeleportFlag {
 +        /**
 +         * If all passengers should not be required to be removed prior to teleportation.
-+         *
++         * <p>
 +         * Note
-+         * Teleporting to a different world with ignorePassengers to true while the entity has entities riding it
++         * Teleporting to a different world with this flag present while the entity has entities riding it
 +         * will cause this teleportation to return false and not occur.
 +         */
-+        IGNORE_PASSENGERS,
++        RETAIN_PASSENGERS,
 +        /**
 +         * If the entity should not be dismounted if they are riding another entity.
-+         *
++         * <p>
 +         * Note:
-+         * Teleporting to a different world with dismount to false while this entity is riding another entity will
++         * Teleporting to a different world with this flag present while this entity is riding another entity will
 +         * cause this teleportation to return false and not occur.
 +         */
-+        IGNORE_DISMOUNT,
++        RETAIN_VEHICLE,
 +        /**
 +         * Indicates that a player should not have their current open inventory closed when teleporting.
-+         *
++         * <p>
 +         * Note:
 +         * This option will be ignored when teleported to a different world.
 +         */
-+        IGNORE_OPEN_INVENTORY;
++        RETAIN_OPEN_INVENTORY;
 +    }
 +
 +}
@@ -219,7 +219,7 @@ index 17ad43c24dc2e18f5cde0ac0bfae1de9fe415964..02979f3bce2d771120a39287cdfcb12c
      @Override
      Spigot spigot();
 diff --git a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
-index 113e620ce38bb8ff97cf24e309af59b717774b36..89f2f4b05c1732960bb844d3e26ec7c4e757246d 100644
+index 113e620ce38bb8ff97cf24e309af59b717774b36..cc75d2e84e68a1f63ec91a909c37407a46ddb16a 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
 @@ -13,8 +13,14 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
@@ -228,7 +228,7 @@ index 113e620ce38bb8ff97cf24e309af59b717774b36..89f2f4b05c1732960bb844d3e26ec7c4
  
 +    // Paper start - Teleport API
 +    private boolean dismounted = true;
-+    private final java.util.Set<io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag> teleportFlagSet;
++    private final java.util.Set<io.papermc.paper.entity.TeleportFlag.Relative> teleportFlagSet;
 +    // Paper end
 +
      public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to) {
@@ -243,7 +243,7 @@ index 113e620ce38bb8ff97cf24e309af59b717774b36..89f2f4b05c1732960bb844d3e26ec7c4
  
 +    // Paper start - Teleport API
 +    @org.jetbrains.annotations.ApiStatus.Experimental
-+    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to, @NotNull final TeleportCause cause, boolean dismounted, @NotNull java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull RelativeTeleportFlag> teleportFlagSet) {
++    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to, @NotNull final TeleportCause cause, boolean dismounted, @NotNull java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull Relative> teleportFlagSet) {
 +        super(player, from, to);
 +
 +        this.dismounted = dismounted;
@@ -278,7 +278,7 @@ index 113e620ce38bb8ff97cf24e309af59b717774b36..89f2f4b05c1732960bb844d3e26ec7c4
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Experimental
 +    @NotNull
-+    public java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull RelativeTeleportFlag> getRelativeTeleportationFlags() {
++    public java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull Relative> getRelativeTeleportationFlags() {
 +        return this.teleportFlagSet;
 +    }
 +    // Paper end

--- a/patches/api/0375-More-Teleport-API.patch
+++ b/patches/api/0375-More-Teleport-API.patch
@@ -37,7 +37,7 @@ index 0000000000000000000000000000000000000000..7713a5b7e06da185685f18e79eae2c97
 +}
 diff --git a/src/main/java/io/papermc/paper/entity/TeleportFlag.java b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4a9143ef4e4b9e822dd65702d4aa8e70c14124e4
+index 0000000000000000000000000000000000000000..dbacefc919fd6ed6a0f5cdaa0f695a12eda9cc3f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
 @@ -0,0 +1,83 @@
@@ -101,7 +101,7 @@ index 0000000000000000000000000000000000000000..4a9143ef4e4b9e822dd65702d4aa8e70
 +        /**
 +         * If all passengers should not be required to be removed prior to teleportation.
 +         * <p>
-+         * Note
++         * Note:
 +         * Teleporting to a different world with this flag present while the entity has entities riding it
 +         * will cause this teleportation to return false and not occur.
 +         */

--- a/patches/api/0378-Collision-API.patch
+++ b/patches/api/0378-Collision-API.patch
@@ -25,10 +25,10 @@ index 3f7e860de4e28745fcdf8d2f41f4a8c210f48909..39fa4c65e0f61450901662ff5c08d54a
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 9bfe62185acb2a208268a2db3aa81dad9e0eed5e..33a6b7a27dc91552799c07a7aad9b3df31ad13f7 100644
+index ec2adecad37c321b7852c34020dc1c61bef5dd8d..833a8abcdcbe70b2912779f6e179fa3739d099bd 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -929,4 +929,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -886,4 +886,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      boolean isInPowderedSnow();
      // Paper end

--- a/patches/api/0388-Elder-Guardian-appearance-API.patch
+++ b/patches/api/0388-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 478c175d1fcb9a6d1211c50618eec4b9b14bc0ba..9ac0f78d1bf434e501c32382ad2e517a1e19fbfa 100644
+index ebe926bff51954785a6f2ad518ba31eaf8bc8f82..2c4ee85e845f145ae7c6d27e4cac46ab9c23b5b2 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2853,6 +2853,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2831,6 +2831,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
      // Paper end - Teleport API
  

--- a/patches/api/0396-Add-Player-Warden-Warning-API.patch
+++ b/patches/api/0396-Add-Player-Warden-Warning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player Warden Warning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9ac0f78d1bf434e501c32382ad2e517a1e19fbfa..3a450af12df6c71e91eab34237dcbf870708f3c6 100644
+index 2c4ee85e845f145ae7c6d27e4cac46ab9c23b5b2..c480f251f912d14726f3f2fc8f40bd921eb39fe6 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2869,6 +2869,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2847,6 +2847,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param silent whether sound should be silenced
       */
      void showElderGuardian(boolean silent);

--- a/patches/api/0407-Add-Sneaking-API-for-Entities.patch
+++ b/patches/api/0407-Add-Sneaking-API-for-Entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Sneaking API for Entities
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 33a6b7a27dc91552799c07a7aad9b3df31ad13f7..cdbc7329cf5f67d66e31eb31e83b9e7997040f72 100644
+index 833a8abcdcbe70b2912779f6e179fa3739d099bd..11cf1bb585e2754bda443b776e9fcaf0a6cc289e 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -781,6 +781,25 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -738,6 +738,25 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      @NotNull
      Pose getPose();
  
@@ -35,7 +35,7 @@ index 33a6b7a27dc91552799c07a7aad9b3df31ad13f7..cdbc7329cf5f67d66e31eb31e83b9e79
       * Get the category of spawn to which this entity belongs.
       *
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 4d7089da20e0667fd7e67ef4da073d938e7b9a67..b27d7414f34f1d49c56dbc33d6d23bc822adf721 100644
+index d162b838a25d7eed6b8fc66c630e8c68e809c4cd..3f2025023dc5cecb37af136042809e9800c77594 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -296,6 +296,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0408-Improve-PortalEvents.patch
+++ b/patches/api/0408-Improve-PortalEvents.patch
@@ -69,7 +69,7 @@ index 67fb9d93e808e907fa980f3004d415ae5d0a53fc..97e36c7f6e09276fbae20eaeee096556
      /**
       * Set the Block radius to search in for available portals.
 diff --git a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
-index 57eeeafae84f83a939925820e827769749ff27ec..da753259e3c461d9fd40b7eb7d0abf7965497a47 100644
+index 57eeeafae84f83a939925820e827769749ff27ec..af334e228c376f81a6d9225b7559630e78101f5a 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
 @@ -32,6 +32,53 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
@@ -119,7 +119,7 @@ index 57eeeafae84f83a939925820e827769749ff27ec..da753259e3c461d9fd40b7eb7d0abf79
 +     */
 +    @Deprecated
 +    @Override
-+    public @NotNull java.util.Set<io.papermc.paper.entity.@NotNull RelativeTeleportFlag> getRelativeTeleportationFlags() {
++    public @NotNull java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull RelativeTeleportFlag> getRelativeTeleportationFlags() {
 +        return super.getRelativeTeleportationFlags();
 +    }
 +    // Paper end

--- a/patches/api/0408-Improve-PortalEvents.patch
+++ b/patches/api/0408-Improve-PortalEvents.patch
@@ -69,7 +69,7 @@ index 67fb9d93e808e907fa980f3004d415ae5d0a53fc..97e36c7f6e09276fbae20eaeee096556
      /**
       * Set the Block radius to search in for available portals.
 diff --git a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
-index 57eeeafae84f83a939925820e827769749ff27ec..af334e228c376f81a6d9225b7559630e78101f5a 100644
+index 57eeeafae84f83a939925820e827769749ff27ec..929a997671de8202efb9da97fbf9b4a0bf7c37e8 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerPortalEvent.java
 @@ -32,6 +32,53 @@ public class PlayerPortalEvent extends PlayerTeleportEvent {
@@ -119,7 +119,7 @@ index 57eeeafae84f83a939925820e827769749ff27ec..af334e228c376f81a6d9225b7559630e
 +     */
 +    @Deprecated
 +    @Override
-+    public @NotNull java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull RelativeTeleportFlag> getRelativeTeleportationFlags() {
++    public @NotNull java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull Relative> getRelativeTeleportationFlags() {
 +        return super.getRelativeTeleportationFlags();
 +    }
 +    // Paper end

--- a/patches/server/0867-More-Teleport-API.patch
+++ b/patches/server/0867-More-Teleport-API.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] More Teleport API
 public net.minecraft.server.network.ServerGamePacketListenerImpl internalTeleport(DDDFFLjava/util/Set;Z)V
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 5f2ca04a299b61f2cce8a4dfd060485e05153650..c1041c3832c73728cbb146815ca3c03b3ba41dc4 100644
+index 5f2ca04a299b61f2cce8a4dfd060485e05153650..886f10337fbae020f75c58fb0bb82f8f262b4db6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1718,11 +1718,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -16,7 +16,7 @@ index 5f2ca04a299b61f2cce8a4dfd060485e05153650..c1041c3832c73728cbb146815ca3c03b
  
 -        PlayerTeleportEvent event = new PlayerTeleportEvent(player, from.clone(), to.clone(), cause);
 +        // Paper start - Teleport API
-+        Set<io.papermc.paper.entity.RelativeTeleportFlag> relativeFlags = java.util.EnumSet.noneOf(io.papermc.paper.entity.RelativeTeleportFlag.class);
++        Set<io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag> relativeFlags = java.util.EnumSet.noneOf(io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.class);
 +        for (net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument relativeArgument : set) {
 +            relativeFlags.add(org.bukkit.craftbukkit.entity.CraftPlayer.toApiRelativeFlag(relativeArgument));
 +        }
@@ -31,25 +31,28 @@ index 5f2ca04a299b61f2cce8a4dfd060485e05153650..c1041c3832c73728cbb146815ca3c03b
              d0 = to.getX();
              d1 = to.getY();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 32b9816283c8c1de929d5664733553277cf6bf3c..32c724060a532e551f0ab4e7277831bb6bf61de3 100644
+index 32b9816283c8c1de929d5664733553277cf6bf3c..4ad29426a638d16aa76b2d2239f09d46a72bf2c8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -550,15 +550,33 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -550,15 +550,36 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
  
      @Override
      public boolean teleport(Location location, TeleportCause cause) {
 +        // Paper start - Teleport passenger API
-+        return teleport(location, cause, false);
++        return teleport(location, cause, new io.papermc.paper.entity.TeleportFlag[0]);
 +    }
 +
 +    @Override
-+    public boolean teleport(Location location, TeleportCause cause, boolean ignorePassengers, boolean dismount) {
++    public boolean teleport(Location location, TeleportCause cause, io.papermc.paper.entity.TeleportFlag... flags) {
 +        // Paper end
          Preconditions.checkArgument(location != null, "location cannot be null");
          location.checkFinite();
 +        // Paper start - Teleport passenger API
++        Set<io.papermc.paper.entity.TeleportFlag> flagSet = Set.of(flags);
++        boolean dismount = !flagSet.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_DISMOUNT);
++        boolean ignorePassengers = flagSet.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_PASSENGERS);
 +        // Don't allow teleporting between worlds while keeping passengers
-+        if (ignorePassengers && this.entity.isVehicle() && location.getWorld() != this.getWorld()) {
++        if (flagSet.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_PASSENGERS) && this.entity.isVehicle() && location.getWorld() != this.getWorld()) {
 +            return false;
 +        }
 +
@@ -71,10 +74,10 @@ index 32b9816283c8c1de929d5664733553277cf6bf3c..32c724060a532e551f0ab4e7277831bb
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..ddafba3daa668281134ec348c6fda48cfab1a007 100644
+index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..eadfac2e099ed28ce2a8f84ecd83d07f235934d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1198,13 +1198,92 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1198,13 +1198,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setRotation(float yaw, float pitch) {
@@ -93,12 +96,7 @@ index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..ddafba3daa668281134ec348c6fda48c
      @Override
      public boolean teleport(Location location, PlayerTeleportEvent.TeleportCause cause) {
 +        // Paper start - Teleport API
-+        return this.teleport(location, cause, false);
-+    }
-+
-+    @Override
-+    public boolean teleport(Location location, PlayerTeleportEvent.TeleportCause cause, boolean ignorePassengers, boolean dismount) {
-+        return this.teleport(location, cause, ignorePassengers, dismount, new io.papermc.paper.entity.RelativeTeleportFlag[0]);
++        return this.teleport(location, cause, new io.papermc.paper.entity.TeleportFlag[0]);
 +    }
 +
 +    @Override
@@ -125,7 +123,7 @@ index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..ddafba3daa668281134ec348c6fda48c
 +        };
 +    }
 +
-+    public static net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument toNmsRelativeFlag(io.papermc.paper.entity.RelativeTeleportFlag apiFlag) {
++    public static net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument toNmsRelativeFlag(io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag apiFlag) {
 +        return switch (apiFlag) {
 +            case X -> net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument.X;
 +            case Y -> net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument.Y;
@@ -135,22 +133,35 @@ index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..ddafba3daa668281134ec348c6fda48c
 +        };
 +    }
 +
-+    public static io.papermc.paper.entity.RelativeTeleportFlag toApiRelativeFlag(net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument nmsFlag) {
++    public static io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag toApiRelativeFlag(net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument nmsFlag) {
 +        return switch (nmsFlag) {
-+            case X -> io.papermc.paper.entity.RelativeTeleportFlag.X;
-+            case Y -> io.papermc.paper.entity.RelativeTeleportFlag.Y;
-+            case Z -> io.papermc.paper.entity.RelativeTeleportFlag.Z;
-+            case X_ROT -> io.papermc.paper.entity.RelativeTeleportFlag.PITCH;
-+            case Y_ROT -> io.papermc.paper.entity.RelativeTeleportFlag.YAW;
++            case X -> io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.X;
++            case Y -> io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.Y;
++            case Z -> io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.Z;
++            case X_ROT -> io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.PITCH;
++            case Y_ROT -> io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.YAW;
 +        };
 +    }
 +
 +    @Override
-+    public boolean teleport(Location location, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause, boolean ignorePassengers, boolean dismount, io.papermc.paper.entity.RelativeTeleportFlag... flags) {
-+        var relativeArguments = java.util.EnumSet.noneOf(net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument.class);
-+        for (io.papermc.paper.entity.RelativeTeleportFlag flag : flags) {
-+            relativeArguments.add(toNmsRelativeFlag(flag));
++    public boolean teleport(Location location, org.bukkit.event.player.PlayerTeleportEvent.TeleportCause cause, io.papermc.paper.entity.TeleportFlag... flags) {
++        java.util.Set<net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument> relativeArguments;
++        java.util.Set<io.papermc.paper.entity.TeleportFlag> allFlags;
++        if (flags.length == 0) {
++            relativeArguments = Set.of();
++            allFlags = Set.of();
++        } else {
++            relativeArguments = java.util.EnumSet.noneOf(net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument.class);
++            allFlags = new HashSet<>();
++            for (io.papermc.paper.entity.TeleportFlag flag : flags) {
++                if (flag instanceof io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag relativeTeleportFlag) {
++                    relativeArguments.add(toNmsRelativeFlag(relativeTeleportFlag));
++                }
++                allFlags.add(flag);
++            }
 +        }
++        boolean dismount = !allFlags.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_DISMOUNT);
++        boolean ignorePassengers = allFlags.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_PASSENGERS);
 +        // Paper end - Teleport API
          Preconditions.checkArgument(location != null, "location");
          Preconditions.checkArgument(location.getWorld() != null, "location.world");
@@ -168,7 +179,7 @@ index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..ddafba3daa668281134ec348c6fda48c
          location.checkFinite();
  
          ServerPlayer entity = this.getHandle();
-@@ -1217,7 +1296,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1217,7 +1304,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
             return false;
          }
  
@@ -177,7 +188,7 @@ index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..ddafba3daa668281134ec348c6fda48c
              return false;
          }
  
-@@ -1235,7 +1314,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1235,7 +1322,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          // If this player is riding another entity, we must dismount before teleporting.
@@ -186,7 +197,14 @@ index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..ddafba3daa668281134ec348c6fda48c
  
          // SPIGOT-5509: Wakeup, similar to riding
          if (this.isSleeping()) {
-@@ -1257,7 +1336,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1251,13 +1338,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         ServerLevel toWorld = ((CraftWorld) to.getWorld()).getHandle();
+ 
+         // Close any foreign inventory
+-        if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {
++        if (this.getHandle().containerMenu != this.getHandle().inventoryMenu && !allFlags.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_OPEN_INVENTORY)) { // Paper
+             this.getHandle().closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.TELEPORT); // Paper
+         }
  
          // Check if the fromWorld and toWorld are the same.
          if (fromWorld == toWorld) {

--- a/patches/server/0867-More-Teleport-API.patch
+++ b/patches/server/0867-More-Teleport-API.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] More Teleport API
 public net.minecraft.server.network.ServerGamePacketListenerImpl internalTeleport(DDDFFLjava/util/Set;Z)V
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 5f2ca04a299b61f2cce8a4dfd060485e05153650..886f10337fbae020f75c58fb0bb82f8f262b4db6 100644
+index 5f2ca04a299b61f2cce8a4dfd060485e05153650..28a2ccb8da1c448873802e1056a08f34a8e27e68 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1718,11 +1718,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -16,7 +16,7 @@ index 5f2ca04a299b61f2cce8a4dfd060485e05153650..886f10337fbae020f75c58fb0bb82f8f
  
 -        PlayerTeleportEvent event = new PlayerTeleportEvent(player, from.clone(), to.clone(), cause);
 +        // Paper start - Teleport API
-+        Set<io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag> relativeFlags = java.util.EnumSet.noneOf(io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.class);
++        Set<io.papermc.paper.entity.TeleportFlag.Relative> relativeFlags = java.util.EnumSet.noneOf(io.papermc.paper.entity.TeleportFlag.Relative.class);
 +        for (net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument relativeArgument : set) {
 +            relativeFlags.add(org.bukkit.craftbukkit.entity.CraftPlayer.toApiRelativeFlag(relativeArgument));
 +        }
@@ -31,7 +31,7 @@ index 5f2ca04a299b61f2cce8a4dfd060485e05153650..886f10337fbae020f75c58fb0bb82f8f
              d0 = to.getX();
              d1 = to.getY();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 32b9816283c8c1de929d5664733553277cf6bf3c..4ad29426a638d16aa76b2d2239f09d46a72bf2c8 100644
+index 32b9816283c8c1de929d5664733553277cf6bf3c..13dbac3b3aa7d67320203b64eaa130925ba0fbbf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -550,15 +550,36 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -49,10 +49,10 @@ index 32b9816283c8c1de929d5664733553277cf6bf3c..4ad29426a638d16aa76b2d2239f09d46
          location.checkFinite();
 +        // Paper start - Teleport passenger API
 +        Set<io.papermc.paper.entity.TeleportFlag> flagSet = Set.of(flags);
-+        boolean dismount = !flagSet.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_DISMOUNT);
-+        boolean ignorePassengers = flagSet.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_PASSENGERS);
++        boolean dismount = !flagSet.contains(io.papermc.paper.entity.TeleportFlag.EntityState.RETAIN_VEHICLE);
++        boolean ignorePassengers = flagSet.contains(io.papermc.paper.entity.TeleportFlag.EntityState.RETAIN_PASSENGERS);
 +        // Don't allow teleporting between worlds while keeping passengers
-+        if (flagSet.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_PASSENGERS) && this.entity.isVehicle() && location.getWorld() != this.getWorld()) {
++        if (flagSet.contains(io.papermc.paper.entity.TeleportFlag.EntityState.RETAIN_PASSENGERS) && this.entity.isVehicle() && location.getWorld() != this.getWorld()) {
 +            return false;
 +        }
 +
@@ -74,7 +74,7 @@ index 32b9816283c8c1de929d5664733553277cf6bf3c..4ad29426a638d16aa76b2d2239f09d46
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..eadfac2e099ed28ce2a8f84ecd83d07f235934d3 100644
+index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..8c1c3f7203eb2c30f2d2e909799071c31e234db7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1198,13 +1198,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -123,7 +123,7 @@ index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..eadfac2e099ed28ce2a8f84ecd83d07f
 +        };
 +    }
 +
-+    public static net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument toNmsRelativeFlag(io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag apiFlag) {
++    public static net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument toNmsRelativeFlag(io.papermc.paper.entity.TeleportFlag.Relative apiFlag) {
 +        return switch (apiFlag) {
 +            case X -> net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument.X;
 +            case Y -> net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument.Y;
@@ -133,13 +133,13 @@ index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..eadfac2e099ed28ce2a8f84ecd83d07f
 +        };
 +    }
 +
-+    public static io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag toApiRelativeFlag(net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument nmsFlag) {
++    public static io.papermc.paper.entity.TeleportFlag.Relative toApiRelativeFlag(net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument nmsFlag) {
 +        return switch (nmsFlag) {
-+            case X -> io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.X;
-+            case Y -> io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.Y;
-+            case Z -> io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.Z;
-+            case X_ROT -> io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.PITCH;
-+            case Y_ROT -> io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag.YAW;
++            case X -> io.papermc.paper.entity.TeleportFlag.Relative.X;
++            case Y -> io.papermc.paper.entity.TeleportFlag.Relative.Y;
++            case Z -> io.papermc.paper.entity.TeleportFlag.Relative.Z;
++            case X_ROT -> io.papermc.paper.entity.TeleportFlag.Relative.PITCH;
++            case Y_ROT -> io.papermc.paper.entity.TeleportFlag.Relative.YAW;
 +        };
 +    }
 +
@@ -154,14 +154,14 @@ index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..eadfac2e099ed28ce2a8f84ecd83d07f
 +            relativeArguments = java.util.EnumSet.noneOf(net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket.RelativeArgument.class);
 +            allFlags = new HashSet<>();
 +            for (io.papermc.paper.entity.TeleportFlag flag : flags) {
-+                if (flag instanceof io.papermc.paper.entity.TeleportFlag.RelativeTeleportFlag relativeTeleportFlag) {
++                if (flag instanceof io.papermc.paper.entity.TeleportFlag.Relative relativeTeleportFlag) {
 +                    relativeArguments.add(toNmsRelativeFlag(relativeTeleportFlag));
 +                }
 +                allFlags.add(flag);
 +            }
 +        }
-+        boolean dismount = !allFlags.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_DISMOUNT);
-+        boolean ignorePassengers = allFlags.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_PASSENGERS);
++        boolean dismount = !allFlags.contains(io.papermc.paper.entity.TeleportFlag.EntityState.RETAIN_VEHICLE);
++        boolean ignorePassengers = allFlags.contains(io.papermc.paper.entity.TeleportFlag.EntityState.RETAIN_PASSENGERS);
 +        // Paper end - Teleport API
          Preconditions.checkArgument(location != null, "location");
          Preconditions.checkArgument(location.getWorld() != null, "location.world");
@@ -202,7 +202,7 @@ index 118a671cdeee8c5fd051192b7b72ad63f79e7eca..eadfac2e099ed28ce2a8f84ecd83d07f
  
          // Close any foreign inventory
 -        if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {
-+        if (this.getHandle().containerMenu != this.getHandle().inventoryMenu && !allFlags.contains(io.papermc.paper.entity.TeleportFlag.EntityStateFlag.IGNORE_OPEN_INVENTORY)) { // Paper
++        if (this.getHandle().containerMenu != this.getHandle().inventoryMenu && !allFlags.contains(io.papermc.paper.entity.TeleportFlag.EntityState.RETAIN_OPEN_INVENTORY)) { // Paper
              this.getHandle().closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.TELEPORT); // Paper
          }
  

--- a/patches/server/0874-Collision-API.patch
+++ b/patches/server/0874-Collision-API.patch
@@ -22,10 +22,10 @@ index 446657577aa843e6ebc5143b6c511f33d27b6360..d99f079e03d0541d7aa3c70d9e8c12b8
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 32c724060a532e551f0ab4e7277831bb6bf61de3..6cd6cb256bde958416a0e4b13fc1d3df74f230fd 100644
+index 4ad29426a638d16aa76b2d2239f09d46a72bf2c8..3145a5cba793d94ca649eb99dd6b69bed5bb759c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1377,4 +1377,19 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1380,4 +1380,19 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return getHandle().isInPowderSnow || getHandle().wasInPowderSnow; // depending on the location in the entity "tick" either could be needed.
      }
      // Paper end

--- a/patches/server/0905-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0905-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6d1309e811e299984823caab24325fa6970dee57..c932bc990dce99c8ce2eaf8563d0ae7859124795 100644
+index 919a31cbce5973c2beea4be6112ec677f68d6990..4bc30ce25c300bf5d2ae2b6388bdc601e0f8441d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3019,6 +3019,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3027,6 +3027,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0922-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0922-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c932bc990dce99c8ce2eaf8563d0ae7859124795..18c2c1454f8f3319b2a0b7649b99d25933cc18a6 100644
+index 4bc30ce25c300bf5d2ae2b6388bdc601e0f8441d..8d68aff5cb1b029e9bf7e86d2a48b0642268dec3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3024,6 +3024,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3032,6 +3032,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0944-Add-Sneaking-API-for-Entities.patch
+++ b/patches/server/0944-Add-Sneaking-API-for-Entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Sneaking API for Entities
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 6cd6cb256bde958416a0e4b13fc1d3df74f230fd..78f53ee557276de85f0431ebcb146445b1f4fb92 100644
+index 3145a5cba793d94ca649eb99dd6b69bed5bb759c..b5e5b3c88820a571f4feb439b1e4ebf7dd22555b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1160,6 +1160,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1163,6 +1163,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return Pose.values()[this.getHandle().getPose().ordinal()];
      }
  

--- a/patches/server/0950-Flying-Fall-Damage.patch
+++ b/patches/server/0950-Flying-Fall-Damage.patch
@@ -26,10 +26,10 @@ index 875a7d2b2ecd75a51af7d158b7acee358b5082fe..1116116e4ba6c5ecec400cd371b70b9e
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ab11ed9d587b633f0f86f13dcb63adac63c3ff78..b1d01555cb919edd16d46df28d6b09661317b233 100644
+index ce51bdb40348f00b57c28b515f447ba25e2ef315..533d1776de24b49c47a1a89eb5f4e5ade5592115 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2186,6 +2186,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2194,6 +2194,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().onUpdateAbilities();
      }
  


### PR DESCRIPTION
Abstracts relative teleport flags and instead makes a generic TeleportFlag option. This has the benefit of being able to easily add new flags in the future.

This adds a new flag, which allows you to keep inventories open when teleporting players (vanilla behavior). 

These are breaking changes to the teleport api, however, it's still marked as experimental so I find this a fair change. 