### PR TITLE
[ci skip] add workflow for auto-managing issue board

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -8,13 +8,12 @@ on:
       - closed
       - reopened
 
-concurrency:
-  group: update-projects-${{ github.event_name }}
-  cancel-in-progress: true
-
 jobs:
   bugs:
     if: "github.event_name == 'issues' && contains(github.event.*.labels.*.name, 'type: bug')"
+    concurrency:
+      group: update-bugs-project-${{ github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: PaperMC/update-projects-action@v0.2.0

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,0 +1,65 @@
+name: Update Projects
+
+on:
+  issues:
+    types:
+      - labeled
+      - unlabeled
+      - closed
+      - reopened
+
+concurrency:
+  group: update-projects-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  bugs:
+    if: "github.event_name == 'issues' && contains(github.event.*.labels.*.name, 'type: bug')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: PaperMC/update-projects-action@v0.2.0
+        name: Update open issue
+        if: github.event.issue.state == 'open'
+        with:
+          github-token: ${{ secrets.PROJECT_ACTIONS_TOKEN }}
+          project-url: https://github.com/orgs/PaperMC/projects/5/views/2
+          column-field: Status
+          label-to-column-map: |
+            {
+              "status: needs triage": "🕑 Needs Triage",
+              "status: accepted": "✅ Accepted",
+              "status: in progress": "Needs Work",
+              "status: rebase required": "Needs Work",
+              "status: blocked": "Needs Work",
+              "status: defer upstream": "Needs Work",
+              "status: input wanted": "Needs Work",
+              "status: waiting on reporter": "⌛ Waiting for Reporter",
+              "resolution: works-as-intended": "Invalid",
+              "resolution: invalid": "Invalid",
+              "resolution: wontfix": "Invalid",
+              "resolution: duplicate": "Invalid",
+              "resolution: cannot reproduce": "Invalid",
+              "resolution: unsupported": "Invalid",
+              "resolution: incomplete": "Invalid",
+              "resolution: superseded": "Invalid"
+            }
+
+      - uses: PaperMC/update-projects-action@v0.2.0
+        name: Update closed issue
+        if: github.event.issue.state == 'closed'
+        with:
+          github-token: ${{ secrets.PROJECT_ACTIONS_TOKEN }}
+          project-url: https://github.com/orgs/PaperMC/projects/5/views/2
+          column-field: Status
+          clear-on-no-match: false
+          label-to-column-map: |
+            {
+              "resolution: works-as-intended": "Invalid",
+              "resolution: invalid": "Invalid",
+              "resolution: wontfix": "Invalid",
+              "resolution: duplicate": "Invalid",
+              "resolution: cannot reproduce": "Invalid",
+              "resolution: unsupported": "Invalid",
+              "resolution: incomplete": "Invalid",
+              "resolution: superseded": "Invalid"
+            }

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -16,11 +16,19 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
+      - name: "authenticate"
+        id: "authenticate"
+        uses: "tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92" # v1
+        with:
+          app_id: "${{ secrets.PROJECTS_APP_ID }}"
+          installation_id: "36153445"
+          private_key: "${{ secrets.PROJECTS_PRIVATE_KEY }}"
+
       - uses: PaperMC/update-projects-action@v0.2.0
         name: Update open issue
         if: github.event.issue.state == 'open'
         with:
-          github-token: ${{ secrets.PROJECT_ACTIONS_TOKEN }}
+          github-token: "${{ steps.authenticate.outputs.token }}"
           project-url: https://github.com/orgs/PaperMC/projects/5/views/2
           column-field: Status
           label-to-column-map: |
@@ -47,7 +55,7 @@ jobs:
         name: Update closed issue
         if: github.event.issue.state == 'closed'
         with:
-          github-token: ${{ secrets.PROJECT_ACTIONS_TOKEN }}
+          github-token: "${{ steps.authenticate.outputs.token }}"
           project-url: https://github.com/orgs/PaperMC/projects/5/views/2
           column-field: Status
           clear-on-no-match: false


### PR DESCRIPTION
This adds a workflow which will run on any label changes to issues or prs and update the associated projects accordingly. The new projects are useful for categorizing things, but they are missing some automation, such as auto-moving between statuses (columns) when labels are changed.

Right now, this only updates the Issues board ([found here](https://github.com/orgs/PaperMC/projects/5/views/2)). Other boards can be added once this is tested on the org project (I only tested it on user projects, but it should be the same).

~~This will require a new secret to be added named `PROJECT_ACTIONS_TOKEN` as the default access token available in actions does not have the required permissions to change user/org projects.~~
Changed it to generate the token in the action using an org-only github app.

The `label-to-column-map` can be changed per any other suggestions, it's just what I came up with after a quick look through of all the issue labels I thought mattered.