### PR TITLE
Fix update folder logging error when no folder exists

### DIFF
--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -443,10 +443,10 @@ index 0000000000000000000000000000000000000000..4ecd00b32c7abc15d655dd3c999b6fec
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java b/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9926eb59b83abffffb578356f148f045edc027cb
+index 0000000000000000000000000000000000000000..21e43223d7942b0e5e3c6b63aa2c455ec17ffde9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java
-@@ -0,0 +1,88 @@
+@@ -0,0 +1,90 @@
 +package io.papermc.paper.plugin;
 +
 +import com.mojang.logging.LogUtils;
@@ -489,9 +489,11 @@ index 0000000000000000000000000000000000000000..9926eb59b83abffffb578356f148f045
 +
 +        final Path resolvedUpdateDirectory = pluginDirectory.resolve(updateDirectoryName);
 +        if (!Files.isDirectory(resolvedUpdateDirectory)) {
-+            LOGGER.error("Misconfigured update directory!");
-+            LOGGER.error(("Your configured update directory (%s) in bukkit.yml is pointing to a non-directory path. " +
-+                "Disabling auto updating functionality.").formatted(resolvedUpdateDirectory));
++            if (Files.exists(resolvedUpdateDirectory)) {
++                LOGGER.error("Misconfigured update directory!");
++                LOGGER.error("Your configured update directory ({}) in bukkit.yml is pointing to a non-directory path. " +
++                    "Auto updating functionality will not work.", resolvedUpdateDirectory);
++            }
 +            return new PluginInitializerManager(pluginDirectory, null);
 +        }
 +


### PR DESCRIPTION
Only show an error message if the configured path for update directory points to an existing non-directory. If it doesn't exist, just ignore it.