### PR TITLE
Additional ExplosiveMinecart API

### DIFF
--- a/patches/api/0304-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0304-Missing-Entity-Behavior-API.patch
@@ -6,6 +6,7 @@ Subject: [PATCH] Missing Entity Behavior API
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 Co-authored-by: William Blake Galbreath <blake.galbreath@gmail.com>
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java b/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
 index dddbb661265aa23f88d93d0681f418f40a872351..998f629852e1103767e005405d1f39c2251ecd28 100644
@@ -1176,28 +1177,53 @@ index 7cc1d9a966454af70b7c25735fe474fe3eb97eb4..ad2eaee347cd2864aef30d2af48c1be6
 +    // Paper stop - missing entity behaviour api - converting without entity event
  }
 diff --git a/src/main/java/org/bukkit/entity/minecart/ExplosiveMinecart.java b/src/main/java/org/bukkit/entity/minecart/ExplosiveMinecart.java
-index a4411daca0d8a770b0d15e08847b82df8a3ec27f..50464aa8c38cd47fc049ee022e25cb4976260fa0 100644
+index a4411daca0d8a770b0d15e08847b82df8a3ec27f..a6234a3fbd389080cb6394b1d824c366f8a5cb8f 100644
 --- a/src/main/java/org/bukkit/entity/minecart/ExplosiveMinecart.java
 +++ b/src/main/java/org/bukkit/entity/minecart/ExplosiveMinecart.java
-@@ -6,4 +6,19 @@ import org.bukkit.entity.Minecart;
+@@ -6,4 +6,44 @@ import org.bukkit.entity.Minecart;
   * Represents a Minecart with TNT inside it that can explode when triggered.
   */
  public interface ExplosiveMinecart extends Minecart {
 +    // Paper start - Entity API
 +    /**
-+     * Set the number of ticks until the minecart explodes after being primed.
++     * Set the number of ticks until the Minecart explodes after being primed.
 +     *
 +     * @param fuseTicks fuse ticks or -1 if the fuse isn't primed
 +     */
 +    void setFuseTicks(int fuseTicks);
 +
 +    /**
-+     * Retrieve the number of ticks until the explosive minecart explodes
++     * Retrieve the number of ticks until the explosive Minecart explodes.
 +     *
 +     * @return number of ticks or -1 if the fuse isn't primed
 +     */
 +    int getFuseTicks();
-+    // Paper end
++
++    /**
++     * Checks whether this explosive Minecart is ignited (its fuse is primed).
++     *
++     * @return whether the Minecart is ignited
++     */
++    boolean isIgnited();
++
++    /**
++     * Ignites this explosive Minecart, beginning its fuse.
++     */
++    void ignite();
++
++    /**
++     * Immediately explodes the Minecart.
++     * Power will depend on the Minecart's horizontal speed.
++     */
++    void explode();
++
++    /**
++     * Immediately explodes the Minecart with the specified power.
++     *
++     * @param power explosion power
++     */
++    void explode(double power);
++    // Paper end - Entity API
  }
 diff --git a/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java b/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java
 index db69687a7ad4b18d17ab1677cae5d8dd4dcd3678..8e4c6ec409f49d4a3378c466acc47f62c7689c0b 100644

--- a/patches/server/0647-Missing-Entity-Behavior-API.patch
+++ b/patches/server/0647-Missing-Entity-Behavior-API.patch
@@ -20,6 +20,7 @@ public net.minecraft.world.entity.ambient.Bat targetPosition
 public net.minecraft.world.entity.monster.Ravager attackTick
 public net.minecraft.world.entity.monster.Ravager stunnedTick
 public net.minecraft.world.entity.monster.Ravager roarTick
+public net.minecraft.world.entity.vehicle.MinecartTNT explode(D)V
 public net.minecraft.world.entity.vehicle.MinecartTNT fuse
 public net.minecraft.world.entity.monster.Endermite life
 public net.minecraft.world.entity.vehicle.MinecartHopper cooldownTime
@@ -33,6 +34,7 @@ public net.minecraft.world.entity.animal.Rabbit moreCarrotTicks
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 Co-authored-by: William Blake Galbreath <blake.galbreath@gmail.com>
+Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
 index 1ec0f71cb9882648bdd1e645f5719d8c3cc53a3d..ed74f2b90afaa43ae66fbd4797d23cfac9ea9e88 100644
@@ -787,7 +789,7 @@ index ee9648739fb39c5842063d7442df6eb5c9336d7f..569763b3c9e92a4071884f139fb12632
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartTNT.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartTNT.java
-index 9569068c0a6e1eb934f063634f5d3efe674aa33d..dfd0b5e018194343ca40629db6f70c6020c2d567 100644
+index 9569068c0a6e1eb934f063634f5d3efe674aa33d..4dd6314c66e2d69b0e072cfc305058b62945d35f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartTNT.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartTNT.java
 @@ -5,7 +5,7 @@ import org.bukkit.craftbukkit.CraftServer;
@@ -799,7 +801,7 @@ index 9569068c0a6e1eb934f063634f5d3efe674aa33d..dfd0b5e018194343ca40629db6f70c60
      CraftMinecartTNT(CraftServer server, MinecartTNT entity) {
          super(server, entity);
      }
-@@ -19,4 +19,20 @@ final class CraftMinecartTNT extends CraftMinecart implements ExplosiveMinecart
+@@ -19,4 +19,41 @@ final class CraftMinecartTNT extends CraftMinecart implements ExplosiveMinecart
      public EntityType getType() {
          return EntityType.MINECART_TNT;
      }
@@ -817,6 +819,27 @@ index 9569068c0a6e1eb934f063634f5d3efe674aa33d..dfd0b5e018194343ca40629db6f70c60
 +    @Override
 +    public int getFuseTicks() {
 +        return this.getHandle().getFuse();
++    }
++
++    @Override
++    public boolean isIgnited() {
++        return this.getHandle().isPrimed();
++    }
++
++    @Override
++    public void ignite() {
++        this.getHandle().primeFuse();
++    }
++
++    @Override
++    public void explode() {
++        explode(this.getHandle().getDeltaMovement().horizontalDistanceSqr());
++    }
++
++    @Override
++    public void explode(double power) {
++        com.google.common.base.Preconditions.checkArgument(power >= 0 && Double.isFinite(power), "Explosion power must be a finite non-negative number");
++        this.getHandle().explode(power);
 +    }
 +    // Paper end
  }


### PR DESCRIPTION
Adds methods to:
- `#isIgnited()` - check if the Minecart is ignited (its fuse is primed)
- `#ignite()` - prime the fuse
  differs from `#setFuseTicks()` by following vanilla behavior (4 seconds before the explosion, notifying the players to play the animation, playing sound if not silent); `#setFuseTicks` can be used additionally after to change the ticks before the explosion)
- `#explode()` and `#explode(power)` - to immediately explode the Minecart (parameterless method follows vanilla behavior)