### PR TITLE
[ci skip] Add missing deprecations for legacy MaterialData api

### DIFF
--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -927,6 +927,29 @@ index 32055a8890425e0b819930f3059da5ea9dfca553..26a336dade83baee97d20eb39a058925
      int getMapId();
  
      /**
+diff --git a/src/main/java/org/bukkit/material/Openable.java b/src/main/java/org/bukkit/material/Openable.java
+index 0ae54f973d11df74abb3105cf9226afb130b4f33..597036bad6bc61b4aa63a61b45e886dd74a0b7f6 100644
+--- a/src/main/java/org/bukkit/material/Openable.java
++++ b/src/main/java/org/bukkit/material/Openable.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.material;
+ 
++@Deprecated // Paper
+ public interface Openable {
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/material/Redstone.java b/src/main/java/org/bukkit/material/Redstone.java
+index 3e46603f8cd38041394e0e1baf788d9009b3ffc7..b15c141f1db07296bb349f11c6f39b0fbe53e7b1 100644
+--- a/src/main/java/org/bukkit/material/Redstone.java
++++ b/src/main/java/org/bukkit/material/Redstone.java
+@@ -3,6 +3,7 @@ package org.bukkit.material;
+ /**
+  * Indicated a Material that may carry or create a Redstone current
+  */
++@Deprecated // Paper
+ public interface Redstone {
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/material/Step.java b/src/main/java/org/bukkit/material/Step.java
 index 9f502e7ee05d0512e190a1722cc112ece068c4e2..10c0465cf58d680bfa9a0f9233f94e8b6d5a9b93 100644
 --- a/src/main/java/org/bukkit/material/Step.java
@@ -953,3 +976,15 @@ index 0ea9c6b2420a0f990bd1fdf50fc015e37a7060d8..e99644eae1c662b117aa19060d2484ac
  public enum MushroomBlockTexture {
  
      /**
+diff --git a/src/test/java/org/bukkit/materials/MaterialDataTest.java b/src/test/java/org/bukkit/materials/MaterialDataTest.java
+index a935ae4a25b7955416652bf8c4690a804f12e903..e83321263bb0e2b67af981dbb2e8fec4e973ae56 100644
+--- a/src/test/java/org/bukkit/materials/MaterialDataTest.java
++++ b/src/test/java/org/bukkit/materials/MaterialDataTest.java
+@@ -22,6 +22,7 @@ import org.bukkit.material.WoodenStep;
+ import org.bukkit.material.types.MushroomBlockTexture;
+ import org.junit.Test;
+ 
++@Deprecated // Paper
+ public class MaterialDataTest {
+ 
+     @Test


### PR DESCRIPTION
I thought I got all of these last time, but found 2 more. I added the annotation on the test to silence some of the "deprecated type still in use" inspections.