### PR TITLE
Fix beehives generating from using bonemeal

### DIFF
--- a/patches/server/0968-Fix-beehives-generating-from-using-bonemeal.patch
+++ b/patches/server/0968-Fix-beehives-generating-from-using-bonemeal.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 26 Mar 2023 18:07:56 -0700
+Subject: [PATCH] Fix beehives generating from using bonemeal
+
+
+diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
+index a6253272205337b3b855679b3057c2519a807a4c..d690b8d0c1da1f56b226376df8c76c34375e3c73 100644
+--- a/src/main/java/net/minecraft/world/item/ItemStack.java
++++ b/src/main/java/net/minecraft/world/item/ItemStack.java
+@@ -386,6 +386,7 @@ public final class ItemStack {
+                     }
+                     for (CraftBlockState blockstate : blocks) {
+                         world.setBlock(blockstate.getPosition(),blockstate.getHandle(), blockstate.getFlag()); // SPIGOT-7248 - manual update to avoid physics where appropriate
++                        if (blockstate instanceof org.bukkit.craftbukkit.block.CapturedBlockState capturedBlockState) capturedBlockState.checkTreeBlockHack(); // Paper
+                     }
+                     entityhuman.awardStat(Stats.ITEM_USED.get(item)); // SPIGOT-7236 - award stat
+                 }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CapturedBlockState.java b/src/main/java/org/bukkit/craftbukkit/block/CapturedBlockState.java
+index fb6454cc64ebc549f61ad7d51efb16ef15f8384d..a3d5e319473e2f6316b3ef8edf719296e02d85a1 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CapturedBlockState.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CapturedBlockState.java
+@@ -25,6 +25,12 @@ public final class CapturedBlockState extends CraftBlockState {
+     public boolean update(boolean force, boolean applyPhysics) {
+         boolean result = super.update(force, applyPhysics);
+ 
++        // Paper start
++        this.checkTreeBlockHack();
++        return result;
++    }
++    public void checkTreeBlockHack() {
++        // Paper end
+         // SPIGOT-5537: Horrible hack to manually add bees given World.captureTreeGeneration does not support tiles
+         if (this.treeBlock && getType() == Material.BEE_NEST) {
+             WorldGenLevel generatoraccessseed = this.world.getHandle();
+@@ -47,7 +53,7 @@ public final class CapturedBlockState extends CraftBlockState {
+             // End copied block
+         }
+ 
+-        return result;
++        // Paper
+     }
+ 
+     public static CapturedBlockState getBlockState(Level world, BlockPos pos, int flag) {


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/9051

Verified that it doesn't break what upstream fixed when they broke it *and* that it does fix generating bees inside of hives when using bonemeal.