### PR TITLE
Feature: FOV Scale

### DIFF
--- a/patches/api/0417-FOV-Scale-API.patch
+++ b/patches/api/0417-FOV-Scale-API.patch
@@ -11,17 +11,6 @@ diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/buk
 index 88c4885569d2b8b22fce55601d50608ac8e9388c..fa63f1d2f8ffe937137b15b9ab1964cdfb7e7cb9 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -890,8 +890,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-      * they have seen it before because this method was called.
-      * Note this method does not make the player invulnerable, which is normally expected when viewing credits.
-      *
--     * @see #hasSeenWinScreen() 
--     * @see #setHasSeenWinScreen(boolean) 
-+     * @see #hasSeenWinScreen()
-+     * @see #setHasSeenWinScreen(boolean)
-      * @see <a href="https://minecraft.fandom.com/wiki/End_Poem#Technical_details">https://minecraft.fandom.com/wiki/End_Poem#Technical_details</a>
-      */
-     public void showWinScreen();
 @@ -1693,6 +1693,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public float getWalkSpeed();
@@ -47,31 +36,4 @@ index 88c4885569d2b8b22fce55601d50608ac8e9388c..fa63f1d2f8ffe937137b15b9ab1964cd
 +
      /**
       * Request that the player's client download and switch texture packs.
-      * <p>
-@@ -2144,7 +2163,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-      * @param saturationLevel the saturation level of the player
-      */
-     public void sendHealthUpdate(final double health, final int foodLevel, final float saturationLevel);
--    
-+
-     /**
-      * Forcefully sends a health update to the player.
-      * This uses the player's current health, saturation, and food level.
-@@ -2153,7 +2172,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-      */
-     public void sendHealthUpdate();
-     // Paper end
--    
-+
-     /**
-      * Gets the entity which is followed by the camera when in
-      * {@link GameMode#SPECTATOR}.
-@@ -2514,7 +2533,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-      * @param simulationDistance the player's new simulation distance
-      */
-     public void setSimulationDistance(int simulationDistance);
--    
-+
-     /**
-      * Gets the no-ticking view distance for this player.
       * <p>

--- a/patches/api/0417-FOV-Scale-API.patch
+++ b/patches/api/0417-FOV-Scale-API.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Moulberry <james.jenour@protonmail.com>
+Date: Tue, 6 Jun 2023 02:11:34 +0800
+Subject: [PATCH] FOV Scale API
+
+Modifies the player's fov by a factor
+The multiplier is affected by the client Accessibility option 'FOV
+Effects'
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 88c4885569d2b8b22fce55601d50608ac8e9388c..fa63f1d2f8ffe937137b15b9ab1964cdfb7e7cb9 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -890,8 +890,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * they have seen it before because this method was called.
+      * Note this method does not make the player invulnerable, which is normally expected when viewing credits.
+      *
+-     * @see #hasSeenWinScreen() 
+-     * @see #setHasSeenWinScreen(boolean) 
++     * @see #hasSeenWinScreen()
++     * @see #setHasSeenWinScreen(boolean)
+      * @see <a href="https://minecraft.fandom.com/wiki/End_Poem#Technical_details">https://minecraft.fandom.com/wiki/End_Poem#Technical_details</a>
+      */
+     public void showWinScreen();
+@@ -1693,6 +1693,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     public float getWalkSpeed();
+ 
++    // Paper start
++    /**
++     * Sets a multiplier applied to the Player's FOV. This is affected by
++     * the client Accessibility option 'FOV Effects'
++     *
++     * @param value The fov scale, typically from 0.1 to 1.5
++     * @throws IllegalArgumentException If new fov scale is {@link Float#NaN},
++     *      {@link Float#POSITIVE_INFINITY} or {@link Float#NEGATIVE_INFINITY}
++     */
++    void setFovScale(float value) throws IllegalArgumentException;
++
++    /**
++     * Gets the current multiplier applied to the Player's FOV
++     *
++     * @return value The fov scale, typically from 0.1 to 1.5
++     */
++    float getFovScale();
++    // Paper end
++
+     /**
+      * Request that the player's client download and switch texture packs.
+      * <p>
+@@ -2144,7 +2163,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @param saturationLevel the saturation level of the player
+      */
+     public void sendHealthUpdate(final double health, final int foodLevel, final float saturationLevel);
+-    
++
+     /**
+      * Forcefully sends a health update to the player.
+      * This uses the player's current health, saturation, and food level.
+@@ -2153,7 +2172,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     public void sendHealthUpdate();
+     // Paper end
+-    
++
+     /**
+      * Gets the entity which is followed by the camera when in
+      * {@link GameMode#SPECTATOR}.
+@@ -2514,7 +2533,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @param simulationDistance the player's new simulation distance
+      */
+     public void setSimulationDistance(int simulationDistance);
+-    
++
+     /**
+      * Gets the no-ticking view distance for this player.
+      * <p>

--- a/patches/api/0417-FOV-Scale-API.patch
+++ b/patches/api/0417-FOV-Scale-API.patch
@@ -8,7 +8,7 @@ The multiplier is affected by the client Accessibility option 'FOV
 Effects'
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 88c4885569d2b8b22fce55601d50608ac8e9388c..fa63f1d2f8ffe937137b15b9ab1964cdfb7e7cb9 100644
+index 88c4885569d2b8b22fce55601d50608ac8e9388c..5f01735ac270af030e4ba65d0f28eaec894d7bb3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1693,6 +1693,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -20,16 +20,16 @@ index 88c4885569d2b8b22fce55601d50608ac8e9388c..fa63f1d2f8ffe937137b15b9ab1964cd
 +     * Sets a multiplier applied to the Player's FOV. This is affected by
 +     * the client Accessibility option 'FOV Effects'
 +     *
-+     * @param value The fov scale, typically from 0.1 to 1.5
-+     * @throws IllegalArgumentException If new fov scale is {@link Float#NaN},
-+     *      {@link Float#POSITIVE_INFINITY} or {@link Float#NEGATIVE_INFINITY}
++     * @param value The fov scale, from 0.5 to 1.5
++     * @throws IllegalArgumentException If new fov scale is less than 0.5 or
++     *     greater than 1.5
 +     */
 +    void setFovScale(float value) throws IllegalArgumentException;
 +
 +    /**
 +     * Gets the current multiplier applied to the Player's FOV
 +     *
-+     * @return value The fov scale, typically from 0.1 to 1.5
++     * @return value The fov scale, from 0.5 to 1.5
 +     */
 +    float getFovScale();
 +    // Paper end

--- a/patches/api/0417-FOV-Scale-API.patch
+++ b/patches/api/0417-FOV-Scale-API.patch
@@ -8,10 +8,10 @@ The multiplier is affected by the client Accessibility option 'FOV
 Effects'
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 88c4885569d2b8b22fce55601d50608ac8e9388c..5f01735ac270af030e4ba65d0f28eaec894d7bb3 100644
+index 88c4885569d2b8b22fce55601d50608ac8e9388c..59a0553137cd4a6492d5e40f51195584230ea9a3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1693,6 +1693,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1693,6 +1693,38 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public float getWalkSpeed();
  
@@ -19,18 +19,31 @@ index 88c4885569d2b8b22fce55601d50608ac8e9388c..5f01735ac270af030e4ba65d0f28eaec
 +    /**
 +     * Sets a multiplier applied to the Player's FOV. This is affected by
 +     * the client Accessibility option 'FOV Effects'
++     * <p>
++     * WARNING: This method relies on an implementation detail of the vanilla
++     * client. Other versions or modded clients may interpret these values
++     * differently (or not at all).
++     * <p>
++     * WARNING: Using a negative value will decrease the FOV further, however
++     * it will also invert normal FOV effects (e.g. a speed potion will decrease
++     * FOV instead of increasing)
++     * <p>
++     * Force the minimum and maximum possible FOV using {@link Float#NEGATIVE_INFINITY}
++     * and {@link Float#POSITIVE_INFINITY} respectively
++     * <p>
++     * Disable normal FOV effects using {@link Float#NaN}
 +     *
-+     * @param value The fov scale, from 0.5 to 1.5
-+     * @throws IllegalArgumentException If new fov scale is less than 0.5 or
-+     *     greater than 1.5
++     * @param value The fov scale, typically from 0.0 to 2.0
 +     */
-+    void setFovScale(float value) throws IllegalArgumentException;
++    @ApiStatus.Experimental
++    void setFovScale(float value);
 +
 +    /**
 +     * Gets the current multiplier applied to the Player's FOV
 +     *
-+     * @return value The fov scale, from 0.5 to 1.5
++     * @return value The fov scale, typically from 0.0 to 2.0
 +     */
++    @ApiStatus.Experimental
 +    float getFovScale();
 +    // Paper end
 +

--- a/patches/server/0986-FOV-Scale-Implementation.patch
+++ b/patches/server/0986-FOV-Scale-Implementation.patch
@@ -17,19 +17,9 @@ However, we want our FOV scale to work additively with the normal FOV scale caus
 Therefore, we replace movementSpeed with walkingSpeed, arriving at the final calculation:
 walkingSpeed = walkingSpeed / (fovScale * 2.0f - 1.0f)
 
-diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java
-index a20bcf5877106ae00c83cf376a0dd16016cd1c7c..f262347fa9de6f3f9d118a1ffa810f7292558509 100644
---- a/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java
-+++ b/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java
-@@ -14,7 +14,7 @@ public class ClientboundPlayerAbilitiesPacket implements Packet<ClientGamePacket
-     private final boolean canFly;
-     private final boolean instabuild;
-     private final float flyingSpeed;
--    private final float walkingSpeed;
-+    public float walkingSpeed; // Paper - expose for ServerPlayer#onUpdateAbilities
- 
-     public ClientboundPlayerAbilitiesPacket(Abilities abilities) {
-         this.invulnerable = abilities.invulnerable;
+== AT ==
+public-f net.minecraft.network.protocol.game.ClientboundPlayerAbilitiesPacket walkingSpeed
+
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 index 98df2463bf41fc736aa6a2b6ddf89e5abde6eb39..d9397ebbc2e34bed77b87d7570f8924230e1965a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java

--- a/patches/server/0986-FOV-Scale-Implementation.patch
+++ b/patches/server/0986-FOV-Scale-Implementation.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Moulberry <james.jenour@protonmail.com>
+Date: Tue, 6 Jun 2023 02:08:29 +0800
+Subject: [PATCH] FOV Scale Implementation
+
+Modifies the player's fov by a factor
+The multiplier is affected by the client Accessibility option 'FOV Effects'
+
+diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java
+index a20bcf5877106ae00c83cf376a0dd16016cd1c7c..f262347fa9de6f3f9d118a1ffa810f7292558509 100644
+--- a/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java
++++ b/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java
+@@ -14,7 +14,7 @@ public class ClientboundPlayerAbilitiesPacket implements Packet<ClientGamePacket
+     private final boolean canFly;
+     private final boolean instabuild;
+     private final float flyingSpeed;
+-    private final float walkingSpeed;
++    public float walkingSpeed; // Paper - expose for ServerPlayer#onUpdateAbilities
+ 
+     public ClientboundPlayerAbilitiesPacket(Abilities abilities) {
+         this.invulnerable = abilities.invulnerable;
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 98df2463bf41fc736aa6a2b6ddf89e5abde6eb39..d9397ebbc2e34bed77b87d7570f8924230e1965a 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -1877,7 +1877,11 @@ public class ServerPlayer extends Player {
+     @Override
+     public void onUpdateAbilities() {
+         if (this.connection != null) {
+-            this.connection.send(new ClientboundPlayerAbilitiesPacket(this.getAbilities()));
++            // Paper start - use fov scale
++            ClientboundPlayerAbilitiesPacket abilitiesPacket = new ClientboundPlayerAbilitiesPacket(this.getAbilities());
++            abilitiesPacket.walkingSpeed = abilitiesPacket.walkingSpeed / (this.getBukkitEntity().getFovScale() * 2 - 1);
++            this.connection.send(abilitiesPacket);
++            // Paper end
+             this.updateInvisibilityStatus();
+         }
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index be64633c8bcee96f2ad5247525cac965b7b031b1..0ee2462e1ed6cc7105fb73bc71a074cbd7111088 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -184,6 +184,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     private String resourcePackHash;
+     private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
+     private long lastSaveTime;
++    private float fovScale = 1.0f;
+     // Paper end
+ 
+     public CraftPlayer(CraftServer server, ServerPlayer entity) {
+@@ -2405,6 +2406,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         return this.getHandle().getAbilities().walkingSpeed * 2f;
+     }
+ 
++    // Paper start - Set/get fov scale
++    @Override
++    public void setFovScale(float value) {
++        if (!Float.isFinite(value)) throw new IllegalArgumentException(value + " must be finite");
++        if (this.fovScale != value) {
++            this.fovScale = value;
++            this.getHandle().onUpdateAbilities();
++        }
++    }
++
++    @Override
++    public float getFovScale() {
++        return this.fovScale;
++    }
++    // Paper end
++
+     private void validateSpeed(float value) {
+         if (value < 0) {
+             if (value < -1f) {

--- a/patches/server/0986-FOV-Scale-Implementation.patch
+++ b/patches/server/0986-FOV-Scale-Implementation.patch
@@ -6,39 +6,52 @@ Subject: [PATCH] FOV Scale Implementation
 Modifies the player's fov by a factor
 The multiplier is affected by the client Accessibility option 'FOV Effects'
 
-The formula used to change walkingSpeed is based on the vanilla FOV scale calculation:
+This works due to the way vanilla calculates FOV scale as a ratio
+between movementSpeed and walkingSpeed:
+
 fovScale = (movementSpeed / walkingSpeed + 1.0f) / 2.0f
 
-Rearranging this formula in terms of walkingSpeed gives:
-walkingSpeed = movementSpeed / (fovScale * 2.0f - 1.0f)
+Normally, servers might implement a 'zoom' by changing the movementSpeed
+- this behaviour is well known. However, changing the walkingSpeed
+achieves a similar effect without affecting the speed at which the
+player is able to move.
 
-If we wanted a fixed FOV scale (regardless of the movement speed), we would use the above formula.
-However, we want our FOV scale to work additively with the normal FOV scale caused by movement speed changes.
-Therefore, we replace movementSpeed with walkingSpeed, arriving at the final calculation:
-walkingSpeed = walkingSpeed / (fovScale * 2.0f - 1.0f)
+This patch adds API to do exactly that.
+
+(Note that 'walkingSpeed' on the client has no other use than to
+calculate the FOV)
 
 == AT ==
 public-f net.minecraft.network.protocol.game.ClientboundPlayerAbilitiesPacket walkingSpeed
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 98df2463bf41fc736aa6a2b6ddf89e5abde6eb39..d9397ebbc2e34bed77b87d7570f8924230e1965a 100644
+index 98df2463bf41fc736aa6a2b6ddf89e5abde6eb39..954382a1442d581bb3f13bf8e9e94c29335bb300 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1877,7 +1877,11 @@ public class ServerPlayer extends Player {
+@@ -1877,7 +1877,20 @@ public class ServerPlayer extends Player {
      @Override
      public void onUpdateAbilities() {
          if (this.connection != null) {
 -            this.connection.send(new ClientboundPlayerAbilitiesPacket(this.getAbilities()));
 +            // Paper start - use fov scale
 +            ClientboundPlayerAbilitiesPacket abilitiesPacket = new ClientboundPlayerAbilitiesPacket(this.getAbilities());
-+            abilitiesPacket.walkingSpeed = abilitiesPacket.walkingSpeed / (this.getBukkitEntity().getFovScale() * 2 - 1);
++            float fovScale = this.getBukkitEntity().getFovScale();
++            if (fovScale < -1E24f) {
++                // Force minimum FOV (0.1), capped to avoid producing -Infinity
++                abilitiesPacket.walkingSpeed = abilitiesPacket.walkingSpeed < 0 ? 1E-24f : -1E-24f;
++            } else if (fovScale > 1E24f) {
++                // Force maximum FOV (1.5), capped to avoid producing +Infinity
++                abilitiesPacket.walkingSpeed = abilitiesPacket.walkingSpeed < 0 ? -1E-24f : 1E-24f;
++            } else {
++                abilitiesPacket.walkingSpeed = abilitiesPacket.walkingSpeed / fovScale;
++            }
 +            this.connection.send(abilitiesPacket);
 +            // Paper end
              this.updateInvisibilityStatus();
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index be64633c8bcee96f2ad5247525cac965b7b031b1..07d0c2143e6920fd973198e52a43cc2a5f766a74 100644
+index be64633c8bcee96f2ad5247525cac965b7b031b1..ec94f95ae947621188110e043a915f344b94e0b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -184,6 +184,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -49,19 +62,13 @@ index be64633c8bcee96f2ad5247525cac965b7b031b1..07d0c2143e6920fd973198e52a43cc2a
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -2405,6 +2406,27 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2405,6 +2406,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().getAbilities().walkingSpeed * 2f;
      }
  
-+    // Paper start - Set/get fov scale
++    // Paper start - set/get fov scale
 +    @Override
 +    public void setFovScale(float value) {
-+        if (value < 0.5) {
-+            throw new IllegalArgumentException(value + " is too low");
-+        }
-+        if (value > 1.5) {
-+            throw new IllegalArgumentException(value + " is too high");
-+        }
 +        if (this.fovScale != value) {
 +            this.fovScale = value;
 +            this.getHandle().onUpdateAbilities();

--- a/patches/server/0986-FOV-Scale-Implementation.patch
+++ b/patches/server/0986-FOV-Scale-Implementation.patch
@@ -38,7 +38,7 @@ index 98df2463bf41fc736aa6a2b6ddf89e5abde6eb39..d9397ebbc2e34bed77b87d7570f89242
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index be64633c8bcee96f2ad5247525cac965b7b031b1..0ee2462e1ed6cc7105fb73bc71a074cbd7111088 100644
+index be64633c8bcee96f2ad5247525cac965b7b031b1..07d0c2143e6920fd973198e52a43cc2a5f766a74 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -184,6 +184,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -49,14 +49,19 @@ index be64633c8bcee96f2ad5247525cac965b7b031b1..0ee2462e1ed6cc7105fb73bc71a074cb
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -2405,6 +2406,22 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2405,6 +2406,27 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().getAbilities().walkingSpeed * 2f;
      }
  
 +    // Paper start - Set/get fov scale
 +    @Override
 +    public void setFovScale(float value) {
-+        if (!Float.isFinite(value)) throw new IllegalArgumentException(value + " must be finite");
++        if (value < 0.5) {
++            throw new IllegalArgumentException(value + " is too low");
++        }
++        if (value > 1.5) {
++            throw new IllegalArgumentException(value + " is too high");
++        }
 +        if (this.fovScale != value) {
 +            this.fovScale = value;
 +            this.getHandle().onUpdateAbilities();

--- a/patches/server/0986-FOV-Scale-Implementation.patch
+++ b/patches/server/0986-FOV-Scale-Implementation.patch
@@ -6,6 +6,17 @@ Subject: [PATCH] FOV Scale Implementation
 Modifies the player's fov by a factor
 The multiplier is affected by the client Accessibility option 'FOV Effects'
 
+The formula used to change walkingSpeed is based on the vanilla FOV scale calculation:
+fovScale = (movementSpeed / walkingSpeed + 1.0f) / 2.0f
+
+Rearranging this formula in terms of walkingSpeed gives:
+walkingSpeed = movementSpeed / (fovScale * 2.0f - 1.0f)
+
+If we wanted a fixed FOV scale (regardless of the movement speed), we would use the above formula.
+However, we want our FOV scale to work additively with the normal FOV scale caused by movement speed changes.
+Therefore, we replace movementSpeed with walkingSpeed, arriving at the final calculation:
+walkingSpeed = walkingSpeed / (fovScale * 2.0f - 1.0f)
+
 diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java
 index a20bcf5877106ae00c83cf376a0dd16016cd1c7c..f262347fa9de6f3f9d118a1ffa810f7292558509 100644
 --- a/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerAbilitiesPacket.java


### PR DESCRIPTION
Modifies the player's fov by a factor
The multiplier is affected by the client Accessibility option 'FOV Effects'

I'm not sure about the approach of exposing a variable in ClientboundPlayerAbilitiesPacket and then mutating it. Alternatively the onUpdateAbilities method could clone Abilities before constructing the packet. Let me know if that approach is preferred