### PR TITLE
Allow non player entities in scoreboards by default

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1448,7 +1448,7 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b6381996810130
+index 0000000000000000000000000000000000000000..56e9155ebe850bcf759f5ae08e838f1a5aa593e5
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 @@ -0,0 +1,475 @@
@@ -1762,7 +1762,7 @@ index 0000000000000000000000000000000000000000..51cf0014c4229fc8671804d885b63819
 +    public Scoreboards scoreboards;
 +
 +    public class Scoreboards extends ConfigurationPart {
-+        public boolean allowNonPlayerEntitiesOnScoreboards = false;
++        public boolean allowNonPlayerEntitiesOnScoreboards = true;
 +        public boolean useVanillaWorldScoreboardNameColoring = false;
 +    }
 +
@@ -4575,7 +4575,7 @@ index ca2d2f44d722d2bf14f50670ac6192830b72c7f0..2cd8fc55056596731b34731a5fdf975f
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index ad6d25b26454c3ec8c11f54e921df8914c3c62d9..7fc066ee281662192aad826840573e4181f5ceff 100644
+index f19755a6096b72d6ca302a4ea2d386fadfe2b122..fe726771b76cabcb58bf624969490d9595965082 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -141,6 +141,19 @@ public class Main {


### PR DESCRIPTION
This in general caused much more confusion than needed, and in general, made rather negligible performance gains on collision.