### PR TITLE
Make ItemStack#displayName only return the display name

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -3746,10 +3746,10 @@ index 5fc95b83dbcd8e533afe6539f97829ce7a52224f..dbf316b63bf3d0c0695ceca84985d67f
      public abstract String getTitle();
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index f89d71b77d1200314df6ca23614d5ca6fb15ceb3..af4a7ce37eb10bab06eadb6583c7894b3ec55ae6 100644
+index f89d71b77d1200314df6ca23614d5ca6fb15ceb3..10d1328da5ea75f0cf373c3faee58e54036835a2 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -159,4 +159,24 @@ public interface ItemFactory {
+@@ -159,4 +159,47 @@ public interface ItemFactory {
      @Deprecated
      @NotNull
      Material updateMaterial(@NotNull final ItemMeta meta, @NotNull final Material material) throws IllegalArgumentException;
@@ -3765,17 +3765,40 @@ index f89d71b77d1200314df6ca23614d5ca6fb15ceb3..af4a7ce37eb10bab06eadb6583c7894b
 +    net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final @NotNull ItemStack item, final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op);
 +
 +    /**
++     * Get the formatted display name of the {@link ItemStack} with brackets and hover information.
++     *
++     * @param itemStack the {@link ItemStack}
++     * @return item data display of the {@link ItemStack}
++     * @deprecated Confusing method name. Use {@link #dataDisplay(ItemStack)} (to get the item with brackets and hover)
++     * or {@link #displayedName(ItemStack)} (to just get the item name component)
++     */
++    @NotNull
++    @Deprecated
++    default net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack) {
++        return dataDisplay(itemStack);
++    }
++
++    /**
++     * Get the formatted display name of the {@link ItemStack} with brackets and hover information.
++     *
++     * @param itemStack the {@link ItemStack}
++     * @return item data display of the {@link ItemStack}
++     */
++    @NotNull
++    net.kyori.adventure.text.Component dataDisplay(@NotNull ItemStack itemStack);
++
++    /**
 +     * Get the formatted display name of the {@link ItemStack}.
 +     *
 +     * @param itemStack the {@link ItemStack}
 +     * @return display name of the {@link ItemStack}
 +     */
 +    @NotNull
-+    net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack);
++    net.kyori.adventure.text.Component displayedName(@NotNull ItemStack itemStack);
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index d80b0a52968920b990a75cff85e436a16d782500..9d327f0832c40d4a8d212346284274f6cf78834f 100644
+index d80b0a52968920b990a75cff85e436a16d782500..6ef5519faf8cd33bd2a82ebdf6da54c5ad6d8d3b 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
@@ -3787,7 +3810,7 @@ index d80b0a52968920b990a75cff85e436a16d782500..9d327f0832c40d4a8d212346284274f6
      private Material type = Material.AIR;
      private int amount = 0;
      private MaterialData data = null;
-@@ -602,4 +602,21 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -602,4 +602,42 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public String getTranslationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }
@@ -3800,12 +3823,33 @@ index d80b0a52968920b990a75cff85e436a16d782500..9d327f0832c40d4a8d212346284274f6
 +    }
 +
 +    /**
++     * Get the formatted display name of the {@link ItemStack} with brackets and hover information.
++     *
++     * @return item data display of the {@link ItemStack}
++     * @deprecated Confusing method name. Use {@link #dataDisplay()} (to get the item with brackets and hover)
++     * or {@link #displayedName()} (to just get the item name component)
++     */
++    @Deprecated
++    public net.kyori.adventure.text.@NotNull Component displayName() {
++        return dataDisplay();
++    }
++
++    /**
++     * Get the formatted display name of the {@link ItemStack} with brackets and hover information.
++     *
++     * @return item data display of the {@link ItemStack}
++     */
++    public net.kyori.adventure.text.@NotNull Component dataDisplay() {
++        return Bukkit.getServer().getItemFactory().dataDisplay(this);
++    }
++
++    /**
 +     * Get the formatted display name of the {@link ItemStack}.
 +     *
 +     * @return display name of the {@link ItemStack}
 +     */
-+    public net.kyori.adventure.text.@NotNull Component displayName() {
-+        return Bukkit.getServer().getItemFactory().displayName(this);
++    public net.kyori.adventure.text.@NotNull Component displayedName() {
++        return Bukkit.getServer().getItemFactory().displayedName(this);
 +    }
 +    // Paper end
  }

--- a/patches/api/0065-Add-getI18NDisplayName-API.patch
+++ b/patches/api/0065-Add-getI18NDisplayName-API.patch
@@ -8,13 +8,13 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index af4a7ce37eb10bab06eadb6583c7894b3ec55ae6..159e5a908b35b84b7fabc36581e093d9aa4c4b67 100644
+index 10d1328da5ea75f0cf373c3faee58e54036835a2..1cbace6fa0deb7364c2b0941d540825a070d74ae 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -178,5 +178,19 @@ public interface ItemFactory {
+@@ -201,5 +201,19 @@ public interface ItemFactory {
       */
      @NotNull
-     net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack);
+     net.kyori.adventure.text.Component displayedName(@NotNull ItemStack itemStack);
 +
 +    /**
 +     * Gets the Display name as seen in the Client.
@@ -32,12 +32,12 @@ index af4a7ce37eb10bab06eadb6583c7894b3ec55ae6..159e5a908b35b84b7fabc36581e093d9
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 9d327f0832c40d4a8d212346284274f6cf78834f..09a36df6edce2a283df80c67d5ef62da7ff73555 100644
+index 6ef5519faf8cd33bd2a82ebdf6da54c5ad6d8d3b..972e4fd803b436789820cc2f57e5a35ae3b97868 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -618,5 +618,20 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
-     public net.kyori.adventure.text.@NotNull Component displayName() {
-         return Bukkit.getServer().getItemFactory().displayName(this);
+@@ -639,5 +639,20 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+     public net.kyori.adventure.text.@NotNull Component displayedName() {
+         return Bukkit.getServer().getItemFactory().displayedName(this);
      }
 +
 +    /**

--- a/patches/api/0066-ensureServerConversions-API.patch
+++ b/patches/api/0066-ensureServerConversions-API.patch
@@ -7,10 +7,10 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 159e5a908b35b84b7fabc36581e093d9aa4c4b67..66ffc658dba85942f179760dc6c50258e24ab903 100644
+index 1cbace6fa0deb7364c2b0941d540825a070d74ae..4580b345c567cd01506f8a696ed821dba3be4237 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -192,5 +192,17 @@ public interface ItemFactory {
+@@ -215,5 +215,17 @@ public interface ItemFactory {
      @Nullable
      @Deprecated
      String getI18NDisplayName(@Nullable ItemStack item);
@@ -29,7 +29,7 @@ index 159e5a908b35b84b7fabc36581e093d9aa4c4b67..66ffc658dba85942f179760dc6c50258
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 87f7942082ad943a97058f58c09ea2fe9caf5bfe..9d32283ee612a50b8a2bfe5151f42c9f181ede4c 100644
+index 972e4fd803b436789820cc2f57e5a35ae3b97868..160e3f4900eb7b953973494d12b906bc0a41f503 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -537,7 +537,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
@@ -41,8 +41,8 @@ index 87f7942082ad943a97058f58c09ea2fe9caf5bfe..9d32283ee612a50b8a2bfe5151f42c9f
      }
  
      /**
-@@ -619,6 +619,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
-         return Bukkit.getServer().getItemFactory().displayName(this);
+@@ -640,6 +640,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+         return Bukkit.getServer().getItemFactory().displayedName(this);
      }
  
 +    /**

--- a/patches/api/0107-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/api/0107-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 9d32283ee612a50b8a2bfe5151f42c9f181ede4c..53d99d214652ae1636f28a179a5b66edc0f8f229 100644
+index 160e3f4900eb7b953973494d12b906bc0a41f503..70306a1415c70ee7bd473c9ff636a69d18167d50 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -646,5 +646,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -667,5 +667,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public String getI18NDisplayName() {
          return Bukkit.getServer().getItemFactory().getI18NDisplayName(this);
      }

--- a/patches/api/0115-ItemStack-API-additions-for-quantity-flags-lore.patch
+++ b/patches/api/0115-ItemStack-API-additions-for-quantity-flags-lore.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ItemStack API additions for quantity/flags/lore
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 53d99d214652ae1636f28a179a5b66edc0f8f229..1907b8cfb4a78415fba8d5445ba98a6208516fd9 100644
+index 70306a1415c70ee7bd473c9ff636a69d18167d50..c92253cb9a281df8ae28f6de709dbaaff0fc6264 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -3,6 +3,7 @@ package org.bukkit.inventory;
@@ -16,7 +16,7 @@ index 53d99d214652ae1636f28a179a5b66edc0f8f229..1907b8cfb4a78415fba8d5445ba98a62
  import java.util.Map;
  import org.bukkit.Bukkit;
  import org.bukkit.Material;
-@@ -654,5 +655,185 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -675,5 +676,185 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          // Requires access to NMS
          return ensureServerConversions().getMaxItemUseDuration();
      }

--- a/patches/api/0188-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/api/0188-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -20,10 +20,10 @@ index 24fad8e59a3a5a174d24505cedda2a3fd52115b1..ee9ed5f0e2936c740903784b01b9e2ff
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index b15645cd56c245214bb5b87b36395fbc8e86e3d3..7c280d7beeb42dca52e36e77bbd41742b2572710 100644
+index 166a42272f5c23b0126610be78aaa1dc62a8affc..d878ff99283cc3ba15e2048c15f581e0448d311e 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -639,6 +639,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -660,6 +660,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          return Bukkit.getServer().getItemFactory().ensureServerConversions(this);
      }
  

--- a/patches/api/0212-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0212-Add-methods-to-get-translation-keys.patch
@@ -283,7 +283,7 @@ index 06ef9e133125d80127e1dbd6ae0eda89fa08a1d7..35ed58bce2589bb097dd0f6bf2a6ebd7
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
-index 5744a9f432ec75f6b6b1991ff488dffb9591c934..0264c2f9a3977b6d47994b1e1b0240b312e5bf65 100644
+index 2dc749936df6168073a5bb9f9051d55f8589ac62..1b6f42ff632b1f3f5034c825e99b72f389a890b4 100644
 --- a/src/main/java/org/bukkit/enchantments/Enchantment.java
 +++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
 @@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
@@ -450,7 +450,7 @@ index 5bd252c0ae3b09fe141d131360c67bb9bfbf5422..78587d9fabe6371a23a7963917b054db
 +
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 7c280d7beeb42dca52e36e77bbd41742b2572710..03a15727c85a08c0c79965be249373a11f31ce6e 100644
+index d878ff99283cc3ba15e2048c15f581e0448d311e..0897d6644438b3c79a90a1b4633d40cac8e0b275 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
@@ -470,7 +470,7 @@ index 7c280d7beeb42dca52e36e77bbd41742b2572710..03a15727c85a08c0c79965be249373a1
      public String getTranslationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }
-@@ -865,5 +866,16 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -886,5 +887,16 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          ItemMeta itemMeta = getItemMeta();
          return itemMeta != null && itemMeta.hasItemFlag(flag);
      }

--- a/patches/api/0213-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/api/0213-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 50fe28b48d885c782278bdb53a0bbae303f4a32d..34c13845f4916fb167fc9d83fe792975e5c52bdc 100644
+index b7ffa38415632180adb1fee4db8e648569479622..a810863ad09c143998f4716b05a87e1300dd0cb9 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -204,5 +204,62 @@ public interface ItemFactory {
+@@ -227,5 +227,62 @@ public interface ItemFactory {
       */
      @NotNull
      ItemStack ensureServerConversions(@NotNull ItemStack item);

--- a/patches/api/0268-Item-Rarity-API.patch
+++ b/patches/api/0268-Item-Rarity-API.patch
@@ -88,10 +88,10 @@ index 6c45841538f2f073691331f975741a62b03a6637..e87cbaf9c1ea1330ab1597f98c8864d0
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 03a15727c85a08c0c79965be249373a11f31ce6e..c6378a880eac9f444c66f640260e8d410efd015b 100644
+index 0897d6644438b3c79a90a1b4633d40cac8e0b275..c46875ca06c3baa99235f0293c4b01ba96d1c09f 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -877,5 +877,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -898,5 +898,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public @NotNull String translationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }

--- a/patches/api/0287-ItemStack-repair-check-API.patch
+++ b/patches/api/0287-ItemStack-repair-check-API.patch
@@ -26,10 +26,10 @@ index 906f313d8c91e65ce934143208ed281ce02f5354..29a91ec8e97ce66383a1dd1fc3dcbcdc
       * Returns the server's protocol version.
       *
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index c6378a880eac9f444c66f640260e8d410efd015b..b731ac4f6cd82d8476e4040a2204f58b0f63a0d3 100644
+index c46875ca06c3baa99235f0293c4b01ba96d1c09f..73b46bd3de323a4413b2b61c6041965a6d7e8c78 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -887,5 +887,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -908,5 +908,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public io.papermc.paper.inventory.ItemRarity getRarity() {
          return Bukkit.getUnsafe().getItemStackRarity(this);
      }

--- a/patches/api/0322-Add-ItemFactory-getSpawnEgg-API.patch
+++ b/patches/api/0322-Add-ItemFactory-getSpawnEgg-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ItemFactory#getSpawnEgg API
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 34c13845f4916fb167fc9d83fe792975e5c52bdc..2acafae468fcbb7213d6b6c30803a3924a3bbc30 100644
+index a810863ad09c143998f4716b05a87e1300dd0cb9..1b94ca93b3ae820984764acc439079c0d5ddd2fd 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -261,5 +261,14 @@ public interface ItemFactory {
+@@ -284,5 +284,14 @@ public interface ItemFactory {
      @NotNull
      @Deprecated
      net.md_5.bungee.api.chat.hover.content.Content hoverContentOf(@NotNull org.bukkit.entity.Entity entity, @NotNull net.md_5.bungee.api.chat.BaseComponent[] customName);

--- a/patches/api/0397-ItemStack-damage-API.patch
+++ b/patches/api/0397-ItemStack-damage-API.patch
@@ -65,10 +65,10 @@ index 454376eada83adc3c7c83a7b720500f998f5593d..329ca07b6e166729d33446c4cd1ae19e
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 6f33145f1ccc7645616f310a68676207318c2a58..449d6e1995eedbfaeffdc5d1f1c2295378006aa8 100644
+index 45ccd07b5a27199dcc39d9d2e909d74fcd41c35c..a8f0fb93cfc52bc57a3f0243e20e68ddd2074d76 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -971,5 +971,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -992,5 +992,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public boolean canRepair(@NotNull ItemStack toBeRepaired) {
          return Bukkit.getUnsafe().isValidRepairItemStack(toBeRepaired, this);
      }

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -4096,10 +4096,10 @@ index 6a64fbb8b4937f39d5fdc2e2cbec26c83c74c486..7d6b5fdb00a5c1614849735634262a36
      public String getTitle() {
          return CraftChatMessage.fromComponent(this.container.getTitle());
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index a7ef4a04358df3f848ace0e6e8b6f2d0a18dbc29..41471ff966ffb0d50831005c397ff56386671431 100644
+index a7ef4a04358df3f848ace0e6e8b6f2d0a18dbc29..73b10b4452bdf4782e815d92c190390f75ec1a2e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -417,4 +417,22 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -417,4 +417,27 @@ public final class CraftItemFactory implements ItemFactory {
      public Material updateMaterial(ItemMeta meta, Material material) throws IllegalArgumentException {
          return ((CraftMetaItem) meta).updateMaterial(material);
      }
@@ -4112,7 +4112,12 @@ index a7ef4a04358df3f848ace0e6e8b6f2d0a18dbc29..41471ff966ffb0d50831005c397ff563
 +    }
 +
 +    @Override
-+    public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component displayName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
++    public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component dataDisplay(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(CraftItemStack.asNMSCopy(itemStack).getDisplayName());
++    }
++
++    @Override
++    public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component displayedName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
 +        net.minecraft.world.item.ItemStack nms = CraftItemStack.asNMSCopy(itemStack);
 +        net.minecraft.network.chat.MutableComponent nmsComponent = net.minecraft.network.chat.Component.empty().append(nms.getHoverName());
 +        if (nms.hasCustomHoverName()) {

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -4096,10 +4096,10 @@ index 6a64fbb8b4937f39d5fdc2e2cbec26c83c74c486..7d6b5fdb00a5c1614849735634262a36
      public String getTitle() {
          return CraftChatMessage.fromComponent(this.container.getTitle());
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index a7ef4a04358df3f848ace0e6e8b6f2d0a18dbc29..4c76692e222d8505558aade9c03b3686612f7c0c 100644
+index a7ef4a04358df3f848ace0e6e8b6f2d0a18dbc29..41471ff966ffb0d50831005c397ff56386671431 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -417,4 +417,17 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -417,4 +417,22 @@ public final class CraftItemFactory implements ItemFactory {
      public Material updateMaterial(ItemMeta meta, Material material) throws IllegalArgumentException {
          return ((CraftMetaItem) meta).updateMaterial(material);
      }
@@ -4113,7 +4113,12 @@ index a7ef4a04358df3f848ace0e6e8b6f2d0a18dbc29..4c76692e222d8505558aade9c03b3686
 +
 +    @Override
 +    public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component displayName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
-+        return io.papermc.paper.adventure.PaperAdventure.asAdventure(CraftItemStack.asNMSCopy(itemStack).getDisplayName());
++        net.minecraft.world.item.ItemStack nms = CraftItemStack.asNMSCopy(itemStack);
++        net.minecraft.network.chat.MutableComponent nmsComponent = net.minecraft.network.chat.Component.empty().append(nms.getHoverName());
++        if (nms.hasCustomHoverName()) {
++            nmsComponent.withStyle(net.minecraft.ChatFormatting.ITALIC);
++        }
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(nmsComponent);
 +    }
 +    // Paper end
  }

--- a/patches/server/0149-Implement-ensureServerConversions-API.patch
+++ b/patches/server/0149-Implement-ensureServerConversions-API.patch
@@ -7,12 +7,12 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 4c76692e222d8505558aade9c03b3686612f7c0c..70607c9458f58a05ccc94bfcb38dae79bd7ad483 100644
+index 41471ff966ffb0d50831005c397ff56386671431..718e50093850dd0d2e906f0f3e75c73b0e53dcf1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -429,5 +429,11 @@ public final class CraftItemFactory implements ItemFactory {
-     public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component displayName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
-         return io.papermc.paper.adventure.PaperAdventure.asAdventure(CraftItemStack.asNMSCopy(itemStack).getDisplayName());
+@@ -434,5 +434,11 @@ public final class CraftItemFactory implements ItemFactory {
+         }
+         return io.papermc.paper.adventure.PaperAdventure.asAdventure(nmsComponent);
      }
 +
 +    // Paper start

--- a/patches/server/0149-Implement-ensureServerConversions-API.patch
+++ b/patches/server/0149-Implement-ensureServerConversions-API.patch
@@ -7,10 +7,10 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 41471ff966ffb0d50831005c397ff56386671431..718e50093850dd0d2e906f0f3e75c73b0e53dcf1 100644
+index 73b10b4452bdf4782e815d92c190390f75ec1a2e..3e45135319240082d602a957d19f67e75151a839 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -434,5 +434,11 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -439,5 +439,11 @@ public final class CraftItemFactory implements ItemFactory {
          }
          return io.papermc.paper.adventure.PaperAdventure.asAdventure(nmsComponent);
      }

--- a/patches/server/0150-Implement-getI18NDisplayName.patch
+++ b/patches/server/0150-Implement-getI18NDisplayName.patch
@@ -8,10 +8,10 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 718e50093850dd0d2e906f0f3e75c73b0e53dcf1..6636520985e0186296eb5ae87d590abe57bb81c1 100644
+index 3e45135319240082d602a957d19f67e75151a839..896c55107ef895016c088e75141c2f2a809fd332 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -440,5 +440,18 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -445,5 +445,18 @@ public final class CraftItemFactory implements ItemFactory {
      public ItemStack ensureServerConversions(ItemStack item) {
          return CraftItemStack.asCraftMirror(CraftItemStack.asNMSCopy(item));
      }

--- a/patches/server/0150-Implement-getI18NDisplayName.patch
+++ b/patches/server/0150-Implement-getI18NDisplayName.patch
@@ -8,10 +8,10 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 70607c9458f58a05ccc94bfcb38dae79bd7ad483..45f37c894a9d862fd9d73908d1dae2e8c62262ff 100644
+index 718e50093850dd0d2e906f0f3e75c73b0e53dcf1..6636520985e0186296eb5ae87d590abe57bb81c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -435,5 +435,18 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -440,5 +440,18 @@ public final class CraftItemFactory implements ItemFactory {
      public ItemStack ensureServerConversions(ItemStack item) {
          return CraftItemStack.asCraftMirror(CraftItemStack.asNMSCopy(item));
      }

--- a/patches/server/0472-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/server/0472-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 6636520985e0186296eb5ae87d590abe57bb81c1..30aac94550d5e6852c9009ffac73783a6ac5e27e 100644
+index 896c55107ef895016c088e75141c2f2a809fd332..ff3e3888e4f403a378a33692d0b64524936ba582 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -453,5 +453,40 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -458,5 +458,40 @@ public final class CraftItemFactory implements ItemFactory {
  
          return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId(nms)) : null;
      }

--- a/patches/server/0472-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/server/0472-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 45f37c894a9d862fd9d73908d1dae2e8c62262ff..081a92415d8a19da4f342e8febee62c844458cb9 100644
+index 6636520985e0186296eb5ae87d590abe57bb81c1..30aac94550d5e6852c9009ffac73783a6ac5e27e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -448,5 +448,40 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -453,5 +453,40 @@ public final class CraftItemFactory implements ItemFactory {
  
          return nms != null ? net.minecraft.locale.Language.getInstance().getOrDefault(nms.getItem().getDescriptionId(nms)) : null;
      }

--- a/patches/server/0684-Add-ItemFactory-getSpawnEgg-API.patch
+++ b/patches/server/0684-Add-ItemFactory-getSpawnEgg-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ItemFactory#getSpawnEgg API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 081a92415d8a19da4f342e8febee62c844458cb9..3c72c95872365a66a19793a613c008720fc681ac 100644
+index 30aac94550d5e6852c9009ffac73783a6ac5e27e..bd39f5b27a23e913d1d1f6f781ee43fadf50d52a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -483,5 +483,17 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -488,5 +488,17 @@ public final class CraftItemFactory implements ItemFactory {
              entity.getUniqueId().toString(),
              new net.md_5.bungee.api.chat.TextComponent(customName));
      }

--- a/patches/server/0684-Add-ItemFactory-getSpawnEgg-API.patch
+++ b/patches/server/0684-Add-ItemFactory-getSpawnEgg-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ItemFactory#getSpawnEgg API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 30aac94550d5e6852c9009ffac73783a6ac5e27e..bd39f5b27a23e913d1d1f6f781ee43fadf50d52a 100644
+index ff3e3888e4f403a378a33692d0b64524936ba582..b774b9cb73bc851893d8101296385ae721c3787b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -488,5 +488,17 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -493,5 +493,17 @@ public final class CraftItemFactory implements ItemFactory {
              entity.getUniqueId().toString(),
              new net.md_5.bungee.api.chat.TextComponent(customName));
      }


### PR DESCRIPTION
Previously additional formatting like brackets around the display name as well as the item information hover event were automatically added when using the `ItemStack#displayName`. In my opinion this did not match the API specification ("Get the formatted display name of the ItemStack", that says nothing about additional characters or hover information) and made it impossible to get the "raw" display name component (which in comparison to `ItemMeta#displayName` fell back to the default translation if no displayName was set) without any additional data. (Especially the brackets were hard to remove)

This changes how the `ItemFactory#displayName` method gets the display name: Instead of directly using the `NMS ItemStack#getDisplayName` method (which isn't really correctly named imo) it now directly uses the `NMS ItemStack#getHoverName` and applies the italic formatting with the same logic as Vanilla would. We end up with a component that only contains the name as the text without additional characters or hover which Vanilla uses for display purposes in chat e.g. on /give.

Old:
![2023-03-26_15-06-15_Minecraft_1 19 4_-_Multiplayer_(3rd-party_Server)](https://user-images.githubusercontent.com/5768781/227782005-be286a8e-694b-4e2f-b68d-534e5f698ff3.png)

New:
![2023-03-26_15-17-15_Minecraft_1 19 4_-_Multiplayer_(3rd-party_Server)](https://user-images.githubusercontent.com/5768781/227782013-fcb0b8a9-96de-49b8-ab8f-aef4d0ce09b5.png)


The old (wrong) functionality can still easily [be achieved](https://phoenix616.dev/📷/gLWnhx2w.png) with existing API by simply adding the hover event (`ItemStack#asHoverEvent`) to the displayName Component like `item.displayName().hoverEvent(item)` or if the brackets are desired `Component.translatable("chat.square_brackets", item.displayName()).hoverEvent(item)`.
