### PR TITLE
New event verbose command

### DIFF
--- a/patches/server/0969-New-event-verbose-logging-command.patch
+++ b/patches/server/0969-New-event-verbose-logging-command.patch
@@ -1,0 +1,178 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: RyGuy <TheRealRyGuy@users.noreply.github.com>
+Date: Tue, 21 Mar 2023 16:21:07 -0400
+Subject: [PATCH] New event verbose logging command
+
+
+diff --git a/src/main/java/io/papermc/paper/command/PaperCommand.java b/src/main/java/io/papermc/paper/command/PaperCommand.java
+index 7ba60b4b4f29a42c58d98aafc5ea0fa3214f554c..652c7df2c783de56b947535ff25781b0af47fbf0 100644
+--- a/src/main/java/io/papermc/paper/command/PaperCommand.java
++++ b/src/main/java/io/papermc/paper/command/PaperCommand.java
+@@ -45,6 +45,7 @@ public final class PaperCommand extends Command {
+         commands.put(Set.of("dumpitem"), new DumpItemCommand());
+         commands.put(Set.of("mobcaps", "playermobcaps"), new MobcapsCommand());
+         commands.put(Set.of("dumplisteners"), new DumpListenersCommand());
++        commands.put(Set.of("dumpevents"), new EventVerboseCommand());
+ 
+         return commands.entrySet().stream()
+             .flatMap(entry -> entry.getKey().stream().map(s -> Map.entry(s, entry.getValue())))
+diff --git a/src/main/java/io/papermc/paper/command/subcommands/EventVerboseCommand.java b/src/main/java/io/papermc/paper/command/subcommands/EventVerboseCommand.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9ba88d7a3d69a8f3c91c6838abe928222376a12d
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/command/subcommands/EventVerboseCommand.java
+@@ -0,0 +1,134 @@
++package io.papermc.paper.command.subcommands;
++
++import com.google.common.collect.Lists;
++import com.google.gson.JsonArray;
++import com.google.gson.JsonObject;
++import com.google.gson.internal.Streams;
++import com.google.gson.stream.JsonWriter;
++import io.papermc.paper.command.PaperSubcommand;
++import net.minecraft.server.MinecraftServer;
++import org.bukkit.command.CommandSender;
++import org.bukkit.event.Event;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.checker.nullness.qual.Nullable;
++import org.checkerframework.framework.qual.DefaultQualifier;
++
++import java.io.IOException;
++import java.io.PrintStream;
++import java.io.StringWriter;
++import java.lang.reflect.Field;
++import java.nio.charset.StandardCharsets;
++import java.nio.file.Files;
++import java.nio.file.Path;
++import java.time.LocalDateTime;
++import java.time.format.DateTimeFormatter;
++import java.util.LinkedList;
++
++import static net.kyori.adventure.text.Component.text;
++import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
++import static net.kyori.adventure.text.format.NamedTextColor.RED;
++
++@DefaultQualifier(NonNull.class)
++public class EventVerboseCommand implements PaperSubcommand {
++
++    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss");
++    @Nullable private Path currentFile;
++    //have to be static to static call from paperpluginmanagerimpl
++    private static boolean isRunning = false;
++    private static final LinkedList<Wrapper> toDump = Lists.newLinkedList();
++
++
++    @Override
++    public boolean execute(CommandSender sender, String subCommand, String[] args) {
++        if(!isRunning) {
++            isRunning = true;
++            Path parent = Path.of("debug");
++            Path path = parent.resolve("event-verbose-" + FORMATTER.format(LocalDateTime.now()) + ".txt");
++            try {
++                Files.createDirectories(parent);
++                currentFile = Files.createFile(path);
++                sender.sendMessage(text("Writing event verbose to " + path, GREEN));
++                sender.sendMessage(text("To save the file, run this command again!", GREEN));
++            } catch (IOException e) {
++                sender.sendMessage(text("Failed to create event verbose files! See the console for more info.", RED));
++                MinecraftServer.LOGGER.warn("Error occurred while creating event verbose files", e);
++                isRunning = false;
++            }
++        }else {
++            isRunning = false;
++            sender.sendMessage(text("Logging events..", GREEN));
++            try {
++                logWrappers();
++                sender.sendMessage(text("Logged all event verbose to " + currentFile, GREEN));
++                currentFile = null;
++                toDump.clear();
++            }catch(IOException e) {
++                sender.sendMessage(text("Failed to create event verbose files! See the console for more info.", RED));
++                MinecraftServer.LOGGER.warn("Error occurred while dumping event verbose", e);
++            }
++        }
++        return true;
++    }
++
++    /**
++     * Dumps all currently stored {@link Wrapper}'s to our {@link #currentFile}
++     * @throws IOException If something broke writing it
++     */
++    private void logWrappers() throws IOException {
++        JsonArray array = new JsonArray();
++        toDump.forEach(w -> array.add(w.serialize()));
++
++        StringWriter stringWriter = new StringWriter();
++        JsonWriter jsonWriter = new JsonWriter(stringWriter);
++        jsonWriter.setIndent(" ");
++        jsonWriter.setLenient(false);
++        Streams.write(array, jsonWriter);
++
++        try (PrintStream out = new PrintStream(Files.newOutputStream(currentFile), false, StandardCharsets.UTF_8)) {
++            out.print(stringWriter);
++        }
++
++    }
++
++    /**
++     * Called in {@link io.papermc.paper.plugin.manager.PaperPluginManagerImpl#callEvent(Event)} to save in {@link #toDump}
++     */
++    public static void tryLogEvent(Event ev) {
++        if(!isRunning)
++            return;
++        toDump.add(new Wrapper(ev));
++    }
++
++    /**
++     * Wrapper class for QoL GSON Serialization
++     */
++    private static final class Wrapper {
++        private final String timestamp;
++        private final Event event;
++
++        public Wrapper(Event event) {
++            this.timestamp = FORMATTER.format(LocalDateTime.now());
++            this.event = event;
++        }
++
++        private JsonObject serialize() {
++            JsonObject parent = new JsonObject();
++            parent.addProperty("timestamp", timestamp);
++            JsonObject obj = new JsonObject();
++            obj.addProperty("event", event.getEventName());
++            try {
++                for (Field f : event.getClass().getDeclaredFields()) {
++                    if(f.getName().equalsIgnoreCase("handlers"))
++                        continue;
++                    f.setAccessible(true);
++                    Object field = f.get(event);
++                    obj.addProperty(f.getName(), field == null ? "null" : field.toString());
++                }
++            } catch(SecurityException | IllegalAccessException ex) {
++                MinecraftServer.LOGGER.warn("Failure to serialize event verbose", ex);
++            }
++            parent.add("info", obj);
++            return parent;
++        }
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/plugin/manager/PaperPluginManagerImpl.java b/src/main/java/io/papermc/paper/plugin/manager/PaperPluginManagerImpl.java
+index dab211c458311869c61779305580a1c7da830f71..88a2a10a8cd20358fb0035357cc3880ad8d20df4 100644
+--- a/src/main/java/io/papermc/paper/plugin/manager/PaperPluginManagerImpl.java
++++ b/src/main/java/io/papermc/paper/plugin/manager/PaperPluginManagerImpl.java
+@@ -1,6 +1,7 @@
+ package io.papermc.paper.plugin.manager;
+ 
+ import com.google.common.graph.MutableGraph;
++import io.papermc.paper.command.subcommands.EventVerboseCommand;
+ import io.papermc.paper.plugin.PermissionManager;
+ import io.papermc.paper.plugin.configuration.PluginMeta;
+ import io.papermc.paper.plugin.provider.entrypoint.DependencyContext;
+@@ -124,6 +125,7 @@ public class PaperPluginManagerImpl implements PluginManager, DependencyContext
+     @Override
+     public void callEvent(@NotNull Event event) throws IllegalStateException {
+         this.paperEventManager.callEvent(event);
++        EventVerboseCommand.tryLogEvent(event);
+     }
+ 
+     @Override


### PR DESCRIPTION
Saw a message from Machine Maker on Discord bringing this up, figured it'd be a fun random thing to do

Essentially just adds a `/paper dumpevents` command. Running this once will begin logging events, and running it again will save the events in order with timestamp and event class fields in JSON to a file in the `debug` directory. Attached below is an example output 

Two issues that aren't too big of a deal with this
- Does not handle inheritance of event classes well, `Field#getDeclaredFields` only retrieves minimal fields, could use a superclass check working all the way up to `org.bukkit.Event`
- Could further serialize non primitive event fields just for a bit more info, stringified versions of them are typically fine though

[event-verbose-2023-03-21_18.03.40.txt](https://github.com/PaperMC/Paper/files/11034346/event-verbose-2023-03-21_18.03.40.txt)
