### PR TITLE
Add component support to bukkit's BossBar

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -1601,6 +1601,48 @@ index ab6b0ec328e94bf65a0dafd0403e5ee3b870296c..f87bdb2757760d95038d1a1cf6e7f5b2
      public void setLine(int index, @NotNull String line) throws IndexOutOfBoundsException;
  
      /**
+diff --git a/src/main/java/org/bukkit/boss/BossBar.java b/src/main/java/org/bukkit/boss/BossBar.java
+index 70274f2e2a1d6f27c4febd9d5d5fa3ee1b49f100..55652a1d2868f7ccf65f5edaf70a097197d5ee72 100644
+--- a/src/main/java/org/bukkit/boss/BossBar.java
++++ b/src/main/java/org/bukkit/boss/BossBar.java
+@@ -11,17 +11,37 @@ public interface BossBar {
+      * Returns the title of this boss bar
+      *
+      * @return the title of the bar
++     * @deprecated in favor of {@link #title()}
+      */
+     @NotNull
++    @Deprecated // Paper
+     String getTitle();
+ 
+     /**
+      * Sets the title of this boss bar
+      *
+      * @param title the title of the bar
++     * @deprecated in favor of {@link #title(net.kyori.adventure.text.Component)}
+      */
++    @Deprecated // Paper
+     void setTitle(@Nullable String title);
+ 
++    // Paper start
++    /**
++     * Returns the title of this boss bar
++     *
++     * @return the title of the bar
++     */
++    net.kyori.adventure.text.Component title();
++
++    /**
++     * Sets the title of this boss bar
++     *
++     * @param title the title of the bar
++     */
++    void title(net.kyori.adventure.text.Component title);
++    // Paper end
++
+     /**
+      * Returns the color of this boss bar
+      *
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
 index 80209bb88a0294d4eedc78509533a6257315d856..75759131bd94b672bec4cd8e271ebff1ad391cba 100644
 --- a/src/main/java/org/bukkit/command/Command.java

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -3218,6 +3218,30 @@ index 55fcabb1d6e0767fc21c1f0beb76e941ed3c0846..9fd6a05fb8022c5e4e3d67f9b0e9df3f
      public static Component[] sanitizeLines(String[] lines) {
          Component[] components = new Component[4];
  
+diff --git a/src/main/java/org/bukkit/craftbukkit/boss/CraftBossBar.java b/src/main/java/org/bukkit/craftbukkit/boss/CraftBossBar.java
+index c23eac5d85d7d5a4b3645c7ed68e3174e8096786..4ac62ab8c721c25fa6dcc53580bc675f18b5ef8c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/boss/CraftBossBar.java
++++ b/src/main/java/org/bukkit/craftbukkit/boss/CraftBossBar.java
+@@ -106,6 +106,19 @@ public class CraftBossBar implements BossBar {
+         this.handle.broadcast(ClientboundBossEventPacket::createUpdateNamePacket);
+     }
+ 
++    // Paper start
++    @Override
++    public net.kyori.adventure.text.Component title() {
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(this.handle.name);
++    }
++
++    @Override
++    public void title(final net.kyori.adventure.text.Component title) {
++        this.handle.name = io.papermc.paper.adventure.PaperAdventure.asVanilla(title);
++        this.handle.broadcast(ClientboundBossEventPacket::createUpdateNamePacket);
++    }
++    // Paper end
++
+     @Override
+     public BarColor getColor() {
+         return this.convertColor(handle.color);
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java
 index 3de88112bdb08d6bd0d28f20582c4090bfd8dbfe..87f2cea36d852c81fdb0a1bc21162d41377ab2e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java


### PR DESCRIPTION
Bukkit's BossBar interface is still very much supported, and I think it probably will continue to be supported, but it was missing methods relating to Component. 