### PR TITLE
[ci skip] Fix missing closing quote

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -41,7 +41,7 @@ jobs:
               "status: blocked": "Needs Work",
               "status: defer upstream": "Needs Work",
               "status: input wanted": "Needs Work",
-              "we must go deeper: "Needs Work",
+              "we must go deeper": "Needs Work",
               "has rough edges": "Needs Work",
               "status: waiting on reporter": "⌛ Waiting for Reporter",
               "resolution: works-as-intended": "Invalid",


### PR DESCRIPTION
There is a missing closing quote that causes a json parsing error.