### PR TITLE
Make debug dump file names consistent

### DIFF
--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -250,7 +250,7 @@ index 0000000000000000000000000000000000000000..f0fce4113fb07c64adbec029d177c236
 +}
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/DumpPluginsCommand.java b/src/main/java/io/papermc/paper/command/subcommands/DumpPluginsCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7159c72408f556d676eded668057a4c5ebb21719
+index 0000000000000000000000000000000000000000..615902ac9fd341d6624d8fdb1c2ae6cc9abf9554
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/subcommands/DumpPluginsCommand.java
 @@ -0,0 +1,200 @@
@@ -313,7 +313,7 @@ index 0000000000000000000000000000000000000000..7159c72408f556d676eded668057a4c5
 +
 +    private void dumpPlugins(final CommandSender sender, final String[] args) {
 +        Path parent = Path.of("debug");
-+        Path path = parent.resolve("plugin-info" + FORMATTER.format(LocalDateTime.now()) + ".txt");
++        Path path = parent.resolve("plugin-info-" + FORMATTER.format(LocalDateTime.now()) + ".txt");
 +        try {
 +            Files.createDirectories(parent);
 +            Files.createFile(path);

--- a/patches/server/0351-Add-debug-for-sync-chunk-loads.patch
+++ b/patches/server/0351-Add-debug-for-sync-chunk-loads.patch
@@ -207,7 +207,7 @@ index 8f16640fc2f1233c10392d7e32a54d784fd8e370..1e9f191dc0f9d98f4404d2796f15b139
              .flatMap(entry -> entry.getKey().stream().map(s -> Map.entry(s, entry.getValue())))
 diff --git a/src/main/java/io/papermc/paper/command/subcommands/SyncLoadInfoCommand.java b/src/main/java/io/papermc/paper/command/subcommands/SyncLoadInfoCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a73e35e7c71c1337c2846010b3ccd6875cae640e
+index 0000000000000000000000000000000000000000..95d6022c9cfb2e36ec5a71be6e34354027c2ec08
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/subcommands/SyncLoadInfoCommand.java
 @@ -0,0 +1,88 @@
@@ -273,7 +273,7 @@ index 0000000000000000000000000000000000000000..a73e35e7c71c1337c2846010b3ccd687
 +        }
 +
 +        File file = new File(new File(new File("."), "debug"),
-+            "sync-load-info" + FORMATTER.format(LocalDateTime.now()) + ".txt");
++            "sync-load-info-" + FORMATTER.format(LocalDateTime.now()) + ".txt");
 +        file.getParentFile().mkdirs();
 +        sender.sendMessage(text("Writing sync load info to " + file, GREEN));
 +


### PR DESCRIPTION
before: 
![image](https://user-images.githubusercontent.com/40437205/228910602-5f07f490-e1a6-4554-8c69-42f63cac5206.png)

after:
![image](https://user-images.githubusercontent.com/40437205/228911363-bdbc31b4-3033-477c-9947-073f90a033ea.png)
