### PR TITLE
Fix SpawnEggMeta#get/setSpawnedType

### DIFF
--- a/patches/api/0419-Fix-SpawnEggMeta-get-setSpawnedType.patch
+++ b/patches/api/0419-Fix-SpawnEggMeta-get-setSpawnedType.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 26 Feb 2023 07:14:19 -0800
+Subject: [PATCH] Fix SpawnEggMeta#get/setSpawnedType
+
+
+diff --git a/src/main/java/org/bukkit/inventory/meta/SpawnEggMeta.java b/src/main/java/org/bukkit/inventory/meta/SpawnEggMeta.java
+index 9ae84de43018e2dc9df5e1a56244d8812c2ffbb8..c190dff53e18994c93c35b6a9502cba38e6886ed 100644
+--- a/src/main/java/org/bukkit/inventory/meta/SpawnEggMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/SpawnEggMeta.java
+@@ -15,7 +15,7 @@ public interface SpawnEggMeta extends ItemMeta {
+      * @return The entity type. May be null for implementation specific default.
+      * @deprecated different types are different items
+      */
+-    @Deprecated
++    @Deprecated(forRemoval = true) // Paper
+     @Contract("-> fail")
+     EntityType getSpawnedType();
+ 
+@@ -26,10 +26,26 @@ public interface SpawnEggMeta extends ItemMeta {
+      * default.
+      * @deprecated different types are different items
+      */
+-    @Deprecated
++    @Deprecated(forRemoval = true) // Paper
+     @Contract("_ -> fail")
+     void setSpawnedType(EntityType type);
+ 
++    // Paper start
++    /**
++     * Get the custom type of entity this egg will spawn.
++     *
++     * @return the entity type or null if no custom type is set
++     */
++    @org.jetbrains.annotations.Nullable EntityType getCustomSpawnedType();
++
++    /**
++     * Set the custom type of entity this egg will spawn.
++     *
++     * @param type the entity type or null to clear the custom type
++     */
++    void setCustomSpawnedType(@org.jetbrains.annotations.Nullable EntityType type);
++    // Paper end
++
+     @NotNull
+     @Override
+     SpawnEggMeta clone();

--- a/patches/server/0966-Fix-SpawnEggMeta-get-setSpawnedType.patch
+++ b/patches/server/0966-Fix-SpawnEggMeta-get-setSpawnedType.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 23 Feb 2023 13:19:13 -0800
+Subject: [PATCH] Fix SpawnEggMeta#get/setSpawnedType
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
+index 2f65ce5d63ea4ad3a0b1b8fa47efa97b6641ef20..3ab43aab043ae59e541f708c8558ddf9bdd82f84 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
+@@ -216,6 +216,31 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
+         throw new UnsupportedOperationException("Must change item type to set spawned type");
+     }
+ 
++    // Paper start
++    @Override
++    public EntityType getCustomSpawnedType() {
++        return java.util.Optional.ofNullable(this.entityTag)
++            .map(tag -> tag.getString(ENTITY_ID.NBT))
++            .flatMap(net.minecraft.world.entity.EntityType::byString)
++            .map(org.bukkit.craftbukkit.util.CraftMagicNumbers::getEntityType)
++            .orElse(null);
++    }
++
++    @Override
++    public void setCustomSpawnedType(final EntityType type) {
++        if (type == null) {
++            if (this.entityTag != null) {
++                this.entityTag.remove(ENTITY_ID.NBT);
++            }
++        } else {
++            if (this.entityTag == null) {
++                this.entityTag = new CompoundTag();
++            }
++            this.entityTag.putString(ENTITY_ID.NBT, type.key().toString());
++        }
++    }
++    // Paper end
++
+     @Override
+     boolean equalsCommon(CraftMetaItem meta) {
+         if (!super.equalsCommon(meta)) {


### PR DESCRIPTION
This is one way to fix the wrongly (imo) deprecated get/setSpawnedType methods on SpawnEggMeta. Spawn eggs set a custom entity type be spawned that isn't the type associated with the item. This lets plugins get and set that custom type. This allows spawn eggs for entities that don't otherwise have a spawn egg item (like item frames).