### PR TITLE
Support per player display names

### DIFF
--- a/patches/api/0418-Support-per-player-display-names.patch
+++ b/patches/api/0418-Support-per-player-display-names.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yannick Lamprecht <yannicklamprecht@live.de>
+Date: Fri, 24 Mar 2023 18:24:51 +0100
+Subject: [PATCH] Support per player display names
+
+
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 8c58018b155c52a7b2a139f784abceb6aa00a268..68503be744eced50fa9c261c6ab487901f8e815d 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -791,6 +791,24 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+     @NotNull
+     SpawnCategory getSpawnCategory();
+ 
++    // Paper start - per player display component
++    /**
++     * Returns the component of the display name override
++     *
++     * @param player the player that sees the overridden displayname
++     * @return a overridden component if one set for the passed player, else null
++     */
++    @Nullable net.kyori.adventure.text.Component displayNamePerPlayerOverride(@NotNull Player player);
++
++    /**
++     *  Allows to override an entities display component for a player.
++     *
++     * @param player the player that should see the overridden display component
++     * @param component the display component the player should see instead
++     */
++    void displayNamePerPlayerOverride(@NotNull Player player, @Nullable net.kyori.adventure.text.Component component);
++    // Paper end - per player display component
++
+     // Spigot start
+     public class Spigot extends CommandSender.Spigot {
+ 

--- a/patches/server/0972-Support-per-player-display-names.patch
+++ b/patches/server/0972-Support-per-player-display-names.patch
@@ -1,0 +1,114 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yannick Lamprecht <yannicklamprecht@live.de>
+Date: Fri, 24 Mar 2023 18:24:08 +0100
+Subject: [PATCH] Support per player display names
+
+== AT ==
+public net.minecraft.world.entity.Entity DATA_CUSTOM_NAME
+
+diff --git a/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java b/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java
+index ff7ba7a161cfed7521354bc6e3f21ba0f17f3760..98a15d9d01aa345051953514728b2e980304fae4 100644
+--- a/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java
++++ b/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java
+@@ -161,14 +161,26 @@ public class SynchedEntityData {
+         return this.isDirty;
+     }
+ 
++    // Paper start - per player display component
+     @Nullable
+     public List<SynchedEntityData.DataValue<?>> packDirty() {
++        return packDirty(null);
++    }
++    @Nullable
++    public List<SynchedEntityData.DataValue<?>> packDirty(@Nullable Entity entity) {
++        // Paper end - per player display component
+         List<SynchedEntityData.DataValue<?>> list = null;
+ 
+         if (this.isDirty) {
+             // this.lock.readLock().lock(); // Spigot - not required
+             ObjectIterator objectiterator = this.itemsById.values().iterator();
+ 
++            // Paper start - per player display component
++            boolean customNamePresent = false;
++            java.util.Optional<net.minecraft.network.chat.Component> component = java.util.Optional.empty();
++            if(entity instanceof ServerPlayer serverPlayer){
++                component = java.util.Optional.ofNullable(this.entity.getBukkitEntity().getDisplayNamePerPlayerOverride(serverPlayer));
++            }
+             while (objectiterator.hasNext()) {
+                 SynchedEntityData.DataItem<?> datawatcher_item = (SynchedEntityData.DataItem) objectiterator.next();
+ 
+@@ -178,9 +190,22 @@ public class SynchedEntityData {
+                         list = new ArrayList();
+                     }
+ 
++                    if(datawatcher_item.accessor == Entity.DATA_CUSTOM_NAME && component != null) {
++                        ((SynchedEntityData.DataItem<java.util.Optional<net.minecraft.network.chat.Component>>)datawatcher_item).value = component;
++                        customNamePresent = true;
++                    }
++
+                     list.add(datawatcher_item.value());
+                 }
+             }
++            if(!customNamePresent && component.isPresent()) {
++                if (list == null) {
++                    list = new ArrayList<>();
++                }
++                list.add(SynchedEntityData.DataValue.create(Entity.DATA_CUSTOM_NAME, component));
++            }
++
++            // Paper end - per player display component
+ 
+             // this.lock.readLock().unlock(); // Spigot - not required
+         }
+diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
+index b7fd8e70413c38923d0719aff803449e392383ac..84525e3092b7b3989789b9f8bd1a0457df7e242c 100644
+--- a/src/main/java/net/minecraft/server/level/ServerEntity.java
++++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
+@@ -393,7 +393,7 @@ public class ServerEntity {
+ 
+     private void sendDirtyEntityData() {
+         SynchedEntityData datawatcher = this.entity.getEntityData();
+-        List<SynchedEntityData.DataValue<?>> list = datawatcher.packDirty();
++        List<SynchedEntityData.DataValue<?>> list = datawatcher.packDirty(this.entity); // Paper - per player display component
+ 
+         if (list != null) {
+             this.trackedDataValues = datawatcher.getNonDefaultValues();
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index 57a0dbb23a32123d30c3b3572f4d129be9d97847..0eebddabf31b7ded6c59f52e91e5f2b3eb96acc3 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -203,6 +203,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+     private EntityDamageEvent lastDamageEvent;
+     private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftEntity.DATA_TYPE_REGISTRY);
+     protected net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
++    private final java.util.Map<UUID, Component> displayNameOverrides = new java.util.concurrent.ConcurrentHashMap<>(); // Paper - per player display component
+ 
+     public CraftEntity(final CraftServer server, final Entity entity) {
+         this.server = server;
+@@ -1442,4 +1443,26 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+         return !this.getHandle().level.noCollision(this.getHandle(), aabb);
+     }
+     // Paper End - Collision API
++    // Paper start - per player display component
++    public Component getDisplayNamePerPlayerOverride(ServerPlayer serverPlayer) {
++        return displayNameOverrides.get(serverPlayer.getUUID());
++    }
++    @Override
++    public @org.jetbrains.annotations.Nullable net.kyori.adventure.text.Component displayNamePerPlayerOverride(@org.jetbrains.annotations.NotNull Player player) {
++        Component component = this.displayNameOverrides.get(player.getUniqueId());
++        if(component == null) {
++            return null;
++        }
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(component);
++    }
++
++    @Override
++    public void displayNamePerPlayerOverride(@org.jetbrains.annotations.NotNull Player player, @org.jetbrains.annotations.Nullable net.kyori.adventure.text.Component component) {
++        if (component == null){
++            this.displayNameOverrides.remove(player.getUniqueId());
++            return;
++        }
++        this.displayNameOverrides.put(player.getUniqueId(), io.papermc.paper.adventure.PaperAdventure.asVanilla(component));
++    }
++    // Paper end - per player display component
+ }


### PR DESCRIPTION
Stuff we probably need to consider:

Currently no per player custom name is displayed when no global custom name is set. Solution would be to add a data entry to the list when none is present and write the custom one. See SynchedEntityData#pack