### PR TITLE
Don't use UnsafeValues for valid API

### DIFF
--- a/patches/api/0005-Paper-Utils.patch
+++ b/patches/api/0005-Paper-Utils.patch
@@ -3,6 +3,7 @@ From: Aikar <aikar@aikar.co>
 Date: Sat, 23 Feb 2019 11:26:21 -0500
 Subject: [PATCH] Paper Utils
 
+Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/util/SneakyThrow.java b/src/main/java/com/destroystokyo/paper/util/SneakyThrow.java
 new file mode 100644
@@ -25,4 +26,24 @@ index 0000000000000000000000000000000000000000..9db0056ab94145819628b3ad8d8d2613
 +        throw (T) exception;
 +    }
 +
++}
+diff --git a/src/main/java/io/papermc/paper/APIBridge.java b/src/main/java/io/papermc/paper/APIBridge.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..3ee5a8ce663d19b39666efb759c35139cb6cce7e
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/APIBridge.java
+@@ -0,0 +1,14 @@
++package io.papermc.paper;
++
++import net.kyori.adventure.util.Services;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
++import org.jetbrains.annotations.ApiStatus;
++
++@ApiStatus.Internal
++@DefaultQualifier(NonNull.class)
++public interface APIBridge {
++
++    @ApiStatus.Internal
++    APIBridge INSTANCE = Services.service(APIBridge.class).orElseThrow();
 +}

--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -76,6 +76,33 @@ index 464a209dbf52ebdfa287a553778a37c382a5405c..b7aa72ae9a8b1f39e7bb355d4c6b3bf4
      // workaround for https://github.com/gradle/gradle/issues/4046
      inputs.dir("src/main/javadoc").withPropertyName("javadoc-sourceset")
      doLast {
+diff --git a/src/main/java/io/papermc/paper/APIBridge.java b/src/main/java/io/papermc/paper/APIBridge.java
+index 3ee5a8ce663d19b39666efb759c35139cb6cce7e..53094557454adfc80bed45ae02e49dcf372ce3a3 100644
+--- a/src/main/java/io/papermc/paper/APIBridge.java
++++ b/src/main/java/io/papermc/paper/APIBridge.java
+@@ -1,7 +1,13 @@
+ package io.papermc.paper;
+ 
++import java.io.IOException;
++import net.kyori.adventure.text.Component;
++import net.kyori.adventure.text.flattener.ComponentFlattener;
+ import net.kyori.adventure.util.Services;
++import org.bukkit.command.CommandSender;
++import org.bukkit.entity.Entity;
+ import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.checker.nullness.qual.Nullable;
+ import org.checkerframework.framework.qual.DefaultQualifier;
+ import org.jetbrains.annotations.ApiStatus;
+ 
+@@ -11,4 +17,8 @@ public interface APIBridge {
+ 
+     @ApiStatus.Internal
+     APIBridge INSTANCE = Services.service(APIBridge.class).orElseThrow();
++
++    ComponentFlattener componentFlattener();
++
++    Component resolveWithContext(Component component, @Nullable CommandSender context, @Nullable Entity scoreboardSubject, boolean bypassPermissions) throws IOException;
+ }
 diff --git a/src/main/java/io/papermc/paper/chat/ChatRenderer.java b/src/main/java/io/papermc/paper/chat/ChatRenderer.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..ffe0a921cc1ebbb95104f22b57e0e3af85e287a6
@@ -567,12 +594,13 @@ index 0000000000000000000000000000000000000000..46c209f61135c7d37ccfbbc7bb1d74e6
 +}
 diff --git a/src/main/java/io/papermc/paper/text/PaperComponents.java b/src/main/java/io/papermc/paper/text/PaperComponents.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f12a2e6e06
+index 0000000000000000000000000000000000000000..829750046f376e893cb81868472f310335c47d07
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/text/PaperComponents.java
-@@ -0,0 +1,177 @@
+@@ -0,0 +1,178 @@
 +package io.papermc.paper.text;
 +
++import io.papermc.paper.APIBridge;
 +import net.kyori.adventure.text.Component;
 +import net.kyori.adventure.text.flattener.ComponentFlattener;
 +import net.kyori.adventure.text.format.NamedTextColor;
@@ -653,7 +681,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     * @throws IOException if a syntax error tripped during resolving
 +     */
 +    public static @NotNull Component resolveWithContext(@NotNull Component input, @Nullable CommandSender context, @Nullable Entity scoreboardSubject, boolean bypassPermissions) throws IOException {
-+        return Bukkit.getUnsafe().resolveWithContext(input, context, scoreboardSubject, bypassPermissions);
++        return APIBridge.INSTANCE.resolveWithContext(input, context, scoreboardSubject, bypassPermissions);
 +    }
 +
 +    /**
@@ -662,7 +690,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     * @return a component flattener
 +     */
 +    public static @NotNull ComponentFlattener flattener() {
-+        return Bukkit.getUnsafe().componentFlattener();
++        return APIBridge.INSTANCE.componentFlattener();
 +    }
 +
 +    /**
@@ -692,7 +720,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     */
 +    @Deprecated(forRemoval = true)
 +    public static @NotNull PlainTextComponentSerializer plainTextSerializer() {
-+        return Bukkit.getUnsafe().plainTextSerializer();
++        return PlainTextComponentSerializer.plainText();
 +    }
 +
 +    /**
@@ -708,7 +736,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     */
 +    @Deprecated(forRemoval = true)
 +    public static @NotNull GsonComponentSerializer gsonSerializer() {
-+        return Bukkit.getUnsafe().gsonComponentSerializer();
++        return GsonComponentSerializer.gson();
 +    }
 +
 +    /**
@@ -725,7 +753,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     */
 +    @Deprecated(forRemoval = true)
 +    public static @NotNull GsonComponentSerializer colorDownsamplingGsonSerializer() {
-+        return Bukkit.getUnsafe().colorDownsamplingGsonComponentSerializer();
++        return GsonComponentSerializer.colorDownsamplingGson();
 +    }
 +
 +    /**
@@ -745,7 +773,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +     */
 +    @Deprecated(forRemoval = true)
 +    public static @NotNull LegacyComponentSerializer legacySectionSerializer() {
-+        return Bukkit.getUnsafe().legacyComponentSerializer();
++        return LegacyComponentSerializer.legacySection();
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
@@ -1413,21 +1441,15 @@ index ac5e263d737973af077e3406a84a84baca4370db..2d91924b7f5ef16a91d40cdc1bfc3d68
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index ba69db36a2a7640fc2a63a1d9fd1b204e00d7ce7..876072a6c91bd02c9c7de53556419b8e1ac48f27 100644
+index ba69db36a2a7640fc2a63a1d9fd1b204e00d7ce7..704c568e234578f39e8d6ceb6dd3115e50d98234 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -23,6 +23,15 @@ import org.bukkit.plugin.PluginDescriptionFile;
+@@ -23,6 +23,9 @@ import org.bukkit.plugin.PluginDescriptionFile;
   */
  @Deprecated
  public interface UnsafeValues {
 +    // Paper start
-+    net.kyori.adventure.text.flattener.ComponentFlattener componentFlattener();
 +    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.plain.PlainComponentSerializer plainComponentSerializer();
-+    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer plainTextSerializer();
-+    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.gson.GsonComponentSerializer gsonComponentSerializer();
-+    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.gson.GsonComponentSerializer colorDownsamplingGsonComponentSerializer();
-+    @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer legacyComponentSerializer();
-+    net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject, boolean bypassPermissions) throws java.io.IOException;
 +    // Paper end
  
      Material toLegacy(Material material);

--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -1310,10 +1310,10 @@ index 0000000000000000000000000000000000000000..6bf3d212a6156ad9ab0e82d1ca0a04f8
 +
 +}
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 876072a6c91bd02c9c7de53556419b8e1ac48f27..dc9a4f12d9f05a3ae7c9f1c7648123e4b3dfd115 100644
+index 704c568e234578f39e8d6ceb6dd3115e50d98234..8f50b31ae2da4ec4e3ae871fd3062d7e8f857898 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -96,4 +96,14 @@ public interface UnsafeValues {
+@@ -90,4 +90,14 @@ public interface UnsafeValues {
      String getTranslationKey(EntityType entityType);
  
      String getTranslationKey(ItemStack itemStack);

--- a/patches/api/0010-Timings-v2.patch
+++ b/patches/api/0010-Timings-v2.patch
@@ -2790,6 +2790,17 @@ index 0000000000000000000000000000000000000000..5989ee21297935651b0edd44b8239e65
 +        return new MRUMapCache<K, V>(map);
 +    }
 +}
+diff --git a/src/main/java/io/papermc/paper/APIBridge.java b/src/main/java/io/papermc/paper/APIBridge.java
+index 53094557454adfc80bed45ae02e49dcf372ce3a3..c695fbe99126f53915e09b7e6df9d16c4498d127 100644
+--- a/src/main/java/io/papermc/paper/APIBridge.java
++++ b/src/main/java/io/papermc/paper/APIBridge.java
+@@ -21,4 +21,6 @@ public interface APIBridge {
+     ComponentFlattener componentFlattener();
+ 
+     Component resolveWithContext(Component component, @Nullable CommandSender context, @Nullable Entity scoreboardSubject, boolean bypassPermissions) throws IOException;
++
++    String getTimingsServerName();
+ }
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
 index 16ec0cd908659d6d53e565281b8db9f81951277d..92b3c40959eac827ed8861fec8658e57f2910628 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
@@ -2834,30 +2845,17 @@ index 0a333c1439b3623d38029b88ce6d5ff159ae1ddd..bce277cd3a452769cd86dc017a2e548a
           * Sends the component to the player
           *
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index dc9a4f12d9f05a3ae7c9f1c7648123e4b3dfd115..daf3ac72cae4d19c0273058dc6a1e1afe9a47f77 100644
+index 8f50b31ae2da4ec4e3ae871fd3062d7e8f857898..49f49bd83b8e9dfa62df59ea90e0155fad6202d0 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -33,6 +33,7 @@ public interface UnsafeValues {
-     net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject, boolean bypassPermissions) throws java.io.IOException;
+@@ -27,6 +27,7 @@ public interface UnsafeValues {
+     @Deprecated(forRemoval = true) net.kyori.adventure.text.serializer.plain.PlainComponentSerializer plainComponentSerializer();
      // Paper end
  
 +    void reportTimings(); // Paper
      Material toLegacy(Material material);
  
      Material fromLegacy(Material material);
-@@ -106,4 +107,12 @@ public interface UnsafeValues {
-         return !Bukkit.getUnsafe().isSupportedApiVersion(plugin.getDescription().getAPIVersion());
-     }
-     // Paper end
-+
-+    // Paper start
-+    /**
-+     * Server name to report to timings v2
-+     * @return name
-+     */
-+    String getTimingsServerName();
-+    // Paper end
- }
 diff --git a/src/main/java/org/bukkit/command/BufferedCommandSender.java b/src/main/java/org/bukkit/command/BufferedCommandSender.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..f9a00aecca5ec41b460bf41dfe1c69694768cf98

--- a/patches/api/0014-Version-Command-2.0.patch
+++ b/patches/api/0014-Version-Command-2.0.patch
@@ -55,25 +55,28 @@ index 0000000000000000000000000000000000000000..a736d7bcdc5861a01b66ba36158db1c7
 +        }
 +    }
 +}
-diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index daf3ac72cae4d19c0273058dc6a1e1afe9a47f77..24fad8e59a3a5a174d24505cedda2a3fd52115b1 100644
---- a/src/main/java/org/bukkit/UnsafeValues.java
-+++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -114,5 +114,12 @@ public interface UnsafeValues {
-      * @return name
-      */
+diff --git a/src/main/java/io/papermc/paper/APIBridge.java b/src/main/java/io/papermc/paper/APIBridge.java
+index c695fbe99126f53915e09b7e6df9d16c4498d127..55f69f262b4c3b4c5d9e60683a52218976108822 100644
+--- a/src/main/java/io/papermc/paper/APIBridge.java
++++ b/src/main/java/io/papermc/paper/APIBridge.java
+@@ -1,5 +1,6 @@
+ package io.papermc.paper;
+ 
++import com.destroystokyo.paper.util.VersionFetcher;
+ import java.io.IOException;
+ import net.kyori.adventure.text.Component;
+ import net.kyori.adventure.text.flattener.ComponentFlattener;
+@@ -23,4 +24,8 @@ public interface APIBridge {
+     Component resolveWithContext(Component component, @Nullable CommandSender context, @Nullable Entity scoreboardSubject, boolean bypassPermissions) throws IOException;
+ 
      String getTimingsServerName();
 +
-+    /**
-+     * Called once by the version command on first use, then cached.
-+     */
-+    default com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {
-+        return new com.destroystokyo.paper.util.VersionFetcher.DummyVersionFetcher();
++    default VersionFetcher getVersionFetcher() {
++        return new VersionFetcher.DummyVersionFetcher();
 +    }
-     // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/defaults/VersionCommand.java b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
-index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..b50f614806f4634960d383e8a33f094c2f46935f 100644
+index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..fe74e8bc5fa694ceb1d2275a3db67c7e4783e31f 100644
 --- a/src/main/java/org/bukkit/command/defaults/VersionCommand.java
 +++ b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
 @@ -1,5 +1,6 @@
@@ -90,7 +93,7 @@ index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..b50f614806f4634960d383e8a33f094c
 +    private VersionFetcher versionFetcher;
 +    private VersionFetcher getVersionFetcher() { // lazy load because unsafe isn't available at command registration
 +        if (versionFetcher == null) {
-+            versionFetcher = Bukkit.getUnsafe().getVersionFetcher();
++            versionFetcher = io.papermc.paper.APIBridge.INSTANCE.getVersionFetcher();
 +        }
 +
 +        return versionFetcher;

--- a/patches/api/0188-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/api/0188-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -5,22 +5,29 @@ Subject: [PATCH] Add Raw Byte ItemStack Serialization
 
 Serializes using NBT which is safer for server data migrations than bukkits format.
 
-diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 24fad8e59a3a5a174d24505cedda2a3fd52115b1..ee9ed5f0e2936c740903784b01b9e2fff75b92f8 100644
---- a/src/main/java/org/bukkit/UnsafeValues.java
-+++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -121,5 +121,9 @@ public interface UnsafeValues {
-     default com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {
-         return new com.destroystokyo.paper.util.VersionFetcher.DummyVersionFetcher();
+diff --git a/src/main/java/io/papermc/paper/APIBridge.java b/src/main/java/io/papermc/paper/APIBridge.java
+index 55f69f262b4c3b4c5d9e60683a52218976108822..afa9664911825ac0b03055074014236a1b522b6a 100644
+--- a/src/main/java/io/papermc/paper/APIBridge.java
++++ b/src/main/java/io/papermc/paper/APIBridge.java
+@@ -7,6 +7,7 @@ import net.kyori.adventure.text.flattener.ComponentFlattener;
+ import net.kyori.adventure.util.Services;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.entity.Entity;
++import org.bukkit.inventory.ItemStack;
+ import org.checkerframework.checker.nullness.qual.NonNull;
+ import org.checkerframework.checker.nullness.qual.Nullable;
+ import org.checkerframework.framework.qual.DefaultQualifier;
+@@ -28,4 +29,8 @@ public interface APIBridge {
+     default VersionFetcher getVersionFetcher() {
+         return new VersionFetcher.DummyVersionFetcher();
      }
 +
 +    byte[] serializeItem(ItemStack item);
 +
 +    ItemStack deserializeItem(byte[] data);
-     // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index b15645cd56c245214bb5b87b36395fbc8e86e3d3..7c280d7beeb42dca52e36e77bbd41742b2572710 100644
+index 3edb648e056c1434d6ecf8466dd21728a71b1314..1b83c240889ef02759c2550786331d607f3ace8d 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -639,6 +639,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
@@ -38,7 +45,7 @@ index b15645cd56c245214bb5b87b36395fbc8e86e3d3..7c280d7beeb42dca52e36e77bbd41742
 +     */
 +    @NotNull
 +    public static ItemStack deserializeBytes(@NotNull byte[] bytes) {
-+        return org.bukkit.Bukkit.getUnsafe().deserializeItem(bytes);
++        return io.papermc.paper.APIBridge.INSTANCE.deserializeItem(bytes);
 +    }
 +
 +    /**
@@ -48,7 +55,7 @@ index b15645cd56c245214bb5b87b36395fbc8e86e3d3..7c280d7beeb42dca52e36e77bbd41742
 +     */
 +    @NotNull
 +    public byte[] serializeAsBytes() {
-+        return org.bukkit.Bukkit.getUnsafe().serializeItem(this);
++        return io.papermc.paper.APIBridge.INSTANCE.serializeItem(this);
 +    }
 +
      /**

--- a/patches/api/0215-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/api/0215-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,19 +6,20 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index ee9ed5f0e2936c740903784b01b9e2fff75b92f8..1f89a3c1c3b73a939c2653102fc1dc8b630672a8 100644
+index 49f49bd83b8e9dfa62df59ea90e0155fad6202d0..5b53521b255cbca4f8e4886c052acbc150513173 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -125,5 +125,12 @@ public interface UnsafeValues {
-     byte[] serializeItem(ItemStack item);
- 
-     ItemStack deserializeItem(byte[] data);
+@@ -101,4 +101,13 @@ public interface UnsafeValues {
+         return !Bukkit.getUnsafe().isSupportedApiVersion(plugin.getDescription().getAPIVersion());
+     }
+     // Paper end
 +
++    // Paper start
 +    /**
 +     * Creates and returns the next EntityId available.
 +     * <p>
 +     * Use this when sending custom packets, so that there are no collisions on the client or server.
 +     */
-+    public int nextEntityId();
-     // Paper end
++    int nextEntityId();
++    // Paper end
  }

--- a/patches/api/0267-Expand-world-key-API.patch
+++ b/patches/api/0267-Expand-world-key-API.patch
@@ -4,6 +4,17 @@ Date: Wed, 6 Jan 2021 00:34:10 -0800
 Subject: [PATCH] Expand world key API
 
 
+diff --git a/src/main/java/io/papermc/paper/APIBridge.java b/src/main/java/io/papermc/paper/APIBridge.java
+index afa9664911825ac0b03055074014236a1b522b6a..672cb1cae3a2a4a09a79cfe83b9e393ffe283502 100644
+--- a/src/main/java/io/papermc/paper/APIBridge.java
++++ b/src/main/java/io/papermc/paper/APIBridge.java
+@@ -33,4 +33,6 @@ public interface APIBridge {
+     byte[] serializeItem(ItemStack item);
+ 
+     ItemStack deserializeItem(byte[] data);
++
++    String getMainLevelName();
+ }
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
 index 95a981218615b9ed167a317aaa5224e9613aa42a..244c836dd24cb49f6219634e3f323befcd68d9da 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
@@ -77,23 +88,8 @@ index 3327810c2ae80b47f6ccbc5b2034b880a774879f..8390b1d4718a4c67d222e19609462d20
      /**
       * Create a new virtual {@link WorldBorder}.
       * <p>
-diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 1f89a3c1c3b73a939c2653102fc1dc8b630672a8..6c45841538f2f073691331f975741a62b03a6637 100644
---- a/src/main/java/org/bukkit/UnsafeValues.java
-+++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -132,5 +132,10 @@ public interface UnsafeValues {
-      * Use this when sending custom packets, so that there are no collisions on the client or server.
-      */
-     public int nextEntityId();
-+
-+    /**
-+     * Just don't use it.
-+     */
-+    @org.jetbrains.annotations.NotNull String getMainLevelName();
-     // Paper end
- }
 diff --git a/src/main/java/org/bukkit/WorldCreator.java b/src/main/java/org/bukkit/WorldCreator.java
-index cbe6b3a1ba7b04826d97c3558e8eb4e5ba11f92f..cbdcac688afb7c13dd7058fa522bbd2c5adc445e 100644
+index cbe6b3a1ba7b04826d97c3558e8eb4e5ba11f92f..9a14f36da0c1c35110b2bd8763bc8139801c138d 100644
 --- a/src/main/java/org/bukkit/WorldCreator.java
 +++ b/src/main/java/org/bukkit/WorldCreator.java
 @@ -12,6 +12,7 @@ import org.jetbrains.annotations.Nullable;
@@ -115,7 +111,7 @@ index cbe6b3a1ba7b04826d97c3558e8eb4e5ba11f92f..cbdcac688afb7c13dd7058fa522bbd2c
 +    }
 +
 +    private static NamespacedKey getWorldKey(String name) {
-+        final String mainLevelName = Bukkit.getUnsafe().getMainLevelName();
++        final String mainLevelName = io.papermc.paper.APIBridge.INSTANCE.getMainLevelName();
 +        if (name.equals(mainLevelName)) {
 +            return NamespacedKey.minecraft("overworld");
 +        } else if (name.equals(mainLevelName + "_nether")) {

--- a/patches/api/0268-Item-Rarity-API.patch
+++ b/patches/api/0268-Item-Rarity-API.patch
@@ -4,9 +4,35 @@ Date: Fri, 12 Mar 2021 17:09:40 -0800
 Subject: [PATCH] Item Rarity API
 
 
+diff --git a/src/main/java/io/papermc/paper/APIBridge.java b/src/main/java/io/papermc/paper/APIBridge.java
+index 672cb1cae3a2a4a09a79cfe83b9e393ffe283502..66c2841b12e765f0b45bcfdbca6c4b58d3eef218 100644
+--- a/src/main/java/io/papermc/paper/APIBridge.java
++++ b/src/main/java/io/papermc/paper/APIBridge.java
+@@ -1,10 +1,12 @@
+ package io.papermc.paper;
+ 
+ import com.destroystokyo.paper.util.VersionFetcher;
++import io.papermc.paper.inventory.ItemRarity;
+ import java.io.IOException;
+ import net.kyori.adventure.text.Component;
+ import net.kyori.adventure.text.flattener.ComponentFlattener;
+ import net.kyori.adventure.util.Services;
++import org.bukkit.Material;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.inventory.ItemStack;
+@@ -35,4 +37,8 @@ public interface APIBridge {
+     ItemStack deserializeItem(byte[] data);
+ 
+     String getMainLevelName();
++
++    ItemRarity getItemRarity(Material material);
++
++    ItemRarity getItemStackRarity(ItemStack itemStack);
+ }
 diff --git a/src/main/java/io/papermc/paper/inventory/ItemRarity.java b/src/main/java/io/papermc/paper/inventory/ItemRarity.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..74ef8395cc040ce488c2acaa416db20272cc2734
+index 0000000000000000000000000000000000000000..7d6cd7812bb70226d88250ffbba57b811bf90cf4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/inventory/ItemRarity.java
 @@ -0,0 +1,28 @@
@@ -23,7 +49,7 @@ index 0000000000000000000000000000000000000000..74ef8395cc040ce488c2acaa416db202
 +    RARE(NamedTextColor.AQUA),
 +    EPIC(NamedTextColor.LIGHT_PURPLE);
 +
-+    TextColor color;
++    final TextColor color;
 +
 +    ItemRarity(TextColor color) {
 +        this.color = color;
@@ -31,18 +57,18 @@ index 0000000000000000000000000000000000000000..74ef8395cc040ce488c2acaa416db202
 +
 +    /**
 +     * Gets the color formatting associated with the rarity.
-+     * @return
++     *
++     * @return the rarity color
 +     */
-+    @NotNull
-+    public TextColor getColor() {
-+        return color;
++    public @NotNull TextColor getColor() {
++        return this.color;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index f0f81ecad42fc3dc894ec0c150346206d70a8720..467282a76dbf2edfd88baa4275991ae1163c0919 100644
+index f0f81ecad42fc3dc894ec0c150346206d70a8720..1ef51b3f4cd716dd24a882d6fc30c80db5796777 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
-@@ -4414,6 +4414,17 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+@@ -4414,6 +4414,16 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
              return Bukkit.getUnsafe().getBlockTranslationKey(this);
          }
      }
@@ -53,57 +79,28 @@ index f0f81ecad42fc3dc894ec0c150346206d70a8720..467282a76dbf2edfd88baa4275991ae1
 +     *
 +     * @return the item rarity
 +     */
-+    @NotNull
-+    public io.papermc.paper.inventory.ItemRarity getItemRarity() {
-+        return Bukkit.getUnsafe().getItemRarity(this);
++    public @NotNull io.papermc.paper.inventory.ItemRarity getItemRarity() {
++        return io.papermc.paper.APIBridge.INSTANCE.getItemRarity(this);
 +    }
      // Paper end
  
      /**
-diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 6c45841538f2f073691331f975741a62b03a6637..e87cbaf9c1ea1330ab1597f98c8864d0c5b8bdcd 100644
---- a/src/main/java/org/bukkit/UnsafeValues.java
-+++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -137,5 +137,22 @@ public interface UnsafeValues {
-      * Just don't use it.
-      */
-     @org.jetbrains.annotations.NotNull String getMainLevelName();
-+
-+    /**
-+     * Gets the item rarity of a material. The material <b>MUST</b> be an item.
-+     * Use {@link Material#isItem()} before this.
-+     *
-+     * @param material the material to get the rarity of
-+     * @return the item rarity
-+     */
-+    public io.papermc.paper.inventory.ItemRarity getItemRarity(Material material);
-+
-+    /**
-+     * Gets the item rarity of the itemstack. The rarity can change based on enchantements.
-+     *
-+     * @param itemStack the itemstack to get the rarity of
-+     * @return the itemstack rarity
-+     */
-+    public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);
-     // Paper end
- }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 03a15727c85a08c0c79965be249373a11f31ce6e..c6378a880eac9f444c66f640260e8d410efd015b 100644
+index ddf3ad69b2255d09f72f76242d6a0888da968ed5..8d741448282f3467b54d5eb64d7a4d7b8971f054 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -877,5 +877,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -877,5 +877,14 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public @NotNull String translationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }
 +
 +    /**
-+     * Gets the item rarity of the itemstack. The rarity can change based on enchantements.
++     * Gets the item rarity of the itemstack. The rarity can change based on enchantments.
 +     *
 +     * @return the itemstack rarity
 +     */
-+    @NotNull
-+    public io.papermc.paper.inventory.ItemRarity getRarity() {
-+        return Bukkit.getUnsafe().getItemStackRarity(this);
++    public @NotNull io.papermc.paper.inventory.ItemRarity getRarity() {
++        return io.papermc.paper.APIBridge.INSTANCE.getItemStackRarity(this);
 +    }
      // Paper end
  }

--- a/patches/api/0269-Expose-protocol-version.patch
+++ b/patches/api/0269-Expose-protocol-version.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index e87cbaf9c1ea1330ab1597f98c8864d0c5b8bdcd..906f313d8c91e65ce934143208ed281ce02f5354 100644
+index 5b53521b255cbca4f8e4886c052acbc150513173..ecc7350634a0e30457eadf40727d5e83303c3f85 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -154,5 +154,12 @@ public interface UnsafeValues {
-      * @return the itemstack rarity
+@@ -109,5 +109,12 @@ public interface UnsafeValues {
+      * Use this when sending custom packets, so that there are no collisions on the client or server.
       */
-     public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);
+     int nextEntityId();
 +
 +    /**
 +     * Returns the server's protocol version.

--- a/patches/api/0287-ItemStack-repair-check-API.patch
+++ b/patches/api/0287-ItemStack-repair-check-API.patch
@@ -4,34 +4,24 @@ Date: Sat, 15 May 2021 22:10:50 -0700
 Subject: [PATCH] ItemStack repair check API
 
 
-diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 906f313d8c91e65ce934143208ed281ce02f5354..29a91ec8e97ce66383a1dd1fc3dcbcdcca7cfc41 100644
---- a/src/main/java/org/bukkit/UnsafeValues.java
-+++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -155,6 +155,16 @@ public interface UnsafeValues {
-      */
-     public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);
+diff --git a/src/main/java/io/papermc/paper/APIBridge.java b/src/main/java/io/papermc/paper/APIBridge.java
+index 66c2841b12e765f0b45bcfdbca6c4b58d3eef218..88b18a32682c8ea26c283a1830a265a414ff501e 100644
+--- a/src/main/java/io/papermc/paper/APIBridge.java
++++ b/src/main/java/io/papermc/paper/APIBridge.java
+@@ -41,4 +41,6 @@ public interface APIBridge {
+     ItemRarity getItemRarity(Material material);
  
-+    /**
-+     * Checks if an itemstack can be repaired with another itemstack.
-+     * Returns false if either argument's type is not an item ({@link Material#isItem()}).
-+     *
-+     * @param itemToBeRepaired the itemstack to be repaired
-+     * @param repairMaterial the repair material
-+     * @return true if valid repair, false if not
-+     */
-+    public boolean isValidRepairItemStack(@org.jetbrains.annotations.NotNull ItemStack itemToBeRepaired, @org.jetbrains.annotations.NotNull ItemStack repairMaterial);
+     ItemRarity getItemStackRarity(ItemStack itemStack);
 +
-     /**
-      * Returns the server's protocol version.
-      *
++    boolean isValidRepairItemStack(ItemStack itemToBeRepaired, ItemStack repairMaterial);
+ }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index c6378a880eac9f444c66f640260e8d410efd015b..b731ac4f6cd82d8476e4040a2204f58b0f63a0d3 100644
+index 8d741448282f3467b54d5eb64d7a4d7b8971f054..3f8634cc9b2ca82739b97b35fd5d48b45a941026 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -887,5 +887,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
-     public io.papermc.paper.inventory.ItemRarity getRarity() {
-         return Bukkit.getUnsafe().getItemStackRarity(this);
+@@ -886,5 +886,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+     public @NotNull io.papermc.paper.inventory.ItemRarity getRarity() {
+         return io.papermc.paper.APIBridge.INSTANCE.getItemStackRarity(this);
      }
 +
 +    /**
@@ -42,7 +32,7 @@ index c6378a880eac9f444c66f640260e8d410efd015b..b731ac4f6cd82d8476e4040a2204f58b
 +     * @return true if it is repairable by, false if not
 +     */
 +    public boolean isRepairableBy(@NotNull ItemStack repairMaterial) {
-+        return Bukkit.getUnsafe().isValidRepairItemStack(this, repairMaterial);
++        return io.papermc.paper.APIBridge.INSTANCE.isValidRepairItemStack(this, repairMaterial);
 +    }
 +
 +    /**
@@ -53,7 +43,7 @@ index c6378a880eac9f444c66f640260e8d410efd015b..b731ac4f6cd82d8476e4040a2204f58b
 +     * @return true if it can repair, false if not
 +     */
 +    public boolean canRepair(@NotNull ItemStack toBeRepaired) {
-+        return Bukkit.getUnsafe().isValidRepairItemStack(toBeRepaired, this);
++        return io.papermc.paper.APIBridge.INSTANCE.isValidRepairItemStack(toBeRepaired, this);
 +    }
      // Paper end
  }

--- a/patches/api/0292-Attributes-API-for-item-defaults.patch
+++ b/patches/api/0292-Attributes-API-for-item-defaults.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Attributes API for item defaults
 
 
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 467282a76dbf2edfd88baa4275991ae1163c0919..31ec16d134fd8eb5607d18e17f93225eef402d7e 100644
+index 1ef51b3f4cd716dd24a882d6fc30c80db5796777..88e2bd069e8e994ad54aa703cebbb608f3c36d31 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
-@@ -4425,6 +4425,21 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
-     public io.papermc.paper.inventory.ItemRarity getItemRarity() {
-         return Bukkit.getUnsafe().getItemRarity(this);
+@@ -4424,6 +4424,21 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+     public @NotNull io.papermc.paper.inventory.ItemRarity getItemRarity() {
+         return io.papermc.paper.APIBridge.INSTANCE.getItemRarity(this);
      }
 +
 +    /**
@@ -31,12 +31,12 @@ index 467282a76dbf2edfd88baa4275991ae1163c0919..31ec16d134fd8eb5607d18e17f93225e
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 29a91ec8e97ce66383a1dd1fc3dcbcdcca7cfc41..0d47278d68cdf015cb980721c234a3abee39646a 100644
+index ecc7350634a0e30457eadf40727d5e83303c3f85..f92cebf53e944731a0a96ad297d3ea46ebaacf3b 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -165,6 +165,18 @@ public interface UnsafeValues {
+@@ -110,6 +110,18 @@ public interface UnsafeValues {
       */
-     public boolean isValidRepairItemStack(@org.jetbrains.annotations.NotNull ItemStack itemToBeRepaired, @org.jetbrains.annotations.NotNull ItemStack repairMaterial);
+     int nextEntityId();
  
 +    /**
 +     * Returns an immutable multimap of attributes for the material and slot.

--- a/patches/api/0319-Get-entity-default-attributes.patch
+++ b/patches/api/0319-Get-entity-default-attributes.patch
@@ -4,35 +4,34 @@ Date: Fri, 20 Aug 2021 13:03:55 -0700
 Subject: [PATCH] Get entity default attributes
 
 
-diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 0d47278d68cdf015cb980721c234a3abee39646a..29ccd90e2733b528ef0866f93053adf66dd9ddf3 100644
---- a/src/main/java/org/bukkit/UnsafeValues.java
-+++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -183,5 +183,22 @@ public interface UnsafeValues {
-      * @return the server's protocol version
-      */
-     int getProtocolVersion();
+diff --git a/src/main/java/io/papermc/paper/APIBridge.java b/src/main/java/io/papermc/paper/APIBridge.java
+index 88b18a32682c8ea26c283a1830a265a414ff501e..5b8c1facc261c4f20c70bc712e4a7a37a178cf1c 100644
+--- a/src/main/java/io/papermc/paper/APIBridge.java
++++ b/src/main/java/io/papermc/paper/APIBridge.java
+@@ -3,10 +3,12 @@ package io.papermc.paper;
+ import com.destroystokyo.paper.util.VersionFetcher;
+ import io.papermc.paper.inventory.ItemRarity;
+ import java.io.IOException;
++import net.kyori.adventure.key.Key;
+ import net.kyori.adventure.text.Component;
+ import net.kyori.adventure.text.flattener.ComponentFlattener;
+ import net.kyori.adventure.util.Services;
+ import org.bukkit.Material;
++import org.bukkit.attribute.Attributable;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.inventory.ItemStack;
+@@ -43,4 +45,8 @@ public interface APIBridge {
+     ItemRarity getItemStackRarity(ItemStack itemStack);
+ 
+     boolean isValidRepairItemStack(ItemStack itemToBeRepaired, ItemStack repairMaterial);
 +
-+    /**
-+     * Checks if the entity represented by the namespaced key has default attributes.
-+     *
-+     * @param entityKey the entity's key
-+     * @return true if it has default attributes
-+     */
-+    boolean hasDefaultEntityAttributes(@org.jetbrains.annotations.NotNull NamespacedKey entityKey);
++    boolean hasDefaultEntityAttributes(Key entityTypeKey);
 +
-+    /**
-+     * Gets the default attributes for the entity represented by the namespaced key.
-+     *
-+     * @param entityKey the entity's key
-+     * @return an unmodifiable instance of Attributable for reading default attributes.
-+     * @throws IllegalArgumentException if the entity does not exist of have default attributes (use {@link #hasDefaultEntityAttributes(NamespacedKey)} first)
-+     */
-+    @org.jetbrains.annotations.NotNull org.bukkit.attribute.Attributable getDefaultEntityAttributes(@org.jetbrains.annotations.NotNull NamespacedKey entityKey);
-     // Paper end
++    Attributable getDefaultEntityAttributes(Key entityTypeKey);
  }
 diff --git a/src/main/java/org/bukkit/entity/EntityType.java b/src/main/java/org/bukkit/entity/EntityType.java
-index 5f78a801d6fd10a0e0fa3ccf13bb1456eed12c13..9f935266f51f4ea5d1193031f52e5327350cc06f 100644
+index 5f78a801d6fd10a0e0fa3ccf13bb1456eed12c13..4b420d2c2abce2b6e140402c742529e79f18ddc3 100644
 --- a/src/main/java/org/bukkit/entity/EntityType.java
 +++ b/src/main/java/org/bukkit/entity/EntityType.java
 @@ -449,5 +449,24 @@ public enum EntityType implements Keyed, Translatable, net.kyori.adventure.trans
@@ -46,7 +45,7 @@ index 5f78a801d6fd10a0e0fa3ccf13bb1456eed12c13..9f935266f51f4ea5d1193031f52e5327
 +     * @return true if it has default attributes
 +     */
 +    public boolean hasDefaultAttributes() {
-+        return org.bukkit.Bukkit.getUnsafe().hasDefaultEntityAttributes(this.key);
++        return io.papermc.paper.APIBridge.INSTANCE.hasDefaultEntityAttributes(this.key);
 +    }
 +
 +    /**
@@ -56,7 +55,7 @@ index 5f78a801d6fd10a0e0fa3ccf13bb1456eed12c13..9f935266f51f4ea5d1193031f52e5327
 +     * @throws IllegalArgumentException if the entity does not exist of have default attributes (use {@link #hasDefaultAttributes()} first)
 +     */
 +    public @NotNull org.bukkit.attribute.Attributable getDefaultAttributes() {
-+        return org.bukkit.Bukkit.getUnsafe().getDefaultEntityAttributes(this.key);
++        return io.papermc.paper.APIBridge.INSTANCE.getDefaultEntityAttributes(this.key);
 +    }
      // Paper end
  }

--- a/patches/api/0325-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/api/0325-Add-isCollidable-methods-to-various-places.patch
@@ -4,11 +4,22 @@ Date: Thu, 4 Nov 2021 11:50:35 -0700
 Subject: [PATCH] Add isCollidable methods to various places
 
 
+diff --git a/src/main/java/io/papermc/paper/APIBridge.java b/src/main/java/io/papermc/paper/APIBridge.java
+index 5b8c1facc261c4f20c70bc712e4a7a37a178cf1c..698fd70ac961216b29834ada409d96caa3c0ba56 100644
+--- a/src/main/java/io/papermc/paper/APIBridge.java
++++ b/src/main/java/io/papermc/paper/APIBridge.java
+@@ -49,4 +49,6 @@ public interface APIBridge {
+     boolean hasDefaultEntityAttributes(Key entityTypeKey);
+ 
+     Attributable getDefaultEntityAttributes(Key entityTypeKey);
++
++    boolean isCollidable(Material block);
+ }
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 31ec16d134fd8eb5607d18e17f93225eef402d7e..842a9dd6f92737699529721ec4e06fbc225fa3e6 100644
+index 88e2bd069e8e994ad54aa703cebbb608f3c36d31..d65ec88d5ae472fcc0bf8985f3cfcb4fffdb4542 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
-@@ -4440,6 +4440,16 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+@@ -4439,6 +4439,16 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
      public Multimap<Attribute, AttributeModifier> getItemAttributes(@NotNull EquipmentSlot equipmentSlot) {
          return Bukkit.getUnsafe().getItemAttributes(this, equipmentSlot);
      }
@@ -20,30 +31,11 @@ index 31ec16d134fd8eb5607d18e17f93225eef402d7e..842a9dd6f92737699529721ec4e06fbc
 +     * @throws IllegalArgumentException if {@link #isBlock()} is false
 +     */
 +    public boolean isCollidable() {
-+        return Bukkit.getUnsafe().isCollidable(this);
++        return io.papermc.paper.APIBridge.INSTANCE.isCollidable(this);
 +    }
      // Paper end
  
      /**
-diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 29ccd90e2733b528ef0866f93053adf66dd9ddf3..2a23e93d9e308c5eba0a2b658f11f571a0c01e26 100644
---- a/src/main/java/org/bukkit/UnsafeValues.java
-+++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -200,5 +200,14 @@ public interface UnsafeValues {
-      * @throws IllegalArgumentException if the entity does not exist of have default attributes (use {@link #hasDefaultEntityAttributes(NamespacedKey)} first)
-      */
-     @org.jetbrains.annotations.NotNull org.bukkit.attribute.Attributable getDefaultEntityAttributes(@org.jetbrains.annotations.NotNull NamespacedKey entityKey);
-+
-+    /**
-+     * Checks if this material is collidable.
-+     *
-+     * @param material the material to check
-+     * @return true if collidable
-+     * @throws IllegalArgumentException if {@link Material#isBlock()} is false
-+     */
-+    boolean isCollidable(@org.jetbrains.annotations.NotNull Material material);
-     // Paper end
- }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
 index 96a3466181a6829e1868b5f5249349e8fd2cdd09..cda6e7d8e032b3edc919995141dc260b1ea82810 100644
 --- a/src/main/java/org/bukkit/block/Block.java

--- a/patches/api/0328-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/api/0328-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 2a23e93d9e308c5eba0a2b658f11f571a0c01e26..b8ca571f8e88e7b676c5d1e1d90f6e5cb8538147 100644
+index f92cebf53e944731a0a96ad297d3ea46ebaacf3b..22ae768908a4cec05208974d7957177cb519e425 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -126,6 +126,14 @@ public interface UnsafeValues {
+@@ -103,6 +103,14 @@ public interface UnsafeValues {
+     // Paper end
  
-     ItemStack deserializeItem(byte[] data);
- 
+     // Paper start
 +    byte[] serializeEntity(org.bukkit.entity.Entity entity);
 +
 +    default org.bukkit.entity.Entity deserializeEntity(byte[] data, World world) {
@@ -24,7 +24,7 @@ index 2a23e93d9e308c5eba0a2b658f11f571a0c01e26..b8ca571f8e88e7b676c5d1e1d90f6e5c
       * Creates and returns the next EntityId available.
       * <p>
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index e0265937a5daf968a9a3f453f4aabf37f76d2c1c..24a409ff2bc554edde610a223f20bbfc09ef5152 100644
+index 368a308e5420f9a9ed403358e7224d2df67a89bb..822d39dde955f981323e6e6ac31d8da6b2289942 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -833,5 +833,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent

--- a/patches/api/0378-Add-NamespacedKey-biome-methods.patch
+++ b/patches/api/0378-Add-NamespacedKey-biome-methods.patch
@@ -6,13 +6,13 @@ Subject: [PATCH] Add NamespacedKey biome methods
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index b8ca571f8e88e7b676c5d1e1d90f6e5cb8538147..b92255a9c87620f46adb140689b1cd328a476d61 100644
+index 22ae768908a4cec05208974d7957177cb519e425..01f7812ec0cfc73aaf777a78a19e1f59130460e2 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -217,5 +217,32 @@ public interface UnsafeValues {
-      * @throws IllegalArgumentException if {@link Material#isBlock()} is false
+@@ -136,5 +136,32 @@ public interface UnsafeValues {
+      * @return the server's protocol version
       */
-     boolean isCollidable(@org.jetbrains.annotations.NotNull Material material);
+     int getProtocolVersion();
 +
 +    /**
 +     * Gets the {@link NamespacedKey} for the biome at the given location.

--- a/patches/api/0397-ItemStack-damage-API.patch
+++ b/patches/api/0397-ItemStack-damage-API.patch
@@ -65,12 +65,12 @@ index 454376eada83adc3c7c83a7b720500f998f5593d..329ca07b6e166729d33446c4cd1ae19e
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 6f33145f1ccc7645616f310a68676207318c2a58..449d6e1995eedbfaeffdc5d1f1c2295378006aa8 100644
+index 46f1681f20943cd3b82a36f164de665143a246bf..2e74beffa1ca45a84410266f7d811dc737e26dd9 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -971,5 +971,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -970,5 +970,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public boolean canRepair(@NotNull ItemStack toBeRepaired) {
-         return Bukkit.getUnsafe().isValidRepairItemStack(toBeRepaired, this);
+         return io.papermc.paper.APIBridge.INSTANCE.isValidRepairItemStack(toBeRepaired, this);
      }
 +
 +    /**

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -2177,6 +2177,22 @@ index 46cab7a8c7b87ab01b26074b04f5a02b3907cfc4..49019b4a9bc4e634d54a9b0acaf9229a
 +    }
 +    // Paper end
  }
+diff --git a/src/main/java/io/papermc/paper/APIBridgeImpl.java b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..57df82abc931f4a458e939149c51f723cd64ec92
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+@@ -0,0 +1,10 @@
++package io.papermc.paper;
++
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
++
++@DefaultQualifier(NonNull.class)
++public final class APIBridgeImpl implements APIBridge {
++
++
++}
 diff --git a/src/main/java/io/papermc/paper/chunk/SingleThreadChunkRegionManager.java b/src/main/java/io/papermc/paper/chunk/SingleThreadChunkRegionManager.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..a5f706d6f716b2a463ae58adcde69d9e665c7733
@@ -7742,3 +7758,10 @@ index b599e098e6d2e6f78b89114e05cb03d716b7c5f4..83eabc34d952bbb13ec4b4bdcf34f647
          try
          {
              SpigotConfig.config.save( CONFIG_FILE );
+diff --git a/src/main/resources/META-INF/services/io.papermc.paper.APIBridge b/src/main/resources/META-INF/services/io.papermc.paper.APIBridge
+new file mode 100644
+index 0000000000000000000000000000000000000000..cc743ae8b7fc7268811d0a510119dbaca529f120
+--- /dev/null
++++ b/src/main/resources/META-INF/services/io.papermc.paper.APIBridge
+@@ -0,0 +1 @@
++io.papermc.paper.APIBridgeImpl

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -6,6 +6,36 @@ Subject: [PATCH] Adventure
 Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
+diff --git a/src/main/java/io/papermc/paper/APIBridgeImpl.java b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+index 57df82abc931f4a458e939149c51f723cd64ec92..3cd2ef8d43f7cc32346cf205332a25d6a85d9fd5 100644
+--- a/src/main/java/io/papermc/paper/APIBridgeImpl.java
++++ b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+@@ -1,10 +1,25 @@
+ package io.papermc.paper;
+ 
++import io.papermc.paper.adventure.PaperAdventure;
++import java.io.IOException;
++import net.kyori.adventure.text.Component;
++import net.kyori.adventure.text.flattener.ComponentFlattener;
++import org.bukkit.command.CommandSender;
++import org.bukkit.entity.Entity;
+ import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.checker.nullness.qual.Nullable;
+ import org.checkerframework.framework.qual.DefaultQualifier;
+ 
+ @DefaultQualifier(NonNull.class)
+ public final class APIBridgeImpl implements APIBridge {
+ 
++    @Override
++    public ComponentFlattener componentFlattener() {
++        return PaperAdventure.FLATTENER;
++    }
+ 
++    @Override
++    public Component resolveWithContext(final Component component, final @Nullable CommandSender context, final @Nullable Entity scoreboardSubject, final boolean bypassPermissions) throws IOException {
++        return PaperAdventure.resolveWithContext(component, context, scoreboardSubject, bypassPermissions);
++    }
+ }
 diff --git a/src/main/java/io/papermc/paper/adventure/AdventureComponent.java b/src/main/java/io/papermc/paper/adventure/AdventureComponent.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..3246049fd557951d971ef40112a411c12aec205c
@@ -4719,47 +4749,17 @@ index 78ea79b66cc9e90402ef5cdc2e5e04e0c74b1c26..4fede2161792ba3e7cdf0cc5a1f53318
  
          boolean hadFormat = false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index eff182a54cbb84693d6cad96b51f743b08049b43..91cf7e26de7d3595e151f7c52683ef82715420ad 100644
+index eff182a54cbb84693d6cad96b51f743b08049b43..063ffc94c72333d38cb3a111a1833dc38d19079f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -72,6 +72,43 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -72,6 +72,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      private CraftMagicNumbers() {}
  
 +    // Paper start
 +    @Override
-+    public net.kyori.adventure.text.flattener.ComponentFlattener componentFlattener() {
-+        return io.papermc.paper.adventure.PaperAdventure.FLATTENER;
-+    }
-+
-+    @Override
-+    public net.kyori.adventure.text.serializer.gson.GsonComponentSerializer colorDownsamplingGsonComponentSerializer() {
-+        return net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.colorDownsamplingGson();
-+    }
-+
-+    @Override
-+    public net.kyori.adventure.text.serializer.gson.GsonComponentSerializer gsonComponentSerializer() {
-+        return net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.gson();
-+    }
-+
-+    @Override
 +    public net.kyori.adventure.text.serializer.plain.PlainComponentSerializer plainComponentSerializer() {
 +        return io.papermc.paper.adventure.PaperAdventure.PLAIN;
-+    }
-+
-+    @Override
-+    public net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer plainTextSerializer() {
-+        return net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer.plainText();
-+    }
-+
-+    @Override
-+    public net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer legacyComponentSerializer() {
-+        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection();
-+    }
-+
-+    @Override
-+    public net.kyori.adventure.text.Component resolveWithContext(final net.kyori.adventure.text.Component component, final org.bukkit.command.CommandSender context, final org.bukkit.entity.Entity scoreboardSubject, final boolean bypassPermissions) throws IOException {
-+        return io.papermc.paper.adventure.PaperAdventure.resolveWithContext(component, context, scoreboardSubject, bypassPermissions);
 +    }
 +    // Paper end
 +

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -6625,10 +6625,10 @@ index 909b2c98e7a9117d2f737245e4661792ffafb744..d96399e9bf1a58db5a4a22e58abb99e7
      @Override
      public FileConfiguration getConfig() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 91cf7e26de7d3595e151f7c52683ef82715420ad..ec9877840fafa14adcfc04eacae1786111990a27 100644
+index 063ffc94c72333d38cb3a111a1833dc38d19079f..00a35f05dbda73a7c86215e6247dcbede812516a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -437,6 +437,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -407,6 +407,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
          net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
          return nmsItemStack.getItem().getDescriptionId(nmsItemStack);
      }

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -180,10 +180,10 @@ index 0000000000000000000000000000000000000000..3f540dc05315103ef97fd53628f681c6
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..46297ac0a19fd2398ab777a381eff4d0a256161e
+index 0000000000000000000000000000000000000000..8ad1851f814574570216506cbfc9ddfbbbc1ba2a
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -0,0 +1,385 @@
+@@ -0,0 +1,386 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -210,6 +210,7 @@ index 0000000000000000000000000000000000000000..46297ac0a19fd2398ab777a381eff4d0
 +package co.aikar.timings;
 +
 +import com.google.common.collect.Sets;
++import io.papermc.paper.APIBridge;
 +import io.papermc.paper.adventure.PaperAdventure;
 +import net.kyori.adventure.text.event.ClickEvent;
 +import net.kyori.adventure.text.format.NamedTextColor;
@@ -306,7 +307,7 @@ index 0000000000000000000000000000000000000000..46297ac0a19fd2398ab777a381eff4d0
 +        );
 +        if (!TimingsManager.privacy) {
 +            appendObjectData(parent,
-+                pair("server", Bukkit.getUnsafe().getTimingsServerName()),
++                pair("server", APIBridge.INSTANCE.getTimingsServerName()),
 +                pair("motd", Bukkit.getServer().getMotd()),
 +                pair("icon", Bukkit.getServer().getServerIcon().getData())
 +            );
@@ -506,7 +507,7 @@ index 0000000000000000000000000000000000000000..46297ac0a19fd2398ab777a381eff4d0
 +            try {
 +                hostName = InetAddress.getLocalHost().getHostName();
 +            } catch (Exception ignored) {}
-+            con.setRequestProperty("User-Agent", "Paper/" + Bukkit.getUnsafe().getTimingsServerName() + "/" + hostName);
++            con.setRequestProperty("User-Agent", "Paper/" + APIBridge.INSTANCE.getTimingsServerName() + "/" + hostName);
 +            con.setRequestMethod("POST");
 +            con.setInstanceFollowRedirects(false);
 +
@@ -694,6 +695,28 @@ index 0000000000000000000000000000000000000000..0fda52841b5e1643efeda92106124998
 +        return Timings.ofSafe(((PrimaryLevelData) worldserver.getLevelData()).getLevelName() + " - Scheduled " + timingsType);
 +    }
 +}
+diff --git a/src/main/java/io/papermc/paper/APIBridgeImpl.java b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+index 3cd2ef8d43f7cc32346cf205332a25d6a85d9fd5..c264815d7215cb5f2c04ab031d4121e2ccb3af97 100644
+--- a/src/main/java/io/papermc/paper/APIBridgeImpl.java
++++ b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+@@ -1,6 +1,7 @@
+ package io.papermc.paper;
+ 
+ import io.papermc.paper.adventure.PaperAdventure;
++import io.papermc.paper.configuration.GlobalConfiguration;
+ import java.io.IOException;
+ import net.kyori.adventure.text.Component;
+ import net.kyori.adventure.text.flattener.ComponentFlattener;
+@@ -22,4 +23,9 @@ public final class APIBridgeImpl implements APIBridge {
+     public Component resolveWithContext(final Component component, final @Nullable CommandSender context, final @Nullable Entity scoreboardSubject, final boolean bypassPermissions) throws IOException {
+         return PaperAdventure.resolveWithContext(component, context, scoreboardSubject, bypassPermissions);
+     }
++
++    @Override
++    public String getTimingsServerName() {
++        return GlobalConfiguration.get().timings.serverName;
++    }
+ }
 diff --git a/src/main/java/net/minecraft/commands/CommandFunction.java b/src/main/java/net/minecraft/commands/CommandFunction.java
 index 3ceeddf4c2898172d24db9ee1bab8d6b17e36128..8273ee1c5e513f02c9743ee38c9b7cf700e2ecad 100644
 --- a/src/main/java/net/minecraft/commands/CommandFunction.java
@@ -1338,7 +1361,7 @@ index d19d1f1595a226ce0472be5e2efafbc0e3e1729f..470e752234813d1031721be95d0bf117
  
      public UserWhiteList getWhiteList() {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 35125c029abbdab4c7043842b6042ea44b00a2c3..f215204e1dd6fb3b805a60a268dae10f786b5171 100644
+index 4cd1cfbf91ea232756de16120eec4339d8144885..9171dfb7443d42a5f6d854b2abea55d2671c1177 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -134,7 +134,6 @@ import org.bukkit.craftbukkit.event.CraftPortalEvent;
@@ -1834,7 +1857,7 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 27cf140f8a7715caec5637d7b487720c2cc5742e..12e7a0a24fe2aa6e7af97ad7d50d81e5c7b26663 100644
+index ac56f49ab0736c3176918379f5ac1fdd7fcadfe4..7c9f1b998ea5447d6ff29cdbb9e3cee0ba1c7c99 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2482,6 +2482,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2034,10 +2057,10 @@ index f97eccb6a17c7876e1e002d798eb67bbe80571a0..76effc345d362047e64d064eb64a5222
 +    } // Paper
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index ec9877840fafa14adcfc04eacae1786111990a27..98083486bddf60074fc8e47e63e780703a792a7c 100644
+index 00a35f05dbda73a7c86215e6247dcbede812516a..c1e60e6b079ad03a883da9e33c1976b6205d08c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -222,6 +222,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -192,6 +192,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
      // Paper end
      // ========================================================================
@@ -2050,20 +2073,6 @@ index ec9877840fafa14adcfc04eacae1786111990a27..98083486bddf60074fc8e47e63e78070
  
      public static byte toLegacyData(BlockState data) {
          return CraftLegacy.toLegacyData(data);
-@@ -444,6 +450,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
-     }
-     // Paper end
- 
-+    // Paper start
-+    @Override
-+    public String getTimingsServerName() {
-+        return io.papermc.paper.configuration.GlobalConfiguration.get().timings.serverName;
-+    }
-+    // Paper end
-+
-     /**
-      * This helper class represents the different NBT Tags.
-      * <p>
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
 index a7675df12d509ae0ff585566b395165f55f8a8cf..38cf408899cef72bc9d2888109a7ac7ce0aec638 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -138,10 +138,10 @@ index 9a5fa60cb8156fe254a123e237d957ccb82f7195..0f7d36933e34e1d1b9dd27d8b0c35ff8
  
      protected static final class LightQueue {
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index 46297ac0a19fd2398ab777a381eff4d0a256161e..98171f6c8e23f6ef89b897e4b80e3afb2a1950a0 100644
+index 8ad1851f814574570216506cbfc9ddfbbbc1ba2a..400d77b28a0ce46696666581a7154d267d3a24e9 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -162,7 +162,11 @@ public class TimingsExport extends Thread {
+@@ -163,7 +163,11 @@ public class TimingsExport extends Thread {
                  pair("gamerules", toObjectMapper(world.getWorld().getGameRules(), rule -> {
                      return pair(rule, world.getWorld().getGameRuleValue(rule));
                  })),

--- a/patches/server/0028-Implement-Paper-VersionChecker.patch
+++ b/patches/server/0028-Implement-Paper-VersionChecker.patch
@@ -139,19 +139,25 @@ index 0000000000000000000000000000000000000000..351159bbdb0c8045f4983f54dee34430
 +        }
 +    }
 +}
-diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 98083486bddf60074fc8e47e63e780703a792a7c..976a8d9019cccd82d8f5cd2cf86202e4076753ed 100644
---- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-+++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -455,6 +455,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+diff --git a/src/main/java/io/papermc/paper/APIBridgeImpl.java b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+index c264815d7215cb5f2c04ab031d4121e2ccb3af97..0e3bc884b680cd35338cc4bfd102bfbaf0c86e9c 100644
+--- a/src/main/java/io/papermc/paper/APIBridgeImpl.java
++++ b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+@@ -1,5 +1,7 @@
+ package io.papermc.paper;
+ 
++import com.destroystokyo.paper.PaperVersionFetcher;
++import com.destroystokyo.paper.util.VersionFetcher;
+ import io.papermc.paper.adventure.PaperAdventure;
+ import io.papermc.paper.configuration.GlobalConfiguration;
+ import java.io.IOException;
+@@ -28,4 +30,9 @@ public final class APIBridgeImpl implements APIBridge {
      public String getTimingsServerName() {
-         return io.papermc.paper.configuration.GlobalConfiguration.get().timings.serverName;
+         return GlobalConfiguration.get().timings.serverName;
      }
 +
 +    @Override
-+    public com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {
-+        return new com.destroystokyo.paper.PaperVersionFetcher();
++    public VersionFetcher getVersionFetcher() {
++        return new PaperVersionFetcher();
 +    }
-     // Paper end
- 
-     /**
+ }

--- a/patches/server/0365-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/server/0365-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -5,60 +5,83 @@ Subject: [PATCH] Add Raw Byte ItemStack Serialization
 
 Serializes using NBT which is safer for server data migrations than bukkits format.
 
-diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 976a8d9019cccd82d8f5cd2cf86202e4076753ed..e50daf4bafa38d92304ffda05326bd335d070422 100644
---- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-+++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -460,6 +460,52 @@ public final class CraftMagicNumbers implements UnsafeValues {
-     public com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {
-         return new com.destroystokyo.paper.PaperVersionFetcher();
+diff --git a/src/main/java/io/papermc/paper/APIBridgeImpl.java b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+index 0e3bc884b680cd35338cc4bfd102bfbaf0c86e9c..91f5e700672998b7fedf0c7defae994205b3818c 100644
+--- a/src/main/java/io/papermc/paper/APIBridgeImpl.java
++++ b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+@@ -1,14 +1,25 @@
+ package io.papermc.paper;
+ 
++import ca.spottedleaf.dataconverter.minecraft.MCDataConverter;
++import ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry;
+ import com.destroystokyo.paper.PaperVersionFetcher;
+ import com.destroystokyo.paper.util.VersionFetcher;
++import com.google.common.base.Preconditions;
+ import io.papermc.paper.adventure.PaperAdventure;
+ import io.papermc.paper.configuration.GlobalConfiguration;
++import java.io.ByteArrayInputStream;
++import java.io.ByteArrayOutputStream;
+ import java.io.IOException;
+ import net.kyori.adventure.text.Component;
+ import net.kyori.adventure.text.flattener.ComponentFlattener;
++import net.minecraft.SharedConstants;
++import net.minecraft.nbt.CompoundTag;
++import net.minecraft.nbt.NbtIo;
++import org.bukkit.Material;
+ import org.bukkit.command.CommandSender;
++import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.entity.Entity;
++import org.bukkit.inventory.ItemStack;
+ import org.checkerframework.checker.nullness.qual.NonNull;
+ import org.checkerframework.checker.nullness.qual.Nullable;
+ import org.checkerframework.framework.qual.DefaultQualifier;
+@@ -35,4 +46,49 @@ public final class APIBridgeImpl implements APIBridge {
+     public VersionFetcher getVersionFetcher() {
+         return new PaperVersionFetcher();
      }
 +
 +    @Override
-+    public byte[] serializeItem(ItemStack item) {
++    public byte[] serializeItem(final ItemStack item) {
 +        Preconditions.checkNotNull(item, "null cannot be serialized");
 +        Preconditions.checkArgument(item.getType() != Material.AIR, "air cannot be serialized");
 +
-+        return serializeNbtToBytes((item instanceof CraftItemStack ? ((CraftItemStack) item).handle : CraftItemStack.asNMSCopy(item)).save(new CompoundTag()));
++        return this.serializeNbtToBytes((item instanceof CraftItemStack ? ((CraftItemStack) item).handle : CraftItemStack.asNMSCopy(item)).save(new CompoundTag()));
 +    }
 +
 +    @Override
-+    public ItemStack deserializeItem(byte[] data) {
++    public ItemStack deserializeItem(final byte[] data) {
 +        Preconditions.checkNotNull(data, "null cannot be deserialized");
 +        Preconditions.checkArgument(data.length > 0, "cannot deserialize nothing");
 +
-+        CompoundTag compound = deserializeNbtFromBytes(data);
++        CompoundTag compound = this.deserializeNbtFromBytes(data);
 +        int dataVersion = compound.getInt("DataVersion");
-+        return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of(ca.spottedleaf.dataconverter.minecraft.MCDataConverter.convertTag(ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry.ITEM_STACK, compound, dataVersion, getDataVersion())));
++        return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of(MCDataConverter.convertTag(MCTypeRegistry.ITEM_STACK, compound, dataVersion, currentDataVersion())));
 +    }
 +
-+    private byte[] serializeNbtToBytes(CompoundTag compound) {
-+        compound.putInt("DataVersion", getDataVersion());
-+        java.io.ByteArrayOutputStream outputStream = new java.io.ByteArrayOutputStream();
++    private byte[] serializeNbtToBytes(final CompoundTag compound) {
++        compound.putInt("DataVersion", currentDataVersion());
++        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 +        try {
-+            net.minecraft.nbt.NbtIo.writeCompressed(
-+                compound,
-+                outputStream
-+            );
++            NbtIo.writeCompressed(compound, outputStream);
 +        } catch (IOException ex) {
 +            throw new RuntimeException(ex);
 +        }
 +        return outputStream.toByteArray();
 +    }
 +
-+    private CompoundTag deserializeNbtFromBytes(byte[] data) {
++    private CompoundTag deserializeNbtFromBytes(final byte[] data) {
 +        CompoundTag compound;
 +        try {
-+            compound = net.minecraft.nbt.NbtIo.readCompressed(
-+                new java.io.ByteArrayInputStream(data)
-+            );
++            compound = NbtIo.readCompressed(new ByteArrayInputStream(data));
 +        } catch (IOException ex) {
 +            throw new RuntimeException(ex);
 +        }
 +        int dataVersion = compound.getInt("DataVersion");
-+        Preconditions.checkArgument(dataVersion <= getDataVersion(), "Newer version! Server downgrades are not supported!");
++        Preconditions.checkArgument(dataVersion <= currentDataVersion(), "Newer version! Server downgrades are not supported!");
 +        return compound;
 +    }
-     // Paper end
- 
-     /**
++
++    private static int currentDataVersion() {
++        return SharedConstants.getCurrentVersion().getDataVersion().getVersion();
++    }
+ }

--- a/patches/server/0478-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0478-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -21,18 +21,20 @@ index a3d547d9fed7e2c9f344aa467f287ba46c4cb338..af258b981a69b0af2787013837c044c7
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index e50daf4bafa38d92304ffda05326bd335d070422..c4cc2833879d14451be507a59a31c67f13cc8b3d 100644
+index c1e60e6b079ad03a883da9e33c1976b6205d08c9..55ce2a8711f31255747feb9482a951c7f4d8a81e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -506,6 +506,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
-         Preconditions.checkArgument(dataVersion <= getDataVersion(), "Newer version! Server downgrades are not supported!");
-         return compound;
+@@ -420,6 +420,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
-+
+     // Paper end
+ 
++    // Paper start
 +    @Override
 +    public int nextEntityId() {
 +        return net.minecraft.world.entity.Entity.nextEntityId();
 +    }
-     // Paper end
- 
++    // Paper end
++
      /**
+      * This helper class represents the different NBT Tags.
+      * <p>

--- a/patches/server/0496-Fix-client-lag-on-advancement-loading.patch
+++ b/patches/server/0496-Fix-client-lag-on-advancement-loading.patch
@@ -15,10 +15,10 @@ manually reload the advancement data for all players, which
 normally takes place as a part of the datapack reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index c4cc2833879d14451be507a59a31c67f13cc8b3d..a933d12dabfee67f2c9bb2419f9ede69c354b3c2 100644
+index 55ce2a8711f31255747feb9482a951c7f4d8a81e..ee9b3bf7a7fb4029cb6df966782b58f62c713c70 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -345,7 +345,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -315,7 +315,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
                      Bukkit.getLogger().log(Level.SEVERE, "Error saving advancement " + key, ex);
                  }
  

--- a/patches/server/0581-Expand-world-key-API.patch
+++ b/patches/server/0581-Expand-world-key-API.patch
@@ -4,6 +4,29 @@ Date: Wed, 6 Jan 2021 00:34:04 -0800
 Subject: [PATCH] Expand world key API
 
 
+diff --git a/src/main/java/io/papermc/paper/APIBridgeImpl.java b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+index 91f5e700672998b7fedf0c7defae994205b3818c..fa249d4f6934a45313244d2cac302fa9b4219a2b 100644
+--- a/src/main/java/io/papermc/paper/APIBridgeImpl.java
++++ b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+@@ -15,6 +15,8 @@ import net.kyori.adventure.text.flattener.ComponentFlattener;
+ import net.minecraft.SharedConstants;
+ import net.minecraft.nbt.CompoundTag;
+ import net.minecraft.nbt.NbtIo;
++import net.minecraft.server.MinecraftServer;
++import net.minecraft.server.dedicated.DedicatedServer;
+ import org.bukkit.Material;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+@@ -91,4 +93,9 @@ public final class APIBridgeImpl implements APIBridge {
+     private static int currentDataVersion() {
+         return SharedConstants.getCurrentVersion().getDataVersion().getVersion();
+     }
++
++    @Override
++    public String getMainLevelName() {
++        return ((DedicatedServer) MinecraftServer.getServer()).getProperties().levelName;
++    }
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 index 9db48bd6dcf0d24132123b86670341c1d8113840..d7ac103b82e9aac1e2f3b807d7b69fdfcf0dcb15 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
@@ -20,7 +43,7 @@ index 9db48bd6dcf0d24132123b86670341c1d8113840..d7ac103b82e9aac1e2f3b807d7b69fdf
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a133e0a0a7a5b646ac3df9c2521d4deed6a1761d..574f50314c17eb12b519ba14fb1dddbc6c8e40c6 100644
+index f492902610602489dcbf8b73bc91d2e390b439eb..2978273094b3840d950dd87ab8f45e837e0ebabd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1134,9 +1134,15 @@ public final class CraftServer implements Server {
@@ -66,19 +89,3 @@ index a133e0a0a7a5b646ac3df9c2521d4deed6a1761d..574f50314c17eb12b519ba14fb1dddbc
      public void addWorld(World world) {
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
-diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index a933d12dabfee67f2c9bb2419f9ede69c354b3c2..12358f5147172d3a3a4159f2c1c8b650f45e87dd 100644
---- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-+++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -517,6 +517,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
-     public int nextEntityId() {
-         return net.minecraft.world.entity.Entity.nextEntityId();
-     }
-+
-+    @Override
-+    public String getMainLevelName() {
-+        return ((net.minecraft.server.dedicated.DedicatedServer) net.minecraft.server.MinecraftServer.getServer()).getProperties().levelName;
-+    }
-     // Paper end
- 
-     /**

--- a/patches/server/0583-Item-Rarity-API.patch
+++ b/patches/server/0583-Item-Rarity-API.patch
@@ -6,31 +6,49 @@ Subject: [PATCH] Item Rarity API
 == AT ==
 public net.minecraft.world.item.Item rarity
 
-diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 12358f5147172d3a3a4159f2c1c8b650f45e87dd..2b262a9dc58f1c7b79f10c44aae016088a34c06f 100644
---- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-+++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -522,6 +522,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
+diff --git a/src/main/java/io/papermc/paper/APIBridgeImpl.java b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+index fa249d4f6934a45313244d2cac302fa9b4219a2b..36acb5ffe30ecec1e104a44e9bbb824d9c8ddfbe 100644
+--- a/src/main/java/io/papermc/paper/APIBridgeImpl.java
++++ b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+@@ -7,6 +7,7 @@ import com.destroystokyo.paper.util.VersionFetcher;
+ import com.google.common.base.Preconditions;
+ import io.papermc.paper.adventure.PaperAdventure;
+ import io.papermc.paper.configuration.GlobalConfiguration;
++import io.papermc.paper.inventory.ItemRarity;
+ import java.io.ByteArrayInputStream;
+ import java.io.ByteArrayOutputStream;
+ import java.io.IOException;
+@@ -17,9 +18,11 @@ import net.minecraft.nbt.CompoundTag;
+ import net.minecraft.nbt.NbtIo;
+ import net.minecraft.server.MinecraftServer;
+ import net.minecraft.server.dedicated.DedicatedServer;
++import net.minecraft.world.item.Item;
+ import org.bukkit.Material;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
++import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+ import org.bukkit.entity.Entity;
+ import org.bukkit.inventory.ItemStack;
+ import org.checkerframework.checker.nullness.qual.NonNull;
+@@ -98,4 +101,18 @@ public final class APIBridgeImpl implements APIBridge {
      public String getMainLevelName() {
-         return ((net.minecraft.server.dedicated.DedicatedServer) net.minecraft.server.MinecraftServer.getServer()).getProperties().levelName;
+         return ((DedicatedServer) MinecraftServer.getServer()).getProperties().levelName;
      }
 +
 +    @Override
-+    public io.papermc.paper.inventory.ItemRarity getItemRarity(org.bukkit.Material material) {
-+        Item item = getItem(material);
++    public ItemRarity getItemRarity(final Material material) {
++        Item item = CraftMagicNumbers.getItem(material);
 +        if (item == null) {
 +            throw new IllegalArgumentException(material + " is not an item, and rarity does not apply to blocks");
 +        }
-+        return io.papermc.paper.inventory.ItemRarity.values()[item.rarity.ordinal()];
++        return ItemRarity.values()[item.rarity.ordinal()];
 +    }
 +
 +    @Override
-+    public io.papermc.paper.inventory.ItemRarity getItemStackRarity(org.bukkit.inventory.ItemStack itemStack) {
-+        return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
++    public ItemRarity getItemStackRarity(final ItemStack itemStack) {
++        return ItemRarity.values()[CraftMagicNumbers.getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
 +    }
-     // Paper end
- 
-     /**
+ }
 diff --git a/src/test/java/io/papermc/paper/inventory/ItemRarityTest.java b/src/test/java/io/papermc/paper/inventory/ItemRarityTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..38e6d42098f216b1d24f50386e7be98181122d8d

--- a/patches/server/0589-Expose-protocol-version.patch
+++ b/patches/server/0589-Expose-protocol-version.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 2b262a9dc58f1c7b79f10c44aae016088a34c06f..3bfe371eb5f08f9e6fbd4ce186bad42cc3478ccb 100644
+index ee9b3bf7a7fb4029cb6df966782b58f62c713c70..ebb63b4171fc6eb39a8d7c61478211e80c2487e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -536,6 +536,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
-     public io.papermc.paper.inventory.ItemRarity getItemStackRarity(org.bukkit.inventory.ItemStack itemStack) {
-         return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
+@@ -431,6 +431,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+     public int nextEntityId() {
+         return net.minecraft.world.entity.Entity.nextEntityId();
      }
 +
 +    @Override

--- a/patches/server/0618-ItemStack-repair-check-API.patch
+++ b/patches/server/0618-ItemStack-repair-check-API.patch
@@ -4,25 +4,23 @@ Date: Sat, 15 May 2021 22:11:11 -0700
 Subject: [PATCH] ItemStack repair check API
 
 
-diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 3bfe371eb5f08f9e6fbd4ce186bad42cc3478ccb..1aa8ba6ff3263c6d2ef9694ad4e7bafc8215ec43 100644
---- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-+++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -537,6 +537,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
-         return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
+diff --git a/src/main/java/io/papermc/paper/APIBridgeImpl.java b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+index 36acb5ffe30ecec1e104a44e9bbb824d9c8ddfbe..7cf4cf9e1687acd72845e530b56f8d9d1517b8d4 100644
+--- a/src/main/java/io/papermc/paper/APIBridgeImpl.java
++++ b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+@@ -115,4 +115,12 @@ public final class APIBridgeImpl implements APIBridge {
+     public ItemRarity getItemStackRarity(final ItemStack itemStack) {
+         return ItemRarity.values()[CraftMagicNumbers.getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
      }
- 
++
 +    @Override
-+    public boolean isValidRepairItemStack(org.bukkit.inventory.ItemStack itemToBeRepaired, org.bukkit.inventory.ItemStack repairMaterial) {
++    public boolean isValidRepairItemStack(final ItemStack itemToBeRepaired, final ItemStack repairMaterial) {
 +        if (!itemToBeRepaired.getType().isItem() || !repairMaterial.getType().isItem()) {
 +            return false;
 +        }
 +        return CraftMagicNumbers.getItem(itemToBeRepaired.getType()).isValidRepairItem(CraftItemStack.asNMSCopy(itemToBeRepaired), CraftItemStack.asNMSCopy(repairMaterial));
 +    }
-+
-     @Override
-     public int getProtocolVersion() {
-         return net.minecraft.SharedConstants.getCurrentVersion().getProtocolVersion();
+ }
 diff --git a/src/test/java/io/papermc/paper/util/ItemStackRepairCheckTest.java b/src/test/java/io/papermc/paper/util/ItemStackRepairCheckTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..8d9c9b3bd53d407391d4fcb7fc773153d1a7b402

--- a/patches/server/0625-Attributes-API-for-item-defaults.patch
+++ b/patches/server/0625-Attributes-API-for-item-defaults.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Attributes API for item defaults
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 1aa8ba6ff3263c6d2ef9694ad4e7bafc8215ec43..aa79564d415af3a61978ba72c95a97cc1de05458 100644
+index ebb63b4171fc6eb39a8d7c61478211e80c2487e4..75c19f58c37a46321badd2ac86ec5df10d342639 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -545,6 +545,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
-         return CraftMagicNumbers.getItem(itemToBeRepaired.getType()).isValidRepairItem(CraftItemStack.asNMSCopy(itemToBeRepaired), CraftItemStack.asNMSCopy(repairMaterial));
+@@ -432,6 +432,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
+         return net.minecraft.world.entity.Entity.nextEntityId();
      }
  
 +    @Override

--- a/patches/server/0681-Get-entity-default-attributes.patch
+++ b/patches/server/0681-Get-entity-default-attributes.patch
@@ -6,6 +6,51 @@ Subject: [PATCH] Get entity default attributes
 == AT ==
 public net.minecraft.world.entity.ai.attributes.AttributeSupplier getAttributeInstance(Lnet/minecraft/world/entity/ai/attributes/Attribute;)Lnet/minecraft/world/entity/ai/attributes/AttributeInstance;
 
+diff --git a/src/main/java/io/papermc/paper/APIBridgeImpl.java b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+index 7cf4cf9e1687acd72845e530b56f8d9d1517b8d4..642c66ad2a5563b52826ae8ce1417179330fffcc 100644
+--- a/src/main/java/io/papermc/paper/APIBridgeImpl.java
++++ b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+@@ -11,15 +11,22 @@ import io.papermc.paper.inventory.ItemRarity;
+ import java.io.ByteArrayInputStream;
+ import java.io.ByteArrayOutputStream;
+ import java.io.IOException;
++import net.kyori.adventure.key.Key;
+ import net.kyori.adventure.text.Component;
+ import net.kyori.adventure.text.flattener.ComponentFlattener;
+ import net.minecraft.SharedConstants;
++import net.minecraft.core.registries.BuiltInRegistries;
+ import net.minecraft.nbt.CompoundTag;
+ import net.minecraft.nbt.NbtIo;
+ import net.minecraft.server.MinecraftServer;
+ import net.minecraft.server.dedicated.DedicatedServer;
++import net.minecraft.world.entity.EntityType;
++import net.minecraft.world.entity.LivingEntity;
++import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
++import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
+ import net.minecraft.world.item.Item;
+ import org.bukkit.Material;
++import org.bukkit.attribute.Attributable;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+@@ -123,4 +130,17 @@ public final class APIBridgeImpl implements APIBridge {
+         }
+         return CraftMagicNumbers.getItem(itemToBeRepaired.getType()).isValidRepairItem(CraftItemStack.asNMSCopy(itemToBeRepaired), CraftItemStack.asNMSCopy(repairMaterial));
+     }
++
++    @Override
++    public boolean hasDefaultEntityAttributes(final Key entityTypeKey) {
++        return DefaultAttributes.hasSupplier(BuiltInRegistries.ENTITY_TYPE.get(PaperAdventure.asVanilla(entityTypeKey)));
++    }
++
++    @SuppressWarnings("unchecked")
++    @Override
++    public Attributable getDefaultEntityAttributes(final Key entityTypeKey) {
++        Preconditions.checkArgument(this.hasDefaultEntityAttributes(entityTypeKey), entityTypeKey + " doesn't have default attributes");
++        AttributeSupplier supplier = net.minecraft.world.entity.ai.attributes.DefaultAttributes.getSupplier((EntityType<? extends LivingEntity>) BuiltInRegistries.ENTITY_TYPE.get(PaperAdventure.asVanilla(entityTypeKey)));
++        return new io.papermc.paper.attribute.UnmodifiableAttributeMap(supplier);
++    }
+ }
 diff --git a/src/main/java/io/papermc/paper/attribute/UnmodifiableAttributeInstance.java b/src/main/java/io/papermc/paper/attribute/UnmodifiableAttributeInstance.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..12135ffeacd648f6bc4d7d327059ea1a7e8c79c4
@@ -80,29 +125,6 @@ index 0000000000000000000000000000000000000000..cf9d28ea97d93cec05c9fb768d59e283
 +        throw new UnsupportedOperationException("Cannot register new attributes here");
 +    }
 +}
-diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index aa79564d415af3a61978ba72c95a97cc1de05458..bac01b70eadcf76121e6e2f20bd57edaa78fd0f8 100644
---- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-+++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -562,6 +562,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
-     public int getProtocolVersion() {
-         return net.minecraft.SharedConstants.getCurrentVersion().getProtocolVersion();
-     }
-+
-+    @Override
-+    public boolean hasDefaultEntityAttributes(NamespacedKey bukkitEntityKey) {
-+        return net.minecraft.world.entity.ai.attributes.DefaultAttributes.hasSupplier(net.minecraft.core.registries.BuiltInRegistries.ENTITY_TYPE.get(CraftNamespacedKey.toMinecraft(bukkitEntityKey)));
-+    }
-+
-+    @Override
-+    public org.bukkit.attribute.Attributable getDefaultEntityAttributes(NamespacedKey bukkitEntityKey) {
-+        Preconditions.checkArgument(hasDefaultEntityAttributes(bukkitEntityKey), bukkitEntityKey + " doesn't have default attributes");
-+        var supplier = net.minecraft.world.entity.ai.attributes.DefaultAttributes.getSupplier((net.minecraft.world.entity.EntityType<? extends net.minecraft.world.entity.LivingEntity>) net.minecraft.core.registries.BuiltInRegistries.ENTITY_TYPE.get(CraftNamespacedKey.toMinecraft(bukkitEntityKey)));
-+        return new io.papermc.paper.attribute.UnmodifiableAttributeMap(supplier);
-+    }
-     // Paper end
- 
-     /**
 diff --git a/src/test/java/io/papermc/paper/attribute/EntityTypeAttributesTest.java b/src/test/java/io/papermc/paper/attribute/EntityTypeAttributesTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..7b999deba66aa6d22cd7520f6c13550a44ca327d

--- a/patches/server/0687-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/server/0687-Add-isCollidable-methods-to-various-places.patch
@@ -6,6 +6,21 @@ Subject: [PATCH] Add isCollidable methods to various places
 == AT ==
 public net.minecraft.world.level.block.state.BlockBehaviour hasCollision
 
+diff --git a/src/main/java/io/papermc/paper/APIBridgeImpl.java b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+index 642c66ad2a5563b52826ae8ce1417179330fffcc..fcc51b8e2a4c4f3586923469db087ac8c8062d11 100644
+--- a/src/main/java/io/papermc/paper/APIBridgeImpl.java
++++ b/src/main/java/io/papermc/paper/APIBridgeImpl.java
+@@ -143,4 +143,10 @@ public final class APIBridgeImpl implements APIBridge {
+         AttributeSupplier supplier = net.minecraft.world.entity.ai.attributes.DefaultAttributes.getSupplier((EntityType<? extends LivingEntity>) BuiltInRegistries.ENTITY_TYPE.get(PaperAdventure.asVanilla(entityTypeKey)));
+         return new io.papermc.paper.attribute.UnmodifiableAttributeMap(supplier);
+     }
++
++    @Override
++    public boolean isCollidable(final Material block) {
++        Preconditions.checkArgument(block.isBlock(), block + " is not a block");
++        return CraftMagicNumbers.getBlock(block).hasCollision;
++    }
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 index 4cfefcd6dc1ccdc9ecc52c9965fef5a3e339f862..5343ae3cdda55d7e0b41747c7eccb52e6828f6c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
@@ -38,20 +53,3 @@ index 7b9e943b391c061782fccd2b8d705ceec8db50fe..966ac60daebb7bb211ab8096fc0c5f33
 +    }
 +    // Paper end
  }
-diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index bac01b70eadcf76121e6e2f20bd57edaa78fd0f8..30dfdbace0f60074d0cb056d2916331882ade295 100644
---- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-+++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -574,6 +574,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
-         var supplier = net.minecraft.world.entity.ai.attributes.DefaultAttributes.getSupplier((net.minecraft.world.entity.EntityType<? extends net.minecraft.world.entity.LivingEntity>) net.minecraft.core.registries.BuiltInRegistries.ENTITY_TYPE.get(CraftNamespacedKey.toMinecraft(bukkitEntityKey)));
-         return new io.papermc.paper.attribute.UnmodifiableAttributeMap(supplier);
-     }
-+
-+    @Override
-+    public boolean isCollidable(Material material) {
-+        Preconditions.checkArgument(material.isBlock(), material + " is not a block");
-+        return getBlock(material).hasCollision;
-+    }
-     // Paper end
- 
-     /**

--- a/patches/server/0690-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0690-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index de50f1aa6b7cebf877e18bc3e2ae3ba707edcd4c..3a388ead677be73b0ae4425a05a45cd34e95d586 100644
+index cfe232364abd407d5ce117428f78fa98a9d305f2..b172f0733491ca6cde6b962f03e15e6e949ebf52 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2018,6 +2018,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -45,13 +45,13 @@ index 38165a364dfeca6d0fb35e7b3ada92d728ec295b..0c65652866de257d2a9019f910506a6f
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 30dfdbace0f60074d0cb056d2916331882ade295..7e9b2497f4b8b0f5e55acd6c83593fb42bb4a52d 100644
+index 75c19f58c37a46321badd2ac86ec5df10d342639..c7a4f179a4bd4ee8871f1dd84b56e7ef4dc51e6a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -485,6 +485,29 @@ public final class CraftMagicNumbers implements UnsafeValues {
-         return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of(ca.spottedleaf.dataconverter.minecraft.MCDataConverter.convertTag(ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry.ITEM_STACK, compound, dataVersion, getDataVersion())));
-     }
+@@ -427,6 +427,57 @@ public final class CraftMagicNumbers implements UnsafeValues {
+     // Paper end
  
+     // Paper start
 +    @Override
 +    public byte[] serializeEntity(org.bukkit.entity.Entity entity) {
 +        Preconditions.checkNotNull(entity, "null cannot be serialized");
@@ -75,6 +75,34 @@ index 30dfdbace0f60074d0cb056d2916331882ade295..7e9b2497f4b8b0f5e55acd6c83593fb4
 +            .orElseThrow(() -> new IllegalArgumentException("An ID was not found for the data. Did you downgrade?")).getBukkitEntity();
 +    }
 +
-     private byte[] serializeNbtToBytes(CompoundTag compound) {
-         compound.putInt("DataVersion", getDataVersion());
-         java.io.ByteArrayOutputStream outputStream = new java.io.ByteArrayOutputStream();
++    private byte[] serializeNbtToBytes(CompoundTag compound) {
++        compound.putInt("DataVersion", getDataVersion());
++        java.io.ByteArrayOutputStream outputStream = new java.io.ByteArrayOutputStream();
++        try {
++            net.minecraft.nbt.NbtIo.writeCompressed(
++                compound,
++                outputStream
++            );
++        } catch (IOException ex) {
++            throw new RuntimeException(ex);
++        }
++        return outputStream.toByteArray();
++    }
++
++    private CompoundTag deserializeNbtFromBytes(byte[] data) {
++        CompoundTag compound;
++        try {
++            compound = net.minecraft.nbt.NbtIo.readCompressed(
++                new java.io.ByteArrayInputStream(data)
++            );
++        } catch (IOException ex) {
++            throw new RuntimeException(ex);
++        }
++        int dataVersion = compound.getInt("DataVersion");
++        Preconditions.checkArgument(dataVersion <= getDataVersion(), "Newer version! Server downgrades are not supported!");
++        return compound;
++    }
++
+     @Override
+     public int nextEntityId() {
+         return net.minecraft.world.entity.Entity.nextEntityId();

--- a/patches/server/0740-Configurable-feature-seeds.patch
+++ b/patches/server/0740-Configurable-feature-seeds.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable feature seeds
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index 98171f6c8e23f6ef89b897e4b80e3afb2a1950a0..06bff37e4c1fddd3be6343049a66787c63fb420c 100644
+index 400d77b28a0ce46696666581a7154d267d3a24e9..b385abea70b7d91375e5693d6735b74a48a10af9 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -287,7 +287,7 @@ public class TimingsExport extends Thread {
+@@ -288,7 +288,7 @@ public class TimingsExport extends Thread {
          JSONObject object = new JSONObject();
          for (String key : config.getKeys(false)) {
              String fullKey = (parentKey != null ? parentKey + "." + key : key);

--- a/patches/server/0878-Add-NamespacedKey-biome-methods.patch
+++ b/patches/server/0878-Add-NamespacedKey-biome-methods.patch
@@ -6,12 +6,12 @@ Subject: [PATCH] Add NamespacedKey biome methods
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 7e9b2497f4b8b0f5e55acd6c83593fb42bb4a52d..64c50c52c11214740de7903e5592b8b6b2c170b3 100644
+index c7a4f179a4bd4ee8871f1dd84b56e7ef4dc51e6a..1e0c9bec8d52e634114f0d32fb04be256c367177 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -603,6 +603,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
-         Preconditions.checkArgument(material.isBlock(), material + " is not a block");
-         return getBlock(material).hasCollision;
+@@ -500,6 +500,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
+     public int getProtocolVersion() {
+         return net.minecraft.SharedConstants.getCurrentVersion().getProtocolVersion();
      }
 +
 +    @Override


### PR DESCRIPTION
Makes a new interface `APIBridge` to function as the place to bridge between API and the server impl without abusing UnsafeValues. UnsafeValue should be for actually unsafe "api". All the methods in `ABIBridge` should be called somewhere else with-in the API.