### PR TITLE
Fix chat messages logged in console

### DIFF
--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2362,7 +2362,7 @@ index be097f13dba5d408f58d6fada893bed2638d4219..3d7d1ba148dbc3591d8c76b99a2ee7d9
  
                  @Override
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 25227822aa0e1dd7fbbe98a0925ccd023af8d0dc..8c1937ff71b8b4dad85e20b55dcf2a0cc06ce2df 100644
+index 25227822aa0e1dd7fbbe98a0925ccd023af8d0dc..dfd2f3ba256edc64e0016e7816ccefff9e7b1b7a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -8,6 +8,7 @@ import com.mojang.logging.LogUtils;
@@ -2500,7 +2500,7 @@ index 25227822aa0e1dd7fbbe98a0925ccd023af8d0dc..8c1937ff71b8b4dad85e20b55dcf2a0c
          boolean flag = this.verifyChatTrusted(message);
  
 -        this.server.logChatMessage(message.decoratedContent(), params, flag ? null : "Not Secure");
-+        this.server.logChatMessage((unsignedFunction == null ? Component.literal(message.signedContent()) : unsignedFunction.apply(this.server.console)), params, flag ? null : "Not Secure"); // Paper
++        this.server.logChatMessage((unsignedFunction == null ? message.decoratedContent() : unsignedFunction.apply(this.server.console)), params, flag ? null : "Not Secure"); // Paper
          OutgoingChatMessage outgoingchatmessage = OutgoingChatMessage.create(message);
          boolean flag1 = false;
  


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/8863

It should use the decoratedContent. In the ChatProcessor it uses the decoratedContent currently if the viewer list changes, this should too.