### PR TITLE
Fix NPE due to Nullable Color in CraftMetaColorableArmor

### DIFF
--- a/patches/server/0975-ColorableArmor-Null-Color-Fix.patch
+++ b/patches/server/0975-ColorableArmor-Null-Color-Fix.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Moulberry <james.jenour@protonmail.com>
+Date: Sun, 9 Apr 2023 15:56:27 +0800
+Subject: [PATCH] Fix NPE with null color value
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
+index cd078f97b023ec26e610cad2b703d14ab2eced1c..28f32dafcaecc387d5ec763ad9afa615eec73fc7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaColorableArmor.java
+@@ -72,7 +72,7 @@ public class CraftMetaColorableArmor extends CraftMetaArmor implements Colorable
+ 
+     @Override
+     public void setColor(Color color) {
+-        this.color = color;
++        this.color = color == null ? DEFAULT_LEATHER_COLOR : color; // Paper - Fix color being set to null, resulting in NPEs
+     }
+ 
+     boolean hasColor() {


### PR DESCRIPTION
CraftMetaLeatherArmor prevents this.color from being set to null by substituting DEFAULT_LEATHER_COLOR CraftMetaColorableArmor does not do this, causing various NPEs when leather armor does not have a color NBT tag

This fix copies the setColor method from CraftMetaLeatherArmor and uses it in CraftMetaColorableArmor