### PR TITLE
Avoid duplicate death event call for armorstands

### DIFF
--- a/patches/server/0253-Improve-death-events.patch
+++ b/patches/server/0253-Improve-death-events.patch
@@ -301,10 +301,10 @@ index ebe207e2c4d8b7e125fec8a5182fe4882c9339e3..8ac82d3efc0f6d8ff40226e4f8084435
      public void addAdditionalSaveData(CompoundTag nbt) {
          super.addAdditionalSaveData(nbt);
 diff --git a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
-index e38cbdff34479673f1640c46d727f1a807a609c7..b09639e8f42213ffc3fe490ac7cb48c2d38996ba 100644
+index 719f68f96e58ddcdd3592131c691d21263c81915..a35a0952ce8e1fc42e92734786d531c7e10b34d7 100644
 --- a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
 +++ b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
-@@ -497,8 +497,10 @@ public class ArmorStand extends LivingEntity {
+@@ -491,8 +491,10 @@ public class ArmorStand extends LivingEntity {
                  }
                  // CraftBukkit end
                  if (source.is(DamageTypeTags.IS_EXPLOSION)) {
@@ -317,18 +317,19 @@ index e38cbdff34479673f1640c46d727f1a807a609c7..b09639e8f42213ffc3fe490ac7cb48c2
                      return false;
                  } else if (source.is(DamageTypeTags.IGNITES_ARMOR_STANDS)) {
                      if (this.isOnFire()) {
-@@ -542,8 +544,9 @@ public class ArmorStand extends LivingEntity {
+@@ -536,9 +538,9 @@ public class ArmorStand extends LivingEntity {
                                  this.gameEvent(GameEvent.ENTITY_DAMAGE, source.getEntity());
                                  this.lastHit = i;
                              } else {
 -                                this.brokenByPlayer(source);
 +                                org.bukkit.event.entity.EntityDeathEvent event = this.brokenByPlayer(source); // Paper
                                  this.showBreakingParticles();
-+                                if (!event.isCancelled()) // Paper
-                                 this.discard(); // CraftBukkit - SPIGOT-4890: remain as this.discard() since above damagesource method will call death event
+-                                this.discard(); // CraftBukkit - SPIGOT-4890: remain as this.discard() since above damagesource method will call death event
++                                if (!event.isCancelled()) this.kill(false); // Paper - we still need to kill to follow vanilla logic (emit the game event etc...)
                              }
  
-@@ -596,8 +599,10 @@ public class ArmorStand extends LivingEntity {
+                             return true;
+@@ -590,8 +592,10 @@ public class ArmorStand extends LivingEntity {
  
          f1 -= amount;
          if (f1 <= 0.5F) {
@@ -341,7 +342,7 @@ index e38cbdff34479673f1640c46d727f1a807a609c7..b09639e8f42213ffc3fe490ac7cb48c2
          } else {
              this.setHealth(f1);
              this.gameEvent(GameEvent.ENTITY_DAMAGE, damageSource.getEntity());
-@@ -605,7 +610,7 @@ public class ArmorStand extends LivingEntity {
+@@ -599,7 +603,7 @@ public class ArmorStand extends LivingEntity {
  
      }
  
@@ -350,7 +351,7 @@ index e38cbdff34479673f1640c46d727f1a807a609c7..b09639e8f42213ffc3fe490ac7cb48c2
          ItemStack itemstack = new ItemStack(Items.ARMOR_STAND);
  
          if (this.hasCustomName()) {
-@@ -613,10 +618,10 @@ public class ArmorStand extends LivingEntity {
+@@ -607,10 +611,10 @@ public class ArmorStand extends LivingEntity {
          }
  
          drops.add(org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(itemstack)); // CraftBukkit - add to drops
@@ -363,7 +364,7 @@ index e38cbdff34479673f1640c46d727f1a807a609c7..b09639e8f42213ffc3fe490ac7cb48c2
          this.playBrokenSound();
          // this.dropAllDeathLoot(damagesource); // CraftBukkit - moved down
  
-@@ -638,7 +643,7 @@ public class ArmorStand extends LivingEntity {
+@@ -632,7 +636,7 @@ public class ArmorStand extends LivingEntity {
                  this.armorItems.set(i, ItemStack.EMPTY);
              }
          }
@@ -372,7 +373,7 @@ index e38cbdff34479673f1640c46d727f1a807a609c7..b09639e8f42213ffc3fe490ac7cb48c2
  
      }
  
-@@ -770,7 +775,16 @@ public class ArmorStand extends LivingEntity {
+@@ -764,7 +768,16 @@ public class ArmorStand extends LivingEntity {
  
      @Override
      public void kill() {

--- a/patches/server/0253-Improve-death-events.patch
+++ b/patches/server/0253-Improve-death-events.patch
@@ -301,10 +301,23 @@ index ebe207e2c4d8b7e125fec8a5182fe4882c9339e3..8ac82d3efc0f6d8ff40226e4f8084435
      public void addAdditionalSaveData(CompoundTag nbt) {
          super.addAdditionalSaveData(nbt);
 diff --git a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
-index 719f68f96e58ddcdd3592131c691d21263c81915..4413b609f1250cf9477fcb3fecd7b67afee0b896 100644
+index e38cbdff34479673f1640c46d727f1a807a609c7..b09639e8f42213ffc3fe490ac7cb48c2d38996ba 100644
 --- a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
 +++ b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
-@@ -536,8 +536,9 @@ public class ArmorStand extends LivingEntity {
+@@ -497,8 +497,10 @@ public class ArmorStand extends LivingEntity {
+                 }
+                 // CraftBukkit end
+                 if (source.is(DamageTypeTags.IS_EXPLOSION)) {
+-                    this.brokenByAnything(source);
+-                    this.kill();
++                    // Paper start - avoid duplicate event call
++                    org.bukkit.event.entity.EntityDeathEvent event = this.brokenByAnything(source);
++                    if (!event.isCancelled()) this.kill(false);
++                    // Paper end
+                     return false;
+                 } else if (source.is(DamageTypeTags.IGNITES_ARMOR_STANDS)) {
+                     if (this.isOnFire()) {
+@@ -542,8 +544,9 @@ public class ArmorStand extends LivingEntity {
                                  this.gameEvent(GameEvent.ENTITY_DAMAGE, source.getEntity());
                                  this.lastHit = i;
                              } else {
@@ -315,7 +328,20 @@ index 719f68f96e58ddcdd3592131c691d21263c81915..4413b609f1250cf9477fcb3fecd7b67a
                                  this.discard(); // CraftBukkit - SPIGOT-4890: remain as this.discard() since above damagesource method will call death event
                              }
  
-@@ -599,7 +600,7 @@ public class ArmorStand extends LivingEntity {
+@@ -596,8 +599,10 @@ public class ArmorStand extends LivingEntity {
+ 
+         f1 -= amount;
+         if (f1 <= 0.5F) {
+-            this.brokenByAnything(damageSource);
+-            this.kill();
++            // Paper start - avoid duplicate event call
++            org.bukkit.event.entity.EntityDeathEvent event = this.brokenByAnything(damageSource);
++            if (!event.isCancelled()) this.kill(false);
++            // Paper end
+         } else {
+             this.setHealth(f1);
+             this.gameEvent(GameEvent.ENTITY_DAMAGE, damageSource.getEntity());
+@@ -605,7 +610,7 @@ public class ArmorStand extends LivingEntity {
  
      }
  
@@ -324,7 +350,7 @@ index 719f68f96e58ddcdd3592131c691d21263c81915..4413b609f1250cf9477fcb3fecd7b67a
          ItemStack itemstack = new ItemStack(Items.ARMOR_STAND);
  
          if (this.hasCustomName()) {
-@@ -607,10 +608,10 @@ public class ArmorStand extends LivingEntity {
+@@ -613,10 +618,10 @@ public class ArmorStand extends LivingEntity {
          }
  
          drops.add(org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(itemstack)); // CraftBukkit - add to drops
@@ -337,7 +363,7 @@ index 719f68f96e58ddcdd3592131c691d21263c81915..4413b609f1250cf9477fcb3fecd7b67a
          this.playBrokenSound();
          // this.dropAllDeathLoot(damagesource); // CraftBukkit - moved down
  
-@@ -632,7 +633,7 @@ public class ArmorStand extends LivingEntity {
+@@ -638,7 +643,7 @@ public class ArmorStand extends LivingEntity {
                  this.armorItems.set(i, ItemStack.EMPTY);
              }
          }
@@ -346,13 +372,21 @@ index 719f68f96e58ddcdd3592131c691d21263c81915..4413b609f1250cf9477fcb3fecd7b67a
  
      }
  
-@@ -764,7 +765,8 @@ public class ArmorStand extends LivingEntity {
+@@ -770,7 +775,16 @@ public class ArmorStand extends LivingEntity {
  
      @Override
      public void kill() {
 -        org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, drops); // CraftBukkit - call event
++        // Paper start
++        kill(true);
++    }
++
++    public void kill(boolean callEvent) {
++        if (callEvent) {
++        // Paper end
 +        org.bukkit.event.entity.EntityDeathEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, drops); // CraftBukkit - call event // Paper - make cancellable
 +        if (event.isCancelled()) return; // Paper - make cancellable
++        } // Paper
          this.remove(Entity.RemovalReason.KILLED);
          this.gameEvent(GameEvent.ENTITY_DIE);
      }

--- a/patches/server/0384-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0384-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -113,10 +113,10 @@ index 02f5992f859163ea3fa77b3607bc9a0a29c17723..f8c2ff77f8db6f3e31eb2ef4d8638a73
          this.drops = new ArrayList<>();
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
-index 4554e6f6b107018a0f7b68dd606d76bf9ba73a51..85b7a358e3d5ae442a87a6d43d5ea368134a7017 100644
+index a35a0952ce8e1fc42e92734786d531c7e10b34d7..498c6664fcfb028111031691348bfa2eb21d605b 100644
 --- a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
 +++ b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
-@@ -631,7 +631,7 @@ public class ArmorStand extends LivingEntity {
+@@ -624,7 +624,7 @@ public class ArmorStand extends LivingEntity {
          for (i = 0; i < this.handItems.size(); ++i) {
              itemstack = (ItemStack) this.handItems.get(i);
              if (!itemstack.isEmpty()) {
@@ -125,7 +125,7 @@ index 4554e6f6b107018a0f7b68dd606d76bf9ba73a51..85b7a358e3d5ae442a87a6d43d5ea368
                  this.handItems.set(i, ItemStack.EMPTY);
              }
          }
-@@ -639,7 +639,7 @@ public class ArmorStand extends LivingEntity {
+@@ -632,7 +632,7 @@ public class ArmorStand extends LivingEntity {
          for (i = 0; i < this.armorItems.size(); ++i) {
              itemstack = (ItemStack) this.armorItems.get(i);
              if (!itemstack.isEmpty()) {

--- a/patches/server/0384-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0384-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -113,10 +113,10 @@ index 02f5992f859163ea3fa77b3607bc9a0a29c17723..f8c2ff77f8db6f3e31eb2ef4d8638a73
          this.drops = new ArrayList<>();
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
-index 4413b609f1250cf9477fcb3fecd7b67afee0b896..101e3a1f0f52b67b55c99c2619cc43298d92a3f2 100644
+index 4554e6f6b107018a0f7b68dd606d76bf9ba73a51..85b7a358e3d5ae442a87a6d43d5ea368134a7017 100644
 --- a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
 +++ b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
-@@ -621,7 +621,7 @@ public class ArmorStand extends LivingEntity {
+@@ -631,7 +631,7 @@ public class ArmorStand extends LivingEntity {
          for (i = 0; i < this.handItems.size(); ++i) {
              itemstack = (ItemStack) this.handItems.get(i);
              if (!itemstack.isEmpty()) {
@@ -125,7 +125,7 @@ index 4413b609f1250cf9477fcb3fecd7b67afee0b896..101e3a1f0f52b67b55c99c2619cc4329
                  this.handItems.set(i, ItemStack.EMPTY);
              }
          }
-@@ -629,7 +629,7 @@ public class ArmorStand extends LivingEntity {
+@@ -639,7 +639,7 @@ public class ArmorStand extends LivingEntity {
          for (i = 0; i < this.armorItems.size(); ++i) {
              itemstack = (ItemStack) this.armorItems.get(i);
              if (!itemstack.isEmpty()) {


### PR DESCRIPTION
This is a remake of https://github.com/PaperMC/Paper/pull/7385
This pr has been closed as duplicate but Noah hasn't fixed theses specific cases.
I have also fixed the fact that spigot doesn't emit the game event like in vanilla when an armorstand is killed in survival