### PR TITLE
Fix api checking banned ips

### DIFF
--- a/patches/server/0970-Fix-api-checking-banned-ips.patch
+++ b/patches/server/0970-Fix-api-checking-banned-ips.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 22 Mar 2023 13:12:01 -0700
+Subject: [PATCH] Fix api checking banned ips
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftIpBanList.java b/src/main/java/org/bukkit/craftbukkit/CraftIpBanList.java
+index 61cb647b2aa590303402e6652bd37b5bca0e0b1d..30f2ddff4108e92eaac50317bdd9ef4eb25ec085 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftIpBanList.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftIpBanList.java
+@@ -64,7 +64,7 @@ public class CraftIpBanList implements org.bukkit.BanList {
+     public boolean isBanned(String target) {
+         Validate.notNull(target, "Target cannot be null");
+ 
+-        return this.list.isBanned(InetSocketAddress.createUnresolved(target, 0));
++        return this.list.isBanned(target); // Paper - fix checking banned ips
+     }
+ 
+     @Override


### PR DESCRIPTION
Bug [since 1.7.8](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/8f771c737850130534b0fade70494f7ce3cbc8fd#src/main/java/org/bukkit/craftbukkit/CraftIpBanList.java).