### PR TITLE
Don't fire 2 game events for certain cauldron interactions

### DIFF
--- a/patches/server/0793-Fire-CauldronLevelChange-on-initial-fill.patch
+++ b/patches/server/0793-Fire-CauldronLevelChange-on-initial-fill.patch
@@ -6,6 +6,46 @@ Subject: [PATCH] Fire CauldronLevelChange on initial fill
 Also don't fire level events or game events if stalactite
 drip is cancelled
 
+diff --git a/src/main/java/net/minecraft/core/cauldron/CauldronInteraction.java b/src/main/java/net/minecraft/core/cauldron/CauldronInteraction.java
+index 4c9334dde0734a3550a810845cee53f474e9c96b..ef7f1a871144f4a6897769f2459a4dd5eeffa5b4 100644
+--- a/src/main/java/net/minecraft/core/cauldron/CauldronInteraction.java
++++ b/src/main/java/net/minecraft/core/cauldron/CauldronInteraction.java
+@@ -80,7 +80,7 @@ public interface CauldronInteraction {
+             } else {
+                 if (!world.isClientSide) {
+                     // CraftBukkit start
+-                    if (!LayeredCauldronBlock.changeLevel(iblockdata, world, blockposition, Blocks.WATER_CAULDRON.defaultBlockState(), entityhuman, CauldronLevelChangeEvent.ChangeReason.BOTTLE_EMPTY)) {
++                    if (!LayeredCauldronBlock.changeLevel(iblockdata, world, blockposition, Blocks.WATER_CAULDRON.defaultBlockState(), entityhuman, CauldronLevelChangeEvent.ChangeReason.BOTTLE_EMPTY, false)) { // Paper
+                         return InteractionResult.SUCCESS;
+                     }
+                     // CraftBukkit end
+@@ -128,7 +128,7 @@ public interface CauldronInteraction {
+             if ((Integer) iblockdata.getValue(LayeredCauldronBlock.LEVEL) != 3 && PotionUtils.getPotion(itemstack) == Potions.WATER) {
+                 if (!world.isClientSide) {
+                     // CraftBukkit start
+-                    if (!LayeredCauldronBlock.changeLevel(iblockdata, world, blockposition, iblockdata.cycle(LayeredCauldronBlock.LEVEL), entityhuman, CauldronLevelChangeEvent.ChangeReason.BOTTLE_EMPTY)) {
++                    if (!LayeredCauldronBlock.changeLevel(iblockdata, world, blockposition, iblockdata.cycle(LayeredCauldronBlock.LEVEL), entityhuman, CauldronLevelChangeEvent.ChangeReason.BOTTLE_EMPTY, false)) { // Paper
+                         return InteractionResult.SUCCESS;
+                     }
+                     // CraftBukkit end
+@@ -212,7 +212,7 @@ public interface CauldronInteraction {
+         } else {
+             if (!world.isClientSide) {
+                 // CraftBukkit start
+-                if (!LayeredCauldronBlock.changeLevel(state, world, pos, Blocks.CAULDRON.defaultBlockState(), player, CauldronLevelChangeEvent.ChangeReason.BUCKET_FILL)) {
++                if (!LayeredCauldronBlock.changeLevel(state, world, pos, Blocks.CAULDRON.defaultBlockState(), player, CauldronLevelChangeEvent.ChangeReason.BUCKET_FILL, false)) { // Paper
+                     return InteractionResult.SUCCESS;
+                 }
+                 // CraftBukkit end
+@@ -233,7 +233,7 @@ public interface CauldronInteraction {
+     static InteractionResult emptyBucket(Level world, BlockPos pos, Player player, InteractionHand hand, ItemStack stack, BlockState state, SoundEvent soundEvent) {
+         if (!world.isClientSide) {
+             // CraftBukkit start
+-            if (!LayeredCauldronBlock.changeLevel(state, world, pos, state, player, CauldronLevelChangeEvent.ChangeReason.BUCKET_EMPTY)) {
++            if (!LayeredCauldronBlock.changeLevel(state, world, pos, state, player, CauldronLevelChangeEvent.ChangeReason.BUCKET_EMPTY, false)) { // Paper
+                 return InteractionResult.SUCCESS;
+             }
+             // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/level/block/CauldronBlock.java b/src/main/java/net/minecraft/world/level/block/CauldronBlock.java
 index 588b3e911d9b22dad2928ea9e32e8a8a3a8e9b96..a821a981adbebdcf22997731b9bbea3d033cd2b1 100644
 --- a/src/main/java/net/minecraft/world/level/block/CauldronBlock.java


### PR DESCRIPTION
These cauldron interactions already fire the FLUID_PLACE game event, it shouldn't also fire the BLOCK_CHANGE game event, which is what the added method by upstream does. 

Follows up on https://github.com/PaperMC/Paper/pull/8887