### PR TITLE
Make ExperienceOrb entities call EntitySpawnEvent

### DIFF
--- a/patches/server/0989-ExperienceOrb-should-call-EntitySpawnEvent.patch
+++ b/patches/server/0989-ExperienceOrb-should-call-EntitySpawnEvent.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Golfing8 <atroo@me.com>
+Date: Mon, 8 May 2023 09:18:17 -0400
+Subject: [PATCH] ExperienceOrb should call EntitySpawnEvent
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 9b9a9606e5be94b394606f2306e7b7a5ed781e1d..acb38f927c2418c91adf91c7b790ea6869835537 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -693,7 +693,10 @@ public class CraftEventFactory {
+         } else if (entity instanceof net.minecraft.world.entity.ExperienceOrb) {
+             net.minecraft.world.entity.ExperienceOrb xp = (net.minecraft.world.entity.ExperienceOrb) entity;
+             double radius = world.spigotConfig.expMerge;
+-            if (radius > 0) {
++            // Paper start - Call EntitySpawnEvent for ExperienceOrb entities.
++            event = CraftEventFactory.callEntitySpawnEvent(entity);
++            if (radius > 0 && !event.isCancelled() && !entity.isRemoved()) {
++                // Paper end
+                 // Paper start - Maximum exp value when merging - Whole section has been tweaked, see comments for specifics
+                 final int maxValue = world.paperConfig().entities.behavior.experienceMergeMaxValue;
+                 final boolean mergeUnconditionally = world.paperConfig().entities.behavior.experienceMergeMaxValue <= 0;


### PR DESCRIPTION
The ExperienceOrb entity currently has no universal 'spawn' event. This patch adds the event prior to the ExperienceOrbMergeEvent call so new experience orbs do not affect old ones.