### PR TITLE
Optimize hoppers by not trying to merge full items.

### DIFF
--- a/patches/server/0963-Optimize-Hoppers.patch
+++ b/patches/server/0963-Optimize-Hoppers.patch
@@ -68,7 +68,7 @@ index 585d1d1f4b1b212295da36e31ae2670b0d2b06c3..1b248db497500aa6bd346b306dcb908a
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index 789e5458f4a137694563a22612455506807de51b..cba114f554644a37339c93026630c66c43f524b9 100644
+index 789e5458f4a137694563a22612455506807de51b..aac5572c1d40a10cd1d17f89c9eb836718837577 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 @@ -193,6 +193,201 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
@@ -551,6 +551,15 @@ index 789e5458f4a137694563a22612455506807de51b..cba114f554644a37339c93026630c66c
              List<Entity> list = world.getEntities((Entity) null, new AABB(x - 0.5D, y - 0.5D, z - 0.5D, x + 0.5D, y + 0.5D, z + 0.5D), EntitySelector.CONTAINER_ENTITY_SELECTOR);
  
              if (!list.isEmpty()) {
+@@ -560,7 +776,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+     }
+ 
+     private static boolean canMergeItems(ItemStack first, ItemStack second) {
+-        return !first.is(second.getItem()) ? false : (first.getDamageValue() != second.getDamageValue() ? false : (first.getCount() > first.getMaxStackSize() ? false : ItemStack.tagMatches(first, second)));
++        return first.is(second.getItem()) && first.getDamageValue() == second.getDamageValue() && first.getCount() < first.getMaxStackSize() && ItemStack.tagMatches(first, second); // Paper - used to return true for full itemstacks?!
+     }
+ 
+     @Override
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java
 index b9f0dae1ec96194fe78c086b63d8a18b1d0cfcf7..79b01e32f89defb6b78f4764600d33d4945af592 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java


### PR DESCRIPTION
This can skip many very expensive call to ItemStack.tagMatches. Makes canMergeItems return false for merging into ItemStacks that are already full.

Noticed this due to a stray item going into a double chest otherwise filled with shulkers of NBT-heavy items, which made the hopper pushing items into that chest start creating a noticeable amount of tick ms usage by itself. In testing on my local machine I've been able to make 6 hoppers and double chest cause about 50ms of tick usage by just tagMatches using shulkers of written bocks.

I don't think there is any reason at all to try and merge into items that are already full (please do tell if there is), the original code checks if the item being merged into is greater then its maximum stack size, which makes me believe it might be a logical error from Mojang, using a greater then instead of equal or greater then?