### PR TITLE
Add method to get ungenerated chunk from long key

### DIFF
--- a/patches/api/0132-Provide-Chunk-Coordinates-as-a-Long-API.patch
+++ b/patches/api/0132-Provide-Chunk-Coordinates-as-a-Long-API.patch
@@ -44,17 +44,17 @@ index efbfed855248cff8b4bdbfc181d3e82058df4749..766d643f0fe79660942fdad25e39e488
       * Gets the world containing this chunk
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index e9af7ce218e44940cd074cc0d511268284e312ef..745933ca3fee4efdba7660f157407ebe0cb91a6b 100644
+index e9af7ce218e44940cd074cc0d511268284e312ef..159307600747c49948c5242d6cf39eed08c902e7 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -179,6 +179,22 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -179,6 +179,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Chunk getChunkAt(@NotNull Block block);
  
-+    // Paper start
++    // Paper start - chunk long key API
 +    /**
 +     * Gets the chunk at the specified chunk key, which is the X and Z packed into a long.
-+     *
++     * <p>
 +     * See {@link Chunk#getChunkKey()} for easy access to the key, or you may calculate it as:
 +     * long chunkKey = (long) chunkX &amp; 0xffffffffL | ((long) chunkZ &amp; 0xffffffffL) &gt;&gt; 32;
 +     *
@@ -62,10 +62,25 @@ index e9af7ce218e44940cd074cc0d511268284e312ef..745933ca3fee4efdba7660f157407ebe
 +     * @return The chunk at the specified key
 +     */
 +    @NotNull
-+    public default Chunk getChunkAt(long chunkKey) {
-+        return getChunkAt((int) chunkKey, (int) (chunkKey >> 32));
++    default Chunk getChunkAt(long chunkKey) {
++        return getChunkAt(chunkKey, true);
 +    }
-+    // Paper end
++
++    /**
++     * Gets the chunk at the specified chunk key, which is the X and Z packed into a long.
++     * <p>
++     * See {@link Chunk#getChunkKey()} for easy access to the key, or you may calculate it as:
++     * long chunkKey = (long) chunkX &amp; 0xffffffffL | ((long) chunkZ &amp; 0xffffffffL) &gt;&gt; 32;
++     *
++     * @param chunkKey The Chunk Key to look up the chunk by
++     * @param generate Whether the chunk should be fully generated or not
++     * @return The chunk at the specified key
++     */
++    @NotNull
++    default Chunk getChunkAt(long chunkKey, boolean generate) {
++        return getChunkAt((int) chunkKey, (int) (chunkKey >> 32), generate);
++    }
++    // Paper end - chunk long key API
 +
      /**
       * Checks if the specified {@link Chunk} is loaded

--- a/patches/api/0135-Allow-Blocks-to-be-accessed-via-a-long-key.patch
+++ b/patches/api/0135-Allow-Blocks-to-be-accessed-via-a-long-key.patch
@@ -50,10 +50,10 @@ index 943c3364f6b931fe11f9a6099504590b2da34657..16a604b6315daff228c827fe02b1234c
       * @return A new location where X/Y/Z are the center of the block
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 745933ca3fee4efdba7660f157407ebe0cb91a6b..18376c635c689b7aaf1a567bee3d1faaaa28a9f0 100644
+index 159307600747c49948c5242d6cf39eed08c902e7..e83de41cbaf0e5a68ce0d5ad2b5ec10877ec4055 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -96,6 +96,40 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -96,6 +96,41 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Block getBlockAt(@NotNull Location location);
  
@@ -83,6 +83,7 @@ index 745933ca3fee4efdba7660f157407ebe0cb91a6b..18376c635c689b7aaf1a567bee3d1faa
 +     * @see Block#getBlockKey(int, int, int)
 +     */
 +    @NotNull
++    @Deprecated
 +    public default Location getLocationAtKey(long key) {
 +        int x = Block.getBlockKeyX(key);
 +        int y = Block.getBlockKeyY(key);

--- a/patches/api/0140-isChunkGenerated-API.patch
+++ b/patches/api/0140-isChunkGenerated-API.patch
@@ -34,14 +34,14 @@ index 16a604b6315daff228c827fe02b1234cca3e884d..20978b269a7757a561d6b872cc77898b
      /**
       * Sets the position of this Location and returns itself
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 18376c635c689b7aaf1a567bee3d1faaaa28a9f0..4c3150a959593c461f6cf92e9fd8a5f22ff94e8a 100644
+index e83de41cbaf0e5a68ce0d5ad2b5ec10877ec4055..c63a660f2deade66fffad9036ce7c7c693bf0207 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -227,6 +227,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
-     public default Chunk getChunkAt(long chunkKey) {
-         return getChunkAt((int) chunkKey, (int) (chunkKey >> 32));
+@@ -245,6 +245,19 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      }
-+
+     // Paper end - chunk long key API
+ 
++    // Paper start - isChunkGenerated API
 +    /**
 +     * Checks if a {@link Chunk} has been generated at the specified chunk key,
 +     * which is the X and Z packed into a long.
@@ -49,9 +49,11 @@ index 18376c635c689b7aaf1a567bee3d1faaaa28a9f0..4c3150a959593c461f6cf92e9fd8a5f2
 +     * @param chunkKey The Chunk Key to look up the chunk by
 +     * @return true if the chunk has been generated, otherwise false
 +     */
-+    public default boolean isChunkGenerated(long chunkKey) {
++    default boolean isChunkGenerated(long chunkKey) {
 +        return isChunkGenerated((int) chunkKey, (int) (chunkKey >> 32));
 +    }
-     // Paper end
- 
++    // Paper end - isChunkGenerated API
++
      /**
+      * Checks if the specified {@link Chunk} is loaded
+      *

--- a/patches/api/0142-Async-Chunks-API.patch
+++ b/patches/api/0142-Async-Chunks-API.patch
@@ -8,10 +8,10 @@ Adds API's to load or generate chunks asynchronously.
 Also adds utility methods to Entity to teleport asynchronously.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 4c3150a959593c461f6cf92e9fd8a5f22ff94e8a..265d1751c5460121b29129d9588ef1a13564073b 100644
+index c63a660f2deade66fffad9036ce7c7c693bf0207..67d14468703e0445afccdbd8de8028fb21b90d2d 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -936,6 +936,482 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -954,6 +954,482 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
          }
          return nearby;
      }

--- a/patches/api/0156-Add-sun-related-API.patch
+++ b/patches/api/0156-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 265d1751c5460121b29129d9588ef1a13564073b..eea0b7edd0a4e8a698c21e8b468f802e072a68cc 100644
+index 67d14468703e0445afccdbd8de8028fb21b90d2d..c6019065869130608ac97af951c7036031eec242 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1763,6 +1763,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1781,6 +1781,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public void setFullTime(long time);
  

--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -282,10 +282,10 @@ index e455eb21abf121dc6ff10ff8a13dd06f67096a8f..bbc01e7c192ae6689c301670047ff114
          return origin;
      }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index eea0b7edd0a4e8a698c21e8b468f802e072a68cc..948a989aeea4165f0714db69c70ca8dcb488d44d 100644
+index c6019065869130608ac97af951c7036031eec242..31fc272b0e82e4eef6d9bf01dd25d39513d354b3 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -397,9 +397,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -415,9 +415,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @param z Z-coordinate of the chunk
       * @return Whether the chunk was actually refreshed
       *
@@ -296,7 +296,7 @@ index eea0b7edd0a4e8a698c21e8b468f802e072a68cc..948a989aeea4165f0714db69c70ca8dc
      public boolean refreshChunk(int x, int z);
  
      /**
-@@ -2112,8 +2111,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2130,8 +2129,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     MaterialData} are null or {@link Material} of the {@link MaterialData} is not a block

--- a/patches/api/0175-Add-Heightmap-API.patch
+++ b/patches/api/0175-Add-Heightmap-API.patch
@@ -103,10 +103,10 @@ index 2b9a117804a8ca54b47e51e23359bd6e01087641..1a60a18e15780128a1914826daa952ff
       * Creates explosion at this location with given power
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 948a989aeea4165f0714db69c70ca8dcb488d44d..1ae0e12125421fd0c36fcfb82ccbb994578415d9 100644
+index 31fc272b0e82e4eef6d9bf01dd25d39513d354b3..0c5ce79c04e8193db248a221f519d80a944ef6ba 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -149,6 +149,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -150,6 +150,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Block getHighestBlockAt(@NotNull Location location);
  

--- a/patches/api/0271-More-World-API.patch
+++ b/patches/api/0271-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 1ae0e12125421fd0c36fcfb82ccbb994578415d9..0fa6f8e99059b26861bc5bb3505ac544587e51bc 100644
+index 0c5ce79c04e8193db248a221f519d80a944ef6ba..fff4d89e978bd0050a298ab8f43401b6c600e5a2 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3698,6 +3698,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3716,6 +3716,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      StructureSearchResult locateNearestStructure(@NotNull Location origin, @NotNull Structure structure, int radius, boolean findUnexplored);
  

--- a/patches/api/0315-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/api/0315-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 0fa6f8e99059b26861bc5bb3505ac544587e51bc..8d5b73b92b78676467c24a73332a2a8c14cd0506 100644
+index fff4d89e978bd0050a298ab8f43401b6c600e5a2..a78563a52ea1a1f05927f10b90f7a94cb28f126f 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -716,6 +716,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -734,6 +734,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public LightningStrike strikeLightningEffect(@NotNull Location loc);
  

--- a/patches/api/0348-Implement-regenerateChunk.patch
+++ b/patches/api/0348-Implement-regenerateChunk.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement regenerateChunk
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 8d5b73b92b78676467c24a73332a2a8c14cd0506..72f1576b8ce5b55b50f053f346ce42c52db4b568 100644
+index a78563a52ea1a1f05927f10b90f7a94cb28f126f..6917931966377c51db88a3364997a110dd987970 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -465,8 +465,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -483,8 +483,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return Whether the chunk was actually regenerated
       *
       * @deprecated regenerating a single chunk is not likely to produce the same


### PR DESCRIPTION
Also added a missing deprecation for a location block key method


Should we add static methods on Chunk to get the X and Z coords individually? We had that on Block for location keys (those are now deprecated along with the rest of the location key api).

