### PR TITLE
Handle location of player if was moved for not valid world

### DIFF
--- a/patches/server/0384-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/patches/server/0384-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -6,8 +6,46 @@ Subject: [PATCH] Move player to spawn point if spawn in unloaded world
 The code following this has better support for null worlds to move
 them back to the world spawn.
 
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index a0832d8e8b9e91073c15e5a87953d6ccee544ae0..89dd1b7d3687df12d84b82666ac5c0201cb11ff8 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -202,13 +202,19 @@ public abstract class PlayerList {
+             s = bukkit.contains("lastKnownName", 8) ? bukkit.getString("lastKnownName") : s;
+         }
+         // CraftBukkit end
++        boolean needResetSpawnPos = false; // Paper
+ 
+         if (nbttagcompound != null) {
+             DataResult<ResourceKey<Level>> dataresult = DimensionType.parseLegacy(new Dynamic(NbtOps.INSTANCE, nbttagcompound.get("Dimension"))); // CraftBukkit - decompile error
+             Logger logger = PlayerList.LOGGER;
+ 
+             Objects.requireNonNull(logger);
+-            resourcekey = (ResourceKey) dataresult.resultOrPartial(logger::error).orElse(Level.OVERWORLD);
++            // Paper start - detect when cannot find the dimension
++            //resourcekey = (ResourceKey) dataresult.resultOrPartial(logger::error).orElse(Level.OVERWORLD);
++            Optional<ResourceKey<Level>> optionalResourceKey = dataresult.resultOrPartial(logger::error);
++            needResetSpawnPos = optionalResourceKey.isEmpty();
++            resourcekey = optionalResourceKey.orElse(Level.OVERWORLD);
++            // Paper stop
+         } else {
+             resourcekey = Level.OVERWORLD;
+         }
+@@ -225,9 +231,9 @@ public abstract class PlayerList {
+         }
+ 
+         // Paper start
+-        if (nbttagcompound == null) {
+-            player.spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT; // set Player SpawnReason to DEFAULT on first login
+-            player.fudgeSpawnLocation(worldserver1); // only move to spawn on first login, otherwise, stay where you are....
++        if (nbttagcompound == null || needResetSpawnPos) {
++            if (nbttagcompound == null) player.spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT; // set Player SpawnReason to DEFAULT on first login
++            player.fudgeSpawnLocation(worldserver1); // only move to spawn on first login or when world spawn was change, otherwise, stay where you are....
+         }
+         // Paper end
+         player.setLevel(worldserver1);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8cfa823940b0fada04022034023f5372f1ca8b9f..d3f9954bda58b459e2f64b5d949807ab60905d48 100644
+index 8c922e29ae57f781d4f27d53b04ed90a24d81ca4..d04c5cd4afd09fbe511811a198135c19ee99c036 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2199,9 +2199,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {

--- a/patches/server/0432-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0432-incremental-chunk-and-player-saving.patch
@@ -127,10 +127,10 @@ index d560e5dee586bb3b501e9a78083b9aa961c48fc5..ce6ae0ec4d104929f2c3fe03b0f44eaf
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      public ServerGamePacketListenerImpl connection;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index a0832d8e8b9e91073c15e5a87953d6ccee544ae0..6837054dc812b249db0dc975dc8f5506437260f4 100644
+index 89dd1b7d3687df12d84b82666ac5c0201cb11ff8..314435def9a15e2c57a6d0c491a5977faac117c6 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -526,6 +526,7 @@ public abstract class PlayerList {
+@@ -532,6 +532,7 @@ public abstract class PlayerList {
  
      protected void save(ServerPlayer player) {
          if (!player.getBukkitEntity().isPersistent()) return; // CraftBukkit
@@ -138,7 +138,7 @@ index a0832d8e8b9e91073c15e5a87953d6ccee544ae0..6837054dc812b249db0dc975dc8f5506
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -1116,10 +1117,22 @@ public abstract class PlayerList {
+@@ -1122,10 +1123,22 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {

--- a/patches/server/0443-Spawn-player-in-correct-world-on-login.patch
+++ b/patches/server/0443-Spawn-player-in-correct-world-on-login.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Spawn player in correct world on login
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6837054dc812b249db0dc975dc8f5506437260f4..00551e6718d4e672f3d6758d1d7aabacc5b6239c 100644
+index 314435def9a15e2c57a6d0c491a5977faac117c6..5f092be2c77f73a8868083cd8d177a171f864838 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -203,7 +203,18 @@ public abstract class PlayerList {
-         }
+@@ -204,7 +204,19 @@ public abstract class PlayerList {
          // CraftBukkit end
+         boolean needResetSpawnPos = false; // Paper
  
 -        if (nbttagcompound != null) {
 +        // Paper start - move logic in Entity to here, to use bukkit supplied world UUID.
@@ -21,6 +21,7 @@ index 6837054dc812b249db0dc975dc8f5506437260f4..00551e6718d4e672f3d6758d1d7aabac
 +                resourcekey = ((CraftWorld) bWorld).getHandle().dimension();
 +            } else {
 +                resourcekey = Level.OVERWORLD;
++                needResetSpawnPos = true; // Paper - set reset the spawn because the world spawn change.
 +            }
 +        } else if (nbttagcompound != null) {
 +            // Vanilla migration support

--- a/patches/server/0449-Fix-SPIGOT-5989.patch
+++ b/patches/server/0449-Fix-SPIGOT-5989.patch
@@ -10,10 +10,10 @@ This fixes that by checking if the modified spawn location is
 still at a respawn anchor.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 00551e6718d4e672f3d6758d1d7aabacc5b6239c..19f525543e95a1b8de2ad3da45724969705e9c15 100644
+index 5f092be2c77f73a8868083cd8d177a171f864838..be48f9f2d0449eeb507022feaf62e9fb4c44b221 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -785,6 +785,7 @@ public abstract class PlayerList {
+@@ -792,6 +792,7 @@ public abstract class PlayerList {
          // Paper start
          boolean isBedSpawn = false;
          boolean isRespawn = false;
@@ -21,7 +21,7 @@ index 00551e6718d4e672f3d6758d1d7aabacc5b6239c..19f525543e95a1b8de2ad3da45724969
          // Paper end
  
          // CraftBukkit start - fire PlayerRespawnEvent
-@@ -795,7 +796,7 @@ public abstract class PlayerList {
+@@ -802,7 +803,7 @@ public abstract class PlayerList {
                  Optional optional;
  
                  if (blockposition != null) {
@@ -30,7 +30,7 @@ index 00551e6718d4e672f3d6758d1d7aabacc5b6239c..19f525543e95a1b8de2ad3da45724969
                  } else {
                      optional = Optional.empty();
                  }
-@@ -839,7 +840,12 @@ public abstract class PlayerList {
+@@ -846,7 +847,12 @@ public abstract class PlayerList {
              }
              // Spigot End
  
@@ -44,7 +44,7 @@ index 00551e6718d4e672f3d6758d1d7aabacc5b6239c..19f525543e95a1b8de2ad3da45724969
              if (!flag) entityplayer.reset(); // SPIGOT-4785
              isRespawn = true; // Paper
          } else {
-@@ -879,8 +885,14 @@ public abstract class PlayerList {
+@@ -886,8 +892,14 @@ public abstract class PlayerList {
          }
          // entityplayer1.initInventoryMenu();
          entityplayer1.setHealth(entityplayer1.getHealth());

--- a/patches/server/0500-Add-API-for-quit-reason.patch
+++ b/patches/server/0500-Add-API-for-quit-reason.patch
@@ -49,10 +49,10 @@ index 0a06cdcccbdf503814386c27a8fb614da671c441..d68db0fc61be13b5970a3c3c8e4b870c
              this.connection.disconnect(ichatbasecomponent);
          }));
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 162b09cda517afe3b87321a4fe871c183db37621..0df62830f211f96e9341f618282c6cb5834d76aa 100644
+index 8171055d3c01e495c64c4e89e580a415d6070adc..7a2ebe96abff795d03a62cf3b47f9812ccb6e766 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -564,7 +564,7 @@ public abstract class PlayerList {
+@@ -571,7 +571,7 @@ public abstract class PlayerList {
              entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  

--- a/patches/server/0502-Expose-world-spawn-angle.patch
+++ b/patches/server/0502-Expose-world-spawn-angle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose world spawn angle
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0df62830f211f96e9341f618282c6cb5834d76aa..bdd87da66db5febfb4e1f69d8c5f75fd28c23ea1 100644
+index 7a2ebe96abff795d03a62cf3b47f9812ccb6e766..a7afa3ddb49e15f9783d7a10b507175eb8268c7a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -828,7 +828,7 @@ public abstract class PlayerList {
+@@ -835,7 +835,7 @@ public abstract class PlayerList {
              if (location == null) {
                  worldserver1 = this.server.getLevel(Level.OVERWORLD);
                  blockposition = entityplayer1.getSpawnPoint(worldserver1);

--- a/patches/server/0544-Fix-villager-boat-exploit.patch
+++ b/patches/server/0544-Fix-villager-boat-exploit.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix villager boat exploit
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index bdd87da66db5febfb4e1f69d8c5f75fd28c23ea1..8184c987ecb91a11b260d89a4807ddfcb1f9aaf8 100644
+index a7afa3ddb49e15f9783d7a10b507175eb8268c7a..5b12fa4cb7a15b713e9774050ef38181efbe027a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -589,6 +589,14 @@ public abstract class PlayerList {
+@@ -596,6 +596,14 @@ public abstract class PlayerList {
                  PlayerList.LOGGER.debug("Removing player mount");
                  entityplayer.stopRiding();
                  entity.getPassengersAndSelf().forEach((entity1) -> {

--- a/patches/server/0545-Add-sendOpLevel-API.patch
+++ b/patches/server/0545-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 8184c987ecb91a11b260d89a4807ddfcb1f9aaf8..a6a58b9f9c3ae4acac374e4a29b41178aa0dec00 100644
+index 5b12fa4cb7a15b713e9774050ef38181efbe027a..46b86dd62b058941bbb9d5360951a1fbaf0f5c38 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1077,6 +1077,11 @@ public abstract class PlayerList {
+@@ -1084,6 +1084,11 @@ public abstract class PlayerList {
      }
  
      private void sendPlayerPermissionLevel(ServerPlayer player, int permissionLevel) {
@@ -20,7 +20,7 @@ index 8184c987ecb91a11b260d89a4807ddfcb1f9aaf8..a6a58b9f9c3ae4acac374e4a29b41178
          if (player.connection != null) {
              byte b0;
  
-@@ -1091,8 +1096,10 @@ public abstract class PlayerList {
+@@ -1098,8 +1103,10 @@ public abstract class PlayerList {
              player.connection.send(new ClientboundEntityEventPacket(player, b0));
          }
  

--- a/patches/server/0585-Drop-carried-item-when-player-has-disconnected.patch
+++ b/patches/server/0585-Drop-carried-item-when-player-has-disconnected.patch
@@ -7,10 +7,10 @@ Fixes disappearance of held items, when a player gets disconnected and PlayerDro
 Closes #5036
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b88f0c64d3509550c699f21505118312f88ff71d..fa195977aa53fcaea0e9873a484148efad51aefc 100644
+index 41239aa22ff917db7146ee502ce4a90470bfe8ab..a057392adb495f6c8deef69239cd1e98c29837f0 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -582,6 +582,14 @@ public abstract class PlayerList {
+@@ -589,6 +589,14 @@ public abstract class PlayerList {
          }
          // Paper end
  

--- a/patches/server/0603-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
+++ b/patches/server/0603-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix anchor respawn acting as a bed respawn from the end
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index fa195977aa53fcaea0e9873a484148efad51aefc..116a52b29beefce65e875a35ddae6caf255b7b54 100644
+index a057392adb495f6c8deef69239cd1e98c29837f0..13d1c21bd10ba9d83fbe6aa6e5390637dd7899e2 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -801,6 +801,7 @@ public abstract class PlayerList {
+@@ -808,6 +808,7 @@ public abstract class PlayerList {
  
          // Paper start
          boolean isBedSpawn = false;
@@ -17,7 +17,7 @@ index fa195977aa53fcaea0e9873a484148efad51aefc..116a52b29beefce65e875a35ddae6caf
          boolean isRespawn = false;
          boolean isLocAltered = false; // Paper - Fix SPIGOT-5989
          // Paper end
-@@ -821,6 +822,7 @@ public abstract class PlayerList {
+@@ -828,6 +829,7 @@ public abstract class PlayerList {
                  if (optional.isPresent()) {
                      BlockState iblockdata = worldserver1.getBlockState(blockposition);
                      boolean flag3 = iblockdata.is(Blocks.RESPAWN_ANCHOR);
@@ -25,7 +25,7 @@ index fa195977aa53fcaea0e9873a484148efad51aefc..116a52b29beefce65e875a35ddae6caf
                      Vec3 vec3d = (Vec3) optional.get();
                      float f1;
  
-@@ -849,7 +851,7 @@ public abstract class PlayerList {
+@@ -856,7 +858,7 @@ public abstract class PlayerList {
              }
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();

--- a/patches/server/0605-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/server/0605-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -18,10 +18,10 @@ index 2ac2390b572c223e8c35a24e8f0978d39da148cc..4df88bd988c2e4d0b6d4d09e6c897b1d
                  } else {
                      if (this.player.getHealth() > 0.0F) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 116a52b29beefce65e875a35ddae6caf255b7b54..54ccfd45a4a8373a40e7153c569b654fe2110506 100644
+index 13d1c21bd10ba9d83fbe6aa6e5390637dd7899e2..2ede045c77a2a1379781667f5beab57f25ccf750 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -760,6 +760,12 @@ public abstract class PlayerList {
+@@ -767,6 +767,12 @@ public abstract class PlayerList {
      }
  
      public ServerPlayer respawn(ServerPlayer entityplayer, ServerLevel worldserver, boolean flag, Location location, boolean avoidSuffocation, RespawnReason reason) {
@@ -34,7 +34,7 @@ index 116a52b29beefce65e875a35ddae6caf255b7b54..54ccfd45a4a8373a40e7153c569b654f
          entityplayer.stopRiding(); // CraftBukkit
          this.players.remove(entityplayer);
          this.playersByName.remove(entityplayer.getScoreboardName().toLowerCase(java.util.Locale.ROOT)); // Spigot
-@@ -851,7 +857,7 @@ public abstract class PlayerList {
+@@ -858,7 +864,7 @@ public abstract class PlayerList {
              }
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();

--- a/patches/server/0629-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0629-Add-PlayerKickEvent-causes.patch
@@ -434,10 +434,10 @@ index ef670cf38d3ddbeff0f2b87a41cbed695116f270..82ddc28c97bf8ecf2ca703b612d752c0
  
              }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 54ccfd45a4a8373a40e7153c569b654fe2110506..dae66865e84352527f5115e37586f729d32c55cd 100644
+index 2ede045c77a2a1379781667f5beab57f25ccf750..aafc2cebd733a101136c83e094c8ca09ec8c8c3c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -669,7 +669,7 @@ public abstract class PlayerList {
+@@ -676,7 +676,7 @@ public abstract class PlayerList {
          while (iterator.hasNext()) {
              entityplayer = (ServerPlayer) iterator.next();
              this.save(entityplayer); // CraftBukkit - Force the player's inventory to be saved
@@ -446,7 +446,7 @@ index 54ccfd45a4a8373a40e7153c569b654fe2110506..dae66865e84352527f5115e37586f729
          }
  
          // Instead of kicking then returning, we need to store the kick reason
-@@ -1305,8 +1305,8 @@ public abstract class PlayerList {
+@@ -1312,8 +1312,8 @@ public abstract class PlayerList {
          // Paper end
          // CraftBukkit start - disconnect safely
          for (ServerPlayer player : this.players) {

--- a/patches/server/0651-Fixes-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0651-Fixes-kick-event-leave-message-not-being-sent.patch
@@ -59,10 +59,10 @@ index d11d2dc10a8add75812f24234b8bf9c97fcb635c..7d257a0461739f0a4a59f9c17b237c44
              this.server.getPlayerList().broadcastSystemMessage(PaperAdventure.asVanilla(quitMessage), false);
              // Paper end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index dae66865e84352527f5115e37586f729d32c55cd..5db5e6b59ff996012f5b2d546f54d1f3b7442ce0 100644
+index aafc2cebd733a101136c83e094c8ca09ec8c8c3c..d684951dc3d7988d1cc60c2b05bb0b1211258188 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -555,6 +555,11 @@ public abstract class PlayerList {
+@@ -562,6 +562,11 @@ public abstract class PlayerList {
      }
  
      public net.kyori.adventure.text.Component remove(ServerPlayer entityplayer) { // Paper - return Component
@@ -74,7 +74,7 @@ index dae66865e84352527f5115e37586f729d32c55cd..5db5e6b59ff996012f5b2d546f54d1f3
          ServerLevel worldserver = entityplayer.getLevel();
  
          entityplayer.awardStat(Stats.LEAVE_GAME);
-@@ -565,7 +570,7 @@ public abstract class PlayerList {
+@@ -572,7 +577,7 @@ public abstract class PlayerList {
              entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  

--- a/patches/server/0665-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0665-Add-PlayerSetSpawnEvent.patch
@@ -89,10 +89,10 @@ index af8af6bb44b84c74553068b6cd64f4e3941d4ae1..bc6ddf50bcd2f38be8c8fa064b49a736
  
      public void trackChunk(ChunkPos chunkPos, Packet<?> chunkDataPacket) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 5db5e6b59ff996012f5b2d546f54d1f3b7442ce0..79aac02a4c702797c72970a40a17bdf4115fa644 100644
+index d684951dc3d7988d1cc60c2b05bb0b1211258188..5a4a8b61ee3b6bc74ac676f175067c4965ff6a1e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -845,13 +845,13 @@ public abstract class PlayerList {
+@@ -852,13 +852,13 @@ public abstract class PlayerList {
                          f1 = (float) Mth.wrapDegrees(Mth.atan2(vec3d1.z, vec3d1.x) * 57.2957763671875D - 90.0D);
                      }
  

--- a/patches/server/0738-Add-config-option-for-logging-player-ip-addresses.patch
+++ b/patches/server/0738-Add-config-option-for-logging-player-ip-addresses.patch
@@ -47,10 +47,10 @@ index 595779cfd0ee1c405d7936f00a7cae1706125e7f..ed3af916dfa875dd0a5f1e730d20d11e
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 79aac02a4c702797c72970a40a17bdf4115fa644..0b3b926e6d9a0afbd2f4674517e39b3addd8acf5 100644
+index 5a4a8b61ee3b6bc74ac676f175067c4965ff6a1e..d0d60559f670a76c0924e783b60d0ce394070a2e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -246,7 +246,7 @@ public abstract class PlayerList {
+@@ -253,7 +253,7 @@ public abstract class PlayerList {
          String s1 = "local";
  
          if (connection.getRemoteAddress() != null) {

--- a/patches/server/0756-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0756-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -1202,10 +1202,10 @@ index d9719e544261b9d2dc85fa9936ae23ea8e8dd08c..5afb17ccc16e614e91ff3cad2f714b4a
              }
          }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0b3b926e6d9a0afbd2f4674517e39b3addd8acf5..3c3e110f7caaf42783638aac74ef5e69513d1fff 100644
+index d0d60559f670a76c0924e783b60d0ce394070a2e..04609a03fc1bb69ba26881750950ee329b4591ad 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -886,7 +886,7 @@ public abstract class PlayerList {
+@@ -893,7 +893,7 @@ public abstract class PlayerList {
          // CraftBukkit end
  
          worldserver1.getChunkSource().addRegionTicket(net.minecraft.server.level.TicketType.POST_TELEPORT, new net.minecraft.world.level.ChunkPos(location.getBlockX() >> 4, location.getBlockZ() >> 4), 1, entityplayer.getId()); // Paper

--- a/patches/server/0773-Validate-usernames.patch
+++ b/patches/server/0773-Validate-usernames.patch
@@ -56,10 +56,10 @@ index ed3af916dfa875dd0a5f1e730d20d11efd6419c6..cd4e76fe5b79c7d9e615b4886a568c74
  
          if (gameprofile != null && packet.name().equalsIgnoreCase(gameprofile.getName())) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3c3e110f7caaf42783638aac74ef5e69513d1fff..c609f63a2e0deffba852f83a5990ad5150029948 100644
+index 04609a03fc1bb69ba26881750950ee329b4591ad..9afcda707e0494ef11c64176dbb8254a4a79cebd 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -664,7 +664,7 @@ public abstract class PlayerList {
+@@ -671,7 +671,7 @@ public abstract class PlayerList {
  
          for (int i = 0; i < this.players.size(); ++i) {
              entityplayer = (ServerPlayer) this.players.get(i);

--- a/patches/server/0804-Force-close-world-loading-screen.patch
+++ b/patches/server/0804-Force-close-world-loading-screen.patch
@@ -10,10 +10,10 @@ so we do not need that. The client only needs the chunk it is currently in to
 be loaded to close the loading screen, so we just send an empty one.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c609f63a2e0deffba852f83a5990ad5150029948..1cdf4d8794e982ff24c50a0267fbb024bbaba668 100644
+index 9afcda707e0494ef11c64176dbb8254a4a79cebd..86e13d016e2f16139d7b0b0011c4c59849eab525 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -387,6 +387,16 @@ public abstract class PlayerList {
+@@ -394,6 +394,16 @@ public abstract class PlayerList {
  
          // Paper start - move vehicle into method so it can be called above - short circuit around that code
          onPlayerJoinFinish(player, worldserver1, s1);

--- a/patches/server/0826-Use-username-instead-of-display-name-in-PlayerList-g.patch
+++ b/patches/server/0826-Use-username-instead-of-display-name-in-PlayerList-g.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Use username instead of display name in
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 1cdf4d8794e982ff24c50a0267fbb024bbaba668..aa67dd615a06d5f109a8f57dd3e6413e159cad2b 100644
+index 86e13d016e2f16139d7b0b0011c4c59849eab525..32037abba98bdd9fa3d4c87776ac0f6e61f43c2f 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1421,7 +1421,7 @@ public abstract class PlayerList {
+@@ -1428,7 +1428,7 @@ public abstract class PlayerList {
      // CraftBukkit start
      public ServerStatsCounter getPlayerStats(ServerPlayer entityhuman) {
          ServerStatsCounter serverstatisticmanager = entityhuman.getStats();

--- a/patches/server/0928-Properly-resend-entities.patch
+++ b/patches/server/0928-Properly-resend-entities.patch
@@ -79,10 +79,10 @@ index b2a72e529b60eac033ac609cc11429ddbef0d422..c3db04aefe288a42d6a82291cc0164c8
                              }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index aa67dd615a06d5f109a8f57dd3e6413e159cad2b..68e47dfff2519ed1fbe92f265f942fcc6cd6a00d 100644
+index 32037abba98bdd9fa3d4c87776ac0f6e61f43c2f..0c5adcb3d51ef5bed497996bc65375761b337ea7 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -362,7 +362,7 @@ public abstract class PlayerList {
+@@ -369,7 +369,7 @@ public abstract class PlayerList {
          ((ServerLevel)player.level).getChunkSource().chunkMap.addEntity(player); // Paper - track entity now
          // CraftBukkit end
  

--- a/patches/server/0945-Use-single-player-info-update-packet-on-join.patch
+++ b/patches/server/0945-Use-single-player-info-update-packet-on-join.patch
@@ -18,10 +18,10 @@ index 9029be5f8a1f2c0719bf5e4012f72b52cf82b060..f5888a2216a017b0db24ff7bfe2fc8f4
          });
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 68e47dfff2519ed1fbe92f265f942fcc6cd6a00d..4d837c1530a3031a4c2a5a39d87bd013d60e14a6 100644
+index 0c5adcb3d51ef5bed497996bc65375761b337ea7..a2c63f2c8fab3442f01c0bca85c66e8fab485f72 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -308,7 +308,7 @@ public abstract class PlayerList {
+@@ -315,7 +315,7 @@ public abstract class PlayerList {
              player.sendServerStatus(serverping);
          }
  
@@ -30,7 +30,7 @@ index 68e47dfff2519ed1fbe92f265f942fcc6cd6a00d..4d837c1530a3031a4c2a5a39d87bd013
          this.players.add(player);
          this.playersByName.put(player.getScoreboardName().toLowerCase(java.util.Locale.ROOT), player); // Spigot
          this.playersByUUID.put(player.getUUID(), player);
-@@ -344,6 +344,7 @@ public abstract class PlayerList {
+@@ -351,6 +351,7 @@ public abstract class PlayerList {
          // CraftBukkit start - sendAll above replaced with this loop
          ClientboundPlayerInfoUpdatePacket packet = ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(player));
  
@@ -38,7 +38,7 @@ index 68e47dfff2519ed1fbe92f265f942fcc6cd6a00d..4d837c1530a3031a4c2a5a39d87bd013
          for (int i = 0; i < this.players.size(); ++i) {
              ServerPlayer entityplayer1 = (ServerPlayer) this.players.get(i);
  
-@@ -351,12 +352,17 @@ public abstract class PlayerList {
+@@ -358,12 +359,17 @@ public abstract class PlayerList {
                  entityplayer1.connection.send(packet);
              }
  


### PR DESCRIPTION
This clos e #9081 like the issue said when the world of spawn change because the world is unloaded or not exists keep the previous location causing issues when the player spawn, this PR modify two patchs related to handle the world spawn for add a conditional for call a method used to handle location for "new" players in world.