### PR TITLE
Close plugin jar file on classloader close and after retrieving name for updating

### DIFF
--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -1969,7 +1969,7 @@ index 669a70faa95d0d6525a731d73499ed6fb0b48320..c9cf9d361a1289aba383718733a2098b
              throw new IllegalStateException("Cannot get plugin for " + clazz + " from a static initializer");
          }
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index 047c0304fd617cec990f80815b43916c6ef5a94c..fa39c93d76ebb9eecce1f4b5203cb361e4778b4f 100644
+index 047c0304fd617cec990f80815b43916c6ef5a94c..d0ad072c832b8fc8a1cfdcafdd42c724531a2e29 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 @@ -49,6 +49,7 @@ import org.yaml.snakeyaml.error.YAMLException;
@@ -1993,7 +1993,7 @@ index 047c0304fd617cec990f80815b43916c6ef5a94c..fa39c93d76ebb9eecce1f4b5203cb361
          final PluginClassLoader loader;
          try {
 -            loader = new PluginClassLoader(this, getClass().getClassLoader(), description, dataFolder, file, (libraryLoader != null) ? libraryLoader.createLoader(description) : null);
-+            loader = new PluginClassLoader(getClass().getClassLoader(), description, dataFolder, file, (libraryLoader != null) ? libraryLoader.createLoader(description) : null); // Paper
++            loader = new PluginClassLoader(getClass().getClassLoader(), description, dataFolder, file, (libraryLoader != null) ? libraryLoader.createLoader(description) : null, null); // Paper
          } catch (InvalidPluginException ex) {
              throw ex;
          } catch (Throwable ex) {
@@ -2014,7 +2014,7 @@ index 6d634b0ea813ccb19f1562a7d0e5a59cea4eab21..f9e67e20133d349e43d126dbb48b34d4
  
      private final Logger logger;
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbcdda6698c 100644
+index 2f74ec96ece706de23156ebabfe493211bc05391..c42663a2ae98fda6dcf2ab6ac899cc6238bce65f 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -29,7 +29,8 @@ import org.jetbrains.annotations.Nullable;
@@ -2027,7 +2027,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbc
      private final JavaPluginLoader loader;
      private final Map<String, Class<?>> classes = new ConcurrentHashMap<String, Class<?>>();
      private final PluginDescriptionFile description;
-@@ -43,24 +44,36 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -43,24 +44,30 @@ final class PluginClassLoader extends URLClassLoader {
      private JavaPlugin pluginInit;
      private IllegalStateException pluginState;
      private final Set<String> seenIllegalAccess = Collections.newSetFromMap(new ConcurrentHashMap<>());
@@ -2040,13 +2040,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbc
  
 -    PluginClassLoader(@NotNull final JavaPluginLoader loader, @Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader) throws IOException, InvalidPluginException, MalformedURLException {
 +    @org.jetbrains.annotations.ApiStatus.Internal // Paper
-+    public PluginClassLoader(@Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader) throws IOException, InvalidPluginException, MalformedURLException { // Paper
-+        // Paper start - use JarFile provided by SpigotPluginProvider
-+        this(parent, description, dataFolder, file, libraryLoader, null);
-+    }
-+    @org.jetbrains.annotations.ApiStatus.Internal // Paper
-+    public PluginClassLoader(@Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader, @Nullable JarFile jarFile) throws IOException, InvalidPluginException, MalformedURLException { // Paper
-+        // Paper end
++    public PluginClassLoader(@Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader, @Nullable JarFile jarFile) throws IOException, InvalidPluginException, MalformedURLException { // Paper // Paper - use JarFile provided by SpigotPluginProvider
          super(new URL[] {file.toURI().toURL()}, parent);
 -        Preconditions.checkArgument(loader != null, "Loader cannot be null");
 +        this.loader = null; // Paper - pass null into loader field
@@ -2068,7 +2062,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbc
          try {
              Class<?> jarClass;
              try {
-@@ -94,6 +107,27 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -94,6 +101,27 @@ final class PluginClassLoader extends URLClassLoader {
          return findResources(name);
      }
  
@@ -2096,7 +2090,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbc
      @Override
      protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
          return loadClass0(name, resolve, true, true);
-@@ -119,26 +153,11 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -119,26 +147,11 @@ final class PluginClassLoader extends URLClassLoader {
  
          if (checkGlobal) {
              // This ignores the libraries of other plugins, unless they are transitive dependencies.
@@ -2125,7 +2119,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbc
  
                  return result;
              }
-@@ -167,7 +186,7 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -167,7 +180,7 @@ final class PluginClassLoader extends URLClassLoader {
                      throw new ClassNotFoundException(name, ex);
                  }
  
@@ -2134,7 +2128,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbc
  
                  int dot = name.lastIndexOf('.');
                  if (dot != -1) {
-@@ -197,8 +216,8 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -197,8 +210,8 @@ final class PluginClassLoader extends URLClassLoader {
                  result = super.findClass(name);
              }
  
@@ -2144,7 +2138,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbc
          }
  
          return result;
-@@ -207,6 +226,12 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -207,6 +220,12 @@ final class PluginClassLoader extends URLClassLoader {
      @Override
      public void close() throws IOException {
          try {
@@ -2157,7 +2151,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbc
              super.close();
          } finally {
              jar.close();
-@@ -218,7 +243,7 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -218,7 +237,7 @@ final class PluginClassLoader extends URLClassLoader {
          return classes.values();
      }
  
@@ -2166,7 +2160,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbc
          Preconditions.checkArgument(javaPlugin != null, "Initializing plugin cannot be null");
          Preconditions.checkArgument(javaPlugin.getClass().getClassLoader() == this, "Cannot initialize plugin outside of this class loader");
          if (this.plugin != null || this.pluginInit != null) {
-@@ -228,6 +253,32 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -228,6 +247,32 @@ final class PluginClassLoader extends URLClassLoader {
          pluginState = new IllegalStateException("Initial initialization");
          this.pluginInit = javaPlugin;
  

--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -2014,7 +2014,7 @@ index 6d634b0ea813ccb19f1562a7d0e5a59cea4eab21..f9e67e20133d349e43d126dbb48b34d4
  
      private final Logger logger;
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bff2d42284 100644
+index 2f74ec96ece706de23156ebabfe493211bc05391..d7761a69630a788cf9d848c4aeb32fbcdda6698c 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -29,7 +29,8 @@ import org.jetbrains.annotations.Nullable;
@@ -2027,7 +2027,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bf
      private final JavaPluginLoader loader;
      private final Map<String, Class<?>> classes = new ConcurrentHashMap<String, Class<?>>();
      private final PluginDescriptionFile description;
-@@ -43,16 +44,18 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -43,24 +44,36 @@ final class PluginClassLoader extends URLClassLoader {
      private JavaPlugin pluginInit;
      private IllegalStateException pluginState;
      private final Set<String> seenIllegalAccess = Collections.newSetFromMap(new ConcurrentHashMap<>());
@@ -2041,6 +2041,12 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bf
 -    PluginClassLoader(@NotNull final JavaPluginLoader loader, @Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader) throws IOException, InvalidPluginException, MalformedURLException {
 +    @org.jetbrains.annotations.ApiStatus.Internal // Paper
 +    public PluginClassLoader(@Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader) throws IOException, InvalidPluginException, MalformedURLException { // Paper
++        // Paper start - use JarFile provided by SpigotPluginProvider
++        this(parent, description, dataFolder, file, libraryLoader, null);
++    }
++    @org.jetbrains.annotations.ApiStatus.Internal // Paper
++    public PluginClassLoader(@Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader, @Nullable JarFile jarFile) throws IOException, InvalidPluginException, MalformedURLException { // Paper
++        // Paper end
          super(new URL[] {file.toURI().toURL()}, parent);
 -        Preconditions.checkArgument(loader != null, "Loader cannot be null");
 +        this.loader = null; // Paper - pass null into loader field
@@ -2049,7 +2055,9 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bf
          this.description = description;
          this.dataFolder = dataFolder;
          this.file = file;
-@@ -61,6 +64,10 @@ final class PluginClassLoader extends URLClassLoader {
+-        this.jar = new JarFile(file);
++        this.jar = jarFile == null ? new JarFile(file) : jarFile; // Paper - use JarFile provided by SpigotPluginProvider
+         this.manifest = jar.getManifest();
          this.url = file.toURI().toURL();
          this.libraryLoader = libraryLoader;
  
@@ -2060,7 +2068,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bf
          try {
              Class<?> jarClass;
              try {
-@@ -94,6 +101,27 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -94,6 +107,27 @@ final class PluginClassLoader extends URLClassLoader {
          return findResources(name);
      }
  
@@ -2088,7 +2096,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bf
      @Override
      protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
          return loadClass0(name, resolve, true, true);
-@@ -119,26 +147,11 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -119,26 +153,11 @@ final class PluginClassLoader extends URLClassLoader {
  
          if (checkGlobal) {
              // This ignores the libraries of other plugins, unless they are transitive dependencies.
@@ -2117,7 +2125,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bf
  
                  return result;
              }
-@@ -167,7 +180,7 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -167,7 +186,7 @@ final class PluginClassLoader extends URLClassLoader {
                      throw new ClassNotFoundException(name, ex);
                  }
  
@@ -2126,7 +2134,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bf
  
                  int dot = name.lastIndexOf('.');
                  if (dot != -1) {
-@@ -197,8 +210,8 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -197,8 +216,8 @@ final class PluginClassLoader extends URLClassLoader {
                  result = super.findClass(name);
              }
  
@@ -2136,7 +2144,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bf
          }
  
          return result;
-@@ -207,6 +220,12 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -207,6 +226,12 @@ final class PluginClassLoader extends URLClassLoader {
      @Override
      public void close() throws IOException {
          try {
@@ -2149,7 +2157,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bf
              super.close();
          } finally {
              jar.close();
-@@ -218,7 +237,7 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -218,7 +243,7 @@ final class PluginClassLoader extends URLClassLoader {
          return classes.values();
      }
  
@@ -2158,7 +2166,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..dd569f2fc6098650d202e834b343b1bf
          Preconditions.checkArgument(javaPlugin != null, "Initializing plugin cannot be null");
          Preconditions.checkArgument(javaPlugin.getClass().getClassLoader() == this, "Cannot initialize plugin outside of this class loader");
          if (this.plugin != null || this.pluginInit != null) {
-@@ -228,6 +247,32 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -228,6 +253,32 @@ final class PluginClassLoader extends URLClassLoader {
          pluginState = new IllegalStateException("Initial initialization");
          this.pluginInit = javaPlugin;
  

--- a/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
+++ b/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
@@ -93,10 +93,10 @@ index 71c8d2345eef6895edb8d210553ec3cddd9c76d0..6d31f3a2569ae9c522a5e6cddd38ac8f
  
      /**
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index d7761a69630a788cf9d848c4aeb32fbcdda6698c..de28197f92d154de0500abfe23da07a9065f50a2 100644
+index c42663a2ae98fda6dcf2ab6ac899cc6238bce65f..ed2492ce51097dd0c2ba72e7b9449561a73ea7e3 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -70,7 +70,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -64,7 +64,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
          this.url = file.toURI().toURL();
          this.libraryLoader = libraryLoader;
  
@@ -105,7 +105,7 @@ index d7761a69630a788cf9d848c4aeb32fbcdda6698c..de28197f92d154de0500abfe23da07a9
          // Paper start
          this.classLoaderGroup = io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage.instance().registerSpigotGroup(this); // Paper
          // Paper end
-@@ -253,6 +253,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -247,6 +247,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
          pluginState = new IllegalStateException("Initial initialization");
          this.pluginInit = javaPlugin;
  

--- a/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
+++ b/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
@@ -93,10 +93,10 @@ index 71c8d2345eef6895edb8d210553ec3cddd9c76d0..6d31f3a2569ae9c522a5e6cddd38ac8f
  
      /**
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index dd569f2fc6098650d202e834b343b1bff2d42284..fade45ef475ae20922f5abea49a0f035d19b7819 100644
+index d7761a69630a788cf9d848c4aeb32fbcdda6698c..de28197f92d154de0500abfe23da07a9065f50a2 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -64,7 +64,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -70,7 +70,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
          this.url = file.toURI().toURL();
          this.libraryLoader = libraryLoader;
  
@@ -105,7 +105,7 @@ index dd569f2fc6098650d202e834b343b1bff2d42284..fade45ef475ae20922f5abea49a0f035
          // Paper start
          this.classLoaderGroup = io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage.instance().registerSpigotGroup(this); // Paper
          // Paper end
-@@ -247,6 +247,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -253,6 +253,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
          pluginState = new IllegalStateException("Initial initialization");
          this.pluginInit = javaPlugin;
  

--- a/patches/api/0231-Enable-multi-release-plugin-jars.patch
+++ b/patches/api/0231-Enable-multi-release-plugin-jars.patch
@@ -5,15 +5,15 @@ Subject: [PATCH] Enable multi-release plugin jars
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index fade45ef475ae20922f5abea49a0f035d19b7819..264d712d3399d24cb01b85fc2d055d9fbf11b23a 100644
+index de28197f92d154de0500abfe23da07a9065f50a2..71e87e53b7daf8b3fc31696a841f3285e54a7b61 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -59,7 +59,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -65,7 +65,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
          this.description = description;
          this.dataFolder = dataFolder;
          this.file = file;
--        this.jar = new JarFile(file);
-+        this.jar = new JarFile(file, true, java.util.zip.ZipFile.OPEN_READ, JarFile.runtimeVersion()); // Paper - enable multi-release jars for Java 9+
+-        this.jar = jarFile == null ? new JarFile(file) : jarFile; // Paper - use JarFile provided by SpigotPluginProvider
++        this.jar = jarFile == null ? new JarFile(file, true, java.util.zip.ZipFile.OPEN_READ, JarFile.runtimeVersion()) : jarFile; // Paper - use JarFile provided by SpigotPluginProvider // Paper - enable multi-release jars for Java 9+
          this.manifest = jar.getManifest();
          this.url = file.toURI().toURL();
          this.libraryLoader = libraryLoader;

--- a/patches/api/0231-Enable-multi-release-plugin-jars.patch
+++ b/patches/api/0231-Enable-multi-release-plugin-jars.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Enable multi-release plugin jars
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index de28197f92d154de0500abfe23da07a9065f50a2..71e87e53b7daf8b3fc31696a841f3285e54a7b61 100644
+index ed2492ce51097dd0c2ba72e7b9449561a73ea7e3..9c409dcd0179bea236311e1d5998daa4245e1542 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -65,7 +65,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -59,7 +59,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
          this.description = description;
          this.dataFolder = dataFolder;
          this.file = file;

--- a/patches/api/0309-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
+++ b/patches/api/0309-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Rewrite LogEvents to contain the source jars in stack traces
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 264d712d3399d24cb01b85fc2d055d9fbf11b23a..327ff03fa1978881fa6f6ba20e33e3c049c2e3cd 100644
+index 71e87e53b7daf8b3fc31696a841f3285e54a7b61..23036482f80c8d285d9f2cfb1ff70d2f4502ea81 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -53,7 +53,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
- 
+@@ -59,7 +59,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
      @org.jetbrains.annotations.ApiStatus.Internal // Paper
-     public PluginClassLoader(@Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader) throws IOException, InvalidPluginException, MalformedURLException { // Paper
+     public PluginClassLoader(@Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader, @Nullable JarFile jarFile) throws IOException, InvalidPluginException, MalformedURLException { // Paper
+         // Paper end
 -        super(new URL[] {file.toURI().toURL()}, parent);
 +        super(file.getName(), new URL[] {file.toURI().toURL()}, parent);
          this.loader = null; // Paper - pass null into loader field

--- a/patches/api/0309-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
+++ b/patches/api/0309-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Rewrite LogEvents to contain the source jars in stack traces
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 71e87e53b7daf8b3fc31696a841f3285e54a7b61..23036482f80c8d285d9f2cfb1ff70d2f4502ea81 100644
+index 9c409dcd0179bea236311e1d5998daa4245e1542..bfc4a97f1fb0d245056598d5211ff2347a431b64 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -59,7 +59,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -53,7 +53,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+ 
      @org.jetbrains.annotations.ApiStatus.Internal // Paper
-     public PluginClassLoader(@Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader, @Nullable JarFile jarFile) throws IOException, InvalidPluginException, MalformedURLException { // Paper
-         // Paper end
+     public PluginClassLoader(@Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader, @Nullable JarFile jarFile) throws IOException, InvalidPluginException, MalformedURLException { // Paper // Paper - use JarFile provided by SpigotPluginProvider
 -        super(new URL[] {file.toURI().toURL()}, parent);
 +        super(file.getName(), new URL[] {file.toURI().toURL()}, parent);
          this.loader = null; // Paper - pass null into loader field

--- a/patches/api/0382-Also-load-resources-from-LibraryLoader.patch
+++ b/patches/api/0382-Also-load-resources-from-LibraryLoader.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Also load resources from LibraryLoader
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 23036482f80c8d285d9f2cfb1ff70d2f4502ea81..673201cea373fa132de89af5e7af0ecd4345e762 100644
+index bfc4a97f1fb0d245056598d5211ff2347a431b64..e89ab347b908cc92274dd5dd796a02249f899977 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -99,14 +99,35 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -93,14 +93,35 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
  
      @Override
      public URL getResource(String name) {

--- a/patches/api/0382-Also-load-resources-from-LibraryLoader.patch
+++ b/patches/api/0382-Also-load-resources-from-LibraryLoader.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Also load resources from LibraryLoader
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 327ff03fa1978881fa6f6ba20e33e3c049c2e3cd..7d300a539ac2ef1c773cfa90cecc8655490a8686 100644
+index 23036482f80c8d285d9f2cfb1ff70d2f4502ea81..673201cea373fa132de89af5e7af0ecd4345e762 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -93,14 +93,35 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -99,14 +99,35 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
  
      @Override
      public URL getResource(String name) {

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -803,10 +803,10 @@ index 0000000000000000000000000000000000000000..f9a2c55a354c877749db3f92956de802
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..392eb260b44d5f9e685ce09596c19f0af9cc0339
+index 0000000000000000000000000000000000000000..79581d917e754998123b94b9f4ea7d1e78f017ae
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
-@@ -0,0 +1,204 @@
+@@ -0,0 +1,202 @@
 +package io.papermc.paper.plugin.entrypoint.classloader;
 +
 +import io.papermc.paper.plugin.configuration.PluginMeta;
@@ -1004,10 +1004,8 @@ index 0000000000000000000000000000000000000000..392eb260b44d5f9e685ce09596c19f0a
 +
 +    @Override
 +    public void close() throws IOException {
-+        try {
++        try (this.jar; this.libraryLoader) {
 +            super.close();
-+        } finally {
-+            this.libraryLoader.close();
 +        }
 +    }
 +}
@@ -4985,10 +4983,10 @@ index 0000000000000000000000000000000000000000..1822e076601db51c8a7954036853bee1
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java b/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e6a99f422038fad519215abf239135b11edc2bce
+index 0000000000000000000000000000000000000000..0077a0a82c04bae0d93ab5c9cf07364b7c947bb3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
-@@ -0,0 +1,156 @@
+@@ -0,0 +1,157 @@
 +package io.papermc.paper.plugin.provider.source;
 +
 +import io.papermc.paper.plugin.PluginInitializerManager;
@@ -5089,13 +5087,14 @@ index 0000000000000000000000000000000000000000..e6a99f422038fad519215abf239135b1
 +    }
 +
 +    private String getPluginName(Path path) throws Exception {
-+        JarFile file = new JarFile(path.toFile());
-+        PluginFileType<?, ?> type = PluginFileType.guessType(file);
-+        if (type == null) {
-+            throw new IllegalArgumentException(path + " is not a valid plugin file, cannot load a plugin from it!");
-+        }
++        try (JarFile file = new JarFile(path.toFile())) {
++            PluginFileType<?, ?> type = PluginFileType.guessType(file);
++            if (type == null) {
++                throw new IllegalArgumentException(path + " is not a valid plugin file, cannot load a plugin from it!");
++            }
 +
-+        return type.getConfig(file).getName();
++            return type.getConfig(file).getName();
++        }
 +    }
 +
 +    private class UpdateFileVisitor implements FileVisitor<Path> {

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -5818,7 +5818,7 @@ index 0000000000000000000000000000000000000000..b2a6544e321fa61c58bdf5684231de10
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/type/spigot/SpigotPluginProvider.java b/src/main/java/io/papermc/paper/plugin/provider/type/spigot/SpigotPluginProvider.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9a19abaccec91df9b2614dd6638d7bc199bdac2c
+index 0000000000000000000000000000000000000000..c074e8651528a19a4485fb7e9d56c649ba704ca4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/type/spigot/SpigotPluginProvider.java
 @@ -0,0 +1,190 @@
@@ -5943,7 +5943,7 @@ index 0000000000000000000000000000000000000000..9a19abaccec91df9b2614dd6638d7bc1
 +
 +            final PluginClassLoader loader;
 +            try {
-+                loader = new PluginClassLoader(this.getClass().getClassLoader(), this.description, dataFolder, this.path.toFile(), LIBRARY_LOADER.createLoader(this.description)); // Paper
++                loader = new PluginClassLoader(this.getClass().getClassLoader(), this.description, dataFolder, this.path.toFile(), LIBRARY_LOADER.createLoader(this.description), this.jarFile); // Paper
 +            } catch (InvalidPluginException ex) {
 +                throw ex;
 +            } catch (Throwable ex) {


### PR DESCRIPTION
This should fix #8879 and similar reports on the Discord server, I can't test it because I'm not on Windows, so perhaps it would be good to add the build-pr-jar label and ask for someone to test the update feature on Windows.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-8902.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/574775468.zip)