### PR TITLE
Fix DamageSource for Falling Blocks

### DIFF
--- a/patches/server/0977-Fix-DamageCause-for-Falling-Blocks.patch
+++ b/patches/server/0977-Fix-DamageCause-for-Falling-Blocks.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Mon, 1 May 2023 13:34:57 -0400
+Subject: [PATCH] Fix DamageCause for Falling Blocks
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 819c9c020f4d5a1373f68850134960d24b8fc308..dee0168b50c7fbaefb762939a04e8f51e7bc58f7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1028,6 +1028,11 @@ public class CraftEventFactory {
+             } else if (source.is(DamageTypes.SONIC_BOOM)) {
+                 cause = DamageCause.SONIC_BOOM;
+             }
++            // Paper start - fix handle of Falling Blocks
++            else if (source.is(DamageTypes.FALLING_STALACTITE) || source.is(DamageTypes.FALLING_BLOCK) || source.is(DamageTypes.FALLING_ANVIL)) {
++                cause = DamageCause.FALLING_BLOCK;
++            }
++            // Paper end
+ 
+             return CraftEventFactory.callEntityDamageEvent(damager, entity, cause, modifiers, modifierFunctions, cancelled, source.isCritical()); // Paper - add critical damage API
+         } else if (source.is(DamageTypes.OUT_OF_WORLD)) {


### PR DESCRIPTION
Mentioned in [discord](https://canary.discord.com/channels/289587909051416579/555462289851940864/1102607328844451910) exists a issue from Upstream where with the change of DamageSource (1.19.4) about the source/direct entity related to the damage, this change cause now the source entity of the damage for falling blocks now is handled before than CraftBukkit expects causing return another DamageSource, this PR is like a "hotfix" for this issue, in [upstream i have a PR](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/pull-requests/1180/overview) for try to clean and improvement this (exposing more info and another things) but consider the times for merge i prefer make this patch for this specific case.