### PR TITLE
Fix exception when using World#generateTree near crops

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -55,4 +55,5 @@ TheFruxz <cedricspitzer@outlook.de>
 Kieran Wallbanks <kieran.wallbanks@gmail.com>
 Denery <dorofeevij@gmail.com>
 Jakubk15 <jakubk15@protonmail.com>
+Redned <redned235@gmail.com>
 ```

--- a/patches/server/0851-Add-missing-important-BlockStateListPopulator-method.patch
+++ b/patches/server/0851-Add-missing-important-BlockStateListPopulator-method.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add missing important BlockStateListPopulator methods
 Without these methods it causes exceptions due to these being used by certain feature generators.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java b/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
-index 4bd59614606962a5371fd0da54bde25bf6a01325..602ce766f00dfde057c735eae3351068d09feab1 100644
+index 4bd59614606962a5371fd0da54bde25bf6a01325..216b413ce29c2557d12b80b29072e7fc822de551 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
 @@ -128,7 +128,7 @@ public class BlockStateListPopulator extends DummyGeneratorAccess {
@@ -18,7 +18,7 @@ index 4bd59614606962a5371fd0da54bde25bf6a01325..602ce766f00dfde057c735eae3351068
      }
  
      @Override
-@@ -140,4 +140,28 @@ public class BlockStateListPopulator extends DummyGeneratorAccess {
+@@ -140,4 +140,38 @@ public class BlockStateListPopulator extends DummyGeneratorAccess {
      public RegistryAccess registryAccess() {
          return this.world.registryAccess();
      }
@@ -44,6 +44,16 @@ index 4bd59614606962a5371fd0da54bde25bf6a01325..602ce766f00dfde057c735eae3351068
 +    @Override
 +    public net.minecraft.world.level.storage.LevelData getLevelData() {
 +        return world.getLevelData();
++    }
++
++    @Override
++    public int getRawBrightness(BlockPos pos, int ambientDarkness) {
++        return world.getRawBrightness(pos, ambientDarkness);
++    }
++
++    @Override
++    public int getBrightness(net.minecraft.world.level.LightLayer type, BlockPos pos) {
++        return world.getBrightness(type, pos);
 +    }
 +    // Paper end
  }


### PR DESCRIPTION
When generating trees near crops, the server will check whether the crop block can survive, and as part of that check in CropBlock#canSurvive, a lookup to the light engine is done. This adds a change into the BlockStateListPopulator to get the brightness from the world itself, since the light engine is not accessible in DummyGeneratorAccess.

Exception from testing prior to fix:
https://paste.gg/p/anonymous/0a29a4634cfd4fb5b412f20b3de8aaf9