### PR TITLE
Fix  #1822

### DIFF
--- a/patches/server/0975-if-there-is-no-recipe-the-ingredients-should-be-unaf.patch
+++ b/patches/server/0975-if-there-is-no-recipe-the-ingredients-should-be-unaf.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: okx-code <okx@okx.sh>
+Date: Sat, 22 Apr 2023 23:19:56 +0100
+Subject: [PATCH] if there is no recipe, the ingredients should be unaffected
+ when taking an item out of the result slot
+
+
+diff --git a/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java b/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
+index ab6dc3449a1d3b7acf1d7bf5ac1c24224cc252c7..38cd98bac4663b0390c237e41e4c77d2f29c0648 100644
+--- a/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
++++ b/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
+@@ -155,7 +155,9 @@ public class RecipeManager extends SimpleJsonResourceReloadListener {
+             NonNullList<ItemStack> nonnulllist = NonNullList.withSize(inventory.getContainerSize(), ItemStack.EMPTY);
+ 
+             for (int i = 0; i < nonnulllist.size(); ++i) {
+-                nonnulllist.set(i, inventory.getItem(i));
++                // Paper start - if there is no recipe, the ingredients should be unaffected
++                nonnulllist.set(i, new ItemStack(inventory.getItem(i).getItem()));
++                // Paper end
+             }
+ 
+             return nonnulllist;


### PR DESCRIPTION
This PR is slightly different to the previous attempts #6418 and #7264 in that it more closely reflects the expected behaviour in the original bug #1822

The pull requests mentioned will still subtract an item from the ingredients when you take an item out of the result, even if the code just sets the result on PrepareItemCraftEvent. This pull request will leave the ingredients unaffected.