### PR TITLE
Added a config option for ticking markers

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1448,10 +1448,10 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b6381996810130
+index 0000000000000000000000000000000000000000..6cd292e67783f64085ff8d857a041229285f394e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,475 @@
+@@ -0,0 +1,501 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1500,13 +1500,15 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +import org.spongepowered.configurate.objectmapping.meta.Required;
 +import org.spongepowered.configurate.objectmapping.meta.Setting;
 +
-+@SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal", "NotNullFieldNotInitialized", "InnerClassMayBeStatic"})
++@SuppressWarnings({ "FieldCanBeLocal", "FieldMayBeFinal", "NotNullFieldNotInitialized", "InnerClassMayBeStatic" })
 +public class WorldConfiguration extends ConfigurationPart {
 +    private static final Logger LOGGER = LogUtils.getClassLogger();
-+    static final int CURRENT_VERSION = 30; // (when you change the version, change the comment, so it conflicts on rebases): rename filter bad nbt from spawn eggs
++    static final int CURRENT_VERSION = 30; // (when you change the version, change the comment, so it conflicts on
++                                           // rebases): rename filter bad nbt from spawn eggs
 +
 +    private transient final SpigotWorldConfig spigotConfig;
 +    private transient final ResourceLocation worldKey;
++
 +    WorldConfiguration(SpigotWorldConfig spigotConfig, ResourceLocation worldKey) {
 +        this.spigotConfig = spigotConfig;
 +        this.worldKey = worldKey;
@@ -1527,6 +1529,7 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +
 +        public class Obfuscation extends ConfigurationPart {
 +            public Items items = new Items();
++
 +            public class Items extends ConfigurationPart {
 +                public boolean hideItemmeta = false;
 +                public boolean hideDurability = false;
@@ -1543,10 +1546,14 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +            public int updateRadius = 2;
 +            public boolean lavaObscures = false;
 +            public boolean usePermission = false;
-+            public List<String> hiddenBlocks = List.of("copper_ore", "deepslate_copper_ore", "gold_ore", "deepslate_gold_ore", "iron_ore", "deepslate_iron_ore",
-+                "coal_ore", "deepslate_coal_ore", "lapis_ore", "deepslate_lapis_ore", "mossy_cobblestone", "obsidian", "chest", "diamond_ore", "deepslate_diamond_ore",
-+                "redstone_ore", "deepslate_redstone_ore", "clay", "emerald_ore", "deepslate_emerald_ore", "ender_chest"); // TODO update type to List<Block>
-+            public List<String> replacementBlocks = List.of("stone", "oak_planks", "deepslate"); // TODO update type to List<Block>
++            public List<String> hiddenBlocks = List.of("copper_ore", "deepslate_copper_ore", "gold_ore",
++                    "deepslate_gold_ore", "iron_ore", "deepslate_iron_ore",
++                    "coal_ore", "deepslate_coal_ore", "lapis_ore", "deepslate_lapis_ore", "mossy_cobblestone",
++                    "obsidian", "chest", "diamond_ore", "deepslate_diamond_ore",
++                    "redstone_ore", "deepslate_redstone_ore", "clay", "emerald_ore", "deepslate_emerald_ore",
++                    "ender_chest"); // TODO update type to List<Block>
++            public List<String> replacementBlocks = List.of("stone", "oak_planks", "deepslate"); // TODO update type to
++                                                                                                 // List<Block>
 +        }
 +    }
 +
@@ -1577,17 +1584,25 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +        public Spawning spawning;
 +
 +        public class Spawning extends ConfigurationPart {
-+            public ArrowDespawnRate nonPlayerArrowDespawnRate = ArrowDespawnRate.def(WorldConfiguration.this.spigotConfig);
-+            public ArrowDespawnRate creativeArrowDespawnRate = ArrowDespawnRate.def(WorldConfiguration.this.spigotConfig);
++            public ArrowDespawnRate nonPlayerArrowDespawnRate = ArrowDespawnRate
++                    .def(WorldConfiguration.this.spigotConfig);
++            public ArrowDespawnRate creativeArrowDespawnRate = ArrowDespawnRate
++                    .def(WorldConfiguration.this.spigotConfig);
 +            public boolean filterBadTileEntityNbtFromFallingBlocks = true;
-+            public List<NbtPathArgument.NbtPath> filteredEntityTagNbtPaths = NbtPathSerializer.fromString(List.of("Pos", "Motion", "SleepingX", "SleepingY", "SleepingZ"));
++            public List<NbtPathArgument.NbtPath> filteredEntityTagNbtPaths = NbtPathSerializer
++                    .fromString(List.of("Pos", "Motion", "SleepingX", "SleepingY", "SleepingZ"));
 +            public boolean disableMobSpawnerSpawnEggTransformation = false;
 +            public boolean perPlayerMobSpawns = true;
 +            public boolean scanForLegacyEnderDragon = true;
 +            @MergeMap
-+            public Reference2IntMap<MobCategory> spawnLimits = Util.make(new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length), map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES).forEach(mobCategory -> map.put(mobCategory, -1)));
++            public Reference2IntMap<MobCategory> spawnLimits = Util.make(
++                    new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length),
++                    map -> Arrays.stream(NaturalSpawner.SPAWNING_CATEGORIES)
++                            .forEach(mobCategory -> map.put(mobCategory, -1)));
 +            @MergeMap
-+            public Map<MobCategory, DespawnRange> despawnRanges = Arrays.stream(MobCategory.values()).collect(Collectors.toMap(Function.identity(), category -> new DespawnRange(category.getNoDespawnDistance(), category.getDespawnDistance())));
++            public Map<MobCategory, DespawnRange> despawnRanges = Arrays.stream(MobCategory.values()).collect(
++                    Collectors.toMap(Function.identity(), category -> new DespawnRange(category.getNoDespawnDistance(),
++                            category.getDespawnDistance())));
 +
 +            @ConfigSerializable
 +            public record DespawnRange(@Required int soft, @Required int hard) {
@@ -1644,6 +1659,7 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +                    SAFE_REGEN, DELETE, NOTHING, WARN;
 +                }
 +            }
++
 +            public AltItemDespawnRate altItemDespawnRate;
 +
 +            public class AltItemDespawnRate extends ConfigurationPart {
@@ -1666,13 +1682,18 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +            public DoorBreakingDifficulty doorBreakingDifficulty;
 +
 +            public class DoorBreakingDifficulty extends ConfigurationPart { // TODO convert to map at some point
-+                public List<Difficulty> zombie = Arrays.stream(Difficulty.values()).filter(Zombie.DOOR_BREAKING_PREDICATE).toList();
-+                public List<Difficulty> husk = Arrays.stream(Difficulty.values()).filter(Zombie.DOOR_BREAKING_PREDICATE).toList();
++                public List<Difficulty> zombie = Arrays.stream(Difficulty.values())
++                        .filter(Zombie.DOOR_BREAKING_PREDICATE).toList();
++                public List<Difficulty> husk = Arrays.stream(Difficulty.values()).filter(Zombie.DOOR_BREAKING_PREDICATE)
++                        .toList();
 +                @Setting("zombie_villager")
-+                public List<Difficulty> zombieVillager = Arrays.stream(Difficulty.values()).filter(Zombie.DOOR_BREAKING_PREDICATE).toList();
++                public List<Difficulty> zombieVillager = Arrays.stream(Difficulty.values())
++                        .filter(Zombie.DOOR_BREAKING_PREDICATE).toList();
 +                @Setting("zombified_piglin")
-+                public List<Difficulty> zombified_piglin = Arrays.stream(Difficulty.values()).filter(Zombie.DOOR_BREAKING_PREDICATE).toList();
-+                public List<Difficulty> vindicator = Arrays.stream(Difficulty.values()).filter(Vindicator.DOOR_BREAKING_PREDICATE).toList();
++                public List<Difficulty> zombified_piglin = Arrays.stream(Difficulty.values())
++                        .filter(Zombie.DOOR_BREAKING_PREDICATE).toList();
++                public List<Difficulty> vindicator = Arrays.stream(Difficulty.values())
++                        .filter(Vindicator.DOOR_BREAKING_PREDICATE).toList();
 +
 +                // TODO remove when this becomes a proper map
 +                public List<Difficulty> get(EntityType<?> type) {
@@ -1787,11 +1808,12 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +        }
 +
 +        public TreasureMaps treasureMaps;
++
 +        public class TreasureMaps extends ConfigurationPart {
 +            public boolean enabled = true;
-+            @NestedSetting({"find-already-discovered", "villager-trade"})
++            @NestedSetting({ "find-already-discovered", "villager-trade" })
 +            public boolean findAlreadyDiscoveredVillager = false;
-+            @NestedSetting({"find-already-discovered", "loot-tables"})
++            @NestedSetting({ "find-already-discovered", "loot-tables" })
 +            public BooleanOrDefault findAlreadyDiscoveredLootTable = BooleanOrDefault.USE_DEFAULT;
 +        }
 +
@@ -1865,15 +1887,16 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +        public int fixedChunkInhabitedTime = -1;
 +        public boolean preventMovingIntoUnloadedChunks = false;
 +        public Duration delayChunkUnloadsBy = Duration.of("10s");
-+        public Reference2IntMap<EntityType<?>> entityPerChunkSaveLimit = Util.make(new Reference2IntOpenHashMap<>(BuiltInRegistries.ENTITY_TYPE.size()), map -> {
-+            map.defaultReturnValue(-1);
-+            map.put(EntityType.EXPERIENCE_ORB, -1);
-+            map.put(EntityType.SNOWBALL, -1);
-+            map.put(EntityType.ENDER_PEARL, -1);
-+            map.put(EntityType.ARROW, -1);
-+            map.put(EntityType.FIREBALL, -1);
-+            map.put(EntityType.SMALL_FIREBALL, -1);
-+        });
++        public Reference2IntMap<EntityType<?>> entityPerChunkSaveLimit = Util
++                .make(new Reference2IntOpenHashMap<>(BuiltInRegistries.ENTITY_TYPE.size()), map -> {
++                    map.defaultReturnValue(-1);
++                    map.put(EntityType.EXPERIENCE_ORB, -1);
++                    map.put(EntityType.SNOWBALL, -1);
++                    map.put(EntityType.ENDER_PEARL, -1);
++                    map.put(EntityType.ARROW, -1);
++                    map.put(EntityType.FIREBALL, -1);
++                    map.put(EntityType.SMALL_FIREBALL, -1);
++                });
 +    }
 +
 +    public FishingTimeRange fishingTimeRange;
@@ -1889,8 +1912,10 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +        public int grassSpread = 1;
 +        public int containerUpdate = 1;
 +        public int mobSpawner = 1;
-+        public Table<EntityType<?>, String, Integer> sensor = Util.make(HashBasedTable.create(), table -> table.put(EntityType.VILLAGER, "secondarypoisensor", 40));
-+        public Table<EntityType<?>, String, Integer> behavior = Util.make(HashBasedTable.create(), table -> table.put(EntityType.VILLAGER, "validatenearbypoi", -1));
++        public Table<EntityType<?>, String, Integer> sensor = Util.make(HashBasedTable.create(),
++                table -> table.put(EntityType.VILLAGER, "secondarypoisensor", 40));
++        public Table<EntityType<?>, String, Integer> behavior = Util.make(HashBasedTable.create(),
++                table -> table.put(EntityType.VILLAGER, "validatenearbypoi", -1));
 +    }
 +
 +    @Setting(FeatureSeedsGeneration.FEATURE_SEEDS_KEY)
@@ -1920,6 +1945,7 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +        public boolean disableSprintInterruptionOnAttack = false;
 +        public int shieldBlockingDelay = 5;
 +        public boolean disableRelativeProjectileVelocity = false;
++        public boolean tickMarkerEntities = false;
 +
 +        public enum RedstoneImplementation {
 +            VANILLA, EIGENCRAFT, ALTERNATE_CURRENT
@@ -4575,7 +4601,7 @@ index ca2d2f44d722d2bf14f50670ac6192830b72c7f0..2cd8fc55056596731b34731a5fdf975f
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index ad6d25b26454c3ec8c11f54e921df8914c3c62d9..7fc066ee281662192aad826840573e4181f5ceff 100644
+index f19755a6096b72d6ca302a4ea2d386fadfe2b122..fe726771b76cabcb58bf624969490d9595965082 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -141,6 +141,19 @@ public class Main {

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1448,10 +1448,10 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6cd292e67783f64085ff8d857a041229285f394e
+index 0000000000000000000000000000000000000000..1a32861d0184076d582da058686b6d7ba8bc33b3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,501 @@
+@@ -0,0 +1,505 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1581,6 +1581,11 @@ index 0000000000000000000000000000000000000000..6cd292e67783f64085ff8d857a041229
 +            public boolean tick = true;
 +        }
 +
++        public Markers markers;
++
++        public class Markers extends ConfigurationPart {
++            public boolean tick = false;
++        }
 +        public Spawning spawning;
 +
 +        public class Spawning extends ConfigurationPart {
@@ -1945,7 +1950,6 @@ index 0000000000000000000000000000000000000000..6cd292e67783f64085ff8d857a041229
 +        public boolean disableSprintInterruptionOnAttack = false;
 +        public int shieldBlockingDelay = 5;
 +        public boolean disableRelativeProjectileVelocity = false;
-+        public boolean tickMarkerEntities = false;
 +
 +        public enum RedstoneImplementation {
 +            VANILLA, EIGENCRAFT, ALTERNATE_CURRENT

--- a/patches/server/0839-Don-t-tick-markers.patch
+++ b/patches/server/0839-Don-t-tick-markers.patch
@@ -3,13 +3,14 @@ From: Noah van der Aa <ndvdaa@gmail.com>
 Date: Fri, 7 Jan 2022 11:58:26 +0100
 Subject: [PATCH] Don't tick markers
 
-Fixes https://github.com/PaperMC/Paper/issues/7276 by not adding markers to the entity
-tick list at all and ignoring them in Spigot's activation range checks. The entity tick
+Fixes https://github.com/PaperMC/Paper/issues/7276 and https://github.com/PaperMC/Paper/issues/8118
+by using a config option that, when set to false, does not add markers to the entity
+tick list at all and ignores them in Spigot's activation range checks. The entity tick
 list is only used in the tick and tickPassenger methods, so we can safely not add the
-markers to it.
+markers to it. When the config option is set to true, markers are ticked as normal.
 
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
-index ff99336e0b8131ae161cfa5c4fc83c6905e3dbc8..4ec1e8ded06c60d81446c67bba2aa8a04111fa9b 100644
+index ff99336e0b8131ae161cfa5c4fc83c6905e3dbc8..899913840dd9b6bd67c55da7bb03bf896e9b7903 100644
 --- a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 +++ b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 @@ -109,7 +109,7 @@ public final class EntityCommand implements PaperSubcommand {
@@ -17,24 +18,24 @@ index ff99336e0b8131ae161cfa5c4fc83c6905e3dbc8..4ec1e8ded06c60d81446c67bba2aa8a0
                  info.left++;
                  info.right.put(chunk, info.right.getOrDefault(chunk, 0) + 1);
 -                if (!chunkProviderServer.isPositionTicking(e)) {
-+                if (!chunkProviderServer.isPositionTicking(e) || e instanceof net.minecraft.world.entity.Marker) { // Markers aren't ticked.
++                if (!chunkProviderServer.isPositionTicking(e) || (e instanceof net.minecraft.world.entity.Marker && !world.paperConfig().misc.tickMarkerEntities)) { // Markers aren't ticked by default.
                      nonEntityTicking.merge(key, 1, Integer::sum);
                  }
              });
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 66b1ef69fe48340b5ccebd845b39f898515ff117..7ae780c4a38eb088f876e5bd03a0dba5836787fb 100644
+index 66b1ef69fe48340b5ccebd845b39f898515ff117..51298751528a807bfac2ce8c362bfbb644cd68a3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2497,6 +2497,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          }
  
          public void onTickingStart(Entity entity) {
-+            if (entity instanceof net.minecraft.world.entity.Marker) return; // Paper - Don't tick markers
++            if (entity instanceof net.minecraft.world.entity.Marker && !paperConfig().misc.tickMarkerEntities) return; // Paper - Don't tick markers by default
              ServerLevel.this.entityTickList.add(entity);
          }
  
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index f158fc8a151272428a33dc5f6e1742876edc80d5..e881584d38dc354204479863f004e974a0ac6c07 100644
+index f158fc8a151272428a33dc5f6e1742876edc80d5..2613abbab50e118460f2d994e0798ce60e6355c8 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -212,7 +212,7 @@ public class ActivationRange
@@ -42,7 +43,7 @@ index f158fc8a151272428a33dc5f6e1742876edc80d5..e881584d38dc354204479863f004e974
  
              // Paper start
 -            java.util.List<Entity> entities = world.getEntities((Entity)null, maxBB, null);
-+            java.util.List<Entity> entities = world.getEntities((Entity)null, maxBB, (e) -> !(e instanceof net.minecraft.world.entity.Marker)); // Don't tick markers
++            java.util.List<Entity> entities = world.getEntities((Entity)null, maxBB, (e) -> !(e instanceof net.minecraft.world.entity.Marker) || world.paperConfig().misc.tickMarkerEntities); // Don't tick markers by default
              for (int i = 0; i < entities.size(); i++) {
                  Entity entity = entities.get(i);
                  ActivationRange.activateEntity(entity);

--- a/patches/server/0839-Don-t-tick-markers.patch
+++ b/patches/server/0839-Don-t-tick-markers.patch
@@ -10,7 +10,7 @@ list is only used in the tick and tickPassenger methods, so we can safely not ad
 markers to it. When the config option is set to true, markers are ticked as normal.
 
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
-index ff99336e0b8131ae161cfa5c4fc83c6905e3dbc8..899913840dd9b6bd67c55da7bb03bf896e9b7903 100644
+index ff99336e0b8131ae161cfa5c4fc83c6905e3dbc8..788b081fdab208769bb8ccc24dbe943a48504f32 100644
 --- a/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 +++ b/src/main/java/io/papermc/paper/command/subcommands/EntityCommand.java
 @@ -109,7 +109,7 @@ public final class EntityCommand implements PaperSubcommand {
@@ -18,24 +18,24 @@ index ff99336e0b8131ae161cfa5c4fc83c6905e3dbc8..899913840dd9b6bd67c55da7bb03bf89
                  info.left++;
                  info.right.put(chunk, info.right.getOrDefault(chunk, 0) + 1);
 -                if (!chunkProviderServer.isPositionTicking(e)) {
-+                if (!chunkProviderServer.isPositionTicking(e) || (e instanceof net.minecraft.world.entity.Marker && !world.paperConfig().misc.tickMarkerEntities)) { // Markers aren't ticked by default.
++                if (!chunkProviderServer.isPositionTicking(e) || (e instanceof net.minecraft.world.entity.Marker && !world.paperConfig().entities.markers.tick)) { // Markers aren't ticked by default.
                      nonEntityTicking.merge(key, 1, Integer::sum);
                  }
              });
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 66b1ef69fe48340b5ccebd845b39f898515ff117..51298751528a807bfac2ce8c362bfbb644cd68a3 100644
+index 66b1ef69fe48340b5ccebd845b39f898515ff117..5051aea4f71c992d1884e4462435775af8beee4f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2497,6 +2497,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          }
  
          public void onTickingStart(Entity entity) {
-+            if (entity instanceof net.minecraft.world.entity.Marker && !paperConfig().misc.tickMarkerEntities) return; // Paper - Don't tick markers by default
++            if (entity instanceof net.minecraft.world.entity.Marker && !paperConfig().entities.markers.tick) return; // Paper - Don't tick markers by default
              ServerLevel.this.entityTickList.add(entity);
          }
  
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index f158fc8a151272428a33dc5f6e1742876edc80d5..2613abbab50e118460f2d994e0798ce60e6355c8 100644
+index f158fc8a151272428a33dc5f6e1742876edc80d5..f8b04e88510e79defe96217c60bcc68f42db03d4 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -212,7 +212,7 @@ public class ActivationRange
@@ -43,7 +43,7 @@ index f158fc8a151272428a33dc5f6e1742876edc80d5..2613abbab50e118460f2d994e0798ce6
  
              // Paper start
 -            java.util.List<Entity> entities = world.getEntities((Entity)null, maxBB, null);
-+            java.util.List<Entity> entities = world.getEntities((Entity)null, maxBB, (e) -> !(e instanceof net.minecraft.world.entity.Marker) || world.paperConfig().misc.tickMarkerEntities); // Don't tick markers by default
++            java.util.List<Entity> entities = world.getEntities((Entity)null, maxBB, (e) -> !(e instanceof net.minecraft.world.entity.Marker) || world.paperConfig().entities.markers.tick); // Don't tick markers by default
              for (int i = 0; i < entities.size(); i++) {
                  Entity entity = entities.get(i);
                  ActivationRange.activateEntity(entity);


### PR DESCRIPTION
Addresses [#8118](https://github.com/PaperMC/Paper/issues/8118) by adding a configuration option that allows the ticking of marker entities to be enabled and disabled. By default, marker ticking is disabled.  

I had an old PR for this, but I didn't modify the patches correctly & the logic in one of the checks was wrong. 