### PR TITLE
add AttemptItemMergeEvent

### DIFF
--- a/patches/api/0416-Add-AttemptItemMergeEvent.patch
+++ b/patches/api/0416-Add-AttemptItemMergeEvent.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mohammed jasem alaajel <xrambad@gmail.com>
+Date: Wed, 19 Apr 2023 09:41:08 +0400
+Subject: [PATCH] Add AttemptItemMergeEvent
+
+Basically this event fires before ItemMergeEvent which allows see what item source item want to merge with and can be canceld and class is exact copy of ItemMergeEvent
+
+diff --git a/src/main/java/org/bukkit/event/entity/AttemptItemMergeEvent.java b/src/main/java/org/bukkit/event/entity/AttemptItemMergeEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..eb1246cfb85c62f5a6014c155206ba248a45e968
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/AttemptItemMergeEvent.java
+@@ -0,0 +1,58 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.Item;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * thrown when are Items trying to merge
++ */
++public class AttemptItemMergeEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancelled;
++    private final Item target;
++
++    public AttemptItemMergeEvent(@NotNull Item item, @NotNull Item target) {
++        super(item);
++        this.target = target;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancelled) {
++        this.cancelled = cancelled;
++    }
++
++    @NotNull
++    @Override
++    public Item getEntity() {
++        return (Item) entity;
++    }
++
++    /**
++     * Gets the Item entity the main Item is being merged into.
++     *
++     * @return The Item being merged with
++     */
++    @NotNull
++    public Item getTarget() {
++        return target;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/patches/server/0975-Implement-event-calling-for-AttemptItemMergeEvent.patch
+++ b/patches/server/0975-Implement-event-calling-for-AttemptItemMergeEvent.patch
@@ -1,0 +1,107 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mohammed jasem alaajel <xrambad@gmail.com>
+Date: Wed, 19 Apr 2023 09:43:46 +0400
+Subject: [PATCH] Implement event calling for AttemptItemMergeEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
+index d47b3ac633e7936d30abfda6fc46c2c7412d76fe..2d39763929e0cf6f4009ba629753ae04057a4881 100644
+--- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
++++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
+@@ -289,7 +289,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+     private void tryToMerge(ItemEntity other) {
+         ItemStack itemstack = this.getItem();
+         ItemStack itemstack1 = other.getItem();
+-
++        if (org.bukkit.craftbukkit.event.CraftEventFactory.callAttemptItemMergeEvent(other, this).isCancelled()) return; // Paper - AttemptItemMergeEvent
+         if (Objects.equals(this.target, other.target) && ItemEntity.areMergable(itemstack, itemstack1)) {
+             if (true || itemstack1.getCount() < itemstack.getCount()) { // Spigot
+                 ItemEntity.merge(this, itemstack, other, itemstack1);
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 819c9c020f4d5a1373f68850134960d24b8fc308..26181d7246458c3175a3b62f019abc11ab9ab418 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -139,52 +139,10 @@ import org.bukkit.event.block.EntityBlockFormEvent;
+ import org.bukkit.event.block.FluidLevelChangeEvent;
+ import org.bukkit.event.block.MoistureChangeEvent;
+ import org.bukkit.event.block.NotePlayEvent;
+-import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
+-import org.bukkit.event.entity.ArrowBodyCountChangeEvent;
+-import org.bukkit.event.entity.BatToggleSleepEvent;
+-import org.bukkit.event.entity.CreatureSpawnEvent;
++import org.bukkit.event.entity.*;
+ import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
+-import org.bukkit.event.entity.CreeperPowerEvent;
+-import org.bukkit.event.entity.EntityBreakDoorEvent;
+-import org.bukkit.event.entity.EntityBreedEvent;
+-import org.bukkit.event.entity.EntityChangeBlockEvent;
+-import org.bukkit.event.entity.EntityDamageByBlockEvent;
+-import org.bukkit.event.entity.EntityDamageByEntityEvent;
+-import org.bukkit.event.entity.EntityDamageEvent;
+ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+ import org.bukkit.event.entity.EntityDamageEvent.DamageModifier;
+-import org.bukkit.event.entity.EntityDeathEvent;
+-import org.bukkit.event.entity.EntityEnterLoveModeEvent;
+-import org.bukkit.event.entity.EntityExhaustionEvent;
+-import org.bukkit.event.entity.EntityPickupItemEvent;
+-import org.bukkit.event.entity.EntityPlaceEvent;
+-import org.bukkit.event.entity.EntityPotionEffectEvent;
+-import org.bukkit.event.entity.EntityShootBowEvent;
+-import org.bukkit.event.entity.EntitySpawnEvent;
+-import org.bukkit.event.entity.EntitySpellCastEvent;
+-import org.bukkit.event.entity.EntityTameEvent;
+-import org.bukkit.event.entity.EntityTargetEvent;
+-import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
+-import org.bukkit.event.entity.EntityToggleGlideEvent;
+-import org.bukkit.event.entity.EntityToggleSwimEvent;
+-import org.bukkit.event.entity.EntityTransformEvent;
+-import org.bukkit.event.entity.ExpBottleEvent;
+-import org.bukkit.event.entity.FireworkExplodeEvent;
+-import org.bukkit.event.entity.FoodLevelChangeEvent;
+-import org.bukkit.event.entity.HorseJumpEvent;
+-import org.bukkit.event.entity.ItemDespawnEvent;
+-import org.bukkit.event.entity.ItemMergeEvent;
+-import org.bukkit.event.entity.ItemSpawnEvent;
+-import org.bukkit.event.entity.LingeringPotionSplashEvent;
+-import org.bukkit.event.entity.PigZapEvent;
+-import org.bukkit.event.entity.PiglinBarterEvent;
+-import org.bukkit.event.entity.PlayerDeathEvent;
+-import org.bukkit.event.entity.PlayerLeashEntityEvent;
+-import org.bukkit.event.entity.PotionSplashEvent;
+-import org.bukkit.event.entity.ProjectileHitEvent;
+-import org.bukkit.event.entity.ProjectileLaunchEvent;
+-import org.bukkit.event.entity.StriderTemperatureChangeEvent;
+-import org.bukkit.event.entity.VillagerCareerChangeEvent;
+ import org.bukkit.event.inventory.InventoryCloseEvent;
+ import org.bukkit.event.inventory.InventoryOpenEvent;
+ import org.bukkit.event.inventory.PrepareAnvilEvent;
+@@ -225,8 +183,6 @@ import org.bukkit.inventory.InventoryView;
+ import org.bukkit.inventory.meta.BookMeta;
+ import org.bukkit.potion.PotionEffect;
+ 
+-import org.bukkit.event.entity.SpawnerSpawnEvent; // Spigot
+-
+ public class CraftEventFactory {
+     public static org.bukkit.block.Block blockDamage; // For use in EntityDamageByBlockEvent
+     public static Entity entityDamage; // For use in EntityDamageByEntityEvent
+@@ -795,7 +751,20 @@ public class CraftEventFactory {
+         entity.getServer().getPluginManager().callEvent(event);
+         return event;
+     }
++    // Paper start - AttemptItemMergeEvent
++    /**
++     * AttemptItemMergeEvent
++     */
++    public static AttemptItemMergeEvent callAttemptItemMergeEvent(ItemEntity merging, ItemEntity mergingWith) {
++        org.bukkit.entity.Item entityMerging = (org.bukkit.entity.Item) merging.getBukkitEntity();
++        org.bukkit.entity.Item entityMergingWith = (org.bukkit.entity.Item) mergingWith.getBukkitEntity();
+ 
++        AttemptItemMergeEvent event = new AttemptItemMergeEvent(entityMerging, entityMergingWith);
++
++        Bukkit.getPluginManager().callEvent(event);
++        return event;
++    }
++    // Paper end
+     /**
+      * ItemMergeEvent
+      */

--- a/patches/server/0975-Implement-event-calling-for-AttemptItemMergeEvent.patch
+++ b/patches/server/0975-Implement-event-calling-for-AttemptItemMergeEvent.patch
@@ -18,73 +18,18 @@ index d47b3ac633e7936d30abfda6fc46c2c7412d76fe..2d39763929e0cf6f4009ba629753ae04
              if (true || itemstack1.getCount() < itemstack.getCount()) { // Spigot
                  ItemEntity.merge(this, itemstack, other, itemstack1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 819c9c020f4d5a1373f68850134960d24b8fc308..26181d7246458c3175a3b62f019abc11ab9ab418 100644
+index 819c9c020f4d5a1373f68850134960d24b8fc308..5ef16cc2566f9735bcfe6ceee1031d2e2e61079f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -139,52 +139,10 @@ import org.bukkit.event.block.EntityBlockFormEvent;
- import org.bukkit.event.block.FluidLevelChangeEvent;
- import org.bukkit.event.block.MoistureChangeEvent;
- import org.bukkit.event.block.NotePlayEvent;
--import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
--import org.bukkit.event.entity.ArrowBodyCountChangeEvent;
--import org.bukkit.event.entity.BatToggleSleepEvent;
--import org.bukkit.event.entity.CreatureSpawnEvent;
-+import org.bukkit.event.entity.*;
- import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
--import org.bukkit.event.entity.CreeperPowerEvent;
--import org.bukkit.event.entity.EntityBreakDoorEvent;
--import org.bukkit.event.entity.EntityBreedEvent;
--import org.bukkit.event.entity.EntityChangeBlockEvent;
--import org.bukkit.event.entity.EntityDamageByBlockEvent;
--import org.bukkit.event.entity.EntityDamageByEntityEvent;
--import org.bukkit.event.entity.EntityDamageEvent;
- import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
- import org.bukkit.event.entity.EntityDamageEvent.DamageModifier;
--import org.bukkit.event.entity.EntityDeathEvent;
--import org.bukkit.event.entity.EntityEnterLoveModeEvent;
--import org.bukkit.event.entity.EntityExhaustionEvent;
--import org.bukkit.event.entity.EntityPickupItemEvent;
--import org.bukkit.event.entity.EntityPlaceEvent;
--import org.bukkit.event.entity.EntityPotionEffectEvent;
--import org.bukkit.event.entity.EntityShootBowEvent;
--import org.bukkit.event.entity.EntitySpawnEvent;
--import org.bukkit.event.entity.EntitySpellCastEvent;
--import org.bukkit.event.entity.EntityTameEvent;
--import org.bukkit.event.entity.EntityTargetEvent;
--import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
--import org.bukkit.event.entity.EntityToggleGlideEvent;
--import org.bukkit.event.entity.EntityToggleSwimEvent;
--import org.bukkit.event.entity.EntityTransformEvent;
--import org.bukkit.event.entity.ExpBottleEvent;
--import org.bukkit.event.entity.FireworkExplodeEvent;
--import org.bukkit.event.entity.FoodLevelChangeEvent;
--import org.bukkit.event.entity.HorseJumpEvent;
--import org.bukkit.event.entity.ItemDespawnEvent;
--import org.bukkit.event.entity.ItemMergeEvent;
--import org.bukkit.event.entity.ItemSpawnEvent;
--import org.bukkit.event.entity.LingeringPotionSplashEvent;
--import org.bukkit.event.entity.PigZapEvent;
--import org.bukkit.event.entity.PiglinBarterEvent;
--import org.bukkit.event.entity.PlayerDeathEvent;
--import org.bukkit.event.entity.PlayerLeashEntityEvent;
--import org.bukkit.event.entity.PotionSplashEvent;
--import org.bukkit.event.entity.ProjectileHitEvent;
--import org.bukkit.event.entity.ProjectileLaunchEvent;
--import org.bukkit.event.entity.StriderTemperatureChangeEvent;
--import org.bukkit.event.entity.VillagerCareerChangeEvent;
- import org.bukkit.event.inventory.InventoryCloseEvent;
- import org.bukkit.event.inventory.InventoryOpenEvent;
- import org.bukkit.event.inventory.PrepareAnvilEvent;
-@@ -225,8 +183,6 @@ import org.bukkit.inventory.InventoryView;
- import org.bukkit.inventory.meta.BookMeta;
- import org.bukkit.potion.PotionEffect;
- 
--import org.bukkit.event.entity.SpawnerSpawnEvent; // Spigot
--
- public class CraftEventFactory {
-     public static org.bukkit.block.Block blockDamage; // For use in EntityDamageByBlockEvent
-     public static Entity entityDamage; // For use in EntityDamageByEntityEvent
-@@ -795,7 +751,20 @@ public class CraftEventFactory {
+@@ -174,6 +174,7 @@ import org.bukkit.event.entity.FoodLevelChangeEvent;
+ import org.bukkit.event.entity.HorseJumpEvent;
+ import org.bukkit.event.entity.ItemDespawnEvent;
+ import org.bukkit.event.entity.ItemMergeEvent;
++import org.bukkit.event.entity.AttemptItemMergeEvent; // Paper - AttemptItemMergeEvent
+ import org.bukkit.event.entity.ItemSpawnEvent;
+ import org.bukkit.event.entity.LingeringPotionSplashEvent;
+ import org.bukkit.event.entity.PigZapEvent;
+@@ -795,6 +796,20 @@ public class CraftEventFactory {
          entity.getServer().getPluginManager().callEvent(event);
          return event;
      }
@@ -95,13 +40,13 @@ index 819c9c020f4d5a1373f68850134960d24b8fc308..26181d7246458c3175a3b62f019abc11
 +    public static AttemptItemMergeEvent callAttemptItemMergeEvent(ItemEntity merging, ItemEntity mergingWith) {
 +        org.bukkit.entity.Item entityMerging = (org.bukkit.entity.Item) merging.getBukkitEntity();
 +        org.bukkit.entity.Item entityMergingWith = (org.bukkit.entity.Item) mergingWith.getBukkitEntity();
- 
++
 +        AttemptItemMergeEvent event = new AttemptItemMergeEvent(entityMerging, entityMergingWith);
 +
 +        Bukkit.getPluginManager().callEvent(event);
 +        return event;
 +    }
 +    // Paper end
+ 
      /**
       * ItemMergeEvent
-      */


### PR DESCRIPTION
Basically this event is called before ItemMergeEvent which can allow to see which items are trying to merge,
unlike ItemMergeEvent which thrown on successful merged items, this event is called before checking if can be merged

## example:
throwing Dead bush with Red

```java
@EventHandler
    public void onAttemptItemMerge(AttemptItemMergeEvent e) {
        Item source = e.getEntity();
        Item target = e.getTarget();
        this.getSLF4JLogger().info("Item {} {}  is trying to merge with {} {}",
                source.getItemStack().getType(), source.getUniqueId(), target.getItemStack().getType(), target.getUniqueId());
    }
```
console:
```
[10:13:27 INFO]: [paperweight-test-plugin] Item DEAD_BUSH a474ec48-be9d-4079-85d2-a5c69d8aed03  is trying to merge with RED_SAND 28cbb557-ca5b-49b7-8524-fe2a77eb4181
[10:13:27 INFO]: [paperweight-test-plugin] Item RED_SAND 28cbb557-ca5b-49b7-8524-fe2a77eb4181  is trying to merge with DEAD_BUSH a474ec48-be9d-4079-85d2-a5c69d8aed03
[10:13:29 INFO]: [paperweight-test-plugin] Item DEAD_BUSH a474ec48-be9d-4079-85d2-a5c69d8aed03  is trying to merge with RED_SAND 28cbb557-ca5b-49b7-8524-fe2a77eb4181
[10:13:29 INFO]: [paperweight-test-plugin] Item RED_SAND 28cbb557-ca5b-49b7-8524-fe2a77eb4181  is trying to merge with DEAD_BUSH a474ec48-be9d-4079-85d2-a5c69d8aed03
```

