### PR TITLE
Add missing deprecation

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -2133,7 +2133,7 @@ index f3afe67f0832cb828d25be3654518ff73a80b0e1..598abaa82c634178043a29f6caa6ac52
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f90365c05807 100644
+index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481aa7f9f51 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -51,7 +51,41 @@ import org.jetbrains.annotations.Nullable;
@@ -2471,19 +2471,27 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
       *     pack correctly.
       * </ul>
       *
-+     * @deprecated in favour of {@link #setResourcePack(String, byte[], Component)}
++     * @deprecated in favour of {@link #setResourcePack(String, byte[], net.kyori.adventure.text.Component)}
       * @param url The URL from which the client will download the resource
       *     pack. The string must contain only US-ASCII characters and should
       *     be encoded as per RFC 1738.
-@@ -1358,6 +1570,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1327,6 +1539,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
+      *     long.
+      */
++    @Deprecated // Paper
+     public void setResourcePack(@NotNull String url, @Nullable byte[] hash);
+ 
+     /**
+@@ -1358,6 +1571,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *     pack correctly.
       * </ul>
       *
-+     * @deprecated in favour of {@link #setResourcePack(String, byte[], Component, boolean)}
++     * @deprecated in favour of {@link #setResourcePack(String, byte[], net.kyori.adventure.text.Component)}
       * @param url The URL from which the client will download the resource
       *     pack. The string must contain only US-ASCII characters and should
       *     be encoded as per RFC 1738.
-@@ -1371,8 +1584,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1371,8 +1585,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
       *     long.
       */
@@ -2541,7 +2549,15 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
      /**
       * Request that the player's client download and switch resource packs.
       * <p>
-@@ -1462,8 +1724,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1447,6 +1710,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      *     pack correctly.
+      * </ul>
+      *
++     * @deprecated in favour of {@link #setResourcePack(String, byte[], net.kyori.adventure.text.Component, boolean)}
+      * @param url The URL from which the client will download the resource
+      *     pack. The string must contain only US-ASCII characters and should
+      *     be encoded as per RFC 1738.
+@@ -1462,8 +1726,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
       *     long.
       */
@@ -2599,7 +2615,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
      /**
       * Gets the Scoreboard displayed to this player
       *
-@@ -1598,7 +1909,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1598,7 +1911,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param title Title text
       * @param subtitle Subtitle text
@@ -2608,7 +2624,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
       */
      @Deprecated
      public void sendTitle(@Nullable String title, @Nullable String subtitle);
-@@ -1617,7 +1928,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1617,7 +1930,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param fadeIn time in ticks for titles to fade in. Defaults to 10.
       * @param stay time in ticks for titles to stay. Defaults to 70.
       * @param fadeOut time in ticks for titles to fade out. Defaults to 20.
@@ -2618,7 +2634,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
      public void sendTitle(@Nullable String title, @Nullable String subtitle, int fadeIn, int stay, int fadeOut);
  
      /**
-@@ -1844,6 +2157,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1844,6 +2159,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -2633,7 +2649,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1869,8 +2190,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1869,8 +2192,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -2644,7 +2660,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
      public String getLocale();
  
      /**
-@@ -1922,6 +2245,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1922,6 +2247,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public boolean isAllowingServerListings();
  
@@ -2659,7 +2675,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1953,11 +2284,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1953,11 +2286,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -2673,7 +2689,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1968,7 +2301,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1968,7 +2303,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -2683,7 +2699,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1978,7 +2313,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1978,7 +2315,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -2693,7 +2709,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1989,7 +2326,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1989,7 +2328,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -2703,7 +2719,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..a5010cb46aa5ef69c559ef9fc717f903
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable java.util.UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -2000,7 +2339,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2000,7 +2341,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send

--- a/patches/api/0010-Timings-v2.patch
+++ b/patches/api/0010-Timings-v2.patch
@@ -3455,10 +3455,10 @@ index 516d7fc7812aac343782861d0d567f54aa578c2a..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index a5010cb46aa5ef69c559ef9fc717f90365c05807..1a54682f584479a5a548f6f1f2ffd5da5dc11c88 100644
+index e5a54a2f35d83f8c7a5f2b6512b86481aa7f9f51..5ae3750e3d88b1c60c982b7108ff6b820375ab99 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2344,7 +2344,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2346,7 +2346,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          @Deprecated // Paper
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable java.util.UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");

--- a/patches/api/0012-Player-affects-spawning-API.patch
+++ b/patches/api/0012-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 1a54682f584479a5a548f6f1f2ffd5da5dc11c88..6b1a198f930a5a995e0cb6c279b455e1639a5039 100644
+index 5ae3750e3d88b1c60c982b7108ff6b820375ab99..e48c12b84d00169f17bc2ac3aca5ffa74c8b7c43 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2196,6 +2196,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2198,6 +2198,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0017-Add-view-distance-API.patch
+++ b/patches/api/0017-Add-view-distance-API.patch
@@ -75,10 +75,10 @@ index 5357291ff0f2f20bd87ab9f6e57f6a4f6ff65226..887aa6217583d224d66f6d238ac269c2
      public class Spigot {
  
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6b1a198f930a5a995e0cb6c279b455e1639a5039..f8e45f70fe23cf73c8677b5d24cefcd3aae5e24e 100644
+index e48c12b84d00169f17bc2ac3aca5ffa74c8b7c43..c8347316f6c54916e07a6f7086b99775c4d2c802 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2210,6 +2210,78 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2212,6 +2212,78 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0027-Complete-resource-pack-API.patch
+++ b/patches/api/0027-Complete-resource-pack-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3650fb2b79368ad39278062f215d25cc99637cac..967ea421aed7f9d4c8edd366c00cf3ceca723b2f 100644
+index 02febdfdd45ee79b659fed23a54886371feded0f..a63a4053c8a17284cd302db1fb6b6b673310ae44 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1655,7 +1655,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -18,7 +18,7 @@ index 3650fb2b79368ad39278062f215d25cc99637cac..967ea421aed7f9d4c8edd366c00cf3ce
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -2500,6 +2502,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2502,6 +2504,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -93,10 +93,10 @@ index 016cee903c7179baf711984503d1d0793d40c5c5..064edd612885b2ea4b35001a864503b5
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2257a1808d19775607e60c155d9e5508e7825811..21952b30559cafb00ddcef54557caea5e4dbb36e 100644
+index 90e7a703934697875edc3c3ca892cc51c598fac1..e7ea7a93f7377c25c2786612f1c6123682e8a0da 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2676,6 +2676,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2678,6 +2678,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
@@ -36,10 +36,10 @@ index abdca9fe5acc90f167219eb769ece66c35682bb1..b3aa3dc6aa5afbc36cc86741b4cba56f
      /**
       * Make the entity drop the item in their hand.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index af7af85887e9463c561ddb0c47862b27b5de5d43..8e7482df076c41ae12813e64153206851e020764 100644
+index e7ea7a93f7377c25c2786612f1c6123682e8a0da..a8213398be954a6cebef8658e62600e0fffe1759 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2521,10 +2521,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2523,10 +2523,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Open a Sign for editing by the Player.
       *

--- a/patches/api/0144-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0144-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 87bc9d5e966d91b2786c89290a5609f94c59dd70..5cabbe3aec83f76cefe34fd3e34be467fe5e59c8 100644
+index 01555373317beafc506f1c7559f7107cd738ac4f..1329e5784bb9941ae5bc35205b057c8e864aa09e 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2852,6 +2852,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2854,6 +2854,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull com.destroystokyo.paper.profile.PlayerProfile profile);

--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -282,7 +282,7 @@ index e455eb21abf121dc6ff10ff8a13dd06f67096a8f..bbc01e7c192ae6689c301670047ff114
          return origin;
      }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index c6019065869130608ac97af951c7036031eec242..31fc272b0e82e4eef6d9bf01dd25d39513d354b3 100644
+index c6019065869130608ac97af951c7036031eec242..fe8f167871563e594cd48892e4d8768ebca92958 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -415,9 +415,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -307,6 +307,53 @@ index c6019065869130608ac97af951c7036031eec242..31fc272b0e82e4eef6d9bf01dd25d395
      public FallingBlock spawnFallingBlock(@NotNull Location location, @NotNull MaterialData data) throws IllegalArgumentException;
  
      /**
+@@ -3707,6 +3708,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+     // Paper end - view distance api
+ 
+     // Spigot start
++    /**
++     * @deprecated Unsupported api
++     */
++    @Deprecated // Paper
+     public class Spigot {
+ 
+         /**
+@@ -3715,8 +3720,12 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+          * @param loc The location to strike lightning
+          * @param isSilent Whether this strike makes no sound
+          * @return The lightning entity.
++         * @deprecated The lightning strike sound has been moved into the client and
++         * this doesn't prevent the sound being played. Use the regular (non spigot) methods instead
++         * for a consistent behavior.
+          */
+         @NotNull
++        @Deprecated // Paper
+         public LightningStrike strikeLightning(@NotNull Location loc, boolean isSilent) {
+             throw new UnsupportedOperationException("Not supported yet.");
+         }
+@@ -3727,14 +3736,22 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+          * @param loc The location to strike lightning
+          * @param isSilent Whether this strike makes no sound
+          * @return The lightning entity.
++         * @deprecated The lightning strike sound has been moved into the client and
++         * this doesn't prevent the sound being played. Use the regular (non spigot) methods instead
++         * for a consistent behavior.
+          */
+         @NotNull
++        @Deprecated // Paper
+         public LightningStrike strikeLightningEffect(@NotNull Location loc, boolean isSilent) {
+             throw new UnsupportedOperationException("Not supported yet.");
+         }
+     }
+ 
++    /**
++     * @deprecated Unsupported api
++     */
+     @NotNull
++    @Deprecated // Paper
+     Spigot spigot();
+     // Spigot end
+ 
 diff --git a/src/main/java/org/bukkit/block/BlockState.java b/src/main/java/org/bukkit/block/BlockState.java
 index 631cbf2be51040eee00aa39a39c5ec4003f91843..3147e278eac674ed21d714bbe318b135c0a6b408 100644
 --- a/src/main/java/org/bukkit/block/BlockState.java
@@ -369,6 +416,43 @@ index 605af1a9fc48602643aec57dd14e8c4ab657a0bc..b3085c7ff8b3e96083d209f6612c0065
      public void setCarriedMaterial(@NotNull MaterialData material);
  
      /**
+diff --git a/src/main/java/org/bukkit/entity/LightningStrike.java b/src/main/java/org/bukkit/entity/LightningStrike.java
+index be347c3d0291f44036bae29a4e7e4645d6a4cdf6..76407851a3401982214c3e20aefb406fc5c63310 100644
+--- a/src/main/java/org/bukkit/entity/LightningStrike.java
++++ b/src/main/java/org/bukkit/entity/LightningStrike.java
+@@ -15,20 +15,31 @@ public interface LightningStrike extends Entity {
+     public boolean isEffect();
+ 
+     // Spigot start
++    /**
++     * @deprecated Unsupported api
++     */
++    @Deprecated // Paper
+     public class Spigot extends Entity.Spigot {
+ 
+-        /*
++        /**
+          * Returns whether the strike is silent.
+          *
+          * @return whether the strike is silent.
++         * @deprecated The lightning strike sound has been moved into the client and
++         * this can't predict if the sound will be played or not accurately.
+          */
++        @Deprecated // Paper
+         public boolean isSilent() {
+             throw new UnsupportedOperationException("Not supported yet.");
+         }
+     }
+ 
++    /**
++     * @deprecated Unsupported api
++     */
+     @NotNull
+     @Override
++    @Deprecated // Paper
+     Spigot spigot();
+     // Spigot end
+ }
 diff --git a/src/main/java/org/bukkit/entity/LingeringPotion.java b/src/main/java/org/bukkit/entity/LingeringPotion.java
 index f124b35ec76e6cb6a1a0dc464005087043c3efd0..f50aaddf8582be55fd4860ad374d8f2206991897 100644
 --- a/src/main/java/org/bukkit/entity/LingeringPotion.java
@@ -604,6 +688,32 @@ index fe58058f9b5d29388d48115cc81dc48ab08c58c1..ac67a4e321f43d1ede09dafe2daa1f07
 +    @NotNull // Paper - fix nullability
      public ItemStack getCursor() {
          return getView().getCursor();
+     }
+diff --git a/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java b/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
+index 1cb70b5c8776863f44f1c4cdde152c35cb51edb5..f09b378508fcc6299e7cb40f174028f6f88ba067 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerBedLeaveEvent.java
+@@ -43,7 +43,10 @@ public class PlayerBedLeaveEvent extends PlayerEvent implements Cancellable {
+      * {@link Player#setBedSpawnLocation(Location)}.
+      *
+      * @return true if the spawn location will be changed
++     * @deprecated the respawn point is now set when the player enter the bed and
++     * this option doesn't work since MC 1.15.
+      */
++    @Deprecated(forRemoval = true) // Paper - Unused
+     public boolean shouldSetSpawnLocation() {
+         return setBedSpawn;
+     }
+@@ -59,7 +62,10 @@ public class PlayerBedLeaveEvent extends PlayerEvent implements Cancellable {
+      * {@link Player#setBedSpawnLocation(Location)}.
+      *
+      * @param setBedSpawn true to change the new spawn location
++     * @deprecated the respawn point is now set when the player enter the bed and
++     * this option doesn't work since MC 1.15.
+      */
++    @Deprecated(forRemoval = true) // Paper - Unused
+     public void setSpawnLocation(boolean setBedSpawn) {
+         this.setBedSpawn = setBedSpawn;
      }
 diff --git a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
 index 1b2267f4e8ebded198773ec80e2bff2c861c7084..1a58734d919fae247eeb85dd785fd59990856505 100644

--- a/patches/api/0189-Add-Player-Client-Options-API.patch
+++ b/patches/api/0189-Add-Player-Client-Options-API.patch
@@ -229,10 +229,10 @@ index 0000000000000000000000000000000000000000..cf67dc7d465223710adbf2b798109f52
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5cabbe3aec83f76cefe34fd3e34be467fe5e59c8..45cd9cf3bfa7a64fca463f76a9e29d5f9abdfd58 100644
+index 1329e5784bb9941ae5bc35205b057c8e864aa09e..1dab97ff89d30f018819dc054241f188319603ba 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2872,6 +2872,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2874,6 +2874,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0206-Brand-support.patch
+++ b/patches/api/0206-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 45cd9cf3bfa7a64fca463f76a9e29d5f9abdfd58..785655dbb660f6b65d9ff2b498600efca6a89144 100644
+index 1dab97ff89d30f018819dc054241f188319603ba..1ede954027c4e81b17948ac4fba272616f0978a6 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2981,6 +2981,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2983,6 +2983,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0217-Player-elytra-boost-API.patch
+++ b/patches/api/0217-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 785655dbb660f6b65d9ff2b498600efca6a89144..19358a956f14053ff5c57a4909ebf82f42a22043 100644
+index 1ede954027c4e81b17948ac4fba272616f0978a6..1796749b58ab23b66905967f0af650c265e3ee27 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2878,6 +2878,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2880,6 +2880,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull com.destroystokyo.paper.ClientOption<T> option);

--- a/patches/api/0226-More-lightning-API.patch
+++ b/patches/api/0226-More-lightning-API.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] More lightning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LightningStrike.java b/src/main/java/org/bukkit/entity/LightningStrike.java
-index be347c3d0291f44036bae29a4e7e4645d6a4cdf6..6f5b6901032eb03606c4566b24459a03baac0c73 100644
+index 76407851a3401982214c3e20aefb406fc5c63310..ba06afd01d1e1fef2123412735653593453d3ab7 100644
 --- a/src/main/java/org/bukkit/entity/LightningStrike.java
 +++ b/src/main/java/org/bukkit/entity/LightningStrike.java
-@@ -31,4 +31,72 @@ public interface LightningStrike extends Entity {
-     @Override
+@@ -42,4 +42,72 @@ public interface LightningStrike extends Entity {
+     @Deprecated // Paper
      Spigot spigot();
      // Spigot end
 +

--- a/patches/api/0244-Add-sendOpLevel-API.patch
+++ b/patches/api/0244-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 19358a956f14053ff5c57a4909ebf82f42a22043..e7bc6db5f802ef9b776fea5f5df6df20b2529258 100644
+index 1796749b58ab23b66905967f0af650c265e3ee27..156a3887628a51e099976842bc1f8ea81d7e2d9f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2891,6 +2891,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2893,6 +2893,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0369-More-Teleport-API.patch
+++ b/patches/api/0369-More-Teleport-API.patch
@@ -165,10 +165,10 @@ index ab0ceaba9ddcbe20a8b8a1fc3ed19cb3c64ecd3d..97f0bc6573c8ba09de77061b6312b91c
       * Teleports this entity to the given location. If this entity is riding a
       * vehicle, it will be dismounted prior to teleportation.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 71bddfd5980452e5f55ea1c6eaa70bad3345739f..b063aba9439f1f32f0716c636d28b2821eeb4fcf 100644
+index a53805af92dab72c8e43c1e215893fb96b2150f6..f11e776c82d8b79281f723c97c398e8e10f2f98b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3046,6 +3046,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3048,6 +3048,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      String getClientBrandName();
      // Paper end
  

--- a/patches/api/0371-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0371-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b063aba9439f1f32f0716c636d28b2821eeb4fcf..847d9723acf141351b4f88a7a70143fa9d684efc 100644
+index f11e776c82d8b79281f723c97c398e8e10f2f98b..7cef68ae3a8ae0f71b8c5e63f0eca175a6383946 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2933,6 +2933,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2935,6 +2935,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException If the level is negative or greater than {@code 4} (i.e. not within {@code [0, 4]}).
       */
      void sendOpLevel(byte level);

--- a/patches/api/0381-Elder-Guardian-appearance-API.patch
+++ b/patches/api/0381-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 847d9723acf141351b4f88a7a70143fa9d684efc..e0fc66a028bffa4e335610c8cf52c6dde7d49584 100644
+index 7cef68ae3a8ae0f71b8c5e63f0eca175a6383946..85bce5830b47a3e915450c0f41df7ccbdd6e50e9 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3112,6 +3112,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3114,6 +3114,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
      // Paper end - Teleport API
  

--- a/patches/api/0389-Add-Player-Warden-Warning-API.patch
+++ b/patches/api/0389-Add-Player-Warden-Warning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player Warden Warning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index e0fc66a028bffa4e335610c8cf52c6dde7d49584..6200dddfd7bd99c17ec8749aca3d387820dbc24b 100644
+index 85bce5830b47a3e915450c0f41df7ccbdd6e50e9..8a7171f0b05d1a9c583ea9cef107c2c0e67aad67 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3128,6 +3128,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3130,6 +3130,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param silent whether sound should be silenced
       */
      void showElderGuardian(boolean silent);


### PR DESCRIPTION
Add missing deprecation around the resource pack api
And also deprecate the spigot silenceable lightning stuff. The lightning sound has been moved clientside and this will just
create some side effect like not spreading more fire in normal+ diff or doesn't power the lightning rod. The only change that could be intended is the sculk sensor that will be unable to listen to that vibration for silent lightning.