### PR TITLE
Undeprecate Server#getMap

### DIFF
--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -9,10 +9,21 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c02b663ab711daa06de054a92f09485231824458..befbbefc97abbac819f4034e3df62f8437844c39 100644
+index c02b663ab711daa06de054a92f09485231824458..08da910016cc55f008acf20070daaa82f3128bf1 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1200,10 +1200,8 @@ public final class Bukkit {
+@@ -806,9 +806,8 @@ public final class Bukkit {
+      *
+      * @param id the id of the map to get
+      * @return a map view if it exists, or null otherwise
+-     * @deprecated Magic value
+      */
+-    @Deprecated
++    //@Deprecated // Paper - Not a magic value
+     @Nullable
+     public static MapView getMap(int id) {
+         return server.getMap(id);
+@@ -1200,10 +1199,8 @@ public final class Bukkit {
       * @param name the name the player to retrieve
       * @return an offline player
       * @see #getOfflinePlayer(java.util.UUID)
@@ -24,7 +35,7 @@ index c02b663ab711daa06de054a92f09485231824458..befbbefc97abbac819f4034e3df62f84
      @NotNull
      public static OfflinePlayer getOfflinePlayer(@NotNull String name) {
          return server.getOfflinePlayer(name);
-@@ -1749,7 +1747,7 @@ public final class Bukkit {
+@@ -1749,7 +1746,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -175,10 +186,21 @@ index 6277451c3c6c551078c237cd767b6d70c4f585ea..10f5cfb1885833a1d2c1027c03974da4
      CRACKED(0x0),
      GLYPHED(0x1),
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 20f9384c30f46e11631a7f79c48915bf55762858..291abd48c3c8af0807bce312c18d8cf287c1f8cf 100644
+index 20f9384c30f46e11631a7f79c48915bf55762858..e75e02b662cc16c2e76ee38dea3cbc8626e51a3c 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1001,10 +1001,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -670,9 +670,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      *
+      * @param id the id of the map to get
+      * @return a map view if it exists, or null otherwise
+-     * @deprecated Magic value
+      */
+-    @Deprecated
++    //@Deprecated // Paper - Not a magic value
+     @Nullable
+     public MapView getMap(int id);
+ 
+@@ -1001,10 +1000,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param name the name the player to retrieve
       * @return an offline player
       * @see #getOfflinePlayer(java.util.UUID)
@@ -190,7 +212,7 @@ index 20f9384c30f46e11631a7f79c48915bf55762858..291abd48c3c8af0807bce312c18d8cf2
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  
-@@ -1467,7 +1465,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1467,7 +1464,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */

--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -893,6 +893,40 @@ index 55e9dc5d1d87fbc9d0dabbb7bd59584fe2c5f379..5c1ca0e47f0ac1525c3d37b55f528748
      void setLocalizedName(@Nullable String name);
  
      /**
+diff --git a/src/main/java/org/bukkit/inventory/meta/MapMeta.java b/src/main/java/org/bukkit/inventory/meta/MapMeta.java
+index 32055a8890425e0b819930f3059da5ea9dfca553..26a336dade83baee97d20eb39a058925659f5777 100644
+--- a/src/main/java/org/bukkit/inventory/meta/MapMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/MapMeta.java
+@@ -16,13 +16,8 @@ public interface MapMeta extends ItemMeta {
+      *
+      * @return true if this has a map ID number.
+      * @see #hasMapView()
+-     * @deprecated These methods are poor API: They rely on the caller to pass
+-     * in an only an integer property, and have poorly defined implementation
+-     * behavior if that integer is not a valid map (the current implementation
+-     * for example will generate a new map with a different ID). The xxxMapView
+-     * family of methods should be used instead.
+      */
+-    @Deprecated
++    //@Deprecated // Paper
+     boolean hasMapId();
+ 
+     /**
+@@ -34,13 +29,8 @@ public interface MapMeta extends ItemMeta {
+      *
+      * @return the map ID that is set
+      * @see #getMapView()
+-     * @deprecated These methods are poor API: They rely on the caller to pass
+-     * in an only an integer property, and have poorly defined implementation
+-     * behavior if that integer is not a valid map (the current implementation
+-     * for example will generate a new map with a different ID). The xxxMapView
+-     * family of methods should be used instead.
+      */
+-    @Deprecated
++    //@Deprecated // Paper
+     int getMapId();
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/material/Step.java b/src/main/java/org/bukkit/material/Step.java
 index 9f502e7ee05d0512e190a1722cc112ece068c4e2..10c0465cf58d680bfa9a0f9233f94e8b6d5a9b93 100644
 --- a/src/main/java/org/bukkit/material/Step.java

--- a/patches/api/0180-Expose-the-internal-current-tick.patch
+++ b/patches/api/0180-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index befbbefc97abbac819f4034e3df62f8437844c39..16e6d0929ce4c7313418aa4635fb77bf112b2936 100644
+index 08da910016cc55f008acf20070daaa82f3128bf1..9790aef0fe2c7ff0818455b1b3870a560eee8448 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2288,6 +2288,10 @@ public final class Bukkit {
+@@ -2287,6 +2287,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfileExact(uuid, name);
      }
@@ -20,10 +20,10 @@ index befbbefc97abbac819f4034e3df62f8437844c39..16e6d0929ce4c7313418aa4635fb77bf
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 291abd48c3c8af0807bce312c18d8cf287c1f8cf..411031322c97d220957e4cff43ca3758c18d60a8 100644
+index e75e02b662cc16c2e76ee38dea3cbc8626e51a3c..9872df17c5b30b876a1423e841db914bf255f9a5 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1987,5 +1987,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1986,5 +1986,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0186-Add-tick-times-API.patch
+++ b/patches/api/0186-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 16e6d0929ce4c7313418aa4635fb77bf112b2936..0a03654b5f15650c0acbbdb464b87cfed3bcaa30 100644
+index 9790aef0fe2c7ff0818455b1b3870a560eee8448..20877004d927d9f6f998ff9502c18ae111ad6490 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1960,6 +1960,25 @@ public final class Bukkit {
+@@ -1959,6 +1959,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index 16e6d0929ce4c7313418aa4635fb77bf112b2936..0a03654b5f15650c0acbbdb464b87cfe
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 411031322c97d220957e4cff43ca3758c18d60a8..770c4ffa0243578b5cdd3502d137f218f38c7491 100644
+index 9872df17c5b30b876a1423e841db914bf255f9a5..68ce7ab1d0a519e270292db103c0b312649f886a 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1649,6 +1649,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1648,6 +1648,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0187-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0187-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 0a03654b5f15650c0acbbdb464b87cfed3bcaa30..ecc06036d928f9b23cd0798a1e97154a005d1427 100644
+index 20877004d927d9f6f998ff9502c18ae111ad6490..80fce2f8b89384691304f69e68de1c1676a905fa 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2311,6 +2311,15 @@ public final class Bukkit {
+@@ -2310,6 +2310,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index 0a03654b5f15650c0acbbdb464b87cfed3bcaa30..ecc06036d928f9b23cd0798a1e97154a
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 770c4ffa0243578b5cdd3502d137f218f38c7491..b334869de8cb51474dcbd4cf24d7552166e0be8b 100644
+index 68ce7ab1d0a519e270292db103c0b312649f886a..2fc042affe26118c50eacea700aaea0c82e10094 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2009,5 +2009,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2008,5 +2008,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0195-Add-Mob-Goal-API.patch
+++ b/patches/api/0195-Add-Mob-Goal-API.patch
@@ -524,10 +524,10 @@ index 0000000000000000000000000000000000000000..dddbb661265aa23f88d93d0681f418f4
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c0908574e079e203b7815b1bf3d304c1d202a4d3..d5e12a33d6f79b2f3ec5079cb4e91830cabe9711 100644
+index 163daca0d6b861a7813848f2ce14713fdac65844..c14067d03cfe4c75896d9d1409f0fca57793f7d0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2332,6 +2332,16 @@ public final class Bukkit {
+@@ -2331,6 +2331,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -545,10 +545,10 @@ index c0908574e079e203b7815b1bf3d304c1d202a4d3..d5e12a33d6f79b2f3ec5079cb4e91830
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e21801904d24e15a9db250b75051347418e20670..ea821f079770a30828519f10b013f80640296442 100644
+index 2ea033b75168aac30caa645f8910cc0b0c27942e..0944406ccb12104ea0ec3371e731d8fd0b8f600d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2026,5 +2026,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2025,5 +2025,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0219-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0219-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index af5ce8bef3529a008a4f105e3812e3aec20e90fa..7cef6511b9b986fd5b3c59072e099f7a4ebb5fc4 100644
+index ba146ba3f3dac06a5e7cde3897bbb44288183ff6..531665375141dd8e070dcd68a864fc63e87bb762 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1230,6 +1230,27 @@ public final class Bukkit {
+@@ -1229,6 +1229,27 @@ public final class Bukkit {
          return server.getOfflinePlayer(name);
      }
  
@@ -37,10 +37,10 @@ index af5ce8bef3529a008a4f105e3812e3aec20e90fa..7cef6511b9b986fd5b3c59072e099f7a
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5b4fc4fa5122cea783e64ff61ae43e5ce45f6af6..9dcd94bc1aedac589192f4bb07d7ae821586f58a 100644
+index 72900dd9d4e8050dc4ec902de4b3e5cc717273b6..204501e7964355d9f8b4e357e5fd636967752455 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1025,6 +1025,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1024,6 +1024,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  

--- a/patches/api/0283-Add-basic-Datapack-API.patch
+++ b/patches/api/0283-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 041c6a9a1adce389f3a7ca6e5bbb7cfed0ab6fd8..890328e1204fc9d8836a69dfbf50ba82d950d6f8 100644
+index c3fe8116133f3e3fdb729607fd20dba6645b9563..21583b3413fcc5a42590464371cd929e37a4c2e0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2386,6 +2386,14 @@ public final class Bukkit {
+@@ -2385,6 +2385,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index 041c6a9a1adce389f3a7ca6e5bbb7cfed0ab6fd8..890328e1204fc9d8836a69dfbf50ba82
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index b283a9ba0c6ea1b24cb03b690984b93d25ddf010..ce3598bd4be5eab4c9b6008bca78c7a470adbf31 100644
+index cde4b79fed3e6b3f35597d11f086defd30bc6d8f..a1f1efc1d953bd2daf46b84ffb3d63d2c2f19bee 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2073,5 +2073,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2072,5 +2072,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0329-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0329-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 890328e1204fc9d8836a69dfbf50ba82d950d6f8..b0a1ae0028387397998c2a53031f6f767c7bf3f4 100644
+index 21583b3413fcc5a42590464371cd929e37a4c2e0..60b2f21195384d544a7e123ce19a09ee437a6538 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1904,6 +1904,24 @@ public final class Bukkit {
+@@ -1903,6 +1903,24 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -34,10 +34,10 @@ index 890328e1204fc9d8836a69dfbf50ba82d950d6f8..b0a1ae0028387397998c2a53031f6f76
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ce3598bd4be5eab4c9b6008bca78c7a470adbf31..492d783eb1376730ac79853bfb0abb7b4d555c0f 100644
+index a1f1efc1d953bd2daf46b84ffb3d63d2c2f19bee..35ec012867c6d87b76fd60d1ff55302612f96b9e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1599,6 +1599,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1598,6 +1598,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  

--- a/patches/api/0348-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0348-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for creating command sender which forwards feedback
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b0a1ae0028387397998c2a53031f6f767c7bf3f4..6b7f6d7f5a6622b41fc4468262985fa0a1266bfc 100644
+index 60b2f21195384d544a7e123ce19a09ee437a6538..b27260b03ed1e49a1ff50db2f00133f92cad37a9 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1412,6 +1412,20 @@ public final class Bukkit {
+@@ -1411,6 +1411,20 @@ public final class Bukkit {
          return server.getConsoleSender();
      }
  
@@ -30,10 +30,10 @@ index b0a1ae0028387397998c2a53031f6f767c7bf3f4..6b7f6d7f5a6622b41fc4468262985fa0
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 492d783eb1376730ac79853bfb0abb7b4d555c0f..70a22d26beec7b4e82f4ab6be06875a53e622002 100644
+index 35ec012867c6d87b76fd60d1ff55302612f96b9e..bdf247e6a8622b2e8a3d2dcdd6a2a7ebd1c01603 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1178,6 +1178,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1177,6 +1177,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/api/0354-Custom-Potion-Mixes.patch
+++ b/patches/api/0354-Custom-Potion-Mixes.patch
@@ -102,10 +102,10 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 6b7f6d7f5a6622b41fc4468262985fa0a1266bfc..d7d6897b1f697f48aa3890d70797dd3195de125e 100644
+index b27260b03ed1e49a1ff50db2f00133f92cad37a9..ebf3243d6c77064d9ba9c1dd0c392985988a303b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2426,6 +2426,15 @@ public final class Bukkit {
+@@ -2425,6 +2425,15 @@ public final class Bukkit {
      public static io.papermc.paper.datapack.DatapackManager getDatapackManager() {
          return server.getDatapackManager();
      }
@@ -122,10 +122,10 @@ index 6b7f6d7f5a6622b41fc4468262985fa0a1266bfc..d7d6897b1f697f48aa3890d70797dd31
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 70a22d26beec7b4e82f4ab6be06875a53e622002..dcd04d2181037c91f004fee339373f0b15534e1d 100644
+index bdf247e6a8622b2e8a3d2dcdd6a2a7ebd1c01603..43bae3e3fc2f9e59ad5f5be0fc158e47af04e342 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2107,5 +2107,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2106,5 +2106,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();


### PR DESCRIPTION
The only way to get a map is via its id, which is not a magic value. This implementation isn't going to be changing anytime soon, so it should be undeprecated.