### PR TITLE
Call EntityChangeBlockEvent for frogs egg (1.19.4)

### DIFF
--- a/patches/server/0881-Fire-EntityChangeBlockEvent-in-more-places.patch
+++ b/patches/server/0881-Fire-EntityChangeBlockEvent-in-more-places.patch
@@ -78,6 +78,23 @@ index 534ff7d4844448eaddb2778f81dfd66d1ee375db..558c14af6415681909f9e3a15f303ce4
              world.setBlockAndUpdate(blockposition1Final, iblockdata1); // CraftBukkit - decompile error
          });
          world.levelEvent(3002, blockposition1, -1);
+diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/TryLaySpawnOnWaterNearLand.java b/src/main/java/net/minecraft/world/entity/ai/behavior/TryLaySpawnOnWaterNearLand.java
+index 04fe142984760a1162703b46e08bf172b7277258..578f98981d3fa50630f8b25ecd69a11e523f7d8d 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/behavior/TryLaySpawnOnWaterNearLand.java
++++ b/src/main/java/net/minecraft/world/entity/ai/behavior/TryLaySpawnOnWaterNearLand.java
+@@ -27,6 +27,12 @@ public class TryLaySpawnOnWaterNearLand {
+                                 BlockPos blockPos3 = blockPos2.above();
+                                 if (world.getBlockState(blockPos3).isAir()) {
+                                     BlockState blockState = frogSpawn.defaultBlockState();
++                                    // Paper start
++                                    if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(entity, blockPos3, blockState).isCancelled()) {
++                                        isPregnant.erase(); // forgot pregnant memory
++                                        return true;
++                                    }
++                                    // Paper end
+                                     world.setBlock(blockPos3, blockState, 3);
+                                     world.gameEvent(GameEvent.BLOCK_PLACE, blockPos3, GameEvent.Context.of(entity, blockState));
+                                     world.playSound((Player)null, entity, SoundEvents.FROG_LAY_SPAWN, SoundSource.BLOCKS, 1.0F, 1.0F);
 diff --git a/src/main/java/net/minecraft/world/item/AxeItem.java b/src/main/java/net/minecraft/world/item/AxeItem.java
 index 2f8ae1786a4c4438515c59fa56acaefdff60703d..9c7d0b9cc2fa98d5785c914c0183f7d4b5b1c1ea 100644
 --- a/src/main/java/net/minecraft/world/item/AxeItem.java


### PR DESCRIPTION
Call EntityChangeBlockEvent when frogs lay eggs in the lake

This is a remake of https://github.com/PaperMC/Paper/pull/8136 dropped during the 1.19.3 update and i believe it wasn't intended.