### PR TITLE
Paper Plugins Dependency Format Update

### DIFF
--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -2017,7 +2017,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
              throw new IllegalStateException("Cannot get plugin for " + clazz + " from a static initializer");
          }
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index 047c0304fd617cec990f80815b43916c6ef5a94c..ab04ffe4cd05315a2ee0f64c553b4c674740eb7f 100644
+index 047c0304fd617cec990f80815b43916c6ef5a94c..d0ad072c832b8fc8a1cfdcafdd42c724531a2e29 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 @@ -49,6 +49,7 @@ import org.yaml.snakeyaml.error.YAMLException;
@@ -2041,7 +2041,7 @@ index 047c0304fd617cec990f80815b43916c6ef5a94c..ab04ffe4cd05315a2ee0f64c553b4c67
          final PluginClassLoader loader;
          try {
 -            loader = new PluginClassLoader(this, getClass().getClassLoader(), description, dataFolder, file, (libraryLoader != null) ? libraryLoader.createLoader(description) : null);
-+            loader = new PluginClassLoader(getClass().getClassLoader(), description, dataFolder, file, (libraryLoader != null) ? libraryLoader.createLoader(description) : null, null, null); // Paper
++            loader = new PluginClassLoader(getClass().getClassLoader(), description, dataFolder, file, (libraryLoader != null) ? libraryLoader.createLoader(description) : null, null); // Paper
          } catch (InvalidPluginException ex) {
              throw ex;
          } catch (Throwable ex) {
@@ -2080,7 +2080,7 @@ index 6d634b0ea813ccb19f1562a7d0e5a59cea4eab21..e4b6f278a811acbb0070e311c5c3bdaf
          }
  
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fdadf45bdc 100644
+index 2f74ec96ece706de23156ebabfe493211bc05391..ea8d2e1048d7aa0aaa91c16e43d0b04122466b69 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -29,7 +29,8 @@ import org.jetbrains.annotations.Nullable;
@@ -2093,13 +2093,12 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
      private final JavaPluginLoader loader;
      private final Map<String, Class<?>> classes = new ConcurrentHashMap<String, Class<?>>();
      private final PluginDescriptionFile description;
-@@ -43,24 +44,32 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -43,24 +44,30 @@ final class PluginClassLoader extends URLClassLoader {
      private JavaPlugin pluginInit;
      private IllegalStateException pluginState;
      private final Set<String> seenIllegalAccess = Collections.newSetFromMap(new ConcurrentHashMap<>());
 +    private java.util.logging.Logger logger; // Paper - add field
 +    private io.papermc.paper.plugin.provider.classloader.PluginClassLoaderGroup classLoaderGroup; // Paper
-+    public io.papermc.paper.plugin.provider.entrypoint.DependencyContext dependencyContext; // Paper
  
      static {
          ClassLoader.registerAsParallelCapable();
@@ -2124,13 +2123,12 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
  
 +
 +        // Paper start
-+        this.dependencyContext = dependencyContext;
 +        this.classLoaderGroup = io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage.instance().registerSpigotGroup(this);
 +        // Paper end
          try {
              Class<?> jarClass;
              try {
-@@ -94,6 +103,27 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -94,6 +101,27 @@ final class PluginClassLoader extends URLClassLoader {
          return findResources(name);
      }
  
@@ -2158,7 +2156,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
      @Override
      protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
          return loadClass0(name, resolve, true, true);
-@@ -119,26 +149,11 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -119,26 +147,11 @@ final class PluginClassLoader extends URLClassLoader {
  
          if (checkGlobal) {
              // This ignores the libraries of other plugins, unless they are transitive dependencies.
@@ -2187,7 +2185,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
  
                  return result;
              }
-@@ -167,7 +182,7 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -167,7 +180,7 @@ final class PluginClassLoader extends URLClassLoader {
                      throw new ClassNotFoundException(name, ex);
                  }
  
@@ -2196,7 +2194,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
  
                  int dot = name.lastIndexOf('.');
                  if (dot != -1) {
-@@ -197,8 +212,8 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -197,8 +210,8 @@ final class PluginClassLoader extends URLClassLoader {
                  result = super.findClass(name);
              }
  
@@ -2206,7 +2204,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
          }
  
          return result;
-@@ -207,6 +222,12 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -207,6 +220,12 @@ final class PluginClassLoader extends URLClassLoader {
      @Override
      public void close() throws IOException {
          try {
@@ -2219,7 +2217,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
              super.close();
          } finally {
              jar.close();
-@@ -218,7 +239,7 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -218,7 +237,7 @@ final class PluginClassLoader extends URLClassLoader {
          return classes.values();
      }
  
@@ -2228,7 +2226,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
          Preconditions.checkArgument(javaPlugin != null, "Initializing plugin cannot be null");
          Preconditions.checkArgument(javaPlugin.getClass().getClassLoader() == this, "Cannot initialize plugin outside of this class loader");
          if (this.plugin != null || this.pluginInit != null) {
-@@ -228,6 +249,38 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -228,6 +247,38 @@ final class PluginClassLoader extends URLClassLoader {
          pluginState = new IllegalStateException("Initial initialization");
          this.pluginInit = javaPlugin;
  

--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -2017,7 +2017,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
              throw new IllegalStateException("Cannot get plugin for " + clazz + " from a static initializer");
          }
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index 047c0304fd617cec990f80815b43916c6ef5a94c..d0ad072c832b8fc8a1cfdcafdd42c724531a2e29 100644
+index 047c0304fd617cec990f80815b43916c6ef5a94c..ab04ffe4cd05315a2ee0f64c553b4c674740eb7f 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 @@ -49,6 +49,7 @@ import org.yaml.snakeyaml.error.YAMLException;
@@ -2041,7 +2041,7 @@ index 047c0304fd617cec990f80815b43916c6ef5a94c..d0ad072c832b8fc8a1cfdcafdd42c724
          final PluginClassLoader loader;
          try {
 -            loader = new PluginClassLoader(this, getClass().getClassLoader(), description, dataFolder, file, (libraryLoader != null) ? libraryLoader.createLoader(description) : null);
-+            loader = new PluginClassLoader(getClass().getClassLoader(), description, dataFolder, file, (libraryLoader != null) ? libraryLoader.createLoader(description) : null, null); // Paper
++            loader = new PluginClassLoader(getClass().getClassLoader(), description, dataFolder, file, (libraryLoader != null) ? libraryLoader.createLoader(description) : null, null, null); // Paper
          } catch (InvalidPluginException ex) {
              throw ex;
          } catch (Throwable ex) {
@@ -2080,7 +2080,7 @@ index 6d634b0ea813ccb19f1562a7d0e5a59cea4eab21..e4b6f278a811acbb0070e311c5c3bdaf
          }
  
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 2f74ec96ece706de23156ebabfe493211bc05391..ea8d2e1048d7aa0aaa91c16e43d0b04122466b69 100644
+index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fdadf45bdc 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -29,7 +29,8 @@ import org.jetbrains.annotations.Nullable;
@@ -2093,12 +2093,13 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..ea8d2e1048d7aa0aaa91c16e43d0b041
      private final JavaPluginLoader loader;
      private final Map<String, Class<?>> classes = new ConcurrentHashMap<String, Class<?>>();
      private final PluginDescriptionFile description;
-@@ -43,24 +44,30 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -43,24 +44,32 @@ final class PluginClassLoader extends URLClassLoader {
      private JavaPlugin pluginInit;
      private IllegalStateException pluginState;
      private final Set<String> seenIllegalAccess = Collections.newSetFromMap(new ConcurrentHashMap<>());
 +    private java.util.logging.Logger logger; // Paper - add field
 +    private io.papermc.paper.plugin.provider.classloader.PluginClassLoaderGroup classLoaderGroup; // Paper
++    public io.papermc.paper.plugin.provider.entrypoint.DependencyContext dependencyContext; // Paper
  
      static {
          ClassLoader.registerAsParallelCapable();
@@ -2123,12 +2124,13 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..ea8d2e1048d7aa0aaa91c16e43d0b041
  
 +
 +        // Paper start
++        this.dependencyContext = dependencyContext;
 +        this.classLoaderGroup = io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage.instance().registerSpigotGroup(this);
 +        // Paper end
          try {
              Class<?> jarClass;
              try {
-@@ -94,6 +101,27 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -94,6 +103,27 @@ final class PluginClassLoader extends URLClassLoader {
          return findResources(name);
      }
  
@@ -2156,7 +2158,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..ea8d2e1048d7aa0aaa91c16e43d0b041
      @Override
      protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
          return loadClass0(name, resolve, true, true);
-@@ -119,26 +147,11 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -119,26 +149,11 @@ final class PluginClassLoader extends URLClassLoader {
  
          if (checkGlobal) {
              // This ignores the libraries of other plugins, unless they are transitive dependencies.
@@ -2185,7 +2187,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..ea8d2e1048d7aa0aaa91c16e43d0b041
  
                  return result;
              }
-@@ -167,7 +180,7 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -167,7 +182,7 @@ final class PluginClassLoader extends URLClassLoader {
                      throw new ClassNotFoundException(name, ex);
                  }
  
@@ -2194,7 +2196,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..ea8d2e1048d7aa0aaa91c16e43d0b041
  
                  int dot = name.lastIndexOf('.');
                  if (dot != -1) {
-@@ -197,8 +210,8 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -197,8 +212,8 @@ final class PluginClassLoader extends URLClassLoader {
                  result = super.findClass(name);
              }
  
@@ -2204,7 +2206,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..ea8d2e1048d7aa0aaa91c16e43d0b041
          }
  
          return result;
-@@ -207,6 +220,12 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -207,6 +222,12 @@ final class PluginClassLoader extends URLClassLoader {
      @Override
      public void close() throws IOException {
          try {
@@ -2217,7 +2219,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..ea8d2e1048d7aa0aaa91c16e43d0b041
              super.close();
          } finally {
              jar.close();
-@@ -218,7 +237,7 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -218,7 +239,7 @@ final class PluginClassLoader extends URLClassLoader {
          return classes.values();
      }
  
@@ -2226,7 +2228,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..ea8d2e1048d7aa0aaa91c16e43d0b041
          Preconditions.checkArgument(javaPlugin != null, "Initializing plugin cannot be null");
          Preconditions.checkArgument(javaPlugin.getClass().getClassLoader() == this, "Cannot initialize plugin outside of this class loader");
          if (this.plugin != null || this.pluginInit != null) {
-@@ -228,6 +247,38 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -228,6 +249,38 @@ final class PluginClassLoader extends URLClassLoader {
          pluginState = new IllegalStateException("Initial initialization");
          this.pluginInit = javaPlugin;
  

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -5280,7 +5280,7 @@ index 0000000000000000000000000000000000000000..a0109a388188b0808900405d334a4031
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/type/DependencyConfiguration.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/type/DependencyConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4ce9c3b17997a42f44e34f95ef3177e0adaa18a8
+index 0000000000000000000000000000000000000000..594357f65813bd6287e982af12e4e5eaf443240e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/type/DependencyConfiguration.java
 @@ -0,0 +1,32 @@
@@ -5304,7 +5304,7 @@ index 0000000000000000000000000000000000000000..4ce9c3b17997a42f44e34f95ef3177e0
 +    }
 +
 +    public DependencyConfiguration() {
-+        this(false);
++        this(true);
 +    }
 +
 +    @ConfigSerializable

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -1868,6 +1868,9 @@ index 0000000000000000000000000000000000000000..e72bec3b0cbc41580f1b4beecae316d1
 +        for (String dependency : configuration.getPluginSoftDependencies()) {
 +            this.graph.removeEdge(identifier, dependency);
 +        }
++        for (String dependency : configuration.getPluginSoftDependencies()) {
++            this.graph.removeEdge(identifier, dependency);
++        }
 +
 +        this.graph.removeNode(identifier); // Remove root node
 +

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -1770,10 +1770,10 @@ index 0000000000000000000000000000000000000000..a2fa8406bc3f0dcab6805633ae984d03
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/MetaDependencyTree.java b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/MetaDependencyTree.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e72bec3b0cbc41580f1b4beecae316d1c083d3e3
+index 0000000000000000000000000000000000000000..b57d12bca82b5aed4f6c5f235e3cf7a10ec30bca
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/MetaDependencyTree.java
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,120 @@
 +package io.papermc.paper.plugin.entrypoint.dependency;
 +
 +import com.google.common.graph.GraphBuilder;

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -1708,34 +1708,6 @@ index 0000000000000000000000000000000000000000..f43295fdeaa587cf30c35a1d54516707
 +    void setContext(DependencyContext context);
 +
 +}
-diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/DependencyUtil.java b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/DependencyUtil.java
-new file mode 100644
-index 0000000000000000000000000000000000000000..ef8653a6c6e0653716887d47bac4ab43e3b6c788
---- /dev/null
-+++ b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/DependencyUtil.java
-@@ -0,0 +1,22 @@
-+package io.papermc.paper.plugin.entrypoint.dependency;
-+
-+import io.papermc.paper.plugin.configuration.PluginMeta;
-+import io.papermc.paper.plugin.provider.entrypoint.DependencyContext;
-+
-+import java.util.ArrayList;
-+import java.util.List;
-+
-+@SuppressWarnings("UnstableApiUsage")
-+public class DependencyUtil {
-+
-+    public static List<String> validateSimple(PluginMeta meta, DependencyContext dependencyContext) {
-+        List<String> missingDependencies = new ArrayList<>();
-+        for (String hardDependency : meta.getPluginDependencies()) {
-+            if (!dependencyContext.hasDependency(hardDependency)) {
-+                missingDependencies.add(hardDependency);
-+            }
-+        }
-+
-+        return missingDependencies;
-+    }
-+}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/GraphDependencyContext.java b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/GraphDependencyContext.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..a2fa8406bc3f0dcab6805633ae984d031d24692a
@@ -2709,17 +2681,16 @@ index 0000000000000000000000000000000000000000..52a110044611c8a0ace6d49549e8acc1
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/modern/LoadOrderTree.java b/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/modern/LoadOrderTree.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..862c2d9f195fe325d5e5d4aacbdf4051fa1feacd
+index 0000000000000000000000000000000000000000..e3f01ec40a704acb46f7ac31d500e9d0185e3db9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/strategy/modern/LoadOrderTree.java
-@@ -0,0 +1,122 @@
+@@ -0,0 +1,121 @@
 +package io.papermc.paper.plugin.entrypoint.strategy.modern;
 +
 +import com.google.common.collect.Lists;
 +import com.google.common.graph.MutableGraph;
 +import com.mojang.logging.LogUtils;
 +import io.papermc.paper.plugin.configuration.PluginMeta;
-+import io.papermc.paper.plugin.entrypoint.dependency.DependencyUtil;
 +import io.papermc.paper.plugin.entrypoint.strategy.JohnsonSimpleCycles;
 +import io.papermc.paper.plugin.entrypoint.strategy.PluginGraphCycleException;
 +import io.papermc.paper.plugin.entrypoint.strategy.TopographicGraphSorter;
@@ -4560,6 +4531,158 @@ index 0000000000000000000000000000000000000000..6ba3bcc468c0a60c76d6d0f0243bda66
 +
 +
 +}
+diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/LegacyPaperMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/LegacyPaperMeta.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..da792ee460a90611550b0d72c4254277fc79347e
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/LegacyPaperMeta.java
+@@ -0,0 +1,146 @@
++package io.papermc.paper.plugin.provider.configuration;
++
++import com.google.gson.reflect.TypeToken;
++import io.papermc.paper.plugin.provider.configuration.type.DependencyConfiguration;
++import io.papermc.paper.plugin.provider.configuration.type.PluginDependencyLifeCycle;
++import org.spongepowered.configurate.CommentedConfigurationNode;
++import org.spongepowered.configurate.ConfigurateException;
++import org.spongepowered.configurate.NodePath;
++import org.spongepowered.configurate.objectmapping.ConfigSerializable;
++import org.spongepowered.configurate.objectmapping.meta.Required;
++import org.spongepowered.configurate.serialize.SerializationException;
++import org.spongepowered.configurate.transformation.ConfigurationTransformation;
++
++import java.util.EnumMap;
++import java.util.EnumSet;
++import java.util.HashMap;
++import java.util.List;
++import java.util.Map;
++import java.util.Set;
++
++class LegacyPaperMeta {
++
++
++    private static final TypeToken<Map<PluginDependencyLifeCycle, Map<String, DependencyConfiguration>>> TYPE_TOKEN = new TypeToken<>() {
++    };
++
++    public static void migrate(CommentedConfigurationNode node) throws ConfigurateException {
++        ConfigurationTransformation.chain(notVersioned()).apply(node);
++    }
++
++    private static ConfigurationTransformation notVersioned() {
++        return ConfigurationTransformation.builder()
++            .addAction(NodePath.path(), (path, value) -> {
++                boolean bootstrapSubSection = value.hasChild("bootstrap");
++                boolean serverSubSection = value.hasChild("server");
++
++                // Ignore if using newer format
++                if (bootstrapSubSection || serverSubSection) {
++                    return null;
++                }
++
++                // First collect all load before elements
++                LegacyConfiguration legacyConfiguration;
++                try {
++                    legacyConfiguration = value.require(LegacyConfiguration.class);
++                } catch (SerializationException exception) {
++                    // Ignore if not present
++                    return null;
++                }
++
++                Map<PluginDependencyLifeCycle, Map<String, DependencyConfiguration>> dependencies = new EnumMap<>(PluginDependencyLifeCycle.class);
++                dependencies.put(PluginDependencyLifeCycle.BOOTSTRAP, new HashMap<>());
++                dependencies.put(PluginDependencyLifeCycle.SERVER, new HashMap<>());
++
++                Map<PluginDependencyLifeCycle, Map<String, Set<DependencyFlag>>> dependencyConfigurationMap = new HashMap<>();
++                dependencyConfigurationMap.put(PluginDependencyLifeCycle.BOOTSTRAP, new HashMap<>());
++                dependencyConfigurationMap.put(PluginDependencyLifeCycle.SERVER, new HashMap<>());
++
++                // Migrate loadafter
++                for (LegacyLoadConfiguration legacyConfig : legacyConfiguration.loadAfter) {
++                    Set<DependencyFlag> dependencyFlags = dependencyConfigurationMap
++                        .get(legacyConfig.bootstrap ? PluginDependencyLifeCycle.BOOTSTRAP : PluginDependencyLifeCycle.SERVER)
++                        .computeIfAbsent(legacyConfig.name, s -> EnumSet.noneOf(DependencyFlag.class));
++
++                    dependencyFlags.add(DependencyFlag.LOAD_AFTER);
++                }
++
++                // Migrate loadbefore
++                for (LegacyLoadConfiguration legacyConfig : legacyConfiguration.loadBefore) {
++                    Set<DependencyFlag> dependencyFlags = dependencyConfigurationMap
++                        .get(legacyConfig.bootstrap ? PluginDependencyLifeCycle.BOOTSTRAP : PluginDependencyLifeCycle.SERVER)
++                        .computeIfAbsent(legacyConfig.name, s -> EnumSet.noneOf(DependencyFlag.class));
++
++                    dependencyFlags.add(DependencyFlag.LOAD_BEFORE);
++                }
++
++                // Migrate dependencies
++                for (LegacyDependencyConfiguration legacyConfig : legacyConfiguration.dependencies) {
++                    Set<DependencyFlag> dependencyFlags = dependencyConfigurationMap
++                        .get(legacyConfig.bootstrap ? PluginDependencyLifeCycle.BOOTSTRAP : PluginDependencyLifeCycle.SERVER)
++                        .computeIfAbsent(legacyConfig.name, s -> EnumSet.noneOf(DependencyFlag.class));
++
++                    dependencyFlags.add(DependencyFlag.DEPENDENCY);
++                    if (legacyConfig.required) {
++                        dependencyFlags.add(DependencyFlag.REQUIRED);
++                    }
++                }
++                for (Map.Entry<PluginDependencyLifeCycle, Map<String, Set<DependencyFlag>>> legacyTypes : dependencyConfigurationMap.entrySet()) {
++                    Map<String, DependencyConfiguration> flagMap = dependencies.get(legacyTypes.getKey());
++                    for (Map.Entry<String, Set<DependencyFlag>> entry : legacyTypes.getValue().entrySet()) {
++                        Set<DependencyFlag> flags = entry.getValue();
++
++
++                        DependencyConfiguration.LoadOrder loadOrder = DependencyConfiguration.LoadOrder.OMIT;
++                        if (flags.contains(DependencyFlag.LOAD_BEFORE)) {
++                            loadOrder = DependencyConfiguration.LoadOrder.BEFORE;
++                        } else if (flags.contains(DependencyFlag.LOAD_AFTER)) {
++                            loadOrder = DependencyConfiguration.LoadOrder.AFTER;
++                        }
++
++                        flagMap.put(entry.getKey(), new DependencyConfiguration(
++                            loadOrder,
++                            flags.contains(DependencyFlag.REQUIRED),
++                            flags.contains(DependencyFlag.DEPENDENCY)
++                        ));
++                    }
++                }
++
++                value.node("dependencies").set(TYPE_TOKEN.getType(), dependencies);
++                return null;
++            })
++            .build();
++    }
++
++    @ConfigSerializable
++    record LegacyLoadConfiguration(
++        @Required String name,
++        boolean bootstrap
++    ) {
++    }
++
++    @ConfigSerializable
++    private static class LegacyConfiguration {
++
++        private List<LegacyLoadConfiguration> loadAfter = List.of();
++        private List<LegacyLoadConfiguration> loadBefore = List.of();
++        private List<LegacyDependencyConfiguration> dependencies = List.of();
++    }
++
++
++    @ConfigSerializable
++    public record LegacyDependencyConfiguration(
++        @Required String name,
++        boolean required,
++        boolean bootstrap
++    ) {
++    }
++
++    enum DependencyFlag {
++        LOAD_AFTER,
++        LOAD_BEFORE,
++        REQUIRED,
++        DEPENDENCY
++    }
++
++}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/LoadOrderConfiguration.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/LoadOrderConfiguration.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..e3430f535e8e9c3b8b44bf2daece8c47e8b14db7
@@ -4606,26 +4729,23 @@ index 0000000000000000000000000000000000000000..e3430f535e8e9c3b8b44bf2daece8c47
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..95cc4dbe336e37f01d9f478068fd21a387754a91
+index 0000000000000000000000000000000000000000..d4a71fbd06ba25d92d0d75a4c148718f464b562b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
-@@ -0,0 +1,232 @@
+@@ -0,0 +1,245 @@
 +package io.papermc.paper.plugin.provider.configuration;
 +
 +import com.google.common.base.Preconditions;
 +import com.google.common.collect.ImmutableList;
-+import io.leangen.geantyref.TypeToken;
 +import io.papermc.paper.configuration.constraint.Constraint;
 +import io.papermc.paper.configuration.serializer.ComponentSerializer;
 +import io.papermc.paper.configuration.serializer.EnumValueSerializer;
-+import io.papermc.paper.configuration.serializer.collections.MapSerializer;
 +import io.papermc.paper.plugin.configuration.PluginMeta;
-+import io.papermc.paper.plugin.provider.configuration.serializer.ImmutableListSerializer;
 +import io.papermc.paper.plugin.provider.configuration.serializer.PermissionConfigurationSerializer;
 +import io.papermc.paper.plugin.provider.configuration.serializer.constraints.PluginConfigConstraints;
 +import io.papermc.paper.plugin.provider.configuration.type.DependencyConfiguration;
-+import io.papermc.paper.plugin.provider.configuration.type.LoadConfiguration;
 +import io.papermc.paper.plugin.provider.configuration.type.PermissionConfiguration;
++import io.papermc.paper.plugin.provider.configuration.type.PluginDependencyLifeCycle;
 +import org.bukkit.permissions.Permission;
 +import org.bukkit.permissions.PermissionDefault;
 +import org.bukkit.plugin.PluginLoadOrder;
@@ -4642,7 +4762,9 @@ index 0000000000000000000000000000000000000000..95cc4dbe336e37f01d9f478068fd21a3
 +import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
 +
 +import java.io.BufferedReader;
++import java.util.EnumMap;
 +import java.util.List;
++import java.util.Map;
 +
 +@SuppressWarnings({"CanBeFinal", "FieldCanBeLocal", "FieldMayBeFinal", "NotNullFieldNotInitialized", "InnerClassMayBeStatic"})
 +@ConfigSerializable
@@ -4658,9 +4780,6 @@ index 0000000000000000000000000000000000000000..95cc4dbe336e37f01d9f478068fd21a3
 +    private String bootstrapper;
 +    @PluginConfigConstraints.PluginNameSpace
 +    private String loader;
-+    private List<DependencyConfiguration> dependencies = List.of();
-+    private List<LoadConfiguration> loadBefore = List.of();
-+    private List<LoadConfiguration> loadAfter = List.of();
 +    private List<String> provides = List.of();
 +    private boolean hasOpenClassloader = false;
 +    @Required
@@ -4677,6 +4796,8 @@ index 0000000000000000000000000000000000000000..95cc4dbe336e37f01d9f478068fd21a3
 +    @PluginConfigConstraints.PluginVersion
 +    private String apiVersion;
 +
++    private Map<PluginDependencyLifeCycle, Map<String, DependencyConfiguration>> dependencies = new EnumMap<>(PluginDependencyLifeCycle.class);
++
 +    public PaperPluginMeta() {
 +    }
 +
@@ -4691,9 +4812,6 @@ index 0000000000000000000000000000000000000000..95cc4dbe336e37f01d9f478068fd21a3
 +                return options.serializers((serializers) -> {
 +                    serializers
 +                        .register(new EnumValueSerializer())
-+                        .register(MapSerializer.TYPE, new MapSerializer(false))
-+                        .register(new TypeToken<>() {
-+                        }, new ImmutableListSerializer())
 +                        .register(PermissionConfiguration.class, PermissionConfigurationSerializer.SERIALIZER)
 +                        .register(new ComponentSerializer())
 +                        .registerAnnotatedObjects(
@@ -4710,6 +4828,7 @@ index 0000000000000000000000000000000000000000..95cc4dbe336e37f01d9f478068fd21a3
 +            })
 +            .build();
 +        CommentedConfigurationNode node = loader.load();
++        LegacyPaperMeta.migrate(node);
 +        PaperPluginMeta pluginConfiguration = node.require(PaperPluginMeta.class);
 +
 +        if (!node.node("author").virtual()) {
@@ -4756,29 +4875,49 @@ index 0000000000000000000000000000000000000000..95cc4dbe336e37f01d9f478068fd21a3
 +
 +    @Override
 +    public @NotNull List<String> getPluginDependencies() {
-+        return this.dependencies.stream().filter((dependency) -> dependency.required() && !dependency.bootstrap()).map(DependencyConfiguration::name).toList();
++        return this.dependencies.getOrDefault(PluginDependencyLifeCycle.SERVER, Map.of())
++            .entrySet()
++            .stream()
++            .filter((entry) -> entry.getValue().required() && entry.getValue().joinClasspath())
++            .map(Map.Entry::getKey)
++            .toList();
 +    }
 +
 +    @Override
 +    public @NotNull List<String> getPluginSoftDependencies() {
-+        return this.dependencies.stream().filter((dependency) -> !dependency.required() && !dependency.bootstrap()).map(DependencyConfiguration::name).toList();
++        return this.dependencies.getOrDefault(PluginDependencyLifeCycle.SERVER, Map.of())
++            .entrySet()
++            .stream()
++            .filter((entry) -> !entry.getValue().required() && entry.getValue().joinClasspath())
++            .map(Map.Entry::getKey)
++            .toList();
 +    }
 +
 +    @Override
 +    public @NotNull List<String> getLoadBeforePlugins() {
-+        return this.loadBefore.stream().filter((dependency) -> !dependency.bootstrap()).map(LoadConfiguration::name).toList();
++        return this.dependencies.getOrDefault(PluginDependencyLifeCycle.SERVER, Map.of())
++            .entrySet()
++            .stream()
++            .filter((entry) -> entry.getValue().loadOrder() == DependencyConfiguration.LoadOrder.BEFORE)
++            .map(Map.Entry::getKey)
++            .toList();
 +    }
 +
 +    public @NotNull List<String> getLoadAfterPlugins() {
-+        return this.loadAfter.stream().filter((dependency) -> !dependency.bootstrap()).map(LoadConfiguration::name).toList();
++        return this.dependencies.getOrDefault(PluginDependencyLifeCycle.SERVER, Map.of())
++            .entrySet()
++            .stream()
++            .filter((entry) -> entry.getValue().loadOrder() == DependencyConfiguration.LoadOrder.AFTER)
++            .map(Map.Entry::getKey)
++            .toList();
 +    }
 +
-+    public List<LoadConfiguration> getLoadAfter() {
-+        return this.loadAfter;
++    public Map<String, DependencyConfiguration> getServerDependencies() {
++        return this.dependencies.getOrDefault(PluginDependencyLifeCycle.SERVER, Map.of());
 +    }
 +
-+    public List<LoadConfiguration> getLoadBefore() {
-+        return this.loadBefore;
++    public Map<String, DependencyConfiguration> getBoostrapDependencies() {
++        return this.dependencies.getOrDefault(PluginDependencyLifeCycle.BOOTSTRAP, Map.of());
 +    }
 +
 +    @Override
@@ -4838,9 +4977,6 @@ index 0000000000000000000000000000000000000000..95cc4dbe336e37f01d9f478068fd21a3
 +        return this.hasOpenClassloader;
 +    }
 +
-+    public List<DependencyConfiguration> getDependencies() {
-+        return dependencies;
-+    }
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/serializer/ImmutableCollectionSerializer.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/serializer/ImmutableCollectionSerializer.java
 new file mode 100644
@@ -5143,21 +5279,39 @@ index 0000000000000000000000000000000000000000..a0109a388188b0808900405d334a4031
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/type/DependencyConfiguration.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/type/DependencyConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..071bff3f988a4391be424bdf7e98a6c35e6cac67
+index 0000000000000000000000000000000000000000..d13d20a501b39d309de15f02c0dda8993987a745
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/type/DependencyConfiguration.java
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,30 @@
 +package io.papermc.paper.plugin.provider.configuration.type;
 +
 +import org.spongepowered.configurate.objectmapping.ConfigSerializable;
-+import org.spongepowered.configurate.objectmapping.meta.Required;
 +
 +@ConfigSerializable
 +public record DependencyConfiguration(
-+    @Required String name,
++    LoadOrder loadOrder,
 +    boolean required,
-+    boolean bootstrap
++    boolean joinClasspath
 +) {
++
++    public DependencyConfiguration(boolean required, boolean joinClasspath) {
++        this(LoadOrder.OMIT, required, joinClasspath);
++    }
++
++    public DependencyConfiguration(boolean required) {
++        this(required, true);
++    }
++
++    public DependencyConfiguration() {
++        this(false);
++    }
++
++    @ConfigSerializable
++    public enum LoadOrder {
++        BEFORE,
++        AFTER,
++        OMIT
++    }
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/type/LoadConfiguration.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/type/LoadConfiguration.java
 new file mode 100644
@@ -5195,6 +5349,18 @@ index 0000000000000000000000000000000000000000..a180612a1ec395202dbae1ca5b97ec01
 +public record PermissionConfiguration(
 +    PermissionDefault defaultPerm,
 +    List<Permission> permissions) {
++}
+diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/type/PluginDependencyLifeCycle.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/type/PluginDependencyLifeCycle.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..49a087381307eab263f7dad43aaa25980db33cc2
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/type/PluginDependencyLifeCycle.java
+@@ -0,0 +1,6 @@
++package io.papermc.paper.plugin.provider.configuration.type;
++
++public enum PluginDependencyLifeCycle {
++    BOOTSTRAP,
++    SERVER
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/source/DirectoryProviderSource.java b/src/main/java/io/papermc/paper/plugin/provider/source/DirectoryProviderSource.java
 new file mode 100644
@@ -5587,20 +5753,21 @@ index 0000000000000000000000000000000000000000..32f230d66f6953520b59ccbf3079c5a6
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/type/paper/PaperBootstrapOrderConfiguration.java b/src/main/java/io/papermc/paper/plugin/provider/type/paper/PaperBootstrapOrderConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..362feffd88e117c0fb93ffeddafe8334275f0d95
+index 0000000000000000000000000000000000000000..5b9627dba32c609610a89d828a2d733f10351741
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/type/paper/PaperBootstrapOrderConfiguration.java
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,48 @@
 +package io.papermc.paper.plugin.provider.type.paper;
 +
 +import io.papermc.paper.plugin.configuration.PluginMeta;
 +import io.papermc.paper.plugin.provider.configuration.LoadOrderConfiguration;
 +import io.papermc.paper.plugin.provider.configuration.PaperPluginMeta;
-+import io.papermc.paper.plugin.provider.configuration.type.LoadConfiguration;
++import io.papermc.paper.plugin.provider.configuration.type.DependencyConfiguration;
 +import org.jetbrains.annotations.NotNull;
 +
 +import java.util.ArrayList;
 +import java.util.List;
++import java.util.Map;
 +
 +public class PaperBootstrapOrderConfiguration implements LoadOrderConfiguration {
 +
@@ -5611,14 +5778,14 @@ index 0000000000000000000000000000000000000000..362feffd88e117c0fb93ffeddafe8334
 +    public PaperBootstrapOrderConfiguration(PaperPluginMeta paperPluginMeta) {
 +        this.paperPluginMeta = paperPluginMeta;
 +
-+        for (LoadConfiguration configuration : paperPluginMeta.getLoadAfter()) {
-+            if (configuration.bootstrap()) {
-+                this.loadAfter.add(configuration.name());
-+            }
-+        }
-+        for (LoadConfiguration configuration : paperPluginMeta.getLoadBefore()) {
-+            if (configuration.bootstrap()) {
-+                this.loadBefore.add(configuration.name());
++        for (Map.Entry<String, DependencyConfiguration> configuration : paperPluginMeta.getBoostrapDependencies().entrySet()) {
++            String name = configuration.getKey();
++            DependencyConfiguration dependencyConfiguration = configuration.getValue();
++
++            if (dependencyConfiguration.loadOrder() == DependencyConfiguration.LoadOrder.BEFORE) {
++                this.loadBefore.add(name);
++            } else if (dependencyConfiguration.loadOrder() == DependencyConfiguration.LoadOrder.AFTER) {
++                this.loadAfter.add(name);
 +            }
 +        }
 +    }
@@ -5690,15 +5857,14 @@ index 0000000000000000000000000000000000000000..b7e8a5ba375a558e0442aa9facf96954
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/type/paper/PaperPluginParent.java b/src/main/java/io/papermc/paper/plugin/provider/type/paper/PaperPluginParent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..009a055c36378353b1b156e04b230519a577bd50
+index 0000000000000000000000000000000000000000..f2bc4d0b55d4c9877a442529e0b144656497dae6
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/type/paper/PaperPluginParent.java
-@@ -0,0 +1,257 @@
+@@ -0,0 +1,264 @@
 +package io.papermc.paper.plugin.provider.type.paper;
 +
 +import com.destroystokyo.paper.util.SneakyThrow;
 +import io.papermc.paper.plugin.bootstrap.PluginProviderContext;
-+import io.papermc.paper.plugin.entrypoint.dependency.DependencyUtil;
 +import io.papermc.paper.plugin.provider.configuration.LoadOrderConfiguration;
 +import io.papermc.paper.plugin.provider.configuration.type.DependencyConfiguration;
 +import io.papermc.paper.plugin.provider.entrypoint.DependencyContext;
@@ -5794,9 +5960,9 @@ index 0000000000000000000000000000000000000000..009a055c36378353b1b156e04b230519
 +        @Override
 +        public List<String> validateDependencies(@NotNull DependencyContext context) {
 +            List<String> missingDependencies = new ArrayList<>();
-+            for (DependencyConfiguration configuration : this.getMeta().getDependencies()) {
-+                String dependency = configuration.name();
-+                if (configuration.required() && configuration.bootstrap() && !context.hasDependency(dependency)) {
++            for (Map.Entry<String, DependencyConfiguration> configuration : this.getMeta().getBoostrapDependencies().entrySet()) {
++                String dependency = configuration.getKey();
++                if (configuration.getValue().required() && !context.hasDependency(dependency)) {
 +                    missingDependencies.add(dependency);
 +                }
 +            }
@@ -5899,7 +6065,15 @@ index 0000000000000000000000000000000000000000..009a055c36378353b1b156e04b230519
 +
 +        @Override
 +        public List<String> validateDependencies(@NotNull DependencyContext context) {
-+            return DependencyUtil.validateSimple(this.getMeta(), context);
++            List<String> missingDependencies = new ArrayList<>();
++            for (Map.Entry<String, DependencyConfiguration> dependency : this.getMeta().getServerDependencies().entrySet()) {
++                String name = dependency.getKey();
++                if (dependency.getValue().required() && !context.hasDependency(name)) {
++                    missingDependencies.add(name);
++                }
++            }
++
++            return missingDependencies;
 +        }
 +
 +        @Override
@@ -6093,15 +6267,14 @@ index 0000000000000000000000000000000000000000..b2a6544e321fa61c58bdf5684231de10
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/type/spigot/SpigotPluginProvider.java b/src/main/java/io/papermc/paper/plugin/provider/type/spigot/SpigotPluginProvider.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..96b252b33047705f6c48917cc1e4e1edec3cf03a
+index 0000000000000000000000000000000000000000..75a2b687d58d76b94f8bec111df8613f120ff74b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/type/spigot/SpigotPluginProvider.java
-@@ -0,0 +1,190 @@
+@@ -0,0 +1,197 @@
 +package io.papermc.paper.plugin.provider.type.spigot;
 +
 +import com.destroystokyo.paper.util.SneakyThrow;
 +import com.destroystokyo.paper.utils.PaperPluginLogger;
-+import io.papermc.paper.plugin.entrypoint.dependency.DependencyUtil;
 +import io.papermc.paper.plugin.manager.PaperPluginManagerImpl;
 +import io.papermc.paper.plugin.provider.configuration.LoadOrderConfiguration;
 +import io.papermc.paper.plugin.provider.entrypoint.DependencyContext;
@@ -6123,6 +6296,7 @@ index 0000000000000000000000000000000000000000..96b252b33047705f6c48917cc1e4e1ed
 +
 +import java.io.File;
 +import java.nio.file.Path;
++import java.util.ArrayList;
 +import java.util.HashSet;
 +import java.util.List;
 +import java.util.Map;
@@ -6258,7 +6432,14 @@ index 0000000000000000000000000000000000000000..96b252b33047705f6c48917cc1e4e1ed
 +
 +    @Override
 +    public List<String> validateDependencies(@NotNull DependencyContext context) {
-+        return DependencyUtil.validateSimple(this.getMeta(), context);
++        List<String> missingDependencies = new ArrayList<>();
++        for (String hardDependency : this.getMeta().getPluginDependencies()) {
++            if (!context.hasDependency(hardDependency)) {
++                missingDependencies.add(hardDependency);
++            }
++        }
++
++        return missingDependencies;
 +    }
 +
 +    @Override
@@ -7479,14 +7660,13 @@ index 0000000000000000000000000000000000000000..04903794a8ee4dd73162ae240862ff6d
 +}
 diff --git a/src/test/java/io/papermc/paper/plugin/TestJavaPluginProvider.java b/src/test/java/io/papermc/paper/plugin/TestJavaPluginProvider.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a4ef50027e4411f13ed840919136ca9ee4c58c41
+index 0000000000000000000000000000000000000000..349932b582349c988f3244552b6e6da5dede3d1d
 --- /dev/null
 +++ b/src/test/java/io/papermc/paper/plugin/TestJavaPluginProvider.java
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,83 @@
 +package io.papermc.paper.plugin;
 +
 +import io.papermc.paper.plugin.configuration.PluginMeta;
-+import io.papermc.paper.plugin.entrypoint.dependency.DependencyUtil;
 +import io.papermc.paper.plugin.provider.PluginProvider;
 +import io.papermc.paper.plugin.provider.configuration.LoadOrderConfiguration;
 +import io.papermc.paper.plugin.provider.entrypoint.DependencyContext;
@@ -7557,7 +7737,14 @@ index 0000000000000000000000000000000000000000..a4ef50027e4411f13ed840919136ca9e
 +
 +    @Override
 +    public List<String> validateDependencies(@NotNull DependencyContext context) {
-+        return DependencyUtil.validateSimple(this.getMeta(), context);
++        List<String> missingDependencies = new ArrayList<>();
++        for (String hardDependency : this.getMeta().getPluginDependencies()) {
++            if (!context.hasDependency(hardDependency)) {
++                missingDependencies.add(hardDependency);
++            }
++        }
++
++        return missingDependencies;
 +    }
 +}
 diff --git a/src/test/java/io/papermc/paper/plugin/TestPluginMeta.java b/src/test/java/io/papermc/paper/plugin/TestPluginMeta.java

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -1770,10 +1770,10 @@ index 0000000000000000000000000000000000000000..a2fa8406bc3f0dcab6805633ae984d03
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/MetaDependencyTree.java b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/MetaDependencyTree.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b57d12bca82b5aed4f6c5f235e3cf7a10ec30bca
+index 0000000000000000000000000000000000000000..e72bec3b0cbc41580f1b4beecae316d1c083d3e3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/MetaDependencyTree.java
-@@ -0,0 +1,120 @@
+@@ -0,0 +1,117 @@
 +package io.papermc.paper.plugin.entrypoint.dependency;
 +
 +import com.google.common.graph.GraphBuilder;
@@ -1835,9 +1835,6 @@ index 0000000000000000000000000000000000000000..b57d12bca82b5aed4f6c5f235e3cf7a1
 +        String identifier = configuration.getName();
 +        // Remove a validated provider's dependencies into the graph
 +        for (String dependency : configuration.getPluginDependencies()) {
-+            this.graph.removeEdge(identifier, dependency);
-+        }
-+        for (String dependency : configuration.getPluginSoftDependencies()) {
 +            this.graph.removeEdge(identifier, dependency);
 +        }
 +        for (String dependency : configuration.getPluginSoftDependencies()) {
@@ -4533,10 +4530,10 @@ index 0000000000000000000000000000000000000000..6ba3bcc468c0a60c76d6d0f0243bda66
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/LegacyPaperMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/LegacyPaperMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..da792ee460a90611550b0d72c4254277fc79347e
+index 0000000000000000000000000000000000000000..8cd649c977172f6b757d68565fcbb9eb8ae100a3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/LegacyPaperMeta.java
-@@ -0,0 +1,146 @@
+@@ -0,0 +1,147 @@
 +package io.papermc.paper.plugin.provider.configuration;
 +
 +import com.google.gson.reflect.TypeToken;
@@ -4631,10 +4628,11 @@ index 0000000000000000000000000000000000000000..da792ee460a90611550b0d72c4254277
 +
 +
 +                        DependencyConfiguration.LoadOrder loadOrder = DependencyConfiguration.LoadOrder.OMIT;
++                        // These meanings are now swapped
 +                        if (flags.contains(DependencyFlag.LOAD_BEFORE)) {
-+                            loadOrder = DependencyConfiguration.LoadOrder.BEFORE;
-+                        } else if (flags.contains(DependencyFlag.LOAD_AFTER)) {
 +                            loadOrder = DependencyConfiguration.LoadOrder.AFTER;
++                        } else if (flags.contains(DependencyFlag.LOAD_AFTER)) {
++                            loadOrder = DependencyConfiguration.LoadOrder.BEFORE;
 +                        }
 +
 +                        flagMap.put(entry.getKey(), new DependencyConfiguration(
@@ -4729,10 +4727,10 @@ index 0000000000000000000000000000000000000000..e3430f535e8e9c3b8b44bf2daece8c47
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d4a71fbd06ba25d92d0d75a4c148718f464b562b
+index 0000000000000000000000000000000000000000..45bd29b70782e29eb11c36eaca0f940aee49799b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
-@@ -0,0 +1,245 @@
+@@ -0,0 +1,248 @@
 +package io.papermc.paper.plugin.provider.configuration;
 +
 +import com.google.common.base.Preconditions;
@@ -4898,7 +4896,8 @@ index 0000000000000000000000000000000000000000..d4a71fbd06ba25d92d0d75a4c148718f
 +        return this.dependencies.getOrDefault(PluginDependencyLifeCycle.SERVER, Map.of())
 +            .entrySet()
 +            .stream()
-+            .filter((entry) -> entry.getValue().loadOrder() == DependencyConfiguration.LoadOrder.BEFORE)
++            // This plugin will load BEFORE all dependencies (so dependencies will load AFTER plugin)
++            .filter((entry) -> entry.getValue().load() == DependencyConfiguration.LoadOrder.AFTER)
 +            .map(Map.Entry::getKey)
 +            .toList();
 +    }
@@ -4907,10 +4906,12 @@ index 0000000000000000000000000000000000000000..d4a71fbd06ba25d92d0d75a4c148718f
 +        return this.dependencies.getOrDefault(PluginDependencyLifeCycle.SERVER, Map.of())
 +            .entrySet()
 +            .stream()
-+            .filter((entry) -> entry.getValue().loadOrder() == DependencyConfiguration.LoadOrder.AFTER)
++            // This plugin will load AFTER all dependencies (so dependencies will load BEFORE plugin)
++            .filter((entry) -> entry.getValue().load() == DependencyConfiguration.LoadOrder.BEFORE)
 +            .map(Map.Entry::getKey)
 +            .toList();
 +    }
++
 +
 +    public Map<String, DependencyConfiguration> getServerDependencies() {
 +        return this.dependencies.getOrDefault(PluginDependencyLifeCycle.SERVER, Map.of());
@@ -5279,17 +5280,17 @@ index 0000000000000000000000000000000000000000..a0109a388188b0808900405d334a4031
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/type/DependencyConfiguration.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/type/DependencyConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d13d20a501b39d309de15f02c0dda8993987a745
+index 0000000000000000000000000000000000000000..4ce9c3b17997a42f44e34f95ef3177e0adaa18a8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/type/DependencyConfiguration.java
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,32 @@
 +package io.papermc.paper.plugin.provider.configuration.type;
 +
 +import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 +
 +@ConfigSerializable
 +public record DependencyConfiguration(
-+    LoadOrder loadOrder,
++    LoadOrder load,
 +    boolean required,
 +    boolean joinClasspath
 +) {
@@ -5308,7 +5309,9 @@ index 0000000000000000000000000000000000000000..d13d20a501b39d309de15f02c0dda899
 +
 +    @ConfigSerializable
 +    public enum LoadOrder {
++        // dependency will now load BEFORE your plugin
 +        BEFORE,
++        // the dependency will now load AFTER your plugin
 +        AFTER,
 +        OMIT
 +    }
@@ -5753,10 +5756,10 @@ index 0000000000000000000000000000000000000000..32f230d66f6953520b59ccbf3079c5a6
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/type/paper/PaperBootstrapOrderConfiguration.java b/src/main/java/io/papermc/paper/plugin/provider/type/paper/PaperBootstrapOrderConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5b9627dba32c609610a89d828a2d733f10351741
+index 0000000000000000000000000000000000000000..e34656fb0573ff6d826eb4d4dcfd517e01589206
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/type/paper/PaperBootstrapOrderConfiguration.java
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,50 @@
 +package io.papermc.paper.plugin.provider.type.paper;
 +
 +import io.papermc.paper.plugin.configuration.PluginMeta;
@@ -5782,9 +5785,11 @@ index 0000000000000000000000000000000000000000..5b9627dba32c609610a89d828a2d733f
 +            String name = configuration.getKey();
 +            DependencyConfiguration dependencyConfiguration = configuration.getValue();
 +
-+            if (dependencyConfiguration.loadOrder() == DependencyConfiguration.LoadOrder.BEFORE) {
++            if (dependencyConfiguration.load() == DependencyConfiguration.LoadOrder.AFTER) {
++                // This plugin will load BEFORE all dependencies (so dependencies will load AFTER plugin)
 +                this.loadBefore.add(name);
-+            } else if (dependencyConfiguration.loadOrder() == DependencyConfiguration.LoadOrder.AFTER) {
++            } else if (dependencyConfiguration.load() == DependencyConfiguration.LoadOrder.BEFORE) {
++                // This plugin will load AFTER all dependencies (so dependencies will load BEFORE plugin)
 +                this.loadAfter.add(name);
 +            }
 +        }


### PR DESCRIPTION
Requires #9129

Updates the dependency declaration format to generally be more structured and avoid bootstrap flags everywhere. Format for the old format will be supported for a little while.

```yml
# BEFORE:
load-before:
  - name: RequiredPlugin
    bootstrap: false
load-after:
  - name: RegistryPlugin
    bootstrap: true
  - name: OtherPlugin
    bootstrap: false
dependencies:
  - name: OtherPlugin
    required: false
    bootstrap: false
  - name: RegistryPlugin
    required: true
    bootstrap: true
```

```yml
#AFTER:
dependencies:
  bootstrap:
    # Lets say that RegistryPlugin has some registry elements that this plugin requires.
    # We don't need this during runtime, so it's not required in the server section. However
    # can be added to both if needed
    RegistryPlugin:
      load: BEFORE
      required: true
      # (this is default)
      join-classpath: true
  server:
    # Add a required "RequiredPlugin" dependency, which this plugin must load BEFORE
    RequiredPlugin:
      load: AFTER
      required: true
      # This means that this plugin won't have access to classpath
      join-classpath: false
    # Add "OtherPlugin" dependency, which the plugin must load AFTER. Is not required. WILL join classpath (by default)
    OtherPlugin:
      load: BEFORE
      required: false
      join-classpath: true
    # Load order can be omitted to cause it to be ignored... or specified by load-order: OMIT
    SpecialDependency:
      required: true
      join-classpath: true
```