### PR TITLE
Do not send plugin headers when it is not required.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -54,4 +54,5 @@ vytskalt <vytskalt@protonmail.com>
 TheFruxz <cedricspitzer@outlook.de>
 Kieran Wallbanks <kieran.wallbanks@gmail.com>
 Denery <dorofeevij@gmail.com>
+Jakubk15 <jakubk15@protonmail.com>
 ```

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -37,10 +37,10 @@ index 6a00f3d38da8107825ab1d405f337fd077b09f72..d44d0074446c1c54e87dc8078dff7fef
  }
 diff --git a/src/main/java/io/papermc/paper/command/PaperPluginsCommand.java b/src/main/java/io/papermc/paper/command/PaperPluginsCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..72096a66a4046633de73a12f5a043ac6dff169b1
+index 0000000000000000000000000000000000000000..f0fce4113fb07c64adbec029d177c236cbdcbae8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/PaperPluginsCommand.java
-@@ -0,0 +1,207 @@
+@@ -0,0 +1,215 @@
 +package io.papermc.paper.command;
 +
 +import com.google.common.collect.Lists;
@@ -229,11 +229,19 @@ index 0000000000000000000000000000000000000000..72096a66a4046633de73a12f5a043ac6
 +            //.append(INFO_ICON_START.hoverEvent(SERVER_PLUGIN_INFO)); TODO: Add docs
 +
 +        sender.sendMessage(infoMessage);
-+        sender.sendMessage(PAPER_HEADER);
++
++        if (!paperPlugins.isEmpty()) {
++            sender.sendMessage(PAPER_HEADER);
++        }
++
 +        for (Component component : formatProviders(paperPlugins)) {
 +            sender.sendMessage(component);
 +        }
-+        sender.sendMessage(BUKKIT_HEADER);
++
++        if (!spigotPlugins.isEmpty()) {
++            sender.sendMessage(BUKKIT_HEADER);
++        }
++        
 +        for (Component component : formatProviders(spigotPlugins)) {
 +            sender.sendMessage(component);
 +        }


### PR DESCRIPTION
This PR removes the redundant plugin headers while they are not required. Imagine a situation when you have no Paper plugins and some Spigot plugins. It will look like this, which is pretty ugly:

```
Paper plugins:
Bukkit plugins:
- plugin 1
- plugin 2
```

The Paper plugins header is redundant here.