### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -1529,18 +1529,94 @@ index 372c0bd5a4d7800a11c24c95e39fe376a96232bf..9c88be68b4f403d0500cb607394b3a16
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Sign.java b/src/main/java/org/bukkit/block/Sign.java
-index ab6b0ec328e94bf65a0dafd0403e5ee3b870296c..f87bdb2757760d95038d1a1cf6e7f5b2cff91432 100644
+index 1844b7136ddcc1aa267b8fb2159244d04900da36..9a9f4af69fc8adbd0a05e2e7574f83ff9befad85 100644
 --- a/src/main/java/org/bukkit/block/Sign.java
 +++ b/src/main/java/org/bukkit/block/Sign.java
-@@ -7,13 +7,48 @@ import org.jetbrains.annotations.NotNull;
+@@ -11,6 +11,42 @@ import org.jetbrains.annotations.NotNull;
   * Represents a captured state of either a SignPost or a WallSign.
   */
  public interface Sign extends TileState, Colorable {
 +    // Paper start
 +    /**
-+     * Gets all the lines of text currently on this sign.
++     * Gets all the lines of text currently on the {@link Side#FRONT} of this sign.
 +     *
-+     * @return Array of Strings containing each line of text
++     * @return List of components containing each line of text
++     * @see #getSide(Side)
++     */
++    @NotNull
++    public java.util.List<net.kyori.adventure.text.Component> lines();
++
++    /**
++     * Gets the line of text at the specified index on the {@link Side#FRONT}.
++     * <p>
++     * For example, getLine(0) will return the first line of text.
++     *
++     * @param index Line number to get the text from, starting at 0
++     * @throws IndexOutOfBoundsException Thrown when the line does not exist
++     * @return Text on the given line
++     * @see #getSide(Side)
++     */
++    @NotNull
++    public net.kyori.adventure.text.Component line(int index) throws IndexOutOfBoundsException;
++
++    /**
++     * Sets the line of text at the specified index on the {@link Side#FRONT}.
++     * <p>
++     * For example, setLine(0, "Line One") will set the first line of text to
++     * "Line One".
++     *
++     * @param index Line number to set the text at, starting from 0
++     * @param line New text to set at the specified index
++     * @throws IndexOutOfBoundsException If the index is out of the range 0..3
++     * @see #getSide(Side)
++     */
++    public void line(int index, net.kyori.adventure.text.@NotNull Component line) throws IndexOutOfBoundsException;
++    // Paper end
+ 
+     /**
+      * Gets all the lines of text currently on the {@link Side#FRONT} of this sign.
+@@ -19,6 +55,7 @@ public interface Sign extends TileState, Colorable {
+      * @see #getSide(Side)
+      */
+     @NotNull
++    @Deprecated // Paper
+     public String[] getLines();
+ 
+     /**
+@@ -30,8 +67,10 @@ public interface Sign extends TileState, Colorable {
+      * @return Text on the given line
+      * @throws IndexOutOfBoundsException Thrown when the line does not exist
+      * @see #getSide(Side)
++     * @deprecated in favour of {@link #line(int)}
+      */
+     @NotNull
++    @Deprecated // Paper
+     public String getLine(int index) throws IndexOutOfBoundsException;
+ 
+     /**
+@@ -44,7 +83,9 @@ public interface Sign extends TileState, Colorable {
+      * @param line New text to set at the specified index
+      * @throws IndexOutOfBoundsException If the index is out of the range 0..3
+      * @see #getSide(Side)
++     * @deprecated in favour of {@link #line(int, net.kyori.adventure.text.Component)}
+      */
++    @Deprecated // Paper
+     public void setLine(int index, @NotNull String line) throws IndexOutOfBoundsException;
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/block/sign/SignSide.java b/src/main/java/org/bukkit/block/sign/SignSide.java
+index 85be6cfa9ed074073656cd0678600780eb03b47b..e6b9a1b0dbf7cdffafe4a9bb5dd1c3e8afb846e5 100644
+--- a/src/main/java/org/bukkit/block/sign/SignSide.java
++++ b/src/main/java/org/bukkit/block/sign/SignSide.java
+@@ -9,6 +9,39 @@ import org.jetbrains.annotations.NotNull;
+  */
+ @Experimental
+ public interface SignSide extends Colorable {
++    // Paper start
++    /**
++     * Gets all the lines of text currently on the sign.
++     *
++     * @return List of components containing each line of text
 +     */
 +    @NotNull
 +    public java.util.List<net.kyori.adventure.text.Component> lines();
@@ -1571,37 +1647,7 @@ index ab6b0ec328e94bf65a0dafd0403e5ee3b870296c..f87bdb2757760d95038d1a1cf6e7f5b2
 +    // Paper end
  
      /**
-      * Gets all the lines of text currently on this sign.
-      *
-      * @return Array of Strings containing each line of text
-+     * @deprecated in favour of {@link #lines()}
-      */
-     @NotNull
-+    @Deprecated // Paper
-     public String[] getLines();
- 
-     /**
-@@ -24,8 +59,10 @@ public interface Sign extends TileState, Colorable {
-      * @param index Line number to get the text from, starting at 0
-      * @return Text on the given line
-      * @throws IndexOutOfBoundsException Thrown when the line does not exist
-+     * @deprecated in favour of {@link #line(int)}
-      */
-     @NotNull
-+    @Deprecated // Paper
-     public String getLine(int index) throws IndexOutOfBoundsException;
- 
-     /**
-@@ -37,7 +74,9 @@ public interface Sign extends TileState, Colorable {
-      * @param index Line number to set the text at, starting from 0
-      * @param line New text to set at the specified index
-      * @throws IndexOutOfBoundsException If the index is out of the range 0..3
-+     * @deprecated in favour of {@link #line(int, net.kyori.adventure.text.Component)}
-      */
-+    @Deprecated // Paper
-     public void setLine(int index, @NotNull String line) throws IndexOutOfBoundsException;
- 
-     /**
+      * Gets all the lines of text currently on this side of the sign.
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
 index 80209bb88a0294d4eedc78509533a6257315d856..75759131bd94b672bec4cd8e271ebff1ad391cba 100644
 --- a/src/main/java/org/bukkit/command/Command.java
@@ -1996,10 +2042,10 @@ index f3afe67f0832cb828d25be3654518ff73a80b0e1..598abaa82c634178043a29f6caa6ac52
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf73c6559a 100644
+index 7fffb5cdac7a0fe9baeb7ef09a4615221dca8322..4190d5b3b3d3eb9525ed342179cb827cc5590e3b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -41,7 +41,28 @@ import org.jetbrains.annotations.Nullable;
+@@ -42,7 +42,28 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a player, connected or not
   */
@@ -2029,7 +2075,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
  
      /**
       * {@inheritDoc}
-@@ -58,7 +79,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -59,7 +80,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * places defined by plugins.
       *
       * @return the friendly name
@@ -2039,7 +2085,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      @NotNull
      public String getDisplayName();
  
-@@ -70,15 +93,50 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -71,15 +94,50 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * places defined by plugins.
       *
       * @param name The new display name.
@@ -2090,7 +2136,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      public String getPlayerListName();
  
      /**
-@@ -87,14 +145,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -88,14 +146,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * If the value is null, the name will be identical to {@link #getName()}.
       *
       * @param name new player list name
@@ -2109,7 +2155,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      @Nullable
      public String getPlayerListHeader();
  
-@@ -102,7 +164,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -103,7 +165,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Gets the currently displayed player list footer for this player.
       *
       * @return player list header or null
@@ -2119,7 +2165,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      @Nullable
      public String getPlayerListFooter();
  
-@@ -110,14 +174,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -111,14 +175,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Sets the currently displayed player list header for this player.
       *
       * @param header player list header, null for empty
@@ -2138,7 +2184,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      public void setPlayerListFooter(@Nullable String footer);
  
      /**
-@@ -126,7 +194,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -127,7 +195,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param header player list header, null for empty
       * @param footer player list footer, null for empty
@@ -2148,7 +2194,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      public void setPlayerListHeaderFooter(@Nullable String header, @Nullable String footer);
  
      /**
-@@ -164,9 +234,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -165,9 +235,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Kicks player with custom kick message.
       *
       * @param message kick message
@@ -2174,7 +2220,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      /**
       * Says a message (or runs a command).
       *
-@@ -608,6 +694,90 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -609,6 +695,90 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull Map<EquipmentSlot, ItemStack> items);
  
@@ -2265,7 +2311,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      /**
       * Send a sign change. This fakes a sign change packet for a user at
       * a certain location. This will not actually change the world in any way.
-@@ -622,7 +792,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -623,7 +793,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param lines the new text on the sign or null to clear it
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -2275,7 +2321,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines) throws IllegalArgumentException;
  
      /**
-@@ -641,7 +813,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -642,7 +814,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -2285,7 +2331,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException;
  
      /**
-@@ -661,7 +835,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -662,7 +836,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -2295,7 +2341,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException;
  
      /**
-@@ -1155,6 +1331,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1156,6 +1332,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *     pack correctly.
       * </ul>
       *
@@ -2303,7 +2349,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
       * @param url The URL from which the client will download the resource
       *     pack. The string must contain only US-ASCII characters and should
       *     be encoded as per RFC 1738.
-@@ -1211,8 +1388,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1212,8 +1389,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
       *     long.
       */
@@ -2314,7 +2360,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      /**
       * Request that the player's client download and switch resource packs.
       * <p>
-@@ -1248,6 +1427,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1249,6 +1428,54 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param hash The sha1 hash sum of the resource pack file which is used
       *     to apply a cached version of the pack directly without downloading
       *     if it is available. Hast to be 20 bytes long!
@@ -2369,7 +2415,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
       * @param force If true, the client will be disconnected from the server
       *     when it declines to use the resource pack.
       * @throws IllegalArgumentException Thrown if the URL is null.
-@@ -1302,8 +1529,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1303,8 +1530,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
       *     long.
       */
@@ -2427,7 +2473,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      /**
       * Gets the Scoreboard displayed to this player
       *
-@@ -1419,7 +1695,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1420,7 +1696,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param title Title text
       * @param subtitle Subtitle text
@@ -2436,7 +2482,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
       */
      @Deprecated
      public void sendTitle(@Nullable String title, @Nullable String subtitle);
-@@ -1438,7 +1714,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1439,7 +1715,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param fadeIn time in ticks for titles to fade in. Defaults to 10.
       * @param stay time in ticks for titles to stay. Defaults to 70.
       * @param fadeOut time in ticks for titles to fade out. Defaults to 20.
@@ -2446,7 +2492,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      public void sendTitle(@Nullable String title, @Nullable String subtitle, int fadeIn, int stay, int fadeOut);
  
      /**
-@@ -1665,6 +1943,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1666,6 +1944,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -2461,7 +2507,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1690,8 +1976,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1691,8 +1977,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -2472,7 +2518,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      public String getLocale();
  
      /**
-@@ -1733,6 +2021,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1744,6 +2032,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public boolean isAllowingServerListings();
  
@@ -2487,7 +2533,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1787,11 +2083,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1798,11 +2094,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -2501,7 +2547,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1802,7 +2100,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1813,7 +2111,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -2511,7 +2557,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1812,7 +2112,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1823,7 +2123,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -2521,7 +2567,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1823,7 +2125,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1834,7 +2136,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -2531,7 +2577,7 @@ index 363567304c9698ffe21eaf0da9aef694c8050eb0..8708ca080bda0f4ec43964db3a4e56cf
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable java.util.UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1834,7 +2138,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1845,7 +2149,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send
@@ -2598,25 +2644,38 @@ index 63c80b4ee1f7adc8a9efc3b607993104b1991f90..91cab8b13d5bba34007f124838b32a1d
  
  }
 diff --git a/src/main/java/org/bukkit/event/block/SignChangeEvent.java b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
-index 7190db11eff7d48df8a99f405a9dbaefdfa76e3d..c40536f781393cb39e6a1a4ba6e780713d5dc126 100644
+index f4ac033ff8794a61c82a49dc6c3f863f3291455d..d944d67f544494355f03c5bc9afd8ea7726e6412 100644
 --- a/src/main/java/org/bukkit/event/block/SignChangeEvent.java
 +++ b/src/main/java/org/bukkit/event/block/SignChangeEvent.java
-@@ -16,12 +16,25 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+@@ -17,18 +17,38 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
      private static final HandlerList handlers = new HandlerList();
      private boolean cancel = false;
      private final Player player;
 -    private final String[] lines;
-+    // Paper start
-+    private final java.util.List<net.kyori.adventure.text.Component> adventure$lines;
++    private final java.util.List<net.kyori.adventure.text.Component> adventure$lines; // Paper
+     private final Side side;
  
-+    public SignChangeEvent(@NotNull final Block theBlock, @NotNull final Player player, @NotNull final java.util.List<net.kyori.adventure.text.Component> adventure$lines) {
++    // Paper start
++    public SignChangeEvent(@NotNull final Block theBlock, @NotNull final Player player, @NotNull final java.util.List<net.kyori.adventure.text.Component> adventure$lines, @NotNull Side side) {
 +        super(theBlock);
 +        this.player = player;
 +        this.adventure$lines = adventure$lines;
++        this.side = side;
 +    }
 +
-+    @Deprecated // Paper end
++    @Deprecated
++    public SignChangeEvent(@NotNull final Block theBlock, @NotNull final Player player, @NotNull final java.util.List<net.kyori.adventure.text.Component> adventure$lines) {
++        this(theBlock, player, adventure$lines, Side.FRONT);
++    }
++    // Paper end
++
+     @Deprecated
      public SignChangeEvent(@NotNull final Block theBlock, @NotNull final Player thePlayer, @NotNull final String[] theLines) {
+         this(theBlock, thePlayer, theLines, Side.FRONT);
+     }
+ 
++    @Deprecated // Paper
+     public SignChangeEvent(@NotNull final Block theBlock, @NotNull final Player thePlayer, @NotNull final String[] theLines, @NotNull Side side) {
          super(theBlock);
          this.player = thePlayer;
 -        this.lines = theLines;
@@ -2626,10 +2685,10 @@ index 7190db11eff7d48df8a99f405a9dbaefdfa76e3d..c40536f781393cb39e6a1a4ba6e78071
 +            this.adventure$lines.add(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(theLine));
 +        }
 +        // Paper end
+         this.side = side;
      }
  
-     /**
-@@ -34,14 +47,52 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+@@ -42,14 +62,52 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
          return player;
      }
  
@@ -2683,7 +2742,7 @@ index 7190db11eff7d48df8a99f405a9dbaefdfa76e3d..c40536f781393cb39e6a1a4ba6e78071
      }
  
      /**
-@@ -52,10 +103,12 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+@@ -60,10 +118,12 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
       *     provided index
       * @throws IndexOutOfBoundsException thrown when the provided index is {@literal > 3
       *     or < 0}
@@ -2697,7 +2756,7 @@ index 7190db11eff7d48df8a99f405a9dbaefdfa76e3d..c40536f781393cb39e6a1a4ba6e78071
      }
  
      /**
-@@ -65,9 +118,11 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
+@@ -73,9 +133,11 @@ public class SignChangeEvent extends BlockEvent implements Cancellable {
       * @param line text to set
       * @throws IndexOutOfBoundsException thrown when the provided index is {@literal > 3
       *     or < 0}
@@ -2709,7 +2768,7 @@ index 7190db11eff7d48df8a99f405a9dbaefdfa76e3d..c40536f781393cb39e6a1a4ba6e78071
 +        adventure$lines.set(index, line != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(line) : null); // Paper
      }
  
-     @Override
+     /**
 diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 index 3c2ea8fec3a748cab7f5ad9100d12bd8213ec6c9..a803bfea5400b3578bb4cf3261874e873b6467d9 100644
 --- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java

--- a/patches/api/0010-Timings-v2.patch
+++ b/patches/api/0010-Timings-v2.patch
@@ -3455,10 +3455,10 @@ index 516d7fc7812aac343782861d0d567f54aa578c2a..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8708ca080bda0f4ec43964db3a4e56cf73c6559a..28f27988d22c0f38b520273920a9965d64107569 100644
+index 4190d5b3b3d3eb9525ed342179cb827cc5590e3b..3fffe6844d5f113f13ae3e2636efd7a8f43940dd 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2143,7 +2143,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2154,7 +2154,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          @Deprecated // Paper
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable java.util.UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");

--- a/patches/api/0012-Player-affects-spawning-API.patch
+++ b/patches/api/0012-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 28f27988d22c0f38b520273920a9965d64107569..6d68274302fc36dd7d32cf6fb2889f86baebab89 100644
+index 3fffe6844d5f113f13ae3e2636efd7a8f43940dd..aaca12b0fd009f605ce8120f0cbe0a1049771cf5 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1982,6 +1982,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1983,6 +1983,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0017-Add-view-distance-API.patch
+++ b/patches/api/0017-Add-view-distance-API.patch
@@ -75,10 +75,10 @@ index 1a71d628d9f593157d92f0c9fda9d3214c138352..cc4e72335d8c66c8081ce64149ce3ac3
      public class Spigot {
  
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6d68274302fc36dd7d32cf6fb2889f86baebab89..70f2cb3126a06079b31b7ea36501ce5253a805fe 100644
+index aaca12b0fd009f605ce8120f0cbe0a1049771cf5..e543a0cc1bd7e4d87038c06cad0f5bde7c64f1b9 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1996,6 +1996,78 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1997,6 +1997,78 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0021-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0021-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -76,10 +76,10 @@ index 866559ab7cd3f351266fb41dce26a210a7702ff8..74e5f26c32e6e0c84c604b9704bfe672
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 70f2cb3126a06079b31b7ea36501ce5253a805fe..b0df10469e98d439e534c26ecc8a5bae98c9b77c 100644
+index e543a0cc1bd7e4d87038c06cad0f5bde7c64f1b9..9caacc128a53d13b049a03f78d9dea16f8ff025e 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -848,6 +848,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -849,6 +849,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  

--- a/patches/api/0025-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/api/0025-Player-Tab-List-and-Title-APIs.patch
@@ -432,10 +432,10 @@ index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb90
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b0df10469e98d439e534c26ecc8a5bae98c9b77c..0f70b49877383351a5ba2033bc6537b7e0deed3b 100644
+index 9caacc128a53d13b049a03f78d9dea16f8ff025e..c7d9185e2f16b77f78779403d075f31dabbc117b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -882,6 +882,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -883,6 +883,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }

--- a/patches/api/0027-Complete-resource-pack-API.patch
+++ b/patches/api/0027-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 0f70b49877383351a5ba2033bc6537b7e0deed3b..f4db9cec173c5018f8896d157405150b67bca253 100644
+index c7d9185e2f16b77f78779403d075f31dabbc117b..29b1cceff7100cbcde7ddca0d1acbb717f3b6b1c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1460,7 +1460,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1461,7 +1461,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the URL is null.
       * @throws IllegalArgumentException Thrown if the URL is too long. The
       *     length restriction is an implementation specific arbitrary value.
@@ -18,7 +18,7 @@ index 0f70b49877383351a5ba2033bc6537b7e0deed3b..f4db9cec173c5018f8896d157405150b
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -2276,6 +2278,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2287,6 +2289,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0046-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0046-Add-String-based-Action-Bar-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f4db9cec173c5018f8896d157405150b67bca253..3826a3f6c525ddb6308fc9ceab86764ab0087c33 100644
+index 29b1cceff7100cbcde7ddca0d1acbb717f3b6b1c..d85ce38bcae05a643479e7f687431dced1834b93 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -849,6 +849,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -850,6 +850,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start
@@ -48,7 +48,7 @@ index f4db9cec173c5018f8896d157405150b67bca253..3826a3f6c525ddb6308fc9ceab86764a
      /**
       * Sends the component to the player
       *
-@@ -876,9 +909,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -877,9 +910,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Sends an array of components as a single message to the specified screen position of this player
       *

--- a/patches/api/0055-Fix-upstream-javadocs.patch
+++ b/patches/api/0055-Fix-upstream-javadocs.patch
@@ -414,10 +414,10 @@ index ae9eaaa8e38e1d9dfc459926c7fc51ddb89de84a..b2ec535bb1b0ce0c114ddd7638b90218
      @Override
      public int getConversionTime();
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3826a3f6c525ddb6308fc9ceab86764ab0087c33..f683159bd02d5c6ea7940f50deecf2f1a8105d5e 100644
+index d85ce38bcae05a643479e7f687431dced1834b93..bb12eb007aeb932c2d89c6e6c4081c4802469cb6 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -312,15 +312,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -313,15 +313,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
  
      /**
       * Saves the players current location, health, inventory, motion, and
@@ -437,7 +437,7 @@ index 3826a3f6c525ddb6308fc9ceab86764ab0087c33..f683159bd02d5c6ea7940f50deecf2f1
       * <p>
       * Note: This will overwrite the players current inventory, health,
       * motion, etc, with the state from the saved dat file.
-@@ -555,7 +555,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -556,7 +556,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Plays an effect to just this player.
       *
@@ -446,7 +446,7 @@ index 3826a3f6c525ddb6308fc9ceab86764ab0087c33..f683159bd02d5c6ea7940f50deecf2f1
       * @param loc the location to play the effect at
       * @param effect the {@link Effect}
       * @param data a data bit needed for some effects
-@@ -866,7 +866,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -867,7 +867,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * Use supplied alternative character to the section symbol to represent legacy color codes.
       *
@@ -455,7 +455,7 @@ index 3826a3f6c525ddb6308fc9ceab86764ab0087c33..f683159bd02d5c6ea7940f50deecf2f1
       * @param message The message to send
       * @deprecated use {@link #sendActionBar(net.kyori.adventure.text.Component)}
       */
-@@ -1330,7 +1330,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1331,7 +1331,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
  
      /**
       * Allows this player to see a player that was previously hidden. If
@@ -464,7 +464,7 @@ index 3826a3f6c525ddb6308fc9ceab86764ab0087c33..f683159bd02d5c6ea7940f50deecf2f1
       * remain hidden until the other plugin calls this method too.
       *
       * @param plugin Plugin that wants to show the player
-@@ -1359,7 +1359,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1360,7 +1360,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
  
      /**
       * Allows this player to see an entity that was previously hidden. If

--- a/patches/api/0076-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/api/0076-Expose-client-protocol-version-and-virtual-host.patch
@@ -57,10 +57,10 @@ index 0000000000000000000000000000000000000000..7b2af1bd72dfbcf4e962a982940fc49b
 +
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f683159bd02d5c6ea7940f50deecf2f1a8105d5e..1d791f76151c1baa762d85cb82c6cfcd7b30d1ab 100644
+index bb12eb007aeb932c2d89c6e6c4081c4802469cb6..c7c23873a09c9eb0d86a6984e3dfe3413f88d5e1 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -41,7 +41,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -42,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a player, connected or not
   */

--- a/patches/api/0080-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/api/0080-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 1d791f76151c1baa762d85cb82c6cfcd7b30d1ab..89af3de0f439cfb5bde2a23147b2ba7da482f9c1 100644
+index c7c23873a09c9eb0d86a6984e3dfe3413f88d5e1..e4e254c26adb15be4f60a59a0cf8a41816b9250a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1173,6 +1173,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1174,6 +1174,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void resetPlayerWeather();
  
@@ -29,7 +29,7 @@ index 1d791f76151c1baa762d85cb82c6cfcd7b30d1ab..89af3de0f439cfb5bde2a23147b2ba7d
      /**
       * Gets the player's cooldown between picking up experience orbs.
       *
-@@ -1198,8 +1207,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1199,8 +1208,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Gives the player the amount of experience specified.
       *
       * @param amount Exp amount to give

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -93,10 +93,10 @@ index d769ad908c3454fa9088a42f32250bbdf8f9fa7e..2eaf31f1053787b39184dfa8ac6df87d
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 89af3de0f439cfb5bde2a23147b2ba7da482f9c1..16f11367a92624d8dd45838d606f0031b1c86903 100644
+index e4e254c26adb15be4f60a59a0cf8a41816b9250a..93129241f182e217478e61df37d6f7789954fc62 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2452,6 +2452,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2463,6 +2463,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
@@ -24,10 +24,10 @@ index abdca9fe5acc90f167219eb769ece66c35682bb1..9715a9d36187e2eecfeab1a05087d27c
      /**
       * Make the entity drop the item in their hand.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 16f11367a92624d8dd45838d606f0031b1c86903..459c9f64a32ec0e5a83146ffff3e436393e60078 100644
+index 93129241f182e217478e61df37d6f7789954fc62..26f9b1b5773f39aad3d8fe02a53d040c4042e81d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2307,7 +2307,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2308,7 +2308,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Open a Sign for editing by the Player.
       *

--- a/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
@@ -74,10 +74,10 @@ index b1ded556a1ce4e1d3c873ab9d7f799b6edcc5118..6ab8f05be11f8101202d56bfebc7ec23
      /**
       * Checks if this player is whitelisted or not
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 459c9f64a32ec0e5a83146ffff3e436393e60078..fdbbe75cad2ecb6b4e404b775d64a49e176ce92c 100644
+index 26f9b1b5773f39aad3d8fe02a53d040c4042e81d..675e1fed283a90c49380f51e4e50e0e7dde9c3e4 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -849,6 +849,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -850,6 +850,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start

--- a/patches/api/0144-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0144-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index fdbbe75cad2ecb6b4e404b775d64a49e176ce92c..23ded8a67663d887f636a2b04d7a7afb86ead22c 100644
+index 675e1fed283a90c49380f51e4e50e0e7dde9c3e4..44aa4ad14818e26993c912460bd91015ded09754 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2622,6 +2622,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2633,6 +2633,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull com.destroystokyo.paper.profile.PlayerProfile profile);

--- a/patches/api/0189-Add-Player-Client-Options-API.patch
+++ b/patches/api/0189-Add-Player-Client-Options-API.patch
@@ -229,10 +229,10 @@ index 0000000000000000000000000000000000000000..cf67dc7d465223710adbf2b798109f52
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 23ded8a67663d887f636a2b04d7a7afb86ead22c..75c15bf4ad598fabc0b9598ab7a0bb57afa61111 100644
+index 44aa4ad14818e26993c912460bd91015ded09754..a2dd30628458a60922a1326c88e2cbc158a28e89 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2642,6 +2642,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2653,6 +2653,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0206-Brand-support.patch
+++ b/patches/api/0206-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 75c15bf4ad598fabc0b9598ab7a0bb57afa61111..c1b7e15c04027ce61621b74ae188f51c883bfc29 100644
+index a2dd30628458a60922a1326c88e2cbc158a28e89..2606c3edf89ca1f435aa3809d4609fe104211523 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2774,6 +2774,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2785,6 +2785,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0218-Player-elytra-boost-API.patch
+++ b/patches/api/0218-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c1b7e15c04027ce61621b74ae188f51c883bfc29..da34d0151dd71ff93db9a1b76271a8fe398ace66 100644
+index 2606c3edf89ca1f435aa3809d4609fe104211523..8caa318f71c8fd765a583c18af72705e3864f23a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2648,6 +2648,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2659,6 +2659,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull com.destroystokyo.paper.ClientOption<T> option);

--- a/patches/api/0245-Add-sendOpLevel-API.patch
+++ b/patches/api/0245-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index da34d0151dd71ff93db9a1b76271a8fe398ace66..842d26eb83836e1d11a5a6b0dbe5f1666bc3b7d7 100644
+index 8caa318f71c8fd765a583c18af72705e3864f23a..f874f4342fbd1095ea4996da5d29f25ba7135e9a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2661,6 +2661,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2672,6 +2672,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0293-Add-PlayerKickEvent-causes.patch
+++ b/patches/api/0293-Add-PlayerKickEvent-causes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 842d26eb83836e1d11a5a6b0dbe5f1666bc3b7d7..8a87c128bb562ad46df4d02d53c72cce3b10db43 100644
+index f874f4342fbd1095ea4996da5d29f25ba7135e9a..44665d304b4245da3e5fe63e9d58649755259647 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -251,6 +251,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -252,6 +252,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param message kick message
       */
      void kick(final net.kyori.adventure.text.@Nullable Component message);

--- a/patches/api/0328-Add-player-health-update-API.patch
+++ b/patches/api/0328-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8a87c128bb562ad46df4d02d53c72cce3b10db43..ba329be88c9da9c4d98eff4b3c6321e2ddab2dba 100644
+index 44665d304b4245da3e5fe63e9d58649755259647..195acdc1d1805caf4ef865e53280f4e8c360eb66 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2049,6 +2049,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2050,6 +2050,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public double getHealthScale();
  

--- a/patches/api/0343-Multi-Block-Change-API.patch
+++ b/patches/api/0343-Multi-Block-Change-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Multi Block Change API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ba329be88c9da9c4d98eff4b3c6321e2ddab2dba..8997a2f854bdcbf40e74a10376de6dfc1acef697 100644
+index 195acdc1d1805caf4ef865e53280f4e8c360eb66..a4eb5ca72061ccc593ec8f03b663aebe9b2ccb02 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -648,6 +648,27 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -649,6 +649,27 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendBlockDamage(@NotNull Location loc, float progress);
  

--- a/patches/api/0371-More-Teleport-API.patch
+++ b/patches/api/0371-More-Teleport-API.patch
@@ -165,10 +165,10 @@ index ab0ceaba9ddcbe20a8b8a1fc3ed19cb3c64ecd3d..97f0bc6573c8ba09de77061b6312b91c
       * Teleports this entity to the given location. If this entity is riding a
       * vehicle, it will be dismounted prior to teleportation.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8997a2f854bdcbf40e74a10376de6dfc1acef697..49aa859225d82c38e974aa6ed62ba92e702bf849 100644
+index a4eb5ca72061ccc593ec8f03b663aebe9b2ccb02..c100a2815a1ee7bd59ecbd8c12a907d8aabb0290 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2862,6 +2862,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2873,6 +2873,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      String getClientBrandName();
      // Paper end
  

--- a/patches/api/0373-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0373-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 49aa859225d82c38e974aa6ed62ba92e702bf849..f3fd12368a5a49ba9415cd871757b38e9211963c 100644
+index c100a2815a1ee7bd59ecbd8c12a907d8aabb0290..b886e9a59272ef6c8afa65f31a42bfc47f48b43a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2726,6 +2726,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2737,6 +2737,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException If the level is negative or greater than {@code 4} (i.e. not within {@code [0, 4]}).
       */
      void sendOpLevel(byte level);

--- a/patches/api/0383-Elder-Guardian-appearance-API.patch
+++ b/patches/api/0383-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f3fd12368a5a49ba9415cd871757b38e9211963c..f313073f745629e75787020d5bb444125f01c714 100644
+index b886e9a59272ef6c8afa65f31a42bfc47f48b43a..a7dca9f902cd9916afd7a453288d669ab06c626c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2924,6 +2924,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2935,6 +2935,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
      // Paper end - Teleport API
  

--- a/patches/api/0391-Add-Player-Warden-Warning-API.patch
+++ b/patches/api/0391-Add-Player-Warden-Warning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player Warden Warning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f313073f745629e75787020d5bb444125f01c714..d02cc0194d492beb4d3e1c88dff7f6b2ea73554f 100644
+index a7dca9f902cd9916afd7a453288d669ab06c626c..bdb63e445c1bc2e08bfa840d61cdeb2d8576bde7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2940,6 +2940,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2951,6 +2951,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param silent whether sound should be silenced
       */
      void showElderGuardian(boolean silent);

--- a/patches/api/0400-fix-Instruments.patch
+++ b/patches/api/0400-fix-Instruments.patch
@@ -110,10 +110,10 @@ index 8f70d86a1d39351424335842c38625d42cfbdfb8..271fb4d41909654b87519edba1c1d4f4
      public static Instrument getByType(final byte type) {
          return BY_DATA.get(type);
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d02cc0194d492beb4d3e1c88dff7f6b2ea73554f..5234c31b640c21e87215671f0235f6450994fcef 100644
+index bdb63e445c1bc2e08bfa840d61cdeb2d8576bde7..fabe9a415c88d3669c7b09e4d7c2453c0f2edeff 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -392,9 +392,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -393,9 +393,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void playNote(@NotNull Location loc, byte instrument, byte note);
  
      /**

--- a/patches/api/0402-Add-Sneaking-API-for-Entities.patch
+++ b/patches/api/0402-Add-Sneaking-API-for-Entities.patch
@@ -35,10 +35,10 @@ index 3f3ea5bb6b3ea6f55b5cd699f1c01ac159619add..a2a423d4e4c2702ba5967223cab0432d
       * Get the category of spawn to which this entity belongs.
       *
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5234c31b640c21e87215671f0235f6450994fcef..462987f2c119509b3bc1b9ff061e975b774ea5dd 100644
+index fabe9a415c88d3669c7b09e4d7c2453c0f2edeff..7627cc0c25fc37cf914befda49ce83eeda9bfbef 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -295,6 +295,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -296,6 +296,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @return true if player is in sneak mode
       */
@@ -46,7 +46,7 @@ index 5234c31b640c21e87215671f0235f6450994fcef..462987f2c119509b3bc1b9ff061e975b
      public boolean isSneaking();
  
      /**
-@@ -302,6 +303,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -303,6 +304,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param sneak true if player should appear sneaking
       */

--- a/patches/api/0405-Flying-Fall-Damage-API.patch
+++ b/patches/api/0405-Flying-Fall-Damage-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Flying Fall Damage API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 462987f2c119509b3bc1b9ff061e975b774ea5dd..3f6eb664988b1f2c9d85157e75f3d5f3d89831d7 100644
+index 7627cc0c25fc37cf914befda49ce83eeda9bfbef..1c79a556c2267b5d87d5469123818e270840a684 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1508,6 +1508,23 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1509,6 +1509,23 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void setAllowFlight(boolean flight);
  

--- a/patches/api/0408-Win-Screen-API.patch
+++ b/patches/api/0408-Win-Screen-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Win Screen API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3f6eb664988b1f2c9d85157e75f3d5f3d89831d7..9cd49bf6db451af67cd15c8857d7bf51a4e1a67a 100644
+index 1c79a556c2267b5d87d5469123818e270840a684..88c4885569d2b8b22fce55601d50608ac8e9388c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -877,6 +877,47 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -878,6 +878,47 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  

--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -28,7 +28,7 @@ index 3df8c60ab5cd1454660980883f80668d535b742b..37c3a00659ce21623be07317f4f6a45b
 +/.factorypath
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..e090175d2fbe8eba664500feafc29c0567bb0c87
+index 0000000000000000000000000000000000000000..c207fd9b001dccaa71ba1615ffcdc093dd2b581c
 --- /dev/null
 +++ b/build.gradle.kts
 @@ -0,0 +1,137 @@
@@ -48,7 +48,7 @@ index 0000000000000000000000000000000000000000..e090175d2fbe8eba664500feafc29c05
 +    }
 +    implementation("org.ow2.asm:asm:9.4")
 +    implementation("commons-lang:commons-lang:2.6")
-+    runtimeOnly("org.xerial:sqlite-jdbc:3.41.0.0")
++    runtimeOnly("org.xerial:sqlite-jdbc:3.41.2.2")
 +    runtimeOnly("com.mysql:mysql-connector-j:8.0.32")
 +
 +    runtimeOnly("org.apache.maven:maven-resolver-provider:3.8.5")
@@ -171,7 +171,7 @@ index 0000000000000000000000000000000000000000..e090175d2fbe8eba664500feafc29c05
 +}
 diff --git a/pom.xml b/pom.xml
 deleted file mode 100644
-index 67ae7c25ee4e007e1fdfb3ac37687e1bd8ab58ca..0000000000000000000000000000000000000000
+index d3490073bebae5918fe97895ead320c06c8358c7..0000000000000000000000000000000000000000
 --- a/pom.xml
 +++ /dev/null
 @@ -1,587 +0,0 @@
@@ -405,7 +405,7 @@ index 67ae7c25ee4e007e1fdfb3ac37687e1bd8ab58ca..00000000000000000000000000000000
 -        <dependency>
 -            <groupId>org.xerial</groupId>
 -            <artifactId>sqlite-jdbc</artifactId>
--            <version>3.41.0.0</version>
+-            <version>3.41.2.2</version>
 -            <scope>runtime</scope>
 -        </dependency>
 -        <dependency>

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index e090175d2fbe8eba664500feafc29c0567bb0c87..d77f15c58f41f1e00c75e0a022919bb7dacc9926 100644
+index c207fd9b001dccaa71ba1615ffcdc093dd2b581c..ac679b0a66ce9676937a9971bf3ee2a935dd9acb 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -9,10 +9,9 @@ plugins {
@@ -19,7 +19,7 @@ index e090175d2fbe8eba664500feafc29c0567bb0c87..d77f15c58f41f1e00c75e0a022919bb7
      implementation("org.ow2.asm:asm:9.4")
 +    implementation("org.ow2.asm:asm-commons:9.4") // Paper - ASM event executor generation
      implementation("commons-lang:commons-lang:2.6")
-     runtimeOnly("org.xerial:sqlite-jdbc:3.41.0.0")
+     runtimeOnly("org.xerial:sqlite-jdbc:3.41.2.2")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.32")
 @@ -23,6 +22,8 @@ dependencies {
  

--- a/patches/server/0004-Test-changes.patch
+++ b/patches/server/0004-Test-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Test changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index d77f15c58f41f1e00c75e0a022919bb7dacc9926..0d04c3af92f7d4e63b1178247e493174cedd9178 100644
+index ac679b0a66ce9676937a9971bf3ee2a935dd9acb..e0724559c70b5967123010e898e66e757b2b1b58 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -12,6 +12,7 @@ dependencies {
@@ -14,7 +14,7 @@ index d77f15c58f41f1e00c75e0a022919bb7dacc9926..0d04c3af92f7d4e63b1178247e493174
      implementation("org.ow2.asm:asm-commons:9.4") // Paper - ASM event executor generation
 +    testImplementation("org.mockito:mockito-core:4.9.0") // Paper - switch to mockito
      implementation("commons-lang:commons-lang:2.6")
-     runtimeOnly("org.xerial:sqlite-jdbc:3.41.0.0")
+     runtimeOnly("org.xerial:sqlite-jdbc:3.41.2.2")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.32")
 diff --git a/src/test/java/io/papermc/paper/testing/DummyServer.java b/src/test/java/io/papermc/paper/testing/DummyServer.java
 new file mode 100644

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -14,7 +14,7 @@ public org.spigotmc.SpigotWorldConfig getString(Ljava/lang/String;Ljava/lang/Str
 public net.minecraft.world.level.NaturalSpawner SPAWNING_CATEGORIES
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 0d04c3af92f7d4e63b1178247e493174cedd9178..1c183e9083a5ce2a2995ae45864c564b7cde3f53 100644
+index e0724559c70b5967123010e898e66e757b2b1b58..b0facb2b0b86fafbfd5776eba2e5bdb69cc1cbed 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -13,6 +13,7 @@ dependencies {
@@ -23,7 +23,7 @@ index 0d04c3af92f7d4e63b1178247e493174cedd9178..1c183e9083a5ce2a2995ae45864c564b
      testImplementation("org.mockito:mockito-core:4.9.0") // Paper - switch to mockito
 +    implementation("org.spongepowered:configurate-yaml:4.1.2") // Paper - config files
      implementation("commons-lang:commons-lang:2.6")
-     runtimeOnly("org.xerial:sqlite-jdbc:3.41.0.0")
+     runtimeOnly("org.xerial:sqlite-jdbc:3.41.2.2")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.32")
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
@@ -4571,10 +4571,10 @@ index 9a86fedb7ea4932590b86ef96785141489b03528..40deaa2463876659c0579b5273b52497
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 07c5931efcb5f3ca269e13183318eee57bb5389f..1e130b0f34d651f2f78f90950c52bac947993a74 100644
+index 6b5d97752b07ebd70a7986331bd28dde14958ccc..79ee400968a82aa5eb125d62f0440f926e3298f9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -881,6 +881,7 @@ public final class CraftServer implements Server {
+@@ -883,6 +883,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot

--- a/patches/server/0008-CB-fixes.patch
+++ b/patches/server/0008-CB-fixes.patch
@@ -83,10 +83,10 @@ index 161ad6ab1443b2ce33a2d7d91d189c855db0453b..15a9736a870055d639d03063c7cf67fd
          this.registryAccess = registryManager;
          this.structureTemplateManager = structureTemplateManager;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1e130b0f34d651f2f78f90950c52bac947993a74..6581c2c498a73c1fb60bb922114e24a43d355748 100644
+index 79ee400968a82aa5eb125d62f0440f926e3298f9..b6ac46929d68207dee5364902a2ba6fa0f1a4a42 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2304,7 +2304,13 @@ public final class CraftServer implements Server {
+@@ -2306,7 +2306,13 @@ public final class CraftServer implements Server {
          Validate.notNull(key, "NamespacedKey cannot be null");
  
          LootTables registry = this.getServer().getLootTables();

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2852,10 +2852,10 @@ index 0e04e7467ee27ea9e3ef60fe598cc21ab39f4c68..0f5e92a2256fe22b55d2428f98db403a
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6581c2c498a73c1fb60bb922114e24a43d355748..15449084959d4dcd112ea112e2bc79ee7f96006a 100644
+index b6ac46929d68207dee5364902a2ba6fa0f1a4a42..df637dec0e910f3879e1e38aa11d8cf3e755bc20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -601,8 +601,10 @@ public final class CraftServer implements Server {
+@@ -603,8 +603,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -2866,7 +2866,7 @@ index 6581c2c498a73c1fb60bb922114e24a43d355748..15449084959d4dcd112ea112e2bc79ee
      }
  
      @Override
-@@ -1440,7 +1442,15 @@ public final class CraftServer implements Server {
+@@ -1442,7 +1444,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -2882,7 +2882,7 @@ index 6581c2c498a73c1fb60bb922114e24a43d355748..15449084959d4dcd112ea112e2bc79ee
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1608,7 +1618,20 @@ public final class CraftServer implements Server {
+@@ -1610,7 +1620,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -2903,7 +2903,7 @@ index 6581c2c498a73c1fb60bb922114e24a43d355748..15449084959d4dcd112ea112e2bc79ee
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1616,14 +1639,14 @@ public final class CraftServer implements Server {
+@@ -1618,14 +1641,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -2920,7 +2920,7 @@ index 6581c2c498a73c1fb60bb922114e24a43d355748..15449084959d4dcd112ea112e2bc79ee
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1874,6 +1897,14 @@ public final class CraftServer implements Server {
+@@ -1876,6 +1899,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -2935,7 +2935,7 @@ index 6581c2c498a73c1fb60bb922114e24a43d355748..15449084959d4dcd112ea112e2bc79ee
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1886,13 +1917,28 @@ public final class CraftServer implements Server {
+@@ -1888,13 +1919,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -2964,7 +2964,7 @@ index 6581c2c498a73c1fb60bb922114e24a43d355748..15449084959d4dcd112ea112e2bc79ee
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1957,6 +2003,12 @@ public final class CraftServer implements Server {
+@@ -1959,6 +2005,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -2977,7 +2977,7 @@ index 6581c2c498a73c1fb60bb922114e24a43d355748..15449084959d4dcd112ea112e2bc79ee
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2383,4 +2435,53 @@ public final class CraftServer implements Server {
+@@ -2385,4 +2437,53 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
@@ -3213,105 +3213,34 @@ index 0beb96dc896f63003e1b1ae458b73902bdbe648a..102eb86bad3000f258775ac06ecd1a6d
      public String getCustomName() {
          EnchantmentTableBlockEntity enchant = this.getSnapshot();
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-index 55fcabb1d6e0767fc21c1f0beb76e941ed3c0846..9fd6a05fb8022c5e4e3d67f9b0e9df3f477ea637 100644
+index 3bdf17b1cc28c390e40299c3edf7941f98393661..46b18cac2c40db01ebd29528d529fe631b03ddbb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-@@ -13,34 +13,60 @@ import org.bukkit.entity.Player;
- public class CraftSign<T extends SignBlockEntity> extends CraftBlockEntityState<T> implements Sign {
- 
-     // Lazily initialized only if requested:
--    private String[] originalLines = null;
--    private String[] lines = null;
-+    // Paper start
-+    private java.util.ArrayList<net.kyori.adventure.text.Component> originalLines = null; // ArrayList for RandomAccess
-+    private java.util.ArrayList<net.kyori.adventure.text.Component> lines = null; // ArrayList for RandomAccess
-+    // Paper end
- 
-     public CraftSign(World world, T tileEntity) {
-         super(world, tileEntity);
+@@ -23,6 +23,23 @@ public class CraftSign<T extends SignBlockEntity> extends CraftBlockEntityState<
+         this.front = new CraftSignSide(this.getSnapshot());
      }
  
 +    // Paper start
-     @Override
--    public String[] getLines() {
--        if (this.lines == null) {
--            // Lazy initialization:
--            SignBlockEntity sign = this.getSnapshot();
--            this.lines = new String[sign.messages.length];
--            System.arraycopy(CraftSign.revertComponents(sign.messages), 0, lines, 0, lines.length);
--            this.originalLines = new String[lines.length];
--            System.arraycopy(lines, 0, originalLines, 0, originalLines.length);
--        }
-+    public java.util.List<net.kyori.adventure.text.Component> lines() {
-+        this.loadLines();
-         return this.lines;
-     }
- 
 +    @Override
-+    public net.kyori.adventure.text.Component line(int index) {
-+        this.loadLines();
-+        return this.lines.get(index);
++    public java.util.@NotNull List<net.kyori.adventure.text.Component> lines() {
++        return this.front.lines();
 +    }
 +
 +    @Override
-+    public void line(int index, net.kyori.adventure.text.Component line) {
-+        this.loadLines();
-+        this.lines.set(index, line);
++    public net.kyori.adventure.text.@NotNull Component line(int index) {
++        return this.front.line(index);
 +    }
 +
-+    private void loadLines() {
-+        if (lines != null) {
-+            return;
-+        }
-+        // Lazy initialization:
-+        SignBlockEntity sign = this.getSnapshot();
-+        lines = io.papermc.paper.adventure.PaperAdventure.asAdventure(com.google.common.collect.Lists.newArrayList(sign.messages));
-+        originalLines = new java.util.ArrayList<>(lines);
++    @Override
++    public void line(int index, net.kyori.adventure.text.@NotNull Component line) {
++        this.front.line(index, line);
 +    }
 +    // Paper end
-+    @Override
-+    public String[] getLines() {
-+        this.loadLines();
-+        return this.lines.stream().map(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection()::serialize).toArray(String[]::new); // Paper
-+    }
 +
      @Override
-     public String getLine(int index) throws IndexOutOfBoundsException {
--        return this.getLines()[index];
-+        this.loadLines();
-+        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.lines.get(index)); // Paper
-     }
- 
-     @Override
-     public void setLine(int index, String line) throws IndexOutOfBoundsException {
--        this.getLines()[index] = line;
-+        this.loadLines();
-+        this.lines.set(index, line != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(line) : net.kyori.adventure.text.Component.empty()); // Paper
-     }
- 
-     @Override
-@@ -78,13 +104,16 @@ public class CraftSign<T extends SignBlockEntity> extends CraftBlockEntityState<
-         super.applyTo(sign);
- 
-         if (this.lines != null) {
--            for (int i = 0; i < lines.length; i++) {
--                String line = (this.lines[i] == null) ? "" : this.lines[i];
--                if (line.equals(this.originalLines[i])) {
-+            // Paper start
-+            for (int i = 0; i < this.lines.size(); ++i) {
-+                net.kyori.adventure.text.Component component = this.lines.get(i);
-+                net.kyori.adventure.text.Component origComp = this.originalLines.get(i);
-+                if (component.equals(origComp)) {
-                     continue; // The line contents are still the same, skip.
-                 }
--                sign.setMessage(i, CraftChatMessage.fromString(line)[0]);
-+                sign.setMessage(i, io.papermc.paper.adventure.PaperAdventure.asVanilla(component));
-             }
-+            // Paper end
-         }
-     }
- 
-@@ -99,6 +128,20 @@ public class CraftSign<T extends SignBlockEntity> extends CraftBlockEntityState<
+     public String[] getLines() {
+         return this.front.getLines();
+@@ -94,6 +111,20 @@ public class CraftSign<T extends SignBlockEntity> extends CraftBlockEntityState<
          ((CraftPlayer) player).getHandle().openTextEdit(handle);
      }
  
@@ -3332,6 +3261,113 @@ index 55fcabb1d6e0767fc21c1f0beb76e941ed3c0846..9fd6a05fb8022c5e4e3d67f9b0e9df3f
      public static Component[] sanitizeLines(String[] lines) {
          Component[] components = new Component[4];
  
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/sign/CraftSignSide.java b/src/main/java/org/bukkit/craftbukkit/block/sign/CraftSignSide.java
+index 5a6bd104a823f011a977f5d8a681dc9d29fbe8f6..e38414fe568e0d84ecacf71dd85c1a12ec7bc053 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/sign/CraftSignSide.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/sign/CraftSignSide.java
+@@ -11,36 +11,69 @@ import org.jetbrains.annotations.Nullable;
+ public class CraftSignSide implements SignSide {
+ 
+     // Lazily initialized only if requested:
+-    private String[] originalLines = null;
+-    private String[] lines = null;
++    // Paper start
++    private java.util.ArrayList<net.kyori.adventure.text.Component> originalLines = null; // ArrayList for RandomAccess
++    private java.util.ArrayList<net.kyori.adventure.text.Component> lines = null; // ArrayList for RandomAccess
++    // Paper end
+     private final SignBlockEntity signText;
+ 
+     public CraftSignSide(SignBlockEntity signText) {
+         this.signText = signText;
+     }
+ 
++    // Paper start
++    @Override
++    public java.util.@NotNull List<net.kyori.adventure.text.Component> lines() {
++        this.loadLines();
++        return this.lines;
++    }
++
++    @Override
++    public net.kyori.adventure.text.@NotNull Component line(final int index) throws IndexOutOfBoundsException {
++        this.loadLines();
++        return this.lines.get(index);
++    }
++
++    @Override
++    public void line(final int index, final net.kyori.adventure.text.@NotNull Component line) throws IndexOutOfBoundsException {
++        this.loadLines();
++        this.lines.set(index, line);
++    }
++
++    private void loadLines() {
++        if (this.lines != null) {
++            return;
++        }
++        // Lazy initialization:
++        this.lines = io.papermc.paper.adventure.PaperAdventure.asAdventure(com.google.common.collect.Lists.newArrayList(this.signText.messages));
++        this.originalLines = new java.util.ArrayList<>(this.lines);
++    }
++    // Paper end
++
+     @NotNull
+     @Override
+     public String[] getLines() {
+-        if (this.lines == null) {
+-            // Lazy initialization:
+-            this.lines = new String[signText.messages.length];
+-            System.arraycopy(CraftSign.revertComponents(signText.messages), 0, lines, 0, lines.length);
+-            this.originalLines = new String[lines.length];
+-            System.arraycopy(lines, 0, originalLines, 0, originalLines.length);
+-        }
+-        return this.lines;
++        // Paper start
++        this.loadLines();
++        return this.lines.stream().map(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection()::serialize).toArray(String[]::new); // Paper
++        // Paper end
+     }
+ 
+     @NotNull
+     @Override
+     public String getLine(int index) throws IndexOutOfBoundsException {
+-        return this.getLines()[index];
++        // Paper start
++        this.loadLines();
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.lines.get(index));
++        // Paper end
+     }
+ 
+     @Override
+     public void setLine(int index, @NotNull String line) throws IndexOutOfBoundsException {
+-        this.getLines()[index] = line;
++        // Paper start
++        this.loadLines();
++        this.lines.set(index, line != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(line) : net.kyori.adventure.text.Component.empty());
++        // Paper end
+     }
+ 
+     @Override
+@@ -66,13 +99,16 @@ public class CraftSignSide implements SignSide {
+ 
+     public void applyLegacyStringToSignSide() {
+         if (this.lines != null) {
+-            for (int i = 0; i < lines.length; i++) {
+-                String line = (this.lines[i] == null) ? "" : this.lines[i];
+-                if (line.equals(this.originalLines[i])) {
++            // Paper start
++            for (int i = 0; i < this.lines.size(); ++i) {
++                net.kyori.adventure.text.Component component = this.lines.get(i);
++                net.kyori.adventure.text.Component origComp = this.originalLines.get(i);
++                if (component.equals(origComp)) {
+                     continue; // The line contents are still the same, skip.
+                 }
+-                this.signText.setMessage(i, CraftChatMessage.fromString(line)[0]);
++                this.signText.setMessage(i, io.papermc.paper.adventure.PaperAdventure.asVanilla(component));
+             }
++            // Paper end
+         }
+     }
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java
 index 3de88112bdb08d6bd0d28f20582c4090bfd8dbfe..87f2cea36d852c81fdb0a1bc21162d41377ab2e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java
@@ -3585,10 +3621,10 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e07921f02 100644
+index 4176633bf32c1e28694f3af1cda2033df05bca94..2162df3654bcad4073f499138f9faac96fbc8007 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -283,14 +283,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -285,14 +285,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getDisplayName() {
@@ -3628,7 +3664,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e
      @Override
      public String getPlayerListName() {
          return this.getHandle().listName == null ? getName() : CraftChatMessage.fromComponent(this.getHandle().listName);
-@@ -309,42 +334,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -311,42 +336,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -3680,7 +3716,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e
          this.getHandle().connection.send(packet);
      }
  
-@@ -376,6 +401,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -378,6 +403,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.disconnect(message == null ? "" : message);
      }
  
@@ -3704,7 +3740,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e
      @Override
      public void setCompassTarget(Location loc) {
          if (this.getHandle().connection == null) return;
-@@ -704,6 +746,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -706,6 +748,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
@@ -3729,7 +3765,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e
      @Override
      public void sendSignChange(Location loc, String[] lines) {
          this.sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -731,6 +791,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -733,6 +793,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          Component[] components = CraftSign.sanitizeLines(lines);
@@ -3741,7 +3777,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e
          SignBlockEntity sign = new SignBlockEntity(CraftLocation.toBlockPosition(loc), Blocks.OAK_SIGN.defaultBlockState());
          sign.setColor(net.minecraft.world.item.DyeColor.byId(dyeColor.getWoolData()));
          sign.setHasGlowingText(hasGlowingText);
-@@ -738,7 +803,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -740,7 +805,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              sign.setMessage(i, components[i]);
          }
  
@@ -3751,7 +3787,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e
      }
  
      @Override
-@@ -1631,7 +1697,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1633,7 +1699,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url) {
@@ -3760,7 +3796,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e
      }
  
      @Override
-@@ -1646,7 +1712,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1648,7 +1714,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url, byte[] hash, boolean force) {
@@ -3769,7 +3805,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e
      }
  
      @Override
-@@ -1662,6 +1728,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1664,6 +1730,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -3791,7 +3827,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e
      public void addChannel(String channel) {
          Preconditions.checkState(this.channels.size() < 128, "Cannot register channel '%s'. Too many channels registered!", channel);
          channel = StandardMessenger.validateAndCorrectChannel(channel);
-@@ -2066,6 +2147,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2068,6 +2149,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -3804,7 +3840,7 @@ index 1fc45821f61b7f14876a31a5792cfbd1f2efe6b2..693978b0ca9eacba0b518d121b03c23e
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -2111,6 +2198,232 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2118,6 +2205,232 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  

--- a/patches/server/0011-Paper-command.patch
+++ b/patches/server/0011-Paper-command.patch
@@ -615,10 +615,10 @@ index 1fe07773cf9664164b29164caba22800e5a6bdae..cb6f192c11cda6230ec365e6cefb44a3
  
          this.setPvpAllowed(dedicatedserverproperties.pvp);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 15449084959d4dcd112ea112e2bc79ee7f96006a..04a1eb79f8fc5651a39b739cc2bbb2412f8a76c1 100644
+index df637dec0e910f3879e1e38aa11d8cf3e755bc20..42d25bed20199403ae75e6a832aaa3e56b0ba44e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -905,6 +905,7 @@ public final class CraftServer implements Server {
+@@ -907,6 +907,7 @@ public final class CraftServer implements Server {
          this.commandMap.clearCommands();
          this.reloadData();
          org.spigotmc.SpigotConfig.registerCommands(); // Spigot
@@ -626,7 +626,7 @@ index 15449084959d4dcd112ea112e2bc79ee7f96006a..04a1eb79f8fc5651a39b739cc2bbb241
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2475,6 +2476,34 @@ public final class CraftServer implements Server {
+@@ -2477,6 +2478,34 @@ public final class CraftServer implements Server {
      // Paper end
  
      // Paper start

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -6750,10 +6750,10 @@ index aa054369cef3da4f90ce17788dcb9ca80dc98010..d9f2518a08bc4ae978051be51e467597
              Bootstrap.validate();
              Util.startTimerHackThread();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index df1058c8f3198fee567938b91021e253e9fbbf00..2d112dd2ea808773e364396b26f04bca54a6fa37 100644
+index 42d25bed20199403ae75e6a832aaa3e56b0ba44e..054a18343ff806d0ad96e9354f82c7906467adb2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -264,7 +264,8 @@ public final class CraftServer implements Server {
+@@ -266,7 +266,8 @@ public final class CraftServer implements Server {
      private final CraftCommandMap commandMap = new CraftCommandMap(this);
      private final SimpleHelpMap helpMap = new SimpleHelpMap(this);
      private final StandardMessenger messenger = new StandardMessenger();
@@ -6763,7 +6763,7 @@ index df1058c8f3198fee567938b91021e253e9fbbf00..2d112dd2ea808773e364396b26f04bca
      private final StructureManager structureManager;
      protected final DedicatedServer console;
      protected final DedicatedPlayerList playerList;
-@@ -412,24 +413,7 @@ public final class CraftServer implements Server {
+@@ -414,24 +415,7 @@ public final class CraftServer implements Server {
      }
  
      public void loadPlugins() {
@@ -6789,7 +6789,7 @@ index df1058c8f3198fee567938b91021e253e9fbbf00..2d112dd2ea808773e364396b26f04bca
      }
  
      public void enablePlugins(PluginLoadOrder type) {
-@@ -518,15 +502,17 @@ public final class CraftServer implements Server {
+@@ -520,15 +504,17 @@ public final class CraftServer implements Server {
      private void enablePlugin(Plugin plugin) {
          try {
              List<Permission> perms = plugin.getDescription().getPermissions();
@@ -6813,7 +6813,7 @@ index df1058c8f3198fee567938b91021e253e9fbbf00..2d112dd2ea808773e364396b26f04bca
  
              this.pluginManager.enablePlugin(plugin);
          } catch (Throwable ex) {
-@@ -929,6 +915,7 @@ public final class CraftServer implements Server {
+@@ -931,6 +917,7 @@ public final class CraftServer implements Server {
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));
          }

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -1632,10 +1632,10 @@ index 9c3ce492051199acb8d38ade121ec8a0cbc50f54..aa4f2dc63dd79e6c3d7594d2fd63fa00
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7eaf75ac95a5651b6245b406983144a484a0832c..3f68ecca17f297e74bfdb8f93c2cfc71c6719b31 100644
+index 054a18343ff806d0ad96e9354f82c7906467adb2..cdc2ae90e70407455ba03b0805941ace809fa7f3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -362,7 +362,7 @@ public final class CraftServer implements Server {
+@@ -364,7 +364,7 @@ public final class CraftServer implements Server {
          this.saveCommandsConfig();
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
@@ -1644,7 +1644,7 @@ index 7eaf75ac95a5651b6245b406983144a484a0832c..3f68ecca17f297e74bfdb8f93c2cfc71
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
-@@ -2392,12 +2392,31 @@ public final class CraftServer implements Server {
+@@ -2394,12 +2394,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  
@@ -1846,10 +1846,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 693978b0ca9eacba0b518d121b03c23e07921f02..ec0eeee342340f8fc099d29a234e658672a7ba7c 100644
+index 2162df3654bcad4073f499138f9faac96fbc8007..12676b0e8860d98693c176287c3904c3f87f1db7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2509,6 +2509,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2516,6 +2516,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
              CraftPlayer.this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(components, position == net.md_5.bungee.api.ChatMessageType.ACTION_BAR));
          }

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -17854,10 +17854,10 @@ index bf4b2f89d3a7133155c6272379c742318b2c1514..33677ec811ceab939c419bf7d31b9958
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3f68ecca17f297e74bfdb8f93c2cfc71c6719b31..c77a7bc3a3e0d244b082ba917412685822df47cb 100644
+index cdc2ae90e70407455ba03b0805941ace809fa7f3..de42661734a2e0484c584c8b017bed5654a2acee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1125,7 +1125,7 @@ public final class CraftServer implements Server {
+@@ -1127,7 +1127,7 @@ public final class CraftServer implements Server {
          this.console.addLevel(internal);
  
          this.getServer().prepareLevels(internal.getChunkSource().chunkMap.progressListener, internal);
@@ -17866,7 +17866,7 @@ index 3f68ecca17f297e74bfdb8f93c2cfc71c6719b31..c77a7bc3a3e0d244b082ba9174126858
  
          this.pluginManager.callEvent(new WorldLoadEvent(internal.getWorld()));
          return internal.getWorld();
-@@ -1169,7 +1169,7 @@ public final class CraftServer implements Server {
+@@ -1171,7 +1171,7 @@ public final class CraftServer implements Server {
              }
  
              handle.getChunkSource().close(save);
@@ -17875,7 +17875,7 @@ index 3f68ecca17f297e74bfdb8f93c2cfc71c6719b31..c77a7bc3a3e0d244b082ba9174126858
              handle.convertable.close();
          } catch (Exception ex) {
              this.getLogger().log(Level.SEVERE, null, ex);
-@@ -1988,7 +1988,7 @@ public final class CraftServer implements Server {
+@@ -1990,7 +1990,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {
@@ -18004,10 +18004,10 @@ index aab8099b9980b4d4b4ee6d7484abcc0b55962a5f..9920eaa5d9efa301462f2dbf7e06835b
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ec0eeee342340f8fc099d29a234e658672a7ba7c..94b8b1c5c624c59cff74be1631cc3e790bf1d4ab 100644
+index 12676b0e8860d98693c176287c3904c3f87f1db7..5237eb9d18fa3ed0474b9c3aa166058c21a66d5e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -182,6 +182,81 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -184,6 +184,81 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = System.currentTimeMillis();
      }
  

--- a/patches/server/0019-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0019-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e6193b5403d4cb762f702b45ca7c07d5f64d8218..401a0976af9f911d1ddcc24b77505dba2665a65f 100644
+index de42661734a2e0484c584c8b017bed5654a2acee..ada6faf50976d7dd7b244c32f376419d31738bb1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -416,6 +416,35 @@ public final class CraftServer implements Server {
+@@ -418,6 +418,35 @@ public final class CraftServer implements Server {
          io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.INSTANCE.enter(io.papermc.paper.plugin.entrypoint.Entrypoint.PLUGIN); // Paper - replace implementation
      }
  

--- a/patches/server/0027-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0027-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -19,10 +19,10 @@ index 6251d93c2ea61c471b4e1069048327782acc78e7..d3cd196e1a6f707ed5e0008123cc65df
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 401a0976af9f911d1ddcc24b77505dba2665a65f..86480565d736e47e9f0c59c80b1242a5589d0f6f 100644
+index ada6faf50976d7dd7b244c32f376419d31738bb1..ee2247aa527f4dacaf0e2083a2df0246dac7514e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -255,7 +255,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -257,7 +257,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
  public final class CraftServer implements Server {

--- a/patches/server/0030-Player-affects-spawning-API.patch
+++ b/patches/server/0030-Player-affects-spawning-API.patch
@@ -137,10 +137,10 @@ index be6e3e21ad62da01e5e2dd78e300cbc8efdbeb42..ea98625fe7c00743b8df74a24e6d4b75
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bfd61549b3df0885a03276a2acfc798f078e3245..910f95f29c033b8d7adce705eae170235acf427e 100644
+index 5237eb9d18fa3ed0474b9c3aa166058c21a66d5e..50612858a0000d488dd9838ebd79403e1edd03e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2236,8 +2236,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2238,8 +2238,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0031-Further-improve-server-tick-loop.patch
+++ b/patches/server/0031-Further-improve-server-tick-loop.patch
@@ -145,10 +145,10 @@ index d3cd196e1a6f707ed5e0008123cc65df80422859..a7f9a3e57c7736b065b8dc4dba6e018c
                  this.startMetricsRecordingTick();
                  this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 86480565d736e47e9f0c59c80b1242a5589d0f6f..4a8aa6dcc8c359c12eadf87d1194cac4919ec2ae 100644
+index ee2247aa527f4dacaf0e2083a2df0246dac7514e..77bfda008ca983ba5ba4b26510f629a9d743b73b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2417,6 +2417,17 @@ public final class CraftServer implements Server {
+@@ -2419,6 +2419,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0032-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0032-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 910f95f29c033b8d7adce705eae170235acf427e..617e504e6d19325a03875fc09eda80014d933724 100644
+index 50612858a0000d488dd9838ebd79403e1edd03e4..a80cd0e9d8c1ff3d653a21b2302d0d27dd0d95b2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1905,12 +1905,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1907,12 +1907,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0045-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0045-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index 0d06bb85f2c81331dcf5cccde31c650a7c46f0b9..10660cd8df20269f07726af53dc07fa7
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 617e504e6d19325a03875fc09eda80014d933724..dcadf816cfe7e4a54261b936ceb1684b9d6bec17 100644
+index a80cd0e9d8c1ff3d653a21b2302d0d27dd0d95b2..ada4dfb8e520eb2e383373771719f924b2062d1b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2236,8 +2236,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2238,8 +2238,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0052-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0052-Ensure-commands-are-not-ran-async.patch
@@ -74,10 +74,10 @@ index 5291581c87b65be72f482b4da1fccd33fa053591..dae74cda3b9faa0c8aeecc6c7bc32995
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + s);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4a8aa6dcc8c359c12eadf87d1194cac4919ec2ae..080afe93a303626254d737dac1222736587a53c3 100644
+index 77bfda008ca983ba5ba4b26510f629a9d743b73b..452171d26219f5169c707f17c56c46b928a84c60 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -853,6 +853,28 @@ public final class CraftServer implements Server {
+@@ -855,6 +855,28 @@ public final class CraftServer implements Server {
          Validate.notNull(commandLine, "CommandLine cannot be null");
          org.spigotmc.AsyncCatcher.catchOp("command dispatch"); // Spigot
  
@@ -107,10 +107,10 @@ index 4a8aa6dcc8c359c12eadf87d1194cac4919ec2ae..080afe93a303626254d737dac1222736
              return true;
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index dcadf816cfe7e4a54261b936ceb1684b9d6bec17..859637f7a5eca51db5a880a06355f1fc601bc266 100644
+index ada4dfb8e520eb2e383373771719f924b2062d1b..ce45e409ea3413cabb2e77c7013fa9b867817ad6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -510,7 +510,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -512,7 +512,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void chat(String msg) {
          if (this.getHandle().connection == null) return;
  

--- a/patches/server/0054-Expose-server-CommandMap.patch
+++ b/patches/server/0054-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 080afe93a303626254d737dac1222736587a53c3..5674691d0f4c8b0a4c4255476d3d156b08225206 100644
+index 452171d26219f5169c707f17c56c46b928a84c60..979bed9ee435cfc17aadb83184b2420b9a81c21e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1992,6 +1992,7 @@ public final class CraftServer implements Server {
+@@ -1994,6 +1994,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0056-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/server/0056-Player-Tab-List-and-Title-APIs.patch
@@ -63,7 +63,7 @@ index bd808eb312ade7122973a47f4b96505829511da5..bf0f9cab7c66c089f35b851e799ba4a4
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 859637f7a5eca51db5a880a06355f1fc601bc266..f1c73e221a0fc0cb24076171b69db5c9fcb271e5 100644
+index ce45e409ea3413cabb2e77c7013fa9b867817ad6..aea668388c2960f515def749d4a8bf5359625dbd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@
@@ -73,7 +73,7 @@ index 859637f7a5eca51db5a880a06355f1fc601bc266..f1c73e221a0fc0cb24076171b69db5c9
  import com.google.common.base.Preconditions;
  import com.google.common.collect.ImmutableSet;
  import com.google.common.io.BaseEncoding;
-@@ -356,6 +357,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -358,6 +359,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0058-Add-velocity-warnings.patch
+++ b/patches/server/0058-Add-velocity-warnings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add velocity warnings
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5674691d0f4c8b0a4c4255476d3d156b08225206..5364bc705fb28380ef66c5faec336287360c7c6f 100644
+index 979bed9ee435cfc17aadb83184b2420b9a81c21e..e5c712fff29255da5173b2a35eba0f35ccd75ee3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -290,6 +290,7 @@ public final class CraftServer implements Server {
+@@ -292,6 +292,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;

--- a/patches/server/0059-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0059-Configurable-inter-world-teleportation-safety.patch
@@ -16,10 +16,10 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f1c73e221a0fc0cb24076171b69db5c9fcb271e5..053c07ae24782ab309900851f1a0e0f2b10186f6 100644
+index aea668388c2960f515def749d4a8bf5359625dbd..470eac3191c09c7c7fe4b36165ed1c213bac421c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1207,7 +1207,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1209,7 +1209,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entity.connection.teleport(to);
          } else {
              // The respawn reason should never be used if the passed location is non null.

--- a/patches/server/0065-Complete-resource-pack-API.patch
+++ b/patches/server/0065-Complete-resource-pack-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ee0cff3525ff6ca47c91363dd7660c7b85111971..b976e99aaabefefab37651467d4c60d664fda036 100644
+index dae74cda3b9faa0c8aeecc6c7bc329950033f653..dac2665008b5ba49134c84373f916c5c6ed355e9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1756,8 +1756,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -23,18 +23,10 @@ index ee0cff3525ff6ca47c91363dd7660c7b85111971..b976e99aaabefefab37651467d4c60d6
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 053c07ae24782ab309900851f1a0e0f2b10186f6..dfa60512f9113524a584d4a874a7d1e9e53259ba 100644
+index 470eac3191c09c7c7fe4b36165ed1c213bac421c..31785e1cee09977356ee2b65a7d41df2c959d1b2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -158,6 +158,7 @@ import org.bukkit.plugin.Plugin;
- import org.bukkit.plugin.messaging.StandardMessenger;
- import org.bukkit.profile.PlayerProfile;
- import org.bukkit.scoreboard.Scoreboard;
-+import org.jetbrains.annotations.NotNull;
- 
- import net.md_5.bungee.api.chat.BaseComponent; // Spigot
- 
-@@ -176,6 +177,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -178,6 +178,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private double healthScale = 20;
      private CraftWorldBorder clientWorldBorder = null;
      private BorderChangeListener clientWorldBorderListener = this.createWorldBorderListener();
@@ -45,7 +37,7 @@ index 053c07ae24782ab309900851f1a0e0f2b10186f6..dfa60512f9113524a584d4a874a7d1e9
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -2359,6 +2364,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2361,6 +2365,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0066-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0066-Default-loading-permissions.yml-before-plugins.patch
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5364bc705fb28380ef66c5faec336287360c7c6f..377e631bb70c4711152ff2895bc8ffd3c032bba4 100644
+index e5c712fff29255da5173b2a35eba0f35ccd75ee3..da13de547f4f4343ca3301f1b8684eb3d42d62a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -450,6 +450,7 @@ public final class CraftServer implements Server {
+@@ -452,6 +452,7 @@ public final class CraftServer implements Server {
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
              this.helpMap.initializeGeneralTopics();
@@ -27,7 +27,7 @@ index 5364bc705fb28380ef66c5faec336287360c7c6f..377e631bb70c4711152ff2895bc8ffd3
          }
  
          Plugin[] plugins = this.pluginManager.getPlugins();
-@@ -469,7 +470,7 @@ public final class CraftServer implements Server {
+@@ -471,7 +472,7 @@ public final class CraftServer implements Server {
              this.commandMap.registerServerAliases();
              DefaultPermissions.registerCorePermissions();
              CraftDefaultPermissions.registerCorePermissions();

--- a/patches/server/0067-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0067-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0a0cb354c7a1016a7c1893581591f6b848bf221c..b6f7d306b35b496d1e85e0de588aea631e63c1d1 100644
+index da13de547f4f4343ca3301f1b8684eb3d42d62a1..488c37ef814a8c592f82cfc4197e9dcfd2a9e95c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2583,5 +2583,23 @@ public final class CraftServer implements Server {
+@@ -2585,5 +2585,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0068-Remove-Metadata-on-reload.patch
+++ b/patches/server/0068-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ec97b740a935196d689fac7ff239968b87884a96..90ab7190b1f59f2a6440ebfa6454a4b395f45ab5 100644
+index 488c37ef814a8c592f82cfc4197e9dcfd2a9e95c..42fa812b86f439b3addce1f33365c7bfc3129fe2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -940,8 +940,16 @@ public final class CraftServer implements Server {
+@@ -942,8 +942,16 @@ public final class CraftServer implements Server {
              world.spigotConfig.init(); // Spigot
          }
  

--- a/patches/server/0073-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0073-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -44,10 +44,10 @@ index 9936fb67766dedba71b582316dd2bddd6567c342..2f161145789890fcd9bfd893b099f25a
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index dfa60512f9113524a584d4a874a7d1e9e53259ba..2525b010fb36bc28327a33a5def6602e1ecfb3de 100644
+index 31785e1cee09977356ee2b65a7d41df2c959d1b2..16dc9546303d692c62b6a1538106019f6bbe149b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2164,6 +2164,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2165,6 +2165,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0106-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0106-Add-setting-for-proxy-online-mode-status.patch
@@ -43,10 +43,10 @@ index da98f074ccd5a40c635824112c97fd174c393cb1..6599f874d9f97e9ef4862039ecad7277
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 90ab7190b1f59f2a6440ebfa6454a4b395f45ab5..94dd69d1b8beaf0edf9faf79a66ba2d41e12b5b8 100644
+index 42fa812b86f439b3addce1f33365c7bfc3129fe2..6c055610a5aa3ae46a0505e533b72c7ea2ae6008 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1715,7 +1715,7 @@ public final class CraftServer implements Server {
+@@ -1717,7 +1717,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 05b10d3f413021353b6cf84e3ec9c2f8413d5216..8c84447e96945f486a687f73bbd35e55d061a130 100644
+index 6c055610a5aa3ae46a0505e533b72c7ea2ae6008..9e6232ff554867a50eab767e1e8457cdfa0db81d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2609,5 +2609,24 @@ public final class CraftServer implements Server {
+@@ -2611,5 +2611,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0122-String-based-Action-Bar-API.patch
+++ b/patches/server/0122-String-based-Action-Bar-API.patch
@@ -26,10 +26,10 @@ index 32ef3edebe94a2014168b7e438752a80b2687e5f..ab6c58eed6707ab7b0aa3e7549a871ad
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2525b010fb36bc28327a33a5def6602e1ecfb3de..0ae1f334eae66cfcca618655942c13809e38060b 100644
+index 16dc9546303d692c62b6a1538106019f6bbe149b..d9205d45b72c5d36feeb4da8a70532eaf0ff215f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -363,6 +363,29 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -364,6 +364,29 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      // Paper start

--- a/patches/server/0135-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0135-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8c84447e96945f486a687f73bbd35e55d061a130..be56089f8e44161606aa5bc3ea89bc51a8f4adff 100644
+index 9e6232ff554867a50eab767e1e8457cdfa0db81d..0918939ff59989a2104d5320fb2fcea13dea3b8b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2628,5 +2628,10 @@ public final class CraftServer implements Server {
+@@ -2630,5 +2630,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0136-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0136-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 1c183e9083a5ce2a2995ae45864c564b7cde3f53..3e8f983cd7c69e9a95bcd863349adaf22be85128 100644
+index b0facb2b0b86fafbfd5776eba2e5bdb69cc1cbed..4a222d6769fe8dd33bcffa2e312e9bdf106e3eee 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -8,7 +8,17 @@ plugins {
@@ -236,7 +236,7 @@ index a34c9da6dbd37ab01385b768c06fef418de9c7c8..ce2291fb34df531b783d34f8453128a7
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 325e65488b31efe609f60b5d6d95ca89eda39f92..cd9a7d5f30e0ca11bd735bbc132a80a228ca4c2e 100644
+index 0918939ff59989a2104d5320fb2fcea13dea3b8b..d29a4681006bd3ae7aa096988eb86f849c47613b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -41,7 +41,6 @@ import java.util.logging.Level;
@@ -247,7 +247,7 @@ index 325e65488b31efe609f60b5d6d95ca89eda39f92..cd9a7d5f30e0ca11bd735bbc132a80a2
  import net.minecraft.advancements.Advancement;
  import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
-@@ -1281,9 +1280,13 @@ public final class CraftServer implements Server {
+@@ -1283,9 +1282,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  

--- a/patches/server/0142-Add-UnknownCommandEvent.patch
+++ b/patches/server/0142-Add-UnknownCommandEvent.patch
@@ -83,10 +83,10 @@ index 971fc7f5f51ba82a7e8abafa6a5139c24a9aac0b..7f561ab6e56cd1749da8eff950080d3a
  
                  b1 = 0;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cd9a7d5f30e0ca11bd735bbc132a80a228ca4c2e..78deb4398cc45cf20d054dcbaacfe04366193ab5 100644
+index d29a4681006bd3ae7aa096988eb86f849c47613b..708203b92f22374501aa252646b6a5e485f0bdad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -516,6 +516,7 @@ public final class CraftServer implements Server {
+@@ -518,6 +518,7 @@ public final class CraftServer implements Server {
                      }
                      node = clone;
                  }
@@ -94,7 +94,7 @@ index cd9a7d5f30e0ca11bd735bbc132a80a228ca4c2e..78deb4398cc45cf20d054dcbaacfe043
  
                  dispatcher.getDispatcher().getRoot().addChild(node);
              } else {
-@@ -882,7 +883,13 @@ public final class CraftServer implements Server {
+@@ -884,7 +885,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -631,10 +631,10 @@ index 4038bb76339d43f18770624bd7fecc79b8d7f2a9..2456edc11b29a92b1648937cd3dd6a9a
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6ec9de5d0a9076a841a183b1c696bb53e48f9f97..b305c6e026ccd0a7f1b2b2ac79da9555c21feeb4 100644
+index 708203b92f22374501aa252646b6a5e485f0bdad..ba53c66b4708e7d2efc2563edf8a39b8664b6f4c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -253,6 +253,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -255,6 +255,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
@@ -644,7 +644,7 @@ index 6ec9de5d0a9076a841a183b1c696bb53e48f9f97..b305c6e026ccd0a7f1b2b2ac79da9555
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -294,6 +297,7 @@ public final class CraftServer implements Server {
+@@ -296,6 +299,7 @@ public final class CraftServer implements Server {
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
          ConfigurationSerialization.registerClass(CraftPlayerProfile.class);
@@ -652,7 +652,7 @@ index 6ec9de5d0a9076a841a183b1c696bb53e48f9f97..b305c6e026ccd0a7f1b2b2ac79da9555
          CraftItemFactory.instance();
      }
  
-@@ -2643,5 +2647,37 @@ public final class CraftServer implements Server {
+@@ -2645,5 +2649,37 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }

--- a/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
@@ -90,10 +90,10 @@ index 2be1bd39ee1341128f02e38afe5698b837735827..cca08b8c6e1e15f13326a2a7e33e7f32
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0ae1f334eae66cfcca618655942c13809e38060b..a88c11fda59484d6d8d15dfca06ae1fe5d41259c 100644
+index d9205d45b72c5d36feeb4da8a70532eaf0ff215f..aafaaa0457c2f52d6b9a30b9774246b564277256 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -307,6 +307,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -308,6 +308,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -16,7 +16,7 @@ Also adds isCommand and getLocation to the sync TabCompleteEvent
 Co-authored-by: Aikar <aikar@aikar.co>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f6365bfdcd3c516ce1ce9ea780e0af3d4102a758..0ad5aed5d1bbfb60d951db4b897e66af6c00ad4d 100644
+index be2b8c7cf8c36242f4eee12c9f7b8217f31b12ab..efc9b3bf0a63f87f8d1cab57b8f521a306aef5f3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -780,12 +780,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -91,10 +91,10 @@ index f6365bfdcd3c516ce1ce9ea780e0af3d4102a758..0ad5aed5d1bbfb60d951db4b897e66af
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 435de87653033ed417d722b99b9acb8e3e68f915..de0b3ab49809702c2194f9d148909e5fcaf2ed2f 100644
+index ba53c66b4708e7d2efc2563edf8a39b8664b6f4c..c5bf6cd46d72d415cf3581823dd8fa9a4f4699c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2096,7 +2096,7 @@ public final class CraftServer implements Server {
+@@ -2098,7 +2098,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
@@ -14,10 +14,10 @@ public net.minecraft.world.entity.ExperienceOrb durabilityToXp(I)I
 public net.minecraft.world.entity.ExperienceOrb xpToDurability(I)I
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a88c11fda59484d6d8d15dfca06ae1fe5d41259c..5cbbed3f8a82c7cb4158b236ffb2a0c20f3d5077 100644
+index aafaaa0457c2f52d6b9a30b9774246b564277256..6ec434b6e07aba63b28f9f03eadc3550e43f9998 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1535,7 +1535,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1536,7 +1536,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override

--- a/patches/server/0184-Player.setPlayerProfile-API.patch
+++ b/patches/server/0184-Player.setPlayerProfile-API.patch
@@ -9,7 +9,7 @@ This can be useful for changing name or skins after a player has logged in.
 public-f net.minecraft.world.entity.player.Player gameProfile
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0ad5aed5d1bbfb60d951db4b897e66af6c00ad4d..560ac213e67d1099b7bc3f385bd8c024f7fd49df 100644
+index efc9b3bf0a63f87f8d1cab57b8f521a306aef5f3..d9c441f600a1f981a9dad075cba9d1d9b28e1aa0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1536,7 +1536,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -55,7 +55,7 @@ index e7442952ef1f03969949014492a7ddc6d0796ba5..69a1852905dd4724c30ac8ab88c14251
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5cbbed3f8a82c7cb4158b236ffb2a0c20f3d5077..a6ecffe0d8f83425617be2a8fbf91e4fec250470 100644
+index 6ec434b6e07aba63b28f9f03eadc3550e43f9998..d3b5c7d0d6ac449ecfb99e0ed62981b296528e07 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -82,6 +82,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -66,7 +66,7 @@ index 5cbbed3f8a82c7cb4158b236ffb2a0c20f3d5077..a6ecffe0d8f83425617be2a8fbf91e4f
  import net.minecraft.world.level.block.entity.SignBlockEntity;
  import net.minecraft.world.level.border.BorderChangeListener;
  import net.minecraft.world.level.saveddata.maps.MapDecoration;
-@@ -290,11 +291,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -291,11 +292,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return server.getPlayer(getUniqueId()) != null;
      }
  
@@ -78,7 +78,7 @@ index 5cbbed3f8a82c7cb4158b236ffb2a0c20f3d5077..a6ecffe0d8f83425617be2a8fbf91e4f
      @Override
      public InetSocketAddress getAddress() {
          if (this.getHandle().connection == null) return null;
-@@ -1685,8 +1681,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1686,8 +1682,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      private void untrackAndHideEntity(org.bukkit.entity.Entity entity) {
          // Remove this entity from the hidden player's EntityTrackerEntry
@@ -95,7 +95,7 @@ index 5cbbed3f8a82c7cb4158b236ffb2a0c20f3d5077..a6ecffe0d8f83425617be2a8fbf91e4f
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1699,8 +1702,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1700,8 +1703,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  this.getHandle().connection.send(new ClientboundPlayerInfoRemovePacket(List.of(otherPlayer.getUUID())));
              }
          }
@@ -104,7 +104,7 @@ index 5cbbed3f8a82c7cb4158b236ffb2a0c20f3d5077..a6ecffe0d8f83425617be2a8fbf91e4f
      }
  
      void resetAndHideEntity(org.bukkit.entity.Entity entity) {
-@@ -1777,8 +1778,38 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1778,8 +1779,38 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (entry != null && !entry.seenBy.contains(this.getHandle().connection)) {
              entry.updatePlayer(this.getHandle());
          }
@@ -144,7 +144,7 @@ index 5cbbed3f8a82c7cb4158b236ffb2a0c20f3d5077..a6ecffe0d8f83425617be2a8fbf91e4f
      }
  
      void resetAndShowEntity(org.bukkit.entity.Entity entity) {
-@@ -1791,6 +1822,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1792,6 +1823,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              this.trackAndShowEntity(entity);
          }
      }

--- a/patches/server/0185-getPlayerUniqueId-API.patch
+++ b/patches/server/0185-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index de0b3ab49809702c2194f9d148909e5fcaf2ed2f..f6e7cfc4d86dfdc0ff87642fbc7af330df8eb725 100644
+index c5bf6cd46d72d415cf3581823dd8fa9a4f4699c1..d43c27328801f1b830f2438fe1d7a11d44c08885 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1718,6 +1718,25 @@ public final class CraftServer implements Server {
+@@ -1720,6 +1720,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0189-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0189-Flag-to-disable-the-channel-limit.patch
@@ -9,10 +9,10 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a6ecffe0d8f83425617be2a8fbf91e4fec250470..eae9f51464d6bcb26178ac79f7026154c12b6bc9 100644
+index d3b5c7d0d6ac449ecfb99e0ed62981b296528e07..e65981b8d064c6f9309b7b574531a6083fe0d783 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -181,6 +181,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -182,6 +182,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper start
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
@@ -20,7 +20,7 @@ index a6ecffe0d8f83425617be2a8fbf91e4fec250470..eae9f51464d6bcb26178ac79f7026154
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -2060,7 +2061,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2061,7 +2062,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0190-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/server/0190-Add-openSign-method-to-HumanEntity.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Add openSign method to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-index 9fd6a05fb8022c5e4e3d67f9b0e9df3f477ea637..32592483dfb477501a72360b6b9bc497a608ce0a 100644
+index 46b18cac2c40db01ebd29528d529fe631b03ddbb..f399a69e9dbac06e591219040634cbdb9382d3a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-@@ -117,15 +117,15 @@ public class CraftSign<T extends SignBlockEntity> extends CraftBlockEntityState<
-         }
+@@ -100,15 +100,15 @@ public class CraftSign<T extends SignBlockEntity> extends CraftBlockEntityState<
+         super.applyTo(sign);
      }
  
 -    public static void openSign(Sign sign, Player player) {

--- a/patches/server/0218-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0218-InventoryCloseEvent-Reason-API.patch
@@ -173,10 +173,10 @@ index 04fe1bd9254b084eacbbca0e2a8a1ac100d17f12..77314674a1f66a514f8f5a0fef5ca188
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index eae9f51464d6bcb26178ac79f7026154c12b6bc9..db79410d56e0defeb710203f9332dff6d5418ee4 100644
+index e65981b8d064c6f9309b7b574531a6083fe0d783..931ad65bc199a3d5089c9f52d7b8b5d29b115285 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1238,7 +1238,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1239,7 +1239,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {

--- a/patches/server/0221-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
+++ b/patches/server/0221-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Use AsyncAppender to keep logging IO off main thread
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 2134a7d28cdf1a1b6ef50d4978e80e4411cf3c5a..6ca33c80c8bd4d87953103c06804fa9a0eef4f3c 100644
+index 8af9299c67ad2a1746bb340287b3373b208568ee..03095720795b994d0d97e7f65d350552792d71a8 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -27,6 +27,7 @@ dependencies {
      implementation("commons-lang:commons-lang:2.6")
-     runtimeOnly("org.xerial:sqlite-jdbc:3.41.0.0")
+     runtimeOnly("org.xerial:sqlite-jdbc:3.41.2.2")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.32")
 +    runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
  

--- a/patches/server/0239-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0239-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -33,10 +33,10 @@ index e6826cd0a596f063e8737dcde3c8c6c5b3f71970..1a2607d1b257cea65c82c661a6b3d46c
          com.destroystokyo.paper.Metrics.PaperMetrics.startMetrics();
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f6e7cfc4d86dfdc0ff87642fbc7af330df8eb725..9894d5d10c76469ad6f26100ce3924b65597e738 100644
+index d43c27328801f1b830f2438fe1d7a11d44c08885..d351c9076cdc8e6c491e5afeaafda59182c169d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -902,6 +902,7 @@ public final class CraftServer implements Server {
+@@ -904,6 +904,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -44,7 +44,7 @@ index f6e7cfc4d86dfdc0ff87642fbc7af330df8eb725..9894d5d10c76469ad6f26100ce3924b6
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -991,6 +992,7 @@ public final class CraftServer implements Server {
+@@ -993,6 +994,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0254-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b1d32f9f272b4cb88d0ed745ea5f6b227dc369bb..30c4cc750aac280475b69d1ab6b7e0c52b9d7350 100644
+index 931ad65bc199a3d5089c9f52d7b8b5d29b115285..31c75a7b7a947626417421287be0f0e2097acbd9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2795,6 +2795,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2801,6 +2801,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0255-Improve-death-events.patch
+++ b/patches/server/0255-Improve-death-events.patch
@@ -352,10 +352,10 @@ index e38cbdff34479673f1640c46d727f1a807a609c7..dbb4bfb3d1f1ce2e435ca531be36ea44
          this.gameEvent(GameEvent.ENTITY_DIE);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 124cc062b8b8f63788d903b5706999dc64b8c974..081317023417d759ff8d0e754af426fb0902b642 100644
+index 31c75a7b7a947626417421287be0f0e2097acbd9..f3d532ea98264c233cacde042d6af0957ca6f31d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2320,7 +2320,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2321,7 +2321,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/patches/server/0284-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0284-Make-the-default-permission-message-configurable.patch
@@ -18,10 +18,10 @@ index e3467aaf6d0c8d486b84362e3c20b3fe631b50ff..8f16640fc2f1233c10392d7e32a54d78
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 153e82a91e01e05cb89a64c88c5660fb9765c3a0..f282954ee9b92749a3bcdcdb0fec67809287f4f0 100644
+index d351c9076cdc8e6c491e5afeaafda59182c169d6..d90435e05330a625514fab36fa7195b4d78ab713 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2669,6 +2669,16 @@ public final class CraftServer implements Server {
+@@ -2671,6 +2671,16 @@ public final class CraftServer implements Server {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }
  

--- a/patches/server/0292-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0292-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -106,10 +106,10 @@ index 69a1852905dd4724c30ac8ab88c14251eee2c371..17b3d5de58a9ef3acc67624c46cd6bbd
      public Location getLastDeathLocation() {
          if (this.getData().contains("LastDeathLocation", 10)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 081317023417d759ff8d0e754af426fb0902b642..ea8dc87ce9a995ace56c27c53a15ef51dc4a871d 100644
+index f3d532ea98264c233cacde042d6af0957ca6f31d..a87007a67ee1188150abab643329fa7314f9e583 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -182,6 +182,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -183,6 +183,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
      private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
@@ -117,7 +117,7 @@ index 081317023417d759ff8d0e754af426fb0902b642..ea8dc87ce9a995ace56c27c53a15ef51
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1932,6 +1933,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1933,6 +1934,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 081317023417d759ff8d0e754af426fb0902b642..ea8dc87ce9a995ace56c27c53a15ef51
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1954,6 +1967,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1955,6 +1968,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index 081317023417d759ff8d0e754af426fb0902b642..ea8dc87ce9a995ace56c27c53a15ef51
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1968,6 +1983,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1969,6 +1984,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0294-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6425c208fb103165b75f7bfde0d9fc937ee08f7a..0f570d7a56c9e7456ce6863af73af19f89a759bc 100644
+index a87007a67ee1188150abab643329fa7314f9e583..fefe3dc1597d7449e0138be2f60918b06864108a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2842,6 +2842,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2848,6 +2848,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0318-Expose-the-internal-current-tick.patch
+++ b/patches/server/0318-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f282954ee9b92749a3bcdcdb0fec67809287f4f0..2fb9698b0037a04472c36b801249c6aa82b09b22 100644
+index d90435e05330a625514fab36fa7195b4d78ab713..af732bd31dc2cce4e65e01d69a0c366e71439097 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2710,5 +2710,10 @@ public final class CraftServer implements Server {
+@@ -2712,5 +2712,10 @@ public final class CraftServer implements Server {
          profile.getProperties().putAll(((CraftPlayer)player).getHandle().getGameProfile().getProperties());
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }

--- a/patches/server/0343-Anti-Xray.patch
+++ b/patches/server/0343-Anti-Xray.patch
@@ -1572,10 +1572,10 @@ index b738e1f7debac7d70910d5ac908ca9d4f60640d5..269ebe8e8826a0c89e471cb59b503900
  
      public CraftChunk(net.minecraft.world.level.chunk.LevelChunk chunk) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5c7bae55758760a67f54c48427ddc3f021c22087..2be7afb4cfd77dd2b6cb0ca700b52812f2b5ffe1 100644
+index af732bd31dc2cce4e65e01d69a0c366e71439097..5096c8a665343c9b6f8be0e5721e8e3b83fdb122 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2244,7 +2244,7 @@ public final class CraftServer implements Server {
+@@ -2246,7 +2246,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Validate.notNull(world, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();
@@ -1585,7 +1585,7 @@ index 5c7bae55758760a67f54c48427ddc3f021c22087..2be7afb4cfd77dd2b6cb0ca700b52812
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e95c0d533f518837d5f6000eb919d685c921d302..dbc211b8d23d766ecff7aab1884c72dc7e568dfb 100644
+index 998bfd1f63fc08067e9cc9fd5ed503e232dd4783..ef9813df00119d3effa48c5d0fb8f07f7ba7da15 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -417,11 +417,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0363-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0363-Add-tick-times-API-and-mspt-command.patch
@@ -184,10 +184,10 @@ index 2e29d1c3e5faf970bfaf3a545ef3553f284d68ef..d00545c31de383470bcb8e4d9c6edad2
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2be7afb4cfd77dd2b6cb0ca700b52812f2b5ffe1..a59e4c85d69f342bb55942e8b12053d907e97dd9 100644
+index 5096c8a665343c9b6f8be0e5721e8e3b83fdb122..42247677468ad3eac34fa1110e3684c2e51268ec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2494,6 +2494,16 @@ public final class CraftServer implements Server {
+@@ -2496,6 +2496,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0364-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0364-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7912c5c1c2dabe698bb0c748449f7edc8a6ce9f6..808517a5912425a36ae446cf08b8600cc3b67a6e 100644
+index 42247677468ad3eac34fa1110e3684c2e51268ec..422413ddd62e19dced2776bb41f73af1ad294f43 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2725,5 +2725,10 @@ public final class CraftServer implements Server {
+@@ -2727,5 +2727,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0381-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0381-Implement-Player-Client-Options-API.patch
@@ -116,10 +116,10 @@ index fedd9727e9d73fdbced6431b313a080705b1d9a5..75350988934c6eb1cd39587fa1f53335
          if (getMainArm() != packet.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5e4735ed74e47c28d85c2e7e08458e74f6559e47..a77858a6253a3195879aaa3bccccee6c0af5b00a 100644
+index fefe3dc1597d7449e0138be2f60918b06864108a..ef7078780b4829e61048233b60150b26f6a9b792 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -626,6 +626,28 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -627,6 +627,28 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              connection.disconnect(message == null ? net.kyori.adventure.text.Component.empty() : message);
          }
      }

--- a/patches/server/0391-Expose-game-version.patch
+++ b/patches/server/0391-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d6ed4cff5dba860f8ccd694052d68034426949be..c69b341774d2e1624344a62e52cdf9764195033a 100644
+index 422413ddd62e19dced2776bb41f73af1ad294f43..44658126e87eacc042752940685b3f7457ad9d5a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -570,6 +570,13 @@ public final class CraftServer implements Server {
+@@ -572,6 +572,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  

--- a/patches/server/0394-misc-debugging-dumps.patch
+++ b/patches/server/0394-misc-debugging-dumps.patch
@@ -74,10 +74,10 @@ index 0c7f280bae81bbb492d5780a43e5ffda0f58756a..238a7bc87ab49da1f0fa3c733dd512fd
                  this.connection.send(new ClientboundDisconnectPacket(ichatmutablecomponent));
                  this.connection.disconnect(ichatmutablecomponent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c69b341774d2e1624344a62e52cdf9764195033a..1f1f63a37fdbed26e7cc77ecc19d546c2ef12c36 100644
+index 44658126e87eacc042752940685b3f7457ad9d5a..88e93f9daa5d69d858f61baf03724b96b8b5f1d8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -993,6 +993,7 @@ public final class CraftServer implements Server {
+@@ -995,6 +995,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getFullName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0396-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0396-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index b6b077262132be3b30f81a2a6c9288afbd11c358..18949b866cd8da3825b730a7d0545bd8af21afa2 100644
+index c04f733d053a52218893ef2b9ca050f911b50b0a..e63ad0e49818709cb292b9e43f5b52f5cb13002f 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -19,6 +19,7 @@ dependencies {
@@ -22,7 +22,7 @@ index b6b077262132be3b30f81a2a6c9288afbd11c358..18949b866cd8da3825b730a7d0545bd8
      implementation("org.spongepowered:configurate-yaml:4.1.2") // Paper - config files
      implementation("commons-lang:commons-lang:2.6")
 +    implementation("net.fabricmc:mapping-io:0.3.0") // Paper - needed to read mappings for stacktrace deobfuscation
-     runtimeOnly("org.xerial:sqlite-jdbc:3.41.0.0")
+     runtimeOnly("org.xerial:sqlite-jdbc:3.41.2.2")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.32")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
 @@ -105,6 +107,18 @@ tasks.check {

--- a/patches/server/0397-Implement-Mob-Goal-API.patch
+++ b/patches/server/0397-Implement-Mob-Goal-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 18949b866cd8da3825b730a7d0545bd8af21afa2..d98add7d741e47d9ff095a817e0f895b7235a488 100644
+index e63ad0e49818709cb292b9e43f5b52f5cb13002f..719f4b4bff2ab651156f17e27412ae8b0e9e5d02 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -36,6 +36,7 @@ dependencies {
@@ -792,10 +792,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9f4489e69bd69183e2ea158515a85828a6643959..cc3703fb00b0da8ec9d835868dbdf8e03fbee7cf 100644
+index 88e93f9daa5d69d858f61baf03724b96b8b5f1d8..164c137ee1cbfa540ec6ce85bfadab4d34e0c038 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2738,5 +2738,11 @@ public final class CraftServer implements Server {
+@@ -2740,5 +2740,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0404-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0404-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,10 +22,10 @@ index e189de6d2aa94e9bbb20f1477ee2e34431adb324..4a58843f7ce2dd9e50f9daf3065d056a
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d8ff8f02adbe532724d47fef5142fdf9b08de10d..86acd4c9acc33197fb9d35381677152521168cf1 100644
+index 164c137ee1cbfa540ec6ce85bfadab4d34e0c038..e2fd9a4fc9b0879416fe70aa5352327d3a901a4a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1003,6 +1003,31 @@ public final class CraftServer implements Server {
+@@ -1005,6 +1005,31 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0427-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0427-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -102,10 +102,10 @@ index e9902fa67719c4b40fb9524bf77798357e9a97d9..b4f17b9c195081b54d79494d9afaf0da
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 86acd4c9acc33197fb9d35381677152521168cf1..d26c17cda10dd0a816175be9ab3a1fff30fcd9bd 100644
+index e2fd9a4fc9b0879416fe70aa5352327d3a901a4a..01f734e0e4eb51083ae4d80f3423122a98190095 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -942,8 +942,8 @@ public final class CraftServer implements Server {
+@@ -944,8 +944,8 @@ public final class CraftServer implements Server {
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
          this.console.paperConfigurations.reloadConfigs(this.console);
          for (ServerLevel world : this.console.getAllLevels()) {
@@ -117,7 +117,7 @@ index 86acd4c9acc33197fb9d35381677152521168cf1..d26c17cda10dd0a816175be9ab3a1fff
              for (SpawnCategory spawnCategory : SpawnCategory.values()) {
                  if (CraftSpawnCategory.isValidForLimits(spawnCategory)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index dbc211b8d23d766ecff7aab1884c72dc7e568dfb..6c6408710bcb67295e5058631e4d56d7e7386ab8 100644
+index ef9813df00119d3effa48c5d0fb8f07f7ba7da15..3f1521b4f5a7b76a648fdaf7af9e2753c98ed545 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1143,7 +1143,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0431-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0431-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,10 +22,10 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 14e6caf028dd6b44d6435e4cecb4d5dd5156d09b..6737fecddad32e65bbdcb43de70504678d4a5077 100644
+index 01f734e0e4eb51083ae4d80f3423122a98190095..5a09fa2042adc34d541b24fff12acca382a8f998 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -370,7 +370,7 @@ public final class CraftServer implements Server {
+@@ -372,7 +372,7 @@ public final class CraftServer implements Server {
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -34,7 +34,7 @@ index 14e6caf028dd6b44d6435e4cecb4d5dd5156d09b..6737fecddad32e65bbdcb43de7050467
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
  
-@@ -922,7 +922,7 @@ public final class CraftServer implements Server {
+@@ -924,7 +924,7 @@ public final class CraftServer implements Server {
          this.console.setMotd(config.motd);
          this.overrideSpawnLimits();
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));

--- a/patches/server/0456-Brand-support.patch
+++ b/patches/server/0456-Brand-support.patch
@@ -56,10 +56,10 @@ index b4f17b9c195081b54d79494d9afaf0da21f292c0..139daac1cc7359be4eebf73b2a578e07
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 486f3b8c802d2224013c648347c91fc14f522d91..eddb463507bd12477345a661e07e8e111aec90b6 100644
+index ef7078780b4829e61048233b60150b26f6a9b792..65d311d01b9d18627f20de5dc89585a9b2055367 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2969,6 +2969,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2975,6 +2975,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0457-Add-setMaxPlayers-API.patch
+++ b/patches/server/0457-Add-setMaxPlayers-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 14d00939b9a8488eba040bf435e6837ecb424d65..9b75cf08096689522b670ad48e73126ad4cfc9b5 100644
+index cfe2dea64104eeaffd6606fdff0d5a1a2c111329..0e22201853ae2befdc6904e194f8bbc6d57fc9f5 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -155,7 +155,7 @@ public abstract class PlayerList {
@@ -18,10 +18,10 @@ index 14d00939b9a8488eba040bf435e6837ecb424d65..9b75cf08096689522b670ad48e73126a
      private int simulationDistance;
      private boolean allowCheatsForAllPlayers;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 64e59d5c545e6bc4e000e2ca779df427a67e5aae..5891dc6a41a0043ff85d343b7da5024c96f9a77e 100644
+index 5a09fa2042adc34d541b24fff12acca382a8f998..24d0419ac82ee388e8d545b3fb391eea424a53f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -665,6 +665,13 @@ public final class CraftServer implements Server {
+@@ -667,6 +667,13 @@ public final class CraftServer implements Server {
          return this.playerList.getMaxPlayers();
      }
  

--- a/patches/server/0490-Player-elytra-boost-API.patch
+++ b/patches/server/0490-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6cac6959133d90f5755ed5272f7edc261a94cb69..aa926c0647acfc98ab9075b826dd34f68a4189c1 100644
+index 65d311d01b9d18627f20de5dc89585a9b2055367..28d0d184e990e30835d2848a32e53c39dd704319 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -648,6 +648,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -649,6 +649,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/patches/server/0493-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0493-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5891dc6a41a0043ff85d343b7da5024c96f9a77e..1a745fbb6325d3dfb87714f54d7aa46ddf93ce04 100644
+index 24d0419ac82ee388e8d545b3fb391eea424a53f7..a6eba94e20b1c134fed45060645d80081a5e2184 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1809,6 +1809,28 @@ public final class CraftServer implements Server {
+@@ -1811,6 +1811,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0504-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0504-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index aa926c0647acfc98ab9075b826dd34f68a4189c1..c4b5267263fdf5b1a7d94ac3f5fd5212d026cefd 100644
+index 28d0d184e990e30835d2848a32e53c39dd704319..01fd98028c3d7a3faa8fb3857116c38c752a2ea9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2513,7 +2513,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2514,7 +2514,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0545-Add-sendOpLevel-API.patch
+++ b/patches/server/0545-Add-sendOpLevel-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 8b683ffd930155adf7b1cd1088322621d4e0a037..e287ed6e916e750ac8e87a5025b9f1503470d1cf 100644
+index 74aacb322ac0ddc8b8f679e7e4d98336782c11c0..81faf7ca99132a87d68a0bc6c9b662a810d0b7b3 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1079,6 +1079,11 @@ public abstract class PlayerList {
@@ -32,10 +32,10 @@ index 8b683ffd930155adf7b1cd1088322621d4e0a037..e287ed6e916e750ac8e87a5025b9f150
  
      public boolean isWhiteListed(GameProfile profile) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c4b5267263fdf5b1a7d94ac3f5fd5212d026cefd..48e6d04473a5c7c66f0d66b8aa119e8da755f321 100644
+index 01fd98028c3d7a3faa8fb3857116c38c752a2ea9..207032804244857b849e38f87479f0fbe2902633 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -662,6 +662,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -663,6 +663,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/patches/server/0581-Expand-world-key-API.patch
+++ b/patches/server/0581-Expand-world-key-API.patch
@@ -20,10 +20,10 @@ index 3ffea505826bbe4151268ed9cffa5f2ddea27b62..287dd68f1aa78bf5f1406f585e4a6575
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1a745fbb6325d3dfb87714f54d7aa46ddf93ce04..79a0db289c837cc37e0d1caca91359bc3d96dbfe 100644
+index a6eba94e20b1c134fed45060645d80081a5e2184..2cdeb4505c02942079fb18cf7af15e63463f550c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1131,9 +1131,15 @@ public final class CraftServer implements Server {
+@@ -1133,9 +1133,15 @@ public final class CraftServer implements Server {
          File folder = new File(this.getWorldContainer(), name);
          World world = this.getWorld(name);
  
@@ -41,7 +41,7 @@ index 1a745fbb6325d3dfb87714f54d7aa46ddf93ce04..79a0db289c837cc37e0d1caca91359bc
  
          if ((folder.exists()) && (!folder.isDirectory())) {
              throw new IllegalArgumentException("File exists with the name '" + name + "' and isn't a folder");
-@@ -1222,7 +1228,7 @@ public final class CraftServer implements Server {
+@@ -1224,7 +1230,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -50,7 +50,7 @@ index 1a745fbb6325d3dfb87714f54d7aa46ddf93ce04..79a0db289c837cc37e0d1caca91359bc
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, worlddimension, this.getServer().progressListenerFactory.create(11),
-@@ -1314,6 +1320,15 @@ public final class CraftServer implements Server {
+@@ -1316,6 +1322,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0584-copy-TESign-isEditable-from-snapshots.patch
+++ b/patches/server/0584-copy-TESign-isEditable-from-snapshots.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] copy TESign#isEditable from snapshots
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-index cdc9474d37028324d39037a456be07fd4f576a6e..548f0676fc42523d6b64f3186508ef004c3a7f9e 100644
+index f399a69e9dbac06e591219040634cbdb9382d3a2..ed570d536d2ffcbcf7a591bc436401ee32b238c6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-@@ -115,6 +115,7 @@ public class CraftSign<T extends SignBlockEntity> extends CraftBlockEntityState<
-             }
-             // Paper end
-         }
+@@ -98,6 +98,7 @@ public class CraftSign<T extends SignBlockEntity> extends CraftBlockEntityState<
+         this.front.applyLegacyStringToSignSide();
+ 
+         super.applyTo(sign);
 +        sign.isEditable = getSnapshot().isEditable; // Paper - copy manually
      }
  

--- a/patches/server/0615-Add-basic-Datapack-API.patch
+++ b/patches/server/0615-Add-basic-Datapack-API.patch
@@ -92,10 +92,10 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7b3e69e4b21fb7dc8a1f3abcdc287f3b29d9f511..b61607c55c968e6a0d5c57799d73a8ccb91a2eea 100644
+index 2cdeb4505c02942079fb18cf7af15e63463f550c..acc119434a0510c89250b1c9c13fc99fb74ec302 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -292,6 +292,7 @@ public final class CraftServer implements Server {
+@@ -294,6 +294,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -103,7 +103,7 @@ index 7b3e69e4b21fb7dc8a1f3abcdc287f3b29d9f511..b61607c55c968e6a0d5c57799d73a8cc
      public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {
-@@ -378,6 +379,7 @@ public final class CraftServer implements Server {
+@@ -380,6 +381,7 @@ public final class CraftServer implements Server {
          if (this.configuration.getBoolean("settings.use-map-color-cache")) {
              MapPalette.setMapColorCache(new CraftMapColorCache(this.logger));
          }
@@ -111,7 +111,7 @@ index 7b3e69e4b21fb7dc8a1f3abcdc287f3b29d9f511..b61607c55c968e6a0d5c57799d73a8cc
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2813,5 +2815,11 @@ public final class CraftServer implements Server {
+@@ -2815,5 +2817,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0617-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0617-additions-to-PlayerGameModeChangeEvent.patch
@@ -142,10 +142,10 @@ index e6cbeae6800d22017b1762eaf9465419fbbe925f..43f02b1de7176f335f88ca6080b6d88b
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 48e6d04473a5c7c66f0d66b8aa119e8da755f321..05c7a359ee18612eeda9672afb362754ca776b2d 100644
+index 207032804244857b849e38f87479f0fbe2902633..45b338d33fae5017ab2eab3af6b83b8109e67c1f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1560,7 +1560,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1561,7 +1561,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0621-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0621-Fix-and-optimise-world-force-upgrading.patch
@@ -359,10 +359,10 @@ index b294ef87fb93e7f4651dc04128124f297575860d..65fd57609e45ccd49ebfc1ba80d25243
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 08e3da659371dc67db7ebea33ee2528f304a13ae..a963c1e6aaba4fd55f5462be89e9afe8b20f082a 100644
+index acc119434a0510c89250b1c9c13fc99fb74ec302..286531263ece5fe3650433445f5e3e7e394371d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1207,12 +1207,7 @@ public final class CraftServer implements Server {
+@@ -1209,12 +1209,7 @@ public final class CraftServer implements Server {
          worlddata.customDimensions = iregistry;
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().shouldReportAsModified());
@@ -376,7 +376,7 @@ index 08e3da659371dc67db7ebea33ee2528f304a13ae..a963c1e6aaba4fd55f5462be89e9afe8
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1223,6 +1218,13 @@ public final class CraftServer implements Server {
+@@ -1225,6 +1220,13 @@ public final class CraftServer implements Server {
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
  

--- a/patches/server/0629-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0629-Add-PlayerKickEvent-causes.patch
@@ -434,7 +434,7 @@ index 6fa63190a39343c50c2d49fe7fa09f7163db7101..18bf0ab7e897d4c75134359fee7e089e
  
              }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 8883a3a0b28377bf3290adfc0353d2e65c70b828..c3e0fa27c34132a99f6cc9c0eb7d9544a9873eed 100644
+index b5a2805999dd93b9af2ee96a3af9684367c80af6..32295fa4016b375800a27a961c42047013d14d1d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -671,7 +671,7 @@ public abstract class PlayerList {
@@ -491,10 +491,10 @@ index a24e7a66d52eddbdad8db71cf5e45f1a458c389f..e1c13ac7b11fb0080435fc34502208c8
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 05c7a359ee18612eeda9672afb362754ca776b2d..6c8649749b3e66d6ab473321be6c48a0ddebc9f0 100644
+index 45b338d33fae5017ab2eab3af6b83b8109e67c1f..fd7d05c097dcb300aab5320b395e7133dc54998f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -608,7 +608,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -609,7 +609,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          org.spigotmc.AsyncCatcher.catchOp("player kick"); // Spigot
          if (this.getHandle().connection == null) return;
  
@@ -503,7 +503,7 @@ index 05c7a359ee18612eeda9672afb362754ca776b2d..6c8649749b3e66d6ab473321be6c48a0
      }
  
      // Paper start
-@@ -620,10 +620,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -621,10 +621,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void kick(final net.kyori.adventure.text.Component message) {

--- a/patches/server/0659-Add-System.out-err-catcher.patch
+++ b/patches/server/0659-Add-System.out-err-catcher.patch
@@ -105,10 +105,10 @@ index 0000000000000000000000000000000000000000..a8e813ca89b033f061e695288b3383bd
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a963c1e6aaba4fd55f5462be89e9afe8b20f082a..8e8e0cc2f60c11ddd1ac2d232a698b3f4286426c 100644
+index 286531263ece5fe3650433445f5e3e7e394371d4..826e288f633a2a7cea9fa0022b44947f75fc1163 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -294,6 +294,7 @@ public final class CraftServer implements Server {
+@@ -296,6 +296,7 @@ public final class CraftServer implements Server {
      public int reloadCount;
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings

--- a/patches/server/0665-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0665-Add-PlayerSetSpawnEvent.patch
@@ -139,7 +139,7 @@ index a649d1baa727dd16cb8e786bdf510021e2d16d26..cdf85898d6ca9f1159b175dbc2760522
  
      public void trackChunk(ChunkPos chunkPos, Packet<?> chunkDataPacket) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0e314e2b85ed17bef7b9cc75573b0dc6c13b46b1..9386d0836ed6dad232aa24219bdbbaeafffc49c0 100644
+index 4771829ba2b2b215567b2f4ceca963a7d2a0f559..801cf17505cee999e7ed58081fa908ca693df498 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -853,7 +853,7 @@ public abstract class PlayerList {
@@ -172,10 +172,10 @@ index 1a27b7faa22e6b3dc5fce329ed06425de56c4315..b9903c29bdea8d1e3b6fce0e97be6bd9
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6c8649749b3e66d6ab473321be6c48a0ddebc9f0..e826a9e405c0ea985f8a742f4bc81b38c9d98bba 100644
+index fd7d05c097dcb300aab5320b395e7133dc54998f..88ec1bb0bea5aeb4a6e0ee628de58ac9f1f546cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1370,9 +1370,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1371,9 +1371,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0695-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0695-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -278,10 +278,10 @@ index a1770e5ae4b3014c3538b52d4912c60864e186a8..906def91bba96bab7c7aea9b87d9ec56
          // Paper start - add parameters and int ret type
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8e8e0cc2f60c11ddd1ac2d232a698b3f4286426c..ce968a5f44282095cec4d44f43bdfe953bce069c 100644
+index 826e288f633a2a7cea9fa0022b44947f75fc1163..95015ceeb458d44229d7a23bbcb092c07f5d322e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2162,6 +2162,11 @@ public final class CraftServer implements Server {
+@@ -2164,6 +2164,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
@@ -294,7 +294,7 @@ index 8e8e0cc2f60c11ddd1ac2d232a698b3f4286426c..ce968a5f44282095cec4d44f43bdfe95
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 60ad39ba1cde4d4d1231f43902af4441a944556f..6e7aba92fd3f6c02680d9902c974bc2af0428fb1 100644
+index 53d1dee6e81697ff2d9d498f27b57882a9418702..ea8a372a13b7729121e084a79540b317a4c028e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1696,9 +1696,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0721-Use-Velocity-compression-and-cipher-natives.patch
+++ b/patches/server/0721-Use-Velocity-compression-and-cipher-natives.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Use Velocity compression and cipher natives
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index d98add7d741e47d9ff095a817e0f895b7235a488..1cd32d28475b3130b02ad39b9f53aa7074792556 100644
+index 719f4b4bff2ab651156f17e27412ae8b0e9e5d02..6d429252023f84d0d512e68a6a3112fa4e27a83f 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -31,6 +31,11 @@ dependencies {
-     runtimeOnly("org.xerial:sqlite-jdbc:3.41.0.0")
+     runtimeOnly("org.xerial:sqlite-jdbc:3.41.2.2")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.32")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
 +    // Paper start - Use Velocity cipher

--- a/patches/server/0753-Add-player-health-update-API.patch
+++ b/patches/server/0753-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e826a9e405c0ea985f8a742f4bc81b38c9d98bba..207ae9c07d4646686bc79156d7b72ade71084ce2 100644
+index 88ec1bb0bea5aeb4a6e0ee628de58ac9f1f546cf..14f7fc4a6724ed4650117de2397052c54ae05df4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2392,9 +2392,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2393,9 +2393,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index e826a9e405c0ea985f8a742f4bc81b38c9d98bba..207ae9c07d4646686bc79156d7b72ade
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2403,6 +2405,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2404,6 +2406,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      }
  

--- a/patches/server/0755-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0755-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ce968a5f44282095cec4d44f43bdfe953bce069c..05605d7a6384349f7ff13950d81d4f08a243b4eb 100644
+index 95015ceeb458d44229d7a23bbcb092c07f5d322e..53a58b6988cd11d37d6cdff6f2699710e3229745 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2334,6 +2334,90 @@ public final class CraftServer implements Server {
+@@ -2336,6 +2336,90 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registries.BIOME), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0775-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0775-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,10 +18,10 @@ index 24c88555ea85dd2a0656e1f67a4828a5137157b8..cbbb0ff40488c430d15c2ed054d1b288
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 05605d7a6384349f7ff13950d81d4f08a243b4eb..4e3ee12d6cdd18372239f35d3ab188e2116128fa 100644
+index 53a58b6988cd11d37d6cdff6f2699710e3229745..fa74b5a331bb33d4ce7205c0fa80faf6eb613081 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1214,7 +1214,7 @@ public final class CraftServer implements Server {
+@@ -1216,7 +1216,7 @@ public final class CraftServer implements Server {
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
          LevelStem worlddimension = iregistry.get(actualDimension);
  
@@ -31,7 +31,7 @@ index 05605d7a6384349f7ff13950d81d4f08a243b4eb..4e3ee12d6cdd18372239f35d3ab188e2
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0855b437d8ba0ec71b4c0a5ed29629ff28f56f8a..4cea156d555688b366b6d54f965132871995015c 100644
+index ea8a372a13b7729121e084a79540b317a4c028e1..0986a740f5b095cc603d67133c684b5224ae66ae 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -201,6 +201,30 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0784-Multi-Block-Change-API-Implementation.patch
+++ b/patches/server/0784-Multi-Block-Change-API-Implementation.patch
@@ -25,10 +25,10 @@ index c96e75456c2f8564d3bc75993cc6e03ba605597d..7c6a6693760638a07b7c7c330aaeffd9
      public void write(FriendlyByteBuf buf) {
          buf.writeLong(this.sectionPos.asLong());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 207ae9c07d4646686bc79156d7b72ade71084ce2..85c28926533c3159d42e8e7d90051472613dda8c 100644
+index 14f7fc4a6724ed4650117de2397052c54ae05df4..5a51b19345670ab9590f9ee2a9668d5f9fd010fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -952,6 +952,32 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -953,6 +953,32 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  

--- a/patches/server/0790-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0790-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4e3ee12d6cdd18372239f35d3ab188e2116128fa..56ab53830525b497d2abc7e422b03d1e98d1118c 100644
+index fa74b5a331bb33d4ce7205c0fa80faf6eb613081..c0df30bcd8d6c7e56fb4c7b1c7c5e4a56f365a2a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1996,6 +1996,13 @@ public final class CraftServer implements Server {
+@@ -1998,6 +1998,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  

--- a/patches/server/0794-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0794-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 56ab53830525b497d2abc7e422b03d1e98d1118c..b6070faf0a30da3956fe64e194250504bada9ba5 100644
+index c0df30bcd8d6c7e56fb4c7b1c7c5e4a56f365a2a..33ae1bf0e904c20626156192d306eb303dc3cdf1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2170,6 +2170,8 @@ public final class CraftServer implements Server {
+@@ -2172,6 +2172,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start

--- a/patches/server/0795-Add-GameEvent-tags.patch
+++ b/patches/server/0795-Add-GameEvent-tags.patch
@@ -46,10 +46,10 @@ index 0000000000000000000000000000000000000000..e7d9fd2702a1ce96596580fff8f5ee4f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b6070faf0a30da3956fe64e194250504bada9ba5..0907143274c0e1d1c122eb6fb4b116f52c360ec9 100644
+index 33ae1bf0e904c20626156192d306eb303dc3cdf1..d4063237f6f3c9e88b90943e09dfef9cf8a69801 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2580,6 +2580,15 @@ public final class CraftServer implements Server {
+@@ -2582,6 +2582,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(BuiltInRegistries.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -65,7 +65,7 @@ index b6070faf0a30da3956fe64e194250504bada9ba5..0907143274c0e1d1c122eb6fb4b116f5
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2612,6 +2621,13 @@ public final class CraftServer implements Server {
+@@ -2614,6 +2623,13 @@ public final class CraftServer implements Server {
                  net.minecraft.core.Registry<EntityType<?>> entityTags = BuiltInRegistries.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0801-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0801-Put-world-into-worldlist-before-initing-the-world.patch
@@ -23,10 +23,10 @@ index 23fce58a5909c5b01a5f0ef6912f90858cd3302c..a30c61e176501d1cbd2e330f85d5d258
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0907143274c0e1d1c122eb6fb4b116f52c360ec9..4736b0f3ac468be99a42b5c0e62cffbbe2149610 100644
+index d4063237f6f3c9e88b90943e09dfef9cf8a69801..1d13a97eba403eb3e21cd8fe5b473d38b8edf5dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1243,10 +1243,11 @@ public final class CraftServer implements Server {
+@@ -1245,10 +1245,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0803-Custom-Potion-Mixes.patch
+++ b/patches/server/0803-Custom-Potion-Mixes.patch
@@ -164,10 +164,10 @@ index 424406d2692856cfd82b6f3b7b6228fa3bd20c2f..c57efcb9a79337ec791e4e8f6671612f
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7922e466e80bf959f2acdf474d6c44159482e791..6712237bb2b2e68c7081265af7ebdf85f7ac07cd 100644
+index 1d13a97eba403eb3e21cd8fe5b473d38b8edf5dd..ec555493b2bacf174cc6fc9924cb9199df442e60 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -295,6 +295,7 @@ public final class CraftServer implements Server {
+@@ -297,6 +297,7 @@ public final class CraftServer implements Server {
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings
      private final io.papermc.paper.logging.SysoutCatcher sysoutCatcher = new io.papermc.paper.logging.SysoutCatcher(); // Paper
@@ -175,7 +175,7 @@ index 7922e466e80bf959f2acdf474d6c44159482e791..6712237bb2b2e68c7081265af7ebdf85
  
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
-@@ -321,7 +322,7 @@ public final class CraftServer implements Server {
+@@ -323,7 +324,7 @@ public final class CraftServer implements Server {
          Enchantments.SHARPNESS.getClass();
          org.bukkit.enchantments.Enchantment.stopAcceptingRegistrations();
  
@@ -184,7 +184,7 @@ index 7922e466e80bf959f2acdf474d6c44159482e791..6712237bb2b2e68c7081265af7ebdf85
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2939,5 +2940,10 @@ public final class CraftServer implements Server {
+@@ -2941,5 +2942,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0814-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0814-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fc088b26c3fab1afcfbcacfd19dc8a3b6111e94c..49eec475f702b9ac35be92e92b77c047ee6e35bb 100644
+index ec555493b2bacf174cc6fc9924cb9199df442e60..ad0b88f32ec9777ca9593c175660a209a45aab4a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1291,7 +1291,7 @@ public final class CraftServer implements Server {
+@@ -1293,7 +1293,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0830-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0830-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 49eec475f702b9ac35be92e92b77c047ee6e35bb..1eca37136dedd5bd8e59446cda7476cab46fb0f6 100644
+index ad0b88f32ec9777ca9593c175660a209a45aab4a..86cdffd1572ab33e61c8ab0ef2e83cf8ca9b5124 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1250,6 +1250,7 @@ public final class CraftServer implements Server {
+@@ -1252,6 +1252,7 @@ public final class CraftServer implements Server {
          internal.setSpawnSettings(true, true);
          // Paper - move up
  

--- a/patches/server/0846-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0846-Throw-exception-on-world-create-while-being-ticked.patch
@@ -45,10 +45,10 @@ index 3e59620c84b3aa93d8ce41b0e9901a1621bb48df..682005e4b19ba3959d4e3a66475487da
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1eca37136dedd5bd8e59446cda7476cab46fb0f6..a141cd0d415e312da0a92349eb9cae3ccda3c397 100644
+index 86cdffd1572ab33e61c8ab0ef2e83cf8ca9b5124..e23023859248fa7fa3aa01a5eccdc3599f54256a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -846,6 +846,11 @@ public final class CraftServer implements Server {
+@@ -848,6 +848,11 @@ public final class CraftServer implements Server {
          return new ArrayList<World>(this.worlds.values());
      }
  
@@ -60,7 +60,7 @@ index 1eca37136dedd5bd8e59446cda7476cab46fb0f6..a141cd0d415e312da0a92349eb9cae3c
      public DedicatedPlayerList getHandle() {
          return this.playerList;
      }
-@@ -1127,6 +1132,7 @@ public final class CraftServer implements Server {
+@@ -1129,6 +1134,7 @@ public final class CraftServer implements Server {
      @Override
      public World createWorld(WorldCreator creator) {
          Preconditions.checkState(this.console.getAllLevels().iterator().hasNext(), "Cannot create additional worlds on STARTUP");
@@ -68,7 +68,7 @@ index 1eca37136dedd5bd8e59446cda7476cab46fb0f6..a141cd0d415e312da0a92349eb9cae3c
          Validate.notNull(creator, "Creator may not be null");
  
          String name = creator.name();
-@@ -1265,6 +1271,7 @@ public final class CraftServer implements Server {
+@@ -1267,6 +1273,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {

--- a/patches/server/0853-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0853-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index 7c7e5f3c0f9cd1f16192a8fc8163da9b2d9519d5..888936385196a178ab8b730fd5e4fff4
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a141cd0d415e312da0a92349eb9cae3ccda3c397..8be0badce29413922dfd744b946ca3e4403bc4f6 100644
+index e23023859248fa7fa3aa01a5eccdc3599f54256a..a06eb05470b145b4d4001b957ec6252b3744eeb5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1769,7 +1769,7 @@ public final class CraftServer implements Server {
+@@ -1771,7 +1771,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {

--- a/patches/server/0863-More-Teleport-API.patch
+++ b/patches/server/0863-More-Teleport-API.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] More Teleport API
 public net.minecraft.server.network.ServerGamePacketListenerImpl internalTeleport(DDDFFLjava/util/Set;Z)V
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f83fd2dd742533285cde99bbc5180a34feb09c31..014a94c5b2f7c900f33a8e29a64d61690c94b150 100644
+index 99fe650529e267f8026c5019eab0295b2cddfc53..f67ce080d9d9e3786009ec86eb9dda658c7b6a30 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1710,11 +1710,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -74,10 +74,10 @@ index 6478faa20adea00349600620c2ab7d559e2fc3b7..52f8a76832b05061dc80381220c86631
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 85c28926533c3159d42e8e7d90051472613dda8c..6e0e0e8405873069274c574240feea793e287f0c 100644
+index 5a51b19345670ab9590f9ee2a9668d5f9fd010fe..5098dc4f380dca3d4a32cbd201e4c925d2504d9a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1259,13 +1259,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1260,13 +1260,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setRotation(float yaw, float pitch) {
@@ -179,7 +179,7 @@ index 85c28926533c3159d42e8e7d90051472613dda8c..6e0e0e8405873069274c574240feea79
          location.checkFinite();
  
          ServerPlayer entity = this.getHandle();
-@@ -1278,7 +1365,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1279,7 +1366,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
             return false;
          }
  
@@ -188,7 +188,7 @@ index 85c28926533c3159d42e8e7d90051472613dda8c..6e0e0e8405873069274c574240feea79
              return false;
          }
  
-@@ -1296,7 +1383,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1297,7 +1384,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          // If this player is riding another entity, we must dismount before teleporting.
@@ -197,7 +197,7 @@ index 85c28926533c3159d42e8e7d90051472613dda8c..6e0e0e8405873069274c574240feea79
  
          // SPIGOT-5509: Wakeup, similar to riding
          if (this.isSleeping()) {
-@@ -1312,13 +1399,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1313,13 +1400,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          ServerLevel toWorld = ((CraftWorld) to.getWorld()).getHandle();
  
          // Close any foreign inventory

--- a/patches/server/0868-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/server/0868-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6e0e0e8405873069274c574240feea793e287f0c..b764d508951e19634aface33b618bd3d3e114479 100644
+index 5098dc4f380dca3d4a32cbd201e4c925d2504d9a..ec5b1a1434a732ffd99113b301088865e5e34400 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -674,6 +674,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -675,6 +675,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          this.getHandle().getServer().getPlayerList().sendPlayerPermissionLevel(this.getHandle(), level, false);
      }

--- a/patches/server/0874-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0874-Add-Velocity-IP-Forwarding-Support.patch
@@ -213,10 +213,10 @@ index 3fcd7bfdb8945b276c94a263e9da6b85ce470366..3431b1132e55c53cda7cf47f021f2306
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8be0badce29413922dfd744b946ca3e4403bc4f6..e769f7b0904814ee63e2a73dca57e5dc33382fba 100644
+index a06eb05470b145b4d4001b957ec6252b3744eeb5..894c0d5bfa001def4374b657e3eb8f15a0caa1e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -775,7 +775,7 @@ public final class CraftServer implements Server {
+@@ -777,7 +777,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0899-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0899-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1dfdc5046b1fe2907734428d7feaab37a2951ea9..24b1f4f479a49976bbf06d08fc6aea74bc18444d 100644
+index ec5b1a1434a732ffd99113b301088865e5e34400..405634ea82f48ccaa170b9de27140573cb647608 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3139,6 +3139,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3145,6 +3145,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0916-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0916-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 24b1f4f479a49976bbf06d08fc6aea74bc18444d..2af561e773338d58bb88bbcdbdf54afbcce30e21 100644
+index 405634ea82f48ccaa170b9de27140573cb647608..ff223f33c3fa712ed2c775836412cfed3624137a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3144,6 +3144,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3150,6 +3150,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0930-fix-Instruments.patch
+++ b/patches/server/0930-fix-Instruments.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] fix Instruments
 properly handle Player#playNote
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 652489579c7014b46ebf67b0c72d2e50508955c2..4edffaef5075de849a3489cdfdee0eaf53b0df57 100644
+index ff223f33c3fa712ed2c775836412cfed3624137a..53f2c187d6a16ba5566d74619bfaf058c684c0b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -776,62 +776,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -777,62 +777,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void playNote(Location loc, Instrument instrument, Note note) {
          if (this.getHandle().connection == null) return;
  

--- a/patches/server/0941-Flying-Fall-Damage.patch
+++ b/patches/server/0941-Flying-Fall-Damage.patch
@@ -26,10 +26,10 @@ index 5b772b3caeafe98aa45a01bffe215a5dd33323b6..0629c471d38a77c44fc1c86ccdfcb069
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4edffaef5075de849a3489cdfdee0eaf53b0df57..124a42abda64f29bb21ea3a48ee9c40d69932721 100644
+index 53f2c187d6a16ba5566d74619bfaf058c684c0b7..e167872b279a59b348218a535555e563a9faaf3f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2329,6 +2329,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2330,6 +2330,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().onUpdateAbilities();
      }
  

--- a/patches/server/0947-Win-Screen-API.patch
+++ b/patches/server/0947-Win-Screen-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Win Screen API
 public net.minecraft.server.level.ServerPlayer seenCredits
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 124a42abda64f29bb21ea3a48ee9c40d69932721..3f498543cf0476ff1b184788d93f13b70c476c16 100644
+index e167872b279a59b348218a535555e563a9faaf3f..5f0146255b050dfc873789e7dd4bc1dc4a929f02 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1229,6 +1229,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1230,6 +1230,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
4727d326 Don't let Sign extend SignSide, mark API as experimental
9b29bdcc PR-845: Add preliminary support for multi sided signs

CraftBukkit Changes:
b346a5f6d PR-1170: Add preliminary support for multi sided signs
86c816189 Update SQLite version
d9324b4bc Fix addition of custom smithing trim / transform recipes

Spigot Changes:
7d7b241e Rebuild patches