### PR TITLE
Correctly handle ArmorStand invisibility

### DIFF
--- a/patches/server/0967-Correctly-handle-ArmorStand-invisibility.patch
+++ b/patches/server/0967-Correctly-handle-ArmorStand-invisibility.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 5 Mar 2023 14:38:21 -0800
+Subject: [PATCH] Correctly handle ArmorStand invisibility
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
+index f80cafe3544c7e6c3c29073ba6539783adf6666c..17d08d2c90047ebfc4098b087be091b83111a40f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
+@@ -158,6 +158,14 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
+         this.getHandle().noPhysics = !gravity;
+     }
+ 
++    // Paper start - Armor Stand has its own invisible field
++    @Override
++    public void setInvisible(final boolean invisible) {
++        this.getHandle().setInvisible(invisible);
++        super.setInvisible(invisible);
++    }
++    // Paper end
++
+     @Override
+     public boolean isVisible() {
+         return !this.getHandle().isInvisible();


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/8943

ArmorStand has a separate field that tracks invisibility which wasn't getting set from the api calls to setInvisible()