### PR TITLE
Fix some NPE for EntityCompostItemEvent

### DIFF
--- a/patches/api/0372-More-Teleport-API.patch
+++ b/patches/api/0372-More-Teleport-API.patch
@@ -6,20 +6,20 @@ Subject: [PATCH] More Teleport API
 
 diff --git a/src/main/java/io/papermc/paper/entity/LookAnchor.java b/src/main/java/io/papermc/paper/entity/LookAnchor.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7713a5b7e06da185685f18e79eae2c972e588696
+index 0000000000000000000000000000000000000000..c8312691c27ae436029ec5011ddf073582b12cba
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/entity/LookAnchor.java
 @@ -0,0 +1,25 @@
 +package io.papermc.paper.entity;
 +
-+import org.bukkit.Location;
++import io.papermc.paper.math.Position;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.entity.LivingEntity;
 +
 +/**
-+ * Represents what part of the entity should be used when determining where to face a location/entity.
++ * Represents what part of the entity should be used when determining where to face a position/entity.
 + *
-+ * @see org.bukkit.entity.Player#lookAt(Location, LookAnchor)
++ * @see org.bukkit.entity.Player#lookAt(Position, LookAnchor)
 + * @see org.bukkit.entity.Player#lookAt(Entity, LookAnchor, LookAnchor)
 + */
 +@org.jetbrains.annotations.ApiStatus.Experimental
@@ -165,7 +165,7 @@ index ab0ceaba9ddcbe20a8b8a1fc3ed19cb3c64ecd3d..97f0bc6573c8ba09de77061b6312b91c
       * Teleports this entity to the given location. If this entity is riding a
       * vehicle, it will be dismounted prior to teleportation.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2e1bd95fdce4571cb9d288e4dea495126834ee31..51e427992bc673b733971c34bb9f0df7c26ba653 100644
+index 2e1bd95fdce4571cb9d288e4dea495126834ee31..84b79db95c433a469e972e6dfec8e2c5ee8ce9ce 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2840,6 +2840,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -194,10 +194,10 @@ index 2e1bd95fdce4571cb9d288e4dea495126834ee31..51e427992bc673b733971c34bb9f0df7
 +    void lookAt(double x, double y, double z, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor);
 +
 +    /**
-+     * Causes the player to look towards the given location.
++     * Causes the player to look towards the given position.
 +     *
 +     * @param position Position to look at in the player's current world
-+     * @param playerAnchor What part of player should face the location
++     * @param playerAnchor What part of the player should face the given position
 +     */
 +    @org.jetbrains.annotations.ApiStatus.Experimental
 +    default void lookAt(@NotNull io.papermc.paper.math.Position position, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor) {

--- a/patches/server/0955-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
+++ b/patches/server/0955-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
@@ -5,31 +5,31 @@ Subject: [PATCH] Add CompostItemEvent and EntityCompostItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/ComposterBlock.java b/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
-index e81bda56c58df6c3109382c17e86f4cc0f16cf81..ae90e86327957bb784e2d81694ee7eea288bb455 100644
+index e81bda56c58df6c3109382c17e86f4cc0f16cf81..fb4382337fe83f7d00c2212a7a71e0ba5bdd51cc 100644
 --- a/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
-@@ -236,6 +236,9 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
-                     return InteractionResult.sidedSuccess(world.isClientSide);
-                 }
-                 BlockState iblockdata1 = ComposterBlock.addItem(player, state, world, pos, itemstack, rand);
-+                if (iblockdata1 == null) {
+@@ -232,6 +232,9 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+                 // Paper start - EntityChangeBlockEvent
+                 double rand = world.getRandom().nextDouble();
+                 BlockState dummyBlockState = ComposterBlock.addItem(player, state, org.bukkit.craftbukkit.util.DummyGeneratorAccess.INSTANCE, pos, itemstack, rand);
++                if (dummyBlockState == null) {
 +                    return InteractionResult.PASS;
 +                }
-                 // Paper end
- 
-                 world.levelEvent(1500, pos, state != iblockdata1 ? 1 : 0);
-@@ -265,6 +268,11 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
-                 return state;
-             }
-             iblockdata1 = ComposterBlock.addItem(user, state, world, pos, stack, rand);
+                 if (state != dummyBlockState && org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, pos, dummyBlockState).isCancelled()) { // if block state will change and event cancelled
+                     return InteractionResult.sidedSuccess(world.isClientSide);
+                 }
+@@ -261,6 +264,11 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+             // CraftBukkit start
+             double rand = world.getRandom().nextDouble();
+             BlockState iblockdata1 = ComposterBlock.addItem(user, state, DummyGeneratorAccess.INSTANCE, pos, stack, rand);
 +            // Paper start
 +            if (iblockdata1 == null) {
 +                return state;
 +            }
 +            // Paper end
-             // CraftBukkit end
- 
-             stack.shrink(1);
+             if (state == iblockdata1 || org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(user, pos, iblockdata1).isCancelled()) {
+                 return state;
+             }
 @@ -315,7 +323,22 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
          int i = (Integer) iblockdata.getValue(ComposterBlock.LEVEL);
          float f = ComposterBlock.COMPOSTABLES.getFloat(itemstack.getItem());


### PR DESCRIPTION
When the EntityCompostItemEvent is cancelled and a player/villager
interact with the composter an NPE is always thrown.

I have found another issue while testing this, the will raise level option doesn't work (it works for the dummy but then is overridden by the vanilla behavior later) but i don't have time rn