### PR TITLE
Fix changeGameModeForPlayer to use gameModeForPlayer MC-259571

### DIFF
--- a/patches/server/0896-Fix-a-bunch-of-vanilla-bugs.patch
+++ b/patches/server/0896-Fix-a-bunch-of-vanilla-bugs.patch
@@ -44,6 +44,9 @@ https://bugs.mojang.com/browse/MC-258535
   by: Jake Potrebic <jake.m.potrebic@gmail.com>
   Fixes certain explosion damage not scaling with difficulty
 
+https://bugs.mojang.com/browse/MC-259571
+  Fix changeGameModeForPlayer to use gameModeForPlayer
+
 Co-authored-by: William Blake Galbreath <blake.galbreath@gmail.com>
 Co-authored-by: MelnCat <melncatuwu@gmail.com>
 
@@ -248,3 +251,17 @@ index 5e70b5f643faabfc05989de9592d8c5c787102e3..2a786c9fd29dc2139cf487fa645cd433
  
      }
  }
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
+index 58b093bb1de78ee3b3b2ea364aa50474883f443a..2be2f87454fc6acaa3ca9f67f869f7ac76afc751 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
+@@ -91,7 +91,7 @@ public class ServerPlayerGameMode {
+                 return event; // Paper
+             }
+             // CraftBukkit end
+-            this.setGameModeForPlayer(gameMode, this.previousGameModeForPlayer);
++            this.setGameModeForPlayer(gameMode, this.gameModeForPlayer); // Paper - Fix MC-259571
+             this.player.onUpdateAbilities();
+             this.player.server.getPlayerList().broadcastAll(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE, this.player), this.player); // CraftBukkit
+             this.level.updateSleepingPlayerList();


### PR DESCRIPTION
Fix changeGameModeForPlayer to use gameModeForPlayer instead of previousGameModeForPlayer as the new previousGameModeForPlayer.
Issue https://github.com/PaperMC/Paper/issues/8975