### PR TITLE
Disable allowListing before received from client

### DIFF
--- a/patches/server/0975-Disable-allowListing-before-received-from-client.patch
+++ b/patches/server/0975-Disable-allowListing-before-received-from-client.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sun, 23 Apr 2023 18:22:50 -0400
+Subject: [PATCH] Disable allowListing before received from client
+
+The client does not send the packet needed to received this information until a little later, which can cause a condition where
+despite a player having disabled listing, they are able to be seen for a brief moment. This causes the player to be listed as an Anonymous
+Player until the actual configuration value is received from the client.
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 1d4d02f26391ac55c7631817f09d05e2769b0d29..a0053455eaeca04855b689f3b00b78dac39d08e3 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -284,7 +284,7 @@ public class ServerPlayer extends Player {
+         this.recipeBook = new ServerRecipeBook();
+         this.lastSectionPos = SectionPos.of(0, 0, 0);
+         this.respawnDimension = Level.OVERWORLD;
+-        this.allowsListing = true;
++        this.allowsListing = false; // Paper - Set to false by default... wait for packet sent by client to populate
+         this.wardenSpawnTracker = new WardenSpawnTracker(0, 0, 0);
+         this.containerSynchronizer = new ContainerSynchronizer() {
+             @Override


### PR DESCRIPTION
The client does not send the packet needed to received this information until a little later, which can cause a condition where despite a player having disabled listing, they are able to be seen for a brief moment. This causes the player to be listed as an Anonymous Player until the actual configuration value is received from the client.