### PR TITLE
[ci skip] Properly document what Entity/BlockExplodeEvent is fired for

### DIFF
--- a/patches/api/0055-Fix-upstream-javadocs.patch
+++ b/patches/api/0055-Fix-upstream-javadocs.patch
@@ -200,6 +200,21 @@ index a5ad3250cebfeb302c58e0bfd6db1295913c927e..bfac874840cf1f36afba16ae4d176c58
       * @param sz The new size of the slime.
       */
      public void setSize(int sz);
+diff --git a/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java b/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
+index 44f7f6939a27b9a0a796d91eac4b7c97ec90a643..641c71ab66bd2499b35cf3c1d533fd105d096e10 100644
+--- a/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
+@@ -7,7 +7,9 @@ import org.bukkit.event.HandlerList;
+ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+- * Called when a block explodes
++ * Called when a block explodes interacting with blocks. The
++ * event isn't called if the {@link org.bukkit.GameRule#MOB_GRIEFING}
++ * is disabled as no block interaction will occur.
+  */
+ public class BlockExplodeEvent extends BlockEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
 diff --git a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java b/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
 index e9de00e9e434d36117a672fa9fbfc7c52f284b67..9a06487e0f76cd7765e6f900b7458a3cf0aa44e7 100644
 --- a/src/main/java/org/bukkit/event/entity/CreatureSpawnEvent.java
@@ -214,6 +229,21 @@ index e9de00e9e434d36117a672fa9fbfc7c52f284b67..9a06487e0f76cd7765e6f900b7458a3c
           */
          EXPLOSION,
          /**
+diff --git a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
+index 10d0e18dfd423b108fe381e8142867eb10399359..099efafa14c10910e4ed04abb1823f0c1a96b6a6 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityExplodeEvent.java
+@@ -9,7 +9,9 @@ import org.bukkit.event.HandlerList;
+ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+- * Called when an entity explodes
++ * Called when an entity explodes interacting with blocks. The
++ * event isn't called if the {@link org.bukkit.GameRule#MOB_GRIEFING}
++ * is disabled as no block interaction will occur.
+  */
+ public class EntityExplodeEvent extends EntityEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
 diff --git a/src/main/java/org/bukkit/event/entity/EntityRegainHealthEvent.java b/src/main/java/org/bukkit/event/entity/EntityRegainHealthEvent.java
 index d51d2ec1d04d9ea8a25a70d0d856f2355ebfcb4a..7ecff9fcee19fc94be784474fea620e5dd434731 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityRegainHealthEvent.java

--- a/patches/api/0407-Add-exploded-block-state-to-BlockExplodeEvent.patch
+++ b/patches/api/0407-Add-exploded-block-state-to-BlockExplodeEvent.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Add exploded block state to BlockExplodeEvent
 
 
 diff --git a/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java b/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
-index 44f7f6939a27b9a0a796d91eac4b7c97ec90a643..2474628851c35fe8500d4d113aaafda6ce087313 100644
+index 641c71ab66bd2499b35cf3c1d533fd105d096e10..d8b5362d0cdc3440efe30d619985018509b669e7 100644
 --- a/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
 +++ b/src/main/java/org/bukkit/event/block/BlockExplodeEvent.java
-@@ -8,18 +8,29 @@ import org.jetbrains.annotations.NotNull;
- 
- /**
-  * Called when a block explodes
+@@ -10,18 +10,29 @@ import org.jetbrains.annotations.NotNull;
+  * Called when a block explodes interacting with blocks. The
+  * event isn't called if the {@link org.bukkit.GameRule#MOB_GRIEFING}
+  * is disabled as no block interaction will occur.
 + * <p>
 + * The {@link Block} returned by this event is not necessarily
 + * the block that caused the explosion, just the block at the location where
@@ -38,7 +38,7 @@ index 44f7f6939a27b9a0a796d91eac4b7c97ec90a643..2474628851c35fe8500d4d113aaafda6
      }
  
      @Override
-@@ -32,6 +43,22 @@ public class BlockExplodeEvent extends BlockEvent implements Cancellable {
+@@ -34,6 +45,22 @@ public class BlockExplodeEvent extends BlockEvent implements Cancellable {
          this.cancel = cancel;
      }
  


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/7460. That issue is asking for the event to be fired when the `mobGriefing` gamerule is set to false, but as far as I can tell, this has been the behavior of the event since it was added in 2015, an event to interact with the blocks broken in an explosion. There are other events dealing with entity explosions, such as `ExplosionPrimeEvent`