### PR TITLE
Deprecate hacky potion meta method on ThrownPotion

### DIFF
--- a/patches/api/0360-More-Projectile-API.patch
+++ b/patches/api/0360-More-Projectile-API.patch
@@ -329,10 +329,10 @@ index 4623e0d767b343cbdc6fcf20b3b2ff7ff14863cf..dd69a68d1f005c25329bb0366d161ae9
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/ThrownPotion.java b/src/main/java/org/bukkit/entity/ThrownPotion.java
-index 7051e07b4e456aae0ec9e37808b59e5fa62a4027..225ac312613b9e8f3cf680819f2ebe350d1bf48a 100644
+index 7051e07b4e456aae0ec9e37808b59e5fa62a4027..1373fd2b624c5f895a1ebb063dc0ca707fd35ab2 100644
 --- a/src/main/java/org/bukkit/entity/ThrownPotion.java
 +++ b/src/main/java/org/bukkit/entity/ThrownPotion.java
-@@ -32,12 +32,34 @@ public interface ThrownPotion extends ThrowableProjectile {
+@@ -32,12 +32,36 @@ public interface ThrownPotion extends ThrowableProjectile {
  
      /**
       * Set the ItemStack for this thrown potion.
@@ -352,6 +352,7 @@ index 7051e07b4e456aae0ec9e37808b59e5fa62a4027..225ac312613b9e8f3cf680819f2ebe35
 +     *
 +     * @return potion meta
 +     */
++    @Deprecated(forRemoval = true)
 +    @NotNull
 +    org.bukkit.inventory.meta.PotionMeta getPotionMeta();
 +
@@ -363,6 +364,7 @@ index 7051e07b4e456aae0ec9e37808b59e5fa62a4027..225ac312613b9e8f3cf680819f2ebe35
 +     *
 +     * @param meta potion meta
 +     */
++    @Deprecated(forRemoval = true)
 +    void setPotionMeta(@NotNull org.bukkit.inventory.meta.PotionMeta meta);
 +
 +    /**


### PR DESCRIPTION
The future item property api should be used instead, as this introduces some "hacky" behavior that might not be wanted with get/setItem