### PR TITLE
Prevent sleeping villagers moving towards food

### DIFF
--- a/patches/server/0962-Fix-MC-157464-Prevent-sleeping-villagers-moving-towa.patch
+++ b/patches/server/0962-Fix-MC-157464-Prevent-sleeping-villagers-moving-towa.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Warrior <50800980+Warriorrrr@users.noreply.github.com>
+Date: Mon, 27 Feb 2023 19:16:07 +0100
+Subject: [PATCH] Fix MC-157464 Prevent sleeping villagers moving towards food
+
+Fixes sleeping villagers moving to nearby food by adding an !isSleeping predicate
+
+Relevant links:
+https://bugs.mojang.com/browse/MC-157464
+https://github.com/PaperMC/Paper/issues/8569
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/VillagerGoalPackages.java b/src/main/java/net/minecraft/world/entity/ai/behavior/VillagerGoalPackages.java
+index 9400556aca4cd06ad311975d74a9e7eb2ccd9c73..cd7a90ec1073b2b452ca70decefe6a594445003b 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/behavior/VillagerGoalPackages.java
++++ b/src/main/java/net/minecraft/world/entity/ai/behavior/VillagerGoalPackages.java
+@@ -22,7 +22,7 @@ public class VillagerGoalPackages {
+     private static final float STROLL_SPEED_MODIFIER = 0.4F;
+ 
+     public static ImmutableList<Pair<Integer, ? extends BehaviorControl<? super Villager>>> getCorePackage(VillagerProfession profession, float speed) {
+-        return ImmutableList.of(Pair.of(0, new Swim(0.8F)), Pair.of(0, InteractWithDoor.create()), Pair.of(0, new LookAtTargetSink(45, 90)), Pair.of(0, new VillagerPanicTrigger()), Pair.of(0, WakeUp.create()), Pair.of(0, ReactToBell.create()), Pair.of(0, SetRaidStatus.create()), Pair.of(0, ValidateNearbyPoi.create(profession.heldJobSite(), MemoryModuleType.JOB_SITE)), Pair.of(0, ValidateNearbyPoi.create(profession.acquirableJobSite(), MemoryModuleType.POTENTIAL_JOB_SITE)), Pair.of(1, new MoveToTargetSink()), Pair.of(2, PoiCompetitorScan.create()), Pair.of(3, new LookAndFollowTradingPlayerSink(speed)), Pair.of(5, GoToWantedItem.create(speed, false, 4)), Pair.of(6, AcquirePoi.create(profession.acquirableJobSite(), MemoryModuleType.JOB_SITE, MemoryModuleType.POTENTIAL_JOB_SITE, true, Optional.empty())), Pair.of(7, new GoToPotentialJobSite(speed)), Pair.of(8, YieldJobSite.create(speed)), Pair.of(10, AcquirePoi.create((poiType) -> {
++        return ImmutableList.of(Pair.of(0, new Swim(0.8F)), Pair.of(0, InteractWithDoor.create()), Pair.of(0, new LookAtTargetSink(45, 90)), Pair.of(0, new VillagerPanicTrigger()), Pair.of(0, WakeUp.create()), Pair.of(0, ReactToBell.create()), Pair.of(0, SetRaidStatus.create()), Pair.of(0, ValidateNearbyPoi.create(profession.heldJobSite(), MemoryModuleType.JOB_SITE)), Pair.of(0, ValidateNearbyPoi.create(profession.acquirableJobSite(), MemoryModuleType.POTENTIAL_JOB_SITE)), Pair.of(1, new MoveToTargetSink()), Pair.of(2, PoiCompetitorScan.create()), Pair.of(3, new LookAndFollowTradingPlayerSink(speed)), Pair.of(5, GoToWantedItem.create(villager -> !villager.isSleeping(), speed, false, 4)), Pair.of(6, AcquirePoi.create(profession.acquirableJobSite(), MemoryModuleType.JOB_SITE, MemoryModuleType.POTENTIAL_JOB_SITE, true, Optional.empty())), Pair.of(7, new GoToPotentialJobSite(speed)), Pair.of(8, YieldJobSite.create(speed)), Pair.of(10, AcquirePoi.create((poiType) -> { // Paper - Fix MC-157464
+             return poiType.is(PoiTypes.HOME);
+         }, MemoryModuleType.HOME, false, Optional.of((byte)14))), Pair.of(10, AcquirePoi.create((poiType) -> {
+             return poiType.is(PoiTypes.MEETING);


### PR DESCRIPTION
Closes #8569

Fixes a funny looking bug where sleeping villagers will move to pick up food dropped nearby while staying in the sleeping animation, with this patch they'll just stay in bed and not move.

Alternatively, it'd also be possible to wake up the villager but I figured this would be best to start off with.