### PR TITLE
More accurate isInOpenWater impl

### DIFF
--- a/patches/server/0980-More-accurate-isInOpenWater-impl.patch
+++ b/patches/server/0980-More-accurate-isInOpenWater-impl.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Warrior <50800980+Warriorrrr@users.noreply.github.com>
+Date: Sun, 7 May 2023 22:33:50 +0200
+Subject: [PATCH] More accurate isInOpenWater impl
+
+For fishing hooks, the openWater field is true by default, and only calculated when a "fish" is approaching the bobber.
+This patch changes the API impl to calculate the open water state itself instead of returning this field.
+
+Relevant link: https://github.com/PaperMC/Paper/issues/9131
+
+== AT ==
+public net.minecraft.world.entity.projectile.FishingHook calculateOpenWater(Lnet/minecraft/core/BlockPos;)Z
+public net.minecraft.world.entity.projectile.FishingHook outOfWaterTime
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+index 7e34d6a986a98f0b9d5c2a66000ea94e2d1f46b0..f4591dfe799538ba8aea104793ceb9995dad0bb6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
+@@ -171,7 +171,7 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
+ 
+     @Override
+     public boolean isInOpenWater() {
+-        return this.getHandle().isOpenWaterFishing();
++        return this.getHandle().outOfWaterTime < 10 && this.getHandle().calculateOpenWater(this.getHandle().blockPosition()); // Paper - isOpenWaterFishing is only calculated when a "fish" is approaching the hook
+     }
+ 
+     @Override


### PR DESCRIPTION
Closes #9131

Changes the impl to always calculate open water instead of using the isOpenWaterFishing method, since that's only calculated when a fish is approaching. I feel this would be more in line with what the [javadoc](https://jd.papermc.io/paper/1.19/org/bukkit/entity/FishHook.html#isInOpenWater()) for the method says.