### PR TITLE
Fix block place logic

### DIFF
--- a/patches/server/0304-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0304-Entity-getEntitySpawnReason.patch
@@ -22,18 +22,18 @@ index e46f18e342f2e682c4d5bbac22187a171df8eb33..58c1769ea15249df950a40e2f164e2ff
              // Paper start
              if (DEBUG_ENTITIES) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 9905d2174582b38913752c2e86e4d610baff181d..ef97fd5cb80626df1c2a3837641c9a06d6ad0390 100644
+index 9905d2174582b38913752c2e86e4d610baff181d..84d2fb06513784e58a917d74c904433b381d2dbf 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -223,6 +223,11 @@ public abstract class PlayerList {
              worldserver1 = worldserver;
          }
  
-+        // Paper
++        // Paper start
 +        if (nbttagcompound == null) {
 +            player.spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT; // set Player SpawnReason to DEFAULT on first login
 +        }
-+        // Paper
++        // Paper end
          player.setLevel(worldserver1);
          String s1 = "local";
  

--- a/patches/server/0373-Don-t-move-existing-players-to-world-spawn.patch
+++ b/patches/server/0373-Don-t-move-existing-players-to-world-spawn.patch
@@ -35,14 +35,14 @@ index 52ee3440b09b227bf1f488f374a0e282690f6ba4..007513080938a8d0cf43c050ef4e1132
          this.gameMode.setLevel((ServerLevel) world);
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 56a8c90d3bf0e860acbabcd45957f51f8431317f..ac8882d0d2939bd6e59dc4e08bc1efc88a580360 100644
+index c3f46b59839c68f03a0468ce7a471cfa2504b23d..cb5921dac91cb52dbd0687c6783595b054c13bdb 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -226,6 +226,7 @@ public abstract class PlayerList {
-         // Paper
+         // Paper start
          if (nbttagcompound == null) {
              player.spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT; // set Player SpawnReason to DEFAULT on first login
 +            player.fudgeSpawnLocation(worldserver1); // only move to spawn on first login, otherwise, stay where you are....
          }
-         // Paper
+         // Paper end
          player.setLevel(worldserver1);

--- a/patches/server/0974-Prevent-GameEvents-being-fired-from-unloaded-chunks.patch
+++ b/patches/server/0974-Prevent-GameEvents-being-fired-from-unloaded-chunks.patch
@@ -5,16 +5,18 @@ Subject: [PATCH] Prevent GameEvents being fired from unloaded chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 309ef1b2181eae609737212a50d037a1565daf86..536bedfe50288ef18468c71d41a6f0f82619f72d 100644
+index 309ef1b2181eae609737212a50d037a1565daf86..3bb63a652aca3c23f5f1bbf9cb70fce6540f2e33 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1640,6 +1640,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1640,6 +1640,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
      @Override
      public void gameEvent(GameEvent event, Vec3 emitterPos, GameEvent.Context emitter) {
++        // Paper start
 +        if (this.getChunkIfLoadedImmediately((Mth.floor(emitterPos.x) >> 4), (Mth.floor(emitterPos.z) >> 4)) == null) {
 +            return;
 +        }
++        // Paper end
          this.gameEventDispatcher.post(event, emitterPos, emitter);
      }
  

--- a/patches/server/0976-Fix-block-place-logic.patch
+++ b/patches/server/0976-Fix-block-place-logic.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com>
+Date: Mon, 3 Apr 2023 18:46:49 +0200
+Subject: [PATCH] Fix block place logic
+
+
+diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
+index b0204af850ee182773ad458208cccd946ad148d5..ebee8de2ed831755b6fd154f6cc77ac993839bb9 100644
+--- a/src/main/java/net/minecraft/world/item/BlockItem.java
++++ b/src/main/java/net/minecraft/world/item/BlockItem.java
+@@ -131,7 +131,7 @@ public class BlockItem extends Item {
+ 
+                     SoundType soundeffecttype = iblockdata1.getSoundType();
+ 
+-                    // world.playSound(entityhuman, blockposition, this.getPlaceSound(iblockdata1), SoundCategory.BLOCKS, (soundeffecttype.getVolume() + 1.0F) / 2.0F, soundeffecttype.getPitch() * 0.8F);
++                    if (entityhuman == null) world.playSound(entityhuman, blockposition, this.getPlaceSound(iblockdata1), net.minecraft.sounds.SoundSource.BLOCKS, (soundeffecttype.getVolume() + 1.0F) / 2.0F, soundeffecttype.getPitch() * 0.8F); // Paper - reintroduce this for the dispenser (i.e the shulker)
+                     world.gameEvent(GameEvent.BLOCK_PLACE, blockposition, GameEvent.Context.of(entityhuman, iblockdata1));
+                     if ((entityhuman == null || !entityhuman.getAbilities().instabuild) && itemstack != ItemStack.EMPTY) { // CraftBukkit
+                         itemstack.shrink(1);
+diff --git a/src/main/java/net/minecraft/world/item/HangingSignItem.java b/src/main/java/net/minecraft/world/item/HangingSignItem.java
+index f8f8392ba16838449354e78f0ce69af37b0b7fed..91caa607a21bfb61849826949b59bcdac73af7ab 100644
+--- a/src/main/java/net/minecraft/world/item/HangingSignItem.java
++++ b/src/main/java/net/minecraft/world/item/HangingSignItem.java
+@@ -33,11 +33,14 @@ public class HangingSignItem extends StandingAndWallBlockItem {
+     protected boolean updateCustomBlockEntityTag(BlockPos pos, Level world, @Nullable Player player, ItemStack stack, BlockState state) {
+         boolean bl = super.updateCustomBlockEntityTag(pos, world, player, stack, state);
+         if (!world.isClientSide && !bl && player != null) {
+-            BlockEntity var8 = world.getBlockEntity(pos);
++            // Paper start - moved in ItemStack use handler for events cancellation
++            /*BlockEntity var8 = world.getBlockEntity(pos);
+             if (var8 instanceof SignBlockEntity) {
+                 SignBlockEntity signBlockEntity = (SignBlockEntity)var8;
+                 player.openTextEdit(signBlockEntity);
+-            }
++            }*/
++            SignItem.openSign = pos;
++            // Paper end
+         }
+ 
+         return bl;
+diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
+index d690b8d0c1da1f56b226376df8c76c34375e3c73..3bfef8ed7dd73f603aef06172f362bb0ed0a5c83 100644
+--- a/src/main/java/net/minecraft/world/item/ItemStack.java
++++ b/src/main/java/net/minecraft/world/item/ItemStack.java
+@@ -456,13 +456,7 @@ public final class ItemStack {
+                         if (tileentity instanceof JukeboxBlockEntity) {
+                             JukeboxBlockEntity tileentityjukebox = (JukeboxBlockEntity) tileentity;
+ 
+-                            // There can only be one
+-                            ItemStack record = this.copy();
+-                            if (!record.isEmpty()) {
+-                                record.setCount(1);
+-                            }
+-
+-                            tileentityjukebox.setFirstItem(record);
++                            tileentityjukebox.setFirstItem(this.copy()); // Paper - sync this with record item, jukebox has now an inventory
+                             world.gameEvent(GameEvent.BLOCK_CHANGE, blockposition, GameEvent.Context.of(entityhuman, world.getBlockState(blockposition)));
+                         }
+ 
+@@ -488,7 +482,7 @@ public final class ItemStack {
+                     }
+ 
+                     // SPIGOT-4678
+-                    if (this.item instanceof SignItem && SignItem.openSign != null) {
++                    if ((this.item instanceof SignItem || this.item instanceof HangingSignItem) && SignItem.openSign != null) { // Paper - trigger the hanging sign text editor now
+                         try {
+                             entityhuman.openTextEdit((SignBlockEntity) world.getBlockEntity(SignItem.openSign));
+                         } finally {


### PR DESCRIPTION
Fix some broken block place logic:
- The dispensed shulker will not play the place sound (due to its logic been removed)
- The hanging sign text editor cannot be cancelled using the BlockPlaceEvent (not consistent with the other regular signs)
- The jukebox logic hasn't been synced with the RecordItem