### PR TITLE
NFC: fix indentation

### DIFF
--- a/patches/server/0072-Custom-replacement-for-eaten-items.patch
+++ b/patches/server/0072-Custom-replacement-for-eaten-items.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Custom replacement for eaten items
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 202eed643693363aa1c052f468d6bd15bb072ff8..92da7117f56c1a5087d589f241a8b9dbe55c9b67 100644
+index 02b3e953f48721030d8c2b4cf82d1b93a4ccf1bf..a7305822c3182f91408fe6bbd62bb7f8cdab9b2e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3599,10 +3599,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -26,12 +26,12 @@ index 202eed643693363aa1c052f468d6bd15bb072ff8..92da7117f56c1a5087d589f241a8b9db
                          itemstack = this.useItem.finishUsingItem(this.level, this);
                      }
 +
-+                // Paper start - save the default replacement item and change it if necessary
-+                final ItemStack defaultReplacement = itemstack;
-+                if (event != null && event.getReplacement() != null) {
-+                    itemstack = CraftItemStack.asNMSCopy(event.getReplacement());
-+                }
-+                // Paper end
++                    // Paper start - save the default replacement item and change it if necessary
++                    final ItemStack defaultReplacement = itemstack;
++                    if (event != null && event.getReplacement() != null) {
++                        itemstack = CraftItemStack.asNMSCopy(event.getReplacement());
++                    }
++                    // Paper end
                      // CraftBukkit end
  
                      if (itemstack != this.useItem) {
@@ -39,11 +39,11 @@ index 202eed643693363aa1c052f468d6bd15bb072ff8..92da7117f56c1a5087d589f241a8b9db
                      }
  
                      this.stopUsingItem();
-+                // Paper start - if the replacement is anything but the default, update the client inventory
-+                if (this instanceof ServerPlayer && !com.google.common.base.Objects.equal(defaultReplacement, itemstack)) {
-+                    ((ServerPlayer) this).getBukkitEntity().updateInventory();
-+                }
-+                // Paper end
++                    // Paper start - if the replacement is anything but the default, update the client inventory
++                    if (this instanceof ServerPlayer && !com.google.common.base.Objects.equal(defaultReplacement, itemstack)) {
++                        ((ServerPlayer) this).getBukkitEntity().updateInventory();
++                    }
++                    // Paper end
                  }
  
              }

--- a/patches/server/0130-Cap-Entity-Collisions.patch
+++ b/patches/server/0130-Cap-Entity-Collisions.patch
@@ -12,7 +12,7 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6d76be16ba1b35a65b851c2c861093c9998fcc61..7d839daeca968df2044bf2071bf1b5ff2b2aa3d6 100644
+index 9e717175e3ea5f634dfdb3673640b703903196f7..d87c6ddefc5efa3e598e1440ecac122e4516007d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -382,6 +382,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -24,7 +24,7 @@ index 6d76be16ba1b35a65b851c2c861093c9998fcc61..7d839daeca968df2044bf2071bf1b5ff
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e004dffee9f1efe44c78f9b2e938b98cc4b2b847..2cd9c02fd664e263d9dae030d2c438a082c9e1b4 100644
+index 5dfd56abffc0c646a644f4f148b435db9eb604bd..ec93fd6d78785331e2723cdb4e0f687e972549b2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3277,8 +3277,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -32,11 +32,11 @@ index e004dffee9f1efe44c78f9b2e938b98cc4b2b847..2cd9c02fd664e263d9dae030d2c438a0
                  }
  
 -                for (j = 0; j < list.size(); ++j) {
-+            this.numCollisions = Math.max(0, this.numCollisions - this.level.paperConfig().collisions.maxEntityCollisions); // Paper
-+            for (j = 0; j < list.size() && this.numCollisions < this.level.paperConfig().collisions.maxEntityCollisions; ++j) { // Paper
++                this.numCollisions = Math.max(0, this.numCollisions - this.level.paperConfig().collisions.maxEntityCollisions); // Paper
++                for (j = 0; j < list.size() && this.numCollisions < this.level.paperConfig().collisions.maxEntityCollisions; ++j) { // Paper
                      Entity entity = (Entity) list.get(j);
-+                entity.numCollisions++; // Paper
-+                this.numCollisions++; // Paper
++                    entity.numCollisions++; // Paper
++                    this.numCollisions++; // Paper
  
                      this.doPush(entity);
                  }

--- a/patches/server/0325-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0325-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 69fbbd2745008e2d9caf6a30dd0779339e1c685b..5eaedecd2e53bcdc30defbf56d6a70a0c49f03ec 100644
+index b61dd722b6dc85709587d3823b0771d3e925d18e..2605d1249fb6dd26704371851418dc71376ea8cc 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3609,9 +3609,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -28,7 +28,7 @@ index 69fbbd2745008e2d9caf6a30dd0779339e1c685b..5eaedecd2e53bcdc30defbf56d6a70a0
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
-+                this.startUsingItem(this.getUsedItemHand(), true); // Paper
++                    this.startUsingItem(this.getUsedItemHand(), true); // Paper
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
@@ -36,10 +36,10 @@ index 69fbbd2745008e2d9caf6a30dd0779339e1c685b..5eaedecd2e53bcdc30defbf56d6a70a0
                      }
  
                      this.stopUsingItem();
--                // Paper start - if the replacement is anything but the default, update the client inventory
--                if (this instanceof ServerPlayer && !com.google.common.base.Objects.equal(defaultReplacement, itemstack)) {
-+                // Paper start
-+                if (this instanceof ServerPlayer) {
-                     ((ServerPlayer) this).getBukkitEntity().updateInventory();
-                 }
-                 // Paper end
+-                    // Paper start - if the replacement is anything but the default, update the client inventory
+-                    if (this instanceof ServerPlayer && !com.google.common.base.Objects.equal(defaultReplacement, itemstack)) {
++                    // Paper start
++                    if (this instanceof ServerPlayer) {
+                         ((ServerPlayer) this).getBukkitEntity().updateInventory();
+                     }
+                     // Paper end

--- a/patches/server/0591-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0591-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,14 +9,14 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 7ce102e7a28b70d1ffeb3a433b927f49fc4d5904..3613422aeb87b83d04fde7341a01d4994a0a3b07 100644
+index 806a7d41328ab2b79eafc2a6bd71b4992f5af44d..3b0064fe41d9774b8cd099cb011f2ca2442ba85f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3774,6 +3774,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                          level.getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {
-+                        this.stopUsingItem(); // Paper - event is using an item, clear active item to reset its use
++                            this.stopUsingItem(); // Paper - event is using an item, clear active item to reset its use
                              // Update client
                              ((ServerPlayer) this).getBukkitEntity().updateInventory();
                              ((ServerPlayer) this).getBukkitEntity().updateScaledHealth();


### PR DESCRIPTION
Fix patch indentation that has become out of sync from the surrounding code over time.
No functional changes, just less confusing.