### PR TITLE
Configure mokitor Server mock as stubOnly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,8 +38,6 @@ subprojects {
             exceptionFormat = TestExceptionFormat.FULL
             events(TestLogEvent.STANDARD_OUT)
         }
-        minHeapSize = "2g"
-        maxHeapSize = "4g"
     }
 
     repositories {

--- a/patches/server/0004-Test-changes.patch
+++ b/patches/server/0004-Test-changes.patch
@@ -18,7 +18,7 @@ index 064a0c5b2a4b379ceec84652ff1e004d57419115..218a0db30ac8e4403da4ee50ca0a67ca
      runtimeOnly("mysql:mysql-connector-java:8.0.29")
 diff --git a/src/test/java/io/papermc/paper/testing/DummyServer.java b/src/test/java/io/papermc/paper/testing/DummyServer.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..286790061c9d81c872108ef63e1a1aba2fbec809
+index 0000000000000000000000000000000000000000..356c1610cc941c5e5ed188a8f900346e510aaf62
 --- /dev/null
 +++ b/src/test/java/io/papermc/paper/testing/DummyServer.java
 @@ -0,0 +1,66 @@
@@ -52,7 +52,7 @@ index 0000000000000000000000000000000000000000..286790061c9d81c872108ef63e1a1aba
 +            return;
 +        }
 +
-+        final Server dummyServer = mock(Server.class);
++        final Server dummyServer = mock(Server.class, org.mockito.Mockito.withSettings().stubOnly());
 +
 +        final Logger logger = Logger.getLogger(DummyServer.class.getCanonicalName());
 +        when(dummyServer.getLogger()).thenReturn(logger);

--- a/patches/server/0004-Test-changes.patch
+++ b/patches/server/0004-Test-changes.patch
@@ -18,10 +18,10 @@ index 064a0c5b2a4b379ceec84652ff1e004d57419115..218a0db30ac8e4403da4ee50ca0a67ca
      runtimeOnly("mysql:mysql-connector-java:8.0.29")
 diff --git a/src/test/java/io/papermc/paper/testing/DummyServer.java b/src/test/java/io/papermc/paper/testing/DummyServer.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..356c1610cc941c5e5ed188a8f900346e510aaf62
+index 0000000000000000000000000000000000000000..c6503ff76f56bab5f383f0ca17d137155e9be447
 --- /dev/null
 +++ b/src/test/java/io/papermc/paper/testing/DummyServer.java
-@@ -0,0 +1,66 @@
+@@ -0,0 +1,67 @@
 +package io.papermc.paper.testing;
 +
 +import java.util.logging.Logger;
@@ -38,6 +38,7 @@ index 0000000000000000000000000000000000000000..356c1610cc941c5e5ed188a8f900346e
 +import org.bukkit.plugin.PluginManager;
 +import org.bukkit.plugin.SimplePluginManager;
 +import org.bukkit.support.AbstractTestingBase;
++import org.mockito.Mockito;
 +
 +import static org.mockito.Mockito.any;
 +import static org.mockito.Mockito.mock;
@@ -52,7 +53,7 @@ index 0000000000000000000000000000000000000000..356c1610cc941c5e5ed188a8f900346e
 +            return;
 +        }
 +
-+        final Server dummyServer = mock(Server.class, org.mockito.Mockito.withSettings().stubOnly());
++        final Server dummyServer = mock(Server.class, Mockito.withSettings().stubOnly());
 +
 +        final Logger logger = Logger.getLogger(DummyServer.class.getCanonicalName());
 +        when(dummyServer.getLogger()).thenReturn(logger);

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -7161,10 +7161,10 @@ index 0000000000000000000000000000000000000000..ba271c35eb2804f94cfc893bf94affb9
 +    }
 +}
 diff --git a/src/test/java/io/papermc/paper/testing/DummyServer.java b/src/test/java/io/papermc/paper/testing/DummyServer.java
-index 286790061c9d81c872108ef63e1a1aba2fbec809..53ac8df47a2c9a84c751955fd4fbb352a3ded16b 100644
+index c6503ff76f56bab5f383f0ca17d137155e9be447..f3db8d2875eaef86223da51b30e9dd722d417daa 100644
 --- a/src/test/java/io/papermc/paper/testing/DummyServer.java
 +++ b/src/test/java/io/papermc/paper/testing/DummyServer.java
-@@ -57,7 +57,7 @@ public final class DummyServer {
+@@ -58,7 +58,7 @@ public final class DummyServer {
              return new LazyRegistry(() -> CraftRegistry.createRegistry(invocation.getArgument(0, Class.class), AbstractTestingBase.REGISTRY_CUSTOM));
          });
  


### PR DESCRIPTION
A recent patch moved the internal unit tests to mokito, allowing deep mocking to easily setup a mocked server instance. While this change is useful, the server's Server#getItemFactory methods is one of the hottest paths during unit testing, being called numerous times by material tests.
As mokito mocks keep track of each invocation to allow for verifications of invocations down the line, the server mock allocates a huge amount of memory to keep track of all invocations, ultimately leading to an OOM exception.

The previous solution solved this by increasing the tests memory to 2 GB, however as of right now simply configuring the server mock as "stubOnly", properly prevents the overflow of invocation records as none of the unit test code relies on invocation verification.