### PR TITLE
Fix getTargetEntity not targeting creative players

### DIFF
--- a/patches/server/0268-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0268-Add-LivingEntity-getTargetEntity.patch
@@ -29,7 +29,7 @@ index 24a07ef9f5cbed34d1aefccda9fe655b7dfef7ec..3cb7bca86c6b0696db7ad156d09e29e9
 +        Vec3 direction = this.getLookAngle();
 +        Vec3 end = start.add(direction.x * maxDistance, direction.y * maxDistance, direction.z * maxDistance);
 +
-+        List<Entity> entityList = level.getEntities(this, getBoundingBox().expandTowards(direction.x * maxDistance, direction.y * maxDistance, direction.z * maxDistance).inflate(1.0D, 1.0D, 1.0D), EntitySelector.NO_CREATIVE_OR_SPECTATOR.and(Entity::isPickable));
++        List<Entity> entityList = level.getEntities(this, getBoundingBox().expandTowards(direction.x * maxDistance, direction.y * maxDistance, direction.z * maxDistance).inflate(1.0D, 1.0D, 1.0D), EntitySelector.NO_SPECTATORS.and(Entity::isPickable));
 +
 +        double distance = 0.0D;
 +        EntityHitResult result = null;


### PR DESCRIPTION
Bug was introduced due to a "badly named reobf helper"