### PR TITLE
/paper entity list QOL improvements

### DIFF
--- a/patches/server/0011-Paper-command.patch
+++ b/patches/server/0011-Paper-command.patch
@@ -287,10 +287,10 @@ index 0000000000000000000000000000000000000000..6ff5d42a866d2752c73a766815aa190b
 +}
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..94366dbc8d1fb67285314c41cc5650e3f0802df7
+index 0000000000000000000000000000000000000000..ec421bb7a9d7de58688c0710a282b488ca836cf5
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
-@@ -0,0 +1,152 @@
+@@ -0,0 +1,158 @@
 +package io.papermc.paper.command.subcommands;
 +
 +import com.google.common.collect.Maps;
@@ -302,6 +302,10 @@ index 0000000000000000000000000000000000000000..94366dbc8d1fb67285314c41cc5650e3
 +import java.util.Map;
 +import java.util.Set;
 +import java.util.stream.Collectors;
++
++import net.kyori.adventure.text.Component;
++import net.kyori.adventure.text.event.ClickEvent;
++import net.kyori.adventure.text.event.HoverEvent;
 +import net.minecraft.core.registries.BuiltInRegistries;
 +import net.minecraft.resources.ResourceLocation;
 +import net.minecraft.server.level.ServerChunkCache;
@@ -311,6 +315,7 @@ index 0000000000000000000000000000000000000000..94366dbc8d1fb67285314c41cc5650e3
 +import org.apache.commons.lang3.tuple.MutablePair;
 +import org.apache.commons.lang3.tuple.Pair;
 +import org.bukkit.Bukkit;
++import org.bukkit.HeightMap;
 +import org.bukkit.World;
 +import org.bukkit.command.CommandSender;
 +import org.bukkit.craftbukkit.CraftWorld;
@@ -320,6 +325,7 @@ index 0000000000000000000000000000000000000000..94366dbc8d1fb67285314c41cc5650e3
 +import org.checkerframework.framework.qual.DefaultQualifier;
 +
 +import static net.kyori.adventure.text.Component.text;
++import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
 +import static net.kyori.adventure.text.format.NamedTextColor.RED;
 +
 +@DefaultQualifier(NonNull.class)
@@ -414,9 +420,9 @@ index 0000000000000000000000000000000000000000..94366dbc8d1fb67285314c41cc5650e3
 +                    .limit(10).forEach(e -> {
 +                        final int x = e.getKey().x << 4;
 +                        final int z = e.getKey().z << 4;
-+                        final net.kyori.adventure.text.Component message = text("  " + e.getValue() + ": " + e.getKey().x + ", " + e.getKey().z + (chunkProviderServer.isPositionTicking(e.getKey().toLong()) ? " (Ticking)" : " (Non-Ticking)"))
-+                            .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(text("Click to teleport to chunk", net.kyori.adventure.text.format.NamedTextColor.GREEN)))
-+                            .clickEvent(net.kyori.adventure.text.event.ClickEvent.clickEvent(net.kyori.adventure.text.event.ClickEvent.Action.RUN_COMMAND, "/minecraft:execute as @s in " + world.getWorld().getKey().getKey() + " run tp " + x + " " + (world.getWorld().getHighestBlockYAt(x, z, org.bukkit.HeightMap.MOTION_BLOCKING) + 1) + " " + z));
++                        final Component message = text("  " + e.getValue() + ": " + e.getKey().x + ", " + e.getKey().z + (chunkProviderServer.isPositionTicking(e.getKey().toLong()) ? " (Ticking)" : " (Non-Ticking)"))
++                            .hoverEvent(HoverEvent.showText(text("Click to teleport to chunk", GREEN)))
++                            .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/minecraft:execute as @s in " + world.getWorld().getKey().getKey() + " run tp " + x + " " + (world.getWorld().getHighestBlockYAt(x, z, HeightMap.MOTION_BLOCKING) + 1) + " " + z));
 +                        sender.sendMessage(message);
 +                    });
 +            } else {

--- a/patches/server/0011-Paper-command.patch
+++ b/patches/server/0011-Paper-command.patch
@@ -287,7 +287,7 @@ index 0000000000000000000000000000000000000000..6ff5d42a866d2752c73a766815aa190b
 +}
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ec421bb7a9d7de58688c0710a282b488ca836cf5
+index 0000000000000000000000000000000000000000..46e22a4d4668eaa347320d20a21f22ad22a26412
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 @@ -0,0 +1,158 @@
@@ -418,8 +418,8 @@ index 0000000000000000000000000000000000000000..ec421bb7a9d7de58688c0710a282b488
 +                info.getRight().entrySet().stream()
 +                    .sorted((a, b) -> !a.getValue().equals(b.getValue()) ? b.getValue() - a.getValue() : a.getKey().toString().compareTo(b.getKey().toString()))
 +                    .limit(10).forEach(e -> {
-+                        final int x = e.getKey().x << 4;
-+                        final int z = e.getKey().z << 4;
++                        final int x = (e.getKey().x << 4) + 8;
++                        final int z = (e.getKey().z << 4) + 8;
 +                        final Component message = text("  " + e.getValue() + ": " + e.getKey().x + ", " + e.getKey().z + (chunkProviderServer.isPositionTicking(e.getKey().toLong()) ? " (Ticking)" : " (Non-Ticking)"))
 +                            .hoverEvent(HoverEvent.showText(text("Click to teleport to chunk", GREEN)))
 +                            .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/minecraft:execute as @s in " + world.getWorld().getKey().getKey() + " run tp " + x + " " + (world.getWorld().getHighestBlockYAt(x, z, HeightMap.MOTION_BLOCKING) + 1) + " " + z));

--- a/patches/server/0011-Paper-command.patch
+++ b/patches/server/0011-Paper-command.patch
@@ -287,7 +287,7 @@ index 0000000000000000000000000000000000000000..6ff5d42a866d2752c73a766815aa190b
 +}
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..46e22a4d4668eaa347320d20a21f22ad22a26412
+index 0000000000000000000000000000000000000000..ff99336e0b8131ae161cfa5c4fc83c6905e3dbc8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 @@ -0,0 +1,158 @@
@@ -422,7 +422,7 @@ index 0000000000000000000000000000000000000000..46e22a4d4668eaa347320d20a21f22ad
 +                        final int z = (e.getKey().z << 4) + 8;
 +                        final Component message = text("  " + e.getValue() + ": " + e.getKey().x + ", " + e.getKey().z + (chunkProviderServer.isPositionTicking(e.getKey().toLong()) ? " (Ticking)" : " (Non-Ticking)"))
 +                            .hoverEvent(HoverEvent.showText(text("Click to teleport to chunk", GREEN)))
-+                            .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/minecraft:execute as @s in " + world.getWorld().getKey().getKey() + " run tp " + x + " " + (world.getWorld().getHighestBlockYAt(x, z, HeightMap.MOTION_BLOCKING) + 1) + " " + z));
++                            .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/minecraft:execute as @s in " + world.getWorld().getKey() + " run tp " + x + " " + (world.getWorld().getHighestBlockYAt(x, z, HeightMap.MOTION_BLOCKING) + 1) + " " + z));
 +                        sender.sendMessage(message);
 +                    });
 +            } else {

--- a/patches/server/0011-Paper-command.patch
+++ b/patches/server/0011-Paper-command.patch
@@ -287,10 +287,10 @@ index 0000000000000000000000000000000000000000..6ff5d42a866d2752c73a766815aa190b
 +}
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9e51b3d1217ad6dc5c0c11d2febac7144e5721af
+index 0000000000000000000000000000000000000000..94366dbc8d1fb67285314c41cc5650e3f0802df7
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,152 @@
 +package io.papermc.paper.command.subcommands;
 +
 +import com.google.common.collect.Maps;
@@ -411,7 +411,14 @@ index 0000000000000000000000000000000000000000..9e51b3d1217ad6dc5c0c11d2febac714
 +                sender.sendMessage("Entity: " + name + " Total Ticking: " + (info.getLeft() - nonTicking) + ", Total Non-Ticking: " + nonTicking);
 +                info.getRight().entrySet().stream()
 +                    .sorted((a, b) -> !a.getValue().equals(b.getValue()) ? b.getValue() - a.getValue() : a.getKey().toString().compareTo(b.getKey().toString()))
-+                    .limit(10).forEach(e -> sender.sendMessage("  " + e.getValue() + ": " + e.getKey().x + ", " + e.getKey().z + (chunkProviderServer.isPositionTicking(e.getKey().toLong()) ? " (Ticking)" : " (Non-Ticking)")));
++                    .limit(10).forEach(e -> {
++                        final int x = e.getKey().x << 4;
++                        final int z = e.getKey().z << 4;
++                        final net.kyori.adventure.text.Component message = text("  " + e.getValue() + ": " + e.getKey().x + ", " + e.getKey().z + (chunkProviderServer.isPositionTicking(e.getKey().toLong()) ? " (Ticking)" : " (Non-Ticking)"))
++                            .hoverEvent(net.kyori.adventure.text.event.HoverEvent.showText(text("Click to teleport to chunk", net.kyori.adventure.text.format.NamedTextColor.GREEN)))
++                            .clickEvent(net.kyori.adventure.text.event.ClickEvent.clickEvent(net.kyori.adventure.text.event.ClickEvent.Action.RUN_COMMAND, "/minecraft:execute as @s in " + world.getWorld().getKey().getKey() + " run tp " + x + " " + (world.getWorld().getHighestBlockYAt(x, z, org.bukkit.HeightMap.MOTION_BLOCKING) + 1) + " " + z));
++                        sender.sendMessage(message);
++                    });
 +            } else {
 +                List<Pair<ResourceLocation, Integer>> info = list.entrySet().stream()
 +                    .filter(e -> names.contains(e.getKey()))

--- a/patches/server/0842-Don-t-tick-markers.patch
+++ b/patches/server/0842-Don-t-tick-markers.patch
@@ -9,10 +9,10 @@ list is only used in the tick and tickPassenger methods, so we can safely not ad
 markers to it.
 
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
-index 9e51b3d1217ad6dc5c0c11d2febac7144e5721af..a38a0c11c9e12aeff73d792368e1a69a856376d4 100644
+index ec421bb7a9d7de58688c0710a282b488ca836cf5..b500cc9b7e035ed90eaaab1277eba42488e329dd 100644
 --- a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 +++ b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
-@@ -103,7 +103,7 @@ public final class EntityCommand implements PaperSubcommand {
+@@ -109,7 +109,7 @@ public final class EntityCommand implements PaperSubcommand {
                  ChunkPos chunk = e.chunkPosition();
                  info.left++;
                  info.right.put(chunk, info.right.getOrDefault(chunk, 0) + 1);


### PR DESCRIPTION
On a different branch this time...

This PR implements a QOL feature to `/paper entity list <entity>` where it will allow a user to teleport to chunk.

https://user-images.githubusercontent.com/21014720/220211324-0173af64-363c-4bf9-a459-6785683ad19c.mp4