### PR TITLE
Copy check for full chunks from saveAll/saveChunkIfNeeded

### DIFF
--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -9252,7 +9252,7 @@ index 0000000000000000000000000000000000000000..396d72c00e47cf1669ae20dc839c1c96
 +}
 diff --git a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8013dd333e27aa5fd0beb431fa32491eec9f5246
+index 0000000000000000000000000000000000000000..f4b74fb223e97b3c3c32ef0710dced2077e45e21
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
 @@ -0,0 +1,2077 @@
@@ -11081,7 +11081,7 @@ index 0000000000000000000000000000000000000000..8013dd333e27aa5fd0beb431fa32491e
 +    }
 +
 +    private boolean saveChunk(final ChunkAccess chunk, final boolean unloading) {
-+        if (!chunk.isUnsaved()) {
++        if (!chunk.isUnsaved() || !(chunk instanceof ImposterProtoChunk || chunk instanceof LevelChunk)) {
 +            if (unloading) {
 +                this.completeAsyncChunkDataSave(null);
 +            }
@@ -15922,7 +15922,7 @@ index e96a0ca47e4701ba187555bd92c968345bc85677..73b96f804079288e9c5fcc11da54e61e
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c1980d00c622c32e7fdbd2a6fa487ba61020e7b5..504f3ddca160797a13a39bc813eb12322359ce50 100644
+index f4db9e1f22e8954665d8a971b5f044e113fa173b..c1db84d0ed569dd44d1f54cca227f77890e0f66a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -778,6 +778,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -17520,7 +17520,7 @@ index b9b50c56e79297bb824a92355f437a5d4d7e6760..18ef7025f7f4dc2a4aff85ca65ff5a2d
  
          while (objectiterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/SectionStorage.java b/src/main/java/net/minecraft/world/level/chunk/storage/SectionStorage.java
-index c6bbf2e695a6b572271c4fde3bea3bddc1dda339..fc5901a257ffd6ec878d1acbf97b9e6be664c52e 100644
+index b0c8a0e64c7a5d41c1b4cc1e39c4399c142b56af..0887cba39bfc4279abec21c6c316abab28beb0a3 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/SectionStorage.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/SectionStorage.java
 @@ -34,27 +34,28 @@ import net.minecraft.world.level.ChunkPos;


### PR DESCRIPTION
Stops empty/non-generated chunks from getting saved