### PR TITLE
Update Alternate Current patch

### DIFF
--- a/patches/server/0851-Add-Alternate-Current-redstone-implementation.patch
+++ b/patches/server/0851-Add-Alternate-Current-redstone-implementation.patch
@@ -725,7 +725,7 @@ index 0000000000000000000000000000000000000000..5a7209f05b549c222f6c9bc2af2a3579
 +}
 diff --git a/src/main/java/alternate/current/wire/WireHandler.java b/src/main/java/alternate/current/wire/WireHandler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..35d9017c21ce77290d8e86cceb0676666e6e0eff
+index 0000000000000000000000000000000000000000..dbd0f5eee8b7f0590817673ee5f9a529bd5184cd
 --- /dev/null
 +++ b/src/main/java/alternate/current/wire/WireHandler.java
 @@ -0,0 +1,1150 @@
@@ -1347,9 +1347,9 @@ index 0000000000000000000000000000000000000000..35d9017c21ce77290d8e86cceb067666
 +        WireNode wire = node.asWire();
 +        findRoot(wire);
 +
-+        // If the wire at the given position is not in an invalid state or is not
-+        // part of a larger network, we can exit early.
-+        if (!wire.searched || wire.connections.total == 0) {
++        // If the wire at the given position is not in an invalid state
++        // we can exit early.
++        if (!wire.searched) {
 +            return;
 +        }
 +


### PR DESCRIPTION
Update the Alternate Current patch to v1.5.0
- Fixes issues where adjacent but disconnected redstone dust dots behave inconsistently.