### PR TITLE
Schedule several things for removal in 1.21

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -365,10 +365,10 @@ index 0000000000000000000000000000000000000000..feece00981ebf932e64760e7a10a04ad
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/AsyncChatDecorateEvent.java b/src/main/java/io/papermc/paper/event/player/AsyncChatDecorateEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9a962337948810b00ceae1124962fcc7058b70ad
+index 0000000000000000000000000000000000000000..667bfa6afc35f8a8f475431171ee474af4e10afd
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/AsyncChatDecorateEvent.java
-@@ -0,0 +1,116 @@
+@@ -0,0 +1,117 @@
 +package io.papermc.paper.event.player;
 +
 +import net.kyori.adventure.text.Component;
@@ -456,6 +456,7 @@ index 0000000000000000000000000000000000000000..9a962337948810b00ceae1124962fcc7
 +     * @deprecated chat preview was removed in 1.19.3
 +     */
 +    @Deprecated(forRemoval = true)
++    @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    @Contract(value = "-> false", pure = true)
 +    public boolean isPreview() {
 +        return false;

--- a/patches/api/0016-Add-PlayerLocaleChangeEvent.patch
+++ b/patches/api/0016-Add-PlayerLocaleChangeEvent.patch
@@ -6,22 +6,23 @@ Subject: [PATCH] Add PlayerLocaleChangeEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerLocaleChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerLocaleChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..29dd763a99ce7c6ecb176b9fb346a400369d48a0
+index 0000000000000000000000000000000000000000..bb7baa91fd4ba763fd8ce216bc9043c5e2c4b7b7
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerLocaleChangeEvent.java
-@@ -0,0 +1,50 @@
+@@ -0,0 +1,51 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.ApiStatus;
 +
 +/**
 + * Called when the locale of the player is changed.
 + *
 + * @deprecated Replaced by {@link org.bukkit.event.player.PlayerLocaleChangeEvent} upstream
 + */
-+@Deprecated
++@Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public class PlayerLocaleChangeEvent extends PlayerEvent {
 +    private static final HandlerList handlers = new HandlerList();
 +    private final String oldLocale;

--- a/patches/api/0019-Add-PlayerInitialSpawnEvent.patch
+++ b/patches/api/0019-Add-PlayerInitialSpawnEvent.patch
@@ -7,21 +7,22 @@ For modifying a player's initial spawn location as they join the server
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerInitialSpawnEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerInitialSpawnEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..626e97bbcaa19d55475a0fc8770412d437af2733
+index 0000000000000000000000000000000000000000..febd384b43560d7d55c96bda5b0701a27fc9e18e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerInitialSpawnEvent.java
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,18 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.Location;
 +import org.bukkit.entity.Player;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 +
 +/**
 + * @deprecated Use {@link PlayerSpawnLocationEvent}, Duplicate API
 + */
-+@Deprecated
++@Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public class PlayerInitialSpawnEvent extends PlayerSpawnLocationEvent {
 +
 +    public PlayerInitialSpawnEvent(@NotNull Player who, @NotNull Location spawnLocation) {

--- a/patches/api/0053-Expose-WorldBorder-isInBounds-Location-check.patch
+++ b/patches/api/0053-Expose-WorldBorder-isInBounds-Location-check.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose WorldBorder#isInBounds(Location) check
 
 
 diff --git a/src/main/java/org/bukkit/WorldBorder.java b/src/main/java/org/bukkit/WorldBorder.java
-index b1c08a7fc5856bcc29ee64d0a87b95a8ac940ddc..0f2f17f0a443ec5087b3373293b23f663be9dbe1 100644
+index b1c08a7fc5856bcc29ee64d0a87b95a8ac940ddc..3ab5700b0b13fbfbf7c5b0b2c4a90bcc1e0a2d9c 100644
 --- a/src/main/java/org/bukkit/WorldBorder.java
 +++ b/src/main/java/org/bukkit/WorldBorder.java
 @@ -162,4 +162,18 @@ public interface WorldBorder {
@@ -21,7 +21,7 @@ index b1c08a7fc5856bcc29ee64d0a87b95a8ac940ddc..0f2f17f0a443ec5087b3373293b23f66
 +     * @return true if the location is within the bounds of this border, false otherwise.
 +     * @deprecated use {@link #isInside(Location)} for an upstream compatible replacement
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    public default boolean isInBounds(@NotNull Location location) {
 +        return this.isInside(location);
 +    }

--- a/patches/api/0125-EntityTransformedEvent.patch
+++ b/patches/api/0125-EntityTransformedEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] EntityTransformedEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityTransformedEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityTransformedEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..12194f1fc7f03ca6785904b6187b3dfd03b16461
+index 0000000000000000000000000000000000000000..c6802ca6acad1b841c01284eef0a601774486f55
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityTransformedEvent.java
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,93 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +
@@ -18,6 +18,7 @@ index 0000000000000000000000000000000000000000..12194f1fc7f03ca6785904b6187b3dfd
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.bukkit.event.entity.EntityTransformEvent;
++import org.jetbrains.annotations.ApiStatus;
 +
 +/**
 + * Fired when an entity transforms into another entity
@@ -25,7 +26,7 @@ index 0000000000000000000000000000000000000000..12194f1fc7f03ca6785904b6187b3dfd
 + * If the event is cancelled, the entity will not transform
 + * @deprecated Bukkit has added {@link EntityTransformEvent}, you should start using that
 + */
-+@Deprecated
++@Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public class EntityTransformedEvent extends EntityEvent implements Cancellable {
 +    private static final HandlerList handlers = new HandlerList();
 +    private boolean cancelled;

--- a/patches/api/0150-Add-ItemStackRecipeChoice-Draft-API.patch
+++ b/patches/api/0150-Add-ItemStackRecipeChoice-Draft-API.patch
@@ -9,10 +9,10 @@ Allows creating recipes that must match isSimilar to full item stack.
 
 diff --git a/src/main/java/com/destroystokyo/paper/inventory/ItemStackRecipeChoice.java b/src/main/java/com/destroystokyo/paper/inventory/ItemStackRecipeChoice.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..43e6576b1d1bb811f9feb22de0024d9c823cb21a
+index 0000000000000000000000000000000000000000..18c96aeef00dc11e5083001adfba4204f0de4e2b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/inventory/ItemStackRecipeChoice.java
-@@ -0,0 +1,51 @@
+@@ -0,0 +1,52 @@
 +package com.destroystokyo.paper.inventory;
 +
 +import org.bukkit.inventory.ItemStack;
@@ -20,12 +20,13 @@ index 0000000000000000000000000000000000000000..43e6576b1d1bb811f9feb22de0024d9c
 +
 +import java.util.ArrayList;
 +import java.util.List;
++import org.jetbrains.annotations.ApiStatus;
 +
 +/**
 + * Allows crafting Items that require full matching itemstacks to complete the recipe for custom items
 + * @deprecated Draft API
 + */
-+@Deprecated
++@Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public class ItemStackRecipeChoice implements RecipeChoice {
 +
 +    protected final List<ItemStack> choices = new ArrayList<>();

--- a/patches/api/0175-Add-Heightmap-API.patch
+++ b/patches/api/0175-Add-Heightmap-API.patch
@@ -7,26 +7,26 @@ Changed to use upstream's heightmap API - Machine_Maker
 
 diff --git a/src/main/java/com/destroystokyo/paper/HeightmapType.java b/src/main/java/com/destroystokyo/paper/HeightmapType.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..709e44ea1b14ab6917501c928e689cc6cbdf4bb4
+index 0000000000000000000000000000000000000000..1c832d69bb3717dcfccf21e45f6f060a64eb4f11
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/HeightmapType.java
 @@ -0,0 +1,39 @@
 +package com.destroystokyo.paper;
 +
-+import org.bukkit.*;
++import org.jetbrains.annotations.ApiStatus;
 +
 +/**
 + * Enumeration of different heightmap types maintained by the server. Generally using these maps is much faster
 + * than using an iterative search for a block in a given x, z coordinate.
 + *
 + * @deprecated Upstream has added their own API for using the game heightmaps. See {@link org.bukkit.HeightMap} and the
-+ * non-deprecated getHighestBlock methods on World such as {@link org.bukkit.World#getHighestBlockAt(Location, HeightMap)}.
++ * non-deprecated getHighestBlock methods on World such as {@link org.bukkit.World#getHighestBlockAt(org.bukkit.Location, org.bukkit.HeightMap)}.
 + */
-+@Deprecated
++@Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public enum HeightmapType {
 +
 +    /**
-+     * The highest block used for lighting in the world. Also the block returned by {@link World#getHighestBlockYAt(int, int)}}
++     * The highest block used for lighting in the world. Also the block returned by {@link org.bukkit.World#getHighestBlockYAt(int, int)}}
 +     */
 +    LIGHT_BLOCKING,
 +
@@ -51,7 +51,7 @@ index 0000000000000000000000000000000000000000..709e44ea1b14ab6917501c928e689cc6
 +    SOLID_OR_LIQUID_NO_LEAVES;
 +}
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 2b9a117804a8ca54b47e51e23359bd6e01087641..6bbf8468bc47e82b0aeb164e49cdb73d93bae87b 100644
+index 2b9a117804a8ca54b47e51e23359bd6e01087641..1a60a18e15780128a1914826daa952ffacb92e9e 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -640,6 +640,47 @@ public class Location implements Cloneable, ConfigurationSerializable, io.paperm
@@ -79,7 +79,7 @@ index 2b9a117804a8ca54b47e51e23359bd6e01087641..6bbf8468bc47e82b0aeb164e49cdb73d
 +     * @deprecated Use {@link org.bukkit.Location#toHighestLocation(HeightMap)}
 +     */
 +    @NotNull
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    public Location toHighestLocation(@NotNull final com.destroystokyo.paper.HeightmapType heightmap) {
 +        final Location ret = this.clone();
 +        ret.setY(this.getWorld().getHighestBlockYAt(this, heightmap));
@@ -103,7 +103,7 @@ index 2b9a117804a8ca54b47e51e23359bd6e01087641..6bbf8468bc47e82b0aeb164e49cdb73d
       * Creates explosion at this location with given power
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 948a989aeea4165f0714db69c70ca8dcb488d44d..530d656aa5573c9783d07de23379657fe0c7cae5 100644
+index 948a989aeea4165f0714db69c70ca8dcb488d44d..1ae0e12125421fd0c36fcfb82ccbb994578415d9 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -149,6 +149,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -127,7 +127,7 @@ index 948a989aeea4165f0714db69c70ca8dcb488d44d..530d656aa5573c9783d07de23379657f
 +     *
 +     * @see com.destroystokyo.paper.HeightmapType
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    public int getHighestBlockYAt(int x, int z, @NotNull com.destroystokyo.paper.HeightmapType heightmap) throws UnsupportedOperationException;
 +
 +    /**
@@ -145,7 +145,7 @@ index 948a989aeea4165f0714db69c70ca8dcb488d44d..530d656aa5573c9783d07de23379657f
 +     * @deprecated Upstream has added support for this, use {@link World#getHighestBlockYAt(Location, HeightMap)}
 +     * @see com.destroystokyo.paper.HeightmapType
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    default int getHighestBlockYAt(@NotNull Location location, @NotNull com.destroystokyo.paper.HeightmapType heightmap) throws UnsupportedOperationException {
 +        return this.getHighestBlockYAt(location.getBlockX(), location.getBlockZ(), heightmap);
 +    }
@@ -164,7 +164,7 @@ index 948a989aeea4165f0714db69c70ca8dcb488d44d..530d656aa5573c9783d07de23379657f
 +     * @deprecated Upstream has added support for this, use {@link World#getHighestBlockAt(int, int, HeightMap)}
 +     * @see com.destroystokyo.paper.HeightmapType
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    @NotNull
 +    default Block getHighestBlockAt(int x, int z, @NotNull com.destroystokyo.paper.HeightmapType heightmap) throws UnsupportedOperationException {
 +        return this.getBlockAt(x, this.getHighestBlockYAt(x, z, heightmap), z);
@@ -184,7 +184,7 @@ index 948a989aeea4165f0714db69c70ca8dcb488d44d..530d656aa5573c9783d07de23379657f
 +     * @deprecated Upstream has added support for this, use {@link World#getHighestBlockAt(Location, HeightMap)}
 +     * @see com.destroystokyo.paper.HeightmapType
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    @NotNull
 +    default Block getHighestBlockAt(@NotNull Location location, @NotNull com.destroystokyo.paper.HeightmapType heightmap) throws UnsupportedOperationException {
 +        return this.getHighestBlockAt(location.getBlockX(), location.getBlockZ(), heightmap);

--- a/patches/api/0195-Add-Mob-Goal-API.patch
+++ b/patches/api/0195-Add-Mob-Goal-API.patch
@@ -227,16 +227,17 @@ index 0000000000000000000000000000000000000000..e21f7574763dd4f13794f91bbef192ef
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java b/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dddbb661265aa23f88d93d0681f418f40a872351
+index 0000000000000000000000000000000000000000..c9837c7c47314b5bdf6c7973e6bc962d390dc13d
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
-@@ -0,0 +1,292 @@
+@@ -0,0 +1,293 @@
 +package com.destroystokyo.paper.entity.ai;
 +
 +import com.destroystokyo.paper.entity.RangedEntity;
 +
 +import org.bukkit.NamespacedKey;
 +import org.bukkit.entity.*;
++import org.jetbrains.annotations.ApiStatus;
 +
 +/**
 + * Represents a vanilla goal. Plugins should never implement this.<br>
@@ -436,92 +437,92 @@ index 0000000000000000000000000000000000000000..dddbb661265aa23f88d93d0681f418f4
 +    /**
 +     * @deprecated removed in 1.16
 +     */
-+    @Deprecated GoalKey<PigZombie> ANGER = GoalKey.of(PigZombie.class, NamespacedKey.minecraft("anger"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<PigZombie> ANGER = GoalKey.of(PigZombie.class, NamespacedKey.minecraft("anger"));
 +    /**
 +     * @deprecated removed in 1.16
 +     */
-+    @Deprecated GoalKey<PigZombie> ANGER_OTHER = GoalKey.of(PigZombie.class, NamespacedKey.minecraft("anger_other"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<PigZombie> ANGER_OTHER = GoalKey.of(PigZombie.class, NamespacedKey.minecraft("anger_other"));
 +
 +    // the constants below use spigot names, they no longer work
-+    @Deprecated GoalKey<Blaze> BLAZE_FIREBALL = GoalKey.of(Blaze.class, NamespacedKey.minecraft("blaze_fireball"));
-+    @Deprecated GoalKey<Cat> TEMPT_CHANCE = GoalKey.of(Cat.class, NamespacedKey.minecraft("tempt_chance"));
-+    @Deprecated GoalKey<Dolphin> DOLPHIN_PLAY_WITH_ITEMS = GoalKey.of(Dolphin.class, NamespacedKey.minecraft("dolphin_play_with_items"));
-+    @Deprecated GoalKey<Drowned> DROWNED_GOTO_BEACH = GoalKey.of(Drowned.class, NamespacedKey.minecraft("drowned_goto_beach"));
-+    @Deprecated GoalKey<Creature> DROWNED_GOTO_WATER = GoalKey.of(Creature.class, NamespacedKey.minecraft("drowned_goto_water"));
-+    @Deprecated GoalKey<Enderman> ENDERMAN_PICKUP_BLOCK = GoalKey.of(Enderman.class, NamespacedKey.minecraft("enderman_pickup_block"));
-+    @Deprecated GoalKey<Enderman> ENDERMAN_PLACE_BLOCK = GoalKey.of(Enderman.class, NamespacedKey.minecraft("enderman_place_block"));
-+    @Deprecated GoalKey<Enderman> PLAYER_WHO_LOOKED_AT_TARGET = GoalKey.of(Enderman.class, NamespacedKey.minecraft("player_who_looked_at_target"));
-+    @Deprecated GoalKey<Evoker> EVOKER_CAST_SPELL = GoalKey.of(Evoker.class, NamespacedKey.minecraft("evoker_cast_spell"));
-+    @Deprecated GoalKey<Fox> FOX_DEFEND_TRUSTED = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_defend_trusted"));
-+    @Deprecated GoalKey<Fox> FOX_FACEPLANT = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_faceplant"));
-+    @Deprecated GoalKey<Fox> FOX_PERCH_AND_SEARCH = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_perch_and_search"));
-+    @Deprecated GoalKey<Fox> FOX_SLEEP = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_sleep"));
-+    @Deprecated GoalKey<Fox> FOX_SEEK_SHELTER = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_seek_shelter"));
-+    @Deprecated GoalKey<Fox> FOX_STALK_PREY = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_stalk_prey"));
-+    @Deprecated GoalKey<Ghast> GHAST_ATTACK_TARGET = GoalKey.of(Ghast.class, NamespacedKey.minecraft("ghast_attack_target"));
-+    @Deprecated GoalKey<Ghast> GHAST_IDLE_MOVE = GoalKey.of(Ghast.class, NamespacedKey.minecraft("ghast_idle_move"));
-+    @Deprecated GoalKey<Ghast> GHAST_MOVE_TOWARDS_TARGET = GoalKey.of(Ghast.class, NamespacedKey.minecraft("ghast_move_towards_target"));
-+    @Deprecated GoalKey<Spellcaster> SPELLCASTER_CAST_SPELL = GoalKey.of(Spellcaster.class, NamespacedKey.minecraft("spellcaster_cast_spell"));
-+    @Deprecated GoalKey<TraderLlama> LLAMATRADER_DEFENDED_WANDERING_TRADER = GoalKey.of(TraderLlama.class, NamespacedKey.minecraft("llamatrader_defended_wandering_trader"));
-+    @Deprecated GoalKey<Panda> PANDA_HURT_BY_TARGET = GoalKey.of(Panda.class, NamespacedKey.minecraft("panda_hurt_by_target"));
-+    @Deprecated GoalKey<PolarBear> POLARBEAR_ATTACK_PLAYERS = GoalKey.of(PolarBear.class, NamespacedKey.minecraft("polarbear_attack_players"));
-+    @Deprecated GoalKey<PolarBear> POLARBEAR_HURT_BY = GoalKey.of(PolarBear.class, NamespacedKey.minecraft("polarbear_hurt_by"));
-+    @Deprecated GoalKey<PolarBear> POLARBEAR_MELEE = GoalKey.of(PolarBear.class, NamespacedKey.minecraft("polarbear_melee"));
-+    @Deprecated GoalKey<PolarBear> POLARBEAR_PANIC = GoalKey.of(PolarBear.class, NamespacedKey.minecraft("polarbear_panic"));
-+    @Deprecated GoalKey<Rabbit> EAT_CARROTS = GoalKey.of(Rabbit.class, NamespacedKey.minecraft("eat_carrots"));
-+    @Deprecated GoalKey<Rabbit> KILLER_RABBIT_MELEE_ATTACK = GoalKey.of(Rabbit.class, NamespacedKey.minecraft("killer_rabbit_melee_attack"));
-+    @Deprecated GoalKey<Rabbit> RABBIT_AVOID_TARGET = GoalKey.of(Rabbit.class, NamespacedKey.minecraft("rabbit_avoid_target"));
-+    @Deprecated GoalKey<Raider> RAIDER_HOLD_GROUND = GoalKey.of(Raider.class, NamespacedKey.minecraft("raider_hold_ground"));
-+    @Deprecated GoalKey<Raider> RAIDER_OBTAIN_BANNER = GoalKey.of(Raider.class, NamespacedKey.minecraft("raider_obtain_banner"));
-+    @Deprecated GoalKey<Shulker> SHULKER_DEFENSE = GoalKey.of(Shulker.class, NamespacedKey.minecraft("shulker_defense"));
-+    @Deprecated GoalKey<Shulker> SHULKER_NEAREST = GoalKey.of(Shulker.class, NamespacedKey.minecraft("shulker_nearest"));
-+    @Deprecated GoalKey<Silverfish> SILVERFISH_HIDE_IN_BLOCK = GoalKey.of(Silverfish.class, NamespacedKey.minecraft("silverfish_hide_in_block"));
-+    @Deprecated GoalKey<Silverfish> SILVERFISH_WAKE_OTHERS = GoalKey.of(Silverfish.class, NamespacedKey.minecraft("silverfish_wake_others"));
-+    @Deprecated GoalKey<Slime> SLIME_IDLE = GoalKey.of(Slime.class, NamespacedKey.minecraft("slime_idle"));
-+    @Deprecated GoalKey<Slime> SLIME_NEAREST_PLAYER = GoalKey.of(Slime.class, NamespacedKey.minecraft("slime_nearest_player"));
-+    @Deprecated GoalKey<Slime> SLIME_RANDOM_JUMP = GoalKey.of(Slime.class, NamespacedKey.minecraft("slime_random_jump"));
-+    @Deprecated GoalKey<Spider> SPIDER_MELEE_ATTACK = GoalKey.of(Spider.class, NamespacedKey.minecraft("spider_melee_attack"));
-+    @Deprecated GoalKey<Spider> SPIDER_NEAREST_ATTACKABLE_TARGET = GoalKey.of(Spider.class, NamespacedKey.minecraft("spider_nearest_attackable_target"));
-+    @Deprecated GoalKey<Squid> SQUID = GoalKey.of(Squid.class, NamespacedKey.minecraft("squid"));
-+    @Deprecated GoalKey<Turtle> TURTLE_GOTO_WATER = GoalKey.of(Turtle.class, NamespacedKey.minecraft("turtle_goto_water"));
-+    @Deprecated GoalKey<Turtle> TURTLE_TEMPT = GoalKey.of(Turtle.class, NamespacedKey.minecraft("turtle_tempt"));
-+    @Deprecated GoalKey<Vex> VEX_COPY_TARGET_OF_OWNER = GoalKey.of(Vex.class, NamespacedKey.minecraft("vex_copy_target_of_owner"));
-+    @Deprecated GoalKey<WanderingTrader> VILLAGERTRADER_WANDER_TO_POSITION = GoalKey.of(WanderingTrader.class, NamespacedKey.minecraft("villagertrader_wander_to_position"));
-+    @Deprecated GoalKey<RangedEntity> ARROW_ATTACK = GoalKey.of(RangedEntity.class, NamespacedKey.minecraft("arrow_attack"));
-+    @Deprecated GoalKey<Creature> AVOID_TARGET = GoalKey.of(Creature.class, NamespacedKey.minecraft("avoid_target"));
-+    @Deprecated GoalKey<Monster> BOW_SHOOT = GoalKey.of(Monster.class, NamespacedKey.minecraft("bow_shoot"));
-+    @Deprecated GoalKey<Creature> BREATH = GoalKey.of(Creature.class, NamespacedKey.minecraft("breath"));
-+    @Deprecated GoalKey<Cat> CAT_SIT_ON_BED = GoalKey.of(Cat.class, NamespacedKey.minecraft("cat_sit_on_bed"));
-+    @Deprecated GoalKey<Monster> CROSSBOW_ATTACK = GoalKey.of(Monster.class, NamespacedKey.minecraft("crossbow_attack"));
-+    @Deprecated GoalKey<Mob> DOOR_OPEN = GoalKey.of(Mob.class, NamespacedKey.minecraft("door_open"));
-+    @Deprecated GoalKey<Mob> EAT_TILE = GoalKey.of(Mob.class, NamespacedKey.minecraft("eat_tile"));
-+    @Deprecated GoalKey<Fish> FISH_SCHOOL = GoalKey.of(Fish.class, NamespacedKey.minecraft("fish_school"));
-+    @Deprecated GoalKey<Mob> FOLLOW_ENTITY = GoalKey.of(Mob.class, NamespacedKey.minecraft("follow_entity"));
-+    @Deprecated GoalKey<SkeletonHorse> HORSE_TRAP = GoalKey.of(SkeletonHorse.class, NamespacedKey.minecraft("horse_trap"));
-+    @Deprecated GoalKey<Creature> HURT_BY_TARGET = GoalKey.of(Creature.class, NamespacedKey.minecraft("hurt_by_target"));
-+    @Deprecated GoalKey<Cat> JUMP_ON_BLOCK = GoalKey.of(Cat.class, NamespacedKey.minecraft("jump_on_block"));
-+    @Deprecated GoalKey<Mob> LEAP_AT_TARGET = GoalKey.of(Mob.class, NamespacedKey.minecraft("leap_at_target"));
-+    @Deprecated GoalKey<Llama> LLAMA_FOLLOW = GoalKey.of(Llama.class, NamespacedKey.minecraft("llama_follow"));
-+    @Deprecated GoalKey<Creature> MOVE_TOWARDS_TARGET = GoalKey.of(Creature.class, NamespacedKey.minecraft("move_towards_target"));
-+    @Deprecated GoalKey<Mob> NEAREST_ATTACKABLE_TARGET = GoalKey.of(Mob.class, NamespacedKey.minecraft("nearest_attackable_target"));
-+    @Deprecated GoalKey<Raider> NEAREST_ATTACKABLE_TARGET_WITCH = GoalKey.of(Raider.class, NamespacedKey.minecraft("nearest_attackable_target_witch"));
-+    @Deprecated GoalKey<Creature> NEAREST_VILLAGE = GoalKey.of(Creature.class, NamespacedKey.minecraft("nearest_village"));
-+    @Deprecated GoalKey<Tameable> OWNER_HURT_BY_TARGET = GoalKey.of(Tameable.class, NamespacedKey.minecraft("owner_hurt_by_target"));
-+    @Deprecated GoalKey<Tameable> OWNER_HURT_TARGET = GoalKey.of(Tameable.class, NamespacedKey.minecraft("owner_hurt_target"));
-+    @Deprecated GoalKey<Parrot> PERCH = GoalKey.of(Parrot.class, NamespacedKey.minecraft("perch"));
-+    @Deprecated GoalKey<Raider> RAID = GoalKey.of(Raider.class, NamespacedKey.minecraft("raid"));
-+    @Deprecated GoalKey<Creature> RANDOM_FLY = GoalKey.of(Creature.class, NamespacedKey.minecraft("random_fly"));
-+    @Deprecated GoalKey<Mob> RANDOM_LOOKAROUND = GoalKey.of(Mob.class, NamespacedKey.minecraft("random_lookaround"));
-+    @Deprecated GoalKey<Creature> RANDOM_STROLL_LAND = GoalKey.of(Creature.class, NamespacedKey.minecraft("random_stroll_land"));
-+    @Deprecated GoalKey<Creature> RANDOM_SWIM = GoalKey.of(Creature.class, NamespacedKey.minecraft("random_swim"));
-+    @Deprecated GoalKey<Tameable> RANDOM_TARGET_NON_TAMED = GoalKey.of(Tameable.class, NamespacedKey.minecraft("random_target_non_tamed"));
-+    @Deprecated GoalKey<Tameable> SIT = GoalKey.of(Tameable.class, NamespacedKey.minecraft("sit"));
-+    @Deprecated GoalKey<Creature> STROLL_VILLAGE = GoalKey.of(Creature.class, NamespacedKey.minecraft("stroll_village"));
-+    @Deprecated GoalKey<AbstractHorse> TAME = GoalKey.of(AbstractHorse.class, NamespacedKey.minecraft("tame"));
-+    @Deprecated GoalKey<Creature> WATER = GoalKey.of(Creature.class, NamespacedKey.minecraft("water"));
-+    @Deprecated GoalKey<Dolphin> WATER_JUMP = GoalKey.of(Dolphin.class, NamespacedKey.minecraft("water_jump"));
-+    @Deprecated GoalKey<Creature> STROLL_VILLAGE_GOLEM = GoalKey.of(Creature.class, NamespacedKey.minecraft("stroll_village_golem"));
-+    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Blaze> BLAZE_FIREBALL = GoalKey.of(Blaze.class, NamespacedKey.minecraft("blaze_fireball"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Cat> TEMPT_CHANCE = GoalKey.of(Cat.class, NamespacedKey.minecraft("tempt_chance"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Dolphin> DOLPHIN_PLAY_WITH_ITEMS = GoalKey.of(Dolphin.class, NamespacedKey.minecraft("dolphin_play_with_items"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Drowned> DROWNED_GOTO_BEACH = GoalKey.of(Drowned.class, NamespacedKey.minecraft("drowned_goto_beach"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> DROWNED_GOTO_WATER = GoalKey.of(Creature.class, NamespacedKey.minecraft("drowned_goto_water"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Enderman> ENDERMAN_PICKUP_BLOCK = GoalKey.of(Enderman.class, NamespacedKey.minecraft("enderman_pickup_block"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Enderman> ENDERMAN_PLACE_BLOCK = GoalKey.of(Enderman.class, NamespacedKey.minecraft("enderman_place_block"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Enderman> PLAYER_WHO_LOOKED_AT_TARGET = GoalKey.of(Enderman.class, NamespacedKey.minecraft("player_who_looked_at_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Evoker> EVOKER_CAST_SPELL = GoalKey.of(Evoker.class, NamespacedKey.minecraft("evoker_cast_spell"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Fox> FOX_DEFEND_TRUSTED = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_defend_trusted"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Fox> FOX_FACEPLANT = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_faceplant"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Fox> FOX_PERCH_AND_SEARCH = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_perch_and_search"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Fox> FOX_SLEEP = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_sleep"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Fox> FOX_SEEK_SHELTER = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_seek_shelter"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Fox> FOX_STALK_PREY = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_stalk_prey"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Ghast> GHAST_ATTACK_TARGET = GoalKey.of(Ghast.class, NamespacedKey.minecraft("ghast_attack_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Ghast> GHAST_IDLE_MOVE = GoalKey.of(Ghast.class, NamespacedKey.minecraft("ghast_idle_move"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Ghast> GHAST_MOVE_TOWARDS_TARGET = GoalKey.of(Ghast.class, NamespacedKey.minecraft("ghast_move_towards_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Spellcaster> SPELLCASTER_CAST_SPELL = GoalKey.of(Spellcaster.class, NamespacedKey.minecraft("spellcaster_cast_spell"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<TraderLlama> LLAMATRADER_DEFENDED_WANDERING_TRADER = GoalKey.of(TraderLlama.class, NamespacedKey.minecraft("llamatrader_defended_wandering_trader"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Panda> PANDA_HURT_BY_TARGET = GoalKey.of(Panda.class, NamespacedKey.minecraft("panda_hurt_by_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<PolarBear> POLARBEAR_ATTACK_PLAYERS = GoalKey.of(PolarBear.class, NamespacedKey.minecraft("polarbear_attack_players"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<PolarBear> POLARBEAR_HURT_BY = GoalKey.of(PolarBear.class, NamespacedKey.minecraft("polarbear_hurt_by"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<PolarBear> POLARBEAR_MELEE = GoalKey.of(PolarBear.class, NamespacedKey.minecraft("polarbear_melee"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<PolarBear> POLARBEAR_PANIC = GoalKey.of(PolarBear.class, NamespacedKey.minecraft("polarbear_panic"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Rabbit> EAT_CARROTS = GoalKey.of(Rabbit.class, NamespacedKey.minecraft("eat_carrots"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Rabbit> KILLER_RABBIT_MELEE_ATTACK = GoalKey.of(Rabbit.class, NamespacedKey.minecraft("killer_rabbit_melee_attack"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Rabbit> RABBIT_AVOID_TARGET = GoalKey.of(Rabbit.class, NamespacedKey.minecraft("rabbit_avoid_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Raider> RAIDER_HOLD_GROUND = GoalKey.of(Raider.class, NamespacedKey.minecraft("raider_hold_ground"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Raider> RAIDER_OBTAIN_BANNER = GoalKey.of(Raider.class, NamespacedKey.minecraft("raider_obtain_banner"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Shulker> SHULKER_DEFENSE = GoalKey.of(Shulker.class, NamespacedKey.minecraft("shulker_defense"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Shulker> SHULKER_NEAREST = GoalKey.of(Shulker.class, NamespacedKey.minecraft("shulker_nearest"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Silverfish> SILVERFISH_HIDE_IN_BLOCK = GoalKey.of(Silverfish.class, NamespacedKey.minecraft("silverfish_hide_in_block"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Silverfish> SILVERFISH_WAKE_OTHERS = GoalKey.of(Silverfish.class, NamespacedKey.minecraft("silverfish_wake_others"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Slime> SLIME_IDLE = GoalKey.of(Slime.class, NamespacedKey.minecraft("slime_idle"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Slime> SLIME_NEAREST_PLAYER = GoalKey.of(Slime.class, NamespacedKey.minecraft("slime_nearest_player"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Slime> SLIME_RANDOM_JUMP = GoalKey.of(Slime.class, NamespacedKey.minecraft("slime_random_jump"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Spider> SPIDER_MELEE_ATTACK = GoalKey.of(Spider.class, NamespacedKey.minecraft("spider_melee_attack"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Spider> SPIDER_NEAREST_ATTACKABLE_TARGET = GoalKey.of(Spider.class, NamespacedKey.minecraft("spider_nearest_attackable_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Squid> SQUID = GoalKey.of(Squid.class, NamespacedKey.minecraft("squid"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Turtle> TURTLE_GOTO_WATER = GoalKey.of(Turtle.class, NamespacedKey.minecraft("turtle_goto_water"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Turtle> TURTLE_TEMPT = GoalKey.of(Turtle.class, NamespacedKey.minecraft("turtle_tempt"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Vex> VEX_COPY_TARGET_OF_OWNER = GoalKey.of(Vex.class, NamespacedKey.minecraft("vex_copy_target_of_owner"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<WanderingTrader> VILLAGERTRADER_WANDER_TO_POSITION = GoalKey.of(WanderingTrader.class, NamespacedKey.minecraft("villagertrader_wander_to_position"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<RangedEntity> ARROW_ATTACK = GoalKey.of(RangedEntity.class, NamespacedKey.minecraft("arrow_attack"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> AVOID_TARGET = GoalKey.of(Creature.class, NamespacedKey.minecraft("avoid_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Monster> BOW_SHOOT = GoalKey.of(Monster.class, NamespacedKey.minecraft("bow_shoot"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> BREATH = GoalKey.of(Creature.class, NamespacedKey.minecraft("breath"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Cat> CAT_SIT_ON_BED = GoalKey.of(Cat.class, NamespacedKey.minecraft("cat_sit_on_bed"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Monster> CROSSBOW_ATTACK = GoalKey.of(Monster.class, NamespacedKey.minecraft("crossbow_attack"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Mob> DOOR_OPEN = GoalKey.of(Mob.class, NamespacedKey.minecraft("door_open"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Mob> EAT_TILE = GoalKey.of(Mob.class, NamespacedKey.minecraft("eat_tile"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Fish> FISH_SCHOOL = GoalKey.of(Fish.class, NamespacedKey.minecraft("fish_school"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Mob> FOLLOW_ENTITY = GoalKey.of(Mob.class, NamespacedKey.minecraft("follow_entity"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<SkeletonHorse> HORSE_TRAP = GoalKey.of(SkeletonHorse.class, NamespacedKey.minecraft("horse_trap"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> HURT_BY_TARGET = GoalKey.of(Creature.class, NamespacedKey.minecraft("hurt_by_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Cat> JUMP_ON_BLOCK = GoalKey.of(Cat.class, NamespacedKey.minecraft("jump_on_block"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Mob> LEAP_AT_TARGET = GoalKey.of(Mob.class, NamespacedKey.minecraft("leap_at_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Llama> LLAMA_FOLLOW = GoalKey.of(Llama.class, NamespacedKey.minecraft("llama_follow"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> MOVE_TOWARDS_TARGET = GoalKey.of(Creature.class, NamespacedKey.minecraft("move_towards_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Mob> NEAREST_ATTACKABLE_TARGET = GoalKey.of(Mob.class, NamespacedKey.minecraft("nearest_attackable_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Raider> NEAREST_ATTACKABLE_TARGET_WITCH = GoalKey.of(Raider.class, NamespacedKey.minecraft("nearest_attackable_target_witch"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> NEAREST_VILLAGE = GoalKey.of(Creature.class, NamespacedKey.minecraft("nearest_village"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Tameable> OWNER_HURT_BY_TARGET = GoalKey.of(Tameable.class, NamespacedKey.minecraft("owner_hurt_by_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Tameable> OWNER_HURT_TARGET = GoalKey.of(Tameable.class, NamespacedKey.minecraft("owner_hurt_target"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Parrot> PERCH = GoalKey.of(Parrot.class, NamespacedKey.minecraft("perch"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Raider> RAID = GoalKey.of(Raider.class, NamespacedKey.minecraft("raid"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> RANDOM_FLY = GoalKey.of(Creature.class, NamespacedKey.minecraft("random_fly"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Mob> RANDOM_LOOKAROUND = GoalKey.of(Mob.class, NamespacedKey.minecraft("random_lookaround"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> RANDOM_STROLL_LAND = GoalKey.of(Creature.class, NamespacedKey.minecraft("random_stroll_land"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> RANDOM_SWIM = GoalKey.of(Creature.class, NamespacedKey.minecraft("random_swim"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Tameable> RANDOM_TARGET_NON_TAMED = GoalKey.of(Tameable.class, NamespacedKey.minecraft("random_target_non_tamed"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Tameable> SIT = GoalKey.of(Tameable.class, NamespacedKey.minecraft("sit"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> STROLL_VILLAGE = GoalKey.of(Creature.class, NamespacedKey.minecraft("stroll_village"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<AbstractHorse> TAME = GoalKey.of(AbstractHorse.class, NamespacedKey.minecraft("tame"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> WATER = GoalKey.of(Creature.class, NamespacedKey.minecraft("water"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Dolphin> WATER_JUMP = GoalKey.of(Dolphin.class, NamespacedKey.minecraft("water_jump"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Creature> STROLL_VILLAGE_GOLEM = GoalKey.of(Creature.class, NamespacedKey.minecraft("stroll_village_golem"));
++    @Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21") GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
 index e1a9a0ec6036133aa8fb195d22611df221bf5661..ce409a88b1f7fc519b2d7795005752b4349e4176 100644

--- a/patches/api/0247-Add-StructuresLocateEvent.patch
+++ b/patches/api/0247-Add-StructuresLocateEvent.patch
@@ -7,10 +7,10 @@ Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/event/world/StructureLocateEvent.java b/src/main/java/io/papermc/paper/event/world/StructureLocateEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0c83a02059d65672ff191c42932d850950e9ea00
+index 0000000000000000000000000000000000000000..679677cf6a889ee23822b728b882e741c500df81
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/world/StructureLocateEvent.java
-@@ -0,0 +1,157 @@
+@@ -0,0 +1,158 @@
 +package io.papermc.paper.event.world;
 +
 +import org.bukkit.Location;
@@ -19,6 +19,7 @@ index 0000000000000000000000000000000000000000..0c83a02059d65672ff191c42932d8509
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.world.WorldEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -33,7 +34,7 @@ index 0000000000000000000000000000000000000000..0c83a02059d65672ff191c42932d8509
 + * </ul>
 + * @deprecated no longer used, see {@link StructuresLocateEvent}
 + */
-+@Deprecated(forRemoval = true)
++@Deprecated(forRemoval = true) @ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public class StructureLocateEvent extends WorldEvent implements Cancellable {
 +    private static final HandlerList handlers = new HandlerList();
 +    private final Location origin;
@@ -386,10 +387,10 @@ index 0000000000000000000000000000000000000000..4342b162f69b6509503e9772ddd2c5ac
 +}
 diff --git a/src/main/java/io/papermc/paper/world/structure/ConfiguredStructure.java b/src/main/java/io/papermc/paper/world/structure/ConfiguredStructure.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b9a98f3c89cf847afd510bd1588d3a6d4b7eac0e
+index 0000000000000000000000000000000000000000..1e7b53f9bc13dcd5a0a4a40004591e4f850496a0
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/world/structure/ConfiguredStructure.java
-@@ -0,0 +1,112 @@
+@@ -0,0 +1,113 @@
 +package io.papermc.paper.world.structure;
 +
 +import io.papermc.paper.registry.Reference;
@@ -410,6 +411,7 @@ index 0000000000000000000000000000000000000000..b9a98f3c89cf847afd510bd1588d3a6d
 + * @deprecated use {@link Structure}
 + */
 +@Deprecated(forRemoval = true)
++@ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +public final class ConfiguredStructure implements Keyed {
 +
 +    public static final Reference<ConfiguredStructure> PILLAGER_OUTPOST = create("pillager_outpost");
@@ -503,7 +505,7 @@ index 0000000000000000000000000000000000000000..b9a98f3c89cf847afd510bd1588d3a6d
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 4a3c42f9c480c53f935d09bcc3656259c755661d..39c13a459dede4992f5a3fa7309733820cfa44c5 100644
+index 1976ed42f255825d1eaf2ee2c9465d22e81abdb3..e22233eed3eb9b6aaf835d682d13450d1ba5e8af 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
 @@ -230,6 +230,15 @@ public interface Registry<T extends Keyed> extends Iterable<T> {

--- a/patches/api/0258-Add-missing-effects.patch
+++ b/patches/api/0258-Add-missing-effects.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add missing effects
 
 
 diff --git a/src/main/java/org/bukkit/Effect.java b/src/main/java/org/bukkit/Effect.java
-index 879d637691683ca862045402f74b751a892bf3ff..e6573b8bd45e0d3ae4f46d64996fa67f13d29f2b 100644
+index 879d637691683ca862045402f74b751a892bf3ff..3ae64e7e42338a2a550917ccd01d755a1ba0bf03 100644
 --- a/src/main/java/org/bukkit/Effect.java
 +++ b/src/main/java/org/bukkit/Effect.java
 @@ -337,7 +337,100 @@ public enum Effect {
@@ -30,42 +30,42 @@ index 879d637691683ca862045402f74b751a892bf3ff..e6573b8bd45e0d3ae4f46d64996fa67f
 +     *
 +     * @deprecated use {@link #PHANTOM_BITE}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    PHANTOM_BITES(1039, Type.SOUND),
 +    /**
 +     * The sound of zombie converting to drowned zombie
 +     *
 +     * @deprecated use {@link #ZOMBIE_CONVERTED_TO_DROWNED}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    ZOMBIE_CONVERTS_TO_DROWNED(1040, Type.SOUND),
 +    /**
 +     * The sound of a husk converting to zombie by drowning
 +     *
 +     * @deprecated use {@link #HUSK_CONVERTED_TO_ZOMBIE}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    HUSK_CONVERTS_TO_ZOMBIE(1041, Type.SOUND),
 +    /**
 +     * The sound of a grindstone being used
 +     *
 +     * @deprecated use {@link #GRINDSTONE_USE}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    GRINDSTONE_USED(1042, Type.SOUND),
 +    /**
 +     * The sound of a book page being turned
 +     *
 +     * @deprecated use {@link #BOOK_PAGE_TURN}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    BOOK_PAGE_TURNED(1043, Type.SOUND),
 +    /**
 +     * Particles displayed when a composter composts
 +     *
 +     * @deprecated use {@link #COMPOSTER_FILL_ATTEMPT}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    COMPOSTER_COMPOSTS(1500, Type.VISUAL),
 +    /**
 +     * Particles displayed when lava converts a block (either water to stone, or
@@ -73,35 +73,35 @@ index 879d637691683ca862045402f74b751a892bf3ff..e6573b8bd45e0d3ae4f46d64996fa67f
 +     *
 +     * @deprecated use {@link #LAVA_INTERACT}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    LAVA_CONVERTS_BLOCK(1501, Type.VISUAL),
 +    /**
 +     * Particles displayd when a redstone torch burns out
 +     *
 +     * @deprecated use {@link #REDSTONE_TORCH_BURNOUT}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    REDSTONE_TORCH_BURNS_OUT(1502, Type.VISUAL),
 +    /**
 +     * Particles displayed when an ender eye is placed
 +     *
 +     * @deprecated use {@link #END_PORTAL_FRAME_FILL}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    ENDER_EYE_PLACED(1503, Type.VISUAL),
 +    /**
 +     * Particles displayed when an ender dragon destroys block
 +     *
 +     * @deprecated use {@link #ENDER_DRAGON_DESTROY_BLOCK}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    ENDER_DRAGON_DESTROYS_BLOCK(2008, Type.VISUAL),
 +    /**
 +     * Particles displayed when a wet sponge vaporizes in nether.
 +     *
 +     * @deprecated use {@link #SPONGE_DRY}
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    WET_SPONGE_VAPORIZES_IN_NETHER(2009, Type.VISUAL),
      ;
 +    private static final org.apache.logging.log4j.Logger LOGGER = org.apache.logging.log4j.LogManager.getLogger();

--- a/patches/api/0272-More-World-API.patch
+++ b/patches/api/0272-More-World-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 530d656aa5573c9783d07de23379657fe0c7cae5..ecf900140d0007b4e69ab8ab0e439828ee718a6b 100644
+index 1ae0e12125421fd0c36fcfb82ccbb994578415d9..0fa6f8e99059b26861bc5bb3505ac544587e51bc 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -3698,6 +3698,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -49,7 +49,7 @@ index 530d656aa5573c9783d07de23379657fe0c7cae5..ecf900140d0007b4e69ab8ab0e439828
 +     * @return true if ultrawarm, false if not
 +     * @deprecated use {@link #isUltraWarm()}
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    boolean isUltrawarm();
 +
 +    /**
@@ -65,7 +65,7 @@ index 530d656aa5573c9783d07de23379657fe0c7cae5..ecf900140d0007b4e69ab8ab0e439828
 +     * @return whether there is skylight
 +     * @deprecated use {@link #hasSkyLight()}
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    boolean hasSkylight();
 +
 +    /**
@@ -74,7 +74,7 @@ index 530d656aa5573c9783d07de23379657fe0c7cae5..ecf900140d0007b4e69ab8ab0e439828
 +     * @return whether the world has a bedrock ceiling
 +     * @deprecated use {@link #hasCeiling()}
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    boolean hasBedrockCeiling();
 +
 +    /**
@@ -83,7 +83,7 @@ index 530d656aa5573c9783d07de23379657fe0c7cae5..ecf900140d0007b4e69ab8ab0e439828
 +     * @return whether beds work
 +     * @deprecated use {@link #isBedWorks()}
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    boolean doesBedWork();
 +
 +    /**
@@ -92,7 +92,7 @@ index 530d656aa5573c9783d07de23379657fe0c7cae5..ecf900140d0007b4e69ab8ab0e439828
 +     * @return whether respawn anchors work
 +     * @deprecated use {@link #isRespawnAnchorWorks()}
 +     */
-+    @Deprecated
++    @Deprecated(forRemoval = true) @org.jetbrains.annotations.ApiStatus.ScheduledForRemoval(inVersion = "1.21")
 +    boolean doesRespawnAnchorWork();
 +
 +    /**

--- a/patches/api/0300-Missing-Entity-Behavior-API.patch
+++ b/patches/api/0300-Missing-Entity-Behavior-API.patch
@@ -10,10 +10,10 @@ Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 Co-authored-by: booky10 <boooky10@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java b/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
-index dddbb661265aa23f88d93d0681f418f40a872351..998f629852e1103767e005405d1f39c2251ecd28 100644
+index 9dc131ac6f6990d2a9997609c1d8f104dbfb2aef..e67eac34839c7a471b85ccd09cab741a3cdae024 100644
 --- a/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
 +++ b/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
-@@ -23,7 +23,7 @@ public interface VanillaGoal<T extends Mob> extends Goal<T> {
+@@ -24,7 +24,7 @@ public interface VanillaGoal<T extends Mob> extends Goal<T> {
      GoalKey<Creature> FLEE_SUN = GoalKey.of(Creature.class, NamespacedKey.minecraft("flee_sun"));
      GoalKey<Mob> FLOAT = GoalKey.of(Mob.class, NamespacedKey.minecraft("float"));
      GoalKey<Creature> FOLLOW_BOAT = GoalKey.of(Creature.class, NamespacedKey.minecraft("follow_boat"));


### PR DESCRIPTION
The items marked for removal in 1.21 have either been deprecated for almost 2 years or didn't exist for that long.

* [AsyncChatDecorateEvent#isPreview()](https://jd.papermc.io/paper/1.19/io/papermc/paper/event/player/AsyncChatDecorateEvent.html#isPreview())
* [PlayerLocaleChangeEvent](https://jd.papermc.io/paper/1.19/com/destroystokyo/paper/event/player/PlayerLocaleChangeEvent.html)
* [PlayerInitialSpawnEvent](https://jd.papermc.io/paper/1.19/com/destroystokyo/paper/event/player/PlayerInitialSpawnEvent.html)
* [WorldBorder#isInBounds(Location)](https://jd.papermc.io/paper/1.19/org/bukkit/WorldBorder.html#isInBounds(org.bukkit.Location))
* [EntityTransformedEvent](https://jd.papermc.io/paper/1.19/com/destroystokyo/paper/event/entity/EntityTransformedEvent.html)
* [ItemStackRecipeChoice](https://jd.papermc.io/paper/1.19/com/destroystokyo/paper/inventory/ItemStackRecipeChoice.html)
* [HeightmapType](https://jd.papermc.io/paper/1.19/com/destroystokyo/paper/HeightmapType.html)
	* All associated methods in `Location` and `World`
* All deprecated or removed `GoalKey`s in [VanillaGoal](https://jd.papermc.io/paper/1.19/com/destroystokyo/paper/entity/ai/VanillaGoal.html)
* [StructureLocateEvent](https://jd.papermc.io/paper/1.19/io/papermc/paper/event/world/StructureLocateEvent.html) (not StructuresLocateEvent, different things)
* Duplicate `Effect`s.
* World API
	* [World#hasSkylight()](https://jd.papermc.io/paper/1.19/org/bukkit/World.html#hasSkylight())
	* [World#hasBedrockCeiling()](https://jd.papermc.io/paper/1.19/org/bukkit/World.html#hasBedrockCeiling())
	* [World#doesBedWork()](https://jd.papermc.io/paper/1.19/org/bukkit/World.html#doesBedWork())
	* [World#doesRespawnAnchorWork()](https://jd.papermc.io/paper/1.19/org/bukkit/World.html#doesRespawnAnchorWork())