### PR TITLE
Undo making JavaPlugin#logger field public

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -57,4 +57,5 @@ Denery <dorofeevij@gmail.com>
 Jakubk15 <jakubk15@protonmail.com>
 Redned <redned235@gmail.com>
 Luke Chambers <consolelogluke@gmail.com>
+Emily <emilia.lopezf.1999@gmail.com>
 ```

--- a/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
+++ b/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
@@ -67,33 +67,33 @@ index 0000000000000000000000000000000000000000..087ee57fe5485bc760fadd45a176d4d9
 +
 +}
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index 71c8d2345eef6895edb8d210553ec3cddd9c76d0..6d31f3a2569ae9c522a5e6cddd38ac8f252f1bfe 100644
+index 71c8d2345eef6895edb8d210553ec3cddd9c76d0..2139377f7370a8352d36f2d10d2a726d528e1a47 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -44,7 +44,7 @@ public abstract class JavaPlugin extends PluginBase {
-     private boolean naggable = true;
-     private FileConfiguration newConfig = null;
-     private File configFile = null;
--    private Logger logger = null; // Paper - PluginLogger -> Logger
-+    public Logger logger = null; // Paper - PluginLogger -> Logger, public
- 
-     public JavaPlugin() {
-         // Paper start
-@@ -302,7 +302,11 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -289,10 +289,10 @@ public abstract class JavaPlugin extends PluginBase {
+             .orElseThrow();
+     }
+     public final void init(@NotNull PluginLoader loader, @NotNull Server server, @NotNull PluginDescriptionFile description, @NotNull File dataFolder, @NotNull File file, @NotNull ClassLoader classLoader) {
+-        init(server, description, dataFolder, file, classLoader, description);
++        init(server, description, dataFolder, file, classLoader, description, com.destroystokyo.paper.utils.PaperPluginLogger.getLogger(description));
+         this.pluginMeta = description;
+     }
+-    public final void init(@NotNull Server server, @NotNull PluginDescriptionFile description, @NotNull File dataFolder, @NotNull File file, @NotNull ClassLoader classLoader, @Nullable io.papermc.paper.plugin.configuration.PluginMeta configuration) {
++    public final void init(@NotNull Server server, @NotNull PluginDescriptionFile description, @NotNull File dataFolder, @NotNull File file, @NotNull ClassLoader classLoader, @Nullable io.papermc.paper.plugin.configuration.PluginMeta configuration, @NotNull Logger logger) {
+     // Paper end
+         this.loader = DummyPluginLoaderImplHolder.INSTANCE; // Paper
+         this.server = server;
+@@ -302,7 +302,7 @@ public abstract class JavaPlugin extends PluginBase {
          this.classLoader = classLoader;
          this.configFile = new File(dataFolder, "config.yml");
          this.pluginMeta = configuration; // Paper
 -        this.logger = Logger.getLogger(description.getPrefix() != null ? description.getPrefix() : description.getName()); // Paper - Handle plugin prefix in implementation
-+        // Paper start
-+        if (this.logger == null) {
-+            this.logger = com.destroystokyo.paper.utils.PaperPluginLogger.getLogger(this.description);
-+        }
-+        // Paper end
++        this.logger = logger; // Paper
      }
  
      /**
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 2d2fa6ce5200eb5c75a733f9f54f400113cc22b0..5c5aadc15c8198e0e79b4ac0f043a45720aef002 100644
+index 302319acbc257a075adfb78d9f5c49fdadf45bdc..a8ac1fb22a6fba50d69bf726b49c49ba190ab79a 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -65,7 +65,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
@@ -105,11 +105,12 @@ index 2d2fa6ce5200eb5c75a733f9f54f400113cc22b0..5c5aadc15c8198e0e79b4ac0f043a457
          // Paper start
          this.dependencyContext = dependencyContext;
          this.classLoaderGroup = io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage.instance().registerSpigotGroup(this);
-@@ -249,6 +249,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -249,7 +249,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
          pluginState = new IllegalStateException("Initial initialization");
          this.pluginInit = javaPlugin;
  
-+        javaPlugin.logger = this.logger; // Paper - set logger
-         javaPlugin.init(null, org.bukkit.Bukkit.getServer(), description, dataFolder, file, this); // Paper
+-        javaPlugin.init(null, org.bukkit.Bukkit.getServer(), description, dataFolder, file, this); // Paper
++        javaPlugin.init(org.bukkit.Bukkit.getServer(), description, dataFolder, file, this, description, this.logger); // Paper
      }
  
+     // Paper start

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -813,10 +813,10 @@ index 0000000000000000000000000000000000000000..f9a2c55a354c877749db3f92956de802
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..56fc3e0984861e8ddb597cad3c0a0e0aca9606e6
+index 0000000000000000000000000000000000000000..82487d656acaf41afe3af9c05a3dbf122bdf19c1
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/PaperPluginClassLoader.java
-@@ -0,0 +1,207 @@
+@@ -0,0 +1,206 @@
 +package io.papermc.paper.plugin.entrypoint.classloader;
 +
 +import io.papermc.paper.plugin.configuration.PluginMeta;
@@ -990,8 +990,7 @@ index 0000000000000000000000000000000000000000..56fc3e0984861e8ddb597cad3c0a0e0a
 +
 +        File dataFolder = new File(Bukkit.getPluginsFolder(), pluginDescriptionFile.getName());
 +
-+        plugin.init(Bukkit.getServer(), pluginDescriptionFile, dataFolder, this.source.toFile(), this, config);
-+        plugin.logger = this.logger;
++        plugin.init(Bukkit.getServer(), pluginDescriptionFile, dataFolder, this.source.toFile(), this, config, this.logger);
 +
 +        this.loadedJavaPlugin = plugin;
 +    }


### PR DESCRIPTION
During the development of paper plugins, [api/0072 Add workaround for plugins modifying the parent of the plugin logger](https://github.com/PaperMC/Paper/blob/e338793603e7b57ab439a1b925e3092cb623f616/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch) was modified to make the `Logger logger` field public so `PaperPluginClassLoader` could set it like `PluginClassLoader` does (the patch originally made the field package-private). This has caused some issues (most noticeably) for devs using Kotlin depending on an API version post paper plugins and trying to run the plugin on older versions (because the kt compiler seeing `plugin.logger` decided to use the field instead of the getter as one would assume) and has been brought a few times already.

MiniDigger suggested the patch could do without making the field public, and I decided to PR that. To change this I decided to DI the logger in the `JavaPlugin#init` method instead of making it package-private or public.

Additionally I added a Commodore fix for the (hopefully few) plugins that were compiled using the field access rather than the getter, mapping getfield to an invokevirtual call (though I did consider not doing this altogether since it would be misuse of the API (?)).


Thanks Owen :3