### PR TITLE
ignoring moved too quickly message for teleports

### DIFF
--- a/patches/server/0979-ignoring-moved-too-quickly-message-for-teleports.patch
+++ b/patches/server/0979-ignoring-moved-too-quickly-message-for-teleports.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: NonSwag <mrminecraft00@gmail.com>
+Date: Thu, 11 May 2023 17:05:44 +0200
+Subject: [PATCH] ignoring moved too quickly message for teleports
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 04a92f33f15d1696e38d38839651adf7d0462cac..2a905674ef59f1de7d1aeada2c10a1ebf769daab 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1471,9 +1471,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                                 this.internalTeleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot(), Collections.emptySet());
+                                 return;
+                             }
+-                            // Paper end
+-
+-                            if (!this.player.isChangingDimension() && (!this.player.getLevel().getGameRules().getBoolean(GameRules.RULE_DISABLE_ELYTRA_MOVEMENT_CHECK) || !this.player.isFallFlying())) {
++                            // Ignoring teleports as they unnecessarily flag the player
++                            // if (!this.player.isChangingDimension() && (!this.player.getLevel().getGameRules().getBoolean(GameRules.RULE_DISABLE_ELYTRA_MOVEMENT_CHECK) || !this.player.isFallFlying())) {
++                            if (!this.justTeleported && !this.player.isChangingDimension() && (!this.player.getLevel().getGameRules().getBoolean(GameRules.RULE_DISABLE_ELYTRA_MOVEMENT_CHECK) || !this.player.isFallFlying())) {
++                                // Paper end
+                                 float f2 = this.player.isFallFlying() ? 300.0F : 100.0F;
+ 
+                                 if (d11 - d10 > Math.max(f2, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {


### PR DESCRIPTION
Almost all the time, a player gets teleported over a bigger distance, the player gets flagged for [moving too quickly](https://github.com/PaperMC/Paper/assets/54660361/35844ad7-5717-426f-826d-5b004cde70b3).
This change simply allows the movement after a teleport it.
_I could not find a way to exploit this, but I am no cheater, so I don't really know what's possible there._
