### PR TITLE
Avoid duplicate poi entries from the first section

### DIFF
--- a/patches/server/0688-Optimise-general-POI-access.patch
+++ b/patches/server/0688-Optimise-general-POI-access.patch
@@ -32,10 +32,10 @@ had to be specifically modified.
 
 diff --git a/src/main/java/io/papermc/paper/util/PoiAccess.java b/src/main/java/io/papermc/paper/util/PoiAccess.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..05640f5f70e81833530e8098d30c400fed7ba6e1
+index 0000000000000000000000000000000000000000..69be1761b3b5ba7b496c1c10a4db897e6212d671
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/PoiAccess.java
-@@ -0,0 +1,800 @@
+@@ -0,0 +1,804 @@
 +package io.papermc.paper.util;
 +
 +import com.mojang.datafixers.util.Pair;
@@ -258,10 +258,12 @@ index 0000000000000000000000000000000000000000..05640f5f70e81833530e8098d30c400f
 +        final int centerX = sourcePosition.getX() >> 4;
 +        final int centerY = Mth.clamp(sourcePosition.getY() >> 4, lowerY, upperY);
 +        final int centerZ = sourcePosition.getZ() >> 4;
++        final long centerKey = CoordinateUtils.getChunkSectionKey(centerX, centerY, centerZ);
 +
 +        final LongArrayFIFOQueue queue = new LongArrayFIFOQueue();
-+        queue.enqueue(CoordinateUtils.getChunkSectionKey(centerX, centerY, centerZ));
 +        final LongOpenHashSet seen = new LongOpenHashSet();
++        seen.add(centerKey);
++        queue.enqueue(centerKey);
 +
 +        while (!queue.isEmpty()) {
 +            final long key = queue.dequeueLong();
@@ -315,7 +317,7 @@ index 0000000000000000000000000000000000000000..05640f5f70e81833530e8098d30c400f
 +                continue;
 +            }
 +
-+            final PoiSection poiSection = poiSectionOptional.orElse(null);
++            final PoiSection poiSection = poiSectionOptional.get();
 +
 +            final Map<Holder<PoiType>, Set<PoiRecord>> sectionData = poiSection.getData();
 +            if (sectionData.isEmpty()) {
@@ -499,10 +501,12 @@ index 0000000000000000000000000000000000000000..05640f5f70e81833530e8098d30c400f
 +        final int centerX = sourcePosition.getX() >> 4;
 +        final int centerY = Mth.clamp(sourcePosition.getY() >> 4, lowerY, upperY);
 +        final int centerZ = sourcePosition.getZ() >> 4;
++        final long centerKey = CoordinateUtils.getChunkSectionKey(centerX, centerY, centerZ);
 +
 +        final LongArrayFIFOQueue queue = new LongArrayFIFOQueue();
-+        queue.enqueue(CoordinateUtils.getChunkSectionKey(centerX, centerY, centerZ));
 +        final LongOpenHashSet seen = new LongOpenHashSet();
++        seen.add(centerKey);
++        queue.enqueue(centerKey);
 +
 +        while (!queue.isEmpty()) {
 +            final long key = queue.dequeueLong();
@@ -557,7 +561,7 @@ index 0000000000000000000000000000000000000000..05640f5f70e81833530e8098d30c400f
 +                continue;
 +            }
 +
-+            final PoiSection poiSection = poiSectionOptional.orElse(null);
++            final PoiSection poiSection = poiSectionOptional.get();
 +
 +            final Map<Holder<PoiType>, Set<PoiRecord>> sectionData = poiSection.getData();
 +            if (sectionData.isEmpty()) {


### PR DESCRIPTION
When the server search for nearby poi, it sometimes do some unneeded work on the center section (where the search start). This happens when the search repick the center section while searching for neighbor section. In this case duplicate entries are found on the returned list and this would cause some issues if a poi api would use theses functions. Vanilla features doesn't seems impacted except some performance implication.
To reproduce this: print the output of one affected function, place a poi block (lightning rod for example) and execute
a locate command in the same chunk section than the poi blocks, so really close.