### PR TITLE
Fix BlockPosition#offset(double,double,double)

### DIFF
--- a/patches/api/0009-Add-Position.patch
+++ b/patches/api/0009-Add-Position.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add Position
 
 diff --git a/src/main/java/io/papermc/paper/math/BlockPosition.java b/src/main/java/io/papermc/paper/math/BlockPosition.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f164d32cfbd5bfd84f3067a149d34bb1185a7e00
+index 0000000000000000000000000000000000000000..f0fdabce4af640da2a406412e67020761ded3ac1
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/math/BlockPosition.java
 @@ -0,0 +1,98 @@
@@ -64,7 +64,7 @@ index 0000000000000000000000000000000000000000..f164d32cfbd5bfd84f3067a149d34bb1
 +
 +    @Override
 +    default @NotNull FinePosition offset(double x, double y, double z) {
-+        return new FinePositionImpl(this.blockX() + z, this.blockY() + y, this.blockZ() + z);
++        return new FinePositionImpl(this.blockX() + x, this.blockY() + y, this.blockZ() + z);
 +    }
 +
 +    /**


### PR DESCRIPTION
The offset method on BlockPosition incorrectly added the passed z offset to its x value when computing the new x value of the resulting position. This commit fixes this oversight.