### PR TITLE
Close library classloader and improve PluginDescriptionFile

### DIFF
--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -748,10 +748,10 @@ index 0000000000000000000000000000000000000000..f9a2c55a354c877749db3f92956de802
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4fa7147d0dcbfd7e40f6eab1f7b0c6d8bbcf6906
+index 0000000000000000000000000000000000000000..392eb260b44d5f9e685ce09596c19f0af9cc0339
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
-@@ -0,0 +1,194 @@
+@@ -0,0 +1,204 @@
 +package io.papermc.paper.plugin.entrypoint.classloader;
 +
 +import io.papermc.paper.plugin.configuration.PluginMeta;
@@ -770,6 +770,7 @@ index 0000000000000000000000000000000000000000..4fa7147d0dcbfd7e40f6eab1f7b0c6d8
 +import java.io.File;
 +import java.io.IOException;
 +import java.net.URL;
++import java.net.URLClassLoader;
 +import java.nio.file.Path;
 +import java.util.ArrayList;
 +import java.util.Collections;
@@ -793,7 +794,7 @@ index 0000000000000000000000000000000000000000..4fa7147d0dcbfd7e40f6eab1f7b0c6d8
 +        registerAsParallelCapable();
 +    }
 +
-+    private final ClassLoader libraryLoader;
++    private final URLClassLoader libraryLoader;
 +    private final Set<String> seenIllegalAccess = Collections.newSetFromMap(new ConcurrentHashMap<>());
 +    private final Logger logger;
 +    @Nullable
@@ -801,7 +802,7 @@ index 0000000000000000000000000000000000000000..4fa7147d0dcbfd7e40f6eab1f7b0c6d8
 +    @Nullable
 +    private PluginClassLoaderGroup group;
 +
-+    public PaperPluginClassLoader(Logger logger, Path source, JarFile file, PaperPluginMeta configuration, ClassLoader parentLoader, ClassLoader libraryLoader) throws IOException {
++    public PaperPluginClassLoader(Logger logger, Path source, JarFile file, PaperPluginMeta configuration, ClassLoader parentLoader, URLClassLoader libraryLoader) throws IOException {
 +        super(source, file, configuration, parentLoader);
 +        this.libraryLoader = libraryLoader;
 +
@@ -904,9 +905,9 @@ index 0000000000000000000000000000000000000000..4fa7147d0dcbfd7e40f6eab1f7b0c6d8
 +            config.getProvidedPlugins(),
 +            config.getMainClass(),
 +            "", // Classloader load order api
-+            List.of(), // Dependencies
-+            List.of(), // Soft Depends
-+            List.of(), // Load Before
++            config.getPluginDependencies(), // Dependencies
++            config.getPluginSoftDependencies(), // Soft Depends
++            config.getLoadBeforePlugins(), // Load Before
 +            config.getVersion(),
 +            Map.of(), // Commands, we use a separate system
 +            config.getDescription(),
@@ -944,6 +945,15 @@ index 0000000000000000000000000000000000000000..4fa7147d0dcbfd7e40f6eab1f7b0c6d8
 +            ", loadedJavaPlugin=" + this.loadedJavaPlugin +
 +            ", group=" + this.group +
 +            '}';
++    }
++
++    @Override
++    public void close() throws IOException {
++        try {
++            super.close();
++        } finally {
++            this.libraryLoader.close();
++        }
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperSimplePluginClassLoader.java b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperSimplePluginClassLoader.java


### PR DESCRIPTION
Readds changes already proposed in a previous PR which were lost, presumably during the fixup process.

Specifically, this commit aims to readd the two previously proposed improvements:

1) Close the library classloader when a paper plugins classloader
   is closed.

2) Pass soft- and normal dependencies as well as the load-before plugins
   specified by a paper plugin to the dummy PluginDescriptionFile
   implementation spigot plugins expect via Plugin#getDescription().

See: #8866