### PR TITLE
Re-implement the compost events

### DIFF
--- a/patches/server/0881-Fire-EntityChangeBlockEvent-in-more-places.patch
+++ b/patches/server/0881-Fire-EntityChangeBlockEvent-in-more-places.patch
@@ -199,25 +199,66 @@ index 32995cb5efdad0bc34ecacacb78cccd21220ba8d..c7195f2e12bbd6545f7bffcc2b4ba5cc
                      level.gameEvent(GameEvent.BLOCK_CHANGE, blockPos, GameEvent.Context.of(player, blockState3));
                      if (player != null) {
 diff --git a/src/main/java/net/minecraft/world/level/block/ComposterBlock.java b/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
-index 53f4a000079f4c056500d03eca71991ae14483a9..e81bda56c58df6c3109382c17e86f4cc0f16cf81 100644
+index 53f4a000079f4c056500d03eca71991ae14483a9..50fd52905d8f69c693cb1b406b681a6af02787e2 100644
 --- a/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
-@@ -229,7 +229,14 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
- 
+@@ -230,6 +230,11 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
          if (i < 8 && ComposterBlock.COMPOSTABLES.containsKey(itemstack.getItem())) {
              if (i < 7 && !world.isClientSide) {
--                BlockState iblockdata1 = ComposterBlock.addItem(player, state, world, pos, itemstack);
-+                // Paper start - EntityChangeBlockEvent
-+                double rand = world.getRandom().nextDouble();
-+                BlockState dummyBlockState = ComposterBlock.addItem(player, state, org.bukkit.craftbukkit.util.DummyGeneratorAccess.INSTANCE, pos, itemstack, rand);
-+                if (state != dummyBlockState && org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, pos, dummyBlockState).isCancelled()) { // if block state will change and event cancelled
-+                    return InteractionResult.sidedSuccess(world.isClientSide);
+                 BlockState iblockdata1 = ComposterBlock.addItem(player, state, world, pos, itemstack);
++                // Paper start - handle cancelled events
++                if (iblockdata1 == null) {
++                    return InteractionResult.PASS;
 +                }
-+                BlockState iblockdata1 = ComposterBlock.addItem(player, state, world, pos, itemstack, rand);
 +                // Paper end
  
                  world.levelEvent(1500, pos, state != iblockdata1 ? 1 : 0);
                  player.awardStat(Stats.ITEM_USED.get(itemstack.getItem()));
+@@ -253,11 +258,16 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+         if (i < 7 && ComposterBlock.COMPOSTABLES.containsKey(stack.getItem())) {
+             // CraftBukkit start
+             double rand = world.getRandom().nextDouble();
+-            BlockState iblockdata1 = ComposterBlock.addItem(user, state, DummyGeneratorAccess.INSTANCE, pos, stack, rand);
+-            if (state == iblockdata1 || org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(user, pos, iblockdata1).isCancelled()) {
++            BlockState iblockdata1 = null; // Paper
++            if (false && (state == iblockdata1 || org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(user, pos, iblockdata1).isCancelled())) { // Paper - call it later
+                 return state;
+             }
+             iblockdata1 = ComposterBlock.addItem(user, state, world, pos, stack, rand);
++            // Paper start - handle cancelled events
++            if (iblockdata1 == null) {
++                return state;
++            }
++            // Paper end
+             // CraftBukkit end
+ 
+             stack.shrink(1);
+@@ -298,11 +308,13 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+         return iblockdata1;
+     }
+ 
++    @Nullable // Paper
+     static BlockState addItem(@Nullable Entity user, BlockState state, LevelAccessor world, BlockPos pos, ItemStack stack) {
+         // CraftBukkit start
+         return ComposterBlock.addItem(user, state, world, pos, stack, world.getRandom().nextDouble());
+     }
+ 
++    @Nullable // Paper - make it nullable
+     static BlockState addItem(@Nullable Entity entity, BlockState iblockdata, LevelAccessor generatoraccess, BlockPos blockposition, ItemStack itemstack, double rand) {
+         // CraftBukkit end
+         int i = (Integer) iblockdata.getValue(ComposterBlock.LEVEL);
+@@ -313,6 +325,11 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+         } else {
+             int j = i + 1;
+             BlockState iblockdata1 = (BlockState) iblockdata.setValue(ComposterBlock.LEVEL, j);
++            // Paper start - move the EntityChangeBlockEvent here to avoid conflict later for the compost events
++            if (entity != null && org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(entity, blockposition, iblockdata1).isCancelled()) {
++                return null;
++            }
++            // Paper end
+ 
+             generatoraccess.setBlock(blockposition, iblockdata1, 3);
+             generatoraccess.gameEvent(GameEvent.BLOCK_CHANGE, blockposition, GameEvent.Context.of(entity, iblockdata1));
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java b/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java
 index 80026dcdb66cc88a080b33ef290a6a7fb7bcbbaa..0b7d882551bcb8be149754209aad5fe4142f0fac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java

--- a/patches/server/0955-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
+++ b/patches/server/0955-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
@@ -5,56 +5,33 @@ Subject: [PATCH] Add CompostItemEvent and EntityCompostItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/ComposterBlock.java b/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
-index e81bda56c58df6c3109382c17e86f4cc0f16cf81..fb4382337fe83f7d00c2212a7a71e0ba5bdd51cc 100644
+index 50fd52905d8f69c693cb1b406b681a6af02787e2..6fab2b69a0af298bd00b309efcd6aa8399e23d1f 100644
 --- a/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
-@@ -232,6 +232,9 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
-                 // Paper start - EntityChangeBlockEvent
-                 double rand = world.getRandom().nextDouble();
-                 BlockState dummyBlockState = ComposterBlock.addItem(player, state, org.bukkit.craftbukkit.util.DummyGeneratorAccess.INSTANCE, pos, itemstack, rand);
-+                if (dummyBlockState == null) {
-+                    return InteractionResult.PASS;
-+                }
-                 if (state != dummyBlockState && org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, pos, dummyBlockState).isCancelled()) { // if block state will change and event cancelled
-                     return InteractionResult.sidedSuccess(world.isClientSide);
-                 }
-@@ -261,6 +264,11 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
-             // CraftBukkit start
-             double rand = world.getRandom().nextDouble();
-             BlockState iblockdata1 = ComposterBlock.addItem(user, state, DummyGeneratorAccess.INSTANCE, pos, stack, rand);
-+            // Paper start
-+            if (iblockdata1 == null) {
-+                return state;
-+            }
-+            // Paper end
-             if (state == iblockdata1 || org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(user, pos, iblockdata1).isCancelled()) {
-                 return state;
-             }
-@@ -315,7 +323,22 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+@@ -320,7 +320,21 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
          int i = (Integer) iblockdata.getValue(ComposterBlock.LEVEL);
          float f = ComposterBlock.COMPOSTABLES.getFloat(itemstack.getItem());
  
 -        if ((i != 0 || f <= 0.0F) && rand >= (double) f) {
 +        // Paper start
 +        boolean willRaiseLevel = !((i != 0 || f <= 0.0F) && rand >= (double) f);
-+        if (generatoraccess == DummyGeneratorAccess.INSTANCE || entity == null) { // call event on test run or when entity is null (via hopper)
-+            final io.papermc.paper.event.block.CompostItemEvent event;
-+            if (entity == null) {
-+                event = new io.papermc.paper.event.block.CompostItemEvent(org.bukkit.craftbukkit.block.CraftBlock.at(generatoraccess, blockposition), itemstack.getBukkitStack(), willRaiseLevel);
-+            } else {
-+                event = new io.papermc.paper.event.entity.EntityCompostItemEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(generatoraccess, blockposition), itemstack.getBukkitStack(), willRaiseLevel);
-+            }
-+            if (!event.callEvent()) {
-+                return null;
-+            }
-+            willRaiseLevel = event.willRaiseLevel();
++        final io.papermc.paper.event.block.CompostItemEvent event;
++        if (entity == null) {
++            event = new io.papermc.paper.event.block.CompostItemEvent(org.bukkit.craftbukkit.block.CraftBlock.at(generatoraccess, blockposition), itemstack.getBukkitStack(), willRaiseLevel);
++        } else {
++            event = new io.papermc.paper.event.entity.EntityCompostItemEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(generatoraccess, blockposition), itemstack.getBukkitStack(), willRaiseLevel);
 +        }
++        if (!event.callEvent()) { // check for cancellation of entity event (non entity event can't be cancelled cause of hoppers)
++            return null;
++        }
++        willRaiseLevel = event.willRaiseLevel();
++
 +        if (!willRaiseLevel) {
 +            // Paper end
              return iblockdata;
          } else {
              int j = i + 1;
-@@ -460,6 +483,11 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+@@ -470,6 +484,11 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
                  this.changed = true;
                  BlockState iblockdata = ComposterBlock.addItem((Entity) null, this.state, this.level, this.pos, itemstack);
  


### PR DESCRIPTION
The current implementation of the compost events is broken, it breaks spigot contract with the dummy call which will be always equals to the "real" call on the physics world. In order to achieve that spigot precompute the random value to have the same output for both calls but the new compost event is only fired for the dummy call and can change the output without being persisted into the "real" call. That break the "will raise level" option on the compost event (trapped into the dummy) and also fire (in the case a plugin change the will raise level) the EntityChangeBlockEvent when nothing change or the reverse things telling a lie to the listener.