### PR TITLE
use class loggers without the fqn for non-debug logging

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -123,7 +123,7 @@ index 0000000000000000000000000000000000000000..7a4a7a654fe2516ed894a68f2657344d
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/Configurations.java b/src/main/java/io/papermc/paper/configuration/Configurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c2dca89291361d60cbf160cab77749cb0130035a
+index 0000000000000000000000000000000000000000..9ef6712c70fcd8912a79f3f61e351aac09572cf3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/Configurations.java
 @@ -0,0 +1,311 @@
@@ -160,7 +160,7 @@ index 0000000000000000000000000000000000000000..c2dca89291361d60cbf160cab77749cb
 +
 +public abstract class Configurations<G, W> {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +    public static final String WORLD_DEFAULTS = "__world_defaults__";
 +    public static final ResourceLocation WORLD_DEFAULTS_KEY = new ResourceLocation("configurations", WORLD_DEFAULTS);
 +    protected final Path globalFolder;
@@ -934,7 +934,7 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9fde9ccb5d069ddce8dd837ef1bc68b93ce66434
+index 0000000000000000000000000000000000000000..f6b9d216c24d8858802f85209fe1a869e5a9be31
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 @@ -0,0 +1,439 @@
@@ -1011,7 +1011,7 @@ index 0000000000000000000000000000000000000000..9fde9ccb5d069ddce8dd837ef1bc68b9
 +@SuppressWarnings("Convert2Diamond")
 +public class PaperConfigurations extends Configurations<GlobalConfiguration, WorldConfiguration> {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +    static final String GLOBAL_CONFIG_FILE_NAME = "paper-global.yml";
 +    static final String WORLD_DEFAULTS_CONFIG_FILE_NAME = "paper-world-defaults.yml";
 +    static final String WORLD_CONFIG_FILE_NAME = "paper-world.yml";
@@ -1448,7 +1448,7 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4532f3a0d74feae0a1249b53e1bfbc18a8808b32
+index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b6381996810130
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 @@ -0,0 +1,475 @@
@@ -1502,7 +1502,7 @@ index 0000000000000000000000000000000000000000..4532f3a0d74feae0a1249b53e1bfbc18
 +
 +@SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal", "NotNullFieldNotInitialized", "InnerClassMayBeStatic"})
 +public class WorldConfiguration extends ConfigurationPart {
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +    static final int CURRENT_VERSION = 30; // (when you change the version, change the comment, so it conflicts on rebases): rename filter bad nbt from spawn eggs
 +
 +    private transient final SpigotWorldConfig spigotConfig;
@@ -1965,7 +1965,7 @@ index 0000000000000000000000000000000000000000..514be9a11e2ca368ea72dd2bac1b84bf
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/constraint/Constraints.java b/src/main/java/io/papermc/paper/configuration/constraint/Constraints.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b470332f542c30c42355adb711ff148e8e1dd7a1
+index 0000000000000000000000000000000000000000..6bcc08698be6eb1bf5607991d52f6dcf05db665c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/constraint/Constraints.java
 @@ -0,0 +1,74 @@
@@ -1993,7 +1993,7 @@ index 0000000000000000000000000000000000000000..b470332f542c30c42355adb711ff148e
 +
 +    public static final class Velocity implements Constraint<GlobalConfiguration.Proxies.Velocity> {
 +
-+        private static final Logger LOGGER = LogUtils.getLogger();
++        private static final Logger LOGGER = LogUtils.getClassLogger();
 +
 +        @Override
 +        public void validate(final GlobalConfiguration.Proxies.@Nullable Velocity value) throws SerializationException {
@@ -2253,7 +2253,7 @@ index 0000000000000000000000000000000000000000..27c0679d376bb31ab52131dfea74b3b5
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/serializer/EnumValueSerializer.java b/src/main/java/io/papermc/paper/configuration/serializer/EnumValueSerializer.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2afb9268447792e3cdb46172b2050dbce066c59a
+index 0000000000000000000000000000000000000000..8535c748a5e355362e77e6c5103e11c4c318a138
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/serializer/EnumValueSerializer.java
 @@ -0,0 +1,50 @@
@@ -2279,7 +2279,7 @@ index 0000000000000000000000000000000000000000..2afb9268447792e3cdb46172b2050dbc
 + */
 +public class EnumValueSerializer extends ScalarSerializer<Enum<?>> {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +
 +    public EnumValueSerializer() {
 +        super(new TypeToken<Enum<?>>() {});
@@ -2367,7 +2367,7 @@ index 0000000000000000000000000000000000000000..b44b2dc28f619594e302417848e95c00
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/serializer/PacketClassSerializer.java b/src/main/java/io/papermc/paper/configuration/serializer/PacketClassSerializer.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bc065d5cc8975dd189954272116a6bc5bc7f4e28
+index 0000000000000000000000000000000000000000..893ad5e7c2d32ccd64962d95d146bbd317c28ab8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/serializer/PacketClassSerializer.java
 @@ -0,0 +1,86 @@
@@ -2393,7 +2393,7 @@ index 0000000000000000000000000000000000000000..bc065d5cc8975dd189954272116a6bc5
 +@SuppressWarnings("Convert2Diamond")
 +public final class PacketClassSerializer extends ScalarSerializer<Class<? extends Packet<?>>> implements MapSerializer.WriteBack {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +    private static final TypeToken<Class<? extends Packet<?>>> TYPE = new TypeToken<Class<? extends Packet<?>>>() {};
 +    private static final List<String> SUBPACKAGES = List.of("game", "handshake", "login", "status");
 +    private static final BiMap<String, String> MOJANG_TO_OBF;
@@ -2592,7 +2592,7 @@ index 0000000000000000000000000000000000000000..4af710e144b70933d750c22edfe484c1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/serializer/collections/MapSerializer.java b/src/main/java/io/papermc/paper/configuration/serializer/collections/MapSerializer.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f44d4cb05eab25d79a8ac09b9da981633380c4fc
+index 0000000000000000000000000000000000000000..9b5075c39a4ef931cdb99e9aee8a33c6d88c2a2e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/serializer/collections/MapSerializer.java
 @@ -0,0 +1,162 @@
@@ -2626,7 +2626,7 @@ index 0000000000000000000000000000000000000000..f44d4cb05eab25d79a8ac09b9da98163
 +
 +    public static final TypeToken<Map<?, ?>> TYPE = new TypeToken<Map<?, ?>>() {};
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +
 +    private final boolean clearInvalids;
 +
@@ -3050,7 +3050,7 @@ index 0000000000000000000000000000000000000000..96e8d03bd4a4d43633a94bb251054610
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/transformation/global/LegacyPaperConfig.java b/src/main/java/io/papermc/paper/configuration/transformation/global/LegacyPaperConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d21335930652ffced22f6fd19ab1a4f9ad599db8
+index 0000000000000000000000000000000000000000..fec6d0b249c6dc7856c5acc4e7dad9fcfabfe35b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/transformation/global/LegacyPaperConfig.java
 @@ -0,0 +1,222 @@
@@ -3076,7 +3076,7 @@ index 0000000000000000000000000000000000000000..d21335930652ffced22f6fd19ab1a4f9
 +import static org.spongepowered.configurate.NodePath.path;
 +
 +public final class LegacyPaperConfig {
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +
 +    private LegacyPaperConfig() {
 +    }
@@ -3278,7 +3278,7 @@ index 0000000000000000000000000000000000000000..d21335930652ffced22f6fd19ab1a4f9
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/transformation/world/FeatureSeedsGeneration.java b/src/main/java/io/papermc/paper/configuration/transformation/world/FeatureSeedsGeneration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..372dda1738da9ab94c963bb73cecdf52e031c903
+index 0000000000000000000000000000000000000000..1326aae8f95ab11f840abdee0c8c7a557705fd73
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/transformation/world/FeatureSeedsGeneration.java
 @@ -0,0 +1,71 @@
@@ -3309,13 +3309,13 @@ index 0000000000000000000000000000000000000000..372dda1738da9ab94c963bb73cecdf52
 +
 +import static org.spongepowered.configurate.NodePath.path;
 +
-+public class FeatureSeedsGeneration implements TransformAction {
++public final class FeatureSeedsGeneration implements TransformAction {
 +
 +    public static final String FEATURE_SEEDS_KEY = "feature-seeds";
 +    public static final String GENERATE_KEY = "generate-random-seeds-for-all";
 +    public static final String FEATURES_KEY = "features";
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +
 +    private final ResourceLocation worldKey;
 +
@@ -4045,7 +4045,7 @@ index 0000000000000000000000000000000000000000..7f8b685762f59049fde88e8d1bc10e15
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/type/IntOr.java b/src/main/java/io/papermc/paper/configuration/type/IntOr.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a03e82fa80a548e18634ac2f536a995c3f518498
+index 0000000000000000000000000000000000000000..4dc1e4a5d92f70b2eda44cbbac2747932892970d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/type/IntOr.java
 @@ -0,0 +1,89 @@
@@ -4064,7 +4064,7 @@ index 0000000000000000000000000000000000000000..a03e82fa80a548e18634ac2f536a995c
 +
 +public interface IntOr {
 +
-+    Logger LOGGER = LogUtils.getLogger();
++    Logger LOGGER = LogUtils.getClassLogger();
 +
 +    default int or(final int fallback) {
 +        return this.value().orElse(fallback);

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -456,7 +456,7 @@ index 0000000000000000000000000000000000000000..7159c72408f556d676eded668057a4c5
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java b/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f7e43c693140b7a820b2432db312df8f7b099d4d
+index 0000000000000000000000000000000000000000..89bf48fd581ee6580b91e2eb31dd532cb622df5e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/PluginInitializerManager.java
 @@ -0,0 +1,132 @@
@@ -483,7 +483,7 @@ index 0000000000000000000000000000000000000000..f7e43c693140b7a820b2432db312df8f
 +
 +public class PluginInitializerManager {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +    private static PluginInitializerManager impl;
 +    private final Path pluginDirectory;
 +    private final Path updateDirectory;
@@ -2951,7 +2951,7 @@ index 0000000000000000000000000000000000000000..ea37ace14849ef4589a4f97287e6dcd6
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/manager/MultiRuntimePluginProviderStorage.java b/src/main/java/io/papermc/paper/plugin/manager/MultiRuntimePluginProviderStorage.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..365aa894c77b095bfe23bdaab354591df32bcda2
+index 0000000000000000000000000000000000000000..48696ee62cfaef27ea512464d33ac502f5ec3ccd
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/manager/MultiRuntimePluginProviderStorage.java
 @@ -0,0 +1,49 @@
@@ -2971,7 +2971,7 @@ index 0000000000000000000000000000000000000000..365aa894c77b095bfe23bdaab354591d
 +
 +public class MultiRuntimePluginProviderStorage extends ServerPluginProviderStorage {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +    private final List<JavaPlugin> provided = new ArrayList<>();
 +
 +    @Override
@@ -4969,7 +4969,7 @@ index 0000000000000000000000000000000000000000..a180612a1ec395202dbae1ca5b97ec01
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/source/DirectoryProviderSource.java b/src/main/java/io/papermc/paper/plugin/provider/source/DirectoryProviderSource.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ed00c412f1703b38674bbd0d483fcb100aa99f9d
+index 0000000000000000000000000000000000000000..1572c3942c850eb36df38cf06395bcafa24e18e0
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/source/DirectoryProviderSource.java
 @@ -0,0 +1,40 @@
@@ -4989,7 +4989,7 @@ index 0000000000000000000000000000000000000000..ed00c412f1703b38674bbd0d483fcb10
 +public class DirectoryProviderSource extends FileProviderSource {
 +
 +    public static final DirectoryProviderSource INSTANCE = new DirectoryProviderSource();
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +
 +    public DirectoryProviderSource() {
 +        super("File '%s'"::formatted);
@@ -5178,7 +5178,7 @@ index 0000000000000000000000000000000000000000..3b1215fcfa1b9de42d8f946c4e2b4572
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/source/PluginFlagProviderSource.java b/src/main/java/io/papermc/paper/plugin/provider/source/PluginFlagProviderSource.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e62b476ddbce2bdc66061c116aa0228622f6fd16
+index 0000000000000000000000000000000000000000..205aec4017df65ab268835a8db1687438fba4e1a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/source/PluginFlagProviderSource.java
 @@ -0,0 +1,29 @@
@@ -5197,7 +5197,7 @@ index 0000000000000000000000000000000000000000..e62b476ddbce2bdc66061c116aa02286
 +public class PluginFlagProviderSource implements ProviderSource<List<File>> {
 +
 +    public static final PluginFlagProviderSource INSTANCE = new PluginFlagProviderSource();
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +    private final FileProviderSource providerSource = new FileProviderSource("File '%s' specified through 'add-plugin' argument"::formatted);
 +
 +    @Override
@@ -6096,7 +6096,7 @@ index 0000000000000000000000000000000000000000..14ed05945ba5bfeb2b539d4786278b0e
 +
 diff --git a/src/main/java/io/papermc/paper/plugin/storage/BootstrapProviderStorage.java b/src/main/java/io/papermc/paper/plugin/storage/BootstrapProviderStorage.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e5b70ff297febd936e64055b79f48712d65dbed9
+index 0000000000000000000000000000000000000000..2851c22ed74792bf7b60139c46776407e5163463
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/storage/BootstrapProviderStorage.java
 @@ -0,0 +1,57 @@
@@ -6124,7 +6124,7 @@ index 0000000000000000000000000000000000000000..e5b70ff297febd936e64055b79f48712
 +
 +public class BootstrapProviderStorage extends SimpleProviderStorage<PluginBootstrap> {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +
 +    public BootstrapProviderStorage() {
 +        super(new ModernPluginLoadingStrategy<>(new ProviderConfiguration<>() {
@@ -6206,7 +6206,7 @@ index 0000000000000000000000000000000000000000..374e7d3d69fc8603ecf54999f173123d
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/storage/ServerPluginProviderStorage.java b/src/main/java/io/papermc/paper/plugin/storage/ServerPluginProviderStorage.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..fbe76a678f45bd3c55f25f2b6a4366efc0521cb8
+index 0000000000000000000000000000000000000000..cb9b13522a976b82bcb71cef486f11f4172e3e99
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/storage/ServerPluginProviderStorage.java
 @@ -0,0 +1,70 @@
@@ -6229,7 +6229,7 @@ index 0000000000000000000000000000000000000000..fbe76a678f45bd3c55f25f2b6a4366ef
 +
 +public class ServerPluginProviderStorage extends ConfiguredProviderStorage<JavaPlugin> {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +
 +    public ServerPluginProviderStorage() {
 +        super(new ProviderConfiguration<>() {
@@ -6282,7 +6282,7 @@ index 0000000000000000000000000000000000000000..fbe76a678f45bd3c55f25f2b6a4366ef
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/storage/SimpleProviderStorage.java b/src/main/java/io/papermc/paper/plugin/storage/SimpleProviderStorage.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a7085dbf2c5ace9b6887d024c0785fa529e0f1da
+index 0000000000000000000000000000000000000000..9abfc8778614f7bc4da32a27c7f4964caff05c63
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/storage/SimpleProviderStorage.java
 @@ -0,0 +1,85 @@
@@ -6300,7 +6300,7 @@ index 0000000000000000000000000000000000000000..a7085dbf2c5ace9b6887d024c0785fa5
 +
 +public abstract class SimpleProviderStorage<T> implements ProviderStorage<T> {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +
 +    protected final List<PluginProvider<T>> providers = new ArrayList<>();
 +    protected ProviderLoadingStrategy<T> strategy;
@@ -6384,7 +6384,7 @@ index 0000000000000000000000000000000000000000..c1114675137e862ac9682b635bfdbfbc
 +package io.papermc.paper.plugin.storage;
 diff --git a/src/main/java/io/papermc/paper/plugin/util/EntrypointUtil.java b/src/main/java/io/papermc/paper/plugin/util/EntrypointUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..98518351e616e536315cd89790b327d3bad33d0e
+index 0000000000000000000000000000000000000000..6507e0103c6afde2bed31e25b70e7402fa3af823
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/util/EntrypointUtil.java
 @@ -0,0 +1,19 @@
@@ -6397,7 +6397,7 @@ index 0000000000000000000000000000000000000000..98518351e616e536315cd89790b327d3
 +
 +public class EntrypointUtil {
 +
-+    private static final Logger LOGGER = LogUtils.getLogger();
++    private static final Logger LOGGER = LogUtils.getClassLogger();
 +
 +    public static <C> void registerProvidersFromSource(ProviderSource<C> source, C context) {
 +        try {


### PR DESCRIPTION
Changes loggers in the paper config and paper plugins patch to use the class logger so the super long fqn isn't prefixed onto the class name in logs. It's unneeded imo for non debug logs as it just clutters error messages. 