### PR TITLE
adventure: make calls with generic component lists more usable

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -1953,7 +1953,7 @@ index 281518d6e1f67722134e22d89b71106aae0c4397..0a539af95e1bd331cec241403a15e4e6
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c60e1fc1cad1b9889a508602df84840723b7b966..baf0887ec941533f8007f2c7f7ab78f16b45bd74 100644
+index c60e1fc1cad1b9889a508602df84840723b7b966..59c1a3a137bd8f469353273cb98afae024b1e6ef 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -39,7 +39,28 @@ import org.jetbrains.annotations.Nullable;
@@ -2151,7 +2151,7 @@ index c60e1fc1cad1b9889a508602df84840723b7b966..baf0887ec941533f8007f2c7f7ab78f1
 +     * @throws IllegalArgumentException if location is null
 +     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
 +     */
-+    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<net.kyori.adventure.text.Component> lines) throws IllegalArgumentException {
++    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<? extends net.kyori.adventure.text.Component> lines) throws IllegalArgumentException {
 +        this.sendSignChange(loc, lines, DyeColor.BLACK);
 +    }
 +
@@ -2172,7 +2172,7 @@ index c60e1fc1cad1b9889a508602df84840723b7b966..baf0887ec941533f8007f2c7f7ab78f1
 +     * @throws IllegalArgumentException if dyeColor is null
 +     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
 +     */
-+    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<net.kyori.adventure.text.Component> lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException {
++    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<? extends net.kyori.adventure.text.Component> lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException {
 +        this.sendSignChange(loc, lines, dyeColor, false);
 +    }
 +
@@ -2193,7 +2193,7 @@ index c60e1fc1cad1b9889a508602df84840723b7b966..baf0887ec941533f8007f2c7f7ab78f1
 +     * @throws IllegalArgumentException if dyeColor is null
 +     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
 +     */
-+    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<net.kyori.adventure.text.Component> lines, boolean hasGlowingText) throws IllegalArgumentException {
++    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<? extends net.kyori.adventure.text.Component> lines, boolean hasGlowingText) throws IllegalArgumentException {
 +        this.sendSignChange(loc, lines, DyeColor.BLACK, hasGlowingText);
 +    }
 +
@@ -2215,7 +2215,7 @@ index c60e1fc1cad1b9889a508602df84840723b7b966..baf0887ec941533f8007f2c7f7ab78f1
 +     * @throws IllegalArgumentException if dyeColor is null
 +     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
 +     */
-+    void sendSignChange(@NotNull Location loc, @Nullable java.util.List<net.kyori.adventure.text.Component> lines, @NotNull DyeColor dyeColor, boolean hasGlowingText)
++    void sendSignChange(@NotNull Location loc, @Nullable java.util.List<? extends net.kyori.adventure.text.Component> lines, @NotNull DyeColor dyeColor, boolean hasGlowingText)
 +        throws IllegalArgumentException;
 +    // Paper end
 +
@@ -4069,7 +4069,7 @@ index 94852d50e88d0594b84b581cd627174043629995..36bcbb3f3acedf7ebecbf6f6b358cf64
              throw new UnsupportedOperationException("Not supported yet.");
          }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 2fbb0b7640dd9b9b0e70d4bc60fbb0310d5ec250..64114b1a9e201df369fc794fbee984d496385420 100644
+index 2fbb0b7640dd9b9b0e70d4bc60fbb0310d5ec250..7476bfb8f26ce541cd10feaaeaf0f9b17e46bee8 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -31,6 +31,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
@@ -4136,7 +4136,7 @@ index 2fbb0b7640dd9b9b0e70d4bc60fbb0310d5ec250..64114b1a9e201df369fc794fbee984d4
 +     *
 +     * @param lore the lore to set
 +     */
-+    void lore(final @Nullable List<net.kyori.adventure.text.Component> lore);
++    void lore(final @Nullable List<? extends net.kyori.adventure.text.Component> lore);
 +    // Paper end
 +
      /**

--- a/patches/api/0115-ItemStack-API-additions-for-quantity-flags-lore.patch
+++ b/patches/api/0115-ItemStack-API-additions-for-quantity-flags-lore.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ItemStack API additions for quantity/flags/lore
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 53d99d214652ae1636f28a179a5b66edc0f8f229..a70de962712c14cb895708e89ad3811041728935 100644
+index 53d99d214652ae1636f28a179a5b66edc0f8f229..1907b8cfb4a78415fba8d5445ba98a6208516fd9 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -3,6 +3,7 @@ package org.bukkit.inventory;
@@ -139,7 +139,7 @@ index 53d99d214652ae1636f28a179a5b66edc0f8f229..a70de962712c14cb895708e89ad38110
 +     *
 +     * @param lore the lore that will be set
 +     */
-+    public void lore(@Nullable List<net.kyori.adventure.text.Component> lore) {
++    public void lore(@Nullable List<? extends net.kyori.adventure.text.Component> lore) {
 +        ItemMeta itemMeta = getItemMeta();
 +        if (itemMeta == null) {
 +            throw new IllegalStateException("Cannot set lore on " + getType());

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -735,7 +735,7 @@ index 0000000000000000000000000000000000000000..2fd6c3e65354071af71c7d8ebb97b559
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..01e424792f68bac73ec41726031ebbb53df13da7
+index 0000000000000000000000000000000000000000..ecddb6fe55e8ee1ca3b163503dd62200ce2d7d04
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 @@ -0,0 +1,354 @@
@@ -893,7 +893,7 @@ index 0000000000000000000000000000000000000000..01e424792f68bac73ec41726031ebbb5
 +        return adventures;
 +    }
 +
-+    public static List<String> asJson(final List<Component> adventures) {
++    public static List<String> asJson(final List<? extends Component> adventures) {
 +        final List<String> jsons = new ArrayList<>(adventures.size());
 +        for (final Component component : adventures) {
 +            jsons.add(GsonComponentSerializer.gson().serialize(component));
@@ -3073,7 +3073,7 @@ index 0beb96dc896f63003e1b1ae458b73902bdbe648a..102eb86bad3000f258775ac06ecd1a6d
      public String getCustomName() {
          EnchantmentTableBlockEntity enchant = this.getSnapshot();
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-index 55fcabb1d6e0767fc21c1f0beb76e941ed3c0846..749f8c6eb39e9cedeec472fc176b6a2a17900201 100644
+index 55fcabb1d6e0767fc21c1f0beb76e941ed3c0846..9fd6a05fb8022c5e4e3d67f9b0e9df3f477ea637 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 @@ -13,34 +13,60 @@ import org.bukkit.entity.Player;
@@ -3176,7 +3176,7 @@ index 55fcabb1d6e0767fc21c1f0beb76e941ed3c0846..749f8c6eb39e9cedeec472fc176b6a2a
      }
  
 +    // Paper start
-+    public static Component[] sanitizeLines(java.util.List<net.kyori.adventure.text.Component> lines) {
++    public static Component[] sanitizeLines(java.util.List<? extends net.kyori.adventure.text.Component> lines) {
 +        Component[] components = new Component[4];
 +        for (int i = 0; i < 4; i++) {
 +            if (i < lines.size() && lines.get(i) != null) {
@@ -3445,7 +3445,7 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4d341db0daecb5f6ff1f0a1a9238f9dedb4b50d1..27cf140f8a7715caec5637d7b487720c2cc5742e 100644
+index 4d341db0daecb5f6ff1f0a1a9238f9dedb4b50d1..ac56f49ab0736c3176918379f5ac1fdd7fcadfe4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -278,14 +278,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -3570,7 +3570,7 @@ index 4d341db0daecb5f6ff1f0a1a9238f9dedb4b50d1..27cf140f8a7715caec5637d7b487720c
  
 +    // Paper start
 +    @Override
-+    public void sendSignChange(Location loc, @Nullable List<net.kyori.adventure.text.Component> lines, DyeColor dyeColor, boolean hasGlowingText) {
++    public void sendSignChange(Location loc, @Nullable List<? extends net.kyori.adventure.text.Component> lines, DyeColor dyeColor, boolean hasGlowingText) {
 +        if (getHandle().connection == null) {
 +            return;
 +        }
@@ -4371,7 +4371,7 @@ index 507fa96a3fb904b74429df5756c9a6378ec8c5b7..abb9e88abc74135284b941e040d40586
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 8ed06dc812fbda72667352fa42c03f9d9ae7ca7e..78029398774f1060e3522e4613259be894d68c22 100644
+index 8ed06dc812fbda72667352fa42c03f9d9ae7ca7e..69f71bf44bbc66a38a877c660c8dbc493a0a8327 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -747,6 +747,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
@@ -4404,7 +4404,7 @@ index 8ed06dc812fbda72667352fa42c03f9d9ae7ca7e..78029398774f1060e3522e4613259be8
 +    }
 +
 +    @Override
-+    public void lore(final List<net.kyori.adventure.text.Component> lore) {
++    public void lore(final List<? extends net.kyori.adventure.text.Component> lore) {
 +        this.lore = lore != null ? io.papermc.paper.adventure.PaperAdventure.asJson(lore) : null;
 +    }
 +    // Paper end


### PR DESCRIPTION
This should allow the usage of methods with a List<Component> parameter like ItemStack#lore with a List<TextComponent>.
Sometimes API methods will return TextComponents so you'd have to parse to get List<Component>.

This api change is backwards compatible unless plugins are implementing Player, ItemStack and ItemMeta.