### PR TITLE
Fix fox drops on death

### DIFF
--- a/patches/server/0246-Improve-death-events.patch
+++ b/patches/server/0246-Improve-death-events.patch
@@ -234,10 +234,31 @@ index 9e0555b1e98bba6a9305c3996c69347e47d73204..bd70046b4fef307b6b8b626a65f0b4a3
      // CraftBukkit start
      public int getExpReward() {
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 4ae0f36276592e37aeb5f881b713efa76d086f8e..c4b05c7e339a2ec01ee3f5e4dec0b3493788d8d2 100644
+index 4ae0f36276592e37aeb5f881b713efa76d086f8e..236b10b86cdf6e0a723d8c9f199dde9cc983198e 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1075,7 +1075,13 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1057,6 +1057,12 @@ public abstract class Mob extends LivingEntity implements Targeting {
+ 
+     }
+ 
++    // Paper start
++    protected boolean shouldSkipLoot(EquipmentSlot slot) { // method to avoid to fallback into the global mob loot logic (i.e fox)
++        return false;
++    }
++    // Paper end
++
+     @Override
+     protected void dropCustomDeathLoot(DamageSource source, int lootingMultiplier, boolean allowDrops) {
+         super.dropCustomDeathLoot(source, lootingMultiplier, allowDrops);
+@@ -1065,6 +1071,7 @@ public abstract class Mob extends LivingEntity implements Targeting {
+ 
+         for (int k = 0; k < j; ++k) {
+             EquipmentSlot enumitemslot = aenumitemslot[k];
++            if (this.shouldSkipLoot(enumitemslot)) continue; // Paper
+             ItemStack itemstack = this.getItemBySlot(enumitemslot);
+             float f = this.getEquipmentDropChance(enumitemslot);
+             boolean flag1 = f > 1.0F;
+@@ -1075,7 +1082,13 @@ public abstract class Mob extends LivingEntity implements Targeting {
                  }
  
                  this.spawnAtLocation(itemstack);
@@ -252,18 +273,32 @@ index 4ae0f36276592e37aeb5f881b713efa76d086f8e..c4b05c7e339a2ec01ee3f5e4dec0b349
          }
  
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Fox.java b/src/main/java/net/minecraft/world/entity/animal/Fox.java
-index 8670d8b2a08e96df787a91f36c48df8b345080dc..6124209f50300eeaab45b66c2f1a5b2944119450 100644
+index 8670d8b2a08e96df787a91f36c48df8b345080dc..950e4b476a03fb5c26351a3b4d1578975a0b0ea8 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Fox.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Fox.java
-@@ -712,15 +712,25 @@ public class Fox extends Animal implements VariantHolder<Fox.Type> {
+@@ -711,16 +711,38 @@ public class Fox extends Animal implements VariantHolder<Fox.Type> {
+         return this.getTrustedUUIDs().contains(uuid);
      }
  
++    // Paper start - handle the bitten item separately like vanilla
      @Override
 -    protected void dropAllDeathLoot(DamageSource source) {
--        ItemStack itemstack = this.getItemBySlot(EquipmentSlot.MAINHAND);
++    protected boolean shouldSkipLoot(EquipmentSlot slot) {
++        return slot == EquipmentSlot.MAINHAND;
++    }
++    // Paper end
++
++    @Override
 +    // Paper start - Cancellable death event
 +    protected org.bukkit.event.entity.EntityDeathEvent dropAllDeathLoot(DamageSource source) {
-+        ItemStack itemstack = this.getItemBySlot(EquipmentSlot.MAINHAND).copy(); // Paper - modified by supercall
+         ItemStack itemstack = this.getItemBySlot(EquipmentSlot.MAINHAND);
+ 
+-        if (!itemstack.isEmpty()) {
++        boolean releaseMouth = false;
++        if (!itemstack.isEmpty() && this.level().getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) { // Fix MC-153010
+             this.spawnAtLocation(itemstack);
++            releaseMouth = true;
++        }
 +
 +        org.bukkit.event.entity.EntityDeathEvent deathEvent = super.dropAllDeathLoot(source);
 +
@@ -272,15 +307,14 @@ index 8670d8b2a08e96df787a91f36c48df8b345080dc..6124209f50300eeaab45b66c2f1a5b29
 +        if (deathEvent == null || deathEvent.isCancelled()) {
 +            return deathEvent;
 +        }
-+        // Paper end
- 
-         if (!itemstack.isEmpty()) {
-             this.spawnAtLocation(itemstack);
++
++        if (releaseMouth) {
++            // Paper end - Cancellable death event
              this.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
          }
  
 -        super.dropAllDeathLoot(source);
-+        return deathEvent; // Paper
++        return deathEvent; // Paper - Cancellable death event
      }
  
      @Override

--- a/patches/server/0508-Expand-EntityUnleashEvent.patch
+++ b/patches/server/0508-Expand-EntityUnleashEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expand EntityUnleashEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index c4b05c7e339a2ec01ee3f5e4dec0b3493788d8d2..8cc40521146d02bbfafbb113dda8183840814c96 100644
+index 236b10b86cdf6e0a723d8c9f199dde9cc983198e..a05914c6d86ad898d03641b6e8a44f7a1f1161dd 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1292,12 +1292,15 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1299,12 +1299,15 @@ public abstract class Mob extends LivingEntity implements Targeting {
              return InteractionResult.PASS;
          } else if (this.getLeashHolder() == player) {
              // CraftBukkit start - fire PlayerUnleashEntityEvent
@@ -26,7 +26,7 @@ index c4b05c7e339a2ec01ee3f5e4dec0b3493788d8d2..8cc40521146d02bbfafbb113dda81838
              this.gameEvent(GameEvent.ENTITY_INTERACT, player);
              return InteractionResult.sidedSuccess(this.level().isClientSide);
          } else {
-@@ -1465,8 +1468,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1472,8 +1475,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
  
          if (this.leashHolder != null) {
              if (!this.isAlive() || !this.leashHolder.isAlive()) {
@@ -40,7 +40,7 @@ index c4b05c7e339a2ec01ee3f5e4dec0b3493788d8d2..8cc40521146d02bbfafbb113dda81838
              }
  
          }
-@@ -1529,8 +1535,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1536,8 +1542,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
          boolean flag1 = super.startRiding(entity, force);
  
          if (flag1 && this.isLeashed()) {
@@ -54,7 +54,7 @@ index c4b05c7e339a2ec01ee3f5e4dec0b3493788d8d2..8cc40521146d02bbfafbb113dda81838
          }
  
          return flag1;
-@@ -1720,8 +1729,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1727,8 +1736,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
      @Override
      protected void removeAfterChangingDimensions() {
          super.removeAfterChangingDimensions();
@@ -122,7 +122,7 @@ index 16784fcc853e23689a854e7dc6c03ed8182a164e..006aba8bbb34a0d45ef626a1d299e819
                              flag1 = true;
                          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1e45ca6c042fe86785ac36645e1ce2f5a85a8d23..54b0e6e6c21c02bd6a2a702f6b6416d573f62f9c 100644
+index 456c1df6b5956b521e8f379b9020ed53f66a365b..7763486f60057ae88649c2692908b4d1cfdac6ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1637,8 +1637,10 @@ public class CraftEventFactory {

--- a/patches/server/0983-Add-PlayerShieldDisableEvent.patch
+++ b/patches/server/0983-Add-PlayerShieldDisableEvent.patch
@@ -16,10 +16,10 @@ sideeffects, meaning the disable event cannot share a handlerlist with
 the cooldown event
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 433d8eccdd225651af8c88babfdb94d19ce546d8..026654c4d3a910f0dbfed5475f23137086618242 100644
+index a1ccd300791ccb3f1ef47b771e4fe33542039fea..7c5d7856a7982f0b3cad21f2cb8dde8569d2ec28 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1690,7 +1690,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1697,7 +1697,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
              float f = 0.25F + (float) EnchantmentHelper.getBlockEfficiency(this) * 0.05F;
  
              if (this.random.nextFloat() < f) {


### PR DESCRIPTION
When a fox died the item in its mouth doesn't have a 100% chance to drops and can even be damaged using the summon command (and having a great luck). This is due to them relying on the generic mob logic before the fox loot.
Also closes MC-153010