### PR TITLE
Switch to adventure Key/Keyed for Registry

### DIFF
--- a/patches/api/0418-Switch-to-adventure-Key-Keyed.patch
+++ b/patches/api/0418-Switch-to-adventure-Key-Keyed.patch
@@ -1,0 +1,135 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 19 Mar 2023 15:39:30 -0700
+Subject: [PATCH] Switch to adventure Key/Keyed
+
+
+diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
+index 0a3a41ae4c488b148266129d3663be3f8830d509..1bba050f425fe70774f9cdba3f2cea2d94c927e6 100644
+--- a/src/main/java/org/bukkit/Registry.java
++++ b/src/main/java/org/bukkit/Registry.java
+@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
+  *
+  * @param <T> type of item in the registry
+  */
+-public interface Registry<T extends Keyed> extends Iterable<T> {
++public interface Registry<T extends net.kyori.adventure.key.Keyed> extends Iterable<T> { // Paper - switch to adventure Key
+ 
+     /**
+      * Server advancements.
+@@ -40,8 +40,8 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+ 
+         @Nullable
+         @Override
+-        public Advancement get(@NotNull NamespacedKey key) {
+-            return Bukkit.getAdvancement(key);
++        public Advancement get(@NotNull net.kyori.adventure.key.Key key) { // Paper - switch to adventure Key
++            return Bukkit.getAdvancement(asBukkit(key)); // Paper - switch to adventure Key
+         }
+ 
+         @NotNull
+@@ -78,8 +78,8 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+ 
+         @Nullable
+         @Override
+-        public KeyedBossBar get(@NotNull NamespacedKey key) {
+-            return Bukkit.getBossBar(key);
++        public KeyedBossBar get(@NotNull net.kyori.adventure.key.Key key) { // Paper - switch to adventure Key
++            return Bukkit.getBossBar(asBukkit(key)); // Paper - switch to adventure Key
+         }
+ 
+         @NotNull
+@@ -97,8 +97,8 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+ 
+         @Nullable
+         @Override
+-        public Enchantment get(@NotNull NamespacedKey key) {
+-            return Enchantment.getByKey(key);
++        public Enchantment get(@NotNull net.kyori.adventure.key.Key key) { // Paper - switch to adventure Key
++            return Enchantment.getByKey(asBukkit(key)); // Paper - switch to adventure Key
+         }
+ 
+         @NotNull
+@@ -176,8 +176,8 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+ 
+         @Nullable
+         @Override
+-        public MemoryKey get(@NotNull NamespacedKey key) {
+-            return MemoryKey.getByKey(key);
++        public MemoryKey get(@NotNull net.kyori.adventure.key.Key key) { // Paper - switch to adventure Key
++            return MemoryKey.getByKey(asBukkit(key)); // Paper - switch to adventure Key
+         }
+     };
+     /**
+@@ -207,8 +207,8 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+ 
+         @Nullable
+         @Override
+-        public GameEvent get(@NotNull NamespacedKey key) {
+-            return GameEvent.getByKey(key);
++        public GameEvent get(@NotNull net.kyori.adventure.key.Key key) { // Paper - switch to adventure Key
++            return GameEvent.getByKey(asBukkit(key)); // Paper - switch to adventure Key
+         }
+     };
+     // Paper start
+@@ -229,8 +229,8 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+ 
+         @Nullable
+         @Override
+-        public org.bukkit.potion.PotionEffectType get(@NotNull NamespacedKey key) {
+-            return org.bukkit.potion.PotionEffectType.getByKey(key);
++        public org.bukkit.potion.PotionEffectType get(@NotNull net.kyori.adventure.key.Key key) { // Paper - switch to adventure Key
++            return org.bukkit.potion.PotionEffectType.getByKey(asBukkit(key)); // Paper - switch to adventure Key
+         }
+ 
+         @NotNull
+@@ -245,10 +245,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      * Get the object by its key.
+      *
+      * @param key non-null key
+-     * @return item or null if does not exist
++     * @return item or null if it does not exist
+      */
+-    @Nullable
+-    T get(@NotNull NamespacedKey key);
++    // Paper start
++    @Nullable T get(@NotNull net.kyori.adventure.key.Key key);
++
++    private static NamespacedKey asBukkit(net.kyori.adventure.key.Key key) {
++        return key instanceof NamespacedKey ns ? ns : new org.bukkit.NamespacedKey(key.namespace(), key.value());
++    }
++    // Paper end
+ 
+     /**
+      * Attempts to match the registered object with the given key.
+@@ -292,10 +297,16 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+         }
+ 
+         @Nullable
+-        @Override
++        // @Override // Paper
+         public T get(@NotNull NamespacedKey key) {
+             return map.get(key);
+         }
++        // Paper start - switch to adventure Key
++        @Override
++        public @Nullable T get(final net.kyori.adventure.key.@NotNull Key key) {
++            return this.map.get(asBukkit(key));
++        }
++        // Paper end
+ 
+         @NotNull
+         @Override
+diff --git a/src/test/java/io/papermc/paper/testing/EmptyRegistry.java b/src/test/java/io/papermc/paper/testing/EmptyRegistry.java
+index ba9ddce87a9f385e729a5c2cf7c5eec120e388a7..1325905466b7fe6220fbba83321053dd23170236 100644
+--- a/src/test/java/io/papermc/paper/testing/EmptyRegistry.java
++++ b/src/test/java/io/papermc/paper/testing/EmptyRegistry.java
+@@ -17,7 +17,7 @@ public record EmptyRegistry() implements Registry<Keyed> {
+     }
+ 
+     @Override
+-    public @Nullable Keyed get(@NotNull final NamespacedKey key) {
++    public @Nullable Keyed get(@NotNull final net.kyori.adventure.key.Key key) {
+         return null;
+     }
+ }

--- a/patches/server/0971-Switch-to-adventure-Key-Keyed.patch
+++ b/patches/server/0971-Switch-to-adventure-Key-Keyed.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 19 Mar 2023 15:39:44 -0700
+Subject: [PATCH] Switch to adventure Key/Keyed
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+index 34888b525fd35ac64e6e5e66036ad965a6769959..40fa74a462c6304f2f14d8c7655b16516de94482 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+@@ -36,7 +36,7 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+         return null;
+     }
+ 
+-    private final Map<NamespacedKey, B> cache = new HashMap<>();
++    private final Map<net.kyori.adventure.key.Key, B> cache = new HashMap<>(); // Paper - switch to adventure Key
+     private final net.minecraft.core.Registry<M> minecraftRegistry;
+     private final BiFunction<NamespacedKey, M, B> minecraftToBukkit;
+ 
+@@ -46,13 +46,13 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+     }
+ 
+     @Override
+-    public B get(NamespacedKey namespacedKey) {
++    public B get(net.kyori.adventure.key.Key namespacedKey) { // Paper - switch to adventure Key
+         B cached = this.cache.get(namespacedKey);
+         if (cached != null) {
+             return cached;
+         }
+ 
+-        B bukkit = this.createBukkit(namespacedKey, this.minecraftRegistry.getOptional(CraftNamespacedKey.toMinecraft(namespacedKey)).orElse(null));
++        B bukkit = this.createBukkit(asBukkit(namespacedKey), this.minecraftRegistry.getOptional(io.papermc.paper.adventure.PaperAdventure.asVanilla(namespacedKey)).orElse(null)); // Paper - switch to adventure Key
+         if (bukkit == null) {
+             return null;
+         }
+@@ -78,4 +78,9 @@ public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
+     public Stream<B> values() {
+         return this.minecraftRegistry.keySet().stream().map(minecraftKey -> this.get(CraftNamespacedKey.fromMinecraft(minecraftKey)));
+     }
++    // Paper start - switch to adventure Key
++    private static NamespacedKey asBukkit(net.kyori.adventure.key.Key key) {
++        return key instanceof NamespacedKey ns ? ns : new org.bukkit.NamespacedKey(key.namespace(), key.value());
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
+index ebbbfc318439fec33331d71563e528cd3429e541..54375e28f2b28540bc79f352e4a32d6c88f6f68a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
+@@ -450,6 +450,12 @@ public class Commodore
+                             return;
+                         }
+                         // Paper end
++                        // Paper start - rewrite Registry generic change
++                        if (owner.equals("org/bukkit/Registry") && name.equals("get") && desc.equals("(Lorg/bukkit/NamespacedKey;)Lorg/bukkit/Keyed;")) {
++                            super.visitMethodInsn(opcode, owner, name, "(Lnet/kyori/adventure/key/Key;)Lnet/kyori/adventure/key/Keyed;", itf);
++                            return;
++                        }
++                        // Paper end
+                         if ( modern )
+                         {
+                             if ( owner.equals( "org/bukkit/Material" ) )
+diff --git a/src/test/java/io/papermc/paper/testing/LazyRegistry.java b/src/test/java/io/papermc/paper/testing/LazyRegistry.java
+index 8dd0df8c2cc25d37a2590a07872682230a9335f2..ff4206938814250c7ff77129dd51bfea22ed3b3c 100644
+--- a/src/test/java/io/papermc/paper/testing/LazyRegistry.java
++++ b/src/test/java/io/papermc/paper/testing/LazyRegistry.java
+@@ -17,7 +17,7 @@ public record LazyRegistry(Supplier<Registry<Keyed>> supplier) implements Regist
+     }
+ 
+     @Override
+-    public @Nullable Keyed get(@NotNull final NamespacedKey key) {
++    public @Nullable Keyed get(@NotNull final net.kyori.adventure.key.Key key) {
+         return this.supplier().get().get(key);
+     }
+ }


### PR DESCRIPTION
I believe this is all we have to do, to migrate away from `org.bukkit.Keyed` when dealing with all things "Registry". The `T` generic in Registry changes to extend `net.kyori.adventure.key.Keyed`, which means just a single method has to be rewritten with Commodore for the new return type of `T get(NamespacedKey)`. Along with maintaining ABI compat, this shouldn't break any compiles either, as `org.bukkit.Keyed` extends `net.kyori.adventure.key.Keyed` and `NamespacedKey` extends `Key`.

Once this is finalized, most of this will go into the server/api adventure patches.

This isn't deprecating anything, like `NamespacedKey` or the other 500 methods that use `NamespacedKey`, it just means we won't have to keep using `NamespacedKey` when `Key` is much better.

I tested this by compiling a plugin against the non-modified API and made sure the Commodore changes work as expected.