### PR TITLE
Don't tick empty worlds

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1390,7 +1390,7 @@ index 0000000000000000000000000000000000000000..351fbbc577556ebbd62222615801a96b
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3e544ff77f6e8226cb7a4d3370264806fdcf948c
+index 0000000000000000000000000000000000000000..15bc01b59bb67f1f5d8590c08d13537fa81ca8e1
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 @@ -0,0 +1,551 @@
@@ -1843,7 +1843,7 @@ index 0000000000000000000000000000000000000000..3e544ff77f6e8226cb7a4d3370264806
 +
 +    public class UnsupportedSettings extends ConfigurationPart {
 +        public boolean fixInvulnerableEndCrystalExploit = true;
-+        public boolean disableTickingWhenEmpty = false;
++        public boolean disableWorldTickingWhenEmpty = false;
 +    }
 +
 +    public Hopper hopper;

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -15,7 +15,7 @@ public net.minecraft.server.dedicated.DedicatedServerProperties reload(Lnet/mine
 public net.minecraft.world.level.NaturalSpawner SPAWNING_CATEGORIES
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 8d2aa99b4bd0d1c46c66274907a1f11d605a75da..e865c5ce514770f4fde9146b6e7138e88932c33b 100644
+index 9098a40f944a3c6c0e907013c212eb3f1895e010..f838b058e6cad9061929509047bbe25c65baecf6 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -11,6 +11,7 @@ dependencies {
@@ -1390,10 +1390,10 @@ index 0000000000000000000000000000000000000000..351fbbc577556ebbd62222615801a96b
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1a914ab53c24476473edc433d64daca6ec1c51d9
+index 0000000000000000000000000000000000000000..3e544ff77f6e8226cb7a4d3370264806fdcf948c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,550 @@
+@@ -0,0 +1,551 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1843,6 +1843,7 @@ index 0000000000000000000000000000000000000000..1a914ab53c24476473edc433d64daca6
 +
 +    public class UnsupportedSettings extends ConfigurationPart {
 +        public boolean fixInvulnerableEndCrystalExploit = true;
++        public boolean disableTickingWhenEmpty = false;
 +    }
 +
 +    public Hopper hopper;
@@ -4925,7 +4926,7 @@ index 397c978c71f36c8abe1c52e545699fc7928a6917..fc45c2c4ecdf3906df6bceaf3e019c46
              }
              // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index ecc61c7b1b4eb887795ffd39578b70b4e77f5213..674c996af91de91ee6302cc67334b836ea4fa4de 100644
+index 50b79de15571ef30f202bae5952a9f825902e11a..aac9513ff4d3d494860bd06607cf8af5e466fd5b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -236,7 +236,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/1052-disable-forced-empty-world-ticks.patch
+++ b/patches/server/1052-disable-forced-empty-world-ticks.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Tue, 21 Mar 2023 23:51:46 +0000
+Subject: [PATCH] disable forced empty world ticks
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 4bca3d20d1a01270a10c1e643a312fe462305b5d..d488441c66e5ec78731bafb1255c59215dc145e5 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -876,7 +876,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+ 
+         this.handlingTick = false;
+         gameprofilerfiller.pop();
+-        boolean flag1 = true || !this.players.isEmpty() || !this.getForcedChunks().isEmpty(); // CraftBukkit - this prevents entity cleanup, other issues on servers with no players
++        boolean flag1 = !paperConfig().unsupportedSettings.disableTickingWhenEmpty || !this.players.isEmpty() || !this.getForcedChunks().isEmpty(); // CraftBukkit - this prevents entity cleanup, other issues on servers with no players // Paper - restore this
+ 
+         if (flag1) {
+             this.resetEmptyTime();

--- a/patches/server/1052-disable-forced-empty-world-ticks.patch
+++ b/patches/server/1052-disable-forced-empty-world-ticks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] disable forced empty world ticks
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4bca3d20d1a01270a10c1e643a312fe462305b5d..d488441c66e5ec78731bafb1255c59215dc145e5 100644
+index 4bca3d20d1a01270a10c1e643a312fe462305b5d..bf5e47e8c3706590fdc0731bd9a5858b56d06136 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -876,7 +876,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -13,7 +13,7 @@ index 4bca3d20d1a01270a10c1e643a312fe462305b5d..d488441c66e5ec78731bafb1255c5921
          this.handlingTick = false;
          gameprofilerfiller.pop();
 -        boolean flag1 = true || !this.players.isEmpty() || !this.getForcedChunks().isEmpty(); // CraftBukkit - this prevents entity cleanup, other issues on servers with no players
-+        boolean flag1 = !paperConfig().unsupportedSettings.disableTickingWhenEmpty || !this.players.isEmpty() || !this.getForcedChunks().isEmpty(); // CraftBukkit - this prevents entity cleanup, other issues on servers with no players // Paper - restore this
++        boolean flag1 = !paperConfig().unsupportedSettings.disableWorldTickingWhenEmpty || !this.players.isEmpty() || !this.getForcedChunks().isEmpty(); // CraftBukkit - this prevents entity cleanup, other issues on servers with no players // Paper - restore this
  
          if (flag1) {
              this.resetEmptyTime();


### PR DESCRIPTION
restores vanilla behavior, will improve commit message if we decide to merge this

This build is intended to debug if anything goes sideways when disabling this check which was added many moons ago

Cross refs: #6456 and various other issues
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9025.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1293198167.zip)