### PR TITLE
Fix NPE on Boat#getStatus

### DIFF
--- a/patches/api/0429-Fix-NPE-on-Boat-getStatus.patch
+++ b/patches/api/0429-Fix-NPE-on-Boat-getStatus.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LemonCaramel <admin@caramel.moe>
+Date: Tue, 11 Apr 2023 04:04:41 +0900
+Subject: [PATCH] Fix NPE on Boat getStatus
+
+
+diff --git a/src/main/java/org/bukkit/entity/Boat.java b/src/main/java/org/bukkit/entity/Boat.java
+index f7548098bcdd033d9c530fdc584fc5538c635ca1..2ac685fb1817f3ce06ebe6391cc863712d68367c 100644
+--- a/src/main/java/org/bukkit/entity/Boat.java
++++ b/src/main/java/org/bukkit/entity/Boat.java
+@@ -169,6 +169,7 @@ public interface Boat extends Vehicle {
+      */
+     public enum Status {
+ 
++        NOT_IN_WORLD, // Paper
+         IN_WATER,
+         UNDER_WATER,
+         UNDER_FLOWING_WATER,

--- a/patches/server/1015-Fix-NPE-on-Boat-getStatus.patch
+++ b/patches/server/1015-Fix-NPE-on-Boat-getStatus.patch
@@ -9,10 +9,10 @@ Boat status is null until the entity is added to the world and the tick() method
 public net.minecraft.world.entity.vehicle.Boat getStatus()Lnet/minecraft/world/entity/vehicle/Boat$Status;
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
-index d7d54df20984352d84ffb9f7b7da583c34587b85..faf9a93c02b6aad9dcda7aa3ce38ce739fc2d671 100644
+index d7d54df20984352d84ffb9f7b7da583c34587b85..69ff732481ce6ba25bcfb27e5f9576bfa8019b8a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
-@@ -88,6 +88,16 @@ public class CraftBoat extends CraftVehicle implements Boat {
+@@ -88,6 +88,17 @@ public class CraftBoat extends CraftVehicle implements Boat {
  
      @Override
      public Status getStatus() {
@@ -20,7 +20,8 @@ index d7d54df20984352d84ffb9f7b7da583c34587b85..faf9a93c02b6aad9dcda7aa3ce38ce73
 +        final net.minecraft.world.entity.vehicle.Boat handle = this.getHandle();
 +        if (handle.status == null) {
 +            if (handle.valid && !handle.updatingSectionStatus) {
-+                handle.status = handle.getStatus();
++                // Don't actually set the status because it would skew the old status check in the next tick
++                return CraftBoat.boatStatusFromNms(this.getHandle().getStatus());
 +            } else {
 +                return Status.NOT_IN_WORLD;
 +            }

--- a/patches/server/1015-Fix-NPE-on-Boat-getStatus.patch
+++ b/patches/server/1015-Fix-NPE-on-Boat-getStatus.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LemonCaramel <admin@caramel.moe>
+Date: Mon, 10 Apr 2023 20:48:26 +0900
+Subject: [PATCH] Fix NPE on Boat getStatus
+
+Boat status is null until the entity is added to the world and the tick() method is called.
+
+== AT ==
+public net.minecraft.world.entity.vehicle.Boat getStatus()Lnet/minecraft/world/entity/vehicle/Boat$Status;
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
+index d7d54df20984352d84ffb9f7b7da583c34587b85..faf9a93c02b6aad9dcda7aa3ce38ce739fc2d671 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
+@@ -88,6 +88,16 @@ public class CraftBoat extends CraftVehicle implements Boat {
+ 
+     @Override
+     public Status getStatus() {
++        // Paper start
++        final net.minecraft.world.entity.vehicle.Boat handle = this.getHandle();
++        if (handle.status == null) {
++            if (handle.valid && !handle.updatingSectionStatus) {
++                handle.status = handle.getStatus();
++            } else {
++                return Status.NOT_IN_WORLD;
++            }
++        }
++        // Paper end
+         return CraftBoat.boatStatusFromNms(this.getHandle().status);
+     }
+ 


### PR DESCRIPTION
Tested in the three situations

TestPlugin.java
```java
@Override
public void onEnable() {
    this.getServer().getPluginManager().registerEvents(this, this);

    /*
     * Get status at the same time as entity spawn
     */
    this.getServer().getCommandMap().register("boat", new Command("boat") {
        @Override
        public boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args) {
            if (sender instanceof Player player) {
                final var loc = player.getLocation();
                player.sendRawMessage( loc.getWorld().spawn(loc, Boat.class).getStatus().name() );
            }
            return false;
        }
    });
}

@EventHandler
void onEntityAddToWorld(final EntityAddToWorldEvent event) {
    if (event.getEntity() instanceof Boat boat) {
        this.logger.info("EntityAddToWorldEvent: " + boat.getStatus().name());
    }
}

/*
 * Ride on the boat and reconnect the server
 */
@EventHandler
void onEntityMount(final EntityMountEvent event) {
    if (event.getMount() instanceof Boat boat) {
        this.logger.info("EntityMountEvent: " + boat.getStatus().name());
    }
}
```