### PR TITLE
Resend more data on profile refresh

### DIFF
--- a/patches/server/0184-Player.setPlayerProfile-API.patch
+++ b/patches/server/0184-Player.setPlayerProfile-API.patch
@@ -55,7 +55,7 @@ index e7442952ef1f03969949014492a7ddc6d0796ba5..69a1852905dd4724c30ac8ab88c14251
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f19b8258e30133f3111ca27e9082b7f3a4ce3877..dd1e5b2ec23b90dff11fce2de0caea10342d3168 100644
+index 61baea9efa7c1b35c437f6f0a4387c7611f401c3..9099604b5bffc92ca46c096d2d6d7d857ef22c38 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -82,6 +82,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -78,7 +78,7 @@ index f19b8258e30133f3111ca27e9082b7f3a4ce3877..dd1e5b2ec23b90dff11fce2de0caea10
      @Override
      public InetSocketAddress getAddress() {
          if (this.getHandle().connection == null) return null;
-@@ -1643,8 +1639,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1646,8 +1642,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      private void untrackAndHideEntity(org.bukkit.entity.Entity entity) {
          // Remove this entity from the hidden player's EntityTrackerEntry
@@ -95,7 +95,7 @@ index f19b8258e30133f3111ca27e9082b7f3a4ce3877..dd1e5b2ec23b90dff11fce2de0caea10
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1657,8 +1660,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1660,8 +1663,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  this.getHandle().connection.send(new ClientboundPlayerInfoRemovePacket(List.of(otherPlayer.getUUID())));
              }
          }
@@ -104,7 +104,7 @@ index f19b8258e30133f3111ca27e9082b7f3a4ce3877..dd1e5b2ec23b90dff11fce2de0caea10
      }
  
      void resetAndHideEntity(org.bukkit.entity.Entity entity) {
-@@ -1735,8 +1736,38 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1738,8 +1739,38 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (entry != null && !entry.seenBy.contains(this.getHandle().connection)) {
              entry.updatePlayer(this.getHandle());
          }
@@ -144,7 +144,7 @@ index f19b8258e30133f3111ca27e9082b7f3a4ce3877..dd1e5b2ec23b90dff11fce2de0caea10
      }
  
      void resetAndShowEntity(org.bukkit.entity.Entity entity) {
-@@ -1749,6 +1780,40 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1752,6 +1783,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              this.trackAndShowEntity(entity);
          }
      }
@@ -171,10 +171,6 @@ index f19b8258e30133f3111ca27e9082b7f3a4ce3877..dd1e5b2ec23b90dff11fce2de0caea10
 +        for (net.minecraft.world.effect.MobEffectInstance mobEffect : handle.getActiveEffects()) {
 +            connection.send(new net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket(handle.getId(), mobEffect));
 +        }
-+
-+        // Resend other player information
-+        handle.onUpdateAbilities();
-+        updateScaledHealth();
 +
 +        if (this.isOp()) {
 +            this.setOp(false);

--- a/patches/server/0184-Player.setPlayerProfile-API.patch
+++ b/patches/server/0184-Player.setPlayerProfile-API.patch
@@ -55,7 +55,7 @@ index e7442952ef1f03969949014492a7ddc6d0796ba5..69a1852905dd4724c30ac8ab88c14251
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 61baea9efa7c1b35c437f6f0a4387c7611f401c3..05f43fab1fbc121ae6e5113ba485e0b2b89cb98b 100644
+index f19b8258e30133f3111ca27e9082b7f3a4ce3877..dd1e5b2ec23b90dff11fce2de0caea10342d3168 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -82,6 +82,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -78,7 +78,7 @@ index 61baea9efa7c1b35c437f6f0a4387c7611f401c3..05f43fab1fbc121ae6e5113ba485e0b2
      @Override
      public InetSocketAddress getAddress() {
          if (this.getHandle().connection == null) return null;
-@@ -1646,8 +1642,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1643,8 +1639,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      private void untrackAndHideEntity(org.bukkit.entity.Entity entity) {
          // Remove this entity from the hidden player's EntityTrackerEntry
@@ -95,7 +95,7 @@ index 61baea9efa7c1b35c437f6f0a4387c7611f401c3..05f43fab1fbc121ae6e5113ba485e0b2
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1660,8 +1663,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1657,8 +1660,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  this.getHandle().connection.send(new ClientboundPlayerInfoRemovePacket(List.of(otherPlayer.getUUID())));
              }
          }
@@ -104,7 +104,7 @@ index 61baea9efa7c1b35c437f6f0a4387c7611f401c3..05f43fab1fbc121ae6e5113ba485e0b2
      }
  
      void resetAndHideEntity(org.bukkit.entity.Entity entity) {
-@@ -1738,8 +1739,38 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1735,8 +1736,38 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (entry != null && !entry.seenBy.contains(this.getHandle().connection)) {
              entry.updatePlayer(this.getHandle());
          }
@@ -144,7 +144,7 @@ index 61baea9efa7c1b35c437f6f0a4387c7611f401c3..05f43fab1fbc121ae6e5113ba485e0b2
      }
  
      void resetAndShowEntity(org.bukkit.entity.Entity entity) {
-@@ -1752,6 +1783,30 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1749,6 +1780,40 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              this.trackAndShowEntity(entity);
          }
      }
@@ -165,6 +165,16 @@ index 61baea9efa7c1b35c437f6f0a4387c7611f401c3..05f43fab1fbc121ae6e5113ba485e0b2
 +        handle.onUpdateAbilities();
 +        connection.internalTeleport(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch(), java.util.Collections.emptySet());
 +        net.minecraft.server.MinecraftServer.getServer().getPlayerList().sendAllPlayerInfo(handle);
++
++        // Resend their XP and effects because the respawn packet resets it
++        connection.send(new net.minecraft.network.protocol.game.ClientboundSetExperiencePacket(handle.experienceProgress, handle.totalExperience, handle.experienceLevel));
++        for (net.minecraft.world.effect.MobEffectInstance mobEffect : handle.getActiveEffects()) {
++            connection.send(new net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket(handle.getId(), mobEffect));
++        }
++
++        // Resend other player information
++        handle.onUpdateAbilities();
++        updateScaledHealth();
 +
 +        if (this.isOp()) {
 +            this.setOp(false);

--- a/patches/server/0189-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0189-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 05f43fab1fbc121ae6e5113ba485e0b2b89cb98b..6d0800737d1e017bc841fddcbd9ac6cb0be0f4fd 100644
+index 9099604b5bffc92ca46c096d2d6d7d857ef22c38..78e6946466d455f39d08df7063a494ee297a477e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -176,6 +176,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index 05f43fab1fbc121ae6e5113ba485e0b2b89cb98b..6d0800737d1e017bc841fddcbd9ac6cb
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -2015,7 +2016,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2021,7 +2022,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 25b3e7f8f8182bb5de491fc2f6debf4d7a8cd252..dd22b04a5a30cc1dce87fba6f08f8f183af049a4 100644
+index cd1a2796f8a16775f6fc5fd43d46a398711601ee..b133bb407b88d7bc3ab8cb2011e8ad9e65df4bcd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2772,6 +2772,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2778,6 +2778,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0255-Improve-death-events.patch
+++ b/patches/server/0255-Improve-death-events.patch
@@ -352,10 +352,10 @@ index e38cbdff34479673f1640c46d727f1a807a609c7..dbb4bfb3d1f1ce2e435ca531be36ea44
          this.gameEvent(GameEvent.ENTITY_DIE);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index dd22b04a5a30cc1dce87fba6f08f8f183af049a4..827e749ec994eb3472e5437e0ddf219da39555a4 100644
+index b133bb407b88d7bc3ab8cb2011e8ad9e65df4bcd..8fdc2b677ef881b28e49f9bf2b39db065ea3d014 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2275,7 +2275,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2281,7 +2281,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/patches/server/0292-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0292-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -106,7 +106,7 @@ index 69a1852905dd4724c30ac8ab88c14251eee2c371..17b3d5de58a9ef3acc67624c46cd6bbd
      public Location getLastDeathLocation() {
          if (this.getData().contains("LastDeathLocation", 10)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 827e749ec994eb3472e5437e0ddf219da39555a4..d16cd51e59589cf9059c8c29e6421fd8f4871ca2 100644
+index 8fdc2b677ef881b28e49f9bf2b39db065ea3d014..05fd3758b4ac1e2a91dfee7862dba2c2a7850e7b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -177,6 +177,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index 827e749ec994eb3472e5437e0ddf219da39555a4..d16cd51e59589cf9059c8c29e6421fd8
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1887,6 +1888,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1893,6 +1894,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 827e749ec994eb3472e5437e0ddf219da39555a4..d16cd51e59589cf9059c8c29e6421fd8
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1909,6 +1922,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1915,6 +1928,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index 827e749ec994eb3472e5437e0ddf219da39555a4..d16cd51e59589cf9059c8c29e6421fd8
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1923,6 +1938,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1929,6 +1944,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d16cd51e59589cf9059c8c29e6421fd8f4871ca2..fdad04d657612979b5b9d30d132ca38efe81858d 100644
+index 05fd3758b4ac1e2a91dfee7862dba2c2a7850e7b..b89faca2cbb7fd597175955ebe1f50c6122f7529 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2819,6 +2819,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2825,6 +2825,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0456-Brand-support.patch
+++ b/patches/server/0456-Brand-support.patch
@@ -56,10 +56,10 @@ index 1517c09ccd95448cb0fce0f9ffbb7bd2e704113b..221a695acf3cbeaeaf9eda818b6cf809
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 254ff289883b37d42095ee286b138015f8dfb81f..56f88fbc08154d30348bdead4e79b5f96b0aeb0d 100644
+index 5d4ad1e41a6a0a4b520645b3dccbaff15f52d044..57641d5d1aea6b322198110dc2430055541fd5c0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2946,6 +2946,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2952,6 +2952,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0504-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0504-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f26aa477634f50e1e868c2f56006a5f058223916..62d646c9bc9f14d6a66a0f1a32164882ef269f67 100644
+index 5b3c1dbb6d37de327efb0c43d9c776b2c0b1b665..0bd24de222863654a1721529508007a8f972a1e6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2468,7 +2468,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2474,7 +2474,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0754-Add-player-health-update-API.patch
+++ b/patches/server/0754-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e5a9d5862461f2458987eecf05ea9a395afe368c..64c2026a5b4231434bb750bdf95a7751942cd701 100644
+index acc5eaab4ecfd16290f845099dfe5ea7b132a7c6..bdcc739eed7adec1610af56c47afff114dc91477 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2347,9 +2347,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2353,9 +2353,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index e5a9d5862461f2458987eecf05ea9a395afe368c..64c2026a5b4231434bb750bdf95a7751
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2358,6 +2360,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2364,6 +2366,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      }
  

--- a/patches/server/0902-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0902-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0bb3a20c1f390b14edc9286eee5d976ab7d45f44..2c3035da5db7374fda5c05b496728f308e53bc2f 100644
+index 215fc81f5241f3fd24723f4d893f6968b1154aa7..1d4850c87ce2e98348f6e3ed951762271a3dae9b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3126,6 +3126,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3132,6 +3132,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0919-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0919-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2c3035da5db7374fda5c05b496728f308e53bc2f..634e1b33996471e2a9dc0274f3a22cffcb0d4ff7 100644
+index 1d4850c87ce2e98348f6e3ed951762271a3dae9b..5738e4494baffb035a82a2778b9f279acf463aeb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3131,6 +3131,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3137,6 +3137,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0944-Flying-Fall-Damage.patch
+++ b/patches/server/0944-Flying-Fall-Damage.patch
@@ -26,10 +26,10 @@ index 5b772b3caeafe98aa45a01bffe215a5dd33323b6..0629c471d38a77c44fc1c86ccdfcb069
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 18357352824fdd6604c450b759646134a3a42074..a13b0db44fca0b9c3b08687a3058fc953aa5e4e2 100644
+index 788b05b3b2c6277051bdf81e2a788e03c42a3e42..68241347f9e69593b34e0073f86150b53bae0122 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2294,6 +2294,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2300,6 +2300,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().onUpdateAbilities();
      }
  


### PR DESCRIPTION
This PR resolves issues with game features resetting to default state on respawn/profile change. Currently, breaking are potion effects and the XP bar, both are now being resent to make the client know about them again. Because the #teleport method also updates abilities and scaled health, I'm updating those as well, just in case.
It may be worth looking into other things that need to be resent in the future.
All of these additions are taken from the teleport respawn code that is used when the respawn packet is sent. There are some other packets like setting view distance or some specific metadata/attributes/permission things for the player, but I think it's a bit unnecessary to mess around with all of those right now. Think I've caught the worst ones in this PR.