### PR TITLE
Fix ignoreCancelled having no effect on events registered by direct EventExecutor

### DIFF
--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -1544,7 +1544,7 @@ index 41e26451fe12d8e6e0ef73c85731b24b4e3f200c..03213fde8315384ec56c16031cfc606a
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index a69c5d5cad6168aeaae41e8adc319dc8c976b1e2..f64a90241ce7f73e111e6b5ac6ff87cd93583c0e 100644
+index a69c5d5cad6168aeaae41e8adc319dc8c976b1e2..77f9ebbe675cf1b6a17e98d98e7666711998eb4e 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 @@ -43,6 +43,8 @@ import org.jetbrains.annotations.Nullable;
@@ -1685,7 +1685,7 @@ index a69c5d5cad6168aeaae41e8adc319dc8c976b1e2..f64a90241ce7f73e111e6b5ac6ff87cd
          Preconditions.checkArgument(priority != null, "Priority cannot be null");
          Preconditions.checkArgument(executor != null, "Executor cannot be null");
          Preconditions.checkArgument(plugin != null, "Plugin cannot be null");
-+        if (true) {this.paperPluginManager.registerEvent(event, listener, priority, executor, plugin); return;} // Paper
++        if (true) {this.paperPluginManager.registerEvent(event, listener, priority, executor, plugin, ignoreCancelled); return;} // Paper
  
          if (!plugin.isEnabled()) {
              throw new IllegalPluginAccessException("Plugin attempted to register " + event + " while not enabled");


### PR DESCRIPTION
We recently updated our Paper version and noticed that `ignoreCancelled` was no longer having an effect on our listeners.

This only impacts events registered by direct `EventExecutor`. Events registered using the `registerEvents` method are not impacted.

This is potentially also the cause of https://github.com/PaperMC/Paper/issues/8911 as it looks like the plugins mentioned are registering events this way (see https://github.com/PaperMC/Paper/issues/8911#issuecomment-1482589353.


 