### PR TITLE
Check any loaded plugins for dependencies

### DIFF
--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -1670,7 +1670,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..bfa258faf17ca6118aeddfa4e95bbd082bcd1390
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/DependencyUtil.java
-@@ -0,0 +1,75 @@
+@@ -0,0 +1,76 @@
 +package io.papermc.paper.plugin.entrypoint.dependency;
 +
 +import com.google.common.graph.MutableGraph;

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -1674,7 +1674,7 @@ index 0000000000000000000000000000000000000000..bfa258faf17ca6118aeddfa4e95bbd08
 +package io.papermc.paper.plugin.entrypoint.dependency;
 +
 +import com.google.common.graph.MutableGraph;
-+import io.papermc.paper.plugin.configuration.PluginMeta
++import io.papermc.paper.plugin.configuration.PluginMeta;
 +import io.papermc.paper.plugin.manager.PaperPluginManagerImpl;
 +import io.papermc.paper.plugin.provider.PluginProvider;
 +import io.papermc.paper.plugin.provider.configuration.LoadOrderConfiguration;

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -1674,7 +1674,8 @@ index 0000000000000000000000000000000000000000..bfa258faf17ca6118aeddfa4e95bbd08
 +package io.papermc.paper.plugin.entrypoint.dependency;
 +
 +import com.google.common.graph.MutableGraph;
-+import io.papermc.paper.plugin.configuration.PluginMeta;
++import io.papermc.paper.plugin.configuration.PluginMeta
++import io.papermc.paper.plugin.manager.PaperPluginManagerImpl;
 +import io.papermc.paper.plugin.provider.PluginProvider;
 +import io.papermc.paper.plugin.provider.configuration.LoadOrderConfiguration;
 +import org.bukkit.plugin.PluginDescriptionFile;
@@ -1738,7 +1739,7 @@ index 0000000000000000000000000000000000000000..bfa258faf17ca6118aeddfa4e95bbd08
 +    public static List<String> validateSimple(PluginMeta meta, Map<String, PluginProvider<?>> toLoad) {
 +        List<String> missingDependencies = new ArrayList<>();
 +        for (String hardDependency : meta.getPluginDependencies()) {
-+            if (!toLoad.containsKey(hardDependency)) {
++            if (!toLoad.containsKey(hardDependency) && !PaperPluginManagerImpl.getInstance().isPluginEnabled(hardDependency)) {
 +                missingDependencies.add(hardDependency);
 +            }
 +        }


### PR DESCRIPTION
This change allows spigot plugins with dependencies to be loaded at runtime and should not affect paper plugins. I know plugin loading at runtime is not something you guys want to support, but this simple change shouldn't hurt your system while still allowing those who accept the risks to continue doing so.