### PR TITLE
Allow non persistent Entities in Raw Byte Serialization

### DIFF
--- a/patches/server/0690-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0690-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,10 +5,29 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index de50f1aa6b7cebf877e18bc3e2ae3ba707edcd4c..3a388ead677be73b0ae4425a05a45cd34e95d586 100644
+index cfe232364abd407d5ce117428f78fa98a9d305f2..ddf02a8cfb0c7fa9ae25e099933686b47b4d3e5d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2018,6 +2018,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2003,12 +2003,17 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+     }
+ 
+     public boolean saveAsPassenger(CompoundTag nbt) {
++        // Paper start - Entity serialization api
++        return saveAsPassenger(nbt, false);
++    }
++    public boolean saveAsPassenger(CompoundTag nbt, boolean force) {
++        // Paper end
+         if (this.removalReason != null && !this.removalReason.shouldSave()) {
+             return false;
+         } else {
+             String s = this.getEncodeId();
+ 
+-            if (!this.persist || s == null) { // CraftBukkit - persist flag
++            if ((!this.persist && !force) || s == null) { // CraftBukkit - persist flag // Paper - Entity serialization api
+                 return false;
+             } else {
+                 nbt.putString("id", s);
+@@ -2018,6 +2023,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
      }
  
@@ -16,7 +35,7 @@ index de50f1aa6b7cebf877e18bc3e2ae3ba707edcd4c..3a388ead677be73b0ae4425a05a45cd3
 +    public boolean serializeEntity(CompoundTag compound) {
 +        List<Entity> pass = new java.util.ArrayList<>(this.getPassengers());
 +        this.passengers = ImmutableList.of();
-+        boolean result = save(compound);
++        boolean result = this.isPassenger() ? false : this.saveAsPassenger(compound, true);
 +        this.passengers = ImmutableList.copyOf(pass);
 +        return result;
 +    }

--- a/patches/server/0703-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0703-Detail-more-information-in-watchdog-dumps.patch
@@ -122,7 +122,7 @@ index 8faf55969232d44b999231b219a208e049a72755..1f683d734b9e272c8f4c48d922f3dcd1
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b172f0733491ca6cde6b962f03e15e6e949ebf52..d87e9e252056d9dea6748f54847434468a0111df 100644
+index ddf02a8cfb0c7fa9ae25e099933686b47b4d3e5d..2111e2c28e33fb4f97a56bec32cdd4a778ddf239 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -972,7 +972,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -182,7 +182,7 @@ index b172f0733491ca6cde6b962f03e15e6e949ebf52..d87e9e252056d9dea6748f5484743446
      }
  
      protected boolean isHorizontalCollisionMinor(Vec3 adjustedMovement) {
-@@ -4097,7 +4139,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4102,7 +4144,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -192,7 +192,7 @@ index b172f0733491ca6cde6b962f03e15e6e949ebf52..d87e9e252056d9dea6748f5484743446
      }
  
      public void addDeltaMovement(Vec3 velocity) {
-@@ -4183,7 +4227,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4188,7 +4232,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
          // Paper end - fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {

--- a/patches/server/0756-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0756-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -1215,7 +1215,7 @@ index 0b3b926e6d9a0afbd2f4674517e39b3addd8acf5..3c3e110f7caaf42783638aac74ef5e69
          }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 45eeef03ab3c885b4fbc332287089e9cc5d85afa..63802f5304f23a6e1e469e383692376d1f4d8f0d 100644
+index 39ae5637c612b06644771f27fb6abea8253a53a1..e32b5ca1db7768eb147c370ec908395d1d80df06 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1161,9 +1161,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -1366,7 +1366,7 @@ index 45eeef03ab3c885b4fbc332287089e9cc5d85afa..63802f5304f23a6e1e469e383692376d
      }
  
      public static Vec3 collideBoundingBox(@Nullable Entity entity, Vec3 movement, AABB entityBoundingBox, Level world, List<VoxelShape> collisions) {
-@@ -2491,11 +2572,30 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2496,11 +2577,30 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              float f = this.dimensions.width * 0.8F;
              AABB axisalignedbb = AABB.ofSize(this.getEyePosition(), (double) f, 1.0E-6D, (double) f);
  

--- a/patches/server/0762-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0762-Forward-CraftEntity-in-teleport-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 63802f5304f23a6e1e469e383692376d1f4d8f0d..374ba7c9a088bc56ec1da96902aab3c81889c64d 100644
+index e32b5ca1db7768eb147c370ec908395d1d80df06..4d006643e695384f469c7227b27b2bb7232dec20 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3330,6 +3330,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3335,6 +3335,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void restoreFrom(Entity original) {
@@ -22,7 +22,7 @@ index 63802f5304f23a6e1e469e383692376d1f4d8f0d..374ba7c9a088bc56ec1da96902aab3c8
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3411,10 +3418,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3416,10 +3423,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      if (worldserver.getTypeKey() == LevelStem.END) { // CraftBukkit
                          ServerLevel.makeObsidianPlatform(worldserver, this); // CraftBukkit
                      }

--- a/patches/server/0786-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0786-Freeze-Tick-Lock-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 374ba7c9a088bc56ec1da96902aab3c81889c64d..dccac696c29a340c5a60fc07aaab7f0f1506b039 100644
+index 4d006643e695384f469c7227b27b2bb7232dec20..20efdaa62fcf95e9cd4bb27546e7cbae65a7ff85 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -397,6 +397,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -25,7 +25,7 @@ index 374ba7c9a088bc56ec1da96902aab3c81889c64d..dccac696c29a340c5a60fc07aaab7f0f
                  this.setTicksFrozen(0);
                  this.level.levelEvent((Player) null, 1009, this.blockPosition, 1);
              }
-@@ -2297,6 +2298,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2302,6 +2303,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (fromNetherPortal) {
                  nbt.putBoolean("Paper.FromNetherPortal", true);
              }
@@ -35,7 +35,7 @@ index 374ba7c9a088bc56ec1da96902aab3c81889c64d..dccac696c29a340c5a60fc07aaab7f0f
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2462,6 +2466,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2467,6 +2471,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (spawnReason == null) {
                  spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT;
              }

--- a/patches/server/0819-Ensure-entity-passenger-world-matches-ridden-entity.patch
+++ b/patches/server/0819-Ensure-entity-passenger-world-matches-ridden-entity.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ensure entity passenger world matches ridden entity
 Bad plugins doing this would cause some obvious problems...
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index dccac696c29a340c5a60fc07aaab7f0f1506b039..e052694ca221508f28cbfbb93a6ec974d9ca65d8 100644
+index 20efdaa62fcf95e9cd4bb27546e7cbae65a7ff85..1a94ba84ab49fd9d77be0b1ce9aec59ff41af1e2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2723,6 +2723,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2728,6 +2728,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/patches/server/0820-Guard-against-invalid-entity-positions.patch
+++ b/patches/server/0820-Guard-against-invalid-entity-positions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Guard against invalid entity positions
 Anything not finite should be blocked and logged
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e052694ca221508f28cbfbb93a6ec974d9ca65d8..b26fc1a1f30bd9736ac0cf09d381dc02c0bc34d6 100644
+index 1a94ba84ab49fd9d77be0b1ce9aec59ff41af1e2..cd7970847adf244fe95b6bb673894fe1b3150c48 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4326,11 +4326,33 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4331,11 +4331,33 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return this.getZ((2.0D * this.random.nextDouble() - 1.0D) * widthScale);
      }
  

--- a/patches/server/0859-Add-various-missing-EntityDropItemEvent-calls.patch
+++ b/patches/server/0859-Add-various-missing-EntityDropItemEvent-calls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add various missing EntityDropItemEvent calls
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 70fe8f109d86265200b2943e504610a2fb386420..496ba4f6a6a9e921bb7b311d96ff7cd7962eee11 100644
+index 3a2a4d966b2c3cf81cc3c5bbb4847a3317f9fedb..d442ad41651029640a2ec53475dfab568eaa450b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2557,6 +2557,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2562,6 +2562,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              stack.setCount(0); // Paper - destroy this item - if this ever leaks due to game bugs, ensure it doesn't dupe
  
              entityitem.setDefaultPickUpDelay();

--- a/patches/server/0864-Add-EntityPortalReadyEvent.patch
+++ b/patches/server/0864-Add-EntityPortalReadyEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add EntityPortalReadyEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 496ba4f6a6a9e921bb7b311d96ff7cd7962eee11..32a74fa1afeef72c9014ded08ffb29eba7be1a1b 100644
+index d442ad41651029640a2ec53475dfab568eaa450b..09a4455c21ab1bdb1aca560b9479f799656337e4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2912,6 +2912,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2917,6 +2917,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  if (true && !this.isPassenger() && this.portalTime++ >= i) { // CraftBukkit
                      this.level.getProfiler().push("portal");
                      this.portalTime = i;
@@ -22,7 +22,7 @@ index 496ba4f6a6a9e921bb7b311d96ff7cd7962eee11..32a74fa1afeef72c9014ded08ffb29eb
                      this.setPortalCooldown();
                      // CraftBukkit start
                      if (this instanceof ServerPlayer) {
-@@ -2919,6 +2926,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2924,6 +2931,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      } else {
                          this.changeDimension(worldserver1);
                      }

--- a/patches/server/0911-Fix-EntityCombustEvent-cancellation-cant-fully-preve.patch
+++ b/patches/server/0911-Fix-EntityCombustEvent-cancellation-cant-fully-preve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix EntityCombustEvent cancellation cant fully prevent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 32a74fa1afeef72c9014ded08ffb29eba7be1a1b..ad7754fc9bc8340ced8e39bcd882a1307781910c 100644
+index 09a4455c21ab1bdb1aca560b9479f799656337e4..cd42fc6e9beb6758efe9194dd85e9efca537a5c8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3183,6 +3183,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3188,6 +3188,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              pluginManager.callEvent(entityCombustEvent);
              if (!entityCombustEvent.isCancelled()) {
                  this.setSecondsOnFire(entityCombustEvent.getDuration(), false);

--- a/patches/server/0926-Player-Entity-Tracking-Events.patch
+++ b/patches/server/0926-Player-Entity-Tracking-Events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player Entity Tracking Events
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ad7754fc9bc8340ced8e39bcd882a1307781910c..8a7af77e8ac456cc89da7e954a8090bf794475c8 100644
+index cd42fc6e9beb6758efe9194dd85e9efca537a5c8..18aa8b44631f1cad3f6f6bbecde51757e4267b91 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3900,9 +3900,21 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3905,9 +3905,21 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          EnchantmentHelper.doPostDamageEffects(attacker, target);
      }
  

--- a/patches/server/0937-Improve-PortalEvents.patch
+++ b/patches/server/0937-Improve-PortalEvents.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Improve PortalEvents
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8a7af77e8ac456cc89da7e954a8090bf794475c8..448b3d68b440cfeeb4bf8c5c7aabfdc9bdb97fc0 100644
+index 18aa8b44631f1cad3f6f6bbecde51757e4267b91..f9b6610eb2b92c39b9f8789d3e2a399becce44a1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3561,7 +3561,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3566,7 +3566,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          Location enter = bukkitEntity.getLocation();
          Location exit = new Location(exitWorldServer.getWorld(), exitPosition.x(), exitPosition.y(), exitPosition.z());
  


### PR DESCRIPTION
This will allow to serialize non persist entities with the current implementation.

In my case I want to store entities not with the default implementation. So I want to set persistent to false and handle it on my own (EntitiesLoadEvent and EntitiesUnloadEvent). Using serializeEntity and deserializeEntity looks promising but it doesn't return the nbt correctly when it's not persistent.