### PR TITLE
Use player scoreboard for determining collision rule when pushing entities

### DIFF
--- a/patches/server/0380-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0380-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -12,7 +12,7 @@ The entity's current team collision rule causes them to NEVER collide.
 Co-authored-by: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e6e4856db7d983460fdf898583915ff2e4a43d14..25e1dc97e3260e7f58b15a1759b8f9531c6a6f20 100644
+index 1619942f973cd20bcfce67e48762c69ffdc1e3e0..cdcb063c1a014cc0028a4eec5ed34a38dd43a697 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3328,10 +3328,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -23,7 +23,7 @@ index e6e4856db7d983460fdf898583915ff2e4a43d14..25e1dc97e3260e7f58b15a1759b8f953
 +            if (!this.isPushable()) {
 +                return;
 +            }
-+            net.minecraft.world.scores.Team team = this.getTeam();
++            net.minecraft.world.scores.Team team = this instanceof net.minecraft.world.entity.player.Player player ? player.getScoreboard().getPlayersTeam(this.getScoreboardName()) : this.getTeam();
 +            if (team != null && team.getCollisionRule() == net.minecraft.world.scores.Team.CollisionRule.NEVER) {
 +                return;
 +            }

--- a/patches/server/0974-Use-player-scoreboard-for-determining-collision-rule.patch
+++ b/patches/server/0974-Use-player-scoreboard-for-determining-collision-rule.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Redned <redned235@gmail.com>
+Date: Tue, 11 Apr 2023 22:43:42 -0500
+Subject: [PATCH] Use player scoreboard for determining collision rule when
+ pushing entities
+
+The vanilla code in EntitySelector#pushable uses the Entity#getTeam method which returns the Level scoreboard. This means the wrong collision option is returned here  when an API scoreboard is being used. Although no actual pushing occurs here as the client takes authority for that, the server still emits footstep sounds and treats it as if collision should be happening when it should not be.
+
+diff --git a/src/main/java/net/minecraft/world/entity/EntitySelector.java b/src/main/java/net/minecraft/world/entity/EntitySelector.java
+index 72abebff2018cde2922e97ad6478f93da9aed3ec..6884e21e587e7c81be3e1596400141f97ecc7665 100644
+--- a/src/main/java/net/minecraft/world/entity/EntitySelector.java
++++ b/src/main/java/net/minecraft/world/entity/EntitySelector.java
+@@ -62,7 +62,7 @@ public final class EntitySelector {
+ 
+     public static Predicate<Entity> pushable(Entity entity, boolean ignoreClimbing) {
+         // Paper end
+-        Team scoreboardteambase = entity.getTeam();
++        Team scoreboardteambase = entity instanceof net.minecraft.world.entity.player.Player player ? player.getScoreboard().getPlayersTeam(player.getScoreboardName()) : entity.getTeam(); // Paper - use player scoreboard team for collision rule
+         Team.CollisionRule scoreboardteambase_enumteampush = scoreboardteambase == null ? Team.CollisionRule.ALWAYS : scoreboardteambase.getCollisionRule();
+ 
+         return (Predicate) (scoreboardteambase_enumteampush == Team.CollisionRule.NEVER ? Predicates.alwaysFalse() : EntitySelector.NO_SPECTATORS.and((entity1) -> {
+@@ -71,7 +71,7 @@ public final class EntitySelector {
+             } else if (entity.level.isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
+                 return false;
+             } else {
+-                Team scoreboardteambase1 = entity1.getTeam();
++                Team scoreboardteambase1 = entity1 instanceof net.minecraft.world.entity.player.Player player ? player.getScoreboard().getPlayersTeam(player.getScoreboardName()) : entity1.getTeam(); // Paper - use player scoreboard team for collision rule
+                 Team.CollisionRule scoreboardteambase_enumteampush1 = scoreboardteambase1 == null ? Team.CollisionRule.ALWAYS : scoreboardteambase1.getCollisionRule();
+ 
+                 if (scoreboardteambase_enumteampush1 == Team.CollisionRule.NEVER) {


### PR DESCRIPTION
The vanilla code in EntitySelector#pushable uses the Entity#getTeam method which returns the Level scoreboard. This means the wrong collision option is returned here  when an API scoreboard is being used. Although no actual pushing occurs here as the client takes authority for that, the server still emits footstep sounds and treats it as if collision should be happening when it should not be.

Demonstration of the issue (turn sound on):

https://user-images.githubusercontent.com/29153871/231344227-2ed04480-a01c-4106-8a33-fdbfe49dd720.mp4

