### PR TITLE
[ci skip] Update paperweight to 1.5.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     java
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "7.1.2" apply false
-    id("io.papermc.paperweight.core") version "1.4.1"
+    id("io.papermc.paperweight.core") version "1.5.1"
 }
 
 allprojects {


### PR DESCRIPTION
Didn't remove the paper repo from settings to make it easier to use snapshots when updating for a new MC version