### PR TITLE
Create raw chat type as resource file instead of in source

### DIFF
--- a/build-data/dev-imports.txt
+++ b/build-data/dev-imports.txt
@@ -8,4 +8,8 @@
 # To import classes from the vanilla Minecraft jar use `minecraft` as the artifactId:
 #     minecraft net.minecraft.world.level.entity.LevelEntityGetterAdapter
 #     minecraft net/minecraft/world/level/entity/LevelEntityGetter.java
+# To import minecraft data files, like the default chat type, use `mc_data` as the prefix:
+#     mc_data chat_type/chat.json
+#     mc_data dimension_type/overworld.json
+#
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     java
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "8.1.1" apply false
-    id("io.papermc.paperweight.core") version "1.5.5"
+    id("io.papermc.paperweight.core") version "1.5.6"
 }
 
 allprojects {

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -3,9 +3,13 @@ From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 29 Feb 2016 20:40:33 -0600
 Subject: [PATCH] Build system changes
 
+== AT ==
+public net.minecraft.server.packs.VanillaPackResourcesBuilder safeGetPath(Ljava/net/URI;)Ljava/nio/file/Path;
+
+Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index f7d5f785f659aa905000d974f573e43f841e7fc0..59579c22db8e028782f284942fb1e4f9791cfe1b 100644
+index f7d5f785f659aa905000d974f573e43f841e7fc0..2fbc68a73575110ded95ca12fa17ab8bb44aae8f 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -9,10 +9,9 @@ plugins {
@@ -78,6 +82,69 @@ index f7d5f785f659aa905000d974f573e43f841e7fc0..59579c22db8e028782f284942fb1e4f9
  tasks.test {
      exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
  }
+@@ -132,7 +153,14 @@ tasks.registerRunTask("runReobf") {
+     classpath(runtimeClasspathWithoutVanillaServer)
+ }
+ 
++val runtimeClasspathForRunDev = sourceSets.main.flatMap { src ->
++    src.runtimeClasspath.elements.map { elements ->
++        elements.filterNot { file -> file.asFile.endsWith("minecraft.jar") }
++    }
++}
+ tasks.registerRunTask("runDev") {
+     description = "Spin up a non-relocated Mojang-mapped test server"
+-    classpath(sourceSets.main.map { it.runtimeClasspath })
++    classpath(tasks.filterProjectDir.flatMap { it.outputJar })
++    classpath(runtimeClasspathForRunDev)
++    jvmArgs("-DPaper.isRunDev=true")
+ }
+diff --git a/src/main/java/net/minecraft/resources/ResourceLocation.java b/src/main/java/net/minecraft/resources/ResourceLocation.java
+index 6eb213981aeb7e75e1ed75f1483bc98187726f6f..de37a6e2edf36107a04b3707b9c5bbd608fcab20 100644
+--- a/src/main/java/net/minecraft/resources/ResourceLocation.java
++++ b/src/main/java/net/minecraft/resources/ResourceLocation.java
+@@ -26,6 +26,7 @@ public class ResourceLocation implements Comparable<ResourceLocation> {
+     public static final char NAMESPACE_SEPARATOR = ':';
+     public static final String DEFAULT_NAMESPACE = "minecraft";
+     public static final String REALMS_NAMESPACE = "realms";
++    public static final String PAPER_NAMESPACE = "paper"; // Paper
+     private final String namespace;
+     private final String path;
+ 
+diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
+index e7240acad17dc9c0d93f2792cc0d90c1855ac436..ba96530f00faa1d113a14242eb8192349c7c944f 100644
+--- a/src/main/java/net/minecraft/server/Main.java
++++ b/src/main/java/net/minecraft/server/Main.java
+@@ -110,6 +110,17 @@ public class Main {
+             */ // CraftBukkit end
+ 
+         try {
++            // Paper start
++            if (Boolean.getBoolean("Paper.isRunDev")) {
++                net.minecraft.server.packs.VanillaPackResourcesBuilder.developmentConfig = builder -> {
++                    try {
++                        builder.pushAssetPath(net.minecraft.server.packs.PackType.SERVER_DATA, net.minecraft.server.packs.VanillaPackResourcesBuilder.safeGetPath(java.util.Objects.requireNonNull(Main.class.getResource("/data/.paperassetsroot"), "Missing required .paperassetsroot file").toURI()).getParent());
++                    } catch (java.net.URISyntaxException | IOException ex) {
++                        throw new RuntimeException(ex);
++                    }
++                };
++            }
++            // Paper end
+ 
+             Path path = (Path) optionset.valueOf("pidFile"); // CraftBukkit
+ 
+diff --git a/src/main/java/net/minecraft/server/packs/repository/ServerPacksSource.java b/src/main/java/net/minecraft/server/packs/repository/ServerPacksSource.java
+index 03bf7dfc289c6a02f19678d3c7041c027154b99d..43ce85977472fd831fa272ff1d81df4586352d72 100644
+--- a/src/main/java/net/minecraft/server/packs/repository/ServerPacksSource.java
++++ b/src/main/java/net/minecraft/server/packs/repository/ServerPacksSource.java
+@@ -28,7 +28,7 @@ public class ServerPacksSource extends BuiltInPackSource {
+     }
+ 
+     private static VanillaPackResources createVanillaPackSource() {
+-        return (new VanillaPackResourcesBuilder()).setMetadata(BUILT_IN_METADATA).exposeNamespace("minecraft").applyDevelopmentConfig().pushJarResources().build();
++        return (new VanillaPackResourcesBuilder()).setMetadata(BUILT_IN_METADATA).exposeNamespace("minecraft", ResourceLocation.PAPER_NAMESPACE).applyDevelopmentConfig().pushJarResources().build(); // Paper
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
 index 23e88fde465853629c4371d1e1a44d1af493ca3e..5a39201392fefe8da495244fdbc380e882ec938f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
@@ -104,3 +171,6 @@ index 93046379d0cefd5d3236fc59e698809acdc18f80..774556a62eb240da42e84db4502e2ed4
          Properties properties = new Properties();
  
          if (stream != null) {
+diff --git a/src/main/resources/data/.paperassetsroot b/src/main/resources/data/.paperassetsroot
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -4566,10 +4566,10 @@ index 0000000000000000000000000000000000000000..70cc7b45e7355f6c8476a74a070f1266
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index e7240acad17dc9c0d93f2792cc0d90c1855ac436..35e7f8e7b19c217fa5f3f55abb0f8b9cd6b16f18 100644
+index 1b2ec70b244cb43bbce218ff1aaa16bb4b640ed9..29269596b94b68f441355202b74c735ebfd44c71 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -131,6 +131,10 @@ public class Main {
+@@ -142,6 +142,10 @@ public class Main {
              dedicatedserversettings.forceSave();
              Path path2 = Paths.get("eula.txt");
              Eula eula = new Eula(path2);
@@ -4580,7 +4580,7 @@ index e7240acad17dc9c0d93f2792cc0d90c1855ac436..35e7f8e7b19c217fa5f3f55abb0f8b9c
  
              if (optionset.has("initSettings")) { // CraftBukkit
                  // CraftBukkit start - SPIGOT-5761: Create bukkit.yml and commands.yml if not present
-@@ -165,7 +169,7 @@ public class Main {
+@@ -176,7 +180,7 @@ public class Main {
              }
  
              File file = (File) optionset.valueOf("universe"); // CraftBukkit

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -345,10 +345,10 @@ index 0000000000000000000000000000000000000000..3b53d87a52cafb2503419f21ddd87d42
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7ddec8e330ab058e72d90b68c5361a6c4feb2393
+index 0000000000000000000000000000000000000000..57081e84d50f7eca7ea11540b550da8269378e9e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
-@@ -0,0 +1,412 @@
+@@ -0,0 +1,414 @@
 +package io.papermc.paper.adventure;
 +
 +import io.papermc.paper.chat.ChatRenderer;
@@ -378,6 +378,7 @@ index 0000000000000000000000000000000000000000..7ddec8e330ab058e72d90b68c5361a6c
 +import net.minecraft.network.chat.OutgoingChatMessage;
 +import net.minecraft.network.chat.PlayerChatMessage;
 +import net.minecraft.resources.ResourceKey;
++import net.minecraft.resources.ResourceLocation;
 +import net.minecraft.server.MinecraftServer;
 +import net.minecraft.server.level.ServerPlayer;
 +import org.bukkit.command.ConsoleCommandSender;
@@ -397,6 +398,7 @@ index 0000000000000000000000000000000000000000..7ddec8e330ab058e72d90b68c5361a6c
 +
 +@DefaultQualifier(NonNull.class)
 +public final class ChatProcessor {
++    static final ResourceKey<ChatType> PAPER_RAW = ResourceKey.create(Registries.CHAT_TYPE, new ResourceLocation(ResourceLocation.PAPER_NAMESPACE, "raw"));
 +    static final String DEFAULT_LEGACY_FORMAT = "<%1$s> %2$s"; // copied from PlayerChatEvent/AsyncPlayerChatEvent
 +    final MinecraftServer server;
 +    final ServerPlayer player;
@@ -568,7 +570,7 @@ index 0000000000000000000000000000000000000000..7ddec8e330ab058e72d90b68c5361a6c
 +        final ChatRenderer renderer = event.renderer();
 +
 +        final Set<Audience> viewers = event.viewers();
-+        final ResourceKey<ChatType> chatTypeKey = renderer instanceof ChatRenderer.Default ? ChatType.CHAT : ChatType.RAW;
++        final ResourceKey<ChatType> chatTypeKey = renderer instanceof ChatRenderer.Default ? ChatType.CHAT : PAPER_RAW;
 +        final ChatType.Bound chatType = ChatType.bind(chatTypeKey, this.player.level().registryAccess(), PaperAdventure.asVanilla(displayName(player)));
 +
 +        OutgoingChat outgoingChat = viewers instanceof LazyChatAudienceSet lazyAudienceSet && lazyAudienceSet.isLazy() ? new ServerOutgoingChat() : new ViewersOutgoingChat();
@@ -1825,26 +1827,6 @@ index 825ab7534f1ad9787ae2a6c2bf9a300f52cbfc95..53be8a43d784db5e8450c242adeb06f3
 +    }
 +    // Paper end
  }
-diff --git a/src/main/java/net/minecraft/network/chat/ChatType.java b/src/main/java/net/minecraft/network/chat/ChatType.java
-index 618a9335faf9df4a7d0cc971a8e62a0e3b239aa3..375b6d1d1bb491680bdb9f664ed10a9cce1a9cfa 100644
---- a/src/main/java/net/minecraft/network/chat/ChatType.java
-+++ b/src/main/java/net/minecraft/network/chat/ChatType.java
-@@ -26,6 +26,7 @@ public record ChatType(ChatTypeDecoration chat, ChatTypeDecoration narration) {
-     public static final ResourceKey<ChatType> TEAM_MSG_COMMAND_INCOMING = create("team_msg_command_incoming");
-     public static final ResourceKey<ChatType> TEAM_MSG_COMMAND_OUTGOING = create("team_msg_command_outgoing");
-     public static final ResourceKey<ChatType> EMOTE_COMMAND = create("emote_command");
-+    public static final ResourceKey<ChatType> RAW = create("raw"); // Paper
- 
-     private static ResourceKey<ChatType> create(String id) {
-         return ResourceKey.create(Registries.CHAT_TYPE, new ResourceLocation(id));
-@@ -39,6 +40,7 @@ public record ChatType(ChatTypeDecoration chat, ChatTypeDecoration narration) {
-         messageTypeRegisterable.register(TEAM_MSG_COMMAND_INCOMING, new ChatType(ChatTypeDecoration.teamMessage("chat.type.team.text"), ChatTypeDecoration.withSender("chat.type.text.narrate")));
-         messageTypeRegisterable.register(TEAM_MSG_COMMAND_OUTGOING, new ChatType(ChatTypeDecoration.teamMessage("chat.type.team.sent"), ChatTypeDecoration.withSender("chat.type.text.narrate")));
-         messageTypeRegisterable.register(EMOTE_COMMAND, new ChatType(ChatTypeDecoration.withSender("chat.type.emote"), ChatTypeDecoration.withSender("chat.type.emote")));
-+        messageTypeRegisterable.register(RAW, new ChatType(new ChatTypeDecoration("%s", java.util.List.of(ChatTypeDecoration.Parameter.CONTENT), Style.EMPTY), new ChatTypeDecoration("%s", java.util.List.of(ChatTypeDecoration.Parameter.CONTENT), Style.EMPTY))); // Paper
-     }
- 
-     public static ChatType.Bound bind(ResourceKey<ChatType> typeKey, Entity entity) {
 diff --git a/src/main/java/net/minecraft/network/chat/Component.java b/src/main/java/net/minecraft/network/chat/Component.java
 index 8f5e07047f88138422ae82143a80427be869a760..37fc353c3e59dd5af2fd6c58ac084fb0e6e155d7 100644
 --- a/src/main/java/net/minecraft/network/chat/Component.java
@@ -2172,22 +2154,6 @@ index 762a9392ffac3042356709dddd15bb3516048bed..3544e2dc2522e9d6305d727d56e73490
          buf.writeComponent(this.header);
          buf.writeComponent(this.footer);
      }
-diff --git a/src/main/java/net/minecraft/resources/RegistryDataLoader.java b/src/main/java/net/minecraft/resources/RegistryDataLoader.java
-index 5f051cb22ae77f4d8994b07ac5b963bd0ff05673..7952635a963e28cb670c8f4869664103c7ebfefb 100644
---- a/src/main/java/net/minecraft/resources/RegistryDataLoader.java
-+++ b/src/main/java/net/minecraft/resources/RegistryDataLoader.java
-@@ -61,6 +61,11 @@ public class RegistryDataLoader {
-         RegistryOps.RegistryInfoLookup registryInfoLookup = createContext(baseRegistryManager, list);
-         list.forEach((loader) -> {
-             loader.getSecond().load(resourceManager, registryInfoLookup);
-+            // Paper start
-+            if (loader.getFirst().key() == Registries.CHAT_TYPE) {
-+                Registry.register((Registry<ChatType>) loader.getFirst(), ChatType.RAW, new ChatType(new net.minecraft.network.chat.ChatTypeDecoration("%s", List.of(net.minecraft.network.chat.ChatTypeDecoration.Parameter.CONTENT), net.minecraft.network.chat.Style.EMPTY), new net.minecraft.network.chat.ChatTypeDecoration("%s", List.of(net.minecraft.network.chat.ChatTypeDecoration.Parameter.CONTENT), net.minecraft.network.chat.Style.EMPTY))); // CraftBukkit
-+            }
-+            // Paper end
-         });
-         list.forEach((loader) -> {
-             Registry<?> registry = loader.getFirst();
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index e896917b3546f9d075179198c6dcd714f6cddd50..58457e3493100e9726288ae7b027ab47947bd4d4 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -5069,6 +5035,26 @@ index 0000000000000000000000000000000000000000..28d777610b52ba74f808bf3245d73b83
 +++ b/src/main/resources/META-INF/services/net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer$Provider
 @@ -0,0 +1 @@
 +io.papermc.paper.adventure.providers.PlainTextComponentSerializerProviderImpl
+diff --git a/src/main/resources/data/paper/chat_type/raw.json b/src/main/resources/data/paper/chat_type/raw.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..3aedd0bbc97edacc1ebf71264b310e55aaaa5cb3
+--- /dev/null
++++ b/src/main/resources/data/paper/chat_type/raw.json
+@@ -0,0 +1,14 @@
++{
++    "chat": {
++        "parameters": [
++            "content"
++        ],
++        "translation_key": "%s"
++    },
++    "narration": {
++        "parameters": [
++            "content"
++        ],
++        "translation_key": "%s"
++    }
++}
 diff --git a/src/test/java/io/papermc/paper/adventure/ComponentServicesTest.java b/src/test/java/io/papermc/paper/adventure/ComponentServicesTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..b6c4f8e2d375396a0ef3300a8bc324d77f23a768

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -6982,10 +6982,10 @@ index 1eabd8b5a99850298838b11ba97e3d220f444378..8ff786c366332588a2df053438f23cc9
                      Bootstrap.wrapStreams();
                      Bootstrap.bootstrapDuration.set(Duration.between(instant, Instant.now()).toMillis());
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 35e7f8e7b19c217fa5f3f55abb0f8b9cd6b16f18..72c2f0bf9434e09a0dd51294d3a2200f1e0ed1b1 100644
+index 29269596b94b68f441355202b74c735ebfd44c71..af70ccbc3142aa63ef4bfefe27c6328a29d1770e 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -122,6 +122,7 @@ public class Main {
+@@ -133,6 +133,7 @@ public class Main {
                  JvmProfiler.INSTANCE.start(Environment.SERVER);
              }
  

--- a/patches/server/0019-Rewrite-chunk-system.patch
+++ b/patches/server/0019-Rewrite-chunk-system.patch
@@ -16837,10 +16837,10 @@ index a5e438a834826161c52ca9db57d234d9ff80a591..b8bc1b9b8e8a33df90a963f9f9769292
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 72c2f0bf9434e09a0dd51294d3a2200f1e0ed1b1..5d56c35d6d3478dbc53e4f5c3547d4dc0d0cefd0 100644
+index af70ccbc3142aa63ef4bfefe27c6328a29d1770e..d8a4db5024fbe5a1240f53e515ceb7066f834972 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -271,6 +271,7 @@ public class Main {
+@@ -282,6 +282,7 @@ public class Main {
  
              convertable_conversionsession.saveDataTag(iregistrycustom_dimension, savedata);
              */

--- a/patches/server/0088-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/patches/server/0088-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -12,7 +12,7 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
-index 7ddec8e330ab058e72d90b68c5361a6c4feb2393..774fb97912f766589f3548f659618ad554e0503f 100644
+index 57081e84d50f7eca7ea11540b550da8269378e9e..e4fd372a1d585887287253a02531cd192929377b 100644
 --- a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 +++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 @@ -19,6 +19,7 @@ import net.kyori.adventure.audience.Audience;
@@ -23,7 +23,7 @@ index 7ddec8e330ab058e72d90b68c5361a6c4feb2393..774fb97912f766589f3548f659618ad5
  import net.minecraft.Optionull;
  import net.minecraft.Util;
  import net.minecraft.core.registries.Registries;
-@@ -30,6 +31,7 @@ import net.minecraft.resources.ResourceKey;
+@@ -31,6 +32,7 @@ import net.minecraft.resources.ResourceLocation;
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ServerPlayer;
  import org.bukkit.command.ConsoleCommandSender;
@@ -31,7 +31,7 @@ index 7ddec8e330ab058e72d90b68c5361a6c4feb2393..774fb97912f766589f3548f659618ad5
  import org.bukkit.craftbukkit.entity.CraftPlayer;
  import org.bukkit.craftbukkit.util.LazyPlayerSet;
  import org.bukkit.craftbukkit.util.Waitable;
-@@ -365,10 +367,16 @@ public final class ChatProcessor {
+@@ -367,10 +369,16 @@ public final class ChatProcessor {
      }
  
      static String legacyDisplayName(final CraftPlayer player) {

--- a/patches/server/0141-Basic-PlayerProfile-API.patch
+++ b/patches/server/0141-Basic-PlayerProfile-API.patch
@@ -596,10 +596,10 @@ index dc2ab968ed010289125ac08f0a9ea85af6f6e8bb..82a1a87822e3fc323b92e1aa30ddb0cd
       * Calculates distance between 2 entities
       * @param e1
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 5d56c35d6d3478dbc53e4f5c3547d4dc0d0cefd0..a3d08de9a35d2f25f0e11c8d95176fabafc09db1 100644
+index d8a4db5024fbe5a1240f53e515ceb7066f834972..b549de337b1556816e3c4932546693cc3b8ad5d3 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -170,7 +170,7 @@ public class Main {
+@@ -181,7 +181,7 @@ public class Main {
              }
  
              File file = (File) optionset.valueOf("universe"); // CraftBukkit

--- a/patches/server/0442-Fix-SPIGOT-5824-Bukkit-world-container-is-not-used.patch
+++ b/patches/server/0442-Fix-SPIGOT-5824-Bukkit-world-container-is-not-used.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SPIGOT-5824 Bukkit world-container is not used
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index a3d08de9a35d2f25f0e11c8d95176fabafc09db1..d23d4ca8786f2758e9e4767f74d67fc4910d00ec 100644
+index b549de337b1556816e3c4932546693cc3b8ad5d3..6b6b59e4a791cd8518e2e25fba1c63d63e81b1d1 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -169,8 +169,17 @@ public class Main {
+@@ -180,8 +180,17 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0443-Fix-SPIGOT-5885-Unable-to-disable-advancements.patch
+++ b/patches/server/0443-Fix-SPIGOT-5885-Unable-to-disable-advancements.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SPIGOT-5885 Unable to disable advancements
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index d23d4ca8786f2758e9e4767f74d67fc4910d00ec..cac1ef2fefc2e3f2dde820b71a23e72a8a5f3fd7 100644
+index 6b6b59e4a791cd8518e2e25fba1c63d63e81b1d1..028b6c09796cec412f4aab56e99ba1b8bdfcc8ff 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -169,6 +169,7 @@ public class Main {
+@@ -180,6 +180,7 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0602-Add-environment-variable-to-disable-server-gui.patch
+++ b/patches/server/0602-Add-environment-variable-to-disable-server-gui.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add environment variable to disable server gui
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index cac1ef2fefc2e3f2dde820b71a23e72a8a5f3fd7..98385550084c9f975e494668961bac6ccb0700ab 100644
+index 028b6c09796cec412f4aab56e99ba1b8bdfcc8ff..4bd47eeb9e4c8ece2ba43a6c8c4e89b1e67ed9d9 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -293,6 +293,7 @@ public class Main {
+@@ -304,6 +304,7 @@ public class Main {
                  */
                  boolean flag1 = !optionset.has("nogui") && !optionset.nonOptionArguments().contains("nogui");
  

--- a/patches/server/0607-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0607-Fix-and-optimise-world-force-upgrading.patch
@@ -247,7 +247,7 @@ index 0000000000000000000000000000000000000000..513833c2ea23df5b079d157bc5cb89d5
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 98385550084c9f975e494668961bac6ccb0700ab..1147044f2c4c2e9510cb6e5c38b6abe85ec994e1 100644
+index 4bd47eeb9e4c8ece2ba43a6c8c4e89b1e67ed9d9..3a27a33899a10745b79ea263d686389ddf4bb5a4 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
 @@ -18,6 +18,7 @@ import java.nio.file.Paths;
@@ -258,7 +258,7 @@ index 98385550084c9f975e494668961bac6ccb0700ab..1147044f2c4c2e9510cb6e5c38b6abe8
  import joptsimple.NonOptionArgumentSpec;
  import joptsimple.OptionParser;
  import joptsimple.OptionSet;
-@@ -351,6 +352,15 @@ public class Main {
+@@ -362,6 +363,15 @@ public class Main {
          return new WorldLoader.InitConfig(worldloader_d, Commands.CommandSelection.DEDICATED, serverPropertiesHandler.functionPermissionLevel);
      }
  

--- a/patches/server/0681-Sanitize-ResourceLocation-error-logging.patch
+++ b/patches/server/0681-Sanitize-ResourceLocation-error-logging.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Sanitize ResourceLocation error logging
 
 
 diff --git a/src/main/java/net/minecraft/resources/ResourceLocation.java b/src/main/java/net/minecraft/resources/ResourceLocation.java
-index 6eb213981aeb7e75e1ed75f1483bc98187726f6f..fa9b84b604659a6b35262fbe5acbee0fdb20a56d 100644
+index de37a6e2edf36107a04b3707b9c5bbd608fcab20..8921b1bc2c870222d145c73bac765169099763f1 100644
 --- a/src/main/java/net/minecraft/resources/ResourceLocation.java
 +++ b/src/main/java/net/minecraft/resources/ResourceLocation.java
-@@ -210,7 +210,7 @@ public class ResourceLocation implements Comparable<ResourceLocation> {
+@@ -211,7 +211,7 @@ public class ResourceLocation implements Comparable<ResourceLocation> {
  
      private static String assertValidNamespace(String namespace, String path) {
          if (!isValidNamespace(namespace)) {
@@ -17,7 +17,7 @@ index 6eb213981aeb7e75e1ed75f1483bc98187726f6f..fa9b84b604659a6b35262fbe5acbee0f
          } else {
              return namespace;
          }
-@@ -231,7 +231,7 @@ public class ResourceLocation implements Comparable<ResourceLocation> {
+@@ -232,7 +232,7 @@ public class ResourceLocation implements Comparable<ResourceLocation> {
  
      private static String assertValidPath(String namespace, String path) {
          if (!isValidPath(path)) {

--- a/patches/server/0881-Detect-headless-JREs.patch
+++ b/patches/server/0881-Detect-headless-JREs.patch
@@ -27,10 +27,10 @@ index 6bd0afddbcc461149dfe9a5c7a86fff6ea13a5f1..148d233f4f5278ff39eacdaa0f4f0e7d
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 1147044f2c4c2e9510cb6e5c38b6abe85ec994e1..a3c400bb4ee5d8f2985f4bc7e3e35be548177cc6 100644
+index 3a27a33899a10745b79ea263d686389ddf4bb5a4..adfec92fe5eed20336bfb82aba60ab7f3498b9dd 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -170,6 +170,18 @@ public class Main {
+@@ -181,6 +181,18 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0950-Fix-demo-flag-not-enabling-demo-mode.patch
+++ b/patches/server/0950-Fix-demo-flag-not-enabling-demo-mode.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix demo flag not enabling demo mode
 https://github.com/PaperMC/Paper/issues/9046
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index a3c400bb4ee5d8f2985f4bc7e3e35be548177cc6..dae36c6452ccd57a436dd918547b64d59957ab0a 100644
+index adfec92fe5eed20336bfb82aba60ab7f3498b9dd..831a43b7fb193e40a0d0c022b397889bf010ac57 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -301,7 +301,7 @@ public class Main {
+@@ -312,7 +312,7 @@ public class Main {
                  /*
                  dedicatedserver1.setSingleplayerProfile(optionset.has(optionspec8) ? new GameProfile((UUID) null, (String) optionset.valueOf(optionspec8)) : null);
                  dedicatedserver1.setPort((Integer) optionset.valueOf(optionspec11));


### PR DESCRIPTION
Sets up the ability to load new or modified resource files into Paper.

Updates paperweight to 1.5.6

This should work with all run configs, like runDev, runShadow, runReobf as well as correctly build jars for production.

```[tasklist]
- [ ] https://github.com/PaperMC/paperweight/pull/190
- [x] Remove demo change
- [x] merge into initial build system changes patch
- [ ] https://github.com/PaperMC/paperweight/pull/198
- [x] paperweight release & update paperweight in build.gradle.kts
```