### PR TITLE
Resend more data on profile change

### DIFF
--- a/patches/server/0184-Player.setPlayerProfile-API.patch
+++ b/patches/server/0184-Player.setPlayerProfile-API.patch
@@ -55,7 +55,7 @@ index e7442952ef1f03969949014492a7ddc6d0796ba5..69a1852905dd4724c30ac8ab88c14251
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f19b8258e30133f3111ca27e9082b7f3a4ce3877..53074702d0d606ce0e26c4cf435c3b71b4336f5e 100644
+index f19b8258e30133f3111ca27e9082b7f3a4ce3877..dd1e5b2ec23b90dff11fce2de0caea10342d3168 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -82,6 +82,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -144,7 +144,7 @@ index f19b8258e30133f3111ca27e9082b7f3a4ce3877..53074702d0d606ce0e26c4cf435c3b71
      }
  
      void resetAndShowEntity(org.bukkit.entity.Entity entity) {
-@@ -1749,6 +1780,30 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1749,6 +1780,40 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              this.trackAndShowEntity(entity);
          }
      }
@@ -165,6 +165,16 @@ index f19b8258e30133f3111ca27e9082b7f3a4ce3877..53074702d0d606ce0e26c4cf435c3b71
 +        handle.onUpdateAbilities();
 +        connection.internalTeleport(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch(), java.util.Collections.emptySet());
 +        net.minecraft.server.MinecraftServer.getServer().getPlayerList().sendAllPlayerInfo(handle);
++
++        // Resend their XP and effects because the respawn packet resets it
++        connection.send(new net.minecraft.network.protocol.game.ClientboundSetExperiencePacket(handle.experienceProgress, handle.totalExperience, handle.experienceLevel));
++        for (net.minecraft.world.effect.MobEffectInstance mobEffect : handle.getActiveEffects()) {
++            connection.send(new net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket(handle.getId(), mobEffect));
++        }
++
++        // Resend other player information
++        handle.onUpdateAbilities();
++        updateScaledHealth();
 +
 +        if (this.isOp()) {
 +            this.setOp(false);

--- a/patches/server/0189-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0189-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 53074702d0d606ce0e26c4cf435c3b71b4336f5e..31fbfff6fb79601ade46b9867cd82da9db9cd2bd 100644
+index dd1e5b2ec23b90dff11fce2de0caea10342d3168..4df8f03898f535be3aac6fac319a00a7dadc1e98 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -176,6 +176,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index 53074702d0d606ce0e26c4cf435c3b71b4336f5e..31fbfff6fb79601ade46b9867cd82da9
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -2012,7 +2013,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2022,7 +2023,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 966232147c9a308743a65fe581c84b449de1dbd3..8fcffb0a9c3fa97758610371b6d03b0094c43c71 100644
+index 486a209d01a29af9500a448995ae2d0d3c7f7da2..5593ed9efd1b1b784db4345bb79bf6bb1519077c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2769,6 +2769,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2779,6 +2779,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0255-Improve-death-events.patch
+++ b/patches/server/0255-Improve-death-events.patch
@@ -352,10 +352,10 @@ index e38cbdff34479673f1640c46d727f1a807a609c7..dbb4bfb3d1f1ce2e435ca531be36ea44
          this.gameEvent(GameEvent.ENTITY_DIE);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8fcffb0a9c3fa97758610371b6d03b0094c43c71..c19b004463e491674b6c4bc8bfc8851d4dbb4501 100644
+index 5593ed9efd1b1b784db4345bb79bf6bb1519077c..a5e5cdf861b86aaa3578af805f82ce3a392c8b48 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2272,7 +2272,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2282,7 +2282,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/patches/server/0292-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0292-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -106,7 +106,7 @@ index 69a1852905dd4724c30ac8ab88c14251eee2c371..17b3d5de58a9ef3acc67624c46cd6bbd
      public Location getLastDeathLocation() {
          if (this.getData().contains("LastDeathLocation", 10)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c19b004463e491674b6c4bc8bfc8851d4dbb4501..66e7fba36b0810a1254f3937988a640db9a0e295 100644
+index a5e5cdf861b86aaa3578af805f82ce3a392c8b48..6fd99cbcfd39dd7e4d83da77c864a2adc4f6fb88 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -177,6 +177,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index c19b004463e491674b6c4bc8bfc8851d4dbb4501..66e7fba36b0810a1254f3937988a640d
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1884,6 +1885,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1894,6 +1895,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index c19b004463e491674b6c4bc8bfc8851d4dbb4501..66e7fba36b0810a1254f3937988a640d
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1906,6 +1919,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1916,6 +1929,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index c19b004463e491674b6c4bc8bfc8851d4dbb4501..66e7fba36b0810a1254f3937988a640d
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1920,6 +1935,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1930,6 +1945,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 66e7fba36b0810a1254f3937988a640db9a0e295..2977d89a4c38346402527dcaa84b51a7707b2480 100644
+index 6fd99cbcfd39dd7e4d83da77c864a2adc4f6fb88..922517f5a0d49028217f47fd9133589872b78f13 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2816,6 +2816,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2826,6 +2826,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0456-Brand-support.patch
+++ b/patches/server/0456-Brand-support.patch
@@ -56,10 +56,10 @@ index 1517c09ccd95448cb0fce0f9ffbb7bd2e704113b..221a695acf3cbeaeaf9eda818b6cf809
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2cfe08bc1de682c845718e758ede718e94384d4d..15caedd46ca0b4dba4d1d0fb3cabd24d324390fa 100644
+index 001c9e340930b50ac807fe5b2422e6f5891cd319..4043f46893eb423cbd736f629e8938051fb1f530 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2943,6 +2943,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2953,6 +2953,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0504-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0504-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cd6a04777fadd22053ff35be18652a8273b217d2..c0338f597b9c50218862005220a8753d5822a6e4 100644
+index 595cd29a101836b17026996b25ae31bdd16cd8bf..c822db9ef3b1f4033f556dfcd6966ffd152ebff4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2465,7 +2465,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2475,7 +2475,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0754-Add-player-health-update-API.patch
+++ b/patches/server/0754-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9833e8bce6cc45fa053b71f64d71a57c1630595f..dae4efa2bceaf2d4e0ed573c9cbc49a8edda0202 100644
+index 9cbdbd2075c54cd4060b5bd895c22d7f49ab3cd3..aa1b11d6e02beb58b21c8637e8b26a838a619ce4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2344,9 +2344,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2354,9 +2354,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index 9833e8bce6cc45fa053b71f64d71a57c1630595f..dae4efa2bceaf2d4e0ed573c9cbc49a8
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2355,6 +2357,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2365,6 +2367,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      }
  

--- a/patches/server/0902-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0902-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 82a955a5c7979090c95ed50478265b39ce89af35..3477315170312911a12ff5825522617a0c6c078c 100644
+index af92d9a3eab69c31112353a748b9e2b8a0fc8bc6..c0ef740961a24fb27552d1dc2aea7352eba752fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3123,6 +3123,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3133,6 +3133,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0919-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0919-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3477315170312911a12ff5825522617a0c6c078c..826fd85d946b7049e95a8e58b9e582f3958f05d4 100644
+index c0ef740961a24fb27552d1dc2aea7352eba752fe..e723809df1abea848e56155eb52749b229c2555f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3128,6 +3128,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3138,6 +3138,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0944-Flying-Fall-Damage.patch
+++ b/patches/server/0944-Flying-Fall-Damage.patch
@@ -26,10 +26,10 @@ index 5b772b3caeafe98aa45a01bffe215a5dd33323b6..0629c471d38a77c44fc1c86ccdfcb069
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 63f8a92cadfecc2d0e5256c5de822fe86d5ed91b..cdb1e5d82ff1e18e3f27c816df57bd9eeebbe80b 100644
+index aed8a72f92394d5a5dbd63787b3459f4450dd072..d659b810541f886d9dbf22f371b2b6f9208f15e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2291,6 +2291,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2301,6 +2301,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().onUpdateAbilities();
      }
  


### PR DESCRIPTION
This PR resolves issues with game features resetting to default state on respawn/profile change. Currently, breaking are potion effects and the XP bar, both are now being resent to make the client know about them again. Because the #teleport method also updates abilities and scaled health, I'm updating those as well, just in case.
It may be worth looking into other things that need to be resent in the future.
All of these additions are taken from the teleport respawn code that is used when the respawn packet is sent. There are some other packets like setting view distance or some specific metadata/attributes/permission things for the player, but I think it's a bit unnecessary to mess around with all of those right now. Think I've caught the worst ones in this PR.