### PR TITLE
Update the flag when a captured block state is outdated

### DIFF
--- a/patches/server/0962-Update-the-flag-when-a-captured-block-state-is-outda.patch
+++ b/patches/server/0962-Update-the-flag-when-a-captured-block-state-is-outda.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com>
+Date: Sat, 18 Feb 2023 16:23:18 +0100
+Subject: [PATCH] Update the flag when a captured block state is outdated
+
+
+diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
+index 3cbf801b2e5420c0e870f73788deb550e49ad54d..0454a9cfb60f17abba516cc2480ef31a95fada90 100644
+--- a/src/main/java/net/minecraft/world/level/Level.java
++++ b/src/main/java/net/minecraft/world/level/Level.java
+@@ -525,6 +525,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+                 blockstate = CapturedBlockState.getTreeBlockState(this, pos, flags);
+                 this.capturedBlockStates.put(pos.immutable(), blockstate);
+             }
++            blockstate.setFlag(flags); // Paper - update the flag also
+             blockstate.setData(state);
+             return true;
+         }


### PR DESCRIPTION
When a tree grows there's multiple update that happens in the same position but since the captured block state list doesn't support that it just override the last one with the new one but without updating the update flag.
Closes https://github.com/PaperMC/Paper/issues/8858