### PR TITLE
EntityEffect#HURT fixes

### DIFF
--- a/patches/api/0419-Deprecate-HURT-EntityEffects-implement-Hurt-effect-i.patch
+++ b/patches/api/0419-Deprecate-HURT-EntityEffects-implement-Hurt-effect-i.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: RyGuy <oboylery@gmail.com>
+Date: Fri, 24 Mar 2023 14:31:03 -0400
+Subject: [PATCH] Deprecate HURT EntityEffects, implement Hurt effect in
+ LivingEntity
+
+
+diff --git a/src/main/java/org/bukkit/EntityEffect.java b/src/main/java/org/bukkit/EntityEffect.java
+index 96ab9a599a75d7e093bdbee2ee6b14ebe4b5ee14..3f8d40591db2d5c4efbfdd5769eb57623e5f2229 100644
+--- a/src/main/java/org/bukkit/EntityEffect.java
++++ b/src/main/java/org/bukkit/EntityEffect.java
+@@ -37,7 +37,10 @@ public enum EntityEffect {
+     RABBIT_JUMP(1, Rabbit.class),
+     /**
+      * When mobs get hurt.
++     *
++     * @deprecated See {@link LivingEntity#playHurtEffect(float)}
+      */
++    @Deprecated
+     HURT(2, LivingEntity.class),
+     /**
+      * When a mob dies.
+@@ -133,7 +136,10 @@ public enum EntityEffect {
+     ARMOR_STAND_HIT(32, ArmorStand.class),
+     /**
+      * Entity hurt by thorns attack.
++     *
++     * @deprecated See {@link LivingEntity#playHurtEffect(float)}
+      */
++    @Deprecated
+     THORNS_HURT(33, LivingEntity.class),
+     /**
+      * Iron golem puts away rose.
+@@ -145,11 +151,17 @@ public enum EntityEffect {
+     TOTEM_RESURRECT(35, LivingEntity.class),
+     /**
+      * Entity hurt due to drowning damage.
++     *
++     * @deprecated See {@link LivingEntity#playHurtEffect(float)}
+      */
++    @Deprecated
+     HURT_DROWN(36, LivingEntity.class),
+     /**
+      * Entity hurt due to explosion damage.
++     *
++     * @deprecated See {@link LivingEntity#playHurtEffect(float)}
+      */
++    @Deprecated
+     HURT_EXPLOSION(37, LivingEntity.class),
+     /**
+      * Dolphin has been fed and is locating a structure.
+@@ -177,7 +189,10 @@ public enum EntityEffect {
+     PLAYER_BAD_OMEN_RAID(43, Player.class),
+     /**
+      * Entity hurt due to berry bush. Prickly!
++     *
++     * @deprecated See {@link LivingEntity#playHurtEffect(float)}
+      */
++    @Deprecated
+     HURT_BERRY_BUSH(44, LivingEntity.class),
+     /**
+      * Fox chews the food in its mouth
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 059dfc40edc6c52f95a30e9ac72f45b6aaf5f9a8..3b260a3603052ae3da6bbaaedf6217ee33031534 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -98,6 +98,12 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+         return getTargetBlock(maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode.NEVER);
+     }
+ 
++    /**
++     * Plays the hurt effect for a client, replacing deprecated {@link org.bukkit.EntityEffect#HURT} and others
++     * @param yaw The yaw to simulate being hurt from
++     */
++    public void playHurtEffect(float yaw);
++
+     /**
+      * Gets the block that the living entity has targeted
+      *

--- a/patches/server/0971-Implement-LivingEntity-playHurtEffect.patch
+++ b/patches/server/0971-Implement-LivingEntity-playHurtEffect.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: RyGuy <TheRealRyGuy@users.noreply.github.com>
+Date: Fri, 24 Mar 2023 14:31:57 -0400
+Subject: [PATCH] Implement LivingEntity#playHurtEffect
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 5a5ff40df37db9cbd53c584ed26a3ce4888b29c0..4ad24c64587ccf4f2ce5a897724c2404c30713c4 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -51,17 +51,7 @@ import net.minecraft.core.registries.Registries;
+ import net.minecraft.network.chat.Component;
+ import net.minecraft.network.chat.MutableComponent;
+ import net.minecraft.network.protocol.Packet;
+-import net.minecraft.network.protocol.game.ClientboundBlockDestructionPacket;
+-import net.minecraft.network.protocol.game.ClientboundBlockEventPacket;
+-import net.minecraft.network.protocol.game.ClientboundDamageEventPacket;
+-import net.minecraft.network.protocol.game.ClientboundEntityEventPacket;
+-import net.minecraft.network.protocol.game.ClientboundExplodePacket;
+-import net.minecraft.network.protocol.game.ClientboundLevelEventPacket;
+-import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket;
+-import net.minecraft.network.protocol.game.ClientboundSetDefaultSpawnPositionPacket;
+-import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
+-import net.minecraft.network.protocol.game.ClientboundSoundPacket;
+-import net.minecraft.network.protocol.game.DebugPackets;
++import net.minecraft.network.protocol.game.*;
+ import net.minecraft.resources.ResourceKey;
+ import io.papermc.paper.util.MCUtil;
+ import net.minecraft.server.MinecraftServer;
+@@ -1723,6 +1713,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+         this.getChunkSource().broadcastAndSend(entity, new ClientboundEntityEventPacket(entity, status));
+     }
+ 
++    @Override
++    public void broadcastEntityHurt(LivingEntity entity, float yaw) {
++        this.getChunkSource().broadcastAndSend(entity, new ClientboundHurtAnimationPacket(entity.getId(), yaw));
++    }
++
+     @Override
+     public void broadcastDamageEvent(Entity entity, DamageSource damageSource) {
+         this.getChunkSource().broadcastAndSend(entity, new ClientboundDamageEventPacket(entity, damageSource));
+diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
+index 973ecd50f9cb6b86c353586e84d15dcb118ccb60..a91af2fce4b09714e06c30df89e4704a80118be3 100644
+--- a/src/main/java/net/minecraft/world/level/Level.java
++++ b/src/main/java/net/minecraft/world/level/Level.java
+@@ -44,6 +44,7 @@ import net.minecraft.world.DifficultyInstance;
+ import net.minecraft.world.damagesource.DamageSource;
+ import net.minecraft.world.damagesource.DamageSources;
+ import net.minecraft.world.entity.Entity;
++import net.minecraft.world.entity.LivingEntity;
+ import net.minecraft.world.entity.boss.EnderDragonPart;
+ import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
+ import net.minecraft.world.entity.item.ItemEntity;
+@@ -1248,6 +1249,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+ 
+     public void broadcastEntityEvent(Entity entity, byte status) {}
+ 
++    public void broadcastEntityHurt(LivingEntity entity, float yaw) {}
++
+     public void broadcastDamageEvent(Entity entity, DamageSource damageSource) {}
+ 
+     public void blockEvent(BlockPos pos, Block block, int type, int data) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index aec588b41f19b2147a4e7267bafa417fbcf7abc0..851b79228ea3f6854ef203534dcd72a992796a5d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -204,6 +204,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         return blocks.get(0);
+     }
+ 
++    @Override
++    public void playHurtEffect(float yaw) {
++        this.getHandle().level.broadcastEntityHurt(this.getHandle(), yaw);
++    }
++
+     // Paper start
+     @Override
+     public Block getTargetBlock(int maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode) {


### PR DESCRIPTION
This directly handles #9022 , and begins to handle #8988. 

This commit just deprecates `EntityEffect#HURT`, `EntityEffect#THORNS_HURT`, `EntityEffect#HURT_DROWN`, `EntityEffect#HURT_EXPLOSION`, and `EntityEffect#HURT_BERRY_PUSH`. 

Hurt effect implementation is now through `LivingEntity#playHurtEffect`, which just has `Level#broadcastEntityHurt` implemented in `ServerLevel` to just send a `ClientboundHurtAnimationPacket`

A couple notes of things I need to fix when I'm back home 
- Accidentally wild card imported `net.minecraft.network.protocol.game` in `ServerLevel`
- Need to mark Paper comments everywhere

Not 100% sure if this was being left until upstream fixes it, but I figured I might as well