### PR TITLE
Properly re-add providers when reloading

### DIFF
--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -451,16 +451,18 @@ index 0000000000000000000000000000000000000000..4ecd00b32c7abc15d655dd3c999b6fec
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java b/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..21e43223d7942b0e5e3c6b63aa2c455ec17ffde9
+index 0000000000000000000000000000000000000000..f7e43c693140b7a820b2432db312df8f7b099d4d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java
-@@ -0,0 +1,131 @@
+@@ -0,0 +1,132 @@
 +package io.papermc.paper.plugin;
 +
 +import com.mojang.logging.LogUtils;
 +import io.papermc.paper.configuration.PaperConfigurations;
 +import io.papermc.paper.plugin.entrypoint.Entrypoint;
 +import io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler;
++import io.papermc.paper.plugin.provider.PluginProvider;
++import io.papermc.paper.plugin.provider.type.paper.PaperPluginParent;
 +import joptsimple.OptionSet;
 +import net.minecraft.server.dedicated.DedicatedServer;
 +import org.bukkit.configuration.file.YamlConfiguration;
@@ -578,13 +580,12 @@ index 0000000000000000000000000000000000000000..21e43223d7942b0e5e3c6b63aa2c455e
 +        }
 +
 +        if (hasPaperPlugin) {
-+            LOGGER.error("======== WARNING ========");
-+            LOGGER.error("You are reloading while having Paper plugins installed on your server.");
-+            LOGGER.error("Paper plugins do NOT support being reloaded. This will cause some unexpected issues.");
-+            LOGGER.error("=========================");
++            LOGGER.warn("======== WARNING ========");
++            LOGGER.warn("You are reloading while having Paper plugins installed on your server.");
++            LOGGER.warn("Paper plugins do NOT support being reloaded. This will cause some unexpected issues.");
++            LOGGER.warn("=========================");
 +        }
 +    }
-+
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/bootstrap/PluginProviderContextImpl.java b/src/main/java/io/papermc/paper/plugin/bootstrap/PluginProviderContextImpl.java
 new file mode 100644

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -454,7 +454,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..21e43223d7942b0e5e3c6b63aa2c455ec17ffde9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java
-@@ -0,0 +1,116 @@
+@@ -0,0 +1,131 @@
 +package io.papermc.paper.plugin;
 +
 +import com.mojang.logging.LogUtils;
@@ -567,6 +567,21 @@ index 0000000000000000000000000000000000000000..21e43223d7942b0e5e3c6b63aa2c455e
 +            load(dedicatedServer.options);
 +        } catch (Exception e) {
 +            throw new RuntimeException("Failed to reload!", e);
++        }
++
++        boolean hasPaperPlugin = false;
++        for (PluginProvider<?> provider : LaunchEntryPointHandler.INSTANCE.getStorage().get(Entrypoint.PLUGIN).getRegisteredProviders()) {
++            if (provider instanceof PaperPluginParent.PaperServerPluginProvider) {
++                hasPaperPlugin = true;
++                break;
++            }
++        }
++
++        if (hasPaperPlugin) {
++            LOGGER.error("======== WARNING ========");
++            LOGGER.error("You are reloading while having Paper plugins installed on your server.");
++            LOGGER.error("Paper plugins do NOT support being reloaded. This will cause some unexpected issues.");
++            LOGGER.error("=========================");
 +        }
 +    }
 +
@@ -6412,16 +6427,14 @@ index b5aa358638b9d0638dfe47f7ebac04cca1dd80b9..e43096e69a00f9ea96badd7c966443cf
                  }
                  // CraftBukkit start - easier than fixing the decompile
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index b7399e29094c66c88a6f4c0e996a906bcaa3b4ca..ed8724cabbbb2907e5f22205c15e1b0c125b4be5 100644
+index b7399e29094c66c88a6f4c0e996a906bcaa3b4ca..cef3b053d79e71eb66eb6bddf9365ed4d7042bae 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -110,6 +110,9 @@ public class Main {
+@@ -110,6 +110,7 @@ public class Main {
                  JvmProfiler.INSTANCE.start(Environment.SERVER);
              }
  
-+            // Paper start
-+            io.papermc.paper.plugin.PluginInitializerManager.load(optionset);
-+            // Paper end
++            io.papermc.paper.plugin.PluginInitializerManager.load(optionset); // Paper
              Bootstrap.bootStrap();
              Bootstrap.validate();
              Util.startTimerHackThread();

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -454,13 +454,17 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..21e43223d7942b0e5e3c6b63aa2c455ec17ffde9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java
-@@ -0,0 +1,90 @@
+@@ -0,0 +1,116 @@
 +package io.papermc.paper.plugin;
 +
 +import com.mojang.logging.LogUtils;
 +import io.papermc.paper.configuration.PaperConfigurations;
++import io.papermc.paper.plugin.entrypoint.Entrypoint;
++import io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler;
 +import joptsimple.OptionSet;
++import net.minecraft.server.dedicated.DedicatedServer;
 +import org.bukkit.configuration.file.YamlConfiguration;
++import org.bukkit.craftbukkit.CraftServer;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +import org.slf4j.Logger;
@@ -542,6 +546,28 @@ index 0000000000000000000000000000000000000000..21e43223d7942b0e5e3c6b63aa2c455e
 +    @Nullable
 +    public Path pluginUpdatePath() {
 +        return updateDirectory;
++    }
++
++    public static void load(OptionSet optionSet) throws Exception {
++        // We have to load the bukkit configuration inorder to get the update folder location.
++        io.papermc.paper.plugin.PluginInitializerManager pluginSystem = io.papermc.paper.plugin.PluginInitializerManager.init(optionSet);
++        // Register the default plugin directory
++        io.papermc.paper.plugin.util.EntrypointUtil.registerProvidersFromSource(io.papermc.paper.plugin.provider.source.DirectoryProviderSource.INSTANCE, pluginSystem.pluginDirectoryPath());
++        @SuppressWarnings("unchecked")
++        java.util.List<File> files = (java.util.List<File>) optionSet.valuesOf("add-plugin");
++        // Register plugins from the flag
++        io.papermc.paper.plugin.util.EntrypointUtil.registerProvidersFromSource(io.papermc.paper.plugin.provider.source.PluginFlagProviderSource.INSTANCE, files);
++    }
++
++    // This will be the end of me...
++    public static void reload(DedicatedServer dedicatedServer) {
++        // Wipe the provider storage
++        LaunchEntryPointHandler.INSTANCE.populateProviderStorage();
++        try {
++            load(dedicatedServer.options);
++        } catch (Exception e) {
++            throw new RuntimeException("Failed to reload!", e);
++        }
 +    }
 +
 +}
@@ -644,10 +670,10 @@ index 0000000000000000000000000000000000000000..b38e1e0f3d3055086f51bb191fd4b60e
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/LaunchEntryPointHandler.java b/src/main/java/io/papermc/paper/plugin/entrypoint/LaunchEntryPointHandler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..61a67971a41527c0e3b614bf48d2bc8eabd443b5
+index 0000000000000000000000000000000000000000..6c0f2c315387734f8dd4a7eca633aa0a9856dd17
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/LaunchEntryPointHandler.java
-@@ -0,0 +1,60 @@
+@@ -0,0 +1,65 @@
 +package io.papermc.paper.plugin.entrypoint;
 +
 +import io.papermc.paper.plugin.provider.PluginProvider;
@@ -668,8 +694,7 @@ index 0000000000000000000000000000000000000000..61a67971a41527c0e3b614bf48d2bc8e
 +    private final Map<Entrypoint<?>, ProviderStorage<?>> storage = new HashMap<>();
 +
 +    LaunchEntryPointHandler() {
-+        this.storage.put(Entrypoint.BOOTSTRAPPER, new BootstrapProviderStorage());
-+        this.storage.put(Entrypoint.PLUGIN, new ServerPluginProviderStorage());
++        this.populateProviderStorage();
 +    }
 +
 +    // Utility
@@ -706,6 +731,12 @@ index 0000000000000000000000000000000000000000..61a67971a41527c0e3b614bf48d2bc8e
 +    @ApiStatus.Internal
 +    public Map<Entrypoint<?>, ProviderStorage<?>> getStorage() {
 +        return storage;
++    }
++
++    // Reload only
++    public void populateProviderStorage() {
++        this.storage.put(Entrypoint.BOOTSTRAPPER, new BootstrapProviderStorage());
++        this.storage.put(Entrypoint.PLUGIN, new ServerPluginProviderStorage());
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/ClassloaderBytecodeModifier.java b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/ClassloaderBytecodeModifier.java
@@ -6381,29 +6412,21 @@ index b5aa358638b9d0638dfe47f7ebac04cca1dd80b9..e43096e69a00f9ea96badd7c966443cf
                  }
                  // CraftBukkit start - easier than fixing the decompile
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index b7399e29094c66c88a6f4c0e996a906bcaa3b4ca..abf4c54eec6881d6e05893983f83f9eb4b249634 100644
+index b7399e29094c66c88a6f4c0e996a906bcaa3b4ca..ed8724cabbbb2907e5f22205c15e1b0c125b4be5 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -110,6 +110,17 @@ public class Main {
+@@ -110,6 +110,9 @@ public class Main {
                  JvmProfiler.INSTANCE.start(Environment.SERVER);
              }
  
 +            // Paper start
-+
-+            // We have to load the bukkit configuration inorder to get the update folder location.
-+            io.papermc.paper.plugin.PluginInitializerManager pluginSystem = io.papermc.paper.plugin.PluginInitializerManager.init(optionset);
-+            // Register the default plugin directory
-+            io.papermc.paper.plugin.util.EntrypointUtil.registerProvidersFromSource(io.papermc.paper.plugin.provider.source.DirectoryProviderSource.INSTANCE, pluginSystem.pluginDirectoryPath());
-+            @SuppressWarnings("unchecked")
-+            java.util.List<File> files = (java.util.List<File>) optionset.valuesOf("add-plugin");
-+            // Register plugins from the flag
-+            io.papermc.paper.plugin.util.EntrypointUtil.registerProvidersFromSource(io.papermc.paper.plugin.provider.source.PluginFlagProviderSource.INSTANCE, files);
++            io.papermc.paper.plugin.PluginInitializerManager.load(optionset);
 +            // Paper end
              Bootstrap.bootStrap();
              Bootstrap.validate();
              Util.startTimerHackThread();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 26ca07b5e302cc4cc02e06f5d07f6d9eb541275e..17a6290969a63be85fa780e2cad4ce63790379b1 100644
+index 26ca07b5e302cc4cc02e06f5d07f6d9eb541275e..976e8b1ff947aa1c0e680ff1b31d26d3be0894d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -268,7 +268,8 @@ public final class CraftServer implements Server {
@@ -6466,6 +6489,14 @@ index 26ca07b5e302cc4cc02e06f5d07f6d9eb541275e..17a6290969a63be85fa780e2cad4ce63
  
              this.pluginManager.enablePlugin(plugin);
          } catch (Throwable ex) {
+@@ -933,6 +919,7 @@ public final class CraftServer implements Server {
+                 "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
+             ));
+         }
++        io.papermc.paper.plugin.PluginInitializerManager.reload(this.console); // Paper
+         this.loadPlugins();
+         this.enablePlugins(PluginLoadOrder.STARTUP);
+         this.enablePlugins(PluginLoadOrder.POSTWORLD);
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java b/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java
 index 909b2c98e7a9117d2f737245e4661792ffafb744..d96399e9bf1a58db5a4a22e58abb99e7660e0694 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -1620,10 +1620,10 @@ index cf496b430bf3d7aab0b8e86c11e015583c1411a7..6fdd5c92ab069896e3921faa042cbdb3
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 17a6290969a63be85fa780e2cad4ce63790379b1..83e0038b3c281c176463d33bacbcc1ca283e41dc 100644
+index 976e8b1ff947aa1c0e680ff1b31d26d3be0894d7..4c99b64945068ec335228301b4ebdb7b933879fb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2392,12 +2392,31 @@ public final class CraftServer implements Server {
+@@ -2393,12 +2393,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -12718,10 +12718,10 @@ index a5e438a834826161c52ca9db57d234d9ff80a591..b8bc1b9b8e8a33df90a963f9f9769292
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index ed8724cabbbb2907e5f22205c15e1b0c125b4be5..ad2ecabbb47ec02417c9502ecf00fc0b90d6ba42 100644
+index cef3b053d79e71eb66eb6bddf9365ed4d7042bae..b04f7240ba96d06ab51199059d29b0faa554b09a 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -262,6 +262,7 @@ public class Main {
+@@ -260,6 +260,7 @@ public class Main {
  
              convertable_conversionsession.saveDataTag(iregistrycustom_dimension, savedata);
              */

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -12718,10 +12718,10 @@ index a5e438a834826161c52ca9db57d234d9ff80a591..b8bc1b9b8e8a33df90a963f9f9769292
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index abf4c54eec6881d6e05893983f83f9eb4b249634..8d61e388bbdfd6097f914fc5f122fdf7f9b9ffe2 100644
+index ed8724cabbbb2907e5f22205c15e1b0c125b4be5..ad2ecabbb47ec02417c9502ecf00fc0b90d6ba42 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -270,6 +270,7 @@ public class Main {
+@@ -262,6 +262,7 @@ public class Main {
  
              convertable_conversionsession.saveDataTag(iregistrycustom_dimension, savedata);
              */
@@ -17854,10 +17854,10 @@ index 738d3ce38a42ff8cd53eec042ef8bc74f2b8d059..a895c81ea6af0822c8371ae93cfe4b72
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 83e0038b3c281c176463d33bacbcc1ca283e41dc..4b8178514bea3f53e1aeec266caa2ed19eb895b0 100644
+index 4c99b64945068ec335228301b4ebdb7b933879fb..d6f858ee1245b313024c36ac2a0edd09b9307bca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1128,7 +1128,7 @@ public final class CraftServer implements Server {
+@@ -1129,7 +1129,7 @@ public final class CraftServer implements Server {
          this.console.addLevel(internal);
  
          this.getServer().prepareLevels(internal.getChunkSource().chunkMap.progressListener, internal);
@@ -17866,7 +17866,7 @@ index 83e0038b3c281c176463d33bacbcc1ca283e41dc..4b8178514bea3f53e1aeec266caa2ed1
  
          this.pluginManager.callEvent(new WorldLoadEvent(internal.getWorld()));
          return internal.getWorld();
-@@ -1172,7 +1172,7 @@ public final class CraftServer implements Server {
+@@ -1173,7 +1173,7 @@ public final class CraftServer implements Server {
              }
  
              handle.getChunkSource().close(save);
@@ -17875,7 +17875,7 @@ index 83e0038b3c281c176463d33bacbcc1ca283e41dc..4b8178514bea3f53e1aeec266caa2ed1
              handle.convertable.close();
          } catch (Exception ex) {
              this.getLogger().log(Level.SEVERE, null, ex);
-@@ -1987,7 +1987,7 @@ public final class CraftServer implements Server {
+@@ -1988,7 +1988,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0031-Further-improve-server-tick-loop.patch
+++ b/patches/server/0031-Further-improve-server-tick-loop.patch
@@ -145,10 +145,10 @@ index e2e66fd4bd34e0ceaab350214a50ddbb1dc76184..ac81428f19e2d445f315000d34173c2d
                  this.startMetricsRecordingTick();
                  this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ea16abd65ff909ad4644f7a98fd29d9c3c9f7ac7..710b06caa91d09f6e3d55f76162e60f41d0037e2 100644
+index e5aa25abee4d4c5447920e64ad45acf9763dedf0..babde3ac7af9b5659bcc7e0298d1d77e7b2d60e2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2417,6 +2417,17 @@ public final class CraftServer implements Server {
+@@ -2418,6 +2418,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0054-Expose-server-CommandMap.patch
+++ b/patches/server/0054-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6654764b00e2b1ff15d54aa94d16474660bc3f47..44cd9d5bccdc751dc9fb72a39f12e74a99133783 100644
+index 369657f5c54dae7b03b09aec1c672dc3f2cba090..5d2ac8720d38b9c8485a3c3da906b0124bb99a03 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1991,6 +1991,7 @@ public final class CraftServer implements Server {
+@@ -1992,6 +1992,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0067-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0067-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2b0defa81e3a250119d8f4337bf75ee17b57b08e..81982d554c53732621a01c14b565a03e2c623c28 100644
+index 6c7b1fe353a4d9bd9e307e7984f9348dd5914ff1..318b3e22cad28ef3a49ff005808c5e3525ccbcf4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2545,5 +2545,23 @@ public final class CraftServer implements Server {
+@@ -2546,5 +2546,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0106-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0106-Add-setting-for-proxy-online-mode-status.patch
@@ -43,10 +43,10 @@ index da98f074ccd5a40c635824112c97fd174c393cb1..6599f874d9f97e9ef4862039ecad7277
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 620cce68ec6407d0777d3f6de4d7de308331df8a..7a4b9f0e26608d984a1e1483b5a549fa4214604f 100644
+index 3a046d3eb6bca6f45f8018a3844c58ac8cba43ac..84a7c0b7826fba63adef2fe7a81fbe9b255d2ecf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1714,7 +1714,7 @@ public final class CraftServer implements Server {
+@@ -1715,7 +1715,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7a4b9f0e26608d984a1e1483b5a549fa4214604f..b1f7b5fe81fa179a6689422c4d3de5e2c8339552 100644
+index 84a7c0b7826fba63adef2fe7a81fbe9b255d2ecf..6396640956daf60bdd885face69425e8ca177d8f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2571,5 +2571,24 @@ public final class CraftServer implements Server {
+@@ -2572,5 +2572,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0135-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0135-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b1f7b5fe81fa179a6689422c4d3de5e2c8339552..6a0f2a8a12a4072d235c3d036ad253ba4a66fa6e 100644
+index 6396640956daf60bdd885face69425e8ca177d8f..50218a10a86926fb050b7e9ef3b17ba17fec59f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2590,5 +2590,10 @@ public final class CraftServer implements Server {
+@@ -2591,5 +2591,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0136-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0136-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -236,7 +236,7 @@ index e6a47361db762bd4b54e28d3665a4aee72f91c19..30a017c54c334f0a8463186367c97c2c
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6a0f2a8a12a4072d235c3d036ad253ba4a66fa6e..95e64a7f0ab010798571b0b6a86dfad43003af62 100644
+index 50218a10a86926fb050b7e9ef3b17ba17fec59f7..5f6ddee55b2289d80c55015f44c431b7025ae944 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -48,7 +48,6 @@ import java.util.logging.Level;
@@ -247,7 +247,7 @@ index 6a0f2a8a12a4072d235c3d036ad253ba4a66fa6e..95e64a7f0ab010798571b0b6a86dfad4
  import net.minecraft.advancements.Advancement;
  import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
-@@ -1284,9 +1283,13 @@ public final class CraftServer implements Server {
+@@ -1285,9 +1284,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -596,10 +596,10 @@ index cf3e083c2ada3275a52c303de16a62576696e83f..b19850ae31f6c796cb3491dd5070d28e
       * Calculates distance between 2 entities
       * @param e1
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 8d61e388bbdfd6097f914fc5f122fdf7f9b9ffe2..c364ff90ea72ba45bc453ea78ca08c1c3fbf35dd 100644
+index ad2ecabbb47ec02417c9502ecf00fc0b90d6ba42..35c390fe23f55d4953c5b05d6fd34d4849db6a51 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -169,7 +169,7 @@ public class Main {
+@@ -161,7 +161,7 @@ public class Main {
              }
  
              File file = (File) optionset.valueOf("universe"); // CraftBukkit
@@ -631,7 +631,7 @@ index 4038bb76339d43f18770624bd7fecc79b8d7f2a9..2456edc11b29a92b1648937cd3dd6a9a
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e17507dfbf9dc9634a0839a045c741bd38ab45ad..dce99265f1a3ef2b54bab3f3bad431f3f8dde888 100644
+index df2ad713d169f458890fc54d53415139d878a4d7..527e22973cb0f7fca9d19a41abf943e48980db19 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -257,6 +257,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -652,7 +652,7 @@ index e17507dfbf9dc9634a0839a045c741bd38ab45ad..dce99265f1a3ef2b54bab3f3bad431f3
          CraftItemFactory.instance();
      }
  
-@@ -2605,5 +2609,37 @@ public final class CraftServer implements Server {
+@@ -2606,5 +2610,37 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -596,10 +596,10 @@ index cf3e083c2ada3275a52c303de16a62576696e83f..b19850ae31f6c796cb3491dd5070d28e
       * Calculates distance between 2 entities
       * @param e1
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index ad2ecabbb47ec02417c9502ecf00fc0b90d6ba42..35c390fe23f55d4953c5b05d6fd34d4849db6a51 100644
+index b04f7240ba96d06ab51199059d29b0faa554b09a..c5224aac75df248df57018b6245f909f19904d7d 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -161,7 +161,7 @@ public class Main {
+@@ -159,7 +159,7 @@ public class Main {
              }
  
              File file = (File) optionset.valueOf("universe"); // CraftBukkit

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -91,10 +91,10 @@ index 66436cd5b6b14914919a1eb612ca133ee4ffef05..43748cb2ee5840ee82d5ab6337a72c86
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dce99265f1a3ef2b54bab3f3bad431f3f8dde888..87b29d0965b460706385aa4e28931f5ddd4a33a7 100644
+index 527e22973cb0f7fca9d19a41abf943e48980db19..23b0a829ab5d7a9b45d72c786c218548962dff11 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2095,7 +2095,7 @@ public final class CraftServer implements Server {
+@@ -2096,7 +2096,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0185-getPlayerUniqueId-API.patch
+++ b/patches/server/0185-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 87b29d0965b460706385aa4e28931f5ddd4a33a7..86d8e08b19316bb202b62bd7ac1187eb4827e5c5 100644
+index 23b0a829ab5d7a9b45d72c786c218548962dff11..969dc6197ae9c65c9a76bda76e48312bbb38d2d5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1717,6 +1717,25 @@ public final class CraftServer implements Server {
+@@ -1718,6 +1718,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0239-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0239-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -33,7 +33,7 @@ index e6826cd0a596f063e8737dcde3c8c6c5b3f71970..1a2607d1b257cea65c82c661a6b3d46c
          com.destroystokyo.paper.Metrics.PaperMetrics.startMetrics();
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 86d8e08b19316bb202b62bd7ac1187eb4827e5c5..ccb176c7292aa49780ef21f7a17d97ca7ef53794 100644
+index 969dc6197ae9c65c9a76bda76e48312bbb38d2d5..aa1408dc26193eb133dd5ab04c2252b49ddb60b3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -906,6 +906,7 @@ public final class CraftServer implements Server {
@@ -44,7 +44,7 @@ index 86d8e08b19316bb202b62bd7ac1187eb4827e5c5..ccb176c7292aa49780ef21f7a17d97ca
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -994,6 +995,7 @@ public final class CraftServer implements Server {
+@@ -995,6 +996,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/patches/server/0284-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0284-Make-the-default-permission-message-configurable.patch
@@ -18,10 +18,10 @@ index e202af893c7ec22bfc0b8dbeb8e1551db685d1d3..32b84c59722970218a1515e21c6454d0
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ccb176c7292aa49780ef21f7a17d97ca7ef53794..ff166f93e511dda7e29f676cb2bd7ea148ff1a9d 100644
+index aa1408dc26193eb133dd5ab04c2252b49ddb60b3..06272dba901fdac535ccbf7721bfd54724f5bf0f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2631,6 +2631,16 @@ public final class CraftServer implements Server {
+@@ -2632,6 +2632,16 @@ public final class CraftServer implements Server {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }
  

--- a/patches/server/0318-Expose-the-internal-current-tick.patch
+++ b/patches/server/0318-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ff166f93e511dda7e29f676cb2bd7ea148ff1a9d..3369e749610fca12aa7dc5b514ffbab9ec40e43c 100644
+index 06272dba901fdac535ccbf7721bfd54724f5bf0f..fda2ab16bf4721ffae53ac2eccf95b96e6f47bbf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2672,5 +2672,10 @@ public final class CraftServer implements Server {
+@@ -2673,5 +2673,10 @@ public final class CraftServer implements Server {
          profile.getProperties().putAll(((CraftPlayer)player).getHandle().getGameProfile().getProperties());
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }

--- a/patches/server/0344-Anti-Xray.patch
+++ b/patches/server/0344-Anti-Xray.patch
@@ -1571,10 +1571,10 @@ index 832c6d92daaa96210a9c7edbd357ca824a60a4a5..0fadc763fb482cf9f3b51ed44427029b
  
      public CraftChunk(net.minecraft.world.level.chunk.LevelChunk chunk) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3369e749610fca12aa7dc5b514ffbab9ec40e43c..d312d6c543f0e09e40c232032c09caae35c8891a 100644
+index fda2ab16bf4721ffae53ac2eccf95b96e6f47bbf..76860d584effba34b09becfb2a68bd755f0f675d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2244,7 +2244,7 @@ public final class CraftServer implements Server {
+@@ -2245,7 +2245,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Validate.notNull(world, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();

--- a/patches/server/0364-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0364-Add-tick-times-API-and-mspt-command.patch
@@ -185,10 +185,10 @@ index 023119624c0534bedb248099d0e12c76622a363a..8dcbeeae50afe23aa7e2a083239f0a31
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d312d6c543f0e09e40c232032c09caae35c8891a..99e0aca5f57516ef09fe0bb57c6b991934bb5cc8 100644
+index 76860d584effba34b09becfb2a68bd755f0f675d..61da47d40f289ebe65d60bd850ab7ef386d46c3f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2494,6 +2494,16 @@ public final class CraftServer implements Server {
+@@ -2495,6 +2495,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0365-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0365-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 99e0aca5f57516ef09fe0bb57c6b991934bb5cc8..dac4dd74f75a9ea5fcd19dc65e958d933ba7560d 100644
+index 61da47d40f289ebe65d60bd850ab7ef386d46c3f..687bf0c2a77ca304bd05ac431965f01b6cabf454 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2687,5 +2687,10 @@ public final class CraftServer implements Server {
+@@ -2688,5 +2688,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0395-misc-debugging-dumps.patch
+++ b/patches/server/0395-misc-debugging-dumps.patch
@@ -74,7 +74,7 @@ index 9d3ea20adba300a38a544c3454eff2edd9b4bbb9..3e6ec2cef2b5b058f240dd471d5c7a22
                  this.connection.send(new ClientboundDisconnectPacket(ichatmutablecomponent));
                  this.connection.disconnect(ichatmutablecomponent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 422d6b39337c3a774dfddcee877dc8281c5d7774..222095ad4cc055565c1a166d21714f7b1140815f 100644
+index 8f57e42cbd691e1d13c651c46a2502b8445f1b71..541b4d7187f5ac21a15581e47b8f18238db37039 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -997,6 +997,7 @@ public final class CraftServer implements Server {
@@ -83,5 +83,5 @@ index 422d6b39337c3a774dfddcee877dc8281c5d7774..222095ad4cc055565c1a166d21714f7b
              ));
 +            if (console.isDebugging()) io.papermc.paper.util.TraceUtil.dumpTraceForThread(worker.getThread(), "still running"); // Paper
          }
+         io.papermc.paper.plugin.PluginInitializerManager.reload(this.console); // Paper
          this.loadPlugins();
-         this.enablePlugins(PluginLoadOrder.STARTUP);

--- a/patches/server/0398-Implement-Mob-Goal-API.patch
+++ b/patches/server/0398-Implement-Mob-Goal-API.patch
@@ -791,10 +791,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 222095ad4cc055565c1a166d21714f7b1140815f..52e852c43556d00ecb2fd0971189de64e0268620 100644
+index 541b4d7187f5ac21a15581e47b8f18238db37039..fd30a811366d3a334be92c9eaa9630f4c1e37540 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2700,5 +2700,11 @@ public final class CraftServer implements Server {
+@@ -2701,5 +2701,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0405-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0405-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,10 +22,10 @@ index 366959f9841eb0ef3669b3b3b069d7670f0ba7e6..93c1a1bf602af1e73202590e78dac833
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 52e852c43556d00ecb2fd0971189de64e0268620..39e5b52d1495b7a0f5f451543ad0329fab0fe27d 100644
+index fd30a811366d3a334be92c9eaa9630f4c1e37540..e31307d12013fed72a84f3d8d4248d115c1f0362 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1006,6 +1006,35 @@ public final class CraftServer implements Server {
+@@ -1007,6 +1007,35 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0452-Fix-SPIGOT-5824-Bukkit-world-container-is-not-used.patch
+++ b/patches/server/0452-Fix-SPIGOT-5824-Bukkit-world-container-is-not-used.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SPIGOT-5824 Bukkit world-container is not used
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index c364ff90ea72ba45bc453ea78ca08c1c3fbf35dd..66eab856e7aac5eb9e7db9236ad7ca3cc370060b 100644
+index 35c390fe23f55d4953c5b05d6fd34d4849db6a51..0927fd1c6993fc848884576085ad3e59b01a3745 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -168,8 +168,17 @@ public class Main {
+@@ -160,8 +160,17 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0452-Fix-SPIGOT-5824-Bukkit-world-container-is-not-used.patch
+++ b/patches/server/0452-Fix-SPIGOT-5824-Bukkit-world-container-is-not-used.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SPIGOT-5824 Bukkit world-container is not used
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 35c390fe23f55d4953c5b05d6fd34d4849db6a51..0927fd1c6993fc848884576085ad3e59b01a3745 100644
+index c5224aac75df248df57018b6245f909f19904d7d..1cb5630dbeed601372f48aee2911f0f4530fdc93 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -160,8 +160,17 @@ public class Main {
+@@ -158,8 +158,17 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0453-Fix-SPIGOT-5885-Unable-to-disable-advancements.patch
+++ b/patches/server/0453-Fix-SPIGOT-5885-Unable-to-disable-advancements.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SPIGOT-5885 Unable to disable advancements
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 66eab856e7aac5eb9e7db9236ad7ca3cc370060b..7989b5bf002ba0995c32fb77498c7f50b34e6150 100644
+index 0927fd1c6993fc848884576085ad3e59b01a3745..e54cf438eaf697c6ce427f4c8884b3b6208b1595 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -168,6 +168,7 @@ public class Main {
+@@ -160,6 +160,7 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0453-Fix-SPIGOT-5885-Unable-to-disable-advancements.patch
+++ b/patches/server/0453-Fix-SPIGOT-5885-Unable-to-disable-advancements.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SPIGOT-5885 Unable to disable advancements
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 0927fd1c6993fc848884576085ad3e59b01a3745..e54cf438eaf697c6ce427f4c8884b3b6208b1595 100644
+index 1cb5630dbeed601372f48aee2911f0f4530fdc93..f935ab8e797b9ae6236c1bcce4bccfd9d0048182 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -160,6 +160,7 @@ public class Main {
+@@ -158,6 +158,7 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0495-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0495-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index facd84b0a2a6dcde32ca47fc5a1b9058c41c5ec4..fed01c7ed32a0207216fd902976902b223cc3518 100644
+index 8720fdec86fa8b400721c66d23d8748afd2ac120..b68b19f32754c9c426e711892235b469a85fefb2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1812,6 +1812,28 @@ public final class CraftServer implements Server {
+@@ -1813,6 +1813,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0583-Expand-world-key-API.patch
+++ b/patches/server/0583-Expand-world-key-API.patch
@@ -20,10 +20,10 @@ index 3e4ac4020c9f51e634eadd43243d34267bea4b22..ce52ae980309ecddf597e14b759b77ea
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5b48102ad1c9940a5f41ba8084be0804b7536d30..8592f56bdaaabc3c263c3ce6cf122c13a6b9f2de 100644
+index 9d9731e52a9038e8e668e5d0f2044bcbf6f7ea86..5fbfc4b44c21ae9137e513972726ddddd2f64aa2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1139,9 +1139,15 @@ public final class CraftServer implements Server {
+@@ -1140,9 +1140,15 @@ public final class CraftServer implements Server {
          File folder = new File(this.getWorldContainer(), name);
          World world = this.getWorld(name);
  
@@ -41,7 +41,7 @@ index 5b48102ad1c9940a5f41ba8084be0804b7536d30..8592f56bdaaabc3c263c3ce6cf122c13
  
          if ((folder.exists()) && (!folder.isDirectory())) {
              throw new IllegalArgumentException("File exists with the name '" + name + "' and isn't a folder");
-@@ -1230,7 +1236,7 @@ public final class CraftServer implements Server {
+@@ -1231,7 +1237,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -50,7 +50,7 @@ index 5b48102ad1c9940a5f41ba8084be0804b7536d30..8592f56bdaaabc3c263c3ce6cf122c13
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, worlddimension, this.getServer().progressListenerFactory.create(11),
-@@ -1322,6 +1328,15 @@ public final class CraftServer implements Server {
+@@ -1323,6 +1329,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0617-Add-basic-Datapack-API.patch
+++ b/patches/server/0617-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8592f56bdaaabc3c263c3ce6cf122c13a6b9f2de..86dda69e39f08de98faba44f4ee7725665f8df68 100644
+index 5fbfc4b44c21ae9137e513972726ddddd2f64aa2..59f9e2c09e72acedde901790f87432e53e8a4b70 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -296,6 +296,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index 8592f56bdaaabc3c263c3ce6cf122c13a6b9f2de..86dda69e39f08de98faba44f4ee77256
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2780,5 +2782,11 @@ public final class CraftServer implements Server {
+@@ -2781,5 +2783,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0618-Add-environment-variable-to-disable-server-gui.patch
+++ b/patches/server/0618-Add-environment-variable-to-disable-server-gui.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add environment variable to disable server gui
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 7989b5bf002ba0995c32fb77498c7f50b34e6150..814a4823ab55d09172b2b699d303ced8bec21b47 100644
+index e54cf438eaf697c6ce427f4c8884b3b6208b1595..f8c2d564357a69a69471bcbfed95584c5ab92337 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -292,6 +292,7 @@ public class Main {
+@@ -284,6 +284,7 @@ public class Main {
                  */
                  boolean flag1 = !optionset.has("nogui") && !optionset.nonOptionArguments().contains("nogui");
  

--- a/patches/server/0618-Add-environment-variable-to-disable-server-gui.patch
+++ b/patches/server/0618-Add-environment-variable-to-disable-server-gui.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add environment variable to disable server gui
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index e54cf438eaf697c6ce427f4c8884b3b6208b1595..f8c2d564357a69a69471bcbfed95584c5ab92337 100644
+index f935ab8e797b9ae6236c1bcce4bccfd9d0048182..bf19d95d9b48310de10ef6819b83035ee63a165c 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -284,6 +284,7 @@ public class Main {
+@@ -282,6 +282,7 @@ public class Main {
                  */
                  boolean flag1 = !optionset.has("nogui") && !optionset.nonOptionArguments().contains("nogui");
  

--- a/patches/server/0623-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0623-Fix-and-optimise-world-force-upgrading.patch
@@ -247,7 +247,7 @@ index 0000000000000000000000000000000000000000..95cac7edae8ac64811fc6a2f6b97dd4a
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index f8c2d564357a69a69471bcbfed95584c5ab92337..7addf1ca232d18db8266dfff4cdd4ace06229cda 100644
+index bf19d95d9b48310de10ef6819b83035ee63a165c..e24b23461c592fae07697d3b2a1929cbc79423df 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
 @@ -15,6 +15,7 @@ import java.nio.file.Paths;
@@ -258,7 +258,7 @@ index f8c2d564357a69a69471bcbfed95584c5ab92337..7addf1ca232d18db8266dfff4cdd4ace
  import joptsimple.NonOptionArgumentSpec;
  import joptsimple.OptionParser;
  import joptsimple.OptionSet;
-@@ -332,6 +333,15 @@ public class Main {
+@@ -330,6 +331,15 @@ public class Main {
          return new WorldLoader.InitConfig(worldloader_d, Commands.CommandSelection.DEDICATED, serverPropertiesHandler.functionPermissionLevel);
      }
  

--- a/patches/server/0623-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0623-Fix-and-optimise-world-force-upgrading.patch
@@ -247,7 +247,7 @@ index 0000000000000000000000000000000000000000..95cac7edae8ac64811fc6a2f6b97dd4a
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 814a4823ab55d09172b2b699d303ced8bec21b47..c98a67de81439f6e5f8e2eedc7b9d8e3ddc5dc5b 100644
+index f8c2d564357a69a69471bcbfed95584c5ab92337..7addf1ca232d18db8266dfff4cdd4ace06229cda 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
 @@ -15,6 +15,7 @@ import java.nio.file.Paths;
@@ -258,7 +258,7 @@ index 814a4823ab55d09172b2b699d303ced8bec21b47..c98a67de81439f6e5f8e2eedc7b9d8e3
  import joptsimple.NonOptionArgumentSpec;
  import joptsimple.OptionParser;
  import joptsimple.OptionSet;
-@@ -340,6 +341,15 @@ public class Main {
+@@ -332,6 +333,15 @@ public class Main {
          return new WorldLoader.InitConfig(worldloader_d, Commands.CommandSelection.DEDICATED, serverPropertiesHandler.functionPermissionLevel);
      }
  
@@ -359,10 +359,10 @@ index b294ef87fb93e7f4651dc04128124f297575860d..65fd57609e45ccd49ebfc1ba80d25243
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 86dda69e39f08de98faba44f4ee7725665f8df68..a24769e0be5c0d67b6a6b8441570e20a622e5cbd 100644
+index 59f9e2c09e72acedde901790f87432e53e8a4b70..b51f51381f765a3ebefc3f563062302211f068b5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1215,12 +1215,7 @@ public final class CraftServer implements Server {
+@@ -1216,12 +1216,7 @@ public final class CraftServer implements Server {
          worlddata.customDimensions = iregistry;
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().shouldReportAsModified());
@@ -376,7 +376,7 @@ index 86dda69e39f08de98faba44f4ee7725665f8df68..a24769e0be5c0d67b6a6b8441570e20a
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1231,6 +1226,13 @@ public final class CraftServer implements Server {
+@@ -1232,6 +1227,13 @@ public final class CraftServer implements Server {
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
  

--- a/patches/server/0698-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0698-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -286,10 +286,10 @@ index bf3fb416d36a19958033cdbf5cc313556fa0201b..0a49769bfa83d0b9c435e3ab4bba8597
          // Paper start - add parameters and int ret type
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6707c96293e3c734628cbb017ddcf098641d69c2..ed7c94b31db6f759c5e24bee01ba6d5df266a126 100644
+index 0aead1e438c4c2c8c138697e9afbf52323ebf6ca..8c592dcae27b91edd6ca9374643097cf73f12750 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2166,6 +2166,11 @@ public final class CraftServer implements Server {
+@@ -2167,6 +2167,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {

--- a/patches/server/0759-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0759-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ed7c94b31db6f759c5e24bee01ba6d5df266a126..a47deed87d662e39981abfa03eed23785f4862ff 100644
+index 8c592dcae27b91edd6ca9374643097cf73f12750..6cf52ff65cd300c89df7030266df815959ec48cd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2339,6 +2339,90 @@ public final class CraftServer implements Server {
+@@ -2340,6 +2340,90 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registries.BIOME), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0779-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0779-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,10 +18,10 @@ index 0868805c78d991c602d8f1d1b5aeb5c790c13384..6986d5475b090bca60b5ae892512fd5e
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a47deed87d662e39981abfa03eed23785f4862ff..aa3387361b9f5b73ed5ecfb12b826f8a17d2623a 100644
+index 6cf52ff65cd300c89df7030266df815959ec48cd..c41954c1c96c5b9e0ee49237e9dc6831a75c635e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1222,7 +1222,7 @@ public final class CraftServer implements Server {
+@@ -1223,7 +1223,7 @@ public final class CraftServer implements Server {
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
          LevelStem worlddimension = iregistry.get(actualDimension);
  

--- a/patches/server/0794-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0794-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index aa3387361b9f5b73ed5ecfb12b826f8a17d2623a..944f9dec587ed17c737846362f63e947a99bc173 100644
+index c41954c1c96c5b9e0ee49237e9dc6831a75c635e..82099415303e91016ed02b0ca75f1437206704c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2000,6 +2000,13 @@ public final class CraftServer implements Server {
+@@ -2001,6 +2001,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  

--- a/patches/server/0798-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0798-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 944f9dec587ed17c737846362f63e947a99bc173..bbeab1eac527d06f867fb6a67c30e93be6642f8b 100644
+index 82099415303e91016ed02b0ca75f1437206704c1..6a5ee59bada7922217a21f1130d329af259eb5c7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2174,6 +2174,8 @@ public final class CraftServer implements Server {
+@@ -2175,6 +2175,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start

--- a/patches/server/0799-Add-GameEvent-tags.patch
+++ b/patches/server/0799-Add-GameEvent-tags.patch
@@ -46,10 +46,10 @@ index 0000000000000000000000000000000000000000..e7d9fd2702a1ce96596580fff8f5ee4f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bbeab1eac527d06f867fb6a67c30e93be6642f8b..782a0ed5b128912257571a527e9ba5e77204896e 100644
+index 6a5ee59bada7922217a21f1130d329af259eb5c7..8ad83861bd928500b206fdff341671d773efc223 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2585,6 +2585,15 @@ public final class CraftServer implements Server {
+@@ -2586,6 +2586,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(BuiltInRegistries.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -65,7 +65,7 @@ index bbeab1eac527d06f867fb6a67c30e93be6642f8b..782a0ed5b128912257571a527e9ba5e7
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2617,6 +2626,13 @@ public final class CraftServer implements Server {
+@@ -2618,6 +2627,13 @@ public final class CraftServer implements Server {
                  net.minecraft.core.Registry<EntityType<?>> entityTags = BuiltInRegistries.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0805-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0805-Put-world-into-worldlist-before-initing-the-world.patch
@@ -23,10 +23,10 @@ index d2409599c9d9765a2e1dc7418339923049abc416..f42d7d9e11542370489fcc8dc42ea6ec
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 782a0ed5b128912257571a527e9ba5e77204896e..e1cb7ae143b1d85cbea494e4694d34f0e954f64e 100644
+index 8ad83861bd928500b206fdff341671d773efc223..850dc6f3977740a3a8f8dbf353e320d71c528d57 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1251,10 +1251,11 @@ public final class CraftServer implements Server {
+@@ -1252,10 +1252,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0807-Custom-Potion-Mixes.patch
+++ b/patches/server/0807-Custom-Potion-Mixes.patch
@@ -164,7 +164,7 @@ index cf2b6487a640a7a613f3b3604ca7b1063b3ff102..0bab2693b91d5bab222c7db8bc6965cc
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e1cb7ae143b1d85cbea494e4694d34f0e954f64e..7936ff9da40a6938268b7020ba751e3724eb1d72 100644
+index 850dc6f3977740a3a8f8dbf353e320d71c528d57..c67dedfb194835473fb1f17d0d318d9ec561d83a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -299,6 +299,7 @@ public final class CraftServer implements Server {
@@ -184,7 +184,7 @@ index e1cb7ae143b1d85cbea494e4694d34f0e954f64e..7936ff9da40a6938268b7020ba751e37
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2906,5 +2907,10 @@ public final class CraftServer implements Server {
+@@ -2907,5 +2908,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0818-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0818-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7936ff9da40a6938268b7020ba751e3724eb1d72..0d8a8a49368401e0c801ee63d99c6910467507b9 100644
+index c67dedfb194835473fb1f17d0d318d9ec561d83a..591ccb3b5be1207a18bc427dbd51758d8960b8cd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1299,7 +1299,7 @@ public final class CraftServer implements Server {
+@@ -1300,7 +1300,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0834-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0834-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0d8a8a49368401e0c801ee63d99c6910467507b9..be087ee023fc124c676fb83f3d0796b2da3b8bc0 100644
+index 591ccb3b5be1207a18bc427dbd51758d8960b8cd..6dcbc6993a2462bc13820d3f8a77c188705fb6c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1258,6 +1258,7 @@ public final class CraftServer implements Server {
+@@ -1259,6 +1259,7 @@ public final class CraftServer implements Server {
          internal.setSpawnSettings(true, true);
          // Paper - move up
  

--- a/patches/server/0850-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0850-Throw-exception-on-world-create-while-being-ticked.patch
@@ -45,7 +45,7 @@ index a8b3f0e8be414c4ea92cc85c9811ecd42e5ce9c1..0e04083ff0598451c66731b1518b2eb6
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index be087ee023fc124c676fb83f3d0796b2da3b8bc0..3ce33ca4ce86a915be1cebb26de1eb3ef5d0d4fb 100644
+index 6dcbc6993a2462bc13820d3f8a77c188705fb6c2..bb0b7081c400b3928677d3c41e398053acd301d9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -851,6 +851,11 @@ public final class CraftServer implements Server {
@@ -60,7 +60,7 @@ index be087ee023fc124c676fb83f3d0796b2da3b8bc0..3ce33ca4ce86a915be1cebb26de1eb3e
      public DedicatedPlayerList getHandle() {
          return this.playerList;
      }
-@@ -1135,6 +1140,7 @@ public final class CraftServer implements Server {
+@@ -1136,6 +1141,7 @@ public final class CraftServer implements Server {
      @Override
      public World createWorld(WorldCreator creator) {
          Preconditions.checkState(this.console.getAllLevels().iterator().hasNext(), "Cannot create additional worlds on STARTUP");
@@ -68,7 +68,7 @@ index be087ee023fc124c676fb83f3d0796b2da3b8bc0..3ce33ca4ce86a915be1cebb26de1eb3e
          Validate.notNull(creator, "Creator may not be null");
  
          String name = creator.name();
-@@ -1273,6 +1279,7 @@ public final class CraftServer implements Server {
+@@ -1274,6 +1280,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {

--- a/patches/server/0857-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0857-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index 7c7e5f3c0f9cd1f16192a8fc8163da9b2d9519d5..888936385196a178ab8b730fd5e4fff4
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3ce33ca4ce86a915be1cebb26de1eb3ef5d0d4fb..9c97e31a00bf226c7298242a6e0d4c0b35a49817 100644
+index bb0b7081c400b3928677d3c41e398053acd301d9..d275ca28f145f3e9bbf21e591129e6108efac57d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1773,7 +1773,7 @@ public final class CraftServer implements Server {
+@@ -1774,7 +1774,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {

--- a/patches/server/0908-Detect-headless-JREs.patch
+++ b/patches/server/0908-Detect-headless-JREs.patch
@@ -27,10 +27,10 @@ index 6bd0afddbcc461149dfe9a5c7a86fff6ea13a5f1..148d233f4f5278ff39eacdaa0f4f0e7d
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 7addf1ca232d18db8266dfff4cdd4ace06229cda..91167bebb828ea1bae1be2f883fdefc1e73ad0c3 100644
+index e24b23461c592fae07697d3b2a1929cbc79423df..781b72fd88149642c9fceaecfbfe7546273fb749 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -161,6 +161,18 @@ public class Main {
+@@ -159,6 +159,18 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0908-Detect-headless-JREs.patch
+++ b/patches/server/0908-Detect-headless-JREs.patch
@@ -27,10 +27,10 @@ index 6bd0afddbcc461149dfe9a5c7a86fff6ea13a5f1..148d233f4f5278ff39eacdaa0f4f0e7d
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index c98a67de81439f6e5f8e2eedc7b9d8e3ddc5dc5b..a821cb33fbc29109aec68f9d6a0eb2efc121ee13 100644
+index 7addf1ca232d18db8266dfff4cdd4ace06229cda..91167bebb828ea1bae1be2f883fdefc1e73ad0c3 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -169,6 +169,18 @@ public class Main {
+@@ -161,6 +161,18 @@ public class Main {
                  return;
              }
  


### PR DESCRIPTION
Paper plugins will explode when reloading, but, I added a little warning.