### PR TITLE
Expand PlayerDeathEvent API

### DIFF
--- a/patches/api/0463-Expand-PlayerDeathEvent-API.patch
+++ b/patches/api/0463-Expand-PlayerDeathEvent-API.patch
@@ -1,0 +1,118 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jakub Zacek <dawon@dawon.eu>
+Date: Tue, 13 Feb 2024 18:58:54 +0100
+Subject: [PATCH] Expand PlayerDeathEvent API
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+index 66e9d65a8dd05bed05d0ab46ec64206a6dae0507..9be6b982a52f95c5dfd8be53f00168c3461598b0 100644
+--- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
++++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
+@@ -17,24 +17,28 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+     private boolean keepLevel = false;
+     private boolean keepInventory = false;
+     private boolean doExpDrop; // Paper - shouldDropExperience API
++    // Paper start - Expand PlayerDeathEvent API
++    private net.kyori.adventure.text.Component deathScreenMessage;
++    private boolean displayDeathMessage;
++    // Paper end - Expand PlayerDeathEvent API
+     // Paper start - adventure
+     @org.jetbrains.annotations.ApiStatus.Internal
+-    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final @Nullable net.kyori.adventure.text.Component deathMessage) {
+-        this(player, drops, droppedExp, 0, deathMessage);
++    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final @Nullable net.kyori.adventure.text.Component deathMessage, boolean displayDeathMessage) { // Paper - Expand PlayerDeathEvent API
++        this(player, drops, droppedExp, 0, deathMessage, displayDeathMessage); // Paper - Expand PlayerDeathEvent API
+     }
+ 
+     @org.jetbrains.annotations.ApiStatus.Internal
+-    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final int newExp, final @Nullable net.kyori.adventure.text.Component deathMessage) {
+-        this(player, drops, droppedExp, newExp, 0, 0, deathMessage);
++    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final int newExp, final @Nullable net.kyori.adventure.text.Component deathMessage, boolean displayDeathMessage) { // Paper - Expand PlayerDeathEvent API
++        this(player, drops, droppedExp, newExp, 0, 0, deathMessage, displayDeathMessage); // Paper - Expand PlayerDeathEvent API
+     }
+ 
+     @org.jetbrains.annotations.ApiStatus.Internal
+-    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final @Nullable net.kyori.adventure.text.Component deathMessage) {
++    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final @Nullable net.kyori.adventure.text.Component deathMessage, boolean displayDeathMessage) { // Paper - Expand PlayerDeathEvent API
+         // Paper start - shouldDropExperience API
+-        this(player, drops, droppedExp, newExp, newTotalExp, newLevel, deathMessage, true);
++        this(player, drops, droppedExp, newExp, newTotalExp, newLevel, deathMessage, true, displayDeathMessage); // Paper - Expand PlayerDeathEvent API
+     }
+     @org.jetbrains.annotations.ApiStatus.Internal
+-    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final @Nullable net.kyori.adventure.text.Component deathMessage, final boolean doExpDrop) {
++    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final @Nullable net.kyori.adventure.text.Component deathMessage, final boolean doExpDrop, boolean displayDeathMessage) { // Paper - death screen api
+         // Paper end - shouldDropExperience API
+         super(player, drops, droppedExp);
+         this.newExp = newExp;
+@@ -42,9 +46,12 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+         this.newLevel = newLevel;
+         this.deathMessage = deathMessage;
+         this.doExpDrop = doExpDrop; // Paper - shouldDropExperience API
++        this.deathScreenMessage = deathMessage; // Paper - Expand PlayerDeathEvent API
++        this.displayDeathMessage = displayDeathMessage; // Paper - Expand PlayerDeathEvent API
+     }
+     // Paper end - adventure
+ 
++    @Deprecated // Paper
+     public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, @Nullable final String deathMessage) {
+         this(player, drops, droppedExp, 0, deathMessage);
+     }
+@@ -69,6 +76,8 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+         this.newLevel = newLevel;
+         this.deathMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(deathMessage); // Paper
+         this.doExpDrop = doExpDrop; // Paper - shouldDropExperience API
++        this.deathScreenMessage = this.deathMessage; // Paper - Expand PlayerDeathEvent API
++        this.displayDeathMessage = true; // Paper - Expand PlayerDeathEvent API
+     }
+ 
+     @Deprecated // Paper
+@@ -160,6 +169,49 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+         return this.deathMessage;
+     }
+     // Paper end - adventure
++    // Paper start - Expand PlayerDeathEvent API
++    /**
++     * Set the death message that will appear on the death screen of the dying player.
++     * <p>
++     * If set to null, no message will be shown to the dying player.
++     * <p>
++     * If the message exceeds 256 characters it will be truncated.
++     *
++     * @param deathScreenMessage Message to appear on the death screen to the dying player.
++     */
++    public void deathScreenMessage(@Nullable net.kyori.adventure.text.Component deathScreenMessage) {
++        this.deathScreenMessage = deathScreenMessage;
++    }
++
++    /**
++     * Get the death message that will appear on the death screen of the dying player.
++     * By default, it is the same value as {@link #deathMessage()}.
++     *
++     * @return Message to appear on the death screen to the dying player.
++     */
++    public @Nullable net.kyori.adventure.text.Component deathScreenMessage() {
++        return this.deathScreenMessage;
++    }
++
++    /**
++     * Returns whether the death message in this event should be displayed according to
++     * `showDeathMessages` game rule.
++     *
++     * @return whether the death message in this event should be displayed
++     */
++    public boolean shouldDisplayDeathMessage() {
++        return displayDeathMessage;
++    }
++
++    /**
++     * Sets whether the death message in this event should be shown.
++     *
++     * @param displayDeathMessage whether the death message in this event should be shown.
++     */
++    public void setDisplayDeathMessage(boolean displayDeathMessage) {
++        this.displayDeathMessage = displayDeathMessage;
++    }
++    // Paper end - Expand PlayerDeathEvent API
+ 
+     /**
+      * Set the death message that will appear to everyone on the server.

--- a/patches/server/1046-Expand-PlayerDeathEvent-API.patch
+++ b/patches/server/1046-Expand-PlayerDeathEvent-API.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jakub Zacek <dawon@dawon.eu>
+Date: Tue, 13 Feb 2024 18:58:43 +0100
+Subject: [PATCH] Expand PlayerDeathEvent API
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 58591bf2f63b9c5e97d9ce4188dff3366968a178..0fb77672fe6dc127835584e13736847be1fb007e 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -965,7 +965,7 @@ public class ServerPlayer extends Player {
+ 
+         String deathmessage = defaultMessage.getString();
+         this.keepLevel = keepInventory; // SPIGOT-2222: pre-set keepLevel
+-        org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), keepInventory); // Paper - Adventure
++        org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), keepInventory, flag); // Paper - Adventure
+         // Paper start - cancellable death event
+         if (event.isCancelled()) {
+             // make compatible with plugins that might have already set the health in an event listener
+@@ -983,13 +983,14 @@ public class ServerPlayer extends Player {
+         }
+ 
+         net.kyori.adventure.text.Component deathMessage = event.deathMessage() != null ? event.deathMessage() : net.kyori.adventure.text.Component.empty(); // Paper - Adventure
++        Component deathScreenMessage = PaperAdventure.asVanilla(event.deathScreenMessage() != null && event.shouldDisplayDeathMessage() ? event.deathScreenMessage() : net.kyori.adventure.text.Component.empty()); // Paper - Expand PlayerDeathEvent API
+ 
+-        if (deathMessage != null && deathMessage != net.kyori.adventure.text.Component.empty() && flag) { // Paper - Adventure // TODO: allow plugins to override?
++        if (deathMessage != null && deathMessage != net.kyori.adventure.text.Component.empty() && event.shouldDisplayDeathMessage()) { // Paper - Adventure // Paper - Expand PlayerDeathEvent API
+             Component ichatbasecomponent = PaperAdventure.asVanilla(deathMessage); // Paper - Adventure
+ 
+-            this.connection.send(new ClientboundPlayerCombatKillPacket(this.getId(), ichatbasecomponent), PacketSendListener.exceptionallySend(() -> {
++            this.connection.send(new ClientboundPlayerCombatKillPacket(this.getId(), deathScreenMessage), PacketSendListener.exceptionallySend(() -> { // Paper - death screen api // Paper - Expand PlayerDeathEvent API
+                 boolean flag1 = true;
+-                String s = ichatbasecomponent.getString(256);
++                String s = deathScreenMessage.getString(256); // Paper - Expand PlayerDeathEvent API
+                 MutableComponent ichatmutablecomponent = Component.translatable("death.attack.message_too_long", Component.literal(s).withStyle(ChatFormatting.YELLOW));
+                 MutableComponent ichatmutablecomponent1 = Component.translatable("death.attack.even_more_magic", this.getDisplayName()).withStyle((chatmodifier) -> {
+                     return chatmodifier.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, ichatmutablecomponent));
+@@ -1009,7 +1010,7 @@ public class ServerPlayer extends Player {
+                 this.server.getPlayerList().broadcastSystemMessage(ichatbasecomponent, false);
+             }
+         } else {
+-            this.connection.send(new ClientboundPlayerCombatKillPacket(this.getId(), CommonComponents.EMPTY));
++            this.connection.send(new ClientboundPlayerCombatKillPacket(this.getId(), deathScreenMessage)); // Paper - Expand PlayerDeathEvent API
+         }
+ 
+         this.removeEntitiesOnShoulder();
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 347bd2482c89e06716121bd7d05941203bab2a8b..06127d7b6f9add10d132a53f23905b879562d98e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1007,9 +1007,9 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
+-    public static PlayerDeathEvent callPlayerDeathEvent(ServerPlayer victim, List<Entity.DefaultDrop> drops, net.kyori.adventure.text.Component deathMessage, boolean keepInventory) { // Paper - Adventure & Restore vanilla drops behavior
++    public static PlayerDeathEvent callPlayerDeathEvent(ServerPlayer victim, List<Entity.DefaultDrop> drops, net.kyori.adventure.text.Component deathMessage, boolean keepInventory, boolean showDeathMessage) { // Paper - Adventure & Restore vanilla drops behavior // Paper - Expand PlayerDeathEvent API
+         CraftPlayer entity = victim.getBukkitEntity();
+-        PlayerDeathEvent event = new PlayerDeathEvent(entity, new io.papermc.paper.util.TransformingRandomAccessList<>(drops, Entity.DefaultDrop::stack, FROM_FUNCTION), victim.getExpReward(), 0, deathMessage); // Paper - Restore vanilla drops behavior
++        PlayerDeathEvent event = new PlayerDeathEvent(entity, new io.papermc.paper.util.TransformingRandomAccessList<>(drops, Entity.DefaultDrop::stack, FROM_FUNCTION), victim.getExpReward(), 0, deathMessage, showDeathMessage); // Paper - Restore vanilla drops behavior // Paper - Expand PlayerDeathEvent API
+         event.setKeepInventory(keepInventory);
+         event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
+         populateFields(victim, event); // Paper - make cancellable


### PR DESCRIPTION
Allows to set death message on the death screen separately from the message sent to all Players