### PR TITLE
Add PlayerTeleportEndExitEvent

### DIFF
--- a/patches/api/0419-Add-PlayerTeleportEndExitEvent.patch
+++ b/patches/api/0419-Add-PlayerTeleportEndExitEvent.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Sun, 5 Mar 2023 15:07:13 -0300
+Subject: [PATCH] Add PlayerTeleportEndExitEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerTeleportEndExitEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerTeleportEndExitEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..b7bd58159bd3d36bee1a8ac3593770daab229d3c
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerTeleportEndExitEvent.java
+@@ -0,0 +1,26 @@
++package io.papermc.paper.event.player;
++import org.bukkit.Location;
++import org.bukkit.entity.Player;
++import org.bukkit.event.player.PlayerTeleportEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Fired when a teleport is triggered for an End Exit to Overworld
++ */
++public class PlayerTeleportEndExitEvent extends PlayerTeleportEvent {
++
++    public PlayerTeleportEndExitEvent(@NotNull Player player, @NotNull Location from, @NotNull Location to) {
++        super(player, from, to, TeleportCause.END_PORTAL);
++    }
++
++    /**
++     * Sets the location that this player will move to.
++     *
++     * @throws UnsupportedOperationException This method it's not allowed here, you can change the destination using {@link org.bukkit.event.player.PlayerRespawnEvent#setRespawnLocation(Location)}
++     * @param to New Location this player will move to
++     */
++    @Override
++    public void setTo(@NotNull Location to) throws UnsupportedOperationException {
++        throw new UnsupportedOperationException("You cannot change the destination when a player");
++    }
++}

--- a/patches/api/0419-Add-PlayerTeleportEndExitEvent.patch
+++ b/patches/api/0419-Add-PlayerTeleportEndExitEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add PlayerTeleportEndExitEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerTeleportEndExitEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerTeleportEndExitEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b7bd58159bd3d36bee1a8ac3593770daab229d3c
+index 0000000000000000000000000000000000000000..d07917cbce68e7711e8e5586cd3e2997bc1b8294
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerTeleportEndExitEvent.java
 @@ -0,0 +1,26 @@
@@ -33,6 +33,6 @@ index 0000000000000000000000000000000000000000..b7bd58159bd3d36bee1a8ac3593770da
 +     */
 +    @Override
 +    public void setTo(@NotNull Location to) throws UnsupportedOperationException {
-+        throw new UnsupportedOperationException("You cannot change the destination when a player");
++        throw new UnsupportedOperationException("You cannot change the destination for this event");
 +    }
 +}

--- a/patches/server/0966-Add-PlayerTeleportEndExitEvent.patch
+++ b/patches/server/0966-Add-PlayerTeleportEndExitEvent.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Sun, 5 Mar 2023 15:07:53 -0300
+Subject: [PATCH] Add PlayerTeleportEndExitEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 289429eb464548acc80262a49444f49f8f57fc0c..fccc98b87433ab991226a3b1a9e28f9ed6a204ca 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -1121,6 +1121,19 @@ public class ServerPlayer extends Player {
+         ResourceKey<LevelStem> resourcekey = worldserver1.getTypeKey(); // CraftBukkit
+ 
+         if (resourcekey == LevelStem.END && worldserver != null && worldserver.getTypeKey() == LevelStem.OVERWORLD) { // CraftBukkit
++            // Paper start - handle teleport event
++            Location enter = this.getBukkitEntity().getLocation();
++            Location exit = this.getBukkitEntity().getBedSpawnLocation();
++            if (exit == null) {
++                BlockPos exitBlockposition = this.getSpawnPoint(worldserver);
++                exit = new Location(worldserver.getWorld(), (double) ((float) exitBlockposition.getX() + 0.5F), (double) ((float) exitBlockposition.getY() + 0.1F), (double) ((float) exitBlockposition.getZ() + 0.5F), worldserver1.levelData.getSpawnAngle(), 0.0F);
++            }
++            io.papermc.paper.event.player.PlayerTeleportEndExitEvent tpEvent = new io.papermc.paper.event.player.PlayerTeleportEndExitEvent(this.getBukkitEntity(), enter, exit);
++            Bukkit.getServer().getPluginManager().callEvent(tpEvent);
++            if (tpEvent.isCancelled()) {
++                return null;
++            }
++            // Paper end
+             this.isChangingDimension = true; // CraftBukkit - Moved down from above
+             this.unRide();
+             this.getLevel().removePlayerImmediately(this, Entity.RemovalReason.CHANGED_DIMENSION);


### PR DESCRIPTION
Based in a conversation in discord i think currently not exists a good form to cancel the teleport of player when going to the end portal in the END to go to overworld like other portals, exists methods but only allow change the destination and not cancel before all happen.

The PR add a new method extented from PlayerTeleportEvent for handle this thing and allow cancel.

This PR has a things im not pretty sure.

- Thanks to mojang this method not allow change the destination because the destination in first place is the respawn position, and this is handled in another place when the packet for respawn is send because yes this send a packet for make all the respawn logic then mess with that is... well "hard"