### PR TITLE
Fix inconsistencies with plugin names

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -56,4 +56,5 @@ Kieran Wallbanks <kieran.wallbanks@gmail.com>
 Denery <dorofeevij@gmail.com>
 Jakubk15 <jakubk15@protonmail.com>
 Redned <redned235@gmail.com>
+Luke Chambers <consolelogluke@gmail.com>
 ```

--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Paper Plugins
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index bb1f3b3d5a22ca391f4362e5d4cf016e7e9be0e3..f900b73c52971fe682171e7f99246afdb8b080f3 100644
+index cff3eb363b17c2a8245b3b2ceb02cbdc1efe3896..03b2fc4c6dd9cbc9f28add7da9420c816f8faa2b 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -45,7 +45,7 @@ dependencies {
@@ -301,10 +301,10 @@ index 0000000000000000000000000000000000000000..a9208254142d270da7bd4815a01b9627
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java b/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2e448979f17566bed8ef45fa3cd7d04098c36c6e
+index 0000000000000000000000000000000000000000..ef393f1f93ca48264fc1b6e3a27787f6a9152e1b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
-@@ -0,0 +1,213 @@
+@@ -0,0 +1,203 @@
 +package io.papermc.paper.plugin.configuration;
 +
 +import org.bukkit.permissions.Permission;
@@ -345,23 +345,13 @@ index 0000000000000000000000000000000000000000..2e448979f17566bed8ef45fa3cd7d040
 +    String getName();
 +
 +    /**
-+     * Provides a human-friendly name for the plugin, suitable for display.
++     * Returns the display name of the plugin, including the version.
 +     *
-+     * @return a human-friendly name for the plugin
++     * @return a descriptive name of the plugin and respective version
 +     */
 +    @NotNull
 +    default String getDisplayName() {
-+        return this.getName();
-+    }
-+
-+    /**
-+     * Provides a human-friendly name for the plugin, including its version, suitable for display.
-+     *
-+     * @return a human-friendly name and respective version for the plugin
-+     */
-+    @NotNull
-+    default String getDisplayNameWithVersion() {
-+        return this.getDisplayName() + " v" + this.getVersion();
++        return this.getName() + " v" + this.getVersion();
 +    }
 +
 +    /**
@@ -1431,7 +1421,7 @@ index 94f8ceb965cecb5669a84a0ec61c0f706c2a2673..e773db6da357ad210eb24d4c389af2dc
      }
  }
 diff --git a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
-index 77a380537b338fdd0aa2f6777ff775056cc6b221..43a0dec949e9f2ba6619670dcade64e3613c1487 100644
+index 77a380537b338fdd0aa2f6777ff775056cc6b221..028805bcdb1d2bb0d11387db165b7376579e5f60 100644
 --- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
 +++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
 @@ -195,7 +195,7 @@ import org.yaml.snakeyaml.nodes.Tag;
@@ -1443,15 +1433,7 @@ index 77a380537b338fdd0aa2f6777ff775056cc6b221..43a0dec949e9f2ba6619670dcade64e3
      private static final Pattern VALID_NAME = Pattern.compile("^[A-Za-z0-9 _.-]+$");
      private static final ThreadLocal<Yaml> YAML = new ThreadLocal<Yaml>() {
          @Override
-@@ -235,6 +235,7 @@ public final class PluginDescriptionFile {
-     };
-     String rawName = null;
-     private String name = null;
-+    private String displayName = null; // Paper
-     private List<String> provides = ImmutableList.of();
-     private String main = null;
-     private String classLoaderOf = null;
-@@ -255,6 +256,79 @@ public final class PluginDescriptionFile {
+@@ -255,6 +255,70 @@ public final class PluginDescriptionFile {
      private Set<PluginAwareness> awareness = ImmutableSet.of();
      private String apiVersion = null;
      private List<String> libraries = ImmutableList.of();
@@ -1460,10 +1442,9 @@ index 77a380537b338fdd0aa2f6777ff775056cc6b221..43a0dec949e9f2ba6619670dcade64e3
 +     * Don't use this.
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Internal
-+    public PluginDescriptionFile(String rawName, String name, String displayName, List<String> provides, String main, String classLoaderOf, List<String> depend, List<String> softDepend, List<String> loadBefore, String version, Map<String, Map<String, Object>> commands, String description, List<String> authors, List<String> contributors, String website, String prefix, PluginLoadOrder order, List<Permission> permissions, PermissionDefault defaultPerm, Set<PluginAwareness> awareness, String apiVersion, List<String> libraries) {
++    public PluginDescriptionFile(String rawName, String name, List<String> provides, String main, String classLoaderOf, List<String> depend, List<String> softDepend, List<String> loadBefore, String version, Map<String, Map<String, Object>> commands, String description, List<String> authors, List<String> contributors, String website, String prefix, PluginLoadOrder order, List<Permission> permissions, PermissionDefault defaultPerm, Set<PluginAwareness> awareness, String apiVersion, List<String> libraries) {
 +        this.rawName = rawName;
 +        this.name = name;
-+        this.displayName = displayName;
 +        this.provides = provides;
 +        this.main = main;
 +        this.classLoaderOf = classLoaderOf;
@@ -1483,14 +1464,6 @@ index 77a380537b338fdd0aa2f6777ff775056cc6b221..43a0dec949e9f2ba6619670dcade64e3
 +        this.awareness = awareness;
 +        this.apiVersion = apiVersion;
 +        this.libraries = libraries;
-+    }
-+
-+    @Override
-+    public @NotNull String getDisplayName() {
-+        if (this.displayName != null) {
-+            return this.displayName;
-+        }
-+        return io.papermc.paper.plugin.configuration.PluginMeta.super.getDisplayName();
 +    }
 +
 +    @Override
@@ -1531,23 +1504,6 @@ index 77a380537b338fdd0aa2f6777ff775056cc6b221..43a0dec949e9f2ba6619670dcade64e3
  
      public PluginDescriptionFile(@NotNull final InputStream stream) throws InvalidDescriptionException {
          loadMap(asMap(YAML.get().load(stream)));
-@@ -937,14 +1011,14 @@ public final class PluginDescriptionFile {
- 
-     /**
-      * Returns the name of a plugin, including the version. This method is
--     * provided for convenience; it uses the {@link #getName()} and {@link
-+     * provided for convenience; it uses the {@link #getDisplayName()} and {@link
-      * #getVersion()} entries.
-      *
-      * @return a descriptive name of the plugin and respective version
-      */
-     @NotNull
-     public String getFullName() {
--        return name + " v" + version;
-+        return getDisplayNameWithVersion(); // Paper
-     }
- 
-     /**
 diff --git a/src/main/java/org/bukkit/plugin/PluginLoader.java b/src/main/java/org/bukkit/plugin/PluginLoader.java
 index a88733f1cd1ddb5d85ab1b0e6af4fd5b80bbc1c6..cb530369e667c426c842da356c31304bb5c3ecfa 100644
 --- a/src/main/java/org/bukkit/plugin/PluginLoader.java

--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -301,10 +301,10 @@ index 0000000000000000000000000000000000000000..a9208254142d270da7bd4815a01b9627
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java b/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ef393f1f93ca48264fc1b6e3a27787f6a9152e1b
+index 0000000000000000000000000000000000000000..2e448979f17566bed8ef45fa3cd7d04098c36c6e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
-@@ -0,0 +1,203 @@
+@@ -0,0 +1,213 @@
 +package io.papermc.paper.plugin.configuration;
 +
 +import org.bukkit.permissions.Permission;
@@ -345,13 +345,23 @@ index 0000000000000000000000000000000000000000..ef393f1f93ca48264fc1b6e3a27787f6
 +    String getName();
 +
 +    /**
-+     * Returns the display name of the plugin, including the version.
++     * Provides a human-friendly name for the plugin, suitable for display.
 +     *
-+     * @return a descriptive name of the plugin and respective version
++     * @return a human-friendly name for the plugin
 +     */
 +    @NotNull
 +    default String getDisplayName() {
-+        return this.getName() + " v" + this.getVersion();
++        return this.getName();
++    }
++
++    /**
++     * Provides a human-friendly name for the plugin, including its version, suitable for display.
++     *
++     * @return a human-friendly name and respective version for the plugin
++     */
++    @NotNull
++    default String getDisplayNameWithVersion() {
++        return this.getDisplayName() + " v" + this.getVersion();
 +    }
 +
 +    /**
@@ -1421,7 +1431,7 @@ index 94f8ceb965cecb5669a84a0ec61c0f706c2a2673..e773db6da357ad210eb24d4c389af2dc
      }
  }
 diff --git a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
-index 77a380537b338fdd0aa2f6777ff775056cc6b221..028805bcdb1d2bb0d11387db165b7376579e5f60 100644
+index 77a380537b338fdd0aa2f6777ff775056cc6b221..43a0dec949e9f2ba6619670dcade64e3613c1487 100644
 --- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
 +++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
 @@ -195,7 +195,7 @@ import org.yaml.snakeyaml.nodes.Tag;
@@ -1433,7 +1443,15 @@ index 77a380537b338fdd0aa2f6777ff775056cc6b221..028805bcdb1d2bb0d11387db165b7376
      private static final Pattern VALID_NAME = Pattern.compile("^[A-Za-z0-9 _.-]+$");
      private static final ThreadLocal<Yaml> YAML = new ThreadLocal<Yaml>() {
          @Override
-@@ -255,6 +255,70 @@ public final class PluginDescriptionFile {
+@@ -235,6 +235,7 @@ public final class PluginDescriptionFile {
+     };
+     String rawName = null;
+     private String name = null;
++    private String displayName = null; // Paper
+     private List<String> provides = ImmutableList.of();
+     private String main = null;
+     private String classLoaderOf = null;
+@@ -255,6 +256,79 @@ public final class PluginDescriptionFile {
      private Set<PluginAwareness> awareness = ImmutableSet.of();
      private String apiVersion = null;
      private List<String> libraries = ImmutableList.of();
@@ -1442,9 +1460,10 @@ index 77a380537b338fdd0aa2f6777ff775056cc6b221..028805bcdb1d2bb0d11387db165b7376
 +     * Don't use this.
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Internal
-+    public PluginDescriptionFile(String rawName, String name, List<String> provides, String main, String classLoaderOf, List<String> depend, List<String> softDepend, List<String> loadBefore, String version, Map<String, Map<String, Object>> commands, String description, List<String> authors, List<String> contributors, String website, String prefix, PluginLoadOrder order, List<Permission> permissions, PermissionDefault defaultPerm, Set<PluginAwareness> awareness, String apiVersion, List<String> libraries) {
++    public PluginDescriptionFile(String rawName, String name, String displayName, List<String> provides, String main, String classLoaderOf, List<String> depend, List<String> softDepend, List<String> loadBefore, String version, Map<String, Map<String, Object>> commands, String description, List<String> authors, List<String> contributors, String website, String prefix, PluginLoadOrder order, List<Permission> permissions, PermissionDefault defaultPerm, Set<PluginAwareness> awareness, String apiVersion, List<String> libraries) {
 +        this.rawName = rawName;
 +        this.name = name;
++        this.displayName = displayName;
 +        this.provides = provides;
 +        this.main = main;
 +        this.classLoaderOf = classLoaderOf;
@@ -1464,6 +1483,14 @@ index 77a380537b338fdd0aa2f6777ff775056cc6b221..028805bcdb1d2bb0d11387db165b7376
 +        this.awareness = awareness;
 +        this.apiVersion = apiVersion;
 +        this.libraries = libraries;
++    }
++
++    @Override
++    public @NotNull String getDisplayName() {
++        if (this.displayName != null) {
++            return this.displayName;
++        }
++        return io.papermc.paper.plugin.configuration.PluginMeta.super.getDisplayName();
 +    }
 +
 +    @Override
@@ -1504,6 +1531,23 @@ index 77a380537b338fdd0aa2f6777ff775056cc6b221..028805bcdb1d2bb0d11387db165b7376
  
      public PluginDescriptionFile(@NotNull final InputStream stream) throws InvalidDescriptionException {
          loadMap(asMap(YAML.get().load(stream)));
+@@ -937,14 +1011,14 @@ public final class PluginDescriptionFile {
+ 
+     /**
+      * Returns the name of a plugin, including the version. This method is
+-     * provided for convenience; it uses the {@link #getName()} and {@link
++     * provided for convenience; it uses the {@link #getDisplayName()} and {@link
+      * #getVersion()} entries.
+      *
+      * @return a descriptive name of the plugin and respective version
+      */
+     @NotNull
+     public String getFullName() {
+-        return name + " v" + version;
++        return getDisplayNameWithVersion(); // Paper
+     }
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/plugin/PluginLoader.java b/src/main/java/org/bukkit/plugin/PluginLoader.java
 index a88733f1cd1ddb5d85ab1b0e6af4fd5b80bbc1c6..cb530369e667c426c842da356c31304bb5c3ecfa 100644
 --- a/src/main/java/org/bukkit/plugin/PluginLoader.java

--- a/patches/api/0014-Version-Command-2.0.patch
+++ b/patches/api/0014-Version-Command-2.0.patch
@@ -73,7 +73,7 @@ index daf3ac72cae4d19c0273058dc6a1e1afe9a47f77..24fad8e59a3a5a174d24505cedda2a3f
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/defaults/VersionCommand.java b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
-index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..2f852f03e16ee4aa87fada623936b71df5ed55fb 100644
+index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..b50f614806f4634960d383e8a33f094c2f46935f 100644
 --- a/src/main/java/org/bukkit/command/defaults/VersionCommand.java
 +++ b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
 @@ -1,5 +1,6 @@
@@ -108,15 +108,6 @@ index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..2f852f03e16ee4aa87fada623936b71d
              sendVersion(sender);
          } else {
              StringBuilder name = new StringBuilder();
-@@ -79,7 +89,7 @@ public class VersionCommand extends BukkitCommand {
- 
-     private void describeToSender(@NotNull Plugin plugin, @NotNull CommandSender sender) {
-         PluginDescriptionFile desc = plugin.getDescription();
--        sender.sendMessage(ChatColor.GREEN + desc.getName() + ChatColor.WHITE + " version " + ChatColor.GREEN + desc.getVersion());
-+        sender.sendMessage(ChatColor.GREEN + desc.getDisplayName() + ChatColor.WHITE + " version " + ChatColor.GREEN + desc.getVersion()); // Paper - use the plugin's display name
- 
-         if (desc.getDescription() != null) {
-             sender.sendMessage(desc.getDescription());
 @@ -146,14 +156,14 @@ public class VersionCommand extends BukkitCommand {
  
      private final ReentrantLock versionLock = new ReentrantLock();

--- a/patches/api/0014-Version-Command-2.0.patch
+++ b/patches/api/0014-Version-Command-2.0.patch
@@ -73,7 +73,7 @@ index daf3ac72cae4d19c0273058dc6a1e1afe9a47f77..24fad8e59a3a5a174d24505cedda2a3f
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/defaults/VersionCommand.java b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
-index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..b50f614806f4634960d383e8a33f094c2f46935f 100644
+index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..2f852f03e16ee4aa87fada623936b71df5ed55fb 100644
 --- a/src/main/java/org/bukkit/command/defaults/VersionCommand.java
 +++ b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
 @@ -1,5 +1,6 @@
@@ -108,6 +108,15 @@ index 04b4fb6859df0221f8f9f92c5a7ac2dda1073355..b50f614806f4634960d383e8a33f094c
              sendVersion(sender);
          } else {
              StringBuilder name = new StringBuilder();
+@@ -79,7 +89,7 @@ public class VersionCommand extends BukkitCommand {
+ 
+     private void describeToSender(@NotNull Plugin plugin, @NotNull CommandSender sender) {
+         PluginDescriptionFile desc = plugin.getDescription();
+-        sender.sendMessage(ChatColor.GREEN + desc.getName() + ChatColor.WHITE + " version " + ChatColor.GREEN + desc.getVersion());
++        sender.sendMessage(ChatColor.GREEN + desc.getDisplayName() + ChatColor.WHITE + " version " + ChatColor.GREEN + desc.getVersion()); // Paper - use the plugin's display name
+ 
+         if (desc.getDescription() != null) {
+             sender.sendMessage(desc.getDescription());
 @@ -146,14 +156,14 @@ public class VersionCommand extends BukkitCommand {
  
      private final ReentrantLock versionLock = new ReentrantLock();

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -29,7 +29,7 @@ index 6a00f3d38da8107825ab1d405f337fd077b09f72..d44d0074446c1c54e87dc8078dff7fef
  }
 diff --git a/src/main/java/io/papermc/paper/command/PaperPluginsCommand.java b/src/main/java/io/papermc/paper/command/PaperPluginsCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f0fce4113fb07c64adbec029d177c236cbdcbae8
+index 0000000000000000000000000000000000000000..a1adbfca5115f31c1aefacf44ad64fe433c3c9e7
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/PaperPluginsCommand.java
 @@ -0,0 +1,215 @@
@@ -150,7 +150,7 @@ index 0000000000000000000000000000000000000000..f0fce4113fb07c64adbec029d177c236
 +            builder.append(LEGACY_PLUGIN_STAR);
 +        }
 +
-+        String name = provider.getMeta().getName();
++        String name = provider.getMeta().getDisplayName();
 +        Component pluginName = Component.text(name, fromStatus(provider))
 +            .clickEvent(ClickEvent.runCommand("/version " + name));
 +
@@ -594,7 +594,7 @@ index 0000000000000000000000000000000000000000..89bf48fd581ee6580b91e2eb31dd532c
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/bootstrap/PluginProviderContextImpl.java b/src/main/java/io/papermc/paper/plugin/bootstrap/PluginProviderContextImpl.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2e450a9fce66e63ec94ee3d2579265eda28a1c3f
+index 0000000000000000000000000000000000000000..deffde92350f7c74694c2aa69799de446a3c3e0a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/bootstrap/PluginProviderContextImpl.java
 @@ -0,0 +1,45 @@
@@ -612,13 +612,13 @@ index 0000000000000000000000000000000000000000..2e450a9fce66e63ec94ee3d2579265ed
 +                                        ComponentLogger logger, Path pluginSource) implements PluginProviderContext {
 +
 +    public static PluginProviderContextImpl of(PluginMeta config, ComponentLogger logger, Path pluginSource) {
-+        Path dataFolder = PluginInitializerManager.instance().pluginDirectoryPath().resolve(config.getDisplayName());
++        Path dataFolder = PluginInitializerManager.instance().pluginDirectoryPath().resolve(config.getName());
 +
 +        return new PluginProviderContextImpl(config, dataFolder, logger, pluginSource);
 +    }
 +
 +    public static PluginProviderContextImpl of(PluginProvider<?> provider, Path pluginFolder) {
-+        Path dataFolder = pluginFolder.resolve(provider.getMeta().getDisplayName());
++        Path dataFolder = pluginFolder.resolve(provider.getMeta().getName());
 +
 +        return new PluginProviderContextImpl(provider.getMeta(), dataFolder, provider.getLogger(), provider.getSource());
 +    }
@@ -813,10 +813,10 @@ index 0000000000000000000000000000000000000000..f9a2c55a354c877749db3f92956de802
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..79995ab1b624d7c7aaaa467a86255ad97385cf72
+index 0000000000000000000000000000000000000000..c40ed0c531c3e211d26d4dd26e2e24be5d799d34
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
-@@ -0,0 +1,207 @@
+@@ -0,0 +1,208 @@
 +package io.papermc.paper.plugin.entrypoint.classloader;
 +
 +import io.papermc.paper.plugin.configuration.PluginMeta;
@@ -966,7 +966,8 @@ index 0000000000000000000000000000000000000000..79995ab1b624d7c7aaaa467a86255ad9
 +        PluginMeta config = this.configuration;
 +        PluginDescriptionFile pluginDescriptionFile = new PluginDescriptionFile(
 +            config.getName(),
-+            config.getName().replace('_', ' '),
++            config.getName(),
++            config.getDisplayName(),
 +            config.getProvidedPlugins(),
 +            config.getMainClass(),
 +            "", // Classloader load order api
@@ -3060,7 +3061,7 @@ index 0000000000000000000000000000000000000000..6f6aaab295018017565ba27d6958a1f5
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/manager/PaperEventManager.java b/src/main/java/io/papermc/paper/plugin/manager/PaperEventManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7ce9ebba8ce304d1f3f21d4f15ee5f3560d7700b
+index 0000000000000000000000000000000000000000..024dcfbcf64a423d4fc9facae90ebb1740e4bdd4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/manager/PaperEventManager.java
 @@ -0,0 +1,194 @@
@@ -3127,12 +3128,12 @@ index 0000000000000000000000000000000000000000..7ce9ebba8ce304d1f3f21d4f15ee5f35
 +                    this.server.getLogger().log(Level.SEVERE, String.format(
 +                        "Nag author(s): '%s' of '%s' about the following: %s",
 +                        plugin.getPluginMeta().getAuthors(),
-+                        plugin.getPluginMeta().getDisplayName(),
++                        plugin.getPluginMeta().getDisplayNameWithVersion(),
 +                        ex.getMessage()
 +                    ));
 +                }
 +            } catch (Throwable ex) {
-+                String msg = "Could not pass event " + event.getEventName() + " to " + registration.getPlugin().getPluginMeta().getDisplayName();
++                String msg = "Could not pass event " + event.getEventName() + " to " + registration.getPlugin().getPluginMeta().getDisplayNameWithVersion();
 +                this.server.getLogger().log(Level.SEVERE, msg, ex);
 +                if (!(event instanceof ServerExceptionEvent)) { // We don't want to cause an endless event loop
 +                    this.callEvent(new ServerExceptionEvent(new ServerEventException(msg, ex, registration.getPlugin(), registration.getListener(), event)));
@@ -3219,7 +3220,7 @@ index 0000000000000000000000000000000000000000..7ce9ebba8ce304d1f3f21d4f15ee5f35
 +            }
 +            final Class<?> checkClass;
 +            if (method.getParameterTypes().length != 1 || !Event.class.isAssignableFrom(checkClass = method.getParameterTypes()[0])) {
-+                plugin.getLogger().severe(plugin.getPluginMeta().getDisplayName() + " attempted to register an invalid EventHandler method signature \"" + method.toGenericString() + "\" in " + listener.getClass());
++                plugin.getLogger().severe(plugin.getPluginMeta().getDisplayNameWithVersion() + " attempted to register an invalid EventHandler method signature \"" + method.toGenericString() + "\" in " + listener.getClass());
 +                continue;
 +            }
 +            final Class<? extends Event> eventClass = checkClass.asSubclass(Event.class);
@@ -3238,7 +3239,7 @@ index 0000000000000000000000000000000000000000..7ce9ebba8ce304d1f3f21d4f15ee5f35
 +                        Level.WARNING,
 +                        String.format(
 +                            "\"%s\" has registered a listener for %s on method \"%s\", but the event is Deprecated. \"%s\"; please notify the authors %s.",
-+                            plugin.getPluginMeta().getDisplayName(),
++                            plugin.getPluginMeta().getDisplayNameWithVersion(),
 +                            clazz.getName(),
 +                            method.toGenericString(),
 +                            (warning != null && warning.reason().length() != 0) ? warning.reason() : "Server performance will be affected",
@@ -3467,7 +3468,7 @@ index 0000000000000000000000000000000000000000..92a69677f21b2c1c035119d8e5a6af63
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java b/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c0e896343c22badd97c774c4ed1daa4e274f5d44
+index 0000000000000000000000000000000000000000..dd5e11e4e1c9308ce726dd5ca12052548ae55aba
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java
 @@ -0,0 +1,304 @@
@@ -3647,7 +3648,7 @@ index 0000000000000000000000000000000000000000..c0e896343c22badd97c774c4ed1daa4e
 +        }
 +
 +        try {
-+            String enableMsg = "Enabling " + plugin.getPluginMeta().getDisplayName();
++            String enableMsg = "Enabling " + plugin.getPluginMeta().getDisplayNameWithVersion();
 +            if (plugin.getPluginMeta() instanceof PluginDescriptionFile descriptionFile && CraftMagicNumbers.isLegacy(descriptionFile)) {
 +                enableMsg += "*";
 +            }
@@ -3657,14 +3658,14 @@ index 0000000000000000000000000000000000000000..c0e896343c22badd97c774c4ed1daa4e
 +
 +            if (jPlugin.getClass().getClassLoader() instanceof ConfiguredPluginClassLoader classLoader) { // Paper
 +                if (PaperClassLoaderStorage.instance().registerUnsafePlugin(classLoader)) {
-+                    this.server.getLogger().log(Level.WARNING, "Enabled plugin with unregistered ConfiguredPluginClassLoader " + plugin.getPluginMeta().getDisplayName());
++                    this.server.getLogger().log(Level.WARNING, "Enabled plugin with unregistered ConfiguredPluginClassLoader " + plugin.getPluginMeta().getDisplayNameWithVersion());
 +                }
 +            } // Paper
 +
 +            try {
 +                jPlugin.setEnabled(true);
 +            } catch (Throwable ex) {
-+                this.server.getLogger().log(Level.SEVERE, "Error occurred while enabling " + plugin.getPluginMeta().getDisplayName() + " (Is it up to date?)", ex);
++                this.server.getLogger().log(Level.SEVERE, "Error occurred while enabling " + plugin.getPluginMeta().getDisplayNameWithVersion() + " (Is it up to date?)", ex);
 +                // Paper start - Disable plugins that fail to load
 +                this.server.getPluginManager().disablePlugin(jPlugin);
 +                return;
@@ -3676,7 +3677,7 @@ index 0000000000000000000000000000000000000000..c0e896343c22badd97c774c4ed1daa4e
 +            this.server.getPluginManager().callEvent(new PluginEnableEvent(plugin));
 +        } catch (Throwable ex) {
 +            this.handlePluginException("Error occurred (in the plugin loader) while enabling "
-+                + plugin.getPluginMeta().getDisplayName() + " (Is it up to date?)", ex, plugin);
++                + plugin.getPluginMeta().getDisplayNameWithVersion() + " (Is it up to date?)", ex, plugin);
 +        }
 +
 +        HandlerList.bakeAll();
@@ -3690,7 +3691,7 @@ index 0000000000000000000000000000000000000000..c0e896343c22badd97c774c4ed1daa4e
 +            return;
 +        }
 +
-+        String pluginName = plugin.getPluginMeta().getDisplayName();
++        String pluginName = plugin.getPluginMeta().getDisplayNameWithVersion();
 +
 +        try {
 +            plugin.getLogger().info("Disabling %s".formatted(pluginName));
@@ -4387,7 +4388,7 @@ index 0000000000000000000000000000000000000000..e3430f535e8e9c3b8b44bf2daece8c47
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7605efe37ac4a63cb95c8c64c576e93c0e676cc0
+index 0000000000000000000000000000000000000000..3808f5a9abc9f084cbabfc4cb95394cc37aaf4bb
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
 @@ -0,0 +1,227 @@
@@ -4500,7 +4501,7 @@ index 0000000000000000000000000000000000000000..7605efe37ac4a63cb95c8c64c576e93c
 +                .build();
 +        }
 +
-+        pluginConfiguration.displayName = pluginConfiguration.name.replace('_', ' ') + " v" + pluginConfiguration.version;
++        pluginConfiguration.displayName = pluginConfiguration.name.replace('_', ' ');
 +
 +        return pluginConfiguration;
 +    }
@@ -6211,10 +6212,10 @@ index 0000000000000000000000000000000000000000..374e7d3d69fc8603ecf54999f173123d
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/storage/ServerPluginProviderStorage.java b/src/main/java/io/papermc/paper/plugin/storage/ServerPluginProviderStorage.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..cb9b13522a976b82bcb71cef486f11f4172e3e99
+index 0000000000000000000000000000000000000000..451aded531906d9b7ff802d2d093b7fe02bdf0e5
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/storage/ServerPluginProviderStorage.java
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,68 @@
 +package io.papermc.paper.plugin.storage;
 +
 +import com.mojang.logging.LogUtils;
@@ -6223,8 +6224,6 @@ index 0000000000000000000000000000000000000000..cb9b13522a976b82bcb71cef486f11f4
 +import io.papermc.paper.plugin.entrypoint.strategy.ProviderConfiguration;
 +import io.papermc.paper.plugin.manager.PaperPluginManagerImpl;
 +import io.papermc.paper.plugin.provider.PluginProvider;
-+import io.papermc.paper.plugin.provider.ProviderStatus;
-+import io.papermc.paper.plugin.provider.ProviderStatusHolder;
 +import io.papermc.paper.plugin.provider.type.paper.PaperPluginParent;
 +import org.bukkit.plugin.Plugin;
 +import org.bukkit.plugin.java.JavaPlugin;
@@ -6272,7 +6271,7 @@ index 0000000000000000000000000000000000000000..cb9b13522a976b82bcb71cef486f11f4
 +    @Override
 +    public void processProvided(PluginProvider<JavaPlugin> provider, JavaPlugin provided) {
 +        try {
-+            provided.getLogger().info(String.format("Loading server plugin %s", provided.getPluginMeta().getDisplayName()));
++            provided.getLogger().info(String.format("Loading server plugin %s", provided.getPluginMeta().getDisplayNameWithVersion()));
 +            provided.onLoad();
 +        } catch (Throwable ex) {
 +            // Don't mark that provider as ERRORED, as this apparently still needs to run the onEnable logic.

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -4387,12 +4387,13 @@ index 0000000000000000000000000000000000000000..e3430f535e8e9c3b8b44bf2daece8c47
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..15e392438816436be0d3b4289d20b9a122f7f20a
+index 0000000000000000000000000000000000000000..95cc4dbe336e37f01d9f478068fd21a387754a91
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
-@@ -0,0 +1,218 @@
+@@ -0,0 +1,232 @@
 +package io.papermc.paper.plugin.provider.configuration;
 +
++import com.google.common.base.Preconditions;
 +import com.google.common.collect.ImmutableList;
 +import io.leangen.geantyref.TypeToken;
 +import io.papermc.paper.configuration.constraint.Constraint;
@@ -4411,6 +4412,7 @@ index 0000000000000000000000000000000000000000..15e392438816436be0d3b4289d20b9a1
 +import org.bukkit.plugin.PluginLoadOrder;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
++import org.jetbrains.annotations.TestOnly;
 +import org.spongepowered.configurate.CommentedConfigurationNode;
 +import org.spongepowered.configurate.ConfigurateException;
 +import org.spongepowered.configurate.loader.HeaderMode;
@@ -4506,6 +4508,12 @@ index 0000000000000000000000000000000000000000..15e392438816436be0d3b4289d20b9a1
 +        return this.name;
 +    }
 +
++    @TestOnly
++    public void setName(@NotNull String name) {
++        Preconditions.checkNotNull(name, "name");
++        this.name = name;
++    }
++
 +    @Override
 +    public @NotNull String getMainClass() {
 +        return this.main;
@@ -4514,6 +4522,12 @@ index 0000000000000000000000000000000000000000..15e392438816436be0d3b4289d20b9a1
 +    @Override
 +    public @NotNull String getVersion() {
 +        return this.version;
++    }
++
++    @TestOnly
++    public void setVersion(@NotNull String version) {
++        Preconditions.checkNotNull(version, "version");
++        this.version = version;
 +    }
 +
 +    @Override
@@ -7041,6 +7055,40 @@ index 0000000000000000000000000000000000000000..726eba26470e62b0e94a91418512e242
 +    public void tearDown() {
 +        pm.clearPlugins();
 +        assertThat(pm.getPermissions(), is(empty()));
++    }
++}
+diff --git a/src/test/java/io/papermc/paper/plugin/PluginNamingTest.java b/src/test/java/io/papermc/paper/plugin/PluginNamingTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..e281caf168677e890e7dafb465a29265edffe18b
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/plugin/PluginNamingTest.java
+@@ -0,0 +1,28 @@
++package io.papermc.paper.plugin;
++
++import io.papermc.paper.plugin.provider.configuration.PaperPluginMeta;
++import org.junit.Assert;
++import org.junit.Test;
++
++public class PluginNamingTest {
++    private static final String TEST_NAME = "Test_Plugin";
++    private static final String TEST_VERSION = "1.0";
++
++    private final PaperPluginMeta pluginMeta;
++
++    public PluginNamingTest() {
++        this.pluginMeta = new PaperPluginMeta();
++        this.pluginMeta.setName(TEST_NAME);
++        this.pluginMeta.setVersion("1.0");
++    }
++
++    @Test
++    public void testName() {
++        Assert.assertEquals(TEST_NAME, this.pluginMeta.getName());
++    }
++
++    @Test
++    public void testDisplayName() {
++        Assert.assertEquals(TEST_NAME + " v" + TEST_VERSION, this.pluginMeta.getDisplayName());
 +    }
 +}
 diff --git a/src/test/java/io/papermc/paper/plugin/SyntheticEventTest.java b/src/test/java/io/papermc/paper/plugin/SyntheticEventTest.java

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -7059,7 +7059,7 @@ index 0000000000000000000000000000000000000000..726eba26470e62b0e94a91418512e242
 +}
 diff --git a/src/test/java/io/papermc/paper/plugin/PluginNamingTest.java b/src/test/java/io/papermc/paper/plugin/PluginNamingTest.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e281caf168677e890e7dafb465a29265edffe18b
+index 0000000000000000000000000000000000000000..860a2bc8200cf41b216a2e37cfbd2f5464d6542c
 --- /dev/null
 +++ b/src/test/java/io/papermc/paper/plugin/PluginNamingTest.java
 @@ -0,0 +1,28 @@
@@ -7078,7 +7078,7 @@ index 0000000000000000000000000000000000000000..e281caf168677e890e7dafb465a29265
 +    public PluginNamingTest() {
 +        this.pluginMeta = new PaperPluginMeta();
 +        this.pluginMeta.setName(TEST_NAME);
-+        this.pluginMeta.setVersion("1.0");
++        this.pluginMeta.setVersion(TEST_VERSION);
 +    }
 +
 +    @Test

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -29,7 +29,7 @@ index 6a00f3d38da8107825ab1d405f337fd077b09f72..d44d0074446c1c54e87dc8078dff7fef
  }
 diff --git a/src/main/java/io/papermc/paper/command/PaperPluginsCommand.java b/src/main/java/io/papermc/paper/command/PaperPluginsCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a1adbfca5115f31c1aefacf44ad64fe433c3c9e7
+index 0000000000000000000000000000000000000000..f0fce4113fb07c64adbec029d177c236cbdcbae8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/command/PaperPluginsCommand.java
 @@ -0,0 +1,215 @@
@@ -150,7 +150,7 @@ index 0000000000000000000000000000000000000000..a1adbfca5115f31c1aefacf44ad64fe4
 +            builder.append(LEGACY_PLUGIN_STAR);
 +        }
 +
-+        String name = provider.getMeta().getDisplayName();
++        String name = provider.getMeta().getName();
 +        Component pluginName = Component.text(name, fromStatus(provider))
 +            .clickEvent(ClickEvent.runCommand("/version " + name));
 +
@@ -813,10 +813,10 @@ index 0000000000000000000000000000000000000000..f9a2c55a354c877749db3f92956de802
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c40ed0c531c3e211d26d4dd26e2e24be5d799d34
+index 0000000000000000000000000000000000000000..56fc3e0984861e8ddb597cad3c0a0e0aca9606e6
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
-@@ -0,0 +1,208 @@
+@@ -0,0 +1,207 @@
 +package io.papermc.paper.plugin.entrypoint.classloader;
 +
 +import io.papermc.paper.plugin.configuration.PluginMeta;
@@ -967,7 +967,6 @@ index 0000000000000000000000000000000000000000..c40ed0c531c3e211d26d4dd26e2e24be
 +        PluginDescriptionFile pluginDescriptionFile = new PluginDescriptionFile(
 +            config.getName(),
 +            config.getName(),
-+            config.getDisplayName(),
 +            config.getProvidedPlugins(),
 +            config.getMainClass(),
 +            "", // Classloader load order api
@@ -3061,7 +3060,7 @@ index 0000000000000000000000000000000000000000..6f6aaab295018017565ba27d6958a1f5
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/manager/PaperEventManager.java b/src/main/java/io/papermc/paper/plugin/manager/PaperEventManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..024dcfbcf64a423d4fc9facae90ebb1740e4bdd4
+index 0000000000000000000000000000000000000000..7ce9ebba8ce304d1f3f21d4f15ee5f3560d7700b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/manager/PaperEventManager.java
 @@ -0,0 +1,194 @@
@@ -3128,12 +3127,12 @@ index 0000000000000000000000000000000000000000..024dcfbcf64a423d4fc9facae90ebb17
 +                    this.server.getLogger().log(Level.SEVERE, String.format(
 +                        "Nag author(s): '%s' of '%s' about the following: %s",
 +                        plugin.getPluginMeta().getAuthors(),
-+                        plugin.getPluginMeta().getDisplayNameWithVersion(),
++                        plugin.getPluginMeta().getDisplayName(),
 +                        ex.getMessage()
 +                    ));
 +                }
 +            } catch (Throwable ex) {
-+                String msg = "Could not pass event " + event.getEventName() + " to " + registration.getPlugin().getPluginMeta().getDisplayNameWithVersion();
++                String msg = "Could not pass event " + event.getEventName() + " to " + registration.getPlugin().getPluginMeta().getDisplayName();
 +                this.server.getLogger().log(Level.SEVERE, msg, ex);
 +                if (!(event instanceof ServerExceptionEvent)) { // We don't want to cause an endless event loop
 +                    this.callEvent(new ServerExceptionEvent(new ServerEventException(msg, ex, registration.getPlugin(), registration.getListener(), event)));
@@ -3220,7 +3219,7 @@ index 0000000000000000000000000000000000000000..024dcfbcf64a423d4fc9facae90ebb17
 +            }
 +            final Class<?> checkClass;
 +            if (method.getParameterTypes().length != 1 || !Event.class.isAssignableFrom(checkClass = method.getParameterTypes()[0])) {
-+                plugin.getLogger().severe(plugin.getPluginMeta().getDisplayNameWithVersion() + " attempted to register an invalid EventHandler method signature \"" + method.toGenericString() + "\" in " + listener.getClass());
++                plugin.getLogger().severe(plugin.getPluginMeta().getDisplayName() + " attempted to register an invalid EventHandler method signature \"" + method.toGenericString() + "\" in " + listener.getClass());
 +                continue;
 +            }
 +            final Class<? extends Event> eventClass = checkClass.asSubclass(Event.class);
@@ -3239,7 +3238,7 @@ index 0000000000000000000000000000000000000000..024dcfbcf64a423d4fc9facae90ebb17
 +                        Level.WARNING,
 +                        String.format(
 +                            "\"%s\" has registered a listener for %s on method \"%s\", but the event is Deprecated. \"%s\"; please notify the authors %s.",
-+                            plugin.getPluginMeta().getDisplayNameWithVersion(),
++                            plugin.getPluginMeta().getDisplayName(),
 +                            clazz.getName(),
 +                            method.toGenericString(),
 +                            (warning != null && warning.reason().length() != 0) ? warning.reason() : "Server performance will be affected",
@@ -3468,7 +3467,7 @@ index 0000000000000000000000000000000000000000..92a69677f21b2c1c035119d8e5a6af63
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java b/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dd5e11e4e1c9308ce726dd5ca12052548ae55aba
+index 0000000000000000000000000000000000000000..c0e896343c22badd97c774c4ed1daa4e274f5d44
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java
 @@ -0,0 +1,304 @@
@@ -3648,7 +3647,7 @@ index 0000000000000000000000000000000000000000..dd5e11e4e1c9308ce726dd5ca1205254
 +        }
 +
 +        try {
-+            String enableMsg = "Enabling " + plugin.getPluginMeta().getDisplayNameWithVersion();
++            String enableMsg = "Enabling " + plugin.getPluginMeta().getDisplayName();
 +            if (plugin.getPluginMeta() instanceof PluginDescriptionFile descriptionFile && CraftMagicNumbers.isLegacy(descriptionFile)) {
 +                enableMsg += "*";
 +            }
@@ -3658,14 +3657,14 @@ index 0000000000000000000000000000000000000000..dd5e11e4e1c9308ce726dd5ca1205254
 +
 +            if (jPlugin.getClass().getClassLoader() instanceof ConfiguredPluginClassLoader classLoader) { // Paper
 +                if (PaperClassLoaderStorage.instance().registerUnsafePlugin(classLoader)) {
-+                    this.server.getLogger().log(Level.WARNING, "Enabled plugin with unregistered ConfiguredPluginClassLoader " + plugin.getPluginMeta().getDisplayNameWithVersion());
++                    this.server.getLogger().log(Level.WARNING, "Enabled plugin with unregistered ConfiguredPluginClassLoader " + plugin.getPluginMeta().getDisplayName());
 +                }
 +            } // Paper
 +
 +            try {
 +                jPlugin.setEnabled(true);
 +            } catch (Throwable ex) {
-+                this.server.getLogger().log(Level.SEVERE, "Error occurred while enabling " + plugin.getPluginMeta().getDisplayNameWithVersion() + " (Is it up to date?)", ex);
++                this.server.getLogger().log(Level.SEVERE, "Error occurred while enabling " + plugin.getPluginMeta().getDisplayName() + " (Is it up to date?)", ex);
 +                // Paper start - Disable plugins that fail to load
 +                this.server.getPluginManager().disablePlugin(jPlugin);
 +                return;
@@ -3677,7 +3676,7 @@ index 0000000000000000000000000000000000000000..dd5e11e4e1c9308ce726dd5ca1205254
 +            this.server.getPluginManager().callEvent(new PluginEnableEvent(plugin));
 +        } catch (Throwable ex) {
 +            this.handlePluginException("Error occurred (in the plugin loader) while enabling "
-+                + plugin.getPluginMeta().getDisplayNameWithVersion() + " (Is it up to date?)", ex, plugin);
++                + plugin.getPluginMeta().getDisplayName() + " (Is it up to date?)", ex, plugin);
 +        }
 +
 +        HandlerList.bakeAll();
@@ -3691,7 +3690,7 @@ index 0000000000000000000000000000000000000000..dd5e11e4e1c9308ce726dd5ca1205254
 +            return;
 +        }
 +
-+        String pluginName = plugin.getPluginMeta().getDisplayNameWithVersion();
++        String pluginName = plugin.getPluginMeta().getDisplayName();
 +
 +        try {
 +            plugin.getLogger().info("Disabling %s".formatted(pluginName));
@@ -4388,10 +4387,10 @@ index 0000000000000000000000000000000000000000..e3430f535e8e9c3b8b44bf2daece8c47
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3808f5a9abc9f084cbabfc4cb95394cc37aaf4bb
+index 0000000000000000000000000000000000000000..15e392438816436be0d3b4289d20b9a122f7f20a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
-@@ -0,0 +1,227 @@
+@@ -0,0 +1,218 @@
 +package io.papermc.paper.plugin.provider.configuration;
 +
 +import com.google.common.collect.ImmutableList;
@@ -4457,8 +4456,6 @@ index 0000000000000000000000000000000000000000..3808f5a9abc9f084cbabfc4cb95394cc
 +    @PluginConfigConstraints.PluginVersion
 +    private String apiVersion;
 +
-+    private transient String displayName;
-+
 +    public PaperPluginMeta() {
 +    }
 +
@@ -4501,8 +4498,6 @@ index 0000000000000000000000000000000000000000..3808f5a9abc9f084cbabfc4cb95394cc
 +                .build();
 +        }
 +
-+        pluginConfiguration.displayName = pluginConfiguration.name.replace('_', ' ');
-+
 +        return pluginConfiguration;
 +    }
 +
@@ -4519,11 +4514,6 @@ index 0000000000000000000000000000000000000000..3808f5a9abc9f084cbabfc4cb95394cc
 +    @Override
 +    public @NotNull String getVersion() {
 +        return this.version;
-+    }
-+
-+    @Override
-+    public @NotNull String getDisplayName() {
-+        return this.displayName;
 +    }
 +
 +    @Override
@@ -6212,10 +6202,10 @@ index 0000000000000000000000000000000000000000..374e7d3d69fc8603ecf54999f173123d
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/storage/ServerPluginProviderStorage.java b/src/main/java/io/papermc/paper/plugin/storage/ServerPluginProviderStorage.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..451aded531906d9b7ff802d2d093b7fe02bdf0e5
+index 0000000000000000000000000000000000000000..cb9b13522a976b82bcb71cef486f11f4172e3e99
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/storage/ServerPluginProviderStorage.java
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,70 @@
 +package io.papermc.paper.plugin.storage;
 +
 +import com.mojang.logging.LogUtils;
@@ -6224,6 +6214,8 @@ index 0000000000000000000000000000000000000000..451aded531906d9b7ff802d2d093b7fe
 +import io.papermc.paper.plugin.entrypoint.strategy.ProviderConfiguration;
 +import io.papermc.paper.plugin.manager.PaperPluginManagerImpl;
 +import io.papermc.paper.plugin.provider.PluginProvider;
++import io.papermc.paper.plugin.provider.ProviderStatus;
++import io.papermc.paper.plugin.provider.ProviderStatusHolder;
 +import io.papermc.paper.plugin.provider.type.paper.PaperPluginParent;
 +import org.bukkit.plugin.Plugin;
 +import org.bukkit.plugin.java.JavaPlugin;
@@ -6271,7 +6263,7 @@ index 0000000000000000000000000000000000000000..451aded531906d9b7ff802d2d093b7fe
 +    @Override
 +    public void processProvided(PluginProvider<JavaPlugin> provider, JavaPlugin provided) {
 +        try {
-+            provided.getLogger().info(String.format("Loading server plugin %s", provided.getPluginMeta().getDisplayNameWithVersion()));
++            provided.getLogger().info(String.format("Loading server plugin %s", provided.getPluginMeta().getDisplayName()));
 +            provided.onLoad();
 +        } catch (Throwable ex) {
 +            // Don't mark that provider as ERRORED, as this apparently still needs to run the onEnable logic.

--- a/patches/server/0404-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0404-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,7 +22,7 @@ index e189de6d2aa94e9bbb20f1477ee2e34431adb324..4a58843f7ce2dd9e50f9daf3065d056a
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4d51834b6e7bc9058579ce5c6b88f5e9e1c3155d..c92b61c0228d112c73253a5c8b6654312f2b6e95 100644
+index 4d51834b6e7bc9058579ce5c6b88f5e9e1c3155d..670ad9f79e2430e956ef204c7e7bf0c651810c06 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1002,6 +1002,31 @@ public final class CraftServer implements Server {
@@ -46,8 +46,8 @@ index 4d51834b6e7bc9058579ce5c6b88f5e9e1c3155d..c92b61c0228d112c73253a5c8b665431
 +            Plugin plugin = worker.getOwner();
 +            getLogger().log(Level.SEVERE, String.format(
 +                "Nag author(s): '%s' of '%s' about the following: %s",
-+                plugin.getDescription().getAuthors(),
-+                plugin.getDescription().getFullName(),
++                plugin.getPluginMeta().getAuthors(),
++                plugin.getPluginMeta().getDisplayName(),
 +                "This plugin is not properly shutting down its async tasks when it is being shut down. This task may throw errors during the final shutdown logs and might not complete before process dies."
 +            ));
 +        }

--- a/patches/server/0404-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0404-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,10 +22,10 @@ index e189de6d2aa94e9bbb20f1477ee2e34431adb324..4a58843f7ce2dd9e50f9daf3065d056a
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bec471a617780e4fa88d4c559c42175370687d7b..9e278a740cf7cb7a593d76f01d6aa590407b087b 100644
+index 4d51834b6e7bc9058579ce5c6b88f5e9e1c3155d..c92b61c0228d112c73253a5c8b6654312f2b6e95 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1002,6 +1002,35 @@ public final class CraftServer implements Server {
+@@ -1002,6 +1002,31 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  
@@ -44,14 +44,10 @@ index bec471a617780e4fa88d4c559c42175370687d7b..9e278a740cf7cb7a593d76f01d6aa590
 +        List<BukkitWorker> overdueWorkers = getScheduler().getActiveWorkers();
 +        for (BukkitWorker worker : overdueWorkers) {
 +            Plugin plugin = worker.getOwner();
-+            String author = "<NoAuthorGiven>";
-+            if (plugin.getDescription().getAuthors().size() > 0) {
-+                author = plugin.getDescription().getAuthors().get(0);
-+            }
 +            getLogger().log(Level.SEVERE, String.format(
-+                "Nag author: '%s' of '%s' about the following: %s",
-+                author,
-+                plugin.getDescription().getName(),
++                "Nag author(s): '%s' of '%s' about the following: %s",
++                plugin.getDescription().getAuthors(),
++                plugin.getDescription().getFullName(),
 +                "This plugin is not properly shutting down its async tasks when it is being shut down. This task may throw errors during the final shutdown logs and might not complete before process dies."
 +            ));
 +        }

--- a/patches/server/0493-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0493-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7971be6c5e9daa6d7f206aafac7479bd5cc0aad5..a133e0a0a7a5b646ac3df9c2521d4deed6a1761d 100644
+index 24f0e19f0ce76d9efa2acae2d8514c97cd4415fa..689ee858c4c0635f03390d30f84f635be4758c49 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1812,6 +1812,28 @@ public final class CraftServer implements Server {
+@@ -1808,6 +1808,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0581-Expand-world-key-API.patch
+++ b/patches/server/0581-Expand-world-key-API.patch
@@ -20,10 +20,10 @@ index 9db48bd6dcf0d24132123b86670341c1d8113840..d7ac103b82e9aac1e2f3b807d7b69fdf
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a133e0a0a7a5b646ac3df9c2521d4deed6a1761d..574f50314c17eb12b519ba14fb1dddbc6c8e40c6 100644
+index 689ee858c4c0635f03390d30f84f635be4758c49..90230aec6707400fe07ab4431235b4f6383bdac0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1134,9 +1134,15 @@ public final class CraftServer implements Server {
+@@ -1130,9 +1130,15 @@ public final class CraftServer implements Server {
          File folder = new File(this.getWorldContainer(), name);
          World world = this.getWorld(name);
  
@@ -41,7 +41,7 @@ index a133e0a0a7a5b646ac3df9c2521d4deed6a1761d..574f50314c17eb12b519ba14fb1dddbc
  
          if ((folder.exists()) && (!folder.isDirectory())) {
              throw new IllegalArgumentException("File exists with the name '" + name + "' and isn't a folder");
-@@ -1225,7 +1231,7 @@ public final class CraftServer implements Server {
+@@ -1221,7 +1227,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -50,7 +50,7 @@ index a133e0a0a7a5b646ac3df9c2521d4deed6a1761d..574f50314c17eb12b519ba14fb1dddbc
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, worlddimension, this.getServer().progressListenerFactory.create(11),
-@@ -1317,6 +1323,15 @@ public final class CraftServer implements Server {
+@@ -1313,6 +1319,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0615-Add-basic-Datapack-API.patch
+++ b/patches/server/0615-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 574f50314c17eb12b519ba14fb1dddbc6c8e40c6..a8116749fb7a2b30e2623165eedb9ee167ee6120 100644
+index 90230aec6707400fe07ab4431235b4f6383bdac0..d3256d726dda08da8f3e9facfd2cb242c2c08655 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -291,6 +291,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index 574f50314c17eb12b519ba14fb1dddbc6c8e40c6..a8116749fb7a2b30e2623165eedb9ee1
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2778,5 +2780,11 @@ public final class CraftServer implements Server {
+@@ -2774,5 +2776,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0621-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0621-Fix-and-optimise-world-force-upgrading.patch
@@ -359,10 +359,10 @@ index b294ef87fb93e7f4651dc04128124f297575860d..65fd57609e45ccd49ebfc1ba80d25243
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 418af5eca12c17c95fb5ec8f6af761372d84a4c1..cfa6915e17d2fcc0cac4030aef8a71503df89e85 100644
+index d3256d726dda08da8f3e9facfd2cb242c2c08655..a469b39c47b1b9feba344672646ee14c11b42a81 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1210,12 +1210,7 @@ public final class CraftServer implements Server {
+@@ -1206,12 +1206,7 @@ public final class CraftServer implements Server {
          worlddata.customDimensions = iregistry;
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().shouldReportAsModified());
@@ -376,7 +376,7 @@ index 418af5eca12c17c95fb5ec8f6af761372d84a4c1..cfa6915e17d2fcc0cac4030aef8a7150
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1226,6 +1221,13 @@ public final class CraftServer implements Server {
+@@ -1222,6 +1217,13 @@ public final class CraftServer implements Server {
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
  

--- a/patches/server/0659-Add-System.out-err-catcher.patch
+++ b/patches/server/0659-Add-System.out-err-catcher.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add System.out/err catcher
 
 diff --git a/src/main/java/io/papermc/paper/logging/SysoutCatcher.java b/src/main/java/io/papermc/paper/logging/SysoutCatcher.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..395a1c34c3ed131d9754eafb7f4579cd46721e76
+index 0000000000000000000000000000000000000000..ba9c7010b9740f24fd247ecae16dc3096df26427
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/logging/SysoutCatcher.java
 @@ -0,0 +1,94 @@
@@ -89,7 +89,7 @@ index 0000000000000000000000000000000000000000..395a1c34c3ed131d9754eafb7f4579cd
 +                    String.format("Nag author(s): '%s' of '%s' about their usage of System.out/err.print. "
 +                            + "Please use your plugin's logger instead (JavaPlugin#getLogger).",
 +                        plugin.getDescription().getAuthors(),
-+                        plugin.getDescription().getDisplayNameWithVersion())
++                        plugin.getDescription().getFullName())
 +                );
 +            } catch (final IllegalArgumentException | IllegalStateException e) {
 +                // If anything happens, the calling class doesn't exist, there is no JavaPlugin that "owns" the calling class, etc
@@ -105,7 +105,7 @@ index 0000000000000000000000000000000000000000..395a1c34c3ed131d9754eafb7f4579cd
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ee48a7b6545454083462c2825545710e03c1f1f7..46755f34fb0af5dea2db8d8321caebfc163a8268 100644
+index a469b39c47b1b9feba344672646ee14c11b42a81..4fcfad88374430b03e6ea8aa4a45e110f644a36b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -293,6 +293,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0659-Add-System.out-err-catcher.patch
+++ b/patches/server/0659-Add-System.out-err-catcher.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add System.out/err catcher
 
 diff --git a/src/main/java/io/papermc/paper/logging/SysoutCatcher.java b/src/main/java/io/papermc/paper/logging/SysoutCatcher.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ba9c7010b9740f24fd247ecae16dc3096df26427
+index 0000000000000000000000000000000000000000..a8e813ca89b033f061e695288b3383bdcf128531
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/logging/SysoutCatcher.java
 @@ -0,0 +1,94 @@
@@ -88,8 +88,8 @@ index 0000000000000000000000000000000000000000..ba9c7010b9740f24fd247ecae16dc309
 +                Bukkit.getLogger().warning(
 +                    String.format("Nag author(s): '%s' of '%s' about their usage of System.out/err.print. "
 +                            + "Please use your plugin's logger instead (JavaPlugin#getLogger).",
-+                        plugin.getDescription().getAuthors(),
-+                        plugin.getDescription().getFullName())
++                        plugin.getPluginMeta().getAuthors(),
++                        plugin.getPluginMeta().getDisplayName())
 +                );
 +            } catch (final IllegalArgumentException | IllegalStateException e) {
 +                // If anything happens, the calling class doesn't exist, there is no JavaPlugin that "owns" the calling class, etc
@@ -105,7 +105,7 @@ index 0000000000000000000000000000000000000000..ba9c7010b9740f24fd247ecae16dc309
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a469b39c47b1b9feba344672646ee14c11b42a81..4fcfad88374430b03e6ea8aa4a45e110f644a36b 100644
+index 8e07aadd4225df5a7f5ac95de6a91309ed036ffa..e90ddf2f2039a954971f23a6dc28d460ab6f18b2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -293,6 +293,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0659-Add-System.out-err-catcher.patch
+++ b/patches/server/0659-Add-System.out-err-catcher.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add System.out/err catcher
 
 diff --git a/src/main/java/io/papermc/paper/logging/SysoutCatcher.java b/src/main/java/io/papermc/paper/logging/SysoutCatcher.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..76d0d00cd6742991e3f3ec827a75ee87d856b6c9
+index 0000000000000000000000000000000000000000..395a1c34c3ed131d9754eafb7f4579cd46721e76
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/logging/SysoutCatcher.java
 @@ -0,0 +1,94 @@
@@ -89,7 +89,7 @@ index 0000000000000000000000000000000000000000..76d0d00cd6742991e3f3ec827a75ee87
 +                    String.format("Nag author(s): '%s' of '%s' about their usage of System.out/err.print. "
 +                            + "Please use your plugin's logger instead (JavaPlugin#getLogger).",
 +                        plugin.getDescription().getAuthors(),
-+                        plugin.getName())
++                        plugin.getDescription().getDisplayNameWithVersion())
 +                );
 +            } catch (final IllegalArgumentException | IllegalStateException e) {
 +                // If anything happens, the calling class doesn't exist, there is no JavaPlugin that "owns" the calling class, etc
@@ -105,7 +105,7 @@ index 0000000000000000000000000000000000000000..76d0d00cd6742991e3f3ec827a75ee87
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 29d8b20d1e90b0097a98f454f2f1209b27fdfa61..a6be09d67043343dc26942d9a0a4d6cebdd6b627 100644
+index ee48a7b6545454083462c2825545710e03c1f1f7..46755f34fb0af5dea2db8d8321caebfc163a8268 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -293,6 +293,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0695-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0695-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -278,10 +278,10 @@ index a1770e5ae4b3014c3538b52d4912c60864e186a8..906def91bba96bab7c7aea9b87d9ec56
          // Paper start - add parameters and int ret type
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 46755f34fb0af5dea2db8d8321caebfc163a8268..9b3f01e84b5855b64e9f59ca29e5ff9a598084a4 100644
+index 4fcfad88374430b03e6ea8aa4a45e110f644a36b..5c4221f8ea476ea218a6222904c6af3841bdb1dc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2165,6 +2165,11 @@ public final class CraftServer implements Server {
+@@ -2161,6 +2161,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {

--- a/patches/server/0755-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0755-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c9e643ca1a2fab8a314e5f232903b3a54bfd0a76..c997788550f03e3441fc879e281eb54f64a44f01 100644
+index 5c4221f8ea476ea218a6222904c6af3841bdb1dc..4a37cfddbf152dad5bd315c20d1546e584e62e1a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2337,6 +2337,90 @@ public final class CraftServer implements Server {
+@@ -2333,6 +2333,90 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registries.BIOME), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0775-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0775-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,10 +18,10 @@ index 24c88555ea85dd2a0656e1f67a4828a5137157b8..cbbb0ff40488c430d15c2ed054d1b288
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c997788550f03e3441fc879e281eb54f64a44f01..aa460a1c8506b6c499d45f7ee7371ebd540ec7dd 100644
+index 4a37cfddbf152dad5bd315c20d1546e584e62e1a..d1bfa05340a983fc14c83d85371206d14197059b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1217,7 +1217,7 @@ public final class CraftServer implements Server {
+@@ -1213,7 +1213,7 @@ public final class CraftServer implements Server {
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
          LevelStem worlddimension = iregistry.get(actualDimension);
  

--- a/patches/server/0790-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0790-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index aa460a1c8506b6c499d45f7ee7371ebd540ec7dd..b3de0224b6837022c4f010f84cf51dc20742764f 100644
+index d1bfa05340a983fc14c83d85371206d14197059b..5704441d2c53bbb5e3eda1c41066299a68e77300 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1999,6 +1999,13 @@ public final class CraftServer implements Server {
+@@ -1995,6 +1995,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  

--- a/patches/server/0794-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0794-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b3de0224b6837022c4f010f84cf51dc20742764f..d55f66b98cc3fc8c8d7beff2f83a3f57cc5d7ca0 100644
+index 5704441d2c53bbb5e3eda1c41066299a68e77300..81109a840669c18f3af92a29a253ee487e0098dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2173,6 +2173,8 @@ public final class CraftServer implements Server {
+@@ -2169,6 +2169,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start

--- a/patches/server/0795-Add-GameEvent-tags.patch
+++ b/patches/server/0795-Add-GameEvent-tags.patch
@@ -46,10 +46,10 @@ index 0000000000000000000000000000000000000000..e7d9fd2702a1ce96596580fff8f5ee4f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d55f66b98cc3fc8c8d7beff2f83a3f57cc5d7ca0..a4b537774069dc5b3272e1fc06292d7b3144ff5b 100644
+index 81109a840669c18f3af92a29a253ee487e0098dd..1938914697c63ac71ac382406d1a47938fa61427 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2583,6 +2583,15 @@ public final class CraftServer implements Server {
+@@ -2579,6 +2579,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(BuiltInRegistries.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -65,7 +65,7 @@ index d55f66b98cc3fc8c8d7beff2f83a3f57cc5d7ca0..a4b537774069dc5b3272e1fc06292d7b
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2615,6 +2624,13 @@ public final class CraftServer implements Server {
+@@ -2611,6 +2620,13 @@ public final class CraftServer implements Server {
                  net.minecraft.core.Registry<EntityType<?>> entityTags = BuiltInRegistries.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0801-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0801-Put-world-into-worldlist-before-initing-the-world.patch
@@ -23,10 +23,10 @@ index 23fce58a5909c5b01a5f0ef6912f90858cd3302c..a30c61e176501d1cbd2e330f85d5d258
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a4b537774069dc5b3272e1fc06292d7b3144ff5b..2e88728e57ed95c458d5cd5071a245c280d4952e 100644
+index 1938914697c63ac71ac382406d1a47938fa61427..e8b8463ff4e896aaa3dcbb045bc94d2c5cb1ecb7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1246,10 +1246,11 @@ public final class CraftServer implements Server {
+@@ -1242,10 +1242,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0803-Custom-Potion-Mixes.patch
+++ b/patches/server/0803-Custom-Potion-Mixes.patch
@@ -164,7 +164,7 @@ index 424406d2692856cfd82b6f3b7b6228fa3bd20c2f..c57efcb9a79337ec791e4e8f6671612f
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2e88728e57ed95c458d5cd5071a245c280d4952e..339458bea9298de78f6a3c88426dbcd1b9a67cce 100644
+index e8b8463ff4e896aaa3dcbb045bc94d2c5cb1ecb7..957af0133b0aeb4ec49949433d88e9c49f57faa0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -294,6 +294,7 @@ public final class CraftServer implements Server {
@@ -184,7 +184,7 @@ index 2e88728e57ed95c458d5cd5071a245c280d4952e..339458bea9298de78f6a3c88426dbcd1
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2904,5 +2905,10 @@ public final class CraftServer implements Server {
+@@ -2900,5 +2901,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0814-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0814-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 339458bea9298de78f6a3c88426dbcd1b9a67cce..24d4150240c28741a25bdfe1fd7f3a423763bd61 100644
+index 957af0133b0aeb4ec49949433d88e9c49f57faa0..1bd1565b02fdcf22e0cb550290ad1ae792002cc0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1294,7 +1294,7 @@ public final class CraftServer implements Server {
+@@ -1290,7 +1290,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0830-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0830-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 24d4150240c28741a25bdfe1fd7f3a423763bd61..0d2c4bc4674fb2ad2a024994c07d62d16bdf6662 100644
+index 1bd1565b02fdcf22e0cb550290ad1ae792002cc0..733b18de16e7924ae81a9255bcd061f95628630f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1253,6 +1253,7 @@ public final class CraftServer implements Server {
+@@ -1249,6 +1249,7 @@ public final class CraftServer implements Server {
          internal.setSpawnSettings(true, true);
          // Paper - move up
  

--- a/patches/server/0846-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0846-Throw-exception-on-world-create-while-being-ticked.patch
@@ -45,7 +45,7 @@ index 3e59620c84b3aa93d8ce41b0e9901a1621bb48df..682005e4b19ba3959d4e3a66475487da
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0d2c4bc4674fb2ad2a024994c07d62d16bdf6662..fc5e363dec88d5a45d9cb788779b9cb5980b5ff5 100644
+index 733b18de16e7924ae81a9255bcd061f95628630f..3713ce052cef9ccbee951473556cba6e0d1b485f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -845,6 +845,11 @@ public final class CraftServer implements Server {
@@ -60,7 +60,7 @@ index 0d2c4bc4674fb2ad2a024994c07d62d16bdf6662..fc5e363dec88d5a45d9cb788779b9cb5
      public DedicatedPlayerList getHandle() {
          return this.playerList;
      }
-@@ -1130,6 +1135,7 @@ public final class CraftServer implements Server {
+@@ -1126,6 +1131,7 @@ public final class CraftServer implements Server {
      @Override
      public World createWorld(WorldCreator creator) {
          Preconditions.checkState(this.console.getAllLevels().iterator().hasNext(), "Cannot create additional worlds on STARTUP");
@@ -68,7 +68,7 @@ index 0d2c4bc4674fb2ad2a024994c07d62d16bdf6662..fc5e363dec88d5a45d9cb788779b9cb5
          Validate.notNull(creator, "Creator may not be null");
  
          String name = creator.name();
-@@ -1268,6 +1274,7 @@ public final class CraftServer implements Server {
+@@ -1264,6 +1270,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {

--- a/patches/server/0853-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0853-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index 7c7e5f3c0f9cd1f16192a8fc8163da9b2d9519d5..888936385196a178ab8b730fd5e4fff4
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fc5e363dec88d5a45d9cb788779b9cb5980b5ff5..c37cb8a3d7f1d463db8d3719e6a4e00446b32e00 100644
+index 3713ce052cef9ccbee951473556cba6e0d1b485f..33fe6f01cfef25482001a04bdd82367424d69317 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1772,7 +1772,7 @@ public final class CraftServer implements Server {
+@@ -1768,7 +1768,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {


### PR DESCRIPTION
Hello! I recently noticed that -- since the introduction of Paper plugins -- there are a number of inconsistencies (and issues) with the different types of plugin names and where they're used. Below is a table showing the results of tests I conducted on multiple versions of Paper. The name of the test plugin is `Very_Fancy_Plugin`.

![Test Results](https://user-images.githubusercontent.com/64972126/229745988-335a8091-9b1a-4e99-b6f6-384a8f65d7ec.png)

The big issues with this currently (specifically with Paper plugins) are:
1. `PluginDescriptionFile#getName()` and `PaperPluginMeta#getName()` return different strings when plugin names contain underscores. This is very unintuitive and -- in the case of `PluginDescriptionFile#getName()` -- incorrect according to the [documentation](https://jd.papermc.io/paper/1.19/io/papermc/paper/plugin/configuration/PluginMeta.html#getName()):
    > - Will only contain alphanumeric characters, underscores, hyphens, and periods: [a-zA-Z0-9_\\-\\.].
2. `PluginProviderContext#getDataDirectory()` returns a directory with the version in the name, while `JavaPlugin#getDataFolder()` returns one without the version. Not only is this inconsistency unintuitive, but it's also problematic to include the version in the directory name. This is a bug caused by #9038.
3. Both of the methods mentioned in <span>#</span>2 can return directories with spaces in their names, which can be a pain to work with.
4. Plugins with underscores in their names will be listed with their original names (e.g., `Very_Fancy_Plugin`) in `/plugins`, despite those underscores being replaced with spaces (e.g., `Very Fancy Plugin`) in `/version [plugin name]`.
5. Nag messages use all kinds of name variations, sometimes containing original plugin names; other times containing original plugin names with underscores replaced with spaces; other times appending the version; etc.

**Everything below here is now irrelevant. See [this comment](https://github.com/PaperMC/Paper/pull/9098#issuecomment-1496450556) instead.**

---

~~My solution uses the following naming conventions:~~
- ~~Plugin **name** = The original name of the plugin as defined in `[paper-]plugin.yml`, e.g., `Very_Fancy_Plugin`.~~
- ~~Plugin **display name** = A human-readable name for the plugin with no defined behavior, e.g., `Very Fancy Plugin` or `Very_Fancy_Plugin`.~~
- ~~Plugin **display name + version** = The plugin's display name + version, e.g., `Very Fancy Plugin v1.0.0` or `Very_Fancy_Plugin v1.0.0`.~~

~~Specifically, my solution is to:~~
- ~~Rename the current `PluginMeta#getDisplayName` method (and all its usages) to `getDisplayNameWithVersion`.~~
- ~~Add a new `PluginMeta#getDisplayName` method that returns just the display name.~~
- ~~Modify `PluginDescriptionFile#getFullName` to use `PluginMeta#getDisplayNameWithVersion`.~~
- ~~Modify the `/plugins` and `/version` commands to use the plugin's display name.~~
- ~~Change plugin data directories to use the plugin's name in all places. This matches the behavior of Spigot plugins.~~
- ~~Change nag messages to use the plugin's display name + version in (I believe) all places.~~

~~This shouldn't cause any API breakages that render plugins uncompilable/unusable, however, naturally, this could break any plugins that depend on a specific implementation of the aforementioned methods. All of these changes will affect Paper plugins, but Spigot plugins should only be affected by the changes to `PluginMeta#getDisplayName` (as well as the addition of `PluginMeta#getDisplayNameWithVersion`).~~

~~Things I'm unsure of are:~~
~~1. Is there a better name for `PluginMeta#getDisplayNameWithVersion`? It could alternatively be `getDisplayNameAndVersion` or `getFullDisplayName` or something entirely different.~~
~~2. Should plugin logger names be changed to use display names? They're technically "displayed" to users, but it could be considered unconventional to use spaces.~~
~~3. Should `/version` tab completion be changed to use display names in some way? I think this would be a little weird considering how tab completion works, but it would be more consistent.~~
~~4. Is this even the right approach? 😬~~

---

Thanks! :)
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9098.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/649665440.zip)