### PR TITLE
Add option to flush region files on save

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1448,10 +1448,10 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ee430563b99e48cd722c2897e4729936457d3017
+index 0000000000000000000000000000000000000000..a33de97340f14219291c4175e9194914cdf441db
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,481 @@
+@@ -0,0 +1,482 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1880,6 +1880,7 @@ index 0000000000000000000000000000000000000000..ee430563b99e48cd722c2897e4729936
 +            map.put(EntityType.FIREBALL, -1);
 +            map.put(EntityType.SMALL_FIREBALL, -1);
 +        });
++        public boolean flushRegionsOnSave = false;
 +    }
 +
 +    public FishingTimeRange fishingTimeRange;

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -5486,10 +5486,10 @@ index 0000000000000000000000000000000000000000..fb42d776f15f735fb59e972e00e2b512
 +}
 diff --git a/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java b/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e4dcadc24b3d73178ee1a4b64b8c6343e5285e59
+index 0000000000000000000000000000000000000000..748cc48c6c42c694d1c9b685e96fbe6d8337d3f3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java
-@@ -0,0 +1,1204 @@
+@@ -0,0 +1,1211 @@
 +package io.papermc.paper.chunk.system.scheduling;
 +
 +import ca.spottedleaf.concurrentutil.executor.standard.PrioritisedExecutor;
@@ -5749,6 +5749,13 @@ index 0000000000000000000000000000000000000000..e4dcadc24b3d73178ee1a4b64b8c6343
 +        }
 +        if (flush) {
 +            RegionFileIOThread.flush();
++            if (this.world.paperConfig().chunks.flushRegionsOnSave) {
++                try {
++                    this.world.chunkSource.chunkMap.regionFileCache.flush();
++                } catch (IOException ex) {
++                    LOGGER.error("Exception when flushing regions in world {}", this.world.getWorld().getName(), ex);
++                }
++            }
 +        }
 +        if (logProgress) {
 +            LOGGER.info("Saved " + savedChunk + " block chunks, " + savedEntity + " entity chunks, " + savedPoi + " poi chunks in world '" + this.world.getWorld().getName() + "' in " + format.format(1.0E-9 * (System.nanoTime() - start)) + "s");

--- a/patches/server/0705-Distance-manager-tick-timings.patch
+++ b/patches/server/0705-Distance-manager-tick-timings.patch
@@ -19,10 +19,10 @@ index efbf77024d235d8af9f7efc938c17afd76a51b0c..670dcfa32d003870091b75937f1603a5
      public static final Timing midTickChunkTasks = Timings.ofSafe("Mid Tick Chunk Tasks");
  
 diff --git a/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java b/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java
-index e4dcadc24b3d73178ee1a4b64b8c6343e5285e59..e5d9c6f2cbe11c2ded6d8ad111fa6a8b2086dfba 100644
+index 748cc48c6c42c694d1c9b685e96fbe6d8337d3f3..ad3560284ae79b9c6bbc8752be7d9d14b18e226e 100644
 --- a/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java
 +++ b/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java
-@@ -915,7 +915,9 @@ public final class ChunkHolderManager {
+@@ -922,7 +922,9 @@ public final class ChunkHolderManager {
      }
  
      public boolean processTicketUpdates() {


### PR DESCRIPTION
Solves #9142. 

I added a config option for this in the event the existing behavior is preferred, however I'm not entirely if this is the best option given vanilla by default will call this same method to flush the region files. Feedback welcome!

 