### PR TITLE
Make banners modifiable with both BannerMeta and BlockStateMeta

### DIFF
--- a/patches/api/0419-Make-banners-modifiable-with-both-BannerMeta-and-Blo.patch
+++ b/patches/api/0419-Make-banners-modifiable-with-both-BannerMeta-and-Blo.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: roro1506HD <roro1506mcpro@gmail.com>
+Date: Fri, 17 Mar 2023 21:21:14 +0100
+Subject: [PATCH] Make banners modifiable with both BannerMeta and
+ BlockStateMeta
+
+
+diff --git a/src/main/java/org/bukkit/inventory/meta/BannerMeta.java b/src/main/java/org/bukkit/inventory/meta/BannerMeta.java
+index 4739d2ecc26e7e4adc1b297013da98e12fe58783..7e83ca570e51172f33e3733039ca4c4eccfe69b3 100644
+--- a/src/main/java/org/bukkit/inventory/meta/BannerMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/BannerMeta.java
+@@ -5,9 +5,13 @@ import org.bukkit.DyeColor;
+ import org.bukkit.block.banner.Pattern;
+ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Nullable;
+-
++// Paper start - Make banners also modifiable with BlockStateMeta
++/**
++ * @deprecated use {@link BlockStateMeta}
++ */
++@Deprecated
++// Paper end - Make banners also modifiable with BlockStateMeta
+ public interface BannerMeta extends ItemMeta {
+-
+     /**
+      * Returns the base color for this banner
+      *

--- a/patches/server/0965-Make-banners-modifiable-with-both-BannerMeta-and-Blo.patch
+++ b/patches/server/0965-Make-banners-modifiable-with-both-BannerMeta-and-Blo.patch
@@ -1,0 +1,270 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: roro1506HD <roro1506mcpro@gmail.com>
+Date: Fri, 17 Mar 2023 21:20:55 +0100
+Subject: [PATCH] Make banners modifiable with both BannerMeta and
+ BlockStateMeta
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+index 83bbfe1ffd0dc8e168064225a02abcaa49df60ed..1df9ab240c3478cc6154fb24cbbc6c3a944673f4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+@@ -130,7 +130,7 @@ public final class CraftItemFactory implements ItemFactory {
+         case WHITE_WALL_BANNER:
+         case YELLOW_BANNER:
+         case YELLOW_WALL_BANNER:
+-            return meta instanceof CraftMetaBanner ? meta : new CraftMetaBanner(meta);
++            return meta instanceof CraftMetaBanner ? meta : new CraftMetaBanner(meta, material); // Paper - Provide the material
+         case ALLAY_SPAWN_EGG:
+         case AXOLOTL_SPAWN_EGG:
+         case BAT_SPAWN_EGG:
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+index f45e4acee69bd95ff2e41feaf44f5414d2e40df0..5d47d47358dfa082e9b7bf142a24bd2e3ac7dd24 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+@@ -362,7 +362,7 @@ public final class CraftItemStack extends ItemStack {
+             case WHITE_WALL_BANNER:
+             case YELLOW_BANNER:
+             case YELLOW_WALL_BANNER:
+-                return new CraftMetaBanner(item.getTag());
++                return new CraftMetaBanner(item.getTag(), material); // Paper - Provide the material
+             case ALLAY_SPAWN_EGG:
+             case AXOLOTL_SPAWN_EGG:
+             case BAT_SPAWN_EGG:
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
+index 881f221517dc062a34489df6f7e006af9540953f..5d11d9888a4bc5d9717c477ccceb2b2ba25c901f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBanner.java
+@@ -18,7 +18,7 @@ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+ import org.bukkit.inventory.meta.BannerMeta;
+ 
+ @DelegateDeserialization(CraftMetaItem.SerializableMeta.class)
+-public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
++public class CraftMetaBanner extends CraftMetaBlockState implements BannerMeta { // Paper - Make banners also modifiable with BlockStateMeta
+ 
+     private static final Set<Material> BANNER_MATERIALS = Sets.newHashSet(
+             Material.BLACK_BANNER,
+@@ -59,14 +59,29 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+     static final ItemMetaKey PATTERNS = new ItemMetaKey("Patterns", "patterns");
+     static final ItemMetaKey COLOR = new ItemMetaKey("Color", "color");
+     static final ItemMetaKey PATTERN = new ItemMetaKey("Pattern", "pattern");
++    // Paper start - Add banner materials to CraftMetaBlockState's material list
++    static {
++        CraftMetaBlockState.BLOCK_STATE_MATERIALS.addAll(CraftMetaBanner.BANNER_MATERIALS);
++    }
++    // Paper end - Add banner materials to CraftMetaBlockState's material list
+ 
+     private DyeColor base;
+     private List<Pattern> patterns = new ArrayList<Pattern>();
+-
++    // Paper start - Create new constructor to properly handle different banners
++    private final org.bukkit.block.Banner bannerBlock;
++    @Deprecated
+     CraftMetaBanner(CraftMetaItem meta) {
+-        super(meta);
++        this(meta, Material.WHITE_BANNER);
++
++        new org.bukkit.plugin.AuthorNagException("Usage of internal deprecated constructor in paper: CraftMetaBanner(CraftMetaItem), this will incorrectly assume the item is a white banner").printStackTrace();
++    }
++
++    CraftMetaBanner(CraftMetaItem meta, Material material) {
++        super(meta, material);
+ 
+-        if (!(meta instanceof CraftMetaBanner)) {
++        if (true || !(meta instanceof CraftMetaBanner)) {
++            this.bannerBlock = (org.bukkit.block.Banner) this.getBlockState();
++            // Paper end - Create new constructor to properly handle different banners
+             return;
+         }
+ 
+@@ -74,11 +89,20 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+         this.base = banner.base;
+         this.patterns = new ArrayList<Pattern>(banner.patterns);
+     }
+-
++    // Paper start - Create new constructor to properly handle different banners
++    @Deprecated
+     CraftMetaBanner(CompoundTag tag) {
+-        super(tag);
++        this(tag, Material.WHITE_BANNER);
++
++        new org.bukkit.plugin.AuthorNagException("Usage of internal deprecated constructor in paper: CraftMetaBanner(CompoundTag), this will incorrectly assume the item is a white banner").printStackTrace();
++    }
+ 
+-        if (!tag.contains("BlockEntityTag")) {
++    CraftMetaBanner(CompoundTag tag, Material material) {
++        super(tag, material);
++
++        if (true || !tag.contains("BlockEntityTag")) {
++            this.bannerBlock = (org.bukkit.block.Banner) this.getBlockState();
++            // Paper end - Create new constructor to properly handle different banners
+             return;
+         }
+ 
+@@ -102,6 +126,12 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+ 
+     CraftMetaBanner(Map<String, Object> map) {
+         super(map);
++        // Paper start - Use underlying banner block state
++        if (true) {
++            this.bannerBlock = (org.bukkit.block.Banner) this.getBlockState();
++            return;
++        }
++        // Paper end - Use underlying banner block state
+ 
+         String baseStr = SerializableMeta.getString(map, BASE.BUKKIT, true);
+         if (baseStr != null) {
+@@ -123,6 +153,7 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+     @Override
+     void applyToItem(CompoundTag tag) {
+         super.applyToItem(tag);
++        if (true) return; // Paper - CraftMetaBlockState already save the banner for us
+ 
+         CompoundTag entityTag = new CompoundTag();
+         if (this.base != null) {
+@@ -144,46 +175,85 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+ 
+     @Override
+     public DyeColor getBaseColor() {
++        if (true) return this.bannerBlock.getBaseColor(); // Paper - Use underlying block state
+         return this.base;
+     }
+ 
+     @Override
+     public void setBaseColor(DyeColor color) {
++        // Paper start - Use underlying block state
++        if (true) {
++            this.bannerBlock.setBaseColor(color);
++            this.setBlockState(this.bannerBlock); // Send changes to the underlying class
++            return;
++        }
++        // Paper end - Use underlying block state
+         this.base = color;
+     }
+ 
+     @Override
+     public List<Pattern> getPatterns() {
++        if (true) return this.bannerBlock.getPatterns(); // Paper - Use underlying block state
+         return new ArrayList<Pattern>(this.patterns);
+     }
+ 
+     @Override
+     public void setPatterns(List<Pattern> patterns) {
++        // Paper start - Use underlying block state
++        if (true) {
++            this.bannerBlock.setPatterns(patterns);
++            this.setBlockState(this.bannerBlock); // Send changes to the underlying class
++            return;
++        }
++        // Paper end - Use underlying block state
+         this.patterns = new ArrayList<Pattern>(patterns);
+     }
+ 
+     @Override
+     public void addPattern(Pattern pattern) {
++        // Paper start - Use underlying block state
++        if (true) {
++            this.bannerBlock.addPattern(pattern);
++            this.setBlockState(this.bannerBlock); // Send changes to the underlying class
++            return;
++        }
++        // Paper end - Use underlying block state
+         this.patterns.add(pattern);
+     }
+ 
+     @Override
+     public Pattern getPattern(int i) {
++        if (true) return this.bannerBlock.getPattern(i); // Paper - Use underlying block state
+         return this.patterns.get(i);
+     }
+ 
+     @Override
+     public Pattern removePattern(int i) {
++        // Paper start - Use underlying block state
++        if (true) {
++            Pattern removedPattern = this.bannerBlock.removePattern(i);
++            this.setBlockState(this.bannerBlock); // Send changes to the underlying class
++            return removedPattern;
++        }
++        // Paper end - Use underlying block state
+         return this.patterns.remove(i);
+     }
+ 
+     @Override
+     public void setPattern(int i, Pattern pattern) {
++        // Paper start - Use underlying block state
++        if (true) {
++            this.bannerBlock.setPattern(i, pattern);
++            this.setBlockState(this.bannerBlock); // Send changes to the underlying class
++            return;
++        }
++        // Paper end - Use underlying block state
+         this.patterns.set(i, pattern);
+     }
+ 
+     @Override
+     public int numberOfPatterns() {
++        if (true) return this.bannerBlock.numberOfPatterns(); // Paper - Use underlying block state
+         return this.patterns.size();
+     }
+ 
+@@ -191,6 +261,7 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+     ImmutableMap.Builder<String, Object> serialize(ImmutableMap.Builder<String, Object> builder) {
+         super.serialize(builder);
+ 
++        if (true) return builder; // Paper - Let CraftMetaBlockState serialize for us
+         if (this.base != null) {
+             builder.put(BASE.BUKKIT, this.base.toString());
+         }
+@@ -206,6 +277,7 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+     int applyHash() {
+         final int original;
+         int hash = original = super.applyHash();
++        if (true) return original; // Paper - CraftMetaBlockState's hash is good enough
+         if (this.base != null) {
+             hash = 31 * hash + this.base.hashCode();
+         }
+@@ -217,6 +289,7 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+ 
+     @Override
+     public boolean equalsCommon(CraftMetaItem meta) {
++        if (true) return super.equalsCommon(meta); // Paper - Only check CraftMetaBlockState's data
+         if (!super.equalsCommon(meta)) {
+             return false;
+         }
+@@ -230,11 +303,13 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+ 
+     @Override
+     boolean notUncommon(CraftMetaItem meta) {
++        if (true) return super.notUncommon(meta) && meta instanceof CraftMetaBanner;  // Paper - Only check CraftMetaBlockState's data
+         return super.notUncommon(meta) && (meta instanceof CraftMetaBanner || (this.patterns.isEmpty() && this.base == null));
+     }
+ 
+     @Override
+     boolean isEmpty() {
++        if (true) return super.isEmpty(); // Paper - Only check CraftMetaBlockState's data
+         return super.isEmpty() && this.patterns.isEmpty() && this.base == null;
+     }
+ 
+@@ -246,7 +321,7 @@ public class CraftMetaBanner extends CraftMetaItem implements BannerMeta {
+     @Override
+     public CraftMetaBanner clone() {
+         CraftMetaBanner meta = (CraftMetaBanner) super.clone();
+-        meta.patterns = new ArrayList<>(this.patterns);
++        // meta.patterns = new ArrayList<>(this.patterns); // Paper - Only copy CraftMetaBlockState's data
+         return meta;
+     }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+index 1957e82b67b4aa301d12468d5a81d96e621dab49..8413721ba51191555d66dedb14cbb2b6ec99e61e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+@@ -40,7 +40,7 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+             Material.BLACK_SHULKER_BOX
+     );
+ 
+-    private static final Set<Material> BLOCK_STATE_MATERIALS = Sets.newHashSet(
++    static final Set<Material> BLOCK_STATE_MATERIALS = Sets.newHashSet( // Paper - Change it to package-private, so we can use that in CraftMetaBanner
+             Material.FURNACE,
+             Material.CHEST,
+             Material.TRAPPED_CHEST,


### PR DESCRIPTION
We have found today that banners are the only items that have their own ItemMeta, and despite the BlockStateMeta being more than 7 years old, the only way is still to use BannerMeta, and doesn't even implement the new standards (i.e PDC)!

This PR is here to make it possible to modify banners using BlockStateMeta, while making sure the old BannerMeta is deprecated, but still working.