### PR TITLE
Expose more native methods for PDC

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -60,4 +60,5 @@ Luke Chambers <consolelogluke@gmail.com>
 Emily <emilia.lopezf.1999@gmail.com>
 dawon <dawon@dawon.eu>
 Ollie <69084614+olijeffers0n@users.noreply.github.com>
+TheRealRyGuy <ryan@ryguy.me>
 ```

--- a/patches/api/0420-More-native-map-PDC-methods-use-adventure-Key.patch
+++ b/patches/api/0420-More-native-map-PDC-methods-use-adventure-Key.patch
@@ -1,0 +1,235 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: RyGuy <git@ryguy.me>
+Date: Tue, 28 Mar 2023 01:27:28 -0400
+Subject: [PATCH] More native map PDC methods, use adventure Key
+
+This commit has PDC inherit Iterable<NamespacedKey>, replaces all NamespacedKey uses with adventure's key,
+and implements these methods
+- #setIfAbsent(NamespacedKey, PersistentDataType, Object)
+- #computeIfAbsent(NamespacedKey, PersistentDataType, Function)
+- #computeIfPresent(NamespacedKey, PersistentDataType, BiFunction)
+- #compute(NamespacedKey, PersistentDataType, BiFunction)
+- #getOrThrow(NamespacedKey, PersistentDataType, Supplier)
+- #getOrThrow(NamespacedKey, PersistentDataType)
+- #replace(NamespacedKey, PersistentDataType, Object, Object)
+- #replace(NamespacedKey, PersistentDataType, Object)
+
+diff --git a/src/main/java/org/bukkit/persistence/PersistentDataContainer.java b/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
+index 57609b7793122e135fa0c3b926500849379637b2..cc38aec898f408b157e8e32aa63cb71a445cbfcb 100644
+--- a/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
++++ b/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
+@@ -1,15 +1,21 @@
+ package org.bukkit.persistence;
+ 
+-import java.util.Set;
+ import org.bukkit.NamespacedKey;
+ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Nullable;
+ 
++import java.util.Iterator;
++import java.util.NoSuchElementException;
++import java.util.Set;
++import java.util.function.BiFunction;
++import java.util.function.Function;
++import java.util.function.Supplier;
++
+ /**
+  * This interface represents a map like object, capable of storing custom tags
+  * in it.
+  */
+-public interface PersistentDataContainer {
++public interface PersistentDataContainer extends Iterable<net.kyori.adventure.key.Key> {
+ 
+     /**
+      * Stores a metadata value on the {@link PersistentDataHolder} instance.
+@@ -116,7 +122,7 @@ public interface PersistentDataContainer {
+     <T, Z> Z getOrDefault(@NotNull NamespacedKey key, @NotNull PersistentDataType<T, Z> type, @NotNull Z defaultValue);
+ 
+     /**
+-     * Get a set of keys present on this {@link PersistentDataContainer}
++     * Get a set of {@link NamespacedKey}s present on this {@link PersistentDataContainer}
+      * instance.
+      *
+      * Any changes made to the returned set will not be reflected on the
+@@ -197,5 +203,181 @@ public interface PersistentDataContainer {
+     default void readFromBytes(byte @NotNull [] bytes) throws java.io.IOException {
+         this.readFromBytes(bytes, true);
+     }
++
++    /**
++     * @return The iterator bound to the set from {@link #keySet()}
++     */
++    @Override
++    default @NotNull Iterator<net.kyori.adventure.key.Key> iterator() {
++        return keySet().iterator();
++    }
++
++    /**
++     * Will set a metadata value on the {@link PersistentDataHolder} instance if the value is not currently set
++     *
++     * @param key   the key this value will be stored under
++     * @param type  the type this tag uses
++     * @param value the value stored in the tag
++     * @param <T>   the generic java type of the tag value
++     * @param <Z>   the generic type of the object to store
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws NullPointerException     if the value is null. Removing a tag should
++     *                                  be done using {@link #remove(NamespacedKey)}
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> void setIfAbsent(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value);
++
++    /**
++     * Attempts to set a metadata value to your {@link PersistentDataHolder} instance if the supplied key isn't bound,
++     * or the current value is null. If your {@param mappingFunction} returns null, it will not set the value
++     *
++     * @param key             the key this value will be stored under
++     * @param type            the type this tag uses
++     * @param mappingFunction the function to compute your value
++     * @param <T>             the generic java type of the tag value
++     * @param <Z>             the generic type of the object to store
++     *
++     * @return The currently existing metadata within your {@link PersistentDataHolder} instance
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> @NotNull Z computeIfAbsent(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type,
++                                     @NotNull Function<net.kyori.adventure.key.Key, Z> mappingFunction);
++
++    /**
++     * Attempts to remap a current metadata value on your {@link PersistentDataHolder} instance if the value
++     * is currently present and the mapping function returns a non-null value
++     * The key is removed if your remapped value is null
++     *
++     * @param key               the key this value will be stored under
++     * @param type              the type this tag uses
++     * @param remappingFunction the function to compute your value
++     * @param <T>               the generic java type of the tag value
++     * @param <Z>               the generic type of the object to store
++     *
++     * @return The currently existing metadata within your {@link PersistentDataHolder} instance
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> @Nullable Z computeIfPresent(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type,
++                                      @NotNull BiFunction<net.kyori.adventure.key.Key, Z, Z> remappingFunction);
++
++    /**
++     * Attempts to remap an {@link PersistentDataHolder} metadata value using a supplied mapping function
++     * Your key is removed if your remapped value is null
++     *
++     * @param key               the key this value will be stored under
++     * @param type              the type this tag uses
++     * @param remappingFunction the function to compute your value
++     * @param <T>               the generic java type of the tag value
++     * @param <Z>               the generic type of the object to store
++     *
++     * @return The currently existing metadata within your {@link PersistentDataHolder} instance
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> @Nullable Z compute(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type,
++                             @NotNull BiFunction<net.kyori.adventure.key.Key, Z, Z> remappingFunction);
++
++    /**
++     * Attempts to retrieve a value from the metadata of your {@link PersistentDataHolder} instance. If there is
++     * no value, it will throw an exception
++     *
++     * @param key               the key this value will be stored under
++     * @param type              the type this tag uses
++     * @param exceptionSupplier supplies the exception you want to throw
++     * @param <T>               the generic java type of the tag value
++     * @param <Z>               the generic type of the object to store
++     * @param <X>               the exception type you want to throw
++     *
++     * @return The currently existing metadata within your {@link PersistentDataHolder} instance, if present
++     *
++     * @throws NullPointerException if the key is null
++     * @throws NullPointerException if the type is null
++     * @throws X                    If there was no metadata element bound to your key and type
++     */
++    <T, Z, X extends Throwable> @NotNull Z getOrThrow(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type,
++                                                     @NotNull Supplier<X> exceptionSupplier) throws X;
++
++    /**
++     * Attempts to retrieve a value from the metadata of your {@link PersistentDataHolder} instance. If there is
++     * no value, it will throw an exception
++     *
++     * @param key  the key this value will be stored under
++     * @param type the type this tag uses
++     * @param <T>  the generic java type of the tag value
++     * @param <Z>  the generic type of the object to store
++     *
++     * @return The currently existing metadata within your {@link PersistentDataHolder} instance, if present
++     *
++     * @throws NullPointerException   if the key is null
++     * @throws NullPointerException   if the type is null
++     * @throws NoSuchElementException If there was no metadata element bound to your key and type
++     */
++    default <T, Z> @NotNull Z getOrThrow(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type) {
++        return getOrThrow(key, type, () -> new NoSuchElementException("Key " + key.asString() + " not present in PDC " +
++            this.getClass().getName()));
++    }
++
++    /**
++     * Replaces the metadata value of your specified key and type if it is currently bound to your `oldValue`
++     *
++     * @param key      the key this value will be stored under
++     * @param type     the type this tag uses
++     * @param oldValue expected value bound to your specified key
++     * @param newValue value to bind to your specified key
++     * @param <T>      the generic java type of the tag value
++     * @param <Z>      the generic type of the object to store
++     *
++     * @return True if the mapped value was changed, false otherwise
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> boolean replace(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type,
++                                   @NotNull Z oldValue, @NotNull Z newValue);
++
++    /**
++     * Replaces any metadata value in your {@link PersistentDataHolder} if it is bound to your supplied key and type
++     *
++     * @param key   the key this value will be stored under
++     * @param type  the type this tag uses
++     * @param value Value to set
++     * @param <T>   the generic java type of the tag value
++     * @param <Z>   the generic type of the object to store
++     *
++     * @return The previous value bound to your key, or null if no value exists
++     * 
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> @NotNull Z replace(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value);
++
++    /**
++     * Get a set of {@link net.kyori.adventure.key.Key}s present on this {@link PersistentDataContainer}
++     * instance.
++     *
++     * Any changes made to the returned set will not be reflected on the
++     * instance.
++     *
++     * @return the key set
++     */
++    @NotNull Set<net.kyori.adventure.key.Key> keySet();
+     // Paper end
+ }

--- a/patches/server/0980-More-native-map-PDC-methods-use-adventure-Key.patch
+++ b/patches/server/0980-More-native-map-PDC-methods-use-adventure-Key.patch
@@ -16,7 +16,7 @@ and implements these methods
 - #replace(NamespacedKey, PersistentDataType, Object)
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
-index 65013fd2ca24c4bf1cfd67e314927e72542d3e68..098663548a62b5ed7e9e1cce028cbba2ca4278bd 100644
+index 65013fd2ca24c4bf1cfd67e314927e72542d3e68..795d6ad456c77ef5ca0c77f8b731d97a5c13f49a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
 @@ -7,6 +7,10 @@ import java.util.Map;
@@ -38,22 +38,17 @@ index 65013fd2ca24c4bf1cfd67e314927e72542d3e68..098663548a62b5ed7e9e1cce028cbba2
  
  public class CraftPersistentDataContainer implements PersistentDataContainer {
  
-@@ -37,16 +42,33 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+@@ -37,16 +42,24 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
          Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
          Preconditions.checkArgument(type != null, "The provided type cannot be null");
          Preconditions.checkArgument(value != null, "The provided value cannot be null");
 +        //Paper start
 +        set(key.toString(), type, value);
 +    }
-+
-+    private <T, Z> void set(String key, PersistentDataType<T, Z> type, Z value) {
-+        //Paper end
-+        Preconditions.checkArgument(key != null, "The provided key for the custom value was null");
-+        Preconditions.checkArgument(type != null, "The provided type for the custom value was null");
-+        Preconditions.checkArgument(value != null, "The provided value for the custom value was null");
  
 -        this.customDataTags.put(key.toString(), this.registry.wrap(type.getPrimitiveType(), type.toPrimitive(value, adapterContext)));
-+        this.customDataTags.put(key, this.registry.wrap(type.getPrimitiveType(), type.toPrimitive(value, adapterContext))); //Paper
++    private <T, Z> void set(String key, PersistentDataType<T, Z> type, Z value) {
++        this.customDataTags.put(key, this.registry.wrap(type.getPrimitiveType(), type.toPrimitive(value, adapterContext))); //Paper end
      }
  
      @Override
@@ -63,18 +58,14 @@ index 65013fd2ca24c4bf1cfd67e314927e72542d3e68..098663548a62b5ed7e9e1cce028cbba2
 +        //Paper start
 +        return has(key.toString(), type);
 +    }
-+
-+    private <T, Z> boolean has(String key, PersistentDataType<T, Z> type) {
-+        //Paper end
-+        Preconditions.checkArgument(key != null, "The provided key for the custom value was null");
-+        Preconditions.checkArgument(type != null, "The provided type for the custom value was null");
  
 -        Tag value = this.customDataTags.get(key.toString());
-+        Tag value = this.customDataTags.get(key); //Paper
++    private <T, Z> boolean has(String key, PersistentDataType<T, Z> type) {
++        Tag value = this.customDataTags.get(key); //Paper end
          if (value == null) {
              return false;
          }
-@@ -58,8 +80,16 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+@@ -58,8 +71,12 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
      public <T, Z> Z get(NamespacedKey key, PersistentDataType<T, Z> type) {
          Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
          Preconditions.checkArgument(type != null, "The provided type cannot be null");
@@ -84,15 +75,11 @@ index 65013fd2ca24c4bf1cfd67e314927e72542d3e68..098663548a62b5ed7e9e1cce028cbba2
  
 -        Tag value = this.customDataTags.get(key.toString());
 +    private <T, Z> Z get(String key, PersistentDataType<T, Z> type) {
-+        //Paper end
-+        Preconditions.checkArgument(key != null, "The provided key for the custom value was null");
-+        Preconditions.checkArgument(type != null, "The provided type for the custom value was null");
-+
-+        Tag value = this.customDataTags.get(key); //Paper
++        Tag value = this.customDataTags.get(key); //Paper end
          if (value == null) {
              return null;
          }
-@@ -90,8 +120,15 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+@@ -90,8 +107,12 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
      @Override
      public void remove(NamespacedKey key) {
          Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
@@ -102,14 +89,11 @@ index 65013fd2ca24c4bf1cfd67e314927e72542d3e68..098663548a62b5ed7e9e1cce028cbba2
  
 -        this.customDataTags.remove(key.toString());
 +    private void remove(String key) {
-+        //Paper end
-+        Preconditions.checkArgument(key != null, "The provided key for the custom value was null");
-+
-+        this.customDataTags.remove(key); //Paper
++        this.customDataTags.remove(key); //Paper end
      }
  
      @Override
-@@ -189,5 +226,115 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+@@ -189,5 +210,115 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
              this.putAll(compound);
          }
      }

--- a/patches/server/0980-More-native-map-PDC-methods-use-adventure-Key.patch
+++ b/patches/server/0980-More-native-map-PDC-methods-use-adventure-Key.patch
@@ -1,0 +1,227 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: RyGuy <git@ryguy.me>
+Date: Tue, 28 Mar 2023 16:39:06 -0400
+Subject: [PATCH] More native map PDC methods, use adventure Key
+
+This commit has PDC inherit Iterable<NamespacedKey>, replaces all
+NamespacedKey uses with adventure's key,
+and implements these methods
+- #setIfAbsent(NamespacedKey, PersistentDataType, Object)
+- #computeIfAbsent(NamespacedKey, PersistentDataType, Function)
+- #computeIfPresent(NamespacedKey, PersistentDataType, BiFunction)
+- #compute(NamespacedKey, PersistentDataType, BiFunction)
+- #getOrThrow(NamespacedKey, PersistentDataType, Supplier)
+- #getOrThrow(NamespacedKey, PersistentDataType)
+- #replace(NamespacedKey, PersistentDataType, Object, Object)
+- #replace(NamespacedKey, PersistentDataType, Object)
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
+index 65013fd2ca24c4bf1cfd67e314927e72542d3e68..098663548a62b5ed7e9e1cce028cbba2ca4278bd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
++++ b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
+@@ -7,6 +7,10 @@ import java.util.Map;
+ import java.util.Map.Entry;
+ import java.util.Objects;
+ import java.util.Set;
++import java.util.function.BiFunction;
++import java.util.function.Function;
++import java.util.function.Supplier;
++
+ import net.minecraft.nbt.CompoundTag;
+ import net.minecraft.nbt.Tag;
+ import org.bukkit.NamespacedKey;
+@@ -14,6 +18,7 @@ import org.bukkit.craftbukkit.util.CraftNBTTagConfigSerializer;
+ import org.bukkit.persistence.PersistentDataAdapterContext;
+ import org.bukkit.persistence.PersistentDataContainer;
+ import org.bukkit.persistence.PersistentDataType;
++import org.jetbrains.annotations.NotNull;
+ 
+ public class CraftPersistentDataContainer implements PersistentDataContainer {
+ 
+@@ -37,16 +42,33 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+         Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+         Preconditions.checkArgument(type != null, "The provided type cannot be null");
+         Preconditions.checkArgument(value != null, "The provided value cannot be null");
++        //Paper start
++        set(key.toString(), type, value);
++    }
++
++    private <T, Z> void set(String key, PersistentDataType<T, Z> type, Z value) {
++        //Paper end
++        Preconditions.checkArgument(key != null, "The provided key for the custom value was null");
++        Preconditions.checkArgument(type != null, "The provided type for the custom value was null");
++        Preconditions.checkArgument(value != null, "The provided value for the custom value was null");
+ 
+-        this.customDataTags.put(key.toString(), this.registry.wrap(type.getPrimitiveType(), type.toPrimitive(value, adapterContext)));
++        this.customDataTags.put(key, this.registry.wrap(type.getPrimitiveType(), type.toPrimitive(value, adapterContext))); //Paper
+     }
+ 
+     @Override
+     public <T, Z> boolean has(NamespacedKey key, PersistentDataType<T, Z> type) {
+         Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+         Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        //Paper start
++        return has(key.toString(), type);
++    }
++
++    private <T, Z> boolean has(String key, PersistentDataType<T, Z> type) {
++        //Paper end
++        Preconditions.checkArgument(key != null, "The provided key for the custom value was null");
++        Preconditions.checkArgument(type != null, "The provided type for the custom value was null");
+ 
+-        Tag value = this.customDataTags.get(key.toString());
++        Tag value = this.customDataTags.get(key); //Paper
+         if (value == null) {
+             return false;
+         }
+@@ -58,8 +80,16 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+     public <T, Z> Z get(NamespacedKey key, PersistentDataType<T, Z> type) {
+         Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+         Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        //Paper start
++        return get(key.toString(), type);
++    }
+ 
+-        Tag value = this.customDataTags.get(key.toString());
++    private <T, Z> Z get(String key, PersistentDataType<T, Z> type) {
++        //Paper end
++        Preconditions.checkArgument(key != null, "The provided key for the custom value was null");
++        Preconditions.checkArgument(type != null, "The provided type for the custom value was null");
++
++        Tag value = this.customDataTags.get(key); //Paper
+         if (value == null) {
+             return null;
+         }
+@@ -90,8 +120,15 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+     @Override
+     public void remove(NamespacedKey key) {
+         Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
++        //Paper start
++        remove(key.toString());
++    }
+ 
+-        this.customDataTags.remove(key.toString());
++    private void remove(String key) {
++        //Paper end
++        Preconditions.checkArgument(key != null, "The provided key for the custom value was null");
++
++        this.customDataTags.remove(key); //Paper
+     }
+ 
+     @Override
+@@ -189,5 +226,115 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+             this.putAll(compound);
+         }
+     }
++
++    @Override
++    public <T, Z> void setIfAbsent(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value) {
++        Z z = this.get(key.asString(), type);
++        if (z == null) {
++            this.set(key.asString(), type, value);
++        }
++    }
++
++    @Override
++    public <T, Z> Z computeIfAbsent(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type,
++                                    @NotNull Function<net.kyori.adventure.key.Key, Z> mappingFunction) {
++        Preconditions.checkArgument(mappingFunction != null);
++            Z v;
++        Z newValue;
++        if ((v = this.get(key.asString(), type)) == null && (newValue = mappingFunction.apply(key)) != null) {
++            this.set(key.asString(), type, newValue);
++            return newValue;
++        } else {
++            return v;
++        }
++    }
++
++    @Override
++    public <T, Z> Z computeIfPresent(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type,
++                                     @NotNull BiFunction<net.kyori.adventure.key.Key, Z, Z> remappingFunction) {
++        Preconditions.checkArgument(remappingFunction != null);
++        Z oldValue;
++        if ((oldValue = this.get(key.asString(), type)) != null) {
++            Z newValue = remappingFunction.apply(key, oldValue);
++            if (newValue != null) {
++                this.set(key.asString(), type, newValue);
++                return newValue;
++            } else {
++                this.remove(key.asString());
++                return null;
++            }
++        } else {
++            return null;
++        }
++    }
++
++    @Override
++    public <T, Z> Z compute(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type,
++                            @NotNull BiFunction<net.kyori.adventure.key.Key, Z, Z> remappingFunction) {
++        Preconditions.checkArgument(remappingFunction != null);
++        Z oldValue = this.get(key.asString(), type);
++        Z newValue = remappingFunction.apply(key, oldValue);
++        if (newValue == null) {
++            if (oldValue == null && !this.has(key.asString(), type)) {
++                return null;
++            } else {
++                this.remove(key.asString());
++                return null;
++            }
++        } else {
++            this.set(key.asString(), type, newValue);
++            return newValue;
++        }
++    }
++
++    @Override
++    public <T, Z, X extends Throwable> Z getOrThrow(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type,
++                                                    @NotNull Supplier<X> exceptionSupplier) throws X {
++        Preconditions.checkArgument(exceptionSupplier != null);
++        Z value = this.get(key.asString(), type);
++        if (value == null) {
++            throw exceptionSupplier.get();
++        } else {
++            return value;
++        }
++    }
++
++    @Override
++    public <T, Z> boolean replace(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type,
++                                  @NotNull Z oldValue, @NotNull Z newValue) {
++        Z curValue = this.get(key.asString(), type);
++        if (Objects.equals(curValue, oldValue) && (curValue != null || this.has(key.asString(), type))) {
++            this.set(key.asString(), type, newValue);
++            return true;
++        } else {
++            return false;
++        }
++    }
++
++    @Override
++    public <T, Z> Z replace(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value) {
++        Z curValue;
++        if ((curValue = this.get(key.asString(), type)) != null || this.has(key.asString(), type)) {
++            set(key.asString(), type, value);
++        }
++
++        return curValue;
++    }
++
++    @Override
++    public Set<net.kyori.adventure.key.Key> keySet() {
++        Set<net.kyori.adventure.key.Key> keys = new HashSet<>();
++
++        this.customDataTags.keySet().forEach(k -> {
++            String[] keyData = k.split(":", 2);
++            if (keyData.length == 2) {
++                keys.add(net.kyori.adventure.key.Key.key(keyData[0], keyData[1]));
++            }
++        });
++
++        return keys;
++    }
++
++
+     // Paper end
+ }


### PR DESCRIPTION
ref #8925 

PDC now inherits `Iterable<NamespacedKey>`, and adds these methods 
- #setIfAbsent(NamespacedKey, PersistentDataType, Object)
- #computeIfAbsent(NamespacedKey, PersistentDataType, Function)
- #computeIfPresent(NamespacedKey, PersistentDataType, BiFunction)
- #compute(NamespacedKey, PersistentDataType, BiFunction)
- #getOrThrow(NamespacedKey, PersistentDataType, Supplier)
- #getOrThrow(NamespacedKey, PersistentDataType)
- #replace(NamespacedKey, PersistentDataType, Object, Object)
- #replace(NamespacedKey, PersistentDataType, Object)

_i suck at java docs and i apologize_