### PR TITLE
Properly log any Throwable on plugin class creation

### DIFF
--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -2060,7 +2060,7 @@ index 0000000000000000000000000000000000000000..22189a1c42459c00d3e8bdeb980d15a6
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/LegacyPluginLoadingStrategy.java b/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/LegacyPluginLoadingStrategy.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d116134db072ecea7caeb90310fab9d83534ef48
+index 0000000000000000000000000000000000000000..746272e0f8fb5311d5408175abe08db8aa356376
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/LegacyPluginLoadingStrategy.java
 @@ -0,0 +1,269 @@
@@ -2272,7 +2272,7 @@ index 0000000000000000000000000000000000000000..d116134db072ecea7caeb90310fab9d8
 +                            javapluginsLoaded.add(new ProviderPair<>(file, loadedPlugin));
 +                        }
 +
-+                    } catch (Exception ex) {
++                    } catch (Throwable ex) {
 +                        LOGGER.log(Level.SEVERE, "Could not load '" + file.getSource() + "' in folder '" + file.getParentSource() + "'", ex); // Paper
 +                    }
 +                }
@@ -2304,7 +2304,7 @@ index 0000000000000000000000000000000000000000..d116134db072ecea7caeb90310fab9d8
 +                                javapluginsLoaded.add(new ProviderPair<>(file, loadedPlugin));
 +                            }
 +                            break;
-+                        } catch (Exception ex) {
++                        } catch (Throwable ex) {
 +                            LOGGER.log(Level.SEVERE, "Could not load '" + file.getSource() + "' in folder '" + file.getParentSource() + "'", ex); // Paper
 +                        }
 +                    }
@@ -2335,7 +2335,7 @@ index 0000000000000000000000000000000000000000..d116134db072ecea7caeb90310fab9d8
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/ModernPluginLoadingStrategy.java b/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/ModernPluginLoadingStrategy.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..969ab63a2096b2a9d0feb5d95e7809122023e3c7
+index 0000000000000000000000000000000000000000..fa7bbfeff53d5cab3d96a5f1181b610f4ce22518
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/ModernPluginLoadingStrategy.java
 @@ -0,0 +1,148 @@
@@ -2362,7 +2362,7 @@ index 0000000000000000000000000000000000000000..969ab63a2096b2a9d0feb5d95e780912
 +@SuppressWarnings("UnstableApiUsage")
 +public class ModernPluginLoadingStrategy<T> implements ProviderLoadingStrategy<T> {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +    private final ProviderConfiguration<T> configuration;
 +
 +    public ModernPluginLoadingStrategy(ProviderConfiguration<T> onLoad) {
@@ -2469,7 +2469,7 @@ index 0000000000000000000000000000000000000000..969ab63a2096b2a9d0feb5d95e780912
 +                if (this.configuration.load(retrievedProvider, instance)) {
 +                    loadedPlugins.add(new ProviderPair<>(retrievedProvider, instance));
 +                }
-+            } catch (Exception ex) {
++            } catch (Throwable ex) {
 +                LOGGER.error("Could not load plugin '%s' in folder '%s'".formatted(retrievedProvider.getFileName(), retrievedProvider.getParentSource()), ex); // Paper
 +            }
 +        }


### PR DESCRIPTION
Makes issues like https://pastes.dev/5YMQs9RYQQ easier to see the cause of (and not crash the server when it doesn't have to).