### PR TITLE
Fix unknown cmd msg for mc namespaced cmds

### DIFF
--- a/patches/server/0142-Add-UnknownCommandEvent.patch
+++ b/patches/server/0142-Add-UnknownCommandEvent.patch
@@ -83,17 +83,17 @@ index 971fc7f5f51ba82a7e8abafa6a5139c24a9aac0b..7f561ab6e56cd1749da8eff950080d3a
  
                  b1 = 0;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8aaba38c7f4dc17c8536a0049be8bdea204f6481..39e51bbc941b7381c901304d69758b2bca2f02d1 100644
+index 8aaba38c7f4dc17c8536a0049be8bdea204f6481..b3500ce8c3c03239fafa529b386bb11610e922fa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -507,6 +507,7 @@ public final class CraftServer implements Server {
- 
-             if (command instanceof VanillaCommandWrapper) {
-                 LiteralCommandNode<CommandSourceStack> node = (LiteralCommandNode<CommandSourceStack>) ((VanillaCommandWrapper) command).vanillaCommand;
+@@ -515,6 +515,7 @@ public final class CraftServer implements Server {
+                     }
+                     node = clone;
+                 }
 +                dispatcher.vanillaCommandNodes.add(node); // Paper
-                 if (!node.getLiteral().equals(label)) {
-                     LiteralCommandNode<CommandSourceStack> clone = new LiteralCommandNode(label, node.getCommand(), node.getRequirement(), node.getRedirect(), node.getRedirectModifier(), node.isFork());
  
+                 dispatcher.getDispatcher().getRoot().addChild(node);
+             } else {
 @@ -881,7 +882,13 @@ public final class CraftServer implements Server {
  
          // Spigot start


### PR DESCRIPTION
Properly account for the re-creation of literal command nodes with the `minecraft:` prefix.