### PR TITLE
Upstream "Fix concurrent access to lookups field in RegistryOps"

### DIFF
--- a/patches/server/0981-Fix-concurrent-access-to-lookups-field-in-RegistryOp.patch
+++ b/patches/server/0981-Fix-concurrent-access-to-lookups-field-in-RegistryOp.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Mon, 15 May 2023 00:20:59 -0700
+Subject: [PATCH] Fix concurrent access to lookups field in RegistryOps
+
+The concurrent access occurs on the Netty IO threads when
+serializing packets. Thus, it seems it was an oversight of
+the implementator of this function as there are typically
+more than one Netty IO thread.
+
+Fixes https://github.com/PaperMC/Folia/issues/11
+
+diff --git a/src/main/java/net/minecraft/resources/RegistryOps.java b/src/main/java/net/minecraft/resources/RegistryOps.java
+index 7709eeac907c4895a264cec0a3d453aa8b194c18..29182c49b30110809f786ae99b47fcc67976562f 100644
+--- a/src/main/java/net/minecraft/resources/RegistryOps.java
++++ b/src/main/java/net/minecraft/resources/RegistryOps.java
+@@ -19,11 +19,11 @@ public class RegistryOps<T> extends DelegatingOps<T> {
+ 
+     private static RegistryOps.RegistryInfoLookup memoizeLookup(final RegistryOps.RegistryInfoLookup registryInfoGetter) {
+         return new RegistryOps.RegistryInfoLookup() {
+-            private final Map<ResourceKey<? extends Registry<?>>, Optional<? extends RegistryOps.RegistryInfo<?>>> lookups = new HashMap<>();
++            private final Map<ResourceKey<? extends Registry<?>>, Optional<? extends RegistryOps.RegistryInfo<?>>> lookups = new java.util.concurrent.ConcurrentHashMap<>(); // Paper - fix concurrent access to lookups field
+ 
+             @Override
+             public <T> Optional<RegistryOps.RegistryInfo<T>> lookup(ResourceKey<? extends Registry<? extends T>> registryRef) {
+-                return this.lookups.computeIfAbsent(registryRef, registryInfoGetter::lookup);
++                return (Optional<RegistryOps.RegistryInfo<T>>)this.lookups.computeIfAbsent(registryRef, registryInfoGetter::lookup); // Paper - fix concurrent access to lookups field
+             }
+         };
+     }

--- a/patches/server/0981-Fix-concurrent-access-to-lookups-field-in-RegistryOp.patch
+++ b/patches/server/0981-Fix-concurrent-access-to-lookups-field-in-RegistryOp.patch
@@ -24,7 +24,7 @@ index 7709eeac907c4895a264cec0a3d453aa8b194c18..29182c49b30110809f786ae99b47fcc6
              @Override
              public <T> Optional<RegistryOps.RegistryInfo<T>> lookup(ResourceKey<? extends Registry<? extends T>> registryRef) {
 -                return this.lookups.computeIfAbsent(registryRef, registryInfoGetter::lookup);
-+                return (Optional<RegistryOps.RegistryInfo<T>>)this.lookups.computeIfAbsent(registryRef, registryInfoGetter::lookup); // Paper - fix concurrent access to lookups field
++                return (Optional<RegistryOps.RegistryInfo<T>>)this.lookups.computeIfAbsent(registryRef, registryInfoGetter::lookup); // Paper - decompile fix
              }
          };
      }


### PR DESCRIPTION
Basing this on my server's error logs, this error occurs in Paper.

<img width="1237" alt="cme-error" src="https://github.com/PaperMC/Paper/assets/111554242/f9e9451a-6298-4051-a6ab-8ef7e62806c6">

Relevant: https://github.com/PaperMC/Folia/issues/11#issuecomment-1547312066
