### PR TITLE
Fix note block sound property on player heads

### DIFF
--- a/patches/api/0319-Add-more-advancement-API.patch
+++ b/patches/api/0319-Add-more-advancement-API.patch
@@ -178,7 +178,7 @@ index 0000000000000000000000000000000000000000..19202e17f362fdffca472178b102d133
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/advancement/Advancement.java b/src/main/java/org/bukkit/advancement/Advancement.java
-index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..3f6b9e59c2ea38031ca74962e02d710fde61fb1f 100644
+index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..243e5f2debad7f12210169e15ef0b29763e988bb 100644
 --- a/src/main/java/org/bukkit/advancement/Advancement.java
 +++ b/src/main/java/org/bukkit/advancement/Advancement.java
 @@ -19,13 +19,53 @@ public interface Advancement extends Keyed {
@@ -196,7 +196,7 @@ index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..3f6b9e59c2ea38031ca74962e02d710f
 -     * This includes it's name, description and other visible tags.
 +     * @return the display info
 +     */
-+    @org.jetbrains.annotations.Nullable
++    @Nullable
 +    io.papermc.paper.advancement.AdvancementDisplay getDisplay();
 +
 +    /**
@@ -209,17 +209,16 @@ index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..3f6b9e59c2ea38031ca74962e02d710f
 -     * @return a AdvancementDisplay object, or null if not set.
 +     * @return the display name
 +     * @see io.papermc.paper.advancement.AdvancementDisplay#displayName()
-      */
--    @Nullable
--    AdvancementDisplay getDisplay();
++     */
 +    @NotNull net.kyori.adventure.text.Component displayName();
 +
 +    /**
 +     * Gets the parent advancement, if any.
 +     *
 +     * @return the parent advancement
-+     */
-+    @org.jetbrains.annotations.Nullable
+      */
+     @Nullable
+-    AdvancementDisplay getDisplay();
 +    Advancement getParent();
 +
 +    /**

--- a/patches/api/0319-Add-more-advancement-API.patch
+++ b/patches/api/0319-Add-more-advancement-API.patch
@@ -178,10 +178,10 @@ index 0000000000000000000000000000000000000000..19202e17f362fdffca472178b102d133
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/advancement/Advancement.java b/src/main/java/org/bukkit/advancement/Advancement.java
-index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..51cab9c3ab0293fcc003db8a540a358ba5fadb84 100644
+index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..3f6b9e59c2ea38031ca74962e02d710fde61fb1f 100644
 --- a/src/main/java/org/bukkit/advancement/Advancement.java
 +++ b/src/main/java/org/bukkit/advancement/Advancement.java
-@@ -19,13 +19,55 @@ public interface Advancement extends Keyed {
+@@ -19,13 +19,53 @@ public interface Advancement extends Keyed {
      @NotNull
      Collection<String> getCriteria();
  
@@ -194,13 +194,8 @@ index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..51cab9c3ab0293fcc003db8a540a358b
 +     * recipes.
       *
 -     * This includes it's name, description and other visible tags.
-+     * This includes its name, description and other visible tags.
-      *
--     * @return a AdvancementDisplay object, or null if not set.
 +     * @return the display info
-      */
--    @Nullable
--    AdvancementDisplay getDisplay();
++     */
 +    @org.jetbrains.annotations.Nullable
 +    io.papermc.paper.advancement.AdvancementDisplay getDisplay();
 +
@@ -210,10 +205,13 @@ index 17527c2f7bd5b8a5528388a53f2472bc1869c7f3..51cab9c3ab0293fcc003db8a540a358b
 +     * completes the advancement. Will return the same as
 +     * {@link io.papermc.paper.advancement.AdvancementDisplay#displayName()} when an
 +     * {@link io.papermc.paper.advancement.AdvancementDisplay} is present.
-+     *
+      *
+-     * @return a AdvancementDisplay object, or null if not set.
 +     * @return the display name
 +     * @see io.papermc.paper.advancement.AdvancementDisplay#displayName()
-+     */
+      */
+-    @Nullable
+-    AdvancementDisplay getDisplay();
 +    @NotNull net.kyori.adventure.text.Component displayName();
 +
 +    /**

--- a/patches/api/0344-Fix-NotePlayEvent.patch
+++ b/patches/api/0344-Fix-NotePlayEvent.patch
@@ -5,11 +5,17 @@ Subject: [PATCH] Fix NotePlayEvent
 
 
 diff --git a/src/main/java/org/bukkit/event/block/NotePlayEvent.java b/src/main/java/org/bukkit/event/block/NotePlayEvent.java
-index a3887067d1b65fb100ac1407a43c455f5d215510..676b31f6f38d4e85cd4bd16ccf42cbc39a5d8423 100644
+index a3887067d1b65fb100ac1407a43c455f5d215510..ea7cb75ba3ecbe40e0390fd5568db77de56c4f16 100644
 --- a/src/main/java/org/bukkit/event/block/NotePlayEvent.java
 +++ b/src/main/java/org/bukkit/event/block/NotePlayEvent.java
-@@ -58,9 +58,7 @@ public class NotePlayEvent extends BlockEvent implements Cancellable {
+@@ -56,11 +56,13 @@ public class NotePlayEvent extends BlockEvent implements Cancellable {
+ 
+     /**
       * Overrides the {@link Instrument} to be used.
++     * <p>
++     * Only works when the note block isn't under a player head.
++     * For this specific case the 'note_block_sound' property of the
++     * player head state takes the priority.
       *
       * @param instrument the Instrument. Has no effect if null.
 -     * @deprecated no effect on newer Minecraft versions
@@ -18,7 +24,7 @@ index a3887067d1b65fb100ac1407a43c455f5d215510..676b31f6f38d4e85cd4bd16ccf42cbc3
      public void setInstrument(@NotNull Instrument instrument) {
          if (instrument != null) {
              this.instrument = instrument;
-@@ -71,9 +69,7 @@ public class NotePlayEvent extends BlockEvent implements Cancellable {
+@@ -71,9 +73,7 @@ public class NotePlayEvent extends BlockEvent implements Cancellable {
       * Overrides the {@link Note} to be played.
       *
       * @param note the Note. Has no effect if null.

--- a/patches/server/0785-Fix-NotePlayEvent.patch
+++ b/patches/server/0785-Fix-NotePlayEvent.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Fix NotePlayEvent
 public org.bukkit.craftbukkit.block.data.CraftBlockData toNMS(Ljava/lang/Enum;Ljava/lang/Class;)Ljava/lang/Enum;
 
 diff --git a/src/main/java/net/minecraft/world/level/block/NoteBlock.java b/src/main/java/net/minecraft/world/level/block/NoteBlock.java
-index 1327eb8ff0f044340d6a1c7058dc6d8a191615dc..50ead76879398222a76f26c36e98800d2d1af167 100644
+index 1327eb8ff0f044340d6a1c7058dc6d8a191615dc..a9c2d254bda5686a35ad2393534b85030dd8b136 100644
 --- a/src/main/java/net/minecraft/world/level/block/NoteBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/NoteBlock.java
 @@ -90,11 +90,12 @@ public class NoteBlock extends Block {
@@ -27,15 +27,14 @@ index 1327eb8ff0f044340d6a1c7058dc6d8a191615dc..50ead76879398222a76f26c36e98800d
              world.blockEvent(pos, this, 0, 0);
              world.gameEvent(entity, GameEvent.NOTE_BLOCK_PLAY, pos);
          }
-@@ -132,11 +133,15 @@ public class NoteBlock extends Block {
- 
+@@ -133,10 +134,14 @@ public class NoteBlock extends Block {
      @Override
      public boolean triggerEvent(BlockState state, Level world, BlockPos pos, int type, int data) {
+         NoteBlockInstrument blockpropertyinstrument = (NoteBlockInstrument) state.getValue(NoteBlock.INSTRUMENT);
 +        // Paper start - move NotePlayEvent call to fix instrument/note changes
-+        org.bukkit.event.block.NotePlayEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callNotePlayEvent(world, pos, state.getValue(INSTRUMENT), state.getValue(NOTE));
++        org.bukkit.event.block.NotePlayEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callNotePlayEvent(world, pos, blockpropertyinstrument, state.getValue(NOTE));
 +        if (event.isCancelled()) return false;
 +        // Paper end
-         NoteBlockInstrument blockpropertyinstrument = (NoteBlockInstrument) state.getValue(NoteBlock.INSTRUMENT);
          float f;
  
          if (blockpropertyinstrument.isTunable()) {
@@ -44,12 +43,12 @@ index 1327eb8ff0f044340d6a1c7058dc6d8a191615dc..50ead76879398222a76f26c36e98800d
  
              f = (float) Math.pow(2.0D, (double) (k - 12) / 12.0D);
              world.addParticle(ParticleTypes.NOTE, (double) pos.getX() + 0.5D, (double) pos.getY() + 1.2D, (double) pos.getZ() + 0.5D, (double) k / 24.0D, 0.0D, 0.0D);
-@@ -158,7 +163,7 @@ public class NoteBlock extends Block {
-             holder = blockpropertyinstrument.getSoundEvent();
+@@ -155,7 +160,7 @@ public class NoteBlock extends Block {
+ 
+             holder = Holder.direct(SoundEvent.createVariableRangeEvent(minecraftkey));
+         } else {
+-            holder = blockpropertyinstrument.getSoundEvent();
++            holder = org.bukkit.craftbukkit.block.data.CraftBlockData.toNMS(event.getInstrument(), NoteBlockInstrument.class).getSoundEvent(); // Paper
          }
  
--        world.playSeededSound((Player) null, (double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, holder, SoundSource.RECORDS, 3.0F, f, world.random.nextLong());
-+        world.playSeededSound((Player) null, (double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, org.bukkit.craftbukkit.block.data.CraftBlockData.toNMS(event.getInstrument(), NoteBlockInstrument.class).getSoundEvent(), SoundSource.RECORDS, 3.0F, f, world.random.nextLong()); // Paper
-         return true;
-     }
- 
+         world.playSeededSound((Player) null, (double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, holder, SoundSource.RECORDS, 3.0F, f, world.random.nextLong());


### PR DESCRIPTION
When a plugin define a custom note block sound on a player head, the sound is ignored and the default click sound is played instead. This changes restore vanilla behavior that will now take the priority over the event instrument.

I have also reverted my mistakes on the javadoc pr. The spawnFallingBlock javadoc is totally reverted since upstream have fixed those (and i have put the wrong javadoc on the wrong override)