### PR TITLE
Deprecate public Timings classes for removal

### DIFF
--- a/patches/api/0010-Timings-v2.patch
+++ b/patches/api/0010-Timings-v2.patch
@@ -8,10 +8,10 @@ expose isRunning
 
 diff --git a/src/main/java/co/aikar/timings/FullServerTickHandler.java b/src/main/java/co/aikar/timings/FullServerTickHandler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..43b85ce3a6c27a2f92c67d62bee7484c2652b72a
+index 0000000000000000000000000000000000000000..36b8fe86335df851f9c85d6bb2a91368b4d945d1
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/FullServerTickHandler.java
-@@ -0,0 +1,85 @@
+@@ -0,0 +1,86 @@
 +package co.aikar.timings;
 +
 +import static co.aikar.timings.TimingsManager.*;
@@ -19,6 +19,7 @@ index 0000000000000000000000000000000000000000..43b85ce3a6c27a2f92c67d62bee7484c
 +import org.bukkit.Bukkit;
 +import org.jetbrains.annotations.NotNull;
 +
++@Deprecated(forRemoval = true)
 +public class FullServerTickHandler extends TimingHandler {
 +    private static final TimingIdentifier IDENTITY = new TimingIdentifier("Minecraft", "Full Server Tick", null);
 +    final TimingData minuteData;
@@ -99,10 +100,10 @@ index 0000000000000000000000000000000000000000..43b85ce3a6c27a2f92c67d62bee7484c
 +}
 diff --git a/src/main/java/co/aikar/timings/NullTimingHandler.java b/src/main/java/co/aikar/timings/NullTimingHandler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9b45ce887b9172f30302b83fe24b99b76b16dac3
+index 0000000000000000000000000000000000000000..81671cf40feeed2844ee8d92348d48062aaf2c46
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/NullTimingHandler.java
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,69 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -131,6 +132,7 @@ index 0000000000000000000000000000000000000000..9b45ce887b9172f30302b83fe24b99b7
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
++@Deprecated(forRemoval = true)
 +public final class NullTimingHandler implements Timing {
 +    public static final Timing NULL = new NullTimingHandler();
 +    @NotNull
@@ -173,10 +175,10 @@ index 0000000000000000000000000000000000000000..9b45ce887b9172f30302b83fe24b99b7
 +}
 diff --git a/src/main/java/co/aikar/timings/TimedEventExecutor.java b/src/main/java/co/aikar/timings/TimedEventExecutor.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4e6e1b8e8aeb07e34536941d2cbfc25e5cfa6c27
+index 0000000000000000000000000000000000000000..be275c25664e0c76123371c6c8fac601f87fa492
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimedEventExecutor.java
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,84 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -213,6 +215,7 @@ index 0000000000000000000000000000000000000000..4e6e1b8e8aeb07e34536941d2cbfc25e
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
++@Deprecated(forRemoval = true)
 +public class TimedEventExecutor implements EventExecutor {
 +
 +    private final EventExecutor executor;
@@ -262,10 +265,10 @@ index 0000000000000000000000000000000000000000..4e6e1b8e8aeb07e34536941d2cbfc25e
 +}
 diff --git a/src/main/java/co/aikar/timings/Timing.java b/src/main/java/co/aikar/timings/Timing.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a21e5ead5024fd0058c5e3302d8201dd249d32bc
+index 0000000000000000000000000000000000000000..7514fad26f955329f8bf17ff17db75f0c8301ee5
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/Timing.java
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,86 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -296,7 +299,10 @@ index 0000000000000000000000000000000000000000..a21e5ead5024fd0058c5e3302d8201dd
 +
 +/**
 + * Provides an ability to time sections of code within the Minecraft Server
++ *
++ * @deprecated Timings will likely be replaced with Spark in the future
 + */
++@Deprecated(forRemoval = true)
 +public interface Timing extends AutoCloseable {
 +    /**
 +     * Starts timing the execution until {@link #stopTiming()} is called.
@@ -711,10 +717,10 @@ index 0000000000000000000000000000000000000000..199789d56d22fcb1b77ebd56805cc28a
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingHistory.java b/src/main/java/co/aikar/timings/TimingHistory.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ddaed81275fcc12d1671b668697acf318e96888b
+index 0000000000000000000000000000000000000000..eb9d58f8852e732a1284beeaf542989301d21b1c
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingHistory.java
-@@ -0,0 +1,354 @@
+@@ -0,0 +1,355 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -767,6 +773,7 @@ index 0000000000000000000000000000000000000000..ddaed81275fcc12d1671b668697acf31
 +import static co.aikar.timings.TimingsManager.MINUTE_REPORTS;
 +import static co.aikar.util.JSONUtil.*;
 +
++@Deprecated(forRemoval = true)
 +@SuppressWarnings({"deprecation", "SuppressionAnnotation", "Convert2Lambda", "Anonymous2MethodRef"})
 +public class TimingHistory {
 +    public static long lastMinuteTime;
@@ -1257,10 +1264,10 @@ index 0000000000000000000000000000000000000000..df142a89b8c43acb81eb383eac0ef048
 +}
 diff --git a/src/main/java/co/aikar/timings/Timings.java b/src/main/java/co/aikar/timings/Timings.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dd72a34eaa4bedd9ea0b92eaa79091b00eb4dd09
+index 0000000000000000000000000000000000000000..852f5673fb3f9c7d7ad44b01d04b3dcdf7352e50
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/Timings.java
-@@ -0,0 +1,295 @@
+@@ -0,0 +1,300 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -1299,6 +1306,10 @@ index 0000000000000000000000000000000000000000..dd72a34eaa4bedd9ea0b92eaa79091b0
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
++/**
++ * @deprecated Timings will likely be replaced with Spark in the future
++ */
++@Deprecated(forRemoval = true)
 +@SuppressWarnings({"UnusedDeclaration", "WeakerAccess", "SameParameterValue"})
 +public final class Timings {
 +
@@ -1556,12 +1567,13 @@ index 0000000000000000000000000000000000000000..dd72a34eaa4bedd9ea0b92eaa79091b0
 +        return TimingsManager.getHandler(groupName, name, groupHandler);
 +    }
 +}
++
 diff --git a/src/main/java/co/aikar/timings/TimingsCommand.java b/src/main/java/co/aikar/timings/TimingsCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3132dc98d26c54c5e46162e53aaed195d7335c8d
+index 0000000000000000000000000000000000000000..61cfad5cd53980836e1fd6ecf08a760166fff2b9
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingsCommand.java
-@@ -0,0 +1,120 @@
+@@ -0,0 +1,121 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -1601,6 +1613,7 @@ index 0000000000000000000000000000000000000000..3132dc98d26c54c5e46162e53aaed195
 +import static net.kyori.adventure.text.Component.text;
 +
 +
++@Deprecated(forRemoval = true)
 +public class TimingsCommand extends BukkitCommand {
 +    private static final List<String> TIMINGS_SUBCOMMANDS = ImmutableList.of("report", "reset", "on", "off", "paste", "verbon", "verboff");
 +    private long lastResetAttempt = 0;
@@ -1684,10 +1697,10 @@ index 0000000000000000000000000000000000000000..3132dc98d26c54c5e46162e53aaed195
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingsManager.java b/src/main/java/co/aikar/timings/TimingsManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a92925d41110226f7fda055b71ce7be60eedd038
+index 0000000000000000000000000000000000000000..5e1558ca3ffeeaf2645fa003965474a442d650bf
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingsManager.java
-@@ -0,0 +1,188 @@
+@@ -0,0 +1,192 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -1729,6 +1742,10 @@ index 0000000000000000000000000000000000000000..a92925d41110226f7fda055b71ce7be6
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
++/**
++ * @deprecated Timings will likely be replaced with Spark in the future
++ */
++@Deprecated(forRemoval = true)
 +public final class TimingsManager {
 +    static final Map<TimingIdentifier, TimingHandler> TIMING_MAP = LoadingMap.of(
 +        new ConcurrentHashMap<>(4096, .5F), TimingHandler::new
@@ -1878,10 +1895,10 @@ index 0000000000000000000000000000000000000000..a92925d41110226f7fda055b71ce7be6
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingsReportListener.java b/src/main/java/co/aikar/timings/TimingsReportListener.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..34f4c02c3bdbe571a7efb1f8c61d8924b0c81268
+index 0000000000000000000000000000000000000000..3af5b8ea795311582044c712de50d29412024b77
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingsReportListener.java
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,87 @@
 +package co.aikar.timings;
 +
 +import com.google.common.base.Preconditions;
@@ -1896,6 +1913,7 @@ index 0000000000000000000000000000000000000000..34f4c02c3bdbe571a7efb1f8c61d8924
 +
 +import java.util.List;
 +
++@Deprecated(forRemoval = true)
 +@SuppressWarnings("WeakerAccess")
 +public class TimingsReportListener implements net.kyori.adventure.audience.ForwardingAudience, MessageCommandSender {
 +    private final List<CommandSender> senders;
@@ -2029,10 +2047,10 @@ index 0000000000000000000000000000000000000000..632c4961515f5052551f841cfa840e60
 +}
 diff --git a/src/main/java/co/aikar/util/Counter.java b/src/main/java/co/aikar/util/Counter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..eff63c371c39e21a5a9cb5af8c2dcf78a60dd52b
+index 0000000000000000000000000000000000000000..dae84243804b4b076cafb3e1b29bdcf614efc93f
 --- /dev/null
 +++ b/src/main/java/co/aikar/util/Counter.java
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,39 @@
 +package co.aikar.util;
 +
 +import com.google.common.collect.ForwardingMap;
@@ -2042,6 +2060,7 @@ index 0000000000000000000000000000000000000000..eff63c371c39e21a5a9cb5af8c2dcf78
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
++@Deprecated(forRemoval = true)
 +public class Counter <T> extends ForwardingMap<T, Long> {
 +    private final Map<T, Long> counts = new HashMap<>();
 +
@@ -2073,10 +2092,10 @@ index 0000000000000000000000000000000000000000..eff63c371c39e21a5a9cb5af8c2dcf78
 +}
 diff --git a/src/main/java/co/aikar/util/JSONUtil.java b/src/main/java/co/aikar/util/JSONUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..190bf0598442c89c2a1c93ad7c8c1a29797304ae
+index 0000000000000000000000000000000000000000..c105a1429ca58b37be265708ec345e00f0d43ed8
 --- /dev/null
 +++ b/src/main/java/co/aikar/util/JSONUtil.java
-@@ -0,0 +1,140 @@
+@@ -0,0 +1,141 @@
 +package co.aikar.util;
 +
 +import com.google.common.base.Function;
@@ -2096,6 +2115,7 @@ index 0000000000000000000000000000000000000000..190bf0598442c89c2a1c93ad7c8c1a29
 + * Provides Utility methods that assist with generating JSON Objects
 + */
 +@SuppressWarnings({"rawtypes", "SuppressionAnnotation"})
++@Deprecated(forRemoval = true)
 +public final class JSONUtil {
 +    private JSONUtil() {}
 +
@@ -2219,10 +2239,10 @@ index 0000000000000000000000000000000000000000..190bf0598442c89c2a1c93ad7c8c1a29
 +}
 diff --git a/src/main/java/co/aikar/util/LoadingIntMap.java b/src/main/java/co/aikar/util/LoadingIntMap.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..63a899c7dbdb69daa4876a2ce2a7dfb734b5af9d
+index 0000000000000000000000000000000000000000..5753b9bce89db2ac378ec41f1b61907cc2e23335
 --- /dev/null
 +++ b/src/main/java/co/aikar/util/LoadingIntMap.java
-@@ -0,0 +1,76 @@
+@@ -0,0 +1,77 @@
 +/*
 + * Copyright (c) 2015. Starlis LLC / dba Empire Minecraft
 + *
@@ -2251,6 +2271,7 @@ index 0000000000000000000000000000000000000000..63a899c7dbdb69daa4876a2ce2a7dfb7
 + *
 + * @param <V> Value
 + */
++@Deprecated(forRemoval = true)
 +public class LoadingIntMap<V> extends Int2ObjectOpenHashMap<V> {
 +    private final Function<Integer, V> loader;
 +
@@ -2301,10 +2322,10 @@ index 0000000000000000000000000000000000000000..63a899c7dbdb69daa4876a2ce2a7dfb7
 +}
 diff --git a/src/main/java/co/aikar/util/LoadingMap.java b/src/main/java/co/aikar/util/LoadingMap.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..aedbb03321886cb267879d7994653e447b485f6a
+index 0000000000000000000000000000000000000000..1786eeb5cbeaad75602c9c5649bbcd9b2af5cf81
 --- /dev/null
 +++ b/src/main/java/co/aikar/util/LoadingMap.java
-@@ -0,0 +1,368 @@
+@@ -0,0 +1,369 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -2357,6 +2378,7 @@ index 0000000000000000000000000000000000000000..aedbb03321886cb267879d7994653e44
 + * @param <K> Key
 + * @param <V> Value
 + */
++@Deprecated(forRemoval = true)
 +public class LoadingMap <K, V> extends AbstractMap<K, V> {
 +    private final Map<K, V> backingMap;
 +    private final java.util.function.Function<K, V> loader;
@@ -2675,10 +2697,10 @@ index 0000000000000000000000000000000000000000..aedbb03321886cb267879d7994653e44
 +}
 diff --git a/src/main/java/co/aikar/util/MRUMapCache.java b/src/main/java/co/aikar/util/MRUMapCache.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5989ee21297935651b0edd44b8239e655eaef1d9
+index 0000000000000000000000000000000000000000..3e61a926620a67daec3af54b72a1b911eaef2ed4
 --- /dev/null
 +++ b/src/main/java/co/aikar/util/MRUMapCache.java
-@@ -0,0 +1,111 @@
+@@ -0,0 +1,112 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -2717,6 +2739,7 @@ index 0000000000000000000000000000000000000000..5989ee21297935651b0edd44b8239e65
 + * @param <K> Key Type of the Map
 + * @param <V> Value Type of the Map
 + */
++@Deprecated(forRemoval = true)
 +public class MRUMapCache<K, V> extends AbstractMap<K, V> {
 +    final Map<K, V> backingMap;
 +    Object cacheKey;
@@ -3538,7 +3561,7 @@ index 5ca863b3692b2e1b58e7fb4d82f554a92cc4f01e..612958a331575d1da2715531ebdf6b11
 +
 +}
 diff --git a/src/main/java/org/spigotmc/CustomTimingsHandler.java b/src/main/java/org/spigotmc/CustomTimingsHandler.java
-index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..123647bb10fc89508437d7a0bd3fd31d58ee7c82 100644
+index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..12946bd55fcf7c40d39081779a7fa30049ee6165 100644
 --- a/src/main/java/org/spigotmc/CustomTimingsHandler.java
 +++ b/src/main/java/org/spigotmc/CustomTimingsHandler.java
 @@ -1,137 +1,67 @@
@@ -3604,7 +3627,7 @@ index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..123647bb10fc89508437d7a0bd3fd31d
 -    private long totalTime = 0;
 -    private long curTickTotal = 0;
 -    private long violations = 0;
-+@Deprecated
++@Deprecated(forRemoval = true)
 +public final class CustomTimingsHandler {
 +    private final Timing handler;
  

--- a/patches/api/0134-Don-t-use-snapshots-for-Timings-Tile-Entity-reports.patch
+++ b/patches/api/0134-Don-t-use-snapshots-for-Timings-Tile-Entity-reports.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't use snapshots for Timings Tile Entity reports
 
 
 diff --git a/src/main/java/co/aikar/timings/TimingHistory.java b/src/main/java/co/aikar/timings/TimingHistory.java
-index ddaed81275fcc12d1671b668697acf318e96888b..203cda0f9a4dea4f28a21ea9ee8db7a7369842e3 100644
+index eb9d58f8852e732a1284beeaf542989301d21b1c..02e88db63be2d5e31da6b65157ba7b971b1f10f3 100644
 --- a/src/main/java/co/aikar/timings/TimingHistory.java
 +++ b/src/main/java/co/aikar/timings/TimingHistory.java
-@@ -119,7 +119,7 @@ public class TimingHistory {
+@@ -120,7 +120,7 @@ public class TimingHistory {
                          data.entityCounts.get(entity.getType()).increment();
                      }
  

--- a/patches/api/0396-Add-paper-dumplisteners-command.patch
+++ b/patches/api/0396-Add-paper-dumplisteners-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add /paper dumplisteners command
 
 
 diff --git a/src/main/java/co/aikar/timings/TimedEventExecutor.java b/src/main/java/co/aikar/timings/TimedEventExecutor.java
-index 4e6e1b8e8aeb07e34536941d2cbfc25e5cfa6c27..34e43e56ccc663e05b9cae36643e8df5eee5cb17 100644
+index be275c25664e0c76123371c6c8fac601f87fa492..8f29c1561ba5916cb5634392edd8bd2a5a294a51 100644
 --- a/src/main/java/co/aikar/timings/TimedEventExecutor.java
 +++ b/src/main/java/co/aikar/timings/TimedEventExecutor.java
-@@ -80,4 +80,10 @@ public class TimedEventExecutor implements EventExecutor {
+@@ -81,4 +81,10 @@ public class TimedEventExecutor implements EventExecutor {
              executor.execute(listener, event);
          }
      }

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Timings v2
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3f540dc05315103ef97fd53628f681c67f7e7c2d
+index 0000000000000000000000000000000000000000..59affb62cb487d60e8c3e32decf89d6cb7d22f8d
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
-@@ -0,0 +1,168 @@
+@@ -0,0 +1,169 @@
 +package co.aikar.timings;
 +
 +import com.google.common.collect.MapMaker;
@@ -26,6 +26,7 @@ index 0000000000000000000000000000000000000000..3f540dc05315103ef97fd53628f681c6
 +import java.util.Map;
 +
 +// TODO: Re-implement missing timers
++@Deprecated(forRemoval = true)
 +public final class MinecraftTimings {
 +
 +    public static final Timing serverOversleep = Timings.ofSafe("Server Oversleep");
@@ -180,10 +181,10 @@ index 0000000000000000000000000000000000000000..3f540dc05315103ef97fd53628f681c6
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..46297ac0a19fd2398ab777a381eff4d0a256161e
+index 0000000000000000000000000000000000000000..38f01952153348d937e326da0ec102cd9b0f80af
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -0,0 +1,385 @@
+@@ -0,0 +1,386 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -252,6 +253,7 @@ index 0000000000000000000000000000000000000000..46297ac0a19fd2398ab777a381eff4d0
 +import static net.kyori.adventure.text.Component.text;
 +
 +@SuppressWarnings({"rawtypes", "SuppressionAnnotation"})
++@Deprecated(forRemoval = true)
 +public class TimingsExport extends Thread {
 +
 +    private final TimingsReportListener listeners;
@@ -571,10 +573,10 @@ index 0000000000000000000000000000000000000000..46297ac0a19fd2398ab777a381eff4d0
 +}
 diff --git a/src/main/java/co/aikar/timings/WorldTimingsHandler.java b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0fda52841b5e1643efeda92106124998abc4e0aa
+index 0000000000000000000000000000000000000000..2f0d9b953802dee821cfde82d22b0567cce8ee91
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
-@@ -0,0 +1,119 @@
+@@ -0,0 +1,120 @@
 +package co.aikar.timings;
 +
 +import net.minecraft.server.level.ServerLevel;
@@ -585,6 +587,7 @@ index 0000000000000000000000000000000000000000..0fda52841b5e1643efeda92106124998
 + * Set of timers per world, to track world specific timings.
 + */
 +// TODO: Re-implement missing timers
++@Deprecated(forRemoval = true)
 +public class WorldTimingsHandler {
 +    public final Timing mobSpawn;
 +    public final Timing doChunkUnload;

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -138,10 +138,10 @@ index 9a5fa60cb8156fe254a123e237d957ccb82f7195..0f7d36933e34e1d1b9dd27d8b0c35ff8
  
      protected static final class LightQueue {
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index 46297ac0a19fd2398ab777a381eff4d0a256161e..98171f6c8e23f6ef89b897e4b80e3afb2a1950a0 100644
+index 38f01952153348d937e326da0ec102cd9b0f80af..43380d5e3a40b64bebdf3c0e7c48eca8998c8ac0 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -162,7 +162,11 @@ public class TimingsExport extends Thread {
+@@ -163,7 +163,11 @@ public class TimingsExport extends Thread {
                  pair("gamerules", toObjectMapper(world.getWorld().getGameRules(), rule -> {
                      return pair(rule, world.getWorld().getGameRuleValue(rule));
                  })),
@@ -155,10 +155,10 @@ index 46297ac0a19fd2398ab777a381eff4d0a256161e..98171f6c8e23f6ef89b897e4b80e3afb
          }));
  
 diff --git a/src/main/java/co/aikar/timings/WorldTimingsHandler.java b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
-index 0fda52841b5e1643efeda92106124998abc4e0aa..fe79c0add4f7cb18d487c5bb9415c40c5b551ea2 100644
+index 2f0d9b953802dee821cfde82d22b0567cce8ee91..22687667ec69a954261e55e59261286ac1b8b8cd 100644
 --- a/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 +++ b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
-@@ -58,6 +58,16 @@ public class WorldTimingsHandler {
+@@ -59,6 +59,16 @@ public class WorldTimingsHandler {
  
      public final Timing miscMobSpawning;
  
@@ -175,7 +175,7 @@ index 0fda52841b5e1643efeda92106124998abc4e0aa..fe79c0add4f7cb18d487c5bb9415c40c
      public WorldTimingsHandler(Level server) {
          String name = ((PrimaryLevelData) server.getLevelData()).getLevelName() + " - ";
  
-@@ -111,6 +121,16 @@ public class WorldTimingsHandler {
+@@ -112,6 +122,16 @@ public class WorldTimingsHandler {
  
  
          miscMobSpawning = Timings.ofSafe(name + "Mob spawning - Misc");

--- a/patches/server/0655-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0655-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -9,10 +9,10 @@ This adds config options to specify the tick rate for sensors
  ones might need tweaking.
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
-index 3f540dc05315103ef97fd53628f681c67f7e7c2d..23e564b05ba438924180c91f9b19a60731eedd1b 100644
+index 59affb62cb487d60e8c3e32decf89d6cb7d22f8d..4d861f9a58f8ea238471af22f387854d855b1801 100644
 --- a/src/main/java/co/aikar/timings/MinecraftTimings.java
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
-@@ -114,6 +114,14 @@ public final class MinecraftTimings {
+@@ -115,6 +115,14 @@ public final class MinecraftTimings {
          return Timings.ofSafe("Minecraft", "## tickEntity - " + entityType + " - " + type, tickEntityTimer);
      }
  

--- a/patches/server/0700-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0700-Execute-chunk-tasks-mid-tick.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Execute chunk tasks mid-tick
 This will help the server load chunks if tick times are high.
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
-index 23e564b05ba438924180c91f9b19a60731eedd1b..5ec241d49ff5e3a161a39006f05823a5de847c5e 100644
+index 4d861f9a58f8ea238471af22f387854d855b1801..efbf77024d235d8af9f7efc938c17afd76a51b0c 100644
 --- a/src/main/java/co/aikar/timings/MinecraftTimings.java
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
-@@ -46,6 +46,8 @@ public final class MinecraftTimings {
+@@ -47,6 +47,8 @@ public final class MinecraftTimings {
      public static final Timing antiXrayUpdateTimer = Timings.ofSafe("anti-xray - update");
      public static final Timing antiXrayObfuscateTimer = Timings.ofSafe("anti-xray - obfuscate");
  

--- a/patches/server/0705-Distance-manager-tick-timings.patch
+++ b/patches/server/0705-Distance-manager-tick-timings.patch
@@ -7,10 +7,10 @@ Recently this has been taking up more time, so add a timings to
 really figure out how much.
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
-index 5ec241d49ff5e3a161a39006f05823a5de847c5e..435b3b6d05e00803386d123c66f961c97da83d40 100644
+index efbf77024d235d8af9f7efc938c17afd76a51b0c..670dcfa32d003870091b75937f1603a5ac9fa7d1 100644
 --- a/src/main/java/co/aikar/timings/MinecraftTimings.java
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
-@@ -45,6 +45,7 @@ public final class MinecraftTimings {
+@@ -46,6 +46,7 @@ public final class MinecraftTimings {
  
      public static final Timing antiXrayUpdateTimer = Timings.ofSafe("anti-xray - update");
      public static final Timing antiXrayObfuscateTimer = Timings.ofSafe("anti-xray - obfuscate");

--- a/patches/server/0712-Time-scoreboard-search.patch
+++ b/patches/server/0712-Time-scoreboard-search.patch
@@ -7,10 +7,10 @@ Plugins leaking scoreboards will make this very expensive,
 let server owners debug it easily
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
-index 435b3b6d05e00803386d123c66f961c97da83d40..9da5a6086323ff4c4fd62a035fa8f7efc3d92e38 100644
+index 670dcfa32d003870091b75937f1603a5ac9fa7d1..112029cb275d45dced60807820f1bfe9f394496d 100644
 --- a/src/main/java/co/aikar/timings/MinecraftTimings.java
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
-@@ -46,6 +46,7 @@ public final class MinecraftTimings {
+@@ -47,6 +47,7 @@ public final class MinecraftTimings {
      public static final Timing antiXrayUpdateTimer = Timings.ofSafe("anti-xray - update");
      public static final Timing antiXrayObfuscateTimer = Timings.ofSafe("anti-xray - obfuscate");
      public static final Timing distanceManagerTick = Timings.ofSafe("Distance Manager Tick"); // Paper - add timings for distance manager

--- a/patches/server/0740-Configurable-feature-seeds.patch
+++ b/patches/server/0740-Configurable-feature-seeds.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable feature seeds
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index 98171f6c8e23f6ef89b897e4b80e3afb2a1950a0..06bff37e4c1fddd3be6343049a66787c63fb420c 100644
+index 43380d5e3a40b64bebdf3c0e7c48eca8998c8ac0..c07eb451a576811a39021f6f97103c77488fd001 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -287,7 +287,7 @@ public class TimingsExport extends Thread {
+@@ -288,7 +288,7 @@ public class TimingsExport extends Thread {
          JSONObject object = new JSONObject();
          for (String key : config.getKeys(false)) {
              String fullKey = (parentKey != null ? parentKey + "." + key : key);

--- a/patches/server/0864-More-Teleport-API.patch
+++ b/patches/server/0864-More-Teleport-API.patch
@@ -74,7 +74,7 @@ index 7df1eebce5b62214943e55314e9ec98f056fa330..2aee8aacd50431c18ff28af678348ec2
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 89d9c6c1e1b9cee8a20a657ab47dd5620e7f395f..ad7d009188f2c54926cdee589c7d92e7e6a967f4 100644
+index 21ad677121cc292bc1d1ecccb4da348829b46a46..2e36c53d5118ab37561e364b1d13c7e2ad72b4bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1231,13 +1231,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {


### PR DESCRIPTION
First step of https://github.com/PaperMC/Paper/issues/8948, assuming we actually decide to remove timings entirely.

After an explicit announcement and some more time passes, we can also add runtime warnings.