### PR TITLE
Restore MC-2025 patch

### DIFF
--- a/patches/server/0978-MC-2025-Save-and-load-entity-AABB-to-prevent-wobble.patch
+++ b/patches/server/0978-MC-2025-Save-and-load-entity-AABB-to-prevent-wobble.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Zach Brown <zach.brown@destroystokyo.com>
+Date: Tue, 4 Sep 2018 19:07:57 -0400
+Subject: [PATCH] MC-2025: Save and load entity AABB to prevent wobble
+
+What follows is a summarized analysis provided on the Mojira and associated subreddit by various MC community members
+who have investigated this issue and found a solution. This work is largely a result of their efforts.
+
+The underlying cause of MC-2025 is that sometimes an AABB ends up slightly smaller than the desired width. If this
+happens before the entity is pushed up against a boundary (i.e. blocks or walls), then upon chunk save and reload, the
+AABB size will be recomputed such that it is intersecting the wall, allowing the entity to be pushed into the wall,
+suffocate, and die. Although the rounding artifacts get larger at larger world coordinates, the drift we see is
+miniscule. Closer to the world origin, we have seen error on the order of 2-46. Compare this to the fact that
+(due to MC-4), entity coordinates send to clients are quantized to multiples of 1/4096 (2-12).
+
+But, OMG, do the rounding errors mean that AABB's accumulate shrinkage over time? Actually, no. The statistics on IEEE
+rounding do not have that kind of bias. What has not been stated is that the AABB is just as likely to end up larger
+than the expected width; on save and reload, the entity ends up slightly away from the wall, and we don't notice any
+problem. In reality, the AABB size ends up undergoing random wobble around the expected value all the time, and that
+wobble isn't functionally any different from the kind we'd get even if we tried to force the AABB size to be stable!
+
+This reasoning leads us to one clear conclusion: The simplest, least invasive, and most correct solution is to just
+store the AABB in NBT data on chunk save and restore the AABB exactly as it was saved upon reload.
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 4705d7066207250c03a5f98eef61554c901f2e35..c47dee4c76fc1767e9cc0f29946b5c2a99eedcbd 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -2303,6 +2303,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+             if (freezeLocked) {
+                 nbt.putBoolean("Paper.FreezeLock", true);
+             }
++            // Paper start - MC-2025 fix - Save entity AABB and load it, floating point issues recalculating AABB can result in wobble
++            AABB boundingBox = this.getBoundingBox();
++            nbt.put("Paper.AAAB", this.newDoubleList(
++                boundingBox.minX, boundingBox.minY, boundingBox.minZ,
++                boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ
++            ));
+             // Paper end
+             return nbt;
+         } catch (Throwable throwable) {
+@@ -2471,6 +2477,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+             if (nbt.contains("Paper.FreezeLock")) {
+                 freezeLocked = nbt.getBoolean("Paper.FreezeLock");
+             }
++            // Paper start - MC-2025 fix - Save entity AABB and load it, floating point issues recalculating AABB can result in wobble
++            // Placement is important, always after the setPosition call above
++            if (nbt.contains("Paper.AABB")) {
++                net.minecraft.nbt.ListTag savedBB = nbt.getList("Paper.AABB", 6);
++                this.setBoundingBox(new AABB(
++                    savedBB.getDouble(0), savedBB.getDouble(1), savedBB.getDouble(2),
++                    savedBB.getDouble(3), savedBB.getDouble(4), savedBB.getDouble(5)
++                ));
++            }
+             // Paper end
+ 
+         } catch (Throwable throwable) {


### PR DESCRIPTION
This patch was originally dropped as it was incorrectly suspected for causing another bug, that bug was subsequently fixed, however, this patch was long forgotten about by most.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9180.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/676366679.zip)