### PR TITLE
Updated Upstream (CraftBukkit)

### DIFF
--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -6528,10 +6528,10 @@ index 3bcbdf37ad9d76ec97ad3f20e7a683e267441ed9..aa164a81d072d9390fa1400120e80197
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, PrimaryLevelData iworlddataserver, ResourceKey<Level> resourcekey, LevelStem worlddimension, ChunkProgressListener worldloadlistener, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider) {
          // IRegistryCustom.Dimension iregistrycustom_dimension = minecraftserver.registryAccess(); // CraftBukkit - decompile error
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 22bd8ceaaa7f273857867e975cb96d4d79e71c17..ab82ed88baae257f87ec6bc285850b81daa3e27d 100644
+index d47db4ba6ebca0f92c205476171387735329fbf5..3243cfd90e11176efc2059d864fb962497d70942 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -252,6 +252,8 @@ public class ServerPlayer extends Player {
+@@ -253,6 +253,8 @@ public class ServerPlayer extends Player {
      public Integer clientViewDistance;
      public String kickLeaveMessage = null; // SPIGOT-3034: Forward leave message to PlayerQuitEvent
      // CraftBukkit end
@@ -6540,7 +6540,7 @@ index 22bd8ceaaa7f273857867e975cb96d4d79e71c17..ab82ed88baae257f87ec6bc285850b81
  
      public ServerPlayer(MinecraftServer server, ServerLevel world, GameProfile profile) {
          super(world, world.getSharedSpawnPos(), world.getSharedSpawnAngle(), profile);
-@@ -317,6 +319,8 @@ public class ServerPlayer extends Player {
+@@ -318,6 +320,8 @@ public class ServerPlayer extends Player {
          this.setMaxUpStep(1.0F);
          this.fudgeSpawnLocation(world);
  

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2188,7 +2188,7 @@ index 5725631835ea68802c75934cd85d5c1b1a78d358..0b859ebcc2c53e74615feca5c8641365
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ab82ed88baae257f87ec6bc285850b81daa3e27d..01fbd70356795a5a1519eca137e8f6095a07ab30 100644
+index 3243cfd90e11176efc2059d864fb962497d70942..7e4c10bfdaf1e7f2dfc03d220e5c731927b0b5f9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -161,6 +161,7 @@ import net.minecraft.world.scores.Score;
@@ -2199,7 +2199,7 @@ index ab82ed88baae257f87ec6bc285850b81daa3e27d..01fbd70356795a5a1519eca137e8f609
  import org.bukkit.Bukkit;
  import org.bukkit.Location;
  import org.bukkit.WeatherType;
-@@ -240,6 +241,7 @@ public class ServerPlayer extends Player {
+@@ -241,6 +242,7 @@ public class ServerPlayer extends Player {
  
      // CraftBukkit start
      public String displayName;
@@ -2207,7 +2207,7 @@ index ab82ed88baae257f87ec6bc285850b81daa3e27d..01fbd70356795a5a1519eca137e8f609
      public Component listName;
      public org.bukkit.Location compassTarget;
      public int newExp = 0;
-@@ -323,6 +325,7 @@ public class ServerPlayer extends Player {
+@@ -324,6 +326,7 @@ public class ServerPlayer extends Player {
  
          // CraftBukkit start
          this.displayName = this.getScoreboardName();
@@ -2215,7 +2215,7 @@ index ab82ed88baae257f87ec6bc285850b81daa3e27d..01fbd70356795a5a1519eca137e8f609
          this.bukkitPickUpLoot = true;
          this.maxHealthCache = this.getMaxHealth();
      }
-@@ -816,22 +819,17 @@ public class ServerPlayer extends Player {
+@@ -817,22 +820,17 @@ public class ServerPlayer extends Player {
  
          String deathmessage = defaultMessage.getString();
          this.keepLevel = keepInventory; // SPIGOT-2222: pre-set keepLevel
@@ -2242,7 +2242,7 @@ index ab82ed88baae257f87ec6bc285850b81daa3e27d..01fbd70356795a5a1519eca137e8f609
  
              this.connection.send(new ClientboundPlayerCombatKillPacket(this.getCombatTracker(), ichatbasecomponent), PacketSendListener.exceptionallySend(() -> {
                  boolean flag1 = true;
-@@ -1758,13 +1756,13 @@ public class ServerPlayer extends Player {
+@@ -1769,13 +1767,13 @@ public class ServerPlayer extends Player {
  
      public void sendSystemMessage(Component message, boolean overlay) {
          if (this.acceptsSystemMessages(overlay)) {
@@ -2258,7 +2258,7 @@ index ab82ed88baae257f87ec6bc285850b81daa3e27d..01fbd70356795a5a1519eca137e8f609
                  } else {
                      return null;
                  }
-@@ -1773,8 +1771,13 @@ public class ServerPlayer extends Player {
+@@ -1784,8 +1782,13 @@ public class ServerPlayer extends Player {
      }
  
      public void sendChatMessage(OutgoingChatMessage message, boolean filterMaskEnabled, ChatType.Bound params) {
@@ -2273,7 +2273,7 @@ index ab82ed88baae257f87ec6bc285850b81daa3e27d..01fbd70356795a5a1519eca137e8f609
          }
  
      }
-@@ -1792,6 +1795,7 @@ public class ServerPlayer extends Player {
+@@ -1803,6 +1806,7 @@ public class ServerPlayer extends Player {
      }
  
      public String locale = "en_us"; // CraftBukkit - add, lowercase
@@ -2281,7 +2281,7 @@ index ab82ed88baae257f87ec6bc285850b81daa3e27d..01fbd70356795a5a1519eca137e8f609
      public void updateOptions(ServerboundClientInformationPacket packet) {
          // CraftBukkit start
          if (getMainArm() != packet.mainHand()) {
-@@ -1803,6 +1807,10 @@ public class ServerPlayer extends Player {
+@@ -1814,6 +1818,10 @@ public class ServerPlayer extends Player {
              this.server.server.getPluginManager().callEvent(event);
          }
          this.locale = packet.language;
@@ -3445,7 +3445,7 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4d341db0daecb5f6ff1f0a1a9238f9dedb4b50d1..ac56f49ab0736c3176918379f5ac1fdd7fcadfe4 100644
+index 4a82ab70a1fd8027af67e7eb5b507c7c2236819a..d7767d86d14df2529f1c17f4e3e0d0b670c41abf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -278,14 +278,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -3618,7 +3618,7 @@ index 4d341db0daecb5f6ff1f0a1a9238f9dedb4b50d1..ac56f49ab0736c3176918379f5ac1fdd
      }
  
      @Override
-@@ -1576,7 +1648,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1586,7 +1658,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url) {
@@ -3627,7 +3627,7 @@ index 4d341db0daecb5f6ff1f0a1a9238f9dedb4b50d1..ac56f49ab0736c3176918379f5ac1fdd
      }
  
      @Override
-@@ -1591,7 +1663,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1601,7 +1673,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url, byte[] hash, boolean force) {
@@ -3636,7 +3636,7 @@ index 4d341db0daecb5f6ff1f0a1a9238f9dedb4b50d1..ac56f49ab0736c3176918379f5ac1fdd
      }
  
      @Override
-@@ -1607,6 +1679,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1617,6 +1689,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -3658,7 +3658,7 @@ index 4d341db0daecb5f6ff1f0a1a9238f9dedb4b50d1..ac56f49ab0736c3176918379f5ac1fdd
      public void addChannel(String channel) {
          Preconditions.checkState(this.channels.size() < 128, "Cannot register channel '%s'. Too many channels registered!", channel);
          channel = StandardMessenger.validateAndCorrectChannel(channel);
-@@ -2011,6 +2098,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2021,6 +2108,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -3671,7 +3671,7 @@ index 4d341db0daecb5f6ff1f0a1a9238f9dedb4b50d1..ac56f49ab0736c3176918379f5ac1fdd
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -2056,6 +2149,254 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2066,6 +2159,254 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -1338,7 +1338,7 @@ index d19d1f1595a226ce0472be5e2efafbc0e3e1729f..470e752234813d1031721be95d0bf117
  
      public UserWhiteList getWhiteList() {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 35125c029abbdab4c7043842b6042ea44b00a2c3..f215204e1dd6fb3b805a60a268dae10f786b5171 100644
+index 4cd1cfbf91ea232756de16120eec4339d8144885..9171dfb7443d42a5f6d854b2abea55d2671c1177 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -134,7 +134,6 @@ import org.bukkit.craftbukkit.event.CraftPortalEvent;
@@ -1834,10 +1834,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 27cf140f8a7715caec5637d7b487720c2cc5742e..12e7a0a24fe2aa6e7af97ad7d50d81e5c7b26663 100644
+index d7767d86d14df2529f1c17f4e3e0d0b670c41abf..a983573269d5e575c845df3a566d147668ccd86b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2482,6 +2482,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2492,6 +2492,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
              CraftPlayer.this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(components, position == net.md_5.bungee.api.ChatMessageType.ACTION_BAR));
          }

--- a/patches/server/0030-Player-affects-spawning-API.patch
+++ b/patches/server/0030-Player-affects-spawning-API.patch
@@ -73,7 +73,7 @@ index 8ea60d388fff4a6368652ff96f648e5880053a2b..8ecbb64f9db9346757c5597404489496
                              entityzombie.finalizeSpawn(worldserver, this.level.getCurrentDifficultyAt(entityzombie.blockPosition()), MobSpawnType.REINFORCEMENT, (SpawnGroupData) null, (CompoundTag) null);
                              worldserver.addFreshEntityWithPassengers(entityzombie, CreatureSpawnEvent.SpawnReason.REINFORCEMENTS); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index f15c717b255a71906ab39644449a172efbaf2d3d..8726d50841da43729f076a2b0a9645ecea2a3f3a 100644
+index 018abaa48614ce2d25df2085bbb65b0b6e0312e7..b36a601ac792f2b1a51f0ae72ae12d992ac38d61 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -182,6 +182,9 @@ public abstract class Player extends LivingEntity {
@@ -137,10 +137,10 @@ index be6e3e21ad62da01e5e2dd78e300cbc8efdbeb42..ea98625fe7c00743b8df74a24e6d4b75
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7b57298ee6c9422fa10dde9cf9441ea10b3443e4..f9cf8b94890be80e383d1e24671aa8b10f54f1b6 100644
+index feb848813b80acb527e981b653208350639c97cc..72ec95cc014de2ac44e3d27b90e7544cb58c2ee4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2187,8 +2187,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2197,8 +2197,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0032-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0032-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index aa8f41ac360592a37306e439c85dda81acaaa6dc..e232d0efc0615017d1d64680ff2ad1de9dcc2bee 100644
+index 72ec95cc014de2ac44e3d27b90e7544cb58c2ee4..cbefc896cf9e2d8899bb78f694bc1ab64082d0eb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1856,12 +1856,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1866,12 +1866,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0038-Configurable-end-credits.patch
+++ b/patches/server/0038-Configurable-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable end credits
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 531d0b0dcd499adf0d973bf336272aa1966069f3..dac816f64a60988291cba8f1a88fd6e0cd5ea1a7 100644
+index 7e4c10bfdaf1e7f2dfc03d220e5c731927b0b5f9..edb8537e4fdd82991eda914a7d5c3ff6ef773fe0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1022,6 +1022,7 @@ public class ServerPlayer extends Player {
+@@ -1023,6 +1023,7 @@ public class ServerPlayer extends Player {
              this.unRide();
              this.getLevel().removePlayerImmediately(this, Entity.RemovalReason.CHANGED_DIMENSION);
              if (!this.wonGame) {

--- a/patches/server/0045-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0045-Implement-PlayerLocaleChangeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement PlayerLocaleChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index dac816f64a60988291cba8f1a88fd6e0cd5ea1a7..76eb270e0d471740bb5d9e80e7a2d6484659e8e4 100644
+index edb8537e4fdd82991eda914a7d5c3ff6ef773fe0..e1b545cda20f5f165497b751044ff323c7827313 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1795,7 +1795,7 @@ public class ServerPlayer extends Player {
+@@ -1806,7 +1806,7 @@ public class ServerPlayer extends Player {
          }
      }
  
@@ -17,7 +17,7 @@ index dac816f64a60988291cba8f1a88fd6e0cd5ea1a7..76eb270e0d471740bb5d9e80e7a2d648
      public java.util.Locale adventure$locale = java.util.Locale.US; // Paper
      public void updateOptions(ServerboundClientInformationPacket packet) {
          // CraftBukkit start
-@@ -1803,9 +1803,10 @@ public class ServerPlayer extends Player {
+@@ -1814,9 +1814,10 @@ public class ServerPlayer extends Player {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
              this.server.server.getPluginManager().callEvent(event);
          }
@@ -30,10 +30,10 @@ index dac816f64a60988291cba8f1a88fd6e0cd5ea1a7..76eb270e0d471740bb5d9e80e7a2d648
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e232d0efc0615017d1d64680ff2ad1de9dcc2bee..10572393e1c45ed277f56e3f8978f73a02eed4c4 100644
+index cbefc896cf9e2d8899bb78f694bc1ab64082d0eb..7eec465d1997dabc57be5731ff6488839d860dea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2187,8 +2187,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2197,8 +2197,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0047-Configurable-container-update-tick-rate.patch
+++ b/patches/server/0047-Configurable-container-update-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable container update tick rate
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 76eb270e0d471740bb5d9e80e7a2d6484659e8e4..b3d285b920a2ec83c320b842183ae8e2d491c455 100644
+index e1b545cda20f5f165497b751044ff323c7827313..fc364823f20f458af936c7209bd7174e05cb0fc0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -238,6 +238,7 @@ public class ServerPlayer extends Player {
+@@ -239,6 +239,7 @@ public class ServerPlayer extends Player {
      private int containerCounter;
      public int latency;
      public boolean wonGame;
@@ -16,7 +16,7 @@ index 76eb270e0d471740bb5d9e80e7a2d6484659e8e4..b3d285b920a2ec83c320b842183ae8e2
  
      // CraftBukkit start
      public String displayName;
-@@ -628,7 +629,12 @@ public class ServerPlayer extends Player {
+@@ -629,7 +630,12 @@ public class ServerPlayer extends Player {
              --this.invulnerableTime;
          }
  

--- a/patches/server/0065-Complete-resource-pack-API.patch
+++ b/patches/server/0065-Complete-resource-pack-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 30a6be5487e0bff49d134c5dcae520071763d2ac..f5b8da00f641a401d7ff4641908dd7de55cbe683 100644
+index 026b43e74d99d7b5a971e4de996a30f02d0f8d24..cf905220ac5bbce62e5e061f0dfc96906fc29328 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1754,8 +1754,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -23,7 +23,7 @@ index 30a6be5487e0bff49d134c5dcae520071763d2ac..f5b8da00f641a401d7ff4641908dd7de
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 120461eb5d4129453ccff4304b376045ccf6f2e7..f4d4164b7a6b4715616712d939f423f0f2ab9e54 100644
+index 238bef8e1e9f1e932476b3bbcc9258bca4adbb08..e46023675573e42e6bd510ddaa4bfc470536136f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -153,6 +153,7 @@ import org.bukkit.plugin.Plugin;
@@ -45,7 +45,7 @@ index 120461eb5d4129453ccff4304b376045ccf6f2e7..f4d4164b7a6b4715616712d939f423f0
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -2310,6 +2315,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2320,6 +2325,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0073-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0073-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 92da7117f56c1a5087d589f241a8b9dbe55c9b67..b14723d093f8a7aa44750b6d0e7eb9db9e2ac34b 100644
+index 9936fb67766dedba71b582316dd2bddd6567c342..2f161145789890fcd9bfd893b099f25a53c61034 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -777,7 +777,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -44,10 +44,10 @@ index 92da7117f56c1a5087d589f241a8b9dbe55c9b67..b14723d093f8a7aa44750b6d0e7eb9db
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f4d4164b7a6b4715616712d939f423f0f2ab9e54..023e477ebe24aff03767a3179e7b2f0e653ffa12 100644
+index e46023675573e42e6bd510ddaa4bfc470536136f..814bcc343fc2568844dd8da1f328fbae8b09f592 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2115,6 +2115,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2125,6 +2125,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0094-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
+++ b/patches/server/0094-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
@@ -25,10 +25,10 @@ index c4bf60739b0f73729f331f2bb82d9d08f346f19c..343e6da38413ab8dad876884241ad311
                                  }
                              }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 8726d50841da43729f076a2b0a9645ecea2a3f3a..03b058b5f989b6182de88d2c2fe9d0f90eb9c432 100644
+index b36a601ac792f2b1a51f0ae72ae12d992ac38d61..aafc1b05b86d9b715cfe5ddbf4abd76a4ad772c3 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -756,6 +756,14 @@ public abstract class Player extends LivingEntity {
+@@ -762,6 +762,14 @@ public abstract class Player extends LivingEntity {
                  return null;
              }
              // CraftBukkit end

--- a/patches/server/0123-Properly-fix-item-duplication-bug.patch
+++ b/patches/server/0123-Properly-fix-item-duplication-bug.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Properly fix item duplication bug
 Credit to prplz for figuring out the real issue
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b3d285b920a2ec83c320b842183ae8e2d491c455..66705a8fb0ba4ca27136ee75420a08bc99ebd965 100644
+index fc364823f20f458af936c7209bd7174e05cb0fc0..9d04d3d1e24222bf255a1fc96761909574f67d66 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2268,7 +2268,7 @@ public class ServerPlayer extends Player {
+@@ -2279,7 +2279,7 @@ public class ServerPlayer extends Player {
  
      @Override
      public boolean isImmobile() {
@@ -19,7 +19,7 @@ index b3d285b920a2ec83c320b842183ae8e2d491c455..66705a8fb0ba4ca27136ee75420a08bc
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4ccb315828005258f5bd4c4a651d572e439c4909..487031aec842719a72abf0037409520ca98ce3f7 100644
+index e3f3ddbf6d5c20489f3cfda9126ef64954b7418d..1c31e887a23398c2717426209a8625bdd0e1a807 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -3178,7 +3178,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic

--- a/patches/server/0134-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0134-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -14,7 +14,7 @@ To be converted into a Paper-API event at some point in the future?
 public net.minecraft.world.entity.player.Player removeEntitiesOnShoulder()V
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 487031aec842719a72abf0037409520ca98ce3f7..38a45efcd2ff3cba9d2e15d7b6939c5ec873a1c5 100644
+index 1c31e887a23398c2717426209a8625bdd0e1a807..2e1f0ac59da4ce1f66a4e720c275744a28191478 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2322,6 +2322,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -32,10 +32,10 @@ index 487031aec842719a72abf0037409520ca98ce3f7..38a45efcd2ff3cba9d2e15d7b6939c5e
              case RELEASE_SHIFT_KEY:
                  this.player.setShiftKeyDown(false);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 03b058b5f989b6182de88d2c2fe9d0f90eb9c432..34bcdda9b3e9040e8afc63db4ccb8292ebea3413 100644
+index aafc1b05b86d9b715cfe5ddbf4abd76a4ad772c3..11f1d8cc6f31b5a38db76ce411209a494c9e7e8a 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -581,7 +581,7 @@ public abstract class Player extends LivingEntity {
+@@ -587,7 +587,7 @@ public abstract class Player extends LivingEntity {
          this.playShoulderEntityAmbientSound(this.getShoulderEntityLeft());
          this.playShoulderEntityAmbientSound(this.getShoulderEntityRight());
          if (!this.level.isClientSide && (this.fallDistance > 0.5F || this.isInWater()) || this.abilities.flying || this.isSleeping() || this.isInPowderSnow) {

--- a/patches/server/0144-Shoulder-Entities-Release-API.patch
+++ b/patches/server/0144-Shoulder-Entities-Release-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Shoulder Entities Release API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 34bcdda9b3e9040e8afc63db4ccb8292ebea3413..f98e25965c9d8fe348a209ef8d2a2109cd2294f2 100644
+index 11f1d8cc6f31b5a38db76ce411209a494c9e7e8a..0ed794b051cae00c71e94700dcd594da85bac0fa 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -2003,20 +2003,44 @@ public abstract class Player extends LivingEntity {
+@@ -2009,20 +2009,44 @@ public abstract class Player extends LivingEntity {
  
      }
  

--- a/patches/server/0163-Send-attack-SoundEffects-only-to-players-who-can-see.patch
+++ b/patches/server/0163-Send-attack-SoundEffects-only-to-players-who-can-see.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Send attack SoundEffects only to players who can see the
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index f98e25965c9d8fe348a209ef8d2a2109cd2294f2..32ee62d4d8d0cdd4719959fc55a40d2673a9a744 100644
+index 0ed794b051cae00c71e94700dcd594da85bac0fa..a5ff76a3eb9c6b08dc5c3ebbe2bbb8a9fcd036ed 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1227,7 +1227,7 @@ public abstract class Player extends LivingEntity {
+@@ -1233,7 +1233,7 @@ public abstract class Player extends LivingEntity {
                      int i = b0 + EnchantmentHelper.getKnockbackBonus(this);
  
                      if (this.isSprinting() && flag) {
@@ -18,7 +18,7 @@ index f98e25965c9d8fe348a209ef8d2a2109cd2294f2..32ee62d4d8d0cdd4719959fc55a40d26
                          ++i;
                          flag1 = true;
                      }
-@@ -1302,7 +1302,7 @@ public abstract class Player extends LivingEntity {
+@@ -1308,7 +1308,7 @@ public abstract class Player extends LivingEntity {
                                  }
                              }
  
@@ -27,7 +27,7 @@ index f98e25965c9d8fe348a209ef8d2a2109cd2294f2..32ee62d4d8d0cdd4719959fc55a40d26
                              this.sweepAttack();
                          }
  
-@@ -1330,15 +1330,15 @@ public abstract class Player extends LivingEntity {
+@@ -1336,15 +1336,15 @@ public abstract class Player extends LivingEntity {
                          }
  
                          if (flag2) {
@@ -46,7 +46,7 @@ index f98e25965c9d8fe348a209ef8d2a2109cd2294f2..32ee62d4d8d0cdd4719959fc55a40d26
                              }
                          }
  
-@@ -1390,7 +1390,7 @@ public abstract class Player extends LivingEntity {
+@@ -1396,7 +1396,7 @@ public abstract class Player extends LivingEntity {
  
                          this.causeFoodExhaustion(level.spigotConfig.combatExhaustion, EntityExhaustionEvent.ExhaustionReason.ATTACK); // CraftBukkit - EntityExhaustionEvent // Spigot - Change to use configurable value
                      } else {
@@ -55,7 +55,7 @@ index f98e25965c9d8fe348a209ef8d2a2109cd2294f2..32ee62d4d8d0cdd4719959fc55a40d26
                          if (flag4) {
                              target.clearFire();
                          }
-@@ -1838,6 +1838,14 @@ public abstract class Player extends LivingEntity {
+@@ -1844,6 +1844,14 @@ public abstract class Player extends LivingEntity {
      public int getXpNeededForNextLevel() {
          return this.experienceLevel >= 30 ? 112 + (this.experienceLevel - 30) * 9 : (this.experienceLevel >= 15 ? 37 + (this.experienceLevel - 15) * 5 : 7 + this.experienceLevel * 2);
      }

--- a/patches/server/0172-PlayerNaturallySpawnCreaturesEvent.patch
+++ b/patches/server/0172-PlayerNaturallySpawnCreaturesEvent.patch
@@ -60,7 +60,7 @@ index 80d108ae7faf3fdcb024931e93032215935fe70b..c021733342c09adb04ce3f675209543f
  
              while (iterator1.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 66705a8fb0ba4ca27136ee75420a08bc99ebd965..0e44abb38eb90d1943137e8e0f297f5529d3f25b 100644
+index 9d04d3d1e24222bf255a1fc96761909574f67d66..67b0a9f8e8f122c406057c5db225fa6a03dd624c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1,5 +1,6 @@
@@ -70,7 +70,7 @@ index 66705a8fb0ba4ca27136ee75420a08bc99ebd965..0e44abb38eb90d1943137e8e0f297f55
  import com.google.common.collect.Lists;
  import com.google.common.net.InetAddresses;
  import com.mojang.authlib.GameProfile;
-@@ -257,6 +258,7 @@ public class ServerPlayer extends Player {
+@@ -258,6 +259,7 @@ public class ServerPlayer extends Player {
      // CraftBukkit end
      public boolean isRealPlayer; // Paper
      public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<ServerPlayer> cachedSingleHashSet; // Paper

--- a/patches/server/0180-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/patches/server/0180-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggleable player crits, helps mitigate hacked clients.
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 32ee62d4d8d0cdd4719959fc55a40d2673a9a744..0665aa0242ca93c19b1488320168be82f85d6b16 100644
+index a5ff76a3eb9c6b08dc5c3ebbe2bbb8a9fcd036ed..ad723fc78d7fc57c67b5a74bb7dd2fd6623d18dd 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1234,6 +1234,7 @@ public abstract class Player extends LivingEntity {
+@@ -1240,6 +1240,7 @@ public abstract class Player extends LivingEntity {
  
                      boolean flag2 = flag && this.fallDistance > 0.0F && !this.onGround && !this.onClimbable() && !this.isInWater() && !this.hasEffect(MobEffects.BLINDNESS) && !this.isPassenger() && target instanceof LivingEntity;
  

--- a/patches/server/0184-Player.setPlayerProfile-API.patch
+++ b/patches/server/0184-Player.setPlayerProfile-API.patch
@@ -55,7 +55,7 @@ index e7442952ef1f03969949014492a7ddc6d0796ba5..69a1852905dd4724c30ac8ab88c14251
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 39ecd1161b2f2636197eaa157a765cfe5d6f6405..5b2322389c2c2f5277a8891c857ba04f8d347e4d 100644
+index f19b8258e30133f3111ca27e9082b7f3a4ce3877..53074702d0d606ce0e26c4cf435c3b71b4336f5e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -82,6 +82,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -104,7 +104,7 @@ index 39ecd1161b2f2636197eaa157a765cfe5d6f6405..5b2322389c2c2f5277a8891c857ba04f
      }
  
      void resetAndHideEntity(org.bukkit.entity.Entity entity) {
-@@ -1730,8 +1731,38 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1735,8 +1736,38 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (entry != null && !entry.seenBy.contains(this.getHandle().connection)) {
              entry.updatePlayer(this.getHandle());
          }
@@ -144,7 +144,7 @@ index 39ecd1161b2f2636197eaa157a765cfe5d6f6405..5b2322389c2c2f5277a8891c857ba04f
      }
  
      void resetAndShowEntity(org.bukkit.entity.Entity entity) {
-@@ -1739,6 +1770,30 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1749,6 +1780,30 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              this.trackAndShowEntity(entity);
          }
      }

--- a/patches/server/0189-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0189-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e3d166dd69470468e17255e994876a305f90c9ba..9d4c164e43915c10821b332c18d440637ef19a8b 100644
+index 53074702d0d606ce0e26c4cf435c3b71b4336f5e..31fbfff6fb79601ade46b9867cd82da9db9cd2bd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -176,6 +176,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index e3d166dd69470468e17255e994876a305f90c9ba..9d4c164e43915c10821b332c18d44063
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -2002,7 +2003,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2012,7 +2013,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0191-Configurable-sprint-interruption-on-attack.patch
+++ b/patches/server/0191-Configurable-sprint-interruption-on-attack.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 0665aa0242ca93c19b1488320168be82f85d6b16..0d34089b28c6f89df81a93e7032a8c52a89187c5 100644
+index ad723fc78d7fc57c67b5a74bb7dd2fd6623d18dd..f92a5fc15b05b247dd62ccfdf690c2ef2b702b65 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1283,7 +1283,11 @@ public abstract class Player extends LivingEntity {
+@@ -1289,7 +1289,11 @@ public abstract class Player extends LivingEntity {
                              }
  
                              this.setDeltaMovement(this.getDeltaMovement().multiply(0.6D, 1.0D, 0.6D));

--- a/patches/server/0211-PlayerReadyArrowEvent.patch
+++ b/patches/server/0211-PlayerReadyArrowEvent.patch
@@ -7,10 +7,10 @@ Called when a player is firing a bow and the server is choosing an arrow to use.
 Plugins can skip selection of certain arrows and control which is used.
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 0d34089b28c6f89df81a93e7032a8c52a89187c5..87573a6ecbf9a74b32f9c686067a34d58fcd5fa1 100644
+index f92a5fc15b05b247dd62ccfdf690c2ef2b702b65..457cafaa39907e85e1d1e9028f0eb75a90f3eb8e 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -2226,18 +2226,29 @@ public abstract class Player extends LivingEntity {
+@@ -2232,18 +2232,29 @@ public abstract class Player extends LivingEntity {
          return ImmutableList.of(Pose.STANDING, Pose.CROUCHING, Pose.SWIMMING);
      }
  

--- a/patches/server/0212-Implement-EntityKnockbackByEntityEvent-and-EntityPus.patch
+++ b/patches/server/0212-Implement-EntityKnockbackByEntityEvent-and-EntityPus.patch
@@ -9,7 +9,7 @@ Co-authored-by: aerulion <aerulion@gmail.com>
 This event is called when an entity receives knockback by another entity.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9d82842982a387287a9c2de36f26a1fc80dd948a..7b4ceab1d9988573f21df3fb1a85a640f060d3af 100644
+index fbceeb5db8601d58cd449e80e423c1eeaedbcaab..213304a9ad145a2fecead78b82f441ae12825e4e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1774,8 +1774,17 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -33,7 +33,7 @@ index 9d82842982a387287a9c2de36f26a1fc80dd948a..7b4ceab1d9988573f21df3fb1a85a640
  
      protected void markHurt() {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 059223a014135cd6f6d8fbc4eee7888569fb46b5..dd82cef26160a1794c47494c99c59eb329879b7b 100644
+index cd0ae977eff36db8a2010596698835dcd9166ef9..10c6f6ac0c56eedf40190216e44d3f5d47b63deb 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1445,7 +1445,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -83,7 +83,7 @@ index 059223a014135cd6f6d8fbc4eee7888569fb46b5..dd82cef26160a1794c47494c99c59eb3
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index dad26405e90c7a784266a336ff1b0aa58b961261..e818687adf432e7ff47c8442ed2ea32d41c06b64 100644
+index 6f1755efd7f1cf9dd65d070a3ba7623333f341bc..984a33d5e1f790a9c78ba57f2dc21fb072a44b3d 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -1631,7 +1631,7 @@ public abstract class Mob extends LivingEntity implements Targeting {
@@ -161,10 +161,10 @@ index f8ccf0cf421bf2d8d6d6ccf8dd9e7c27eb9024ed..de73183166962d84b3fcbb408e011bc9
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 87573a6ecbf9a74b32f9c686067a34d58fcd5fa1..10fcfa561ec74a04934d2078eb19b0c1b67b1e6a 100644
+index 457cafaa39907e85e1d1e9028f0eb75a90f3eb8e..2961e08fc315a0d5f3b95de9d127948da07e66c8 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1277,9 +1277,9 @@ public abstract class Player extends LivingEntity {
+@@ -1283,9 +1283,9 @@ public abstract class Player extends LivingEntity {
                      if (flag5) {
                          if (i > 0) {
                              if (target instanceof LivingEntity) {
@@ -176,7 +176,7 @@ index 87573a6ecbf9a74b32f9c686067a34d58fcd5fa1..10fcfa561ec74a04934d2078eb19b0c1
                              }
  
                              this.setDeltaMovement(this.getDeltaMovement().multiply(0.6D, 1.0D, 0.6D));
-@@ -1301,7 +1301,7 @@ public abstract class Player extends LivingEntity {
+@@ -1307,7 +1307,7 @@ public abstract class Player extends LivingEntity {
                                  if (entityliving != this && entityliving != target && !this.isAlliedTo((Entity) entityliving) && (!(entityliving instanceof ArmorStand) || !((ArmorStand) entityliving).isMarker()) && this.distanceToSqr((Entity) entityliving) < 9.0D) {
                                      // CraftBukkit start - Only apply knockback if the damage hits
                                      if (entityliving.hurt(this.damageSources().playerAttack(this).sweep(), f4)) {

--- a/patches/server/0218-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0218-InventoryCloseEvent-Reason-API.patch
@@ -29,10 +29,10 @@ index 65110445ff8a245742c4f7a7055f544ff6344f75..718a403799246228e085280cb539236b
              }
              // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 0e44abb38eb90d1943137e8e0f297f5529d3f25b..dad0368c8b55be018167bd8b113a80b7508647f1 100644
+index 67b0a9f8e8f122c406057c5db225fa6a03dd624c..9e4c827bba4c87595db8cb8896b77558b3feadf5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -638,7 +638,7 @@ public class ServerPlayer extends Player {
+@@ -639,7 +639,7 @@ public class ServerPlayer extends Player {
          }
          // Paper end
          if (!this.level.isClientSide && !this.containerMenu.stillValid(this)) {
@@ -41,7 +41,7 @@ index 0e44abb38eb90d1943137e8e0f297f5529d3f25b..dad0368c8b55be018167bd8b113a80b7
              this.containerMenu = this.inventoryMenu;
          }
  
-@@ -831,7 +831,7 @@ public class ServerPlayer extends Player {
+@@ -832,7 +832,7 @@ public class ServerPlayer extends Player {
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.containerMenu != this.inventoryMenu) {
@@ -50,7 +50,7 @@ index 0e44abb38eb90d1943137e8e0f297f5529d3f25b..dad0368c8b55be018167bd8b113a80b7
          }
  
          net.kyori.adventure.text.Component deathMessage = event.deathMessage() != null ? event.deathMessage() : net.kyori.adventure.text.Component.empty(); // Paper - Adventure
-@@ -1450,7 +1450,7 @@ public class ServerPlayer extends Player {
+@@ -1451,7 +1451,7 @@ public class ServerPlayer extends Player {
          }
          // CraftBukkit end
          if (this.containerMenu != this.inventoryMenu) {
@@ -59,7 +59,7 @@ index 0e44abb38eb90d1943137e8e0f297f5529d3f25b..dad0368c8b55be018167bd8b113a80b7
          }
  
          // this.nextContainerCounter(); // CraftBukkit - moved up
-@@ -1478,7 +1478,13 @@ public class ServerPlayer extends Player {
+@@ -1479,7 +1479,13 @@ public class ServerPlayer extends Player {
  
      @Override
      public void closeContainer() {
@@ -117,7 +117,7 @@ index 2cde0807c224f008bd2e652ff8a46244ebc53059..2f18121596b957202dfd8227b995ea06
  
          PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : PaperAdventure.asAdventure(entityplayer.getDisplayName()))); // Paper - Adventure
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 10fcfa561ec74a04934d2078eb19b0c1b67b1e6a..ad000e1f7fb6b3d3ec423b6e3d44efdb46f69849 100644
+index 2961e08fc315a0d5f3b95de9d127948da07e66c8..9c12fc197c5367a35acda4155707c602f043e571 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -268,7 +268,7 @@ public abstract class Player extends LivingEntity {
@@ -173,7 +173,7 @@ index 787ccb37a39bb506cf9fd8d54cf772b346981f85..f5b3190ffb9e9f92977afc9e40ddfa15
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ecbcabc24529c7a7becf709fa6f24cfaa22f7f0e..bef819229c4d9c4742f907532f0d3f4689c30c00 100644
+index 31fbfff6fb79601ade46b9867cd82da9db9cd2bd..966232147c9a308743a65fe581c84b449de1dbd3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1207,7 +1207,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1beecfc947f52467bd10e454877bc0678fd2dc41..2d704af9491bec382e00a40fde36c6e01c8484f2 100644
+index 966232147c9a308743a65fe581c84b449de1dbd3..8fcffb0a9c3fa97758610371b6d03b0094c43c71 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2759,6 +2759,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2769,6 +2769,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0255-Improve-death-events.patch
+++ b/patches/server/0255-Improve-death-events.patch
@@ -19,10 +19,10 @@ public net.minecraft.world.entity.LivingEntity getDeathSound()Lnet/minecraft/sou
 public net.minecraft.world.entity.LivingEntity getSoundVolume()F
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 34e5466211c56f691f0c8bb1ad0e6238fc59dd1b..e39444b842c7faf47830e1cc4034716aa6ee5233 100644
+index 9e4c827bba4c87595db8cb8896b77558b3feadf5..e5058fae42532c20f5d3332f881177e9294c4c3f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -240,6 +240,10 @@ public class ServerPlayer extends Player {
+@@ -241,6 +241,10 @@ public class ServerPlayer extends Player {
      public int latency;
      public boolean wonGame;
      private int containerUpdateDelay; // Paper
@@ -33,7 +33,7 @@ index 34e5466211c56f691f0c8bb1ad0e6238fc59dd1b..e39444b842c7faf47830e1cc4034716a
  
      // CraftBukkit start
      public String displayName;
-@@ -828,6 +832,15 @@ public class ServerPlayer extends Player {
+@@ -829,6 +833,15 @@ public class ServerPlayer extends Player {
          String deathmessage = defaultMessage.getString();
          this.keepLevel = keepInventory; // SPIGOT-2222: pre-set keepLevel
          org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), defaultMessage.getString(), keepInventory); // Paper - Adventure
@@ -49,7 +49,7 @@ index 34e5466211c56f691f0c8bb1ad0e6238fc59dd1b..e39444b842c7faf47830e1cc4034716a
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.containerMenu != this.inventoryMenu) {
-@@ -979,8 +992,17 @@ public class ServerPlayer extends Player {
+@@ -980,8 +993,17 @@ public class ServerPlayer extends Player {
                          }
                      }
                  }
@@ -352,10 +352,10 @@ index e38cbdff34479673f1640c46d727f1a807a609c7..dbb4bfb3d1f1ce2e435ca531be36ea44
          this.gameEvent(GameEvent.ENTITY_DIE);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6b1b1b49b1b070dab106e9712d66c3916f0a7797..3a4a1f32409d7dddd30a643017da9bc6f6694187 100644
+index 8fcffb0a9c3fa97758610371b6d03b0094c43c71..c19b004463e491674b6c4bc8bfc8851d4dbb4501 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2262,7 +2262,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2272,7 +2272,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/patches/server/0271-Call-player-spectator-target-events-and-improve-impl.patch
+++ b/patches/server/0271-Call-player-spectator-target-events-and-improve-impl.patch
@@ -19,10 +19,10 @@ spectate the target entity.
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 77a74d41679e88d748d903295ac4f455e1f33b71..87b6f0d448b9ca40ab081d55f4309a6eed8cd830 100644
+index e5058fae42532c20f5d3332f881177e9294c4c3f..4d4e1f62a33ca04401c00424934302867e2efa0c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1920,6 +1920,19 @@ public class ServerPlayer extends Player {
+@@ -1931,6 +1931,19 @@ public class ServerPlayer extends Player {
  
          this.camera = (Entity) (entity == null ? this : entity);
          if (entity1 != this.camera) {
@@ -42,7 +42,7 @@ index 77a74d41679e88d748d903295ac4f455e1f33b71..87b6f0d448b9ca40ab081d55f4309a6e
              Level world = this.camera.getLevel();
  
              if (world instanceof ServerLevel) {
-@@ -1935,7 +1948,6 @@ public class ServerPlayer extends Player {
+@@ -1946,7 +1959,6 @@ public class ServerPlayer extends Player {
              this.connection.send(new ClientboundSetCameraPacket(this.camera));
              this.connection.resetPosition();
          }

--- a/patches/server/0276-Reset-players-airTicks-on-respawn.patch
+++ b/patches/server/0276-Reset-players-airTicks-on-respawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset players airTicks on respawn
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 87b6f0d448b9ca40ab081d55f4309a6eed8cd830..bdc5cd6ec51ff64688c25a5a31882f5b1b6448af 100644
+index 4d4e1f62a33ca04401c00424934302867e2efa0c..dd729d17eadd8e8860bf2344a534534bf21c2619 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2330,6 +2330,7 @@ public class ServerPlayer extends Player {
+@@ -2341,6 +2341,7 @@ public class ServerPlayer extends Player {
  
          this.setHealth(this.getMaxHealth());
          this.stopUsingItem(); // CraftBukkit - SPIGOT-6682: Clear active item on reset

--- a/patches/server/0287-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0287-force-entity-dismount-during-teleportation.patch
@@ -20,7 +20,7 @@ this is going to be the best soultion all around.
 Improvements/suggestions welcome!
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8663ea3cc8d5672b03b4b8345d7d970fcbc6a80b..b4929ecb7e49266b88eec433a65fd8cf049dd805 100644
+index 584927547bbaf7e76db9d1a4275fba41d4467227..1b6b71d80a8c1e213186473f1c0ff72ca72ce307 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2422,11 +2422,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -72,7 +72,7 @@ index 8663ea3cc8d5672b03b4b8345d7d970fcbc6a80b..b4929ecb7e49266b88eec433a65fd8cf
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index eb58b3230b46ade4403c31113d244b933b8a4a71..69fbbd2745008e2d9caf6a30dd0779339e1c685b 100644
+index 30abef77152b77b563b3da0df8e5bf5731999e53..406d495a410c23d43cf72444e8f0c2dc8b3fa52c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3396,9 +3396,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -93,10 +93,10 @@ index eb58b3230b46ade4403c31113d244b933b8a4a71..69fbbd2745008e2d9caf6a30dd077933
              this.dismountVehicle(entity);
          }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index ad000e1f7fb6b3d3ec423b6e3d44efdb46f69849..65adadd9e35f2ec6c10acd24ebf61e3cfba173e4 100644
+index 9c12fc197c5367a35acda4155707c602f043e571..a7e0203cc4bf7d98b65230fdbc4d873eeabdf9da 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1141,7 +1141,13 @@ public abstract class Player extends LivingEntity {
+@@ -1147,7 +1147,13 @@ public abstract class Player extends LivingEntity {
  
      @Override
      public void removeVehicle() {

--- a/patches/server/0292-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0292-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,10 +16,10 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index bdc5cd6ec51ff64688c25a5a31882f5b1b6448af..3ff9823da9e906189f1bd4fa98838de5dcfc428a 100644
+index dd729d17eadd8e8860bf2344a534534bf21c2619..35db7ee2aace8d7375a1474a849b78a1ca4059be 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -240,6 +240,7 @@ public class ServerPlayer extends Player {
+@@ -241,6 +241,7 @@ public class ServerPlayer extends Player {
      public int latency;
      public boolean wonGame;
      private int containerUpdateDelay; // Paper
@@ -106,7 +106,7 @@ index 69a1852905dd4724c30ac8ab88c14251eee2c371..17b3d5de58a9ef3acc67624c46cd6bbd
      public Location getLastDeathLocation() {
          if (this.getData().contains("LastDeathLocation", 10)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e3239cfb4237163389313f88496ad5e69b891c86..5fa39672210af814e078a1463d493bfb114efc66 100644
+index c19b004463e491674b6c4bc8bfc8851d4dbb4501..66e7fba36b0810a1254f3937988a640db9a0e295 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -177,6 +177,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index e3239cfb4237163389313f88496ad5e69b891c86..5fa39672210af814e078a1463d493bfb
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1874,6 +1875,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1884,6 +1885,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index e3239cfb4237163389313f88496ad5e69b891c86..5fa39672210af814e078a1463d493bfb
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1896,6 +1909,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1906,6 +1919,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index e3239cfb4237163389313f88496ad5e69b891c86..5fa39672210af814e078a1463d493bfb
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1910,6 +1925,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1920,6 +1935,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0293-Workaround-for-vehicle-tracking-issue-on-disconnect.patch
+++ b/patches/server/0293-Workaround-for-vehicle-tracking-issue-on-disconnect.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Workaround for vehicle tracking issue on disconnect
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3ff9823da9e906189f1bd4fa98838de5dcfc428a..8d4cddb68fd074d7a8ca4986a86d378434cb5fb5 100644
+index 35db7ee2aace8d7375a1474a849b78a1ca4059be..74c2f5bf6adfce37cdf152578edf1f8a17b885af 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1585,6 +1585,13 @@ public class ServerPlayer extends Player {
+@@ -1596,6 +1596,13 @@ public class ServerPlayer extends Player {
      public void disconnect() {
          this.disconnected = true;
          this.ejectPassengers();

--- a/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5fa39672210af814e078a1463d493bfb114efc66..bb9940422a87e5d97a7c2d3ed368644074e9348c 100644
+index 66e7fba36b0810a1254f3937988a640db9a0e295..2977d89a4c38346402527dcaa84b51a7707b2480 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2806,6 +2806,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2816,6 +2816,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0309-PlayerDeathEvent-getItemsToKeep.patch
+++ b/patches/server/0309-PlayerDeathEvent-getItemsToKeep.patch
@@ -11,10 +11,10 @@ Example Usage: https://gist.github.com/aikar/5bb202de6057a051a950ce1f29feb0b4
 public net.minecraft.world.entity.player.Inventory compartments
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 8d4cddb68fd074d7a8ca4986a86d378434cb5fb5..fe7be6e6b2471abaf7e810daf4baa6eb8e12dba5 100644
+index 74c2f5bf6adfce37cdf152578edf1f8a17b885af..8b23e586b9b8f68dbec65a9f738e0e735c124b6b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -803,6 +803,46 @@ public class ServerPlayer extends Player {
+@@ -804,6 +804,46 @@ public class ServerPlayer extends Player {
          });
      }
  
@@ -61,7 +61,7 @@ index 8d4cddb68fd074d7a8ca4986a86d378434cb5fb5..fe7be6e6b2471abaf7e810daf4baa6eb
      @Override
      public void die(DamageSource damageSource) {
          this.gameEvent(GameEvent.ENTITY_DIE);
-@@ -886,7 +926,12 @@ public class ServerPlayer extends Player {
+@@ -887,7 +927,12 @@ public class ServerPlayer extends Player {
          this.dropExperience();
          // we clean the player's inventory after the EntityDeathEvent is called so plugins can get the exact state of the inventory.
          if (!event.getKeepInventory()) {

--- a/patches/server/0332-PlayerDeathEvent-shouldDropExperience.patch
+++ b/patches/server/0332-PlayerDeathEvent-shouldDropExperience.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerDeathEvent#shouldDropExperience
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index fe7be6e6b2471abaf7e810daf4baa6eb8e12dba5..db3d5fd301f38ae3bf13ff6d7530d6e70acb8296 100644
+index 8b23e586b9b8f68dbec65a9f738e0e735c124b6b..d159433db275cc7308c6f4ad93b5fee075e0cfb1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -923,7 +923,7 @@ public class ServerPlayer extends Player {
+@@ -924,7 +924,7 @@ public class ServerPlayer extends Player {
              this.tellNeutralMobsThatIDied();
          }
          // SPIGOT-5478 must be called manually now

--- a/patches/server/0347-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0347-implement-optional-per-player-mob-spawns.patch
@@ -362,10 +362,10 @@ index c021733342c09adb04ce3f675209543f84ac4bda..d137aa95f670aab516e9e08272f33b21
  
              this.lastSpawnState = spawnercreature_d;
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index db3d5fd301f38ae3bf13ff6d7530d6e70acb8296..a8f51ab23b46287f6066c421271f4c0fcfe04c3a 100644
+index d159433db275cc7308c6f4ad93b5fee075e0cfb1..72e29dc97b38bde3c44edec505fa26633fcdd243 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -245,6 +245,11 @@ public class ServerPlayer extends Player {
+@@ -246,6 +246,11 @@ public class ServerPlayer extends Player {
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.network.protocol.game.ClientboundSetHealthPacket queuedHealthUpdatePacket;
      // Paper end
@@ -377,7 +377,7 @@ index db3d5fd301f38ae3bf13ff6d7530d6e70acb8296..a8f51ab23b46287f6066c421271f4c0f
  
      // CraftBukkit start
      public String displayName;
-@@ -336,6 +341,7 @@ public class ServerPlayer extends Player {
+@@ -337,6 +342,7 @@ public class ServerPlayer extends Player {
          this.adventure$displayName = net.kyori.adventure.text.Component.text(this.getScoreboardName()); // Paper
          this.bukkitPickUpLoot = true;
          this.maxHealthCache = this.getMaxHealth();

--- a/patches/server/0366-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/patches/server/0366-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 762afd06eb13f5e4fa8c4085c6013d6056dae083..dc08768928707e5a47e65771262645e675a5093f 100644
+index 72e29dc97b38bde3c44edec505fa26633fcdd243..9726ff668e252be8edf35ff3611ad0e774ca9aca 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -241,6 +241,7 @@ public class ServerPlayer extends Player {
+@@ -242,6 +242,7 @@ public class ServerPlayer extends Player {
      public boolean wonGame;
      private int containerUpdateDelay; // Paper
      public long loginTime; // Paper

--- a/patches/server/0370-Don-t-tick-dead-players.patch
+++ b/patches/server/0370-Don-t-tick-dead-players.patch
@@ -7,10 +7,10 @@ Causes sync chunk loads and who knows what all else.
 This is safe because Spectators are skipped in unloaded chunks too in vanilla.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2d1c3d222cfced339fb098b09c3c84e0c0805255..206a66b6e403c8b7e60ff5b31eb478303d34b272 100644
+index 9726ff668e252be8edf35ff3611ad0e774ca9aca..52ee3440b09b227bf1f488f374a0e282690f6ba4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -680,7 +680,7 @@ public class ServerPlayer extends Player {
+@@ -681,7 +681,7 @@ public class ServerPlayer extends Player {
  
      public void doTick() {
          try {

--- a/patches/server/0371-Dead-Player-s-shouldn-t-be-able-to-move.patch
+++ b/patches/server/0371-Dead-Player-s-shouldn-t-be-able-to-move.patch
@@ -7,10 +7,10 @@ This fixes a lot of game state issues where packets were delayed for processing
 due to 1.15's new queue but processed while dead.
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 65adadd9e35f2ec6c10acd24ebf61e3cfba173e4..a7dc305297d1a17291ffff40fe6c3bd7b8cc6bdb 100644
+index a7e0203cc4bf7d98b65230fdbc4d873eeabdf9da..1ada0736ce35c0299e40d4ce8fbe49f170ea0c6f 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1153,7 +1153,7 @@ public abstract class Player extends LivingEntity {
+@@ -1159,7 +1159,7 @@ public abstract class Player extends LivingEntity {
  
      @Override
      protected boolean isImmobile() {

--- a/patches/server/0373-Don-t-move-existing-players-to-world-spawn.patch
+++ b/patches/server/0373-Don-t-move-existing-players-to-world-spawn.patch
@@ -13,10 +13,10 @@ By skipping this, we avoid potential for a large spike on server start.
 public net.minecraft.server.level.ServerPlayer fudgeSpawnLocation(Lnet/minecraft/server/level/ServerLevel;)V
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 206a66b6e403c8b7e60ff5b31eb478303d34b272..8754a37b405e96d2f5d02ef6b9864afac136212a 100644
+index 52ee3440b09b227bf1f488f374a0e282690f6ba4..007513080938a8d0cf43c050ef4e1132a939918c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -333,7 +333,7 @@ public class ServerPlayer extends Player {
+@@ -334,7 +334,7 @@ public class ServerPlayer extends Player {
          this.stats = server.getPlayerList().getPlayerStats(this);
          this.advancements = server.getPlayerList().getPlayerAdvancements(this);
          this.setMaxUpStep(1.0F);
@@ -25,7 +25,7 @@ index 206a66b6e403c8b7e60ff5b31eb478303d34b272..8754a37b405e96d2f5d02ef6b9864afa
  
          this.cachedSingleHashSet = new com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<>(this); // Paper
  
-@@ -567,7 +567,7 @@ public class ServerPlayer extends Player {
+@@ -568,7 +568,7 @@ public class ServerPlayer extends Player {
                  position = Vec3.atCenterOf(((ServerLevel) world).getSharedSpawnPos());
              }
              this.level = world;

--- a/patches/server/0379-Prevent-opening-inventories-when-frozen.patch
+++ b/patches/server/0379-Prevent-opening-inventories-when-frozen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent opening inventories when frozen
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 8754a37b405e96d2f5d02ef6b9864afac136212a..40100da5295aaa9113b0decc44ff7ca385cfd440 100644
+index 007513080938a8d0cf43c050ef4e1132a939918c..71fac1a579b375759462b843d9ef7c8a2a463db5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -649,7 +649,7 @@ public class ServerPlayer extends Player {
+@@ -650,7 +650,7 @@ public class ServerPlayer extends Player {
              containerUpdateDelay = level.paperConfig().tickRates.containerUpdate;
          }
          // Paper end
@@ -17,7 +17,7 @@ index 8754a37b405e96d2f5d02ef6b9864afac136212a..40100da5295aaa9113b0decc44ff7ca3
              this.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.CANT_USE); // Paper
              this.containerMenu = this.inventoryMenu;
          }
-@@ -1498,7 +1498,7 @@ public class ServerPlayer extends Player {
+@@ -1499,7 +1499,7 @@ public class ServerPlayer extends Player {
              } else {
                  // CraftBukkit start
                  this.containerMenu = container;

--- a/patches/server/0381-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0381-Implement-Player-Client-Options-API.patch
@@ -87,10 +87,10 @@ index 0000000000000000000000000000000000000000..b6f4400df3d8ec7e06a996de54f8cabb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 40100da5295aaa9113b0decc44ff7ca385cfd440..b5cca159c392e329b4283aafdffa80d9aabdda10 100644
+index 71fac1a579b375759462b843d9ef7c8a2a463db5..2d54f2abae82521fbd34aa046f26ec8e72df8362 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1891,9 +1891,24 @@ public class ServerPlayer extends Player {
+@@ -1902,9 +1902,24 @@ public class ServerPlayer extends Player {
          }
      }
  
@@ -116,7 +116,7 @@ index 40100da5295aaa9113b0decc44ff7ca385cfd440..b5cca159c392e329b4283aafdffa80d9
          if (getMainArm() != packet.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bb9940422a87e5d97a7c2d3ed368644074e9348c..3ea01452f4b18ac1c6a13a79f8e5c486e4c6f85b 100644
+index 2977d89a4c38346402527dcaa84b51a7707b2480..2cfe08bc1de682c845718e758ede718e94384d4d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -618,6 +618,28 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0383-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/patches/server/0383-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -43,10 +43,10 @@ index 9c5925bc6a0fb277970d46c34dd812cc765a537a..f2bdb647f137a1334789dc56e517844b
          if (!(entity instanceof EnderDragonPart)) {
              EntityType<?> entitytypes = entity.getType();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b5cca159c392e329b4283aafdffa80d9aabdda10..308df2980f45d25902afd5e696449f6397b186b0 100644
+index 2d54f2abae82521fbd34aa046f26ec8e72df8362..e465e3e45eeeecc31dafc1f04505c04ea382615a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -264,6 +264,7 @@ public class ServerPlayer extends Player {
+@@ -265,6 +265,7 @@ public class ServerPlayer extends Player {
      public double maxHealthCache;
      public boolean joining = true;
      public boolean sentListPacket = false;

--- a/patches/server/0411-Optimize-anyPlayerCloseEnoughForSpawning-to-use-dist.patch
+++ b/patches/server/0411-Optimize-anyPlayerCloseEnoughForSpawning-to-use-dist.patch
@@ -333,10 +333,10 @@ index 665e088cb0b73f6a0c62f29c56da462bab7c927e..298e4468f7b5346733257f7117f76c66
                      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3c3df5575208b9b66b59e53346f2d3cf49b7b04c..9627a725079866ebb40ccbb59c50dcfecc343fa6 100644
+index e465e3e45eeeecc31dafc1f04505c04ea382615a..5be828ad63184ee01519ef937e98f621a4e83dee 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -269,6 +269,7 @@ public class ServerPlayer extends Player {
+@@ -270,6 +270,7 @@ public class ServerPlayer extends Player {
      public String kickLeaveMessage = null; // SPIGOT-3034: Forward leave message to PlayerQuitEvent
      // CraftBukkit end
      public boolean isRealPlayer; // Paper

--- a/patches/server/0427-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0427-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -76,10 +76,10 @@ index 771677c0e1cd7bfe089b9a5bb9095650216ff588..520cd1a6b347687b2ec6d13f034be391
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 33dd4513fd2a95994460a9d844bcf40b5a4a1fc1..3dd7c2b12d56c875074c8cc6032eae1408154aae 100644
+index 5be828ad63184ee01519ef937e98f621a4e83dee..d560e5dee586bb3b501e9a78083b9aa961c48fc5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1160,7 +1160,7 @@ public class ServerPlayer extends Player {
+@@ -1161,7 +1161,7 @@ public class ServerPlayer extends Player {
                  this.isChangingDimension = true; // CraftBukkit - Set teleport invulnerability only if player changing worlds
  
                  this.connection.send(new ClientboundRespawnPacket(worldserver.dimensionTypeId(), worldserver.dimension(), BiomeManager.obfuscateSeed(worldserver.getSeed()), this.gameMode.getGameModeForPlayer(), this.gameMode.getPreviousGameModeForPlayer(), worldserver.isDebug(), worldserver.isFlat(), (byte) 3, this.getLastDeathLocation()));

--- a/patches/server/0432-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0432-incremental-chunk-and-player-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] incremental chunk and player saving
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 61f1d565254ccba500a8c30722183ae9bfc0deb3..dfc8b3441ca35aba19a7e1bf61a0d60c5722ce96 100644
+index c4c1201a2f7904b2044e163393722227d159453b..173b3852ae55cd1204e8e493bfdf434e9dda9f3b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -874,7 +874,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -115,10 +115,10 @@ index 51e8070864ffc4a35377021a7ded9813a40c1a11..06d20e9fde26540d1575975345f3d694
          // Paper start - rewrite chunk system - add close param
          this.save(progressListener, flush, savingDisabled, false);
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3dd7c2b12d56c875074c8cc6032eae1408154aae..4e25b015c7b37b1249d2bca4a3d97d26bcefd61e 100644
+index d560e5dee586bb3b501e9a78083b9aa961c48fc5..ce6ae0ec4d104929f2c3fe03b0f44eafbfec1d9a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -186,6 +186,7 @@ import org.bukkit.inventory.MainHand;
+@@ -187,6 +187,7 @@ import org.bukkit.inventory.MainHand;
  public class ServerPlayer extends Player {
  
      private static final Logger LOGGER = LogUtils.getLogger();

--- a/patches/server/0456-Brand-support.patch
+++ b/patches/server/0456-Brand-support.patch
@@ -56,10 +56,10 @@ index 1517c09ccd95448cb0fce0f9ffbb7bd2e704113b..221a695acf3cbeaeaf9eda818b6cf809
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3ea01452f4b18ac1c6a13a79f8e5c486e4c6f85b..d127eba33abe5c0ae711221504b67cc2af3b0822 100644
+index 2cfe08bc1de682c845718e758ede718e94384d4d..15caedd46ca0b4dba4d1d0fb3cabd24d324390fa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2933,6 +2933,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2943,6 +2943,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0500-Add-API-for-quit-reason.patch
+++ b/patches/server/0500-Add-API-for-quit-reason.patch
@@ -25,10 +25,10 @@ index e4c471ad111efb40a820670328b67ac28c79bff0..6ef3a08ea5223ee28dd175d66c6405ef
                          Connection.LOGGER.debug("Failed to sent packet", throwable);
                          ConnectionProtocol enumprotocol = this.getCurrentProtocol();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 4e25b015c7b37b1249d2bca4a3d97d26bcefd61e..35a2638214e427f24c265fa11318311cd8315337 100644
+index ce6ae0ec4d104929f2c3fe03b0f44eafbfec1d9a..e746d6f303c5df3ec367963c4335304f15028146 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -273,6 +273,7 @@ public class ServerPlayer extends Player {
+@@ -274,6 +274,7 @@ public class ServerPlayer extends Player {
      public double lastEntitySpawnRadiusSquared; // Paper - optimise isOutsideRange, this field is in blocks
      public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<ServerPlayer> cachedSingleHashSet; // Paper
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper

--- a/patches/server/0504-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0504-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 42f5a42b916e0d8ce9583d06c1ad3bc5ee6c4c9c..08d006e190cf13c8d737654b8c8f2045610afd43 100644
+index cd6a04777fadd22053ff35be18652a8273b217d2..c0338f597b9c50218862005220a8753d5822a6e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2455,7 +2455,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2465,7 +2465,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0515-Player-Chunk-Load-Unload-Events.patch
+++ b/patches/server/0515-Player-Chunk-Load-Unload-Events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player Chunk Load/Unload Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 35a2638214e427f24c265fa11318311cd8315337..d88332382c1280b15056c5a93873cadd0b8702b8 100644
+index e746d6f303c5df3ec367963c4335304f15028146..1add3a672179d6a558ba64545b4e8e22bab4ea3d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2149,11 +2149,21 @@ public class ServerPlayer extends Player {
+@@ -2160,11 +2160,21 @@ public class ServerPlayer extends Player {
  
      public void trackChunk(ChunkPos chunkPos, Packet<?> chunkDataPacket) {
          this.connection.send(chunkDataPacket);

--- a/patches/server/0558-Reset-shield-blocking-on-dimension-change.patch
+++ b/patches/server/0558-Reset-shield-blocking-on-dimension-change.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset shield blocking on dimension change
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index d88332382c1280b15056c5a93873cadd0b8702b8..7550137b4d35fee77ab75a615ca1ecbb4c066006 100644
+index 1add3a672179d6a558ba64545b4e8e22bab4ea3d..7062e2576f9158ac95f4c78255e210754ce90507 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1197,6 +1197,11 @@ public class ServerPlayer extends Player {
+@@ -1198,6 +1198,11 @@ public class ServerPlayer extends Player {
                  this.level.getCraftServer().getPluginManager().callEvent(changeEvent);
                  // CraftBukkit end
              }

--- a/patches/server/0617-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0617-additions-to-PlayerGameModeChangeEvent.patch
@@ -45,10 +45,10 @@ index d47f3d255eddd652fedb4aa55286b756fe962995..27c0aaf123c3e945eb24e8a3892bd8ac
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 7550137b4d35fee77ab75a615ca1ecbb4c066006..575fb9a95e38e68f7d8af1482f6e4166c5112dde 100644
+index 7062e2576f9158ac95f4c78255e210754ce90507..e4c6bff2a1e601266d889cc0532827d0c8885ece 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1828,8 +1828,15 @@ public class ServerPlayer extends Player {
+@@ -1839,8 +1839,15 @@ public class ServerPlayer extends Player {
      }
  
      public boolean setGameMode(GameType gameMode) {
@@ -66,7 +66,7 @@ index 7550137b4d35fee77ab75a615ca1ecbb4c066006..575fb9a95e38e68f7d8af1482f6e4166
          } else {
              this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.CHANGE_GAME_MODE, (float) gameMode.getId()));
              if (gameMode == GameType.SPECTATOR) {
-@@ -1841,7 +1848,7 @@ public class ServerPlayer extends Player {
+@@ -1852,7 +1859,7 @@ public class ServerPlayer extends Player {
  
              this.onUpdateAbilities();
              this.updateEffectVisibility();
@@ -75,7 +75,7 @@ index 7550137b4d35fee77ab75a615ca1ecbb4c066006..575fb9a95e38e68f7d8af1482f6e4166
          }
      }
  
-@@ -2234,6 +2241,16 @@ public class ServerPlayer extends Player {
+@@ -2245,6 +2252,16 @@ public class ServerPlayer extends Player {
      }
  
      public void loadGameTypes(@Nullable CompoundTag nbt) {
@@ -93,7 +93,7 @@ index 7550137b4d35fee77ab75a615ca1ecbb4c066006..575fb9a95e38e68f7d8af1482f6e4166
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 645a226c2e3f6dcf1c25187d006d425038b4545d..17c313b9cb45c8158cab751ffc4e0dc3b7e1fa3c 100644
+index e6154cf74df39d0c87fc820027adc9641156f888..5461e6ff769be93054b3d8369a7aa286d1244875 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -73,21 +73,27 @@ public class ServerPlayerGameMode {
@@ -142,7 +142,7 @@ index dffb219c0abdac46320aaec168e232df322a4bca..8987bbb4feed89c44e3615a58dac321a
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d784cef362b1c13348d49ffb60f3403fc9471f0c..750decc331963ab89ff90d228e169a9675f17022 100644
+index 0b0dc51dfb7174c359305448575ae714398917e4..86276267f68d68c50184343186fd8d8867b1dc3f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1518,7 +1518,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0644-Fix-PlayerDropItemEvent-using-wrong-item.patch
+++ b/patches/server/0644-Fix-PlayerDropItemEvent-using-wrong-item.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix PlayerDropItemEvent using wrong item
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 575fb9a95e38e68f7d8af1482f6e4166c5112dde..e67095f26df56e5edd8477601feeab346998f507 100644
+index e4c6bff2a1e601266d889cc0532827d0c8885ece..d9cacc372e1d40e6b2b5d83c88a01121b7f3f101 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2210,7 +2210,7 @@ public class ServerPlayer extends Player {
+@@ -2221,7 +2221,7 @@ public class ServerPlayer extends Player {
  
              if (retainOwnership) {
                  if (!itemstack1.isEmpty()) {
@@ -18,10 +18,10 @@ index 575fb9a95e38e68f7d8af1482f6e4166c5112dde..e67095f26df56e5edd8477601feeab34
  
                  this.awardStat(Stats.DROP);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 532e2444e15e532d6be5f703bfa5de26c5bc3957..496e10067267df07db9fa2570786d3b281f432c1 100644
+index eb0f9c2e54d75ee80bcc421d1042d1eea7c57a16..997b2458a3e14296437e76737b837d90d4936072 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -716,6 +716,11 @@ public abstract class Player extends LivingEntity {
+@@ -722,6 +722,11 @@ public abstract class Player extends LivingEntity {
              }
  
              double d0 = this.getEyeY() - 0.30000001192092896D;

--- a/patches/server/0651-Fixes-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0651-Fixes-kick-event-leave-message-not-being-sent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fixes kick event leave message not being sent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e67095f26df56e5edd8477601feeab346998f507..bd6bae442445fb27cf71be3e300172c1a7a55911 100644
+index d9cacc372e1d40e6b2b5d83c88a01121b7f3f101..72f9f443fb69603d986d41f0776e6b9b30228431 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -267,7 +267,6 @@ public class ServerPlayer extends Player {
+@@ -268,7 +268,6 @@ public class ServerPlayer extends Player {
      public boolean sentListPacket = false;
      public boolean supressTrackerForLogin = false; // Paper
      public Integer clientViewDistance;

--- a/patches/server/0654-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0654-Don-t-apply-cramming-damage-to-players.patch
@@ -11,7 +11,7 @@ It does not make a lot of sense to damage players if they get crammed,
 For those who really want it a config option is provided.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index bd6bae442445fb27cf71be3e300172c1a7a55911..427e5021de37801634d889c13ed8f9193b401de6 100644
+index 72f9f443fb69603d986d41f0776e6b9b30228431..af8af6bb44b84c74553068b6cd64f4e3941d4ae1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -100,6 +100,7 @@ import net.minecraft.util.Mth;
@@ -22,7 +22,7 @@ index bd6bae442445fb27cf71be3e300172c1a7a55911..427e5021de37801634d889c13ed8f919
  import net.minecraft.world.effect.MobEffectInstance;
  import net.minecraft.world.effect.MobEffects;
  import net.minecraft.world.entity.Entity;
-@@ -1429,7 +1430,7 @@ public class ServerPlayer extends Player {
+@@ -1430,7 +1431,7 @@ public class ServerPlayer extends Player {
  
      @Override
      public boolean isInvulnerableTo(DamageSource damageSource) {

--- a/patches/server/0665-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0665-Add-PlayerSetSpawnEvent.patch
@@ -32,10 +32,10 @@ index 7679d6b8b1eb8e849ce7e63cf293598db7eb4588..b0ed00b95b273f0916cbade0e3bac47a
          String string = resourceKey.location().toString();
          if (targets.size() == 1) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 427e5021de37801634d889c13ed8f9193b401de6..c4b273d20b8526b9a4c7e271585a826b49f2a05a 100644
+index af8af6bb44b84c74553068b6cd64f4e3941d4ae1..bc6ddf50bcd2f38be8c8fa064b49a7363643b9bd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1306,7 +1306,7 @@ public class ServerPlayer extends Player {
+@@ -1307,7 +1307,7 @@ public class ServerPlayer extends Player {
              } else if (this.bedBlocked(blockposition, enumdirection)) {
                  return Either.left(Player.BedSleepingProblem.OBSTRUCTED);
              } else {
@@ -44,7 +44,7 @@ index 427e5021de37801634d889c13ed8f9193b401de6..c4b273d20b8526b9a4c7e271585a826b
                  if (this.level.isDay()) {
                      return Either.left(Player.BedSleepingProblem.NOT_POSSIBLE_NOW);
                  } else {
-@@ -2138,12 +2138,33 @@ public class ServerPlayer extends Player {
+@@ -2149,12 +2149,33 @@ public class ServerPlayer extends Player {
          return this.respawnForced;
      }
  
@@ -80,7 +80,7 @@ index 427e5021de37801634d889c13ed8f9193b401de6..c4b273d20b8526b9a4c7e271585a826b
              }
  
              this.respawnPosition = pos;
-@@ -2157,6 +2178,7 @@ public class ServerPlayer extends Player {
+@@ -2168,6 +2189,7 @@ public class ServerPlayer extends Player {
              this.respawnForced = false;
          }
  
@@ -129,7 +129,7 @@ index a64cd3b54840af9a9c946b3e4e4f91d1c5f4bc97..16f23ecffa52925904d585f3fed76aa6
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 348022a7c037ce5f72c5c69db54f0ce5de9948ca..8f88d8a6f05d0f021608a035a39354ad480150f4 100644
+index d79c2ce6acc9a5b1239349ad5e1438cb035a9401..9833e8bce6cc45fa053b71f64d71a57c1630595f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1338,9 +1338,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0685-Add-critical-damage-API.patch
+++ b/patches/server/0685-Add-critical-damage-API.patch
@@ -28,10 +28,10 @@ index 9ec30af85095a9993076dafacbecc21b580d06ce..72d62387bfdcbf8e69fe433145be81fb
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index b716f297462b29c79500820859b9735c3576a2be..dcbf1e6e494493d81b7a10454a531b0fb719e024 100644
+index 997b2458a3e14296437e76737b837d90d4936072..6416cd9a20a40c24b3182891da04d660f9fa9aee 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1255,7 +1255,7 @@ public abstract class Player extends LivingEntity {
+@@ -1261,7 +1261,7 @@ public abstract class Player extends LivingEntity {
                          flag1 = true;
                      }
  
@@ -40,7 +40,7 @@ index b716f297462b29c79500820859b9735c3576a2be..dcbf1e6e494493d81b7a10454a531b0f
  
                      flag2 = flag2 && !level.paperConfig().entities.behavior.disablePlayerCrits; // Paper
                      flag2 = flag2 && !this.isSprinting();
-@@ -1295,7 +1295,7 @@ public abstract class Player extends LivingEntity {
+@@ -1301,7 +1301,7 @@ public abstract class Player extends LivingEntity {
                      }
  
                      Vec3 vec3d = target.getDeltaMovement();
@@ -49,7 +49,7 @@ index b716f297462b29c79500820859b9735c3576a2be..dcbf1e6e494493d81b7a10454a531b0f
  
                      if (flag5) {
                          if (i > 0) {
-@@ -1323,7 +1323,7 @@ public abstract class Player extends LivingEntity {
+@@ -1329,7 +1329,7 @@ public abstract class Player extends LivingEntity {
  
                                  if (entityliving != this && entityliving != target && !this.isAlliedTo((Entity) entityliving) && (!(entityliving instanceof ArmorStand) || !((ArmorStand) entityliving).isMarker()) && this.distanceToSqr((Entity) entityliving) < 9.0D) {
                                      // CraftBukkit start - Only apply knockback if the damage hits

--- a/patches/server/0692-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
+++ b/patches/server/0692-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
@@ -28,10 +28,10 @@ index f12d844d422ca4175d4cb2b8e3112b590a207a16..834e5d2ef6045ef703321852f988db3f
          }
          // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index c4b273d20b8526b9a4c7e271585a826b49f2a05a..7f445787e25f2b0064c51705ffe5a5b92c5c62e4 100644
+index bc6ddf50bcd2f38be8c8fa064b49a7363643b9bd..aac412ebb2af3c63a2a6fda1dd647fbdee35ec1b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1572,6 +1572,18 @@ public class ServerPlayer extends Player {
+@@ -1573,6 +1573,18 @@ public class ServerPlayer extends Player {
          this.connection.send(new ClientboundContainerClosePacket(this.containerMenu.containerId));
          this.doCloseContainer();
      }
@@ -51,7 +51,7 @@ index c4b273d20b8526b9a4c7e271585a826b49f2a05a..7f445787e25f2b0064c51705ffe5a5b9
      @Override
      public void doCloseContainer() {
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 166e39a8c6854814dc47c995d23d2d572b56adab..c01cefe0d57f151b48022f3c6965f5558f796852 100644
+index 6416cd9a20a40c24b3182891da04d660f9fa9aee..4f9931ecdea8742db9e1db78143168d69ee635fb 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -502,6 +502,11 @@ public abstract class Player extends LivingEntity {

--- a/patches/server/0729-Ensure-valid-vehicle-status.patch
+++ b/patches/server/0729-Ensure-valid-vehicle-status.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure valid vehicle status
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 7f445787e25f2b0064c51705ffe5a5b92c5c62e4..ee35f2696d73dea748bc30a7b3d8172366159696 100644
+index aac412ebb2af3c63a2a6fda1dd647fbdee35ec1b..d9719e544261b9d2dc85fa9936ae23ea8e8dd08c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -524,7 +524,7 @@ public class ServerPlayer extends Player {
+@@ -525,7 +525,7 @@ public class ServerPlayer extends Player {
              }
          }
  

--- a/patches/server/0754-Add-player-health-update-API.patch
+++ b/patches/server/0754-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8f88d8a6f05d0f021608a035a39354ad480150f4..3a870ba7c66340ac47e6f6445cf99542d41415c6 100644
+index 9833e8bce6cc45fa053b71f64d71a57c1630595f..dae4efa2bceaf2d4e0ed573c9cbc49a8edda0202 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2334,9 +2334,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2344,9 +2344,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index 8f88d8a6f05d0f021608a035a39354ad480150f4..3a870ba7c66340ac47e6f6445cf99542
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2345,6 +2347,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2355,6 +2357,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      }
  

--- a/patches/server/0757-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0757-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -1180,10 +1180,10 @@ index 0000000000000000000000000000000000000000..d67a40e7be030142443680c89e1763fc
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ecdeb2bcfcb23d39f98325b0a36c3c905b12c178..1eda9f5e240bc72cd06dd7fa9fba5df7313c3dde 100644
+index d9719e544261b9d2dc85fa9936ae23ea8e8dd08c..5afb17ccc16e614e91ff3cad2f714b4ab40fb979 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -417,7 +417,7 @@ public class ServerPlayer extends Player {
+@@ -418,7 +418,7 @@ public class ServerPlayer extends Player {
  
                  if (blockposition1 != null) {
                      this.moveTo(blockposition1, 0.0F, 0.0F);
@@ -1192,7 +1192,7 @@ index ecdeb2bcfcb23d39f98325b0a36c3c905b12c178..1eda9f5e240bc72cd06dd7fa9fba5df7
                          break;
                      }
                  }
-@@ -425,7 +425,7 @@ public class ServerPlayer extends Player {
+@@ -426,7 +426,7 @@ public class ServerPlayer extends Player {
          } else {
              this.moveTo(blockposition, 0.0F, 0.0F);
  

--- a/patches/server/0819-fix-player-loottables-running-when-mob-loot-gamerule.patch
+++ b/patches/server/0819-fix-player-loottables-running-when-mob-loot-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] fix player loottables running when mob loot gamerule is false
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index d4bccae5b83a77af733b5d9466ae24b13323b2ba..0d09e674e3dc18c074c8dd730fe171de07cd27f9 100644
+index 5afb17ccc16e614e91ff3cad2f714b4ab40fb979..c9529b1157bd8c813f8e303dd35b6416d5a72838 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -872,12 +872,14 @@ public class ServerPlayer extends Player {
+@@ -873,12 +873,14 @@ public class ServerPlayer extends Player {
                  }
              }
          }

--- a/patches/server/0851-Add-option-for-strict-advancement-dimension-checks.patch
+++ b/patches/server/0851-Add-option-for-strict-advancement-dimension-checks.patch
@@ -11,10 +11,10 @@ distance trigger. This adds a config option to ignore that
 and use the exact dimension key of the worlds involved.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 0d09e674e3dc18c074c8dd730fe171de07cd27f9..c380c596dcba3f8f93d472df74fd614bbdbfce5e 100644
+index c9529b1157bd8c813f8e303dd35b6416d5a72838..ad63ba47e8d48daa80e00ca3bc26d68672cef3b3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1270,6 +1270,12 @@ public class ServerPlayer extends Player {
+@@ -1271,6 +1271,12 @@ public class ServerPlayer extends Player {
          // CraftBukkit start
          ResourceKey<Level> maindimensionkey = CraftDimensionUtil.getMainDimensionKey(origin);
          ResourceKey<Level> maindimensionkey1 = CraftDimensionUtil.getMainDimensionKey(this.level);

--- a/patches/server/0892-Set-position-before-player-sending-on-dimension-chan.patch
+++ b/patches/server/0892-Set-position-before-player-sending-on-dimension-chan.patch
@@ -7,10 +7,10 @@ This causes a moment where the player entity is sent with the previous location,
 teleport packet which is sent shortly after is meant to correct that.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index c380c596dcba3f8f93d472df74fd614bbdbfce5e..e484d1ee7519d74b9f60f339f67974b93ce10ab5 100644
+index ad63ba47e8d48daa80e00ca3bc26d68672cef3b3..cf80b3cc36919b1ab448d472089b98c4edc9fe4d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1173,6 +1173,7 @@ public class ServerPlayer extends Player {
+@@ -1174,6 +1174,7 @@ public class ServerPlayer extends Player {
  
                  // CraftBukkit end
                  this.setLevel(worldserver);

--- a/patches/server/0901-Add-PlayerInventorySlotChangeEvent.patch
+++ b/patches/server/0901-Add-PlayerInventorySlotChangeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerInventorySlotChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e484d1ee7519d74b9f60f339f67974b93ce10ab5..b18d8e23e98a01d095a27227516d9ff44fd1d14c 100644
+index cf80b3cc36919b1ab448d472089b98c4edc9fe4d..2eface459a431038db994f49f77a5834039cdaf6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -327,6 +327,25 @@ public class ServerPlayer extends Player {
+@@ -328,6 +328,25 @@ public class ServerPlayer extends Player {
  
                  }
              }

--- a/patches/server/0902-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0902-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 01978d9c56ec46669d22d363af36c1c596c318ba..d25aa840e1f1ac4877819ba679c1b0dcf71cc6ee 100644
+index 82a955a5c7979090c95ed50478265b39ce89af35..3477315170312911a12ff5825522617a0c6c078c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3113,6 +3113,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3123,6 +3123,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0916-Add-PrePlayerAttackEntityEvent.patch
+++ b/patches/server/0916-Add-PrePlayerAttackEntityEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PrePlayerAttackEntityEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index c01cefe0d57f151b48022f3c6965f5558f796852..11c6fc510ae03005060782a675ed1cd370a07596 100644
+index 4f9931ecdea8742db9e1db78143168d69ee635fb..5b772b3caeafe98aa45a01bffe215a5dd33323b6 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1232,8 +1232,17 @@ public abstract class Player extends LivingEntity {
+@@ -1238,8 +1238,17 @@ public abstract class Player extends LivingEntity {
      }
  
      public void attack(Entity target) {

--- a/patches/server/0919-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0919-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d25aa840e1f1ac4877819ba679c1b0dcf71cc6ee..7944f6a130da8f370f8018fad495694c61a94338 100644
+index 3477315170312911a12ff5825522617a0c6c078c..826fd85d946b7049e95a8e58b9e582f3958f05d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3118,6 +3118,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3128,6 +3128,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0928-Sync-offhand-slot-in-menus.patch
+++ b/patches/server/0928-Sync-offhand-slot-in-menus.patch
@@ -8,10 +8,10 @@ offhand slot isn't sent. This is not correct because you *can* put stuff into th
 by pressing the offhand swap item
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b18d8e23e98a01d095a27227516d9ff44fd1d14c..ca5291a9573a62cb5c19539cf5c7aceff11f9829 100644
+index 2eface459a431038db994f49f77a5834039cdaf6..1d4d02f26391ac55c7631817f09d05e2769b0d29 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -296,6 +296,13 @@ public class ServerPlayer extends Player {
+@@ -297,6 +297,13 @@ public class ServerPlayer extends Player {
  
              }
  

--- a/patches/server/0945-Flying-Fall-Damage.patch
+++ b/patches/server/0945-Flying-Fall-Damage.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Flying Fall Damage
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 48e116d3b3c1629c8cd6e2e8daa43afa40e5ff4c..2b02800666b358159c8ecb63208a14855f90657b 100644
+index 5b772b3caeafe98aa45a01bffe215a5dd33323b6..0629c471d38a77c44fc1c86ccdfcb0690f61ca17 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -184,6 +184,7 @@ public abstract class Player extends LivingEntity {
@@ -16,7 +16,7 @@ index 48e116d3b3c1629c8cd6e2e8daa43afa40e5ff4c..2b02800666b358159c8ecb63208a1485
      // Paper end
  
      // CraftBukkit start
-@@ -1748,7 +1749,7 @@ public abstract class Player extends LivingEntity {
+@@ -1754,7 +1755,7 @@ public abstract class Player extends LivingEntity {
  
      @Override
      public boolean causeFallDamage(float fallDistance, float damageMultiplier, DamageSource damageSource) {
@@ -26,10 +26,10 @@ index 48e116d3b3c1629c8cd6e2e8daa43afa40e5ff4c..2b02800666b358159c8ecb63208a1485
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a63060b91aa5cee9f4c6bf141fc2ae6d8a77a0fe..d06f2b6313eadf196b2e1fdc2310e4fd6c50321a 100644
+index 63f8a92cadfecc2d0e5256c5de822fe86d5ed91b..cdb1e5d82ff1e18e3f27c816df57bd9eeebbe80b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2281,6 +2281,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2291,6 +2291,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().onUpdateAbilities();
      }
  

--- a/patches/server/0969-Properly-cancel-bed-block-placement.patch
+++ b/patches/server/0969-Properly-cancel-bed-block-placement.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 26 Mar 2023 13:17:41 -0700
+Subject: [PATCH] Properly cancel bed block placement
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/BedBlock.java b/src/main/java/net/minecraft/world/level/block/BedBlock.java
+index 96434f14525a2159f335b94aad95081f488fadf3..3aa79a441ac4bd6b4d87d19bdb3011455210fd41 100644
+--- a/src/main/java/net/minecraft/world/level/block/BedBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/BedBlock.java
+@@ -363,7 +363,7 @@ public class BedBlock extends HorizontalDirectionalBlock implements EntityBlock
+ 
+             world.setBlock(blockposition1, (BlockState) state.setValue(BedBlock.PART, BedPart.HEAD), 3);
+             world.blockUpdated(pos, Blocks.AIR);
+-            state.updateNeighbourShapes(world, pos, 3);
++            // state.updateNeighbourShapes(world, pos, 3); // Paper - shapes will be updated on successful block place
+         }
+ 
+     }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
f92c94517 SPIGOT-7310: PlayerToggleSneakEvent is not called when a player sneaks while riding an entity b5714184d SPIGOT-7316: Cancelling EntityUnmountEvent does not stop the all effects of the unmounting e237f8c88 SPIGOT-7312: Entity#setVisibleByDefault on player causes skin reset on this player client