### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0055-Fix-upstream-javadocs.patch
+++ b/patches/api/0055-Fix-upstream-javadocs.patch
@@ -89,6 +89,19 @@ index f9bd74f9ce6bd6650726e5a993f9b6e292cdc74d..f4c37ce1fe7aac3dde8485ee51fc8888
 +    void setColor(@org.bukkit.UndefinedNullability("not supported") org.bukkit.DyeColor color);
 +// Paper end
 +}
+diff --git a/src/main/java/org/bukkit/block/data/BlockData.java b/src/main/java/org/bukkit/block/data/BlockData.java
+index 12a7ca1808cb80daceb7695a2f0e8f97e0e21a49..0d5ef61e100d972a5cf308b23d5e8f2fdbad5718 100644
+--- a/src/main/java/org/bukkit/block/data/BlockData.java
++++ b/src/main/java/org/bukkit/block/data/BlockData.java
+@@ -211,7 +211,7 @@ public interface BlockData extends Cloneable {
+      * {@link Material#REDSTONE_WIRE} -> {@link Material#REDSTONE}
+      * {@link Material#CARROTS} -> {@link Material#CARROT}
+      * </pre>
+-     * @return placement material
++     * @return placement material or {@link Material#AIR} if it doesn't have one
+      */
+     @NotNull
+     Material getPlacementMaterial();
 diff --git a/src/main/java/org/bukkit/entity/ArmorStand.java b/src/main/java/org/bukkit/entity/ArmorStand.java
 index 91fc11dda99de506be83d40df8929bf7cd8e8d85..7dc631ebd009f5f5c3ac1699c3f3515c47609c05 100644
 --- a/src/main/java/org/bukkit/entity/ArmorStand.java
@@ -134,7 +147,7 @@ index 2926fa6071bc7640cc10280b5c3962b0ce7686f1..4f63988848443aff55619bc12ef12c92
       * Instructs this Mob to set the specified LivingEntity as its target.
       * <p>
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 0fdaf416960ace84fbe9b9c461641efbb8b631a4..1017db005f8c7a095911f5dd0dbe37d9fc239c95 100644
+index be2626e57d77f570a61cb822d3804245c0419cb3..a95efd61d171d1194ae545d8d89710aca82e40a6 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -310,15 +310,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0105-PotionEffect-clone-methods.patch
+++ b/patches/api/0105-PotionEffect-clone-methods.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PotionEffect clone methods
 
 
 diff --git a/src/main/java/org/bukkit/potion/PotionEffect.java b/src/main/java/org/bukkit/potion/PotionEffect.java
-index 1f0faf16071f0be44c87248582ba173e51aafb52..24e36cdf580da885ac64002673a786b9c5a3f787 100644
+index 66dfed07bfb44e99a94fb02dc056e8601115994a..ccdca0d75868135dc7b96daeff2236b225c4add1 100644
 --- a/src/main/java/org/bukkit/potion/PotionEffect.java
 +++ b/src/main/java/org/bukkit/potion/PotionEffect.java
-@@ -101,6 +101,33 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -106,6 +106,33 @@ public class PotionEffect implements ConfigurationSerializable {
          this(getEffectType(map), getInt(map, DURATION), getInt(map, AMPLIFIER), getBool(map, AMBIENT, false), getBool(map, PARTICLES, true), getBool(map, ICON, getBool(map, PARTICLES, true)));
      }
  

--- a/patches/api/0377-Block-Ticking-API.patch
+++ b/patches/api/0377-Block-Ticking-API.patch
@@ -31,13 +31,13 @@ index 13485933b8b897b5a9b35f337b43eab5c968f13a..390a2a2611df35a9ea6f1eb996b47e2a
  
      /**
 diff --git a/src/main/java/org/bukkit/block/data/BlockData.java b/src/main/java/org/bukkit/block/data/BlockData.java
-index e7ea3f9a60968f257c631bbefcc31653e6ae3728..dcfd515af841cbb957a9a651b6350c88840c041e 100644
+index 12a7ca1808cb80daceb7695a2f0e8f97e0e21a49..f531ef38b07d95f68d6b985ce7714bd6e93d6876 100644
 --- a/src/main/java/org/bukkit/block/data/BlockData.java
 +++ b/src/main/java/org/bukkit/block/data/BlockData.java
-@@ -199,4 +199,14 @@ public interface BlockData extends Cloneable {
-      * @return true if the face is sturdy and can support a block, false otherwise
+@@ -215,4 +215,14 @@ public interface BlockData extends Cloneable {
       */
-     boolean isFaceSturdy(@NotNull BlockFace face, @NotNull BlockSupport support);
+     @NotNull
+     Material getPlacementMaterial();
 +
 +    // Paper start - Tick API
 +    /**

--- a/patches/api/0402-Mark-experimental-api-as-such.patch
+++ b/patches/api/0402-Mark-experimental-api-as-such.patch
@@ -1190,7 +1190,7 @@ index 8f601e85df580ef8106eaff8b9eafb5691a4874b..99ca502a14e3f321c323d7675bc47e7e
  
      /**
 diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
-index 456eb20f8d603b1ebbaa11b8832e56c08406b7c9..374b06a5e098f81dfe059df35f02139afd1e7991 100644
+index 65a1cd5837d944db1ade9dbed1caa083f73da53e..90a846e23d2b41e3f658fbf48cd43bd5e72b709f 100644
 --- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
 +++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
 @@ -137,13 +137,14 @@ public enum InventoryType {
@@ -1198,7 +1198,7 @@ index 456eb20f8d603b1ebbaa11b8832e56c08406b7c9..374b06a5e098f81dfe059df35f02139a
       * Pseudo chiseled bookshelf inventory, with 6 slots of undefined type.
       */
 +    @org.jetbrains.annotations.ApiStatus.Experimental // Paper - 1.20
-     CHISELED_BOOKSHELF(6, "Chiseled Bookshelf"),
+     CHISELED_BOOKSHELF(6, "Chiseled Bookshelf", false),
      /**
       * The new smithing inventory, with 3 CRAFTING slots and 1 RESULT slot.
       *

--- a/patches/api/0416-Fix-Jukeboxes.patch
+++ b/patches/api/0416-Fix-Jukeboxes.patch
@@ -39,7 +39,7 @@ index 321e5e034a906129142341cec952fac3c1e7e360..37967acb9ee85f1d1c9b3b2d3472b460
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
-index 374b06a5e098f81dfe059df35f02139afd1e7991..6957d5b88c549f08dd3afe272f018be122f3a4a6 100644
+index 90a846e23d2b41e3f658fbf48cd43bd5e72b709f..35aac79a7c58d00e6b3c6c042b291093c9c7af71 100644
 --- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
 +++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
 @@ -146,6 +146,13 @@ public enum InventoryType {
@@ -51,7 +51,7 @@ index 374b06a5e098f81dfe059df35f02139afd1e7991..6957d5b88c549f08dd3afe272f018be1
 +     * Pseudo jukebox inventory
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Experimental
-+    JUKEBOX(1, "Jukebox");
++    JUKEBOX(1, "Jukebox", false);
 +    // Paper end
      ;
  

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -67,7 +67,7 @@ index e090175d2fbe8eba664500feafc29c0567bb0c87..d77f15c58f41f1e00c75e0a022919bb7
      exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 575329e6fb95a003452592a3e55fa014dd29070c..ad6d25b26454c3ec8c11f54e921df8914c3c62d9 100644
+index 0b608dcf8dde96a8a240954aaf6c6a82d3f506e7..f19755a6096b72d6ca302a4ea2d386fadfe2b122 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -202,7 +202,7 @@ public class Main {
@@ -78,7 +78,7 @@ index 575329e6fb95a003452592a3e55fa014dd29070c..ad6d25b26454c3ec8c11f54e921df891
 +                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -7);
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 index 93046379d0cefd5d3236fc59e698809acdc18f80..774556a62eb240da42e84db4502e2ed43495be17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java

--- a/patches/server/0027-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0027-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -32,11 +32,11 @@ index b9eae8760a642ab5a38980787dde045a3c08046d..fbc62e2b07a430dea8a827790bda5fbf
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 0cbabd6ffc7bbc9494c1a0d631567fae828fb045..2d1df61cc7ec645add8f729cc6cfdea0c56755aa 100644
+index 7252677bd6dabe094bfc9d47882059b9cb86e791..422a7764ec8713ef6dc2f7cfbe152679ad91a891 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -233,12 +233,25 @@ public class Main {
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -7);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");
 -                        System.err.println("*** Please download a new build as per instructions from https://www.spigotmc.org/go/outdated-spigot ***");

--- a/patches/server/0110-Add-EntityZapEvent.patch
+++ b/patches/server/0110-Add-EntityZapEvent.patch
@@ -28,10 +28,10 @@ index efbf6b316a70b94e4bd490df8ebe77cd9f638ba4..cad8854cc7523d60c06ca1f03bfd4fbf
                  entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
                  entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2c3518ea974be5fce424093e9b710c853fd52a7a..b8ddc96bb444381f3a980e740e109419cffd07ae 100644
+index 54a9a630ca1aa3cabc9aa29ba7d9e516c0f88a00..ed1a1ca9494bbdde3f496ee284d63e86665d6de0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1161,6 +1161,14 @@ public class CraftEventFactory {
+@@ -1164,6 +1164,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0114-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0114-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index 5391c60398c8a7d1d49dc2e73116b27862653873..5a79b49e321cba352d8e4189dfbfdd05
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b8ddc96bb444381f3a980e740e109419cffd07ae..012cbdbaf56a856879b00fb7664fc4eb0d1987c1 100644
+index ed1a1ca9494bbdde3f496ee284d63e86665d6de0..e7f673b38615c116227bb1abcbd10746d4cc74d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1120,6 +1120,17 @@ public class CraftEventFactory {
+@@ -1123,6 +1123,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0115-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0115-Add-ProjectileCollideEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add ProjectileCollideEvent
 Deprecated now and replaced with ProjectileHitEvent
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 012cbdbaf56a856879b00fb7664fc4eb0d1987c1..427c63945e207236fc2e5caa99e22b3f7b171854 100644
+index e7f673b38615c116227bb1abcbd10746d4cc74d4..a1efb66de4cb509781de498bee5c44456ad93395 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1264,6 +1264,17 @@ public class CraftEventFactory {
+@@ -1267,6 +1267,17 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  
@@ -27,7 +27,7 @@ index 012cbdbaf56a856879b00fb7664fc4eb0d1987c1..427c63945e207236fc2e5caa99e22b3f
      public static ProjectileLaunchEvent callProjectileLaunchEvent(Entity entity) {
          Projectile bukkitEntity = (Projectile) entity.getBukkitEntity();
          ProjectileLaunchEvent event = new ProjectileLaunchEvent(bukkitEntity);
-@@ -1288,8 +1299,15 @@ public class CraftEventFactory {
+@@ -1291,8 +1302,15 @@ public class CraftEventFactory {
          if (position.getType() == HitResult.Type.ENTITY) {
              hitEntity = ((EntityHitResult) position).getEntity().getBukkitEntity();
          }

--- a/patches/server/0152-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0152-Fix-this-stupid-bullshit.patch
@@ -31,12 +31,12 @@ index e43096e69a00f9ea96badd7c966443cfcf3e7b95..ac2b7b5161eaaca3620268ae865d6f2a
              Bootstrap.isBootstrapped = true;
              if (BuiltInRegistries.REGISTRY.keySet().isEmpty()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index a736afdd6671ad36157d1d0c908b6ccb37f602b6..7968b883847877f7ddc11f7a25efbbb71605d2bf 100644
+index ebf561bce1b442f2b3a138d4ba0ed252e4ba3207..a8b21195ca304b3ff68c8bf7e336b4df64603c10 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -250,10 +250,12 @@ public class Main {
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -3);
+                     deadline.add(Calendar.DAY_OF_YEAR, -7);
                      if (buildDate.before(deadline.getTime())) {
 -                        System.err.println("*** Error, this build is outdated ***");
 +                        // Paper start - This is some stupid bullshit

--- a/patches/server/0218-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0218-InventoryCloseEvent-Reason-API.patch
@@ -186,10 +186,10 @@ index ecbcabc24529c7a7becf709fa6f24cfaa22f7f0e..bef819229c4d9c4742f907532f0d3f46
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 427c63945e207236fc2e5caa99e22b3f7b171854..200c9694336f5670edef10693a82cbd89bd9b477 100644
+index a1efb66de4cb509781de498bee5c44456ad93395..9d088e25eb24af5cbb5cf3038de589313b0afe1d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1233,7 +1233,7 @@ public class CraftEventFactory {
+@@ -1236,7 +1236,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -198,7 +198,7 @@ index 427c63945e207236fc2e5caa99e22b3f7b171854..200c9694336f5670edef10693a82cbd8
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1407,8 +1407,18 @@ public class CraftEventFactory {
+@@ -1410,8 +1410,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0228-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0228-Vanished-players-don-t-have-rights.patch
@@ -89,10 +89,10 @@ index f07e70ab26fffaec5055a7dd2571dc4d29c66d35..754e1667aadef89bbaccebc0f437197b
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 200c9694336f5670edef10693a82cbd89bd9b477..1b4e7c9e3452537a13001c23b00eb7ea89c8449b 100644
+index 9d088e25eb24af5cbb5cf3038de589313b0afe1d..ea385119db05699e355411e779f4464067f923f1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1270,6 +1270,14 @@ public class CraftEventFactory {
+@@ -1273,6 +1273,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0444-Add-PrepareResultEvent.patch
+++ b/patches/server/0444-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index 665b01ff3579c8fd87074edfc6da6b7ef07693b2..24c31e96be460bcb5062a1fcf7f86c1a
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 529116b00cf03ef8616803e59ebeeb655ad76387..e94c80d067c94e96888284020c414c28d7f6f775 100644
+index 1061f45f20ff085c88123e7ca9aa05f8927035e2..b8a3bdb98ce4be5813996d178da06910b13d38bd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1596,26 +1596,53 @@ public class CraftEventFactory {
+@@ -1599,26 +1599,53 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0537-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0537-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 1415ad60163f6584619cc7caa61f1848d6ebaa93..801c4c120e98584bcf218a4ef9bd66d7
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index dea024f5fb0fa769cf1901938e3af4293bf7fca7..ef2e8523c4c90546960e66ca441e723741e73bbb 100644
+index 791f1c454a1ead8eeb4c18483bf9e40b898b5f7a..48d499c60739835f603629e248a9a92f54b3cda4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1879,4 +1879,12 @@ public class CraftEventFactory {
+@@ -1882,4 +1882,12 @@ public class CraftEventFactory {
          EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
      }

--- a/patches/server/0553-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0553-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 85c5319837295bd2f85baebfe8d6660b267f1d5f..8f55d0753fa26924235c943595f0d1a0
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b0c045aa60a0b942995ae30e385628fd765f6c36..e534f8b57dda54be0ad4c8fe62efa9bdb7b270db 100644
+index a7c8736391692dfdf028c40d82754adf47fd26dc..a86b1f163bf1801ba8b5118b9994c1c57808bc1a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1897,5 +1897,11 @@ public class CraftEventFactory {
+@@ -1900,5 +1900,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0557-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0557-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index b5e35033e63da0e5f2c21fddf3b704d6730f0938..7a6cdae1b566f59508b180e720de4eff
                              flag1 = true;
                          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e534f8b57dda54be0ad4c8fe62efa9bdb7b270db..a91ef675f139171bca0158832d1c6266b431d293 100644
+index a86b1f163bf1801ba8b5118b9994c1c57808bc1a..15b4be18064137d21565434adae97883fb0a8d6a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1529,8 +1529,10 @@ public class CraftEventFactory {
+@@ -1532,8 +1532,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0685-Add-critical-damage-API.patch
+++ b/patches/server/0685-Add-critical-damage-API.patch
@@ -71,7 +71,7 @@ index 6486fa86e4bf3c90c09c0425d825bab568a68757..8257563afc3fe04c9e821da363b1f3f6
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 6c891278af90a0a7ad4cf28b85284cceb7e63df1..f6f76a659257ae86f868f3af1280565c108678ab 100644
+index 451fee716b07c8daadcffc9b87973a56641e8198..30360517235b2a568b92a43aa5efc0d6759c7e8e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -969,7 +969,7 @@ public class CraftEventFactory {
@@ -83,7 +83,7 @@ index 6c891278af90a0a7ad4cf28b85284cceb7e63df1..f6f76a659257ae86f868f3af1280565c
              }
              event.setCancelled(cancelled);
  
-@@ -998,7 +998,7 @@ public class CraftEventFactory {
+@@ -1001,7 +1001,7 @@ public class CraftEventFactory {
                  cause = DamageCause.SONIC_BOOM;
              }
  
@@ -92,7 +92,7 @@ index 6c891278af90a0a7ad4cf28b85284cceb7e63df1..f6f76a659257ae86f868f3af1280565c
          } else if (source.is(DamageTypes.OUT_OF_WORLD)) {
              EntityDamageEvent event = new EntityDamageByBlockEvent(null, entity.getBukkitEntity(), DamageCause.VOID, modifiers, modifierFunctions);
              event.setCancelled(cancelled);
-@@ -1068,7 +1068,7 @@ public class CraftEventFactory {
+@@ -1071,7 +1071,7 @@ public class CraftEventFactory {
              } else {
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager.getHandle(), source.getMsgId()));
              }
@@ -101,7 +101,7 @@ index 6c891278af90a0a7ad4cf28b85284cceb7e63df1..f6f76a659257ae86f868f3af1280565c
              event.setCancelled(cancelled);
              CraftEventFactory.callEvent(event);
              if (!event.isCancelled()) {
-@@ -1113,20 +1113,28 @@ public class CraftEventFactory {
+@@ -1116,20 +1116,28 @@ public class CraftEventFactory {
          }
  
          if (cause != null) {

--- a/patches/server/0875-Block-Ticking-API.patch
+++ b/patches/server/0875-Block-Ticking-API.patch
@@ -31,13 +31,14 @@ index 0d30b388d8d93a6dbbf8dfb30d26eb44c73e1e4e..962c950ca9c7e047a3aec215d4faa736
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-index 6361f096eeb5da035a01fc3a2d79f48def33b38d..74a6e68047560d2aca1479c2d25692021f2f6dde 100644
+index b052f197a4616e0e6151f81ec3287666b64da5ad..d70541cf10674aeb7581043d09269793f109e657 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-@@ -657,4 +657,10 @@ public class CraftBlockData implements BlockData {
- 
-         return this.state.isFaceSturdy(EmptyBlockGetter.INSTANCE, BlockPos.ZERO, CraftBlock.blockFaceToNotch(face), CraftBlockSupport.toNMS(support));
+@@ -662,4 +662,11 @@ public class CraftBlockData implements BlockData {
+     public Material getPlacementMaterial() {
+         return CraftMagicNumbers.getMaterial(this.state.getBlock().asItem());
      }
++
 +    // Paper start - Block tick API
 +    @Override
 +    public boolean isRandomlyTicked() {

--- a/patches/server/0967-Fix-chiseled-bookshelf-and-jukebox-setItem-with-air.patch
+++ b/patches/server/0967-Fix-chiseled-bookshelf-and-jukebox-setItem-with-air.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nassim Jahnke <nassim@njahnke.dev>
 Date: Sat, 18 Mar 2023 18:51:33 +0100
-Subject: [PATCH] Fix chiseled bookshelf setItem with air
+Subject: [PATCH] Fix chiseled bookshelf and jukebox setItem with air
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity.java
@@ -17,3 +17,20 @@ index 6986b2a5df34bfe078c902594f6409ad0ea847ef..ed12a23448dc9ada423ebd79a131eab2
              this.items.set(slot, stack);
              this.updateState(slot);
          }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/JukeboxBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/JukeboxBlockEntity.java
+index dfc41db5c94ef3591f46551a61018eb9db6e25b6..8f999cf55ab90a0334b45796ba5587df030cef70 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/JukeboxBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/JukeboxBlockEntity.java
+@@ -183,6 +183,12 @@ public class JukeboxBlockEntity extends BlockEntity implements Clearable, Contai
+ 
+     @Override
+     public void setItem(int slot, ItemStack stack) {
++        // Paper start
++        if (stack.isEmpty()) {
++            this.removeItem(slot, 0);
++            return;
++        }
++        // Paper end
+         if (stack.is(ItemTags.MUSIC_DISCS) && this.level != null) {
+             this.items.set(slot, stack);
+             this.setHasRecordBlockState((Entity) null, true);


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
150a2861 PR-827: Add BlockData#getPlacementMaterial 58c9c8ce SPIGOT-7301: Prevent creating non-openable inventories 3741079b PR-824: Expand upon PotionEffect API to better accommodate infinite durations

CraftBukkit Changes:
e5a7921f0 PR-1149: Add BlockData#getPlacementMaterial 58504fa61 SPIGOT-7302: Fix more issues with EntityDamageByEntity - Fix Projectile damage by dispenser - Fix cases where only exists a direct entity damager 48394703d Increase outdated build delay