### PR TITLE
Don't warn for deprecated PrepareGrindstoneEvent

### DIFF
--- a/patches/api/0205-Add-PrepareResultEvent-PrepareGrindstoneEvent.patch
+++ b/patches/api/0205-Add-PrepareResultEvent-PrepareGrindstoneEvent.patch
@@ -11,12 +11,13 @@ Grindstone is a backwards compat from a previous PrepareGrindstoneEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a89d189e1175e980e5af8476f539f0a025e8903b
+index 0000000000000000000000000000000000000000..83bfb7276b458bae1e21cb7ba9f4f7c4c2acf76f
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/inventory/PrepareGrindstoneEvent.java
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,28 @@
 +package com.destroystokyo.paper.event.inventory;
 +
++import org.bukkit.Warning;
 +import org.bukkit.inventory.GrindstoneInventory;
 +import org.bukkit.inventory.InventoryView;
 +import org.bukkit.inventory.ItemStack;
@@ -28,6 +29,7 @@ index 0000000000000000000000000000000000000000..a89d189e1175e980e5af8476f539f0a0
 + * @deprecated use {@link org.bukkit.event.inventory.PrepareGrindstoneEvent}
 + */
 +@Deprecated
++@Warning(false)
 +public class PrepareGrindstoneEvent extends PrepareResultEvent {
 +
 +    public PrepareGrindstoneEvent(@NotNull InventoryView inventory, @Nullable ItemStack result) {


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/9035

This should've always had `@Warning(false)` since its subclass is the preferred event to use.