### PR TITLE
Validate providers when populating load order tree

### DIFF
--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -1574,10 +1574,10 @@ index 0000000000000000000000000000000000000000..f43295fdeaa587cf30c35a1d54516707
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/DependencyUtil.java b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/DependencyUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b963fae0285d2d87a6f6a4eddf98996a27dabac2
+index 0000000000000000000000000000000000000000..bfa258faf17ca6118aeddfa4e95bbd082bcd1390
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/DependencyUtil.java
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,75 @@
 +package io.papermc.paper.plugin.entrypoint.dependency;
 +
 +import com.google.common.graph.MutableGraph;
@@ -1590,6 +1590,7 @@ index 0000000000000000000000000000000000000000..b963fae0285d2d87a6f6a4eddf98996a
 +import java.util.ArrayList;
 +import java.util.List;
 +import java.util.Map;
++import java.util.function.Predicate;
 +
 +@SuppressWarnings("UnstableApiUsage")
 +public class DependencyUtil {
@@ -1614,14 +1615,18 @@ index 0000000000000000000000000000000000000000..b963fae0285d2d87a6f6a4eddf98996a
 +    }
 +
 +    @NotNull
-+    public static MutableGraph<String> buildLoadGraph(@NotNull MutableGraph<String> dependencyGraph, @NotNull LoadOrderConfiguration configuration) {
++    public static MutableGraph<String> buildLoadGraph(@NotNull MutableGraph<String> dependencyGraph, @NotNull LoadOrderConfiguration configuration, Predicate<String> validator) {
 +        String identifier = configuration.getMeta().getName();
 +        for (String dependency : configuration.getLoadAfter()) {
-+            dependencyGraph.putEdge(identifier, dependency);
++            if (validator.test(dependency)) {
++                dependencyGraph.putEdge(identifier, dependency);
++            }
 +        }
 +
 +        for (String loadBeforeTarget : configuration.getLoadBefore()) {
-+            dependencyGraph.putEdge(loadBeforeTarget, identifier);
++            if (validator.test(loadBeforeTarget)) {
++                dependencyGraph.putEdge(loadBeforeTarget, identifier);
++            }
 +        }
 +
 +        dependencyGraph.addNode(identifier); // Make sure dependencies at least have a node
@@ -2330,7 +2335,7 @@ index 0000000000000000000000000000000000000000..d116134db072ecea7caeb90310fab9d8
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/ModernPluginLoadingStrategy.java b/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/ModernPluginLoadingStrategy.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f2ef0ac8b498013d232ee56fdafba331c7dcbe27
+index 0000000000000000000000000000000000000000..969ab63a2096b2a9d0feb5d95e7809122023e3c7
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/ModernPluginLoadingStrategy.java
 @@ -0,0 +1,148 @@
@@ -2422,7 +2427,7 @@ index 0000000000000000000000000000000000000000..f2ef0ac8b498013d232ee56fdafba331
 +            LoadOrderConfiguration loadOrderConfiguration = validated.createConfiguration(providerMapMirror);
 +
 +            // Build a validated provider's load order changes
-+            DependencyUtil.buildLoadGraph(loadOrderGraph, loadOrderConfiguration);
++            DependencyUtil.buildLoadGraph(loadOrderGraph, loadOrderConfiguration, providerMap::containsKey);
 +
 +            // Build a validated provider's dependencies into the graph
 +            DependencyUtil.buildDependencyGraph(dependencyGraph, configuration);


### PR DESCRIPTION
Addresses https://github.com/PaperMC/Paper/pull/8873#issuecomment-1439376713

This prevents building dependency trees on providers that don't even exist, which should hopefully eliminate some of the possible plugin loading loops that are currently introduced.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-8890.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/567094861.zip)