### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -750,10 +750,10 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 446e4d21c5b9b624e633875df62160a7351517d9..16ec0cd908659d6d53e565281b8db9f81951277d 100644
+index f8051479fbf0b63f671a343cdb375429a3f7bd2f..fe86d25bfc444ad7143fb60e88bc46ad749c8579 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -358,7 +358,9 @@ public final class Bukkit {
+@@ -379,7 +379,9 @@ public final class Bukkit {
       *
       * @param message the message
       * @return the number of players
@@ -763,7 +763,7 @@ index 446e4d21c5b9b624e633875df62160a7351517d9..16ec0cd908659d6d53e565281b8db9f8
      public static int broadcastMessage(@NotNull String message) {
          return server.broadcastMessage(message);
      }
-@@ -1074,6 +1076,19 @@ public final class Bukkit {
+@@ -1095,6 +1097,19 @@ public final class Bukkit {
          server.shutdown();
      }
  
@@ -783,7 +783,7 @@ index 446e4d21c5b9b624e633875df62160a7351517d9..16ec0cd908659d6d53e565281b8db9f8
      /**
       * Broadcasts the specified message to every user with the given
       * permission name.
-@@ -1083,6 +1098,21 @@ public final class Bukkit {
+@@ -1104,6 +1119,21 @@ public final class Bukkit {
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
       */
@@ -805,7 +805,7 @@ index 446e4d21c5b9b624e633875df62160a7351517d9..16ec0cd908659d6d53e565281b8db9f8
      public static int broadcast(@NotNull String message, @NotNull String permission) {
          return server.broadcast(message, permission);
      }
-@@ -1321,6 +1351,7 @@ public final class Bukkit {
+@@ -1342,6 +1372,7 @@ public final class Bukkit {
          return server.createInventory(owner, type);
      }
  
@@ -813,7 +813,7 @@ index 446e4d21c5b9b624e633875df62160a7351517d9..16ec0cd908659d6d53e565281b8db9f8
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1346,6 +1377,38 @@ public final class Bukkit {
+@@ -1367,6 +1398,38 @@ public final class Bukkit {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -852,7 +852,7 @@ index 446e4d21c5b9b624e633875df62160a7351517d9..16ec0cd908659d6d53e565281b8db9f8
      public static Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title) {
          return server.createInventory(owner, type, title);
      }
-@@ -1364,6 +1427,7 @@ public final class Bukkit {
+@@ -1385,6 +1448,7 @@ public final class Bukkit {
          return server.createInventory(owner, size);
      }
  
@@ -860,7 +860,7 @@ index 446e4d21c5b9b624e633875df62160a7351517d9..16ec0cd908659d6d53e565281b8db9f8
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1376,10 +1440,30 @@ public final class Bukkit {
+@@ -1397,10 +1461,30 @@ public final class Bukkit {
       * @throws IllegalArgumentException if the size is not a multiple of 9
       */
      @NotNull
@@ -891,7 +891,7 @@ index 446e4d21c5b9b624e633875df62160a7351517d9..16ec0cd908659d6d53e565281b8db9f8
      /**
       * Creates an empty merchant.
       *
-@@ -1387,7 +1471,20 @@ public final class Bukkit {
+@@ -1408,7 +1492,20 @@ public final class Bukkit {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -912,7 +912,7 @@ index 446e4d21c5b9b624e633875df62160a7351517d9..16ec0cd908659d6d53e565281b8db9f8
      public static Merchant createMerchant(@Nullable String title) {
          return server.createMerchant(title);
      }
-@@ -1504,22 +1601,47 @@ public final class Bukkit {
+@@ -1525,22 +1622,47 @@ public final class Bukkit {
          return server.isPrimaryThread();
      }
  
@@ -1129,10 +1129,10 @@ index c559f38fdb92cfee9f2e0ffb7088d1cf74a7f73d..a42f1d53340e4073038d46b7fabf5d44
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff159ae1ddd 100644
+index 6f97c680535fabf88509a49ec21704eb527b2add..b516021b6772d8266ed72b73170510ca7bfedba7 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -59,13 +59,13 @@ import org.jetbrains.annotations.Nullable;
+@@ -60,13 +60,13 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a server implementation.
   */
@@ -1148,7 +1148,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
       */
      public static final String BROADCAST_CHANNEL_ADMINISTRATIVE = "bukkit.broadcast.admin";
  
-@@ -73,7 +73,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -74,7 +74,7 @@ public interface Server extends PluginMessageRecipient {
       * Used for all announcement messages, such as informing users that a
       * player has joined.
       * <p>
@@ -1157,7 +1157,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
       */
      public static final String BROADCAST_CHANNEL_USERS = "bukkit.broadcast.user";
  
-@@ -295,7 +295,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -320,7 +320,9 @@ public interface Server extends PluginMessageRecipient {
       *
       * @param message the message
       * @return the number of players
@@ -1167,7 +1167,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
      public int broadcastMessage(@NotNull String message);
  
      /**
-@@ -913,8 +915,33 @@ public interface Server extends PluginMessageRecipient {
+@@ -938,8 +940,33 @@ public interface Server extends PluginMessageRecipient {
       * @param permission the required permission {@link Permissible
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
@@ -1201,7 +1201,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
  
      /**
       * Gets the player by the given name, regardless if they are offline or
-@@ -1112,6 +1139,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -1137,6 +1164,7 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type);
  
@@ -1209,7 +1209,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1137,6 +1165,36 @@ public interface Server extends PluginMessageRecipient {
+@@ -1162,6 +1190,36 @@ public interface Server extends PluginMessageRecipient {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -1246,7 +1246,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title);
  
      /**
-@@ -1151,6 +1209,22 @@ public interface Server extends PluginMessageRecipient {
+@@ -1176,6 +1234,22 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, int size) throws IllegalArgumentException;
  
@@ -1269,7 +1269,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1161,10 +1235,13 @@ public interface Server extends PluginMessageRecipient {
+@@ -1186,10 +1260,13 @@ public interface Server extends PluginMessageRecipient {
       *     viewed
       * @return a new inventory
       * @throws IllegalArgumentException if the size is not a multiple of 9
@@ -1283,7 +1283,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
      /**
       * Creates an empty merchant.
       *
-@@ -1172,7 +1249,18 @@ public interface Server extends PluginMessageRecipient {
+@@ -1197,7 +1274,18 @@ public interface Server extends PluginMessageRecipient {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -1302,7 +1302,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
      Merchant createMerchant(@Nullable String title);
  
      /**
-@@ -1268,20 +1356,41 @@ public interface Server extends PluginMessageRecipient {
+@@ -1293,20 +1381,41 @@ public interface Server extends PluginMessageRecipient {
       */
      boolean isPrimaryThread();
  
@@ -1344,7 +1344,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
      String getShutdownMessage();
  
      /**
-@@ -1663,7 +1772,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1688,7 +1797,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends the component to the player
           *
           * @param component the components to send
@@ -1354,7 +1354,7 @@ index 52dd3148ae2a3480982593dc627ef7eede52bc5a..0a333c1439b3623d38029b88ce6d5ff1
          public void broadcast(@NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1672,7 +1783,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1697,7 +1808,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends an array of components as a single message to the player
           *
           * @param components the components to send
@@ -1426,10 +1426,10 @@ index ac5e263d737973af077e3406a84a84baca4370db..2d91924b7f5ef16a91d40cdc1bfc3d68
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index ba69db36a2a7640fc2a63a1d9fd1b204e00d7ce7..876072a6c91bd02c9c7de53556419b8e1ac48f27 100644
+index 650adcecdca839518e0b57bc47935d010ca0f64f..fd0ae07b8a19f6b628601a487329a929f3a26c91 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -23,6 +23,15 @@ import org.bukkit.plugin.PluginDescriptionFile;
+@@ -25,6 +25,15 @@ import org.jetbrains.annotations.Nullable;
   */
  @Deprecated
  public interface UnsafeValues {
@@ -1458,10 +1458,10 @@ index efb97712cc9dc7c1e12a59f5b94e4f2ad7c6b7d8..3024468af4c073324e536c1cb26beffb
                  return warning == null || warning.value();
              }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index e75cd4484aa2d2b4f0896a6fe66d4a090047085c..1a71d628d9f593157d92f0c9fda9d3214c138352 100644
+index c4d2a13d62059ca1f148a9af909f424b745bc8df..5357291ff0f2f20bd87ab9f6e57f6a4f6ff65226 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -43,7 +43,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -44,7 +44,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a world, which may contain entities, chunks and blocks
   */
@@ -1470,7 +1470,7 @@ index e75cd4484aa2d2b4f0896a6fe66d4a090047085c..1a71d628d9f593157d92f0c9fda9d321
  
      /**
       * Gets the {@link Block} at the given coordinates
-@@ -604,6 +604,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -605,6 +605,14 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public List<Player> getPlayers();
  

--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -1318,13 +1318,13 @@ index 0000000000000000000000000000000000000000..6bf3d212a6156ad9ab0e82d1ca0a04f8
 +
 +}
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 876072a6c91bd02c9c7de53556419b8e1ac48f27..dc9a4f12d9f05a3ae7c9f1c7648123e4b3dfd115 100644
+index fd0ae07b8a19f6b628601a487329a929f3a26c91..2042e3fb0ea347148814d9838cd7bb475bd23984 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -96,4 +96,14 @@ public interface UnsafeValues {
-     String getTranslationKey(EntityType entityType);
+@@ -101,4 +101,14 @@ public interface UnsafeValues {
  
-     String getTranslationKey(ItemStack itemStack);
+     @Nullable
+     FeatureFlag getFeatureFlag(@NotNull NamespacedKey key);
 +
 +    // Paper start
 +    @Deprecated(forRemoval = true)

--- a/patches/api/0010-Timings-v2.patch
+++ b/patches/api/0010-Timings-v2.patch
@@ -2854,10 +2854,10 @@ index 0000000000000000000000000000000000000000..3e61a926620a67daec3af54b72a1b911
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 16ec0cd908659d6d53e565281b8db9f81951277d..92b3c40959eac827ed8861fec8658e57f2910628 100644
+index fe86d25bfc444ad7143fb60e88bc46ad749c8579..ffacdd168e2b68663becfcfc5c917a41f8ec817d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -802,7 +802,6 @@ public final class Bukkit {
+@@ -823,7 +823,6 @@ public final class Bukkit {
       */
      public static void reload() {
          server.reload();
@@ -2866,10 +2866,10 @@ index 16ec0cd908659d6d53e565281b8db9f81951277d..92b3c40959eac827ed8861fec8658e57
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 0a333c1439b3623d38029b88ce6d5ff159ae1ddd..bce277cd3a452769cd86dc017a2e548a170d6acc 100644
+index b516021b6772d8266ed72b73170510ca7bfedba7..cadf590c7e597a503078892b3d5671642a80eb3f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1768,6 +1768,26 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1793,6 +1793,26 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -2897,10 +2897,10 @@ index 0a333c1439b3623d38029b88ce6d5ff159ae1ddd..bce277cd3a452769cd86dc017a2e548a
           * Sends the component to the player
           *
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index dc9a4f12d9f05a3ae7c9f1c7648123e4b3dfd115..daf3ac72cae4d19c0273058dc6a1e1afe9a47f77 100644
+index 2042e3fb0ea347148814d9838cd7bb475bd23984..f68ef89f37057cf677a767026ab395f7a839a2f9 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -33,6 +33,7 @@ public interface UnsafeValues {
+@@ -35,6 +35,7 @@ public interface UnsafeValues {
      net.kyori.adventure.text.Component resolveWithContext(net.kyori.adventure.text.Component component, org.bukkit.command.CommandSender context, org.bukkit.entity.Entity scoreboardSubject, boolean bypassPermissions) throws java.io.IOException;
      // Paper end
  
@@ -2908,7 +2908,7 @@ index dc9a4f12d9f05a3ae7c9f1c7648123e4b3dfd115..daf3ac72cae4d19c0273058dc6a1e1af
      Material toLegacy(Material material);
  
      Material fromLegacy(Material material);
-@@ -106,4 +107,12 @@ public interface UnsafeValues {
+@@ -111,4 +112,12 @@ public interface UnsafeValues {
          return !Bukkit.getUnsafe().isSupportedApiVersion(plugin.getDescription().getAPIVersion());
      }
      // Paper end

--- a/patches/api/0011-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/api/0011-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index e24589a4cb42b0163e4a1455b8b11d7130b5cd41..71a09ed2b9863d2d339967f41ab6373ec27429d3 100644
+index ffacdd168e2b68663becfcfc5c917a41f8ec817d..003d1613fb1b5a24146fb3eeba0be7bf5a4eb8b8 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -76,6 +76,20 @@ public final class Bukkit {
+@@ -77,6 +77,20 @@ public final class Bukkit {
          return server;
      }
  
@@ -32,10 +32,10 @@ index e24589a4cb42b0163e4a1455b8b11d7130b5cd41..71a09ed2b9863d2d339967f41ab6373e
       * Attempts to set the {@link Server} singleton.
       * <p>
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ac087402c90dad4b3c499fcf8507e50e9099cea5..a4f8035b40eebff8afe01788781128b04247f28c 100644
+index cadf590c7e597a503078892b3d5671642a80eb3f..15b07d05d948d5df21591dc9e1b0fc0232c984ec 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -61,6 +61,18 @@ import org.jetbrains.annotations.Nullable;
+@@ -62,6 +62,18 @@ import org.jetbrains.annotations.Nullable;
   */
  public interface Server extends PluginMessageRecipient, net.kyori.adventure.audience.ForwardingAudience { // Paper
  
@@ -55,7 +55,7 @@ index ac087402c90dad4b3c499fcf8507e50e9099cea5..a4f8035b40eebff8afe01788781128b0
       * Used for all administrative messages, such as an operator using a
       * command.
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index f13dcbe448111b24b36105d25527ba87ccc9334e..3fcb73a0fc2daaeb76dd4c6757afce52c5b3118b 100644
+index 63389474a2b3f0e283b42e7004aa6a94904a3d17..974ff7116b294473ec450757e8a9341540f43dcd 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 @@ -116,9 +116,22 @@ public final class SimplePluginManager implements PluginManager {

--- a/patches/api/0013-Add-getTPS-method.patch
+++ b/patches/api/0013-Add-getTPS-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getTPS method
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 71a09ed2b9863d2d339967f41ab6373ec27429d3..397f57f0ab4844fb88c60681bf6e6e3db8a98945 100644
+index 003d1613fb1b5a24146fb3eeba0be7bf5a4eb8b8..ad7ab68bb2cb4516217984c1c8c07f7a892734a0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1891,6 +1891,17 @@ public final class Bukkit {
+@@ -1912,6 +1912,17 @@ public final class Bukkit {
          return server.getEntity(uuid);
      }
  
@@ -27,10 +27,10 @@ index 71a09ed2b9863d2d339967f41ab6373ec27429d3..397f57f0ab4844fb88c60681bf6e6e3d
       * Get the advancement specified by this key.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a4f8035b40eebff8afe01788781128b04247f28c..3f3531e208472a0e76f76e2b1a08a699527cef8f 100644
+index 15b07d05d948d5df21591dc9e1b0fc0232c984ec..1f09705726d9114821eeb8321805cac0f7966944 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1605,6 +1605,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1630,6 +1630,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      Entity getEntity(@NotNull UUID uuid);
  

--- a/patches/api/0014-Version-Command-2.0.patch
+++ b/patches/api/0014-Version-Command-2.0.patch
@@ -56,10 +56,10 @@ index 0000000000000000000000000000000000000000..a736d7bcdc5861a01b66ba36158db1c7
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index daf3ac72cae4d19c0273058dc6a1e1afe9a47f77..24fad8e59a3a5a174d24505cedda2a3fd52115b1 100644
+index f68ef89f37057cf677a767026ab395f7a839a2f9..a6aa33b9574d0278e10927007a62290e1d102e73 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -114,5 +114,12 @@ public interface UnsafeValues {
+@@ -119,5 +119,12 @@ public interface UnsafeValues {
       * @return name
       */
      String getTimingsServerName();

--- a/patches/api/0017-Add-view-distance-API.patch
+++ b/patches/api/0017-Add-view-distance-API.patch
@@ -8,10 +8,10 @@ Add per player no-tick, tick, and send view distances.
 Also add send/no-tick view distance to World.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 1a71d628d9f593157d92f0c9fda9d3214c138352..cc4e72335d8c66c8081ce64149ce3ac377e03323 100644
+index 5357291ff0f2f20bd87ab9f6e57f6a4f6ff65226..887aa6217583d224d66f6d238ac269c23725d459 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2661,6 +2661,62 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2662,6 +2662,62 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      int getSimulationDistance();
      // Spigot end
  

--- a/patches/api/0020-Expose-server-CommandMap.patch
+++ b/patches/api/0020-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 397f57f0ab4844fb88c60681bf6e6e3db8a98945..1035ce181415a19f8d6460f70d3d900e3f7017d3 100644
+index ad7ab68bb2cb4516217984c1c8c07f7a892734a0..b28d196a810e121d0502e0035b16d2c6ed2efe2d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2092,6 +2092,19 @@ public final class Bukkit {
+@@ -2113,6 +2113,19 @@ public final class Bukkit {
          return server.getUnsafe();
      }
  
@@ -29,10 +29,10 @@ index 397f57f0ab4844fb88c60681bf6e6e3db8a98945..1035ce181415a19f8d6460f70d3d900e
      public static Server.Spigot spigot() {
          return server.spigot();
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 3f3531e208472a0e76f76e2b1a08a699527cef8f..6a7b91af3e738613cf79c13e2844efe9a2efd254 100644
+index 1f09705726d9114821eeb8321805cac0f7966944..b6ff3a80fcb5c0e843caa1cfdb165cf2cadb8bd2 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1615,6 +1615,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1640,6 +1640,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      public double[] getTPS();
      // Paper end
  

--- a/patches/api/0021-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0021-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Graduate bungeecord chat API from spigot subclasses
 Change Javadoc to be accurate
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 07f092fa9edf11515b8c79ac8dca4f83905e9ff5..f05ff4bd1b41a957bb2f33ab5a88b4aeac9cebc4 100644
+index b28d196a810e121d0502e0035b16d2c6ed2efe2d..61734532c341dcbc0565189b63fd05f53b041039 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -379,6 +379,30 @@ public final class Bukkit {
+@@ -400,6 +400,30 @@ public final class Bukkit {
          return server.broadcastMessage(message);
      }
  
@@ -41,10 +41,10 @@ index 07f092fa9edf11515b8c79ac8dca4f83905e9ff5..f05ff4bd1b41a957bb2f33ab5a88b4ae
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 866559ab7cd3f351266fb41dce26a210a7702ff8..74e5f26c32e6e0c84c604b9704bfe672ee1915ef 100644
+index b6ff3a80fcb5c0e843caa1cfdb165cf2cadb8bd2..f24bb5b22975bcbdce1bf1e80cf7a1b338ad12a5 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -312,6 +312,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -337,6 +337,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Deprecated // Paper
      public int broadcastMessage(@NotNull String message);
  

--- a/patches/api/0030-Add-command-to-reload-permissions.yml-and-require-co.patch
+++ b/patches/api/0030-Add-command-to-reload-permissions.yml-and-require-co.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add command to reload permissions.yml and require confirm to
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 316146305465b68b703e898206745de94ad5350f..6311d7ef36b3c6922c73695c353c561c507f2128 100644
+index 61734532c341dcbc0565189b63fd05f53b041039..cb021ea553f7330473f8e8bcc47803f8c544971a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2127,6 +2127,13 @@ public final class Bukkit {
+@@ -2148,6 +2148,13 @@ public final class Bukkit {
      public static org.bukkit.command.CommandMap getCommandMap() {
          return server.getCommandMap();
      }
@@ -24,10 +24,10 @@ index 316146305465b68b703e898206745de94ad5350f..6311d7ef36b3c6922c73695c353c561c
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index bef555b3de44fed312b45a5d5cd811b18fda88c8..994f494fe7cace5c88738858def4051788391a3c 100644
+index f24bb5b22975bcbdce1bf1e80cf7a1b338ad12a5..ecd0b92f487b9c2d1f7fed1e98e10c8c0946ab9e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1876,4 +1876,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1901,4 +1901,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      Spigot spigot();
      // Spigot end

--- a/patches/api/0043-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/api/0043-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 6311d7ef36b3c6922c73695c353c561c507f2128..a314ff1363cb527fa7e1b366f9191939e9c7ca6e 100644
+index cb021ea553f7330473f8e8bcc47803f8c544971a..7f5da77075a8c180848312d85e554a0e309fa3e5 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2134,6 +2134,15 @@ public final class Bukkit {
+@@ -2155,6 +2155,15 @@ public final class Bukkit {
      public static void reloadPermissions() {
          server.reloadPermissions();
      }
@@ -26,10 +26,10 @@ index 6311d7ef36b3c6922c73695c353c561c507f2128..a314ff1363cb527fa7e1b366f9191939
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 994f494fe7cace5c88738858def4051788391a3c..610475aff60b7f19c4bedb932985c736fb890684 100644
+index ecd0b92f487b9c2d1f7fed1e98e10c8c0946ab9e..b2d13b1e31a09aad903f0c24b14641f911cfaee5 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1878,4 +1878,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1903,4 +1903,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      // Spigot end
  
      void reloadPermissions(); // Paper

--- a/patches/api/0051-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/api/0051-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -7,10 +7,10 @@ Provides counts without the ineffeciency of using .getEntities().size()
 which creates copy of the collections.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 8a6a548314eef8d486be908e38e3a4562f26bdb4..749d3de7dad480965be536938733d72bdfc2995b 100644
+index 887aa6217583d224d66f6d238ac269c23725d459..4ef6bbfa753da439ac57bd8d70dd114d73665c8d 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -45,6 +45,33 @@ import org.jetbrains.annotations.Nullable;
+@@ -46,6 +46,33 @@ import org.jetbrains.annotations.Nullable;
   */
  public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient, Metadatable, PersistentDataHolder, Keyed, net.kyori.adventure.audience.ForwardingAudience { // Paper
  

--- a/patches/api/0054-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/api/0054-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index a314ff1363cb527fa7e1b366f9191939e9c7ca6e..d3d8c5ac59cee2ec24e91223e0c994016a4f9752 100644
+index 7f5da77075a8c180848312d85e554a0e309fa3e5..8bc4615fd1e227de53d18c3ad6172f62fd38893b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2143,6 +2143,16 @@ public final class Bukkit {
+@@ -2164,6 +2164,16 @@ public final class Bukkit {
      public static boolean reloadCommandAliases() {
          return server.reloadCommandAliases();
      }
@@ -27,10 +27,10 @@ index a314ff1363cb527fa7e1b366f9191939e9c7ca6e..d3d8c5ac59cee2ec24e91223e0c99401
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 610475aff60b7f19c4bedb932985c736fb890684..a8d3addae5b0ed261d6a27052ad4e54970de597c 100644
+index b2d13b1e31a09aad903f0c24b14641f911cfaee5..3f307c4e1f9231164f146d7d44a7327aee0293bd 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1880,4 +1880,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1905,4 +1905,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      void reloadPermissions(); // Paper
  
      boolean reloadCommandAliases(); // Paper
@@ -46,7 +46,7 @@ index 610475aff60b7f19c4bedb932985c736fb890684..a8d3addae5b0ed261d6a27052ad4e549
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
-index 6fd341482d5250ad814e870360e40b52427f799a..a26df5f6341d22ecd5e71da59b8f091848e627ad 100644
+index 5cfd88eec9bf02e83d77b6fce1a5c14b7687f48b..1c6205cc667bbec8f6aca479f13b3e9cfcd63ab2 100644
 --- a/src/main/java/org/bukkit/command/Command.java
 +++ b/src/main/java/org/bukkit/command/Command.java
 @@ -99,7 +99,7 @@ public abstract class Command {

--- a/patches/api/0055-Fix-upstream-javadocs.patch
+++ b/patches/api/0055-Fix-upstream-javadocs.patch
@@ -53,10 +53,10 @@ index 96ef22fe879c7be4f67bbb4d60c45ad11764dd5b..5dc9f9ede98d93925c99ee382e93f15f
       * @param target the target to remove from this list
       */
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f66552fd08092761ac83b112aa1aa7584cfe0c32..72d414b756d3531ca83362b20097ab63656fecb1 100644
+index 8bc4615fd1e227de53d18c3ad6172f62fd38893b..a0faa4ef90086bfb7b49bd59e566c01fa9ec380d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1269,10 +1269,7 @@ public final class Bukkit {
+@@ -1290,10 +1290,7 @@ public final class Bukkit {
      }
  
      /**
@@ -68,7 +68,7 @@ index f66552fd08092761ac83b112aa1aa7584cfe0c32..72d414b756d3531ca83362b20097ab63
       *
       * @param type the type of list to fetch, cannot be null
       * @return a ban list of the specified type
-@@ -1334,6 +1331,8 @@ public final class Bukkit {
+@@ -1355,6 +1352,8 @@ public final class Bukkit {
  
      /**
       * Gets every player that has ever played on this server.
@@ -130,10 +130,10 @@ index 43f5aab2fe70af5f570de1f21eca83905f1e2f57..05c29cbd2ae1ca0434a90f8389479bd6
       * @param statePredicate The predicate which should get used to test if a block should be set or not.
       * @return true if the tree was created successfully, otherwise false
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 7d06f2a8f17cf42eeb05567e3f5c0c16074af9bc..9b5dcd897df91e6ba3c71c216e7a180b76a96694 100644
+index 3f307c4e1f9231164f146d7d44a7327aee0293bd..8f64461f8c05143e8e8e10c0efbb6d6b8f71fd83 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -510,13 +510,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -535,13 +535,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * </ul>
       * <p>
       * <b>Note:</b> If set to 0, {@link SpawnCategory} mobs spawning will be disabled.
@@ -148,7 +148,7 @@ index 7d06f2a8f17cf42eeb05567e3f5c0c16074af9bc..9b5dcd897df91e6ba3c71c216e7a180b
       */
      public int getTicksPerSpawns(@NotNull SpawnCategory spawnCategory);
  
-@@ -1076,10 +1073,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1101,10 +1098,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      public Set<OfflinePlayer> getBannedPlayers();
  
      /**
@@ -160,7 +160,7 @@ index 7d06f2a8f17cf42eeb05567e3f5c0c16074af9bc..9b5dcd897df91e6ba3c71c216e7a180b
       *
       * @param type the type of list to fetch, cannot be null
       * @return a ban list of the specified type
-@@ -1129,6 +1123,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1154,6 +1148,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
  
      /**
       * Gets every player that has ever played on this server.
@@ -170,10 +170,10 @@ index 7d06f2a8f17cf42eeb05567e3f5c0c16074af9bc..9b5dcd897df91e6ba3c71c216e7a180b
       * @return an array containing all previous players
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 730894d0b1b891a59c7ad1d78ff1e2cd061ae913..4270367085a83c368f96c8eab669f1bdc0e74f4d 100644
+index 4ef6bbfa753da439ac57bd8d70dd114d73665c8d..7f23527168a33b92d823f76765edfe00abe0e4f6 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2575,7 +2575,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2576,7 +2576,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link StructureType}.
       * Finding unexplored structures can, and will, block if the world is
@@ -182,7 +182,7 @@ index 730894d0b1b891a59c7ad1d78ff1e2cd061ae913..4270367085a83c368f96c8eab669f1bd
       * temporarily freezing while locating an unexplored structure.
       * <p>
       * The {@code radius} is not a rigid square radius. Each structure may alter
-@@ -2609,7 +2609,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2610,7 +2610,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link StructureType}.
       * Finding unexplored structures can, and will, block if the world is
@@ -191,7 +191,7 @@ index 730894d0b1b891a59c7ad1d78ff1e2cd061ae913..4270367085a83c368f96c8eab669f1bd
       * temporarily freezing while locating an unexplored structure.
       * <p>
       * The {@code radius} is not a rigid square radius. Each structure may alter
-@@ -2642,7 +2642,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2643,7 +2643,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link Structure}. Finding
       * unexplored structures can, and will, block if the world is looking in

--- a/patches/api/0059-Basic-PlayerProfile-API.patch
+++ b/patches/api/0059-Basic-PlayerProfile-API.patch
@@ -321,10 +321,10 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 72d414b756d3531ca83362b20097ab63656fecb1..e6707eca1dd96a4fb6c019285c764684aa336ebf 100644
+index a0faa4ef90086bfb7b49bd59e566c01fa9ec380d..cbd89729d1ba4866fdb9b72b7f0a4fbd4e161cd2 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2152,6 +2152,83 @@ public final class Bukkit {
+@@ -2173,6 +2173,83 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
@@ -409,10 +409,10 @@ index 72d414b756d3531ca83362b20097ab63656fecb1..e6707eca1dd96a4fb6c019285c764684
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 9b5dcd897df91e6ba3c71c216e7a180b76a96694..d769ad908c3454fa9088a42f32250bbdf8f9fa7e 100644
+index 8f64461f8c05143e8e8e10c0efbb6d6b8f71fd83..7f6400c58530d4827c197f3d1fbabfa34554010f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1885,5 +1885,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1910,5 +1910,74 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index e6707eca1dd96a4fb6c019285c764684aa336ebf..008a960a63cf3efe87aab1e237c3b87056f58302 100644
+index cbd89729d1ba4866fdb9b72b7f0a4fbd4e161cd2..551948a83965b38bf29aeb8daafc25bde05a5a1c 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1199,8 +1199,10 @@ public final class Bukkit {
+@@ -1220,8 +1220,10 @@ public final class Bukkit {
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if both the unique id is
       * <code>null</code> and the name is <code>null</code> or blank
@@ -20,7 +20,7 @@ index e6707eca1dd96a4fb6c019285c764684aa336ebf..008a960a63cf3efe87aab1e237c3b870
      public static PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name) {
          return server.createPlayerProfile(uniqueId, name);
      }
-@@ -1211,8 +1213,10 @@ public final class Bukkit {
+@@ -1232,8 +1234,10 @@ public final class Bukkit {
       * @param uniqueId the unique id
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the unique id is <code>null</code>
@@ -31,7 +31,7 @@ index e6707eca1dd96a4fb6c019285c764684aa336ebf..008a960a63cf3efe87aab1e237c3b870
      public static PlayerProfile createPlayerProfile(@NotNull UUID uniqueId) {
          return server.createPlayerProfile(uniqueId);
      }
-@@ -1224,8 +1228,10 @@ public final class Bukkit {
+@@ -1245,8 +1249,10 @@ public final class Bukkit {
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the name is <code>null</code> or
       * blank
@@ -56,10 +56,10 @@ index 5acb0d36a008cf5ad332c867e9303d35235b4028..b1ded556a1ce4e1d3c873ab9d7f799b6
      /**
       * Checks if this player is banned or not
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d769ad908c3454fa9088a42f32250bbdf8f9fa7e..2eaf31f1053787b39184dfa8ac6df87d93b0a7b7 100644
+index 7f6400c58530d4827c197f3d1fbabfa34554010f..e4c85e67713c5ed4b8b1fcc3c4231327e987a460 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1017,8 +1017,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1042,8 +1042,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if both the unique id is
       * <code>null</code> and the name is <code>null</code> or blank
@@ -70,7 +70,7 @@ index d769ad908c3454fa9088a42f32250bbdf8f9fa7e..2eaf31f1053787b39184dfa8ac6df87d
      PlayerProfile createPlayerProfile(@Nullable UUID uniqueId, @Nullable String name);
  
      /**
-@@ -1027,8 +1029,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1052,8 +1054,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param uniqueId the unique id
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the unique id is <code>null</code>
@@ -81,7 +81,7 @@ index d769ad908c3454fa9088a42f32250bbdf8f9fa7e..2eaf31f1053787b39184dfa8ac6df87d
      PlayerProfile createPlayerProfile(@NotNull UUID uniqueId);
  
      /**
-@@ -1038,8 +1042,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1063,8 +1067,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return the new PlayerProfile
       * @throws IllegalArgumentException if the name is <code>null</code> or
       * blank

--- a/patches/api/0092-getPlayerUniqueId-API.patch
+++ b/patches/api/0092-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 008a960a63cf3efe87aab1e237c3b87056f58302..d0bc1943f6a3a17fe890b018c2b99f815a5c9b61 100644
+index 551948a83965b38bf29aeb8daafc25bde05a5a1c..7113f38eac400bc86a427972e501b0ca5653dae6 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -657,6 +657,20 @@ public final class Bukkit {
+@@ -678,6 +678,20 @@ public final class Bukkit {
          return server.getPlayer(id);
      }
  
@@ -34,10 +34,10 @@ index 008a960a63cf3efe87aab1e237c3b87056f58302..d0bc1943f6a3a17fe890b018c2b99f81
       * Gets the plugin manager for interfacing with plugins.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 2eaf31f1053787b39184dfa8ac6df87d93b0a7b7..f5223be2d011b56a6138257bcae3ea2335a5940b 100644
+index e4c85e67713c5ed4b8b1fcc3c4231327e987a460..878b3ff92be8fcb977240824ae404fb5bed42d48 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -559,6 +559,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -584,6 +584,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      public Player getPlayer(@NotNull UUID id);
  

--- a/patches/api/0098-Additional-world.getNearbyEntities-API-s.patch
+++ b/patches/api/0098-Additional-world.getNearbyEntities-API-s.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Additional world.getNearbyEntities API's
 Provides more methods to get nearby entities, and filter by types and predicates
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 4270367085a83c368f96c8eab669f1bdc0e74f4d..ee06fdba69313e5352e5d1dca381c8131112fc3a 100644
+index 7f23527168a33b92d823f76765edfe00abe0e4f6..0f76496471c50d5f18cedc735e667265e6c27422 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -1,6 +1,9 @@
@@ -19,7 +19,7 @@ index 4270367085a83c368f96c8eab669f1bdc0e74f4d..ee06fdba69313e5352e5d1dca381c813
  import java.util.Collection;
  import java.util.HashMap;
  import java.util.List;
-@@ -623,6 +626,256 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -624,6 +627,256 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Collection<Entity> getEntitiesByClasses(@NotNull Class<?>... classes);
  

--- a/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -522,10 +522,10 @@ index 7336edb91e7095cce381318220496b51962afbe9..0125890a258ee58a43990285b341f8a6
       * Options which can be applied to redstone dust particles - a particle
       * color and size.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index ee06fdba69313e5352e5d1dca381c8131112fc3a..211d702f07e724d1c56f47048e05518d9f5bba5e 100644
+index 0f76496471c50d5f18cedc735e667265e6c27422..0ed7a7db90856ff50ed1354f9914c0cc321d2d09 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2775,7 +2775,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2776,7 +2776,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
       */

--- a/patches/api/0114-Expand-Explosions-API.patch
+++ b/patches/api/0114-Expand-Explosions-API.patch
@@ -106,10 +106,10 @@ index 6693e3d8dc2519facb12db981a6b6325faa095bf..5a6b33c6d9a68affdbd02c13fdb0854e
       * Returns a list of entities within a bounding box centered around a Location.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 211d702f07e724d1c56f47048e05518d9f5bba5e..ca46efebe628ac558470e5b351a13821227f8c00 100644
+index 0ed7a7db90856ff50ed1354f9914c0cc321d2d09..fa192be9916ccd0a443281c104637ba09cde7755 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1390,6 +1390,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1391,6 +1391,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public boolean createExplosion(@NotNull Location loc, float power, boolean setFire);
  

--- a/patches/api/0118-Add-World.getEntity-UUID-API.patch
+++ b/patches/api/0118-Add-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index ca46efebe628ac558470e5b351a13821227f8c00..e0c9a5060d139a6b897d42518136f814e5174a9c 100644
+index fa192be9916ccd0a443281c104637ba09cde7755..e9af7ce218e44940cd074cc0d511268284e312ef 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -910,6 +910,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -911,6 +911,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Collection<Entity> getNearbyEntities(@NotNull Location location, double x, double y, double z);
  

--- a/patches/api/0132-Provide-Chunk-Coordinates-as-a-Long-API.patch
+++ b/patches/api/0132-Provide-Chunk-Coordinates-as-a-Long-API.patch
@@ -44,10 +44,10 @@ index efbfed855248cff8b4bdbfc181d3e82058df4749..766d643f0fe79660942fdad25e39e488
       * Gets the world containing this chunk
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index e0c9a5060d139a6b897d42518136f814e5174a9c..710fb46ca92d9e4f3d9498603dd9e3f6a02269cc 100644
+index e9af7ce218e44940cd074cc0d511268284e312ef..745933ca3fee4efdba7660f157407ebe0cb91a6b 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -178,6 +178,22 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -179,6 +179,22 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Chunk getChunkAt(@NotNull Block block);
  

--- a/patches/api/0135-Allow-Blocks-to-be-accessed-via-a-long-key.patch
+++ b/patches/api/0135-Allow-Blocks-to-be-accessed-via-a-long-key.patch
@@ -50,10 +50,10 @@ index 943c3364f6b931fe11f9a6099504590b2da34657..16a604b6315daff228c827fe02b1234c
       * @return A new location where X/Y/Z are the center of the block
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 710fb46ca92d9e4f3d9498603dd9e3f6a02269cc..ad862d3822594925d2a740b384f8c1b79c4d92fc 100644
+index 745933ca3fee4efdba7660f157407ebe0cb91a6b..18376c635c689b7aaf1a567bee3d1faaaa28a9f0 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -95,6 +95,40 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -96,6 +96,40 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Block getBlockAt(@NotNull Location location);
  

--- a/patches/api/0140-isChunkGenerated-API.patch
+++ b/patches/api/0140-isChunkGenerated-API.patch
@@ -34,10 +34,10 @@ index 16a604b6315daff228c827fe02b1234cca3e884d..20978b269a7757a561d6b872cc77898b
      /**
       * Sets the position of this Location and returns itself
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index ad862d3822594925d2a740b384f8c1b79c4d92fc..9d3a3d67712037a4edb723dbf3c9f121680f2b7a 100644
+index 18376c635c689b7aaf1a567bee3d1faaaa28a9f0..4c3150a959593c461f6cf92e9fd8a5f22ff94e8a 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -226,6 +226,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -227,6 +227,17 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      public default Chunk getChunkAt(long chunkKey) {
          return getChunkAt((int) chunkKey, (int) (chunkKey >> 32));
      }

--- a/patches/api/0142-Async-Chunks-API.patch
+++ b/patches/api/0142-Async-Chunks-API.patch
@@ -8,10 +8,10 @@ Adds API's to load or generate chunks asynchronously.
 Also adds utility methods to Entity to teleport asynchronously.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 9d3a3d67712037a4edb723dbf3c9f121680f2b7a..75511f11d4c43dc997b6eb8947a2f225301ea29e 100644
+index 4c3150a959593c461f6cf92e9fd8a5f22ff94e8a..265d1751c5460121b29129d9588ef1a13564073b 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -935,6 +935,482 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -936,6 +936,482 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
          }
          return nearby;
      }

--- a/patches/api/0146-Add-Git-information-to-version-command-on-startup.patch
+++ b/patches/api/0146-Add-Git-information-to-version-command-on-startup.patch
@@ -48,10 +48,10 @@ index 0000000000000000000000000000000000000000..909617079db61b675cc7b60b44ef96b3
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index aa4217c87756cffe774aaa2d390217b9056c4b95..6567da9e9c89f1995b9c3544b4dd767d66e6f5f2 100644
+index 7113f38eac400bc86a427972e501b0ca5653dae6..733b537d4236e5cb06efc188183ad876db31c0ff 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -54,6 +54,7 @@ import org.bukkit.util.CachedServerIcon;
+@@ -55,6 +55,7 @@ import org.bukkit.util.CachedServerIcon;
  import org.jetbrains.annotations.Contract;
  import org.jetbrains.annotations.NotNull;
  import org.jetbrains.annotations.Nullable;
@@ -59,7 +59,7 @@ index aa4217c87756cffe774aaa2d390217b9056c4b95..6567da9e9c89f1995b9c3544b4dd767d
  
  /**
   * Represents the Bukkit core, for version and Server singleton handling
-@@ -103,7 +104,25 @@ public final class Bukkit {
+@@ -104,7 +105,25 @@ public final class Bukkit {
          }
  
          Bukkit.server = server;

--- a/patches/api/0156-Add-sun-related-API.patch
+++ b/patches/api/0156-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 75511f11d4c43dc997b6eb8947a2f225301ea29e..4587b866d3d3bcd0080f072245d46f719d61f767 100644
+index 265d1751c5460121b29129d9588ef1a13564073b..eea0b7edd0a4e8a698c21e8b468f802e072a68cc 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1762,6 +1762,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1763,6 +1763,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public void setFullTime(long time);
  

--- a/patches/api/0160-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0160-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 12cb4630257669222dded61c54ce210cd082a720..c02b663ab711daa06de054a92f09485231824458 100644
+index 733b537d4236e5cb06efc188183ad876db31c0ff..71cd6f405c35e1e1a02c1bac64b509ae6ba5c7cd 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2192,6 +2192,28 @@ public final class Bukkit {
+@@ -2213,6 +2213,28 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
@@ -38,10 +38,10 @@ index 12cb4630257669222dded61c54ce210cd082a720..c02b663ab711daa06de054a92f094852
       * Creates a PlayerProfile for the specified uuid, with name as null.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f5223be2d011b56a6138257bcae3ea2335a5940b..20f9384c30f46e11631a7f79c48915bf55762858 100644
+index 878b3ff92be8fcb977240824ae404fb5bed42d48..43c14b492879d56993586a7b64eb374654ca67a6 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1904,6 +1904,23 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1929,6 +1929,23 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  

--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -9,10 +9,10 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c02b663ab711daa06de054a92f09485231824458..08da910016cc55f008acf20070daaa82f3128bf1 100644
+index 71cd6f405c35e1e1a02c1bac64b509ae6ba5c7cd..a5b792d94a2357f0536def00e80430d00a0b4fa7 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -806,9 +806,8 @@ public final class Bukkit {
+@@ -827,9 +827,8 @@ public final class Bukkit {
       *
       * @param id the id of the map to get
       * @return a map view if it exists, or null otherwise
@@ -23,7 +23,7 @@ index c02b663ab711daa06de054a92f09485231824458..08da910016cc55f008acf20070daaa82
      @Nullable
      public static MapView getMap(int id) {
          return server.getMap(id);
-@@ -1200,10 +1199,8 @@ public final class Bukkit {
+@@ -1221,10 +1220,8 @@ public final class Bukkit {
       * @param name the name the player to retrieve
       * @return an offline player
       * @see #getOfflinePlayer(java.util.UUID)
@@ -35,7 +35,7 @@ index c02b663ab711daa06de054a92f09485231824458..08da910016cc55f008acf20070daaa82
      @NotNull
      public static OfflinePlayer getOfflinePlayer(@NotNull String name) {
          return server.getOfflinePlayer(name);
-@@ -1749,7 +1746,7 @@ public final class Bukkit {
+@@ -1770,7 +1767,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -90,7 +90,7 @@ index 20978b269a7757a561d6b872cc77898b44bbd272..2b9a117804a8ca54b47e51e23359bd6e
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index fb23fce97a1930b968b76fa9ff4fbbb452768096..20cc192e89562e1455ec3eacc15593c4eed89907 100644
+index 2126636b646068312a49242917808f5d91bce614..96e44836b3634a53d8a9f0785d4cdcec872b95f7 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4578,11 +4578,11 @@ public enum Material implements Keyed, Translatable {
@@ -156,7 +156,7 @@ index f43209cf7b752c26718c303ca8c3e1c7d9912ad3..f0094e6fb05e526736629ad3181c8d2c
  
      /**
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 3e5d6fd08bcc66593d7669104705436f6dfb20fc..4a3c42f9c480c53f935d09bcc3656259c755661d 100644
+index bb333b90e103e49923808b1ee0e1cd2787086cea..1976ed42f255825d1eaf2ee2c9465d22e81abdb3 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
 @@ -248,8 +248,11 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
@@ -186,10 +186,10 @@ index 6277451c3c6c551078c237cd767b6d70c4f585ea..10f5cfb1885833a1d2c1027c03974da4
      CRACKED(0x0),
      GLYPHED(0x1),
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 20f9384c30f46e11631a7f79c48915bf55762858..e75e02b662cc16c2e76ee38dea3cbc8626e51a3c 100644
+index 43c14b492879d56993586a7b64eb374654ca67a6..38eb76e9f0dc8dd377bb82990eea0c598bdb1000 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -670,9 +670,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -695,9 +695,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @param id the id of the map to get
       * @return a map view if it exists, or null otherwise
@@ -200,7 +200,7 @@ index 20f9384c30f46e11631a7f79c48915bf55762858..e75e02b662cc16c2e76ee38dea3cbc86
      @Nullable
      public MapView getMap(int id);
  
-@@ -1001,10 +1000,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1026,10 +1025,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param name the name the player to retrieve
       * @return an offline player
       * @see #getOfflinePlayer(java.util.UUID)
@@ -212,7 +212,7 @@ index 20f9384c30f46e11631a7f79c48915bf55762858..e75e02b662cc16c2e76ee38dea3cbc86
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  
-@@ -1467,7 +1464,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1492,7 +1489,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -265,10 +265,10 @@ index e455eb21abf121dc6ff10ff8a13dd06f67096a8f..bbc01e7c192ae6689c301670047ff114
          return origin;
      }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 4587b866d3d3bcd0080f072245d46f719d61f767..d667ac100f1bf11f4a8f9e8c53887a86e890ac6f 100644
+index eea0b7edd0a4e8a698c21e8b468f802e072a68cc..948a989aeea4165f0714db69c70ca8dcb488d44d 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -396,9 +396,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -397,9 +397,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @param z Z-coordinate of the chunk
       * @return Whether the chunk was actually refreshed
       *
@@ -279,7 +279,7 @@ index 4587b866d3d3bcd0080f072245d46f719d61f767..d667ac100f1bf11f4a8f9e8c53887a86
      public boolean refreshChunk(int x, int z);
  
      /**
-@@ -2111,8 +2110,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2112,8 +2111,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     MaterialData} are null or {@link Material} of the {@link MaterialData} is not a block

--- a/patches/api/0175-Add-Heightmap-API.patch
+++ b/patches/api/0175-Add-Heightmap-API.patch
@@ -103,10 +103,10 @@ index 2b9a117804a8ca54b47e51e23359bd6e01087641..6bbf8468bc47e82b0aeb164e49cdb73d
       * Creates explosion at this location with given power
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index d667ac100f1bf11f4a8f9e8c53887a86e890ac6f..711fc41dbd029fa2d43f35165b62d09de89509b7 100644
+index 948a989aeea4165f0714db69c70ca8dcb488d44d..530d656aa5573c9783d07de23379657fe0c7cae5 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -148,6 +148,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -149,6 +149,87 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public Block getHighestBlockAt(@NotNull Location location);
  

--- a/patches/api/0180-Expose-the-internal-current-tick.patch
+++ b/patches/api/0180-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 08da910016cc55f008acf20070daaa82f3128bf1..9790aef0fe2c7ff0818455b1b3870a560eee8448 100644
+index a5b792d94a2357f0536def00e80430d00a0b4fa7..e32094b8e7710158f75450c477c91110d83ba71b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2287,6 +2287,10 @@ public final class Bukkit {
+@@ -2308,6 +2308,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfileExact(uuid, name);
      }
@@ -20,10 +20,10 @@ index 08da910016cc55f008acf20070daaa82f3128bf1..9790aef0fe2c7ff0818455b1b3870a56
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e75e02b662cc16c2e76ee38dea3cbc8626e51a3c..9872df17c5b30b876a1423e841db914bf255f9a5 100644
+index 38eb76e9f0dc8dd377bb82990eea0c598bdb1000..fc8a6468c61a84a1fe719505adb274d48e24e8f4 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1986,5 +1986,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2011,5 +2011,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfileExact(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0186-Add-tick-times-API.patch
+++ b/patches/api/0186-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9790aef0fe2c7ff0818455b1b3870a560eee8448..20877004d927d9f6f998ff9502c18ae111ad6490 100644
+index e32094b8e7710158f75450c477c91110d83ba71b..82940fa20f5f958e6473f318ee2c5da3647e0228 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1959,6 +1959,25 @@ public final class Bukkit {
+@@ -1980,6 +1980,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index 9790aef0fe2c7ff0818455b1b3870a560eee8448..20877004d927d9f6f998ff9502c18ae1
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 9872df17c5b30b876a1423e841db914bf255f9a5..68ce7ab1d0a519e270292db103c0b312649f886a 100644
+index fc8a6468c61a84a1fe719505adb274d48e24e8f4..ffd1f47690083b40aa349ed0f92d6fc2fdc56609 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1648,6 +1648,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1673,6 +1673,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0187-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0187-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 20877004d927d9f6f998ff9502c18ae111ad6490..80fce2f8b89384691304f69e68de1c1676a905fa 100644
+index 82940fa20f5f958e6473f318ee2c5da3647e0228..39fdcada6aa98058491aa6b5e5b9943c8a57a59d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2310,6 +2310,15 @@ public final class Bukkit {
+@@ -2331,6 +2331,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index 20877004d927d9f6f998ff9502c18ae111ad6490..80fce2f8b89384691304f69e68de1c16
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 68ce7ab1d0a519e270292db103c0b312649f886a..2fc042affe26118c50eacea700aaea0c82e10094 100644
+index ffd1f47690083b40aa349ed0f92d6fc2fdc56609..65daa359f000cf1acc3067af62e3210ced378519 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2008,5 +2008,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2033,5 +2033,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0188-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/api/0188-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Raw Byte ItemStack Serialization
 Serializes using NBT which is safer for server data migrations than bukkits format.
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 24fad8e59a3a5a174d24505cedda2a3fd52115b1..ee9ed5f0e2936c740903784b01b9e2fff75b92f8 100644
+index a6aa33b9574d0278e10927007a62290e1d102e73..beddcb13a598d799c8ae1cec9c01c900e38b1458 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -121,5 +121,9 @@ public interface UnsafeValues {
+@@ -126,5 +126,9 @@ public interface UnsafeValues {
      default com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {
          return new com.destroystokyo.paper.util.VersionFetcher.DummyVersionFetcher();
      }
@@ -20,7 +20,7 @@ index 24fad8e59a3a5a174d24505cedda2a3fd52115b1..ee9ed5f0e2936c740903784b01b9e2ff
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index b15645cd56c245214bb5b87b36395fbc8e86e3d3..7c280d7beeb42dca52e36e77bbd41742b2572710 100644
+index 60a25898fb17c467ffae05039fcd4d3b154a99ff..3da071798b89e1dd1453f4339af87933cdf0105e 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -639,6 +639,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat

--- a/patches/api/0194-Expose-game-version.patch
+++ b/patches/api/0194-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 51a43429e58fbebf8c95d23257cd9c84ce57b1aa..f4897529322f57eaf0d26ce82307dcd785511af8 100644
+index 39fdcada6aa98058491aa6b5e5b9943c8a57a59d..e1a9a0ec6036133aa8fb195d22611df221bf5661 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -155,6 +155,18 @@ public final class Bukkit {
+@@ -156,6 +156,18 @@ public final class Bukkit {
          return server.getBukkitVersion();
      }
  
@@ -28,10 +28,10 @@ index 51a43429e58fbebf8c95d23257cd9c84ce57b1aa..f4897529322f57eaf0d26ce82307dcd7
       * Gets a view of all currently logged in players. This {@linkplain
       * Collections#unmodifiableCollection(Collection) view} is a reused
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 122ef60bcb1548713f2e355cb77eccbebcd17f04..97c2708b69ff01f9e7898ad7282016cac605bc79 100644
+index 65daa359f000cf1acc3067af62e3210ced378519..357f59f07387d3de75a0792e7e883cb82aafa2e2 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -113,6 +113,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -114,6 +114,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public String getBukkitVersion();
  

--- a/patches/api/0195-Add-Mob-Goal-API.patch
+++ b/patches/api/0195-Add-Mob-Goal-API.patch
@@ -524,10 +524,10 @@ index 0000000000000000000000000000000000000000..dddbb661265aa23f88d93d0681f418f4
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 163daca0d6b861a7813848f2ce14713fdac65844..c14067d03cfe4c75896d9d1409f0fca57793f7d0 100644
+index e1a9a0ec6036133aa8fb195d22611df221bf5661..ce409a88b1f7fc519b2d7795005752b4349e4176 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2331,6 +2331,16 @@ public final class Bukkit {
+@@ -2352,6 +2352,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -545,10 +545,10 @@ index 163daca0d6b861a7813848f2ce14713fdac65844..c14067d03cfe4c75896d9d1409f0fca5
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 2ea033b75168aac30caa645f8910cc0b0c27942e..0944406ccb12104ea0ec3371e731d8fd0b8f600d 100644
+index 357f59f07387d3de75a0792e7e883cb82aafa2e2..d080d535275b28400471265315e0d70bf806cbb8 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2025,5 +2025,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2050,5 +2050,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0207-Add-setMaxPlayers-API.patch
+++ b/patches/api/0207-Add-setMaxPlayers-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 93a74792837e6dcff354e5f0afb7aacd0a19f7e1..6d98664f2da191c2327e80b8212c1ad979f7d6ac 100644
+index ce409a88b1f7fc519b2d7795005752b4349e4176..bae2ef297ba585c916ea06c4316e9511696000da 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -208,6 +208,17 @@ public final class Bukkit {
+@@ -209,6 +209,17 @@ public final class Bukkit {
          return server.getMaxPlayers();
      }
  
@@ -27,10 +27,10 @@ index 93a74792837e6dcff354e5f0afb7aacd0a19f7e1..6d98664f2da191c2327e80b8212c1ad9
       * Get the game port that the server runs on.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index cd3ce4155ff46d85d4c603a688dd96893400ed77..936ebaf531a76cab12809cfa334e2b0d89e625c3 100644
+index d080d535275b28400471265315e0d70bf806cbb8..31e8a002f9b0641f16bc4cf330e6022b13942321 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -160,6 +160,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -161,6 +161,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      public int getMaxPlayers();
  

--- a/patches/api/0212-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0212-Add-methods-to-get-translation-keys.patch
@@ -144,7 +144,7 @@ index 753bfcec441533071120d925c83789ef53afa176..c6bc84a8755b2fe5d7d8d3ec857700ec
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 20cc192e89562e1455ec3eacc15593c4eed89907..3da281e454f1f242c57e0174917084557f9c85df 100644
+index 96e44836b3634a53d8a9f0785d4cdcec872b95f7..fb4d98c8538e21936b256a7cbc8242e7a3b3b26c 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -117,7 +117,7 @@ import org.jetbrains.annotations.Nullable;
@@ -257,7 +257,7 @@ index a5908d0a03801757d1f6184d73c3c89981afa107..d268498c779d6b2ec07812d4d1c0b168
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 06ef9e133125d80127e1dbd6ae0eda89fa08a1d7..35ed58bce2589bb097dd0f6bf2a6ebd76dc31fcd 100644
+index 232662f3130ca49156ed8b71acf4495aea33c212..5ae85ddc2cff3145dcba877a7bf55abd818f6881 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -32,7 +32,7 @@ import org.jetbrains.annotations.Nullable;
@@ -311,7 +311,7 @@ index 4d5f0837bd0e02a30c943d8969fb6b13452322e0..a39f9c078f42451bd122f3e3729d10ca
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/EntityType.java b/src/main/java/org/bukkit/entity/EntityType.java
-index bed9c519a594f44191c2e13b2f13a0de906e21e5..712db16df7a3b30f844b391321b5acd6ffa5aec5 100644
+index 16f1ed5bdad79928806b4509af03581bdbf002c5..bf3aa78cb901301571aa3fad5bd0bcebee8e6e1b 100644
 --- a/src/main/java/org/bukkit/entity/EntityType.java
 +++ b/src/main/java/org/bukkit/entity/EntityType.java
 @@ -24,7 +24,7 @@ import org.jetbrains.annotations.Contract;
@@ -323,7 +323,7 @@ index bed9c519a594f44191c2e13b2f13a0de906e21e5..712db16df7a3b30f844b391321b5acd6
  
      // These strings MUST match the strings in nms.EntityTypes and are case sensitive.
      /**
-@@ -441,7 +441,19 @@ public enum EntityType implements Keyed, Translatable {
+@@ -441,10 +441,22 @@ public enum EntityType implements Keyed, Translatable {
  
      @Override
      @NotNull
@@ -331,7 +331,7 @@ index bed9c519a594f44191c2e13b2f13a0de906e21e5..712db16df7a3b30f844b391321b5acd6
      public String getTranslationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }
-+
+ 
 +    // Paper start
 +    /**
 +     * @throws IllegalArgumentException if the entity does not have a translation key (is probably a custom entity)
@@ -342,7 +342,10 @@ index bed9c519a594f44191c2e13b2f13a0de906e21e5..712db16df7a3b30f844b391321b5acd6
 +        return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
 +    }
 +    // Paper end
- }
++
+     /**
+      * Gets if this EntityType is enabled by feature in a world.
+      *
 diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
 index d841d94d46462e0ceb7c6b04cc8fc36792bd9201..8c8176121cafed0ed09239b6a7b392dc846438e2 100644
 --- a/src/main/java/org/bukkit/entity/Villager.java

--- a/patches/api/0215-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/api/0215-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index ee9ed5f0e2936c740903784b01b9e2fff75b92f8..1f89a3c1c3b73a939c2653102fc1dc8b630672a8 100644
+index beddcb13a598d799c8ae1cec9c01c900e38b1458..eabbe1cd18316948f70e7b56fb80827fdd3672f0 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -125,5 +125,12 @@ public interface UnsafeValues {
+@@ -130,5 +130,12 @@ public interface UnsafeValues {
      byte[] serializeItem(ItemStack item);
  
      ItemStack deserializeItem(byte[] data);

--- a/patches/api/0219-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0219-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ba146ba3f3dac06a5e7cde3897bbb44288183ff6..531665375141dd8e070dcd68a864fc63e87bb762 100644
+index bae2ef297ba585c916ea06c4316e9511696000da..0bc59cd1b27303dff7f13f79087b13097606ae65 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1229,6 +1229,27 @@ public final class Bukkit {
+@@ -1250,6 +1250,27 @@ public final class Bukkit {
          return server.getOfflinePlayer(name);
      }
  
@@ -37,10 +37,10 @@ index ba146ba3f3dac06a5e7cde3897bbb44288183ff6..531665375141dd8e070dcd68a864fc63
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 72900dd9d4e8050dc4ec902de4b3e5cc717273b6..204501e7964355d9f8b4e357e5fd636967752455 100644
+index 31e8a002f9b0641f16bc4cf330e6022b13942321..247bd6d2101d280a00727cacdeb8f40a7d7c4dcb 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1024,6 +1024,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1049,6 +1049,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  

--- a/patches/api/0265-Expand-world-key-API.patch
+++ b/patches/api/0265-Expand-world-key-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expand world key API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 7cef6511b9b986fd5b3c59072e099f7a4ebb5fc4..041c6a9a1adce389f3a7ca6e5bbb7cfed0ab6fd8 100644
+index 0bc59cd1b27303dff7f13f79087b13097606ae65..cda896b2278dfb71f1fac8665397a01abcc0d096 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -811,6 +811,18 @@ public final class Bukkit {
+@@ -832,6 +832,18 @@ public final class Bukkit {
      public static World getWorld(@NotNull UUID uid) {
          return server.getWorld(uid);
      }
@@ -56,10 +56,10 @@ index 501dd5a26c27294420821b3d75f8938596afb1a8..71ef9b479888aa83455757560b607455
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 9dcd94bc1aedac589192f4bb07d7ae821586f58a..b283a9ba0c6ea1b24cb03b690984b93d25ddf010 100644
+index 247bd6d2101d280a00727cacdeb8f40a7d7c4dcb..1044ffa10c12b645e2e82431ba809641048e757f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -671,6 +671,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -696,6 +696,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      public World getWorld(@NotNull UUID uid);
  
@@ -78,10 +78,10 @@ index 9dcd94bc1aedac589192f4bb07d7ae821586f58a..b283a9ba0c6ea1b24cb03b690984b93d
       * Create a new virtual {@link WorldBorder}.
       * <p>
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 1f89a3c1c3b73a939c2653102fc1dc8b630672a8..6c45841538f2f073691331f975741a62b03a6637 100644
+index eabbe1cd18316948f70e7b56fb80827fdd3672f0..a00d93eee9710bb0fdf0fb791ef1a9262f89ef60 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -132,5 +132,10 @@ public interface UnsafeValues {
+@@ -137,5 +137,10 @@ public interface UnsafeValues {
       * Use this when sending custom packets, so that there are no collisions on the client or server.
       */
      public int nextEntityId();

--- a/patches/api/0266-Item-Rarity-API.patch
+++ b/patches/api/0266-Item-Rarity-API.patch
@@ -39,7 +39,7 @@ index 0000000000000000000000000000000000000000..74ef8395cc040ce488c2acaa416db202
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 6ec19c038ce3c551b5207028355594f8a0c80bd2..22649f3ba10a0b6e33c584ee84b76cbbda992919 100644
+index ac9395474e17c3a03c611c777b04a5bd18948be6..0b3b623455337c6500b9ce518ad8e6a7e5e9a17f 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4573,6 +4573,17 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
@@ -61,10 +61,10 @@ index 6ec19c038ce3c551b5207028355594f8a0c80bd2..22649f3ba10a0b6e33c584ee84b76cbb
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 6c45841538f2f073691331f975741a62b03a6637..e87cbaf9c1ea1330ab1597f98c8864d0c5b8bdcd 100644
+index a00d93eee9710bb0fdf0fb791ef1a9262f89ef60..f79784e1823f646181a434a6dbce3bac0eaf25c9 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -137,5 +137,22 @@ public interface UnsafeValues {
+@@ -142,5 +142,22 @@ public interface UnsafeValues {
       * Just don't use it.
       */
      @org.jetbrains.annotations.NotNull String getMainLevelName();

--- a/patches/api/0267-Expose-protocol-version.patch
+++ b/patches/api/0267-Expose-protocol-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index e87cbaf9c1ea1330ab1597f98c8864d0c5b8bdcd..906f313d8c91e65ce934143208ed281ce02f5354 100644
+index f79784e1823f646181a434a6dbce3bac0eaf25c9..a27e14e00d759d6c15530ef038bcf4b5cbd9f120 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -154,5 +154,12 @@ public interface UnsafeValues {
+@@ -159,5 +159,12 @@ public interface UnsafeValues {
       * @return the itemstack rarity
       */
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);

--- a/patches/api/0272-More-World-API.patch
+++ b/patches/api/0272-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 711fc41dbd029fa2d43f35165b62d09de89509b7..ff1330d091a3bbab99f3ad813e1322c806f4ea32 100644
+index 530d656aa5573c9783d07de23379657fe0c7cae5..ecf900140d0007b4e69ab8ab0e439828ee718a6b 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3697,6 +3697,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3698,6 +3698,114 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      StructureSearchResult locateNearestStructure(@NotNull Location origin, @NotNull Structure structure, int radius, boolean findUnexplored);
  

--- a/patches/api/0283-Add-basic-Datapack-API.patch
+++ b/patches/api/0283-Add-basic-Datapack-API.patch
@@ -70,10 +70,22 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index cda896b2278dfb71f1fac8665397a01abcc0d096..6a823ee8037ad18710062d731bd626b8289704f0 100644
+index cda896b2278dfb71f1fac8665397a01abcc0d096..ce47379dec112f204062092e2e056a2e219c7405 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2406,6 +2406,14 @@ public final class Bukkit {
+@@ -318,9 +318,11 @@ public final class Bukkit {
+     /**
+      * Get the DataPack Manager.
+      *
++     * @deprecated use {@link #getDatapackManager()}
+      * @return the manager
+      */
+     @NotNull
++    @Deprecated(forRemoval = true)
+     public static DataPackManager getDataPackManager() {
+         return server.getDataPackManager();
+     }
+@@ -2406,6 +2408,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +101,22 @@ index cda896b2278dfb71f1fac8665397a01abcc0d096..6a823ee8037ad18710062d731bd626b8
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1044ffa10c12b645e2e82431ba809641048e757f..48649724f62e430b20f65a595fee53843ffb4d64 100644
+index 1044ffa10c12b645e2e82431ba809641048e757f..7f289d358480806b6af3a02b88a0f632a5b5681c 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2097,5 +2097,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -256,9 +256,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+     /**
+      * Get the DataPack Manager.
+      *
++     * @deprecated use {@link #getDatapackManager()}
+      * @return the manager
+      */
+     @NotNull
++    @Deprecated(forRemoval = true) // Paper
+     public DataPackManager getDataPackManager();
+ 
+     /**
+@@ -2097,5 +2099,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();
@@ -104,3 +128,33 @@ index 1044ffa10c12b645e2e82431ba809641048e757f..48649724f62e430b20f65a595fee5384
 +    io.papermc.paper.datapack.DatapackManager getDatapackManager();
      // Paper end
  }
+diff --git a/src/main/java/org/bukkit/packs/DataPack.java b/src/main/java/org/bukkit/packs/DataPack.java
+index 744d8c055b0e643e2e0d12218af4ef856f56340f..2ac72913e2a5b70eb98a4f25f865855b48b01ed3 100644
+--- a/src/main/java/org/bukkit/packs/DataPack.java
++++ b/src/main/java/org/bukkit/packs/DataPack.java
+@@ -8,8 +8,10 @@ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+  * Represents a data pack.
++ * @deprecated use {@link io.papermc.paper.datapack.Datapack}
+  */
+ @ApiStatus.Experimental
++@Deprecated(forRemoval = true) // Paper
+ public interface DataPack extends Keyed {
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/packs/DataPackManager.java b/src/main/java/org/bukkit/packs/DataPackManager.java
+index d7fb6310e6b1050c496d748388310bc6f8d78e23..2cd505046277febe010e9476539b064321d8b2ec 100644
+--- a/src/main/java/org/bukkit/packs/DataPackManager.java
++++ b/src/main/java/org/bukkit/packs/DataPackManager.java
+@@ -11,8 +11,10 @@ import org.jetbrains.annotations.Nullable;
+ 
+ /**
+  * Manager of data packs.
++ * @deprecated use {@link io.papermc.paper.datapack.DatapackManager}
+  */
+ @ApiStatus.Experimental
++@Deprecated(forRemoval = true) // Paper
+ public interface DataPackManager {
+ 
+     /**

--- a/patches/api/0283-Add-basic-Datapack-API.patch
+++ b/patches/api/0283-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c3fe8116133f3e3fdb729607fd20dba6645b9563..21583b3413fcc5a42590464371cd929e37a4c2e0 100644
+index cda896b2278dfb71f1fac8665397a01abcc0d096..6a823ee8037ad18710062d731bd626b8289704f0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2385,6 +2385,14 @@ public final class Bukkit {
+@@ -2406,6 +2406,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index c3fe8116133f3e3fdb729607fd20dba6645b9563..21583b3413fcc5a42590464371cd929e
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index cde4b79fed3e6b3f35597d11f086defd30bc6d8f..a1f1efc1d953bd2daf46b84ffb3d63d2c2f19bee 100644
+index 1044ffa10c12b645e2e82431ba809641048e757f..48649724f62e430b20f65a595fee53843ffb4d64 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2072,5 +2072,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2097,5 +2097,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0285-ItemStack-repair-check-API.patch
+++ b/patches/api/0285-ItemStack-repair-check-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack repair check API
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 906f313d8c91e65ce934143208ed281ce02f5354..29a91ec8e97ce66383a1dd1fc3dcbcdcca7cfc41 100644
+index a27e14e00d759d6c15530ef038bcf4b5cbd9f120..00e61ab3103c86c9aabcdfa2fd4c565adcc091da 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -155,6 +155,16 @@ public interface UnsafeValues {
+@@ -160,6 +160,16 @@ public interface UnsafeValues {
       */
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);
  

--- a/patches/api/0290-Attributes-API-for-item-defaults.patch
+++ b/patches/api/0290-Attributes-API-for-item-defaults.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Attributes API for item defaults
 
 
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 22649f3ba10a0b6e33c584ee84b76cbbda992919..041fe4384c611b9d88121bda0cb9e5e034ff7e7b 100644
+index 0b3b623455337c6500b9ce518ad8e6a7e5e9a17f..220db091ce8b79688f82a099b5c227c86dd2c803 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4584,6 +4584,21 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
@@ -31,10 +31,10 @@ index 22649f3ba10a0b6e33c584ee84b76cbbda992919..041fe4384c611b9d88121bda0cb9e5e0
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 29a91ec8e97ce66383a1dd1fc3dcbcdcca7cfc41..0d47278d68cdf015cb980721c234a3abee39646a 100644
+index 00e61ab3103c86c9aabcdfa2fd4c565adcc091da..a9e7c64e1f98ff73c1804466d7c79eaf343dde7c 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -165,6 +165,18 @@ public interface UnsafeValues {
+@@ -170,6 +170,18 @@ public interface UnsafeValues {
       */
      public boolean isValidRepairItemStack(@org.jetbrains.annotations.NotNull ItemStack itemToBeRepaired, @org.jetbrains.annotations.NotNull ItemStack repairMaterial);
  

--- a/patches/api/0316-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/api/0316-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index ff1330d091a3bbab99f3ad813e1322c806f4ea32..e088ffbf5c137754864e21d1f570793eb4e23f6a 100644
+index ecf900140d0007b4e69ab8ab0e439828ee718a6b..0baf878c80ae42d7e77e3f1a57c5f3e715b163ba 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -715,6 +715,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -716,6 +716,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @NotNull
      public LightningStrike strikeLightningEffect(@NotNull Location loc);
  

--- a/patches/api/0317-Get-entity-default-attributes.patch
+++ b/patches/api/0317-Get-entity-default-attributes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Get entity default attributes
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 0d47278d68cdf015cb980721c234a3abee39646a..29ccd90e2733b528ef0866f93053adf66dd9ddf3 100644
+index a9e7c64e1f98ff73c1804466d7c79eaf343dde7c..c2b042ced0f32b0dafc13a2933c2bd9b18db774a 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -183,5 +183,22 @@ public interface UnsafeValues {
+@@ -188,5 +188,22 @@ public interface UnsafeValues {
       * @return the server's protocol version
       */
      int getProtocolVersion();
@@ -32,10 +32,10 @@ index 0d47278d68cdf015cb980721c234a3abee39646a..29ccd90e2733b528ef0866f93053adf6
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/EntityType.java b/src/main/java/org/bukkit/entity/EntityType.java
-index 712db16df7a3b30f844b391321b5acd6ffa5aec5..653f370f18f685e9dc49271b251eea01b428d021 100644
+index bf3aa78cb901301571aa3fad5bd0bcebee8e6e1b..22cb13b3d63e06476581e3d92e2b7c245944cb38 100644
 --- a/src/main/java/org/bukkit/entity/EntityType.java
 +++ b/src/main/java/org/bukkit/entity/EntityType.java
-@@ -455,5 +455,24 @@ public enum EntityType implements Keyed, Translatable, net.kyori.adventure.trans
+@@ -455,6 +455,25 @@ public enum EntityType implements Keyed, Translatable, net.kyori.adventure.trans
          Preconditions.checkArgument(this != UNKNOWN, "UNKNOWN entities do not have translation keys");
          return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
      }
@@ -59,4 +59,5 @@ index 712db16df7a3b30f844b391321b5acd6ffa5aec5..653f370f18f685e9dc49271b251eea01
 +        return org.bukkit.Bukkit.getUnsafe().getDefaultEntityAttributes(this.key);
 +    }
      // Paper end
- }
+ 
+     /**

--- a/patches/api/0323-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/api/0323-Add-isCollidable-methods-to-various-places.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add isCollidable methods to various places
 
 
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 041fe4384c611b9d88121bda0cb9e5e034ff7e7b..7ce5ac66e6d598c9ecffc52e5c75d80f644e8895 100644
+index 220db091ce8b79688f82a099b5c227c86dd2c803..48a2fbe33a8b0522d53bd79bdd253eaed6b6357f 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4599,6 +4599,16 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
@@ -26,10 +26,10 @@ index 041fe4384c611b9d88121bda0cb9e5e034ff7e7b..7ce5ac66e6d598c9ecffc52e5c75d80f
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 29ccd90e2733b528ef0866f93053adf66dd9ddf3..2a23e93d9e308c5eba0a2b658f11f571a0c01e26 100644
+index c2b042ced0f32b0dafc13a2933c2bd9b18db774a..820c7e8f28d7276e4d4b31a81746720a1cc10f09 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -200,5 +200,14 @@ public interface UnsafeValues {
+@@ -205,5 +205,14 @@ public interface UnsafeValues {
       * @throws IllegalArgumentException if the entity does not exist of have default attributes (use {@link #hasDefaultEntityAttributes(NamespacedKey)} first)
       */
      @org.jetbrains.annotations.NotNull org.bukkit.attribute.Attributable getDefaultEntityAttributes(@org.jetbrains.annotations.NotNull NamespacedKey entityKey);

--- a/patches/api/0326-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/api/0326-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 2a23e93d9e308c5eba0a2b658f11f571a0c01e26..b8ca571f8e88e7b676c5d1e1d90f6e5cb8538147 100644
+index 820c7e8f28d7276e4d4b31a81746720a1cc10f09..fed8f959f87f82a7f8fb8afe770f5cb73fcf27b2 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -126,6 +126,14 @@ public interface UnsafeValues {
+@@ -131,6 +131,14 @@ public interface UnsafeValues {
  
      ItemStack deserializeItem(byte[] data);
  

--- a/patches/api/0329-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0329-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 21583b3413fcc5a42590464371cd929e37a4c2e0..60b2f21195384d544a7e123ce19a09ee437a6538 100644
+index 6a823ee8037ad18710062d731bd626b8289704f0..9035c56dad77731e7c77dbefaaf1b8c595bc74a5 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1903,6 +1903,24 @@ public final class Bukkit {
+@@ -1924,6 +1924,24 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -34,10 +34,10 @@ index 21583b3413fcc5a42590464371cd929e37a4c2e0..60b2f21195384d544a7e123ce19a09ee
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a1f1efc1d953bd2daf46b84ffb3d63d2c2f19bee..35ec012867c6d87b76fd60d1ff55302612f96b9e 100644
+index 48649724f62e430b20f65a595fee53843ffb4d64..ec0764da757e162cb3e11e2d5e0a0f0a01fea2ca 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1598,6 +1598,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1623,6 +1623,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  

--- a/patches/api/0329-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0329-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 6a823ee8037ad18710062d731bd626b8289704f0..9035c56dad77731e7c77dbefaaf1b8c595bc74a5 100644
+index ce47379dec112f204062092e2e056a2e219c7405..d4b522ee3d44ec755046cc406708086b5f5cf625 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1924,6 +1924,24 @@ public final class Bukkit {
+@@ -1926,6 +1926,24 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -34,10 +34,10 @@ index 6a823ee8037ad18710062d731bd626b8289704f0..9035c56dad77731e7c77dbefaaf1b8c5
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 48649724f62e430b20f65a595fee53843ffb4d64..ec0764da757e162cb3e11e2d5e0a0f0a01fea2ca 100644
+index 7f289d358480806b6af3a02b88a0f632a5b5681c..feb2c76bd20c1146d22ec1988943e5b94a982de9 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1623,6 +1623,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1625,6 +1625,22 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  

--- a/patches/api/0348-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0348-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for creating command sender which forwards feedback
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9035c56dad77731e7c77dbefaaf1b8c595bc74a5..9e89982278c43ad9ff43b617d432e28c5f89c780 100644
+index d4b522ee3d44ec755046cc406708086b5f5cf625..3c7cedf0f2654d68fc7fa9fb32a17d362bba459e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1432,6 +1432,20 @@ public final class Bukkit {
+@@ -1434,6 +1434,20 @@ public final class Bukkit {
          return server.getConsoleSender();
      }
  
@@ -30,10 +30,10 @@ index 9035c56dad77731e7c77dbefaaf1b8c595bc74a5..9e89982278c43ad9ff43b617d432e28c
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index ec0764da757e162cb3e11e2d5e0a0f0a01fea2ca..06c90ee527302570a4b48be604103729be00e256 100644
+index feb2c76bd20c1146d22ec1988943e5b94a982de9..57e117583ba6d562e2ffd308e058e5ea7de90b24 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1202,6 +1202,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1204,6 +1204,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/api/0348-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/api/0348-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for creating command sender which forwards feedback
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 60b2f21195384d544a7e123ce19a09ee437a6538..b27260b03ed1e49a1ff50db2f00133f92cad37a9 100644
+index 9035c56dad77731e7c77dbefaaf1b8c595bc74a5..9e89982278c43ad9ff43b617d432e28c5f89c780 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1411,6 +1411,20 @@ public final class Bukkit {
+@@ -1432,6 +1432,20 @@ public final class Bukkit {
          return server.getConsoleSender();
      }
  
@@ -30,10 +30,10 @@ index 60b2f21195384d544a7e123ce19a09ee437a6538..b27260b03ed1e49a1ff50db2f00133f9
       * Gets the folder that contains all of the various {@link World}s.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 35ec012867c6d87b76fd60d1ff55302612f96b9e..bdf247e6a8622b2e8a3d2dcdd6a2a7ebd1c01603 100644
+index ec0764da757e162cb3e11e2d5e0a0f0a01fea2ca..06c90ee527302570a4b48be604103729be00e256 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1177,6 +1177,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1202,6 +1202,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ConsoleCommandSender getConsoleSender();
  

--- a/patches/api/0349-Implement-regenerateChunk.patch
+++ b/patches/api/0349-Implement-regenerateChunk.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement regenerateChunk
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index e088ffbf5c137754864e21d1f570793eb4e23f6a..2b45aa9b438d7856ec448c56832b2b2100961565 100644
+index 0baf878c80ae42d7e77e3f1a57c5f3e715b163ba..c1827f97e9255e72c082548c8b2782e39f1ebb8c 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -464,8 +464,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -465,8 +465,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return Whether the chunk was actually regenerated
       *
       * @deprecated regenerating a single chunk is not likely to produce the same

--- a/patches/api/0354-Custom-Potion-Mixes.patch
+++ b/patches/api/0354-Custom-Potion-Mixes.patch
@@ -102,10 +102,10 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 9e89982278c43ad9ff43b617d432e28c5f89c780..cc16840e5c130d8cfbd0e79617b7b780b50a3635 100644
+index 3c7cedf0f2654d68fc7fa9fb32a17d362bba459e..7c2f5f1e3ce496d55471027cc069d7f1863dc7e6 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2446,6 +2446,15 @@ public final class Bukkit {
+@@ -2448,6 +2448,15 @@ public final class Bukkit {
      public static io.papermc.paper.datapack.DatapackManager getDatapackManager() {
          return server.getDatapackManager();
      }
@@ -122,10 +122,10 @@ index 9e89982278c43ad9ff43b617d432e28c5f89c780..cc16840e5c130d8cfbd0e79617b7b780
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 06c90ee527302570a4b48be604103729be00e256..1bae52090758914390c7c745bf4cb556ff44e07d 100644
+index 57e117583ba6d562e2ffd308e058e5ea7de90b24..474835e0a0d174a97ad25406d4a13a43d7a3644e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2131,5 +2131,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2133,5 +2133,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();

--- a/patches/api/0354-Custom-Potion-Mixes.patch
+++ b/patches/api/0354-Custom-Potion-Mixes.patch
@@ -102,10 +102,10 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b27260b03ed1e49a1ff50db2f00133f92cad37a9..ebf3243d6c77064d9ba9c1dd0c392985988a303b 100644
+index 9e89982278c43ad9ff43b617d432e28c5f89c780..cc16840e5c130d8cfbd0e79617b7b780b50a3635 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -2425,6 +2425,15 @@ public final class Bukkit {
+@@ -2446,6 +2446,15 @@ public final class Bukkit {
      public static io.papermc.paper.datapack.DatapackManager getDatapackManager() {
          return server.getDatapackManager();
      }
@@ -122,10 +122,10 @@ index b27260b03ed1e49a1ff50db2f00133f92cad37a9..ebf3243d6c77064d9ba9c1dd0c392985
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index bdf247e6a8622b2e8a3d2dcdd6a2a7ebd1c01603..43bae3e3fc2f9e59ad5f5be0fc158e47af04e342 100644
+index 06c90ee527302570a4b48be604103729be00e256..1bae52090758914390c7c745bf4cb556ff44e07d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2106,5 +2106,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2131,5 +2131,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();

--- a/patches/api/0367-Add-method-isTickingWorlds-to-Bukkit.patch
+++ b/patches/api/0367-Add-method-isTickingWorlds-to-Bukkit.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add method isTickingWorlds() to Bukkit.
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index cc16840e5c130d8cfbd0e79617b7b780b50a3635..f81be25dec5399b0fa29ec5d79c6dda87cfac899 100644
+index 7c2f5f1e3ce496d55471027cc069d7f1863dc7e6..b0bc2df41506770e2854a287813f1c53f003eda1 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -774,12 +774,26 @@ public final class Bukkit {
+@@ -776,12 +776,26 @@ public final class Bukkit {
          return server.getWorlds();
      }
  
@@ -35,7 +35,7 @@ index cc16840e5c130d8cfbd0e79617b7b780b50a3635..f81be25dec5399b0fa29ec5d79c6dda8
       *
       * @param creator the options to use when creating the world
       * @return newly created or loaded world
-@@ -791,6 +805,9 @@ public final class Bukkit {
+@@ -793,6 +807,9 @@ public final class Bukkit {
  
      /**
       * Unloads a world with the given name.
@@ -45,7 +45,7 @@ index cc16840e5c130d8cfbd0e79617b7b780b50a3635..f81be25dec5399b0fa29ec5d79c6dda8
       *
       * @param name Name of the world to unload
       * @param save whether to save the chunks before unloading
-@@ -802,6 +819,9 @@ public final class Bukkit {
+@@ -804,6 +821,9 @@ public final class Bukkit {
  
      /**
       * Unloads the given world.
@@ -56,10 +56,10 @@ index cc16840e5c130d8cfbd0e79617b7b780b50a3635..f81be25dec5399b0fa29ec5d79c6dda8
       * @param world the world to unload
       * @param save whether to save the chunks before unloading
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1bae52090758914390c7c745bf4cb556ff44e07d..5f5bfe3622c71f81bd5d6dedc79ef9db1b46da54 100644
+index 474835e0a0d174a97ad25406d4a13a43d7a3644e..1d1a1d087dabc9794e0062a064da2cced4062309 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -647,34 +647,55 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -649,34 +649,55 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public List<World> getWorlds();
  

--- a/patches/api/0367-Add-method-isTickingWorlds-to-Bukkit.patch
+++ b/patches/api/0367-Add-method-isTickingWorlds-to-Bukkit.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add method isTickingWorlds() to Bukkit.
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index d7d6897b1f697f48aa3890d70797dd3195de125e..f1af93319d6b29d7bc709e7e273e8abe26c7b4af 100644
+index cc16840e5c130d8cfbd0e79617b7b780b50a3635..f81be25dec5399b0fa29ec5d79c6dda87cfac899 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -753,12 +753,26 @@ public final class Bukkit {
+@@ -774,12 +774,26 @@ public final class Bukkit {
          return server.getWorlds();
      }
  
@@ -35,7 +35,7 @@ index d7d6897b1f697f48aa3890d70797dd3195de125e..f1af93319d6b29d7bc709e7e273e8abe
       *
       * @param creator the options to use when creating the world
       * @return newly created or loaded world
-@@ -770,6 +784,9 @@ public final class Bukkit {
+@@ -791,6 +805,9 @@ public final class Bukkit {
  
      /**
       * Unloads a world with the given name.
@@ -45,7 +45,7 @@ index d7d6897b1f697f48aa3890d70797dd3195de125e..f1af93319d6b29d7bc709e7e273e8abe
       *
       * @param name Name of the world to unload
       * @param save whether to save the chunks before unloading
-@@ -781,6 +798,9 @@ public final class Bukkit {
+@@ -802,6 +819,9 @@ public final class Bukkit {
  
      /**
       * Unloads the given world.
@@ -56,10 +56,10 @@ index d7d6897b1f697f48aa3890d70797dd3195de125e..f1af93319d6b29d7bc709e7e273e8abe
       * @param world the world to unload
       * @param save whether to save the chunks before unloading
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index dcd04d2181037c91f004fee339373f0b15534e1d..8621dba7f10ab822b5b99ce0d05da58823605cb6 100644
+index 1bae52090758914390c7c745bf4cb556ff44e07d..5f5bfe3622c71f81bd5d6dedc79ef9db1b46da54 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -622,34 +622,55 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -647,34 +647,55 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public List<World> getWorlds();
  

--- a/patches/api/0376-Add-NamespacedKey-biome-methods.patch
+++ b/patches/api/0376-Add-NamespacedKey-biome-methods.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add NamespacedKey biome methods
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index b8ca571f8e88e7b676c5d1e1d90f6e5cb8538147..b92255a9c87620f46adb140689b1cd328a476d61 100644
+index fed8f959f87f82a7f8fb8afe770f5cb73fcf27b2..c661eab343ae76488de701630424e2d589f44fc0 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -217,5 +217,32 @@ public interface UnsafeValues {
+@@ -222,5 +222,32 @@ public interface UnsafeValues {
       * @throws IllegalArgumentException if {@link Material#isBlock()} is false
       */
      boolean isCollidable(@org.jetbrains.annotations.NotNull Material material);

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -67,10 +67,10 @@ index c207fd9b001dccaa71ba1615ffcdc093dd2b581c..ac679b0a66ce9676937a9971bf3ee2a9
      exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 39d0908d8a39524915a894f649b3e2a5c4a4e907..0d76c6880572e7620770f045e1faf59ea047a946 100644
+index 23e88fde465853629c4371d1e1a44d1af493ca3e..5a39201392fefe8da495244fdbc380e882ec938f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -202,7 +202,7 @@ public class Main {
+@@ -209,7 +209,7 @@ public class Main {
                  }
  
                  if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -4571,10 +4571,10 @@ index 9a86fedb7ea4932590b86ef96785141489b03528..40deaa2463876659c0579b5273b52497
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6b5d97752b07ebd70a7986331bd28dde14958ccc..79ee400968a82aa5eb125d62f0440f926e3298f9 100644
+index 0ae7df422a58df7acb8e57e21d5e8ded592192ee..6e2a1ca2a1d6cb457c1eb70ce5c25f8287f5ccb9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -883,6 +883,7 @@ public final class CraftServer implements Server {
+@@ -903,6 +903,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
@@ -4583,7 +4583,7 @@ index 6b5d97752b07ebd70a7986331bd28dde14958ccc..79ee400968a82aa5eb125d62f0440f92
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 0d76c6880572e7620770f045e1faf59ea047a946..6f4efb5553da256ee3a6dc422167d4cdbb208a5d 100644
+index 5a39201392fefe8da495244fdbc380e882ec938f..e8fb9e3454282ad328e6bc0d078142285d9cfa76 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -141,6 +141,19 @@ public class Main {

--- a/patches/server/0008-CB-fixes.patch
+++ b/patches/server/0008-CB-fixes.patch
@@ -83,10 +83,10 @@ index 161ad6ab1443b2ce33a2d7d91d189c855db0453b..15a9736a870055d639d03063c7cf67fd
          this.registryAccess = registryManager;
          this.structureTemplateManager = structureTemplateManager;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 79ee400968a82aa5eb125d62f0440f926e3298f9..b6ac46929d68207dee5364902a2ba6fa0f1a4a42 100644
+index 6e2a1ca2a1d6cb457c1eb70ce5c25f8287f5ccb9..1177d64793be0d82c99dcd9e037c3e4cef2f74d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2306,7 +2306,13 @@ public final class CraftServer implements Server {
+@@ -2326,7 +2326,13 @@ public final class CraftServer implements Server {
          Validate.notNull(key, "NamespacedKey cannot be null");
  
          LootTables registry = this.getServer().getLootTables();

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -7303,10 +7303,10 @@ index f66369ddaeab5c5ac643c0979dac3ed21337ff71..038abf2ac104ceecaab11b10d466ea69
              return false;
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 52ce5136087e954189d3737ca315226515375b3b..981bfb92cd4d167620631facc51da564633b3adc 100644
+index fa2872042a6ee6b5e865c50b3f8eabab3e7d6a46..e75f3d6f0c14f49cb828e919e12d0f69c898d46f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -241,8 +241,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -243,8 +243,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {
@@ -7317,7 +7317,7 @@ index 52ce5136087e954189d3737ca315226515375b3b..981bfb92cd4d167620631facc51da564
      }
  
      @Override
-@@ -317,7 +317,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -319,7 +319,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean refreshChunk(int x, int z) {
@@ -7326,7 +7326,7 @@ index 52ce5136087e954189d3737ca315226515375b3b..981bfb92cd4d167620631facc51da564
          if (playerChunk == null) return false;
  
          playerChunk.getTickingChunkFuture().thenAccept(either -> {
-@@ -1956,4 +1956,32 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1963,4 +1963,32 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.spigot;
      }
      // Spigot end
@@ -7624,10 +7624,10 @@ index 0000000000000000000000000000000000000000..909b2c98e7a9117d2f737245e4661792
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 1d41e9d1682df8fa000a36eab5196dcca810c769..eff182a54cbb84693d6cad96b51f743b08049b43 100644
+index 8d8f76feea13c2daeef310a572dec8f75f0f6103..3c41b9d3d7bdb0b2657eeb337499dfcca5ec4068 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -102,8 +102,17 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -104,8 +104,17 @@ public final class CraftMagicNumbers implements UnsafeValues {
      private static final BiMap<net.minecraft.world.level.material.Fluid, Fluid> FLUIDTYPE_FLUID = HashBiMap.create();
      private static final Map<Material, Item> MATERIAL_ITEM = new HashMap<>();
      private static final Map<Material, Block> MATERIAL_BLOCK = new HashMap<>();
@@ -7645,7 +7645,7 @@ index 1d41e9d1682df8fa000a36eab5196dcca810c769..eff182a54cbb84693d6cad96b51f743b
          for (Block block : BuiltInRegistries.BLOCK) {
              BLOCK_MATERIAL.put(block, Material.getMaterial(BuiltInRegistries.BLOCK.getKey(block).getPath().toUpperCase(Locale.ROOT)));
          }
-@@ -167,6 +176,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -169,6 +178,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public static ResourceLocation key(Material mat) {
          return CraftNamespacedKey.toMinecraft(mat.getKey());
      }

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2852,10 +2852,10 @@ index 0e04e7467ee27ea9e3ef60fe598cc21ab39f4c68..0f5e92a2256fe22b55d2428f98db403a
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b6ac46929d68207dee5364902a2ba6fa0f1a4a42..df637dec0e910f3879e1e38aa11d8cf3e755bc20 100644
+index 1177d64793be0d82c99dcd9e037c3e4cef2f74d3..26033d5f44efe81cab9085155587afe90887c110 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -603,8 +603,10 @@ public final class CraftServer implements Server {
+@@ -608,8 +608,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -2866,7 +2866,7 @@ index b6ac46929d68207dee5364902a2ba6fa0f1a4a42..df637dec0e910f3879e1e38aa11d8cf3
      }
  
      @Override
-@@ -1442,7 +1444,15 @@ public final class CraftServer implements Server {
+@@ -1462,7 +1464,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -2882,7 +2882,7 @@ index b6ac46929d68207dee5364902a2ba6fa0f1a4a42..df637dec0e910f3879e1e38aa11d8cf3
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1610,7 +1620,20 @@ public final class CraftServer implements Server {
+@@ -1630,7 +1640,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -2903,7 +2903,7 @@ index b6ac46929d68207dee5364902a2ba6fa0f1a4a42..df637dec0e910f3879e1e38aa11d8cf3
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1618,14 +1641,14 @@ public final class CraftServer implements Server {
+@@ -1638,14 +1661,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -2920,7 +2920,7 @@ index b6ac46929d68207dee5364902a2ba6fa0f1a4a42..df637dec0e910f3879e1e38aa11d8cf3
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1876,6 +1899,14 @@ public final class CraftServer implements Server {
+@@ -1896,6 +1919,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -2935,7 +2935,7 @@ index b6ac46929d68207dee5364902a2ba6fa0f1a4a42..df637dec0e910f3879e1e38aa11d8cf3
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1888,13 +1919,28 @@ public final class CraftServer implements Server {
+@@ -1908,13 +1939,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -2964,7 +2964,7 @@ index b6ac46929d68207dee5364902a2ba6fa0f1a4a42..df637dec0e910f3879e1e38aa11d8cf3
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1959,6 +2005,12 @@ public final class CraftServer implements Server {
+@@ -1979,6 +2025,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -2977,7 +2977,7 @@ index b6ac46929d68207dee5364902a2ba6fa0f1a4a42..df637dec0e910f3879e1e38aa11d8cf3
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2385,4 +2437,53 @@ public final class CraftServer implements Server {
+@@ -2405,4 +2457,53 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
@@ -3032,10 +3032,10 @@ index b6ac46929d68207dee5364902a2ba6fa0f1a4a42..df637dec0e910f3879e1e38aa11d8cf3
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 981bfb92cd4d167620631facc51da564633b3adc..aab8099b9980b4d4b4ee6d7484abcc0b55962a5f 100644
+index e75f3d6f0c14f49cb828e919e12d0f69c898d46f..7a3e6cc4d29d541c1075d5956b0b72f7aa8269da 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -151,6 +151,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -153,6 +153,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      private final BlockMetadataStore blockMetadata = new BlockMetadataStore(this);
      private final Object2IntOpenHashMap<SpawnCategory> spawnCategoryLimit = new Object2IntOpenHashMap<>();
      private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftWorld.DATA_TYPE_REGISTRY);
@@ -3043,7 +3043,7 @@ index 981bfb92cd4d167620631facc51da564633b3adc..aab8099b9980b4d4b4ee6d7484abcc0b
  
      private static final Random rand = new Random();
  
-@@ -1595,6 +1596,39 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1597,6 +1598,39 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              entityTracker.broadcastAndSend(packet);
          }
      }
@@ -3083,7 +3083,7 @@ index 981bfb92cd4d167620631facc51da564633b3adc..aab8099b9980b4d4b4ee6d7484abcc0b
  
      private static Map<String, GameRules.Key<?>> gamerules;
      public static synchronized Map<String, GameRules.Key<?>> getGameRulesNMS() {
-@@ -1983,5 +2017,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1990,5 +2024,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return ret;
      }
@@ -3103,7 +3103,7 @@ index 981bfb92cd4d167620631facc51da564633b3adc..aab8099b9980b4d4b4ee6d7484abcc0b
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 6f4efb5553da256ee3a6dc422167d4cdbb208a5d..4e7208a891da461a10920482e4e4427ace23fb45 100644
+index e8fb9e3454282ad328e6bc0d078142285d9cfa76..ab22205c758768cd0c8a4fc6bca3d7de2e823078 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -20,6 +20,12 @@ public class Main {
@@ -4866,10 +4866,10 @@ index 78ea79b66cc9e90402ef5cdc2e5e04e0c74b1c26..4fede2161792ba3e7cdf0cc5a1f53318
  
          boolean hadFormat = false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index eff182a54cbb84693d6cad96b51f743b08049b43..91cf7e26de7d3595e151f7c52683ef82715420ad 100644
+index 3c41b9d3d7bdb0b2657eeb337499dfcca5ec4068..e785bf77ddb37b2409fbc5982927161b36504fb7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -72,6 +72,43 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -74,6 +74,43 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      private CraftMagicNumbers() {}
  

--- a/patches/server/0011-Paper-command.patch
+++ b/patches/server/0011-Paper-command.patch
@@ -615,10 +615,10 @@ index 1fe07773cf9664164b29164caba22800e5a6bdae..cb6f192c11cda6230ec365e6cefb44a3
  
          this.setPvpAllowed(dedicatedserverproperties.pvp);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index df637dec0e910f3879e1e38aa11d8cf3e755bc20..42d25bed20199403ae75e6a832aaa3e56b0ba44e 100644
+index 26033d5f44efe81cab9085155587afe90887c110..6752bae2a976906609d05e3d0c8a18c7413fa5b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -907,6 +907,7 @@ public final class CraftServer implements Server {
+@@ -927,6 +927,7 @@ public final class CraftServer implements Server {
          this.commandMap.clearCommands();
          this.reloadData();
          org.spigotmc.SpigotConfig.registerCommands(); // Spigot
@@ -626,7 +626,7 @@ index df637dec0e910f3879e1e38aa11d8cf3e755bc20..42d25bed20199403ae75e6a832aaa3e5
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2477,6 +2478,34 @@ public final class CraftServer implements Server {
+@@ -2497,6 +2498,34 @@ public final class CraftServer implements Server {
      // Paper end
  
      // Paper start

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -6750,10 +6750,10 @@ index aa054369cef3da4f90ce17788dcb9ca80dc98010..d9f2518a08bc4ae978051be51e467597
              Bootstrap.validate();
              Util.startTimerHackThread();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 42d25bed20199403ae75e6a832aaa3e56b0ba44e..054a18343ff806d0ad96e9354f82c7906467adb2 100644
+index 6752bae2a976906609d05e3d0c8a18c7413fa5b1..6e1f782938992debbfd9617ab9e2cce4e423876c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -266,7 +266,8 @@ public final class CraftServer implements Server {
+@@ -269,7 +269,8 @@ public final class CraftServer implements Server {
      private final CraftCommandMap commandMap = new CraftCommandMap(this);
      private final SimpleHelpMap helpMap = new SimpleHelpMap(this);
      private final StandardMessenger messenger = new StandardMessenger();
@@ -6763,7 +6763,7 @@ index 42d25bed20199403ae75e6a832aaa3e56b0ba44e..054a18343ff806d0ad96e9354f82c790
      private final StructureManager structureManager;
      protected final DedicatedServer console;
      protected final DedicatedPlayerList playerList;
-@@ -414,24 +415,7 @@ public final class CraftServer implements Server {
+@@ -419,24 +420,7 @@ public final class CraftServer implements Server {
      }
  
      public void loadPlugins() {
@@ -6789,7 +6789,7 @@ index 42d25bed20199403ae75e6a832aaa3e56b0ba44e..054a18343ff806d0ad96e9354f82c790
      }
  
      public void enablePlugins(PluginLoadOrder type) {
-@@ -520,15 +504,17 @@ public final class CraftServer implements Server {
+@@ -525,15 +509,17 @@ public final class CraftServer implements Server {
      private void enablePlugin(Plugin plugin) {
          try {
              List<Permission> perms = plugin.getDescription().getPermissions();
@@ -6813,7 +6813,7 @@ index 42d25bed20199403ae75e6a832aaa3e56b0ba44e..054a18343ff806d0ad96e9354f82c790
  
              this.pluginManager.enablePlugin(plugin);
          } catch (Throwable ex) {
-@@ -931,6 +917,7 @@ public final class CraftServer implements Server {
+@@ -951,6 +937,7 @@ public final class CraftServer implements Server {
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));
          }
@@ -6839,10 +6839,10 @@ index 909b2c98e7a9117d2f737245e4661792ffafb744..d96399e9bf1a58db5a4a22e58abb99e7
      @Override
      public FileConfiguration getConfig() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 91cf7e26de7d3595e151f7c52683ef82715420ad..ec9877840fafa14adcfc04eacae1786111990a27 100644
+index e785bf77ddb37b2409fbc5982927161b36504fb7..a90bfabd166afcd248c5d467d18ec9c0324b7858 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -437,6 +437,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -439,6 +439,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
          net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
          return nmsItemStack.getItem().getDescriptionId(nmsItemStack);
      }
@@ -6853,8 +6853,8 @@ index 91cf7e26de7d3595e151f7c52683ef82715420ad..ec9877840fafa14adcfc04eacae17861
 +    }
 +    // Paper end
  
-     /**
-      * This helper class represents the different NBT Tags.
+     @Override
+     public FeatureFlag getFeatureFlag(NamespacedKey namespacedKey) {
 diff --git a/src/main/resources/META-INF/services/io.papermc.paper.plugin.entrypoint.classloader.ClassloaderBytecodeModifier b/src/main/resources/META-INF/services/io.papermc.paper.plugin.entrypoint.classloader.ClassloaderBytecodeModifier
 new file mode 100644
 index 0000000000000000000000000000000000000000..20dbe2775951bfcdb85c5d679ac86c77a93e0847

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -1632,10 +1632,10 @@ index 9c3ce492051199acb8d38ade121ec8a0cbc50f54..aa4f2dc63dd79e6c3d7594d2fd63fa00
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 054a18343ff806d0ad96e9354f82c7906467adb2..cdc2ae90e70407455ba03b0805941ace809fa7f3 100644
+index 6e1f782938992debbfd9617ab9e2cce4e423876c..ff78f576472434eb8299012a146d0e4d8659d82c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -364,7 +364,7 @@ public final class CraftServer implements Server {
+@@ -369,7 +369,7 @@ public final class CraftServer implements Server {
          this.saveCommandsConfig();
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
@@ -1644,7 +1644,7 @@ index 054a18343ff806d0ad96e9354f82c7906467adb2..cdc2ae90e70407455ba03b0805941ace
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
-@@ -2394,12 +2394,31 @@ public final class CraftServer implements Server {
+@@ -2414,12 +2414,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  
@@ -2046,10 +2046,10 @@ index f97eccb6a17c7876e1e002d798eb67bbe80571a0..76effc345d362047e64d064eb64a5222
 +    } // Paper
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index ec9877840fafa14adcfc04eacae1786111990a27..98083486bddf60074fc8e47e63e780703a792a7c 100644
+index a90bfabd166afcd248c5d467d18ec9c0324b7858..a2203cd809810eb8793ae730d163192d87f615c8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -222,6 +222,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -224,6 +224,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
      // Paper end
      // ========================================================================
@@ -2062,9 +2062,9 @@ index ec9877840fafa14adcfc04eacae1786111990a27..98083486bddf60074fc8e47e63e78070
  
      public static byte toLegacyData(BlockState data) {
          return CraftLegacy.toLegacyData(data);
-@@ -444,6 +450,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -452,6 +458,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
+         return CraftFeatureFlag.getFromNMS(namespacedKey);
      }
-     // Paper end
  
 +    // Paper start
 +    @Override

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -17854,10 +17854,10 @@ index bf4b2f89d3a7133155c6272379c742318b2c1514..33677ec811ceab939c419bf7d31b9958
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cdc2ae90e70407455ba03b0805941ace809fa7f3..de42661734a2e0484c584c8b017bed5654a2acee 100644
+index ff78f576472434eb8299012a146d0e4d8659d82c..3a7d50651ab149665ac655b4f264278608335486 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1127,7 +1127,7 @@ public final class CraftServer implements Server {
+@@ -1147,7 +1147,7 @@ public final class CraftServer implements Server {
          this.console.addLevel(internal);
  
          this.getServer().prepareLevels(internal.getChunkSource().chunkMap.progressListener, internal);
@@ -17866,7 +17866,7 @@ index cdc2ae90e70407455ba03b0805941ace809fa7f3..de42661734a2e0484c584c8b017bed56
  
          this.pluginManager.callEvent(new WorldLoadEvent(internal.getWorld()));
          return internal.getWorld();
-@@ -1171,7 +1171,7 @@ public final class CraftServer implements Server {
+@@ -1191,7 +1191,7 @@ public final class CraftServer implements Server {
              }
  
              handle.getChunkSource().close(save);
@@ -17875,7 +17875,7 @@ index cdc2ae90e70407455ba03b0805941ace809fa7f3..de42661734a2e0484c584c8b017bed56
              handle.convertable.close();
          } catch (Exception ex) {
              this.getLogger().log(Level.SEVERE, null, ex);
-@@ -1990,7 +1990,7 @@ public final class CraftServer implements Server {
+@@ -2010,7 +2010,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {
@@ -17885,10 +17885,10 @@ index cdc2ae90e70407455ba03b0805941ace809fa7f3..de42661734a2e0484c584c8b017bed56
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index aab8099b9980b4d4b4ee6d7484abcc0b55962a5f..9920eaa5d9efa301462f2dbf7e06835b819df3e1 100644
+index 7a3e6cc4d29d541c1075d5956b0b72f7aa8269da..61189dc031be93f2cd0a819598049fcb5e2ed6bc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -321,10 +321,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -323,10 +323,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          ChunkHolder playerChunk = this.world.getChunkSource().chunkMap.getVisibleChunkIfPresent(ChunkPos.asLong(x, z));
          if (playerChunk == null) return false;
  
@@ -17906,7 +17906,7 @@ index aab8099b9980b4d4b4ee6d7484abcc0b55962a5f..9920eaa5d9efa301462f2dbf7e06835b
  
                  ClientboundLevelChunkWithLightPacket refreshPacket = new ClientboundLevelChunkWithLightPacket(chunk, this.world.getLightEngine(), null, null, true);
                  for (ServerPlayer player : playersInRange) {
-@@ -332,8 +336,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -334,8 +338,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
                      player.connection.send(refreshPacket);
                  }
@@ -17916,7 +17916,7 @@ index aab8099b9980b4d4b4ee6d7484abcc0b55962a5f..9920eaa5d9efa301462f2dbf7e06835b
  
          return true;
      }
-@@ -410,20 +413,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -412,20 +415,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public Collection<Plugin> getPluginChunkTickets(int x, int z) {
          DistanceManager chunkDistanceManager = this.world.getChunkSource().chunkMap.distanceManager;
@@ -17938,7 +17938,7 @@ index aab8099b9980b4d4b4ee6d7484abcc0b55962a5f..9920eaa5d9efa301462f2dbf7e06835b
      }
  
      @Override
-@@ -431,7 +421,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -433,7 +423,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Map<Plugin, ImmutableList.Builder<Chunk>> ret = new HashMap<>();
          DistanceManager chunkDistanceManager = this.world.getChunkSource().chunkMap.distanceManager;
  
@@ -17947,7 +17947,7 @@ index aab8099b9980b4d4b4ee6d7484abcc0b55962a5f..9920eaa5d9efa301462f2dbf7e06835b
              long chunkKey = chunkTickets.getLongKey();
              SortedArraySet<Ticket<?>> tickets = chunkTickets.getValue();
  
-@@ -1950,14 +1940,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1957,14 +1947,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {

--- a/patches/server/0019-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0019-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index de42661734a2e0484c584c8b017bed5654a2acee..ada6faf50976d7dd7b244c32f376419d31738bb1 100644
+index 3a7d50651ab149665ac655b4f264278608335486..0a7979357a8c1e815d9527c341381b231d9e7bbd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -418,6 +418,35 @@ public final class CraftServer implements Server {
+@@ -423,6 +423,35 @@ public final class CraftServer implements Server {
          io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.INSTANCE.enter(io.papermc.paper.plugin.entrypoint.Entrypoint.PLUGIN); // Paper - replace implementation
      }
  
@@ -47,7 +47,7 @@ index de42661734a2e0484c584c8b017bed5654a2acee..ada6faf50976d7dd7b244c32f376419d
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 4e7208a891da461a10920482e4e4427ace23fb45..a1dc92c7fc48a0fafc14c254b0c0b93afd6481e4 100644
+index ab22205c758768cd0c8a4fc6bca3d7de2e823078..ff955d3a20bf953770cc81f8b89a6d4425a5f813 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -159,6 +159,12 @@ public class Main {

--- a/patches/server/0027-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0027-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -19,10 +19,10 @@ index 6251d93c2ea61c471b4e1069048327782acc78e7..d3cd196e1a6f707ed5e0008123cc65df
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ada6faf50976d7dd7b244c32f376419d31738bb1..ee2247aa527f4dacaf0e2083a2df0246dac7514e 100644
+index 0a7979357a8c1e815d9527c341381b231d9e7bbd..de60f523f589bcaadb037d660953f2ddd06d69a5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -257,7 +257,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -260,7 +260,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
  public final class CraftServer implements Server {
@@ -32,10 +32,10 @@ index ada6faf50976d7dd7b244c32f376419d31738bb1..ee2247aa527f4dacaf0e2083a2df0246
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index a1dc92c7fc48a0fafc14c254b0c0b93afd6481e4..f5554fe1aac5e68c2956989e8629d642c473ffa3 100644
+index ff955d3a20bf953770cc81f8b89a6d4425a5f813..268192b06592eaa56a454e0f02b2d848f766d9ac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -233,12 +233,25 @@ public class Main {
+@@ -240,12 +240,25 @@ public class Main {
                      deadline.add(Calendar.DAY_OF_YEAR, -21);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");

--- a/patches/server/0028-Implement-Paper-VersionChecker.patch
+++ b/patches/server/0028-Implement-Paper-VersionChecker.patch
@@ -140,10 +140,10 @@ index 0000000000000000000000000000000000000000..22a55be34fde453fedd987173d95b8b3
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 98083486bddf60074fc8e47e63e780703a792a7c..976a8d9019cccd82d8f5cd2cf86202e4076753ed 100644
+index a2203cd809810eb8793ae730d163192d87f615c8..4aa7969297cfbbbfe4964a3f793d9f11d684a713 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -455,6 +455,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -463,6 +463,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public String getTimingsServerName() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().timings.serverName;
      }

--- a/patches/server/0031-Further-improve-server-tick-loop.patch
+++ b/patches/server/0031-Further-improve-server-tick-loop.patch
@@ -145,10 +145,10 @@ index d3cd196e1a6f707ed5e0008123cc65df80422859..a7f9a3e57c7736b065b8dc4dba6e018c
                  this.startMetricsRecordingTick();
                  this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ee2247aa527f4dacaf0e2083a2df0246dac7514e..77bfda008ca983ba5ba4b26510f629a9d743b73b 100644
+index de60f523f589bcaadb037d660953f2ddd06d69a5..c454a9078e8a498095a078ec8d2acd2c32ccb991 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2419,6 +2419,17 @@ public final class CraftServer implements Server {
+@@ -2439,6 +2439,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0052-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0052-Ensure-commands-are-not-ran-async.patch
@@ -74,10 +74,10 @@ index 5291581c87b65be72f482b4da1fccd33fa053591..dae74cda3b9faa0c8aeecc6c7bc32995
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + s);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 77bfda008ca983ba5ba4b26510f629a9d743b73b..452171d26219f5169c707f17c56c46b928a84c60 100644
+index c454a9078e8a498095a078ec8d2acd2c32ccb991..ad6cb2a20bb494b9c0618e42d612fdd4639017cb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -855,6 +855,28 @@ public final class CraftServer implements Server {
+@@ -875,6 +875,28 @@ public final class CraftServer implements Server {
          Validate.notNull(commandLine, "CommandLine cannot be null");
          org.spigotmc.AsyncCatcher.catchOp("command dispatch"); // Spigot
  

--- a/patches/server/0054-Expose-server-CommandMap.patch
+++ b/patches/server/0054-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 452171d26219f5169c707f17c56c46b928a84c60..979bed9ee435cfc17aadb83184b2420b9a81c21e 100644
+index ad6cb2a20bb494b9c0618e42d612fdd4639017cb..bbe1147d7dc584c808c7f72747d48f5116e0e3dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1994,6 +1994,7 @@ public final class CraftServer implements Server {
+@@ -2014,6 +2014,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0058-Add-velocity-warnings.patch
+++ b/patches/server/0058-Add-velocity-warnings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add velocity warnings
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 979bed9ee435cfc17aadb83184b2420b9a81c21e..e5c712fff29255da5173b2a35eba0f35ccd75ee3 100644
+index bbe1147d7dc584c808c7f72747d48f5116e0e3dd..319caeca0737ab5b8f847a7e00784461839aad8c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -292,6 +292,7 @@ public final class CraftServer implements Server {
+@@ -296,6 +296,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;

--- a/patches/server/0066-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0066-Default-loading-permissions.yml-before-plugins.patch
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e5c712fff29255da5173b2a35eba0f35ccd75ee3..da13de547f4f4343ca3301f1b8684eb3d42d62a1 100644
+index 319caeca0737ab5b8f847a7e00784461839aad8c..ac33dc1b3ffe743276032fa5f73a92a2977b9c20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -452,6 +452,7 @@ public final class CraftServer implements Server {
+@@ -457,6 +457,7 @@ public final class CraftServer implements Server {
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
              this.helpMap.initializeGeneralTopics();
@@ -27,7 +27,7 @@ index e5c712fff29255da5173b2a35eba0f35ccd75ee3..da13de547f4f4343ca3301f1b8684eb3
          }
  
          Plugin[] plugins = this.pluginManager.getPlugins();
-@@ -471,7 +472,7 @@ public final class CraftServer implements Server {
+@@ -476,7 +477,7 @@ public final class CraftServer implements Server {
              this.commandMap.registerServerAliases();
              DefaultPermissions.registerCorePermissions();
              CraftDefaultPermissions.registerCorePermissions();

--- a/patches/server/0067-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0067-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index da13de547f4f4343ca3301f1b8684eb3d42d62a1..488c37ef814a8c592f82cfc4197e9dcfd2a9e95c 100644
+index ac33dc1b3ffe743276032fa5f73a92a2977b9c20..518306efc0e41a5bde0ad232cab8347969a5f364 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2585,5 +2585,23 @@ public final class CraftServer implements Server {
+@@ -2605,5 +2605,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0068-Remove-Metadata-on-reload.patch
+++ b/patches/server/0068-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 488c37ef814a8c592f82cfc4197e9dcfd2a9e95c..42fa812b86f439b3addce1f33365c7bfc3129fe2 100644
+index 518306efc0e41a5bde0ad232cab8347969a5f364..cf9db3ed2c9caba0bd40d310aaf1cc10603926c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -942,8 +942,16 @@ public final class CraftServer implements Server {
+@@ -962,8 +962,16 @@ public final class CraftServer implements Server {
              world.spigotConfig.init(); // Spigot
          }
  

--- a/patches/server/0106-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0106-Add-setting-for-proxy-online-mode-status.patch
@@ -43,10 +43,10 @@ index da98f074ccd5a40c635824112c97fd174c393cb1..6599f874d9f97e9ef4862039ecad7277
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 42fa812b86f439b3addce1f33365c7bfc3129fe2..6c055610a5aa3ae46a0505e533b72c7ea2ae6008 100644
+index cf9db3ed2c9caba0bd40d310aaf1cc10603926c4..f526b2701756062ef17ed0496685c4ac2d6288a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1717,7 +1717,7 @@ public final class CraftServer implements Server {
+@@ -1737,7 +1737,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6c055610a5aa3ae46a0505e533b72c7ea2ae6008..9e6232ff554867a50eab767e1e8457cdfa0db81d 100644
+index f526b2701756062ef17ed0496685c4ac2d6288a6..ded2e2df6bed222779a39e6f3cfd9170fdc0b494 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2611,5 +2611,24 @@ public final class CraftServer implements Server {
+@@ -2631,5 +2631,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -20,10 +20,10 @@ index 1a0accca970ca5eb895c63c5a45a5261440d0e12..35eecb719a813fda6113da24a858188a
      private final List<TickingBlockEntity> pendingBlockEntityTickers = Lists.newArrayList();
      private boolean tickingBlockEntities;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 40e532b616178aced5aac5871f71654f1f740877..6d93bbfcbdb01ba9424b7107bcd1e685c9a15701 100644
+index 61189dc031be93f2cd0a819598049fcb5e2ed6bc..632cc1e185b61677d42405d212f41833ee1bc9d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -153,6 +153,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -155,6 +155,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftWorld.DATA_TYPE_REGISTRY);
      private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  

--- a/patches/server/0135-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0135-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9e6232ff554867a50eab767e1e8457cdfa0db81d..0918939ff59989a2104d5320fb2fcea13dea3b8b 100644
+index ded2e2df6bed222779a39e6f3cfd9170fdc0b494..a4b3d4c72295d46cbd5901c0f5c59cb897c05b0e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2630,5 +2630,10 @@ public final class CraftServer implements Server {
+@@ -2650,5 +2650,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0136-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0136-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -236,10 +236,10 @@ index a34c9da6dbd37ab01385b768c06fef418de9c7c8..ce2291fb34df531b783d34f8453128a7
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0918939ff59989a2104d5320fb2fcea13dea3b8b..d29a4681006bd3ae7aa096988eb86f849c47613b 100644
+index a4b3d4c72295d46cbd5901c0f5c59cb897c05b0e..544ab33166e6410339dbd0ef70b692dfe33cd4fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -41,7 +41,6 @@ import java.util.logging.Level;
+@@ -42,7 +42,6 @@ import java.util.logging.Level;
  import java.util.logging.Logger;
  import java.util.stream.Collectors;
  import javax.imageio.ImageIO;
@@ -247,7 +247,7 @@ index 0918939ff59989a2104d5320fb2fcea13dea3b8b..d29a4681006bd3ae7aa096988eb86f84
  import net.minecraft.advancements.Advancement;
  import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
-@@ -1283,9 +1282,13 @@ public final class CraftServer implements Server {
+@@ -1303,9 +1302,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  
@@ -262,7 +262,7 @@ index 0918939ff59989a2104d5320fb2fcea13dea3b8b..d29a4681006bd3ae7aa096988eb86f84
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index d6e9f626b9c6ec5b16d37f0816775f1391487a11..730f805790bcab15e97c56bc6fc92cf38e70f5b0 100644
+index 4646911b65129d49b2398c7d86f2d6aa9213fe97..c5a403bc04fcb7a0fbc1dd1fe9ebf374e6a62af3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -13,7 +13,6 @@ import java.util.logging.Logger;
@@ -273,7 +273,7 @@ index d6e9f626b9c6ec5b16d37f0816775f1391487a11..730f805790bcab15e97c56bc6fc92cf3
  
  public class Main {
      public static boolean useJline = true;
-@@ -212,6 +211,8 @@ public class Main {
+@@ -219,6 +218,8 @@ public class Main {
              }
  
              try {
@@ -282,7 +282,7 @@ index d6e9f626b9c6ec5b16d37f0816775f1391487a11..730f805790bcab15e97c56bc6fc92cf3
                  // This trick bypasses Maven Shade's clever rewriting of our getProperty call when using String literals
                  String jline_UnsupportedTerminal = new String(new char[]{'j', 'l', 'i', 'n', 'e', '.', 'U', 'n', 's', 'u', 'p', 'p', 'o', 'r', 't', 'e', 'd', 'T', 'e', 'r', 'm', 'i', 'n', 'a', 'l'});
                  String jline_terminal = new String(new char[]{'j', 'l', 'i', 'n', 'e', '.', 't', 'e', 'r', 'm', 'i', 'n', 'a', 'l'});
-@@ -229,9 +230,18 @@ public class Main {
+@@ -236,9 +237,18 @@ public class Main {
                      // This ensures the terminal literal will always match the jline implementation
                      System.setProperty(jline.TerminalFactory.JLINE_TERMINAL, jline.UnsupportedTerminal.class.getName());
                  }
@@ -301,7 +301,7 @@ index d6e9f626b9c6ec5b16d37f0816775f1391487a11..730f805790bcab15e97c56bc6fc92cf3
                  }
  
                  if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
-@@ -259,7 +269,7 @@ public class Main {
+@@ -266,7 +276,7 @@ public class Main {
                      System.out.println("Unable to read system info");
                  }
                  // Paper end

--- a/patches/server/0142-Add-UnknownCommandEvent.patch
+++ b/patches/server/0142-Add-UnknownCommandEvent.patch
@@ -83,10 +83,10 @@ index 971fc7f5f51ba82a7e8abafa6a5139c24a9aac0b..7f561ab6e56cd1749da8eff950080d3a
  
                  b1 = 0;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d29a4681006bd3ae7aa096988eb86f849c47613b..708203b92f22374501aa252646b6a5e485f0bdad 100644
+index 544ab33166e6410339dbd0ef70b692dfe33cd4fe..97bd0993b49e18b47c2316663025564bca4d4b41 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -518,6 +518,7 @@ public final class CraftServer implements Server {
+@@ -523,6 +523,7 @@ public final class CraftServer implements Server {
                      }
                      node = clone;
                  }
@@ -94,7 +94,7 @@ index d29a4681006bd3ae7aa096988eb86f849c47613b..708203b92f22374501aa252646b6a5e4
  
                  dispatcher.getDispatcher().getRoot().addChild(node);
              } else {
-@@ -884,7 +885,13 @@ public final class CraftServer implements Server {
+@@ -904,7 +905,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -631,10 +631,10 @@ index 4038bb76339d43f18770624bd7fecc79b8d7f2a9..2456edc11b29a92b1648937cd3dd6a9a
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 708203b92f22374501aa252646b6a5e485f0bdad..ba53c66b4708e7d2efc2563edf8a39b8664b6f4c 100644
+index 97bd0993b49e18b47c2316663025564bca4d4b41..d92f7eadf13cdab064a1f2a5c132faeabc2e25cb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -255,6 +255,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -258,6 +258,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
@@ -644,7 +644,7 @@ index 708203b92f22374501aa252646b6a5e485f0bdad..ba53c66b4708e7d2efc2563edf8a39b8
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -296,6 +299,7 @@ public final class CraftServer implements Server {
+@@ -300,6 +303,7 @@ public final class CraftServer implements Server {
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
          ConfigurationSerialization.registerClass(CraftPlayerProfile.class);
@@ -652,7 +652,7 @@ index 708203b92f22374501aa252646b6a5e485f0bdad..ba53c66b4708e7d2efc2563edf8a39b8
          CraftItemFactory.instance();
      }
  
-@@ -2645,5 +2649,37 @@ public final class CraftServer implements Server {
+@@ -2665,5 +2669,37 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }

--- a/patches/server/0152-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0152-Fix-this-stupid-bullshit.patch
@@ -31,10 +31,10 @@ index e43096e69a00f9ea96badd7c966443cfcf3e7b95..ac2b7b5161eaaca3620268ae865d6f2a
              Bootstrap.isBootstrapped = true;
              if (BuiltInRegistries.REGISTRY.keySet().isEmpty()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 730f805790bcab15e97c56bc6fc92cf38e70f5b0..ac153f5f08e0acea60eb1ee01cd0ad3eb6ba410b 100644
+index c5a403bc04fcb7a0fbc1dd1fe9ebf374e6a62af3..c79afabed432ca9094967ae0e48b04133dc4c51b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -250,10 +250,12 @@ public class Main {
+@@ -257,10 +257,12 @@ public class Main {
                      Calendar deadline = Calendar.getInstance();
                      deadline.add(Calendar.DAY_OF_YEAR, -21);
                      if (buildDate.before(deadline.getTime())) {

--- a/patches/server/0168-API-to-get-a-BlockState-without-a-snapshot.patch
+++ b/patches/server/0168-API-to-get-a-BlockState-without-a-snapshot.patch
@@ -51,10 +51,10 @@ index b701a1344db066b9368841f2377ee493514bf282..5768ff2c3e15c038d132c7ad391332fb
          return null;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 4974e8366488446ec5bea16454e5b4fbb99a85c5..0cd58fd473f8cc6cb61798ceca972caef3f5c4d4 100644
+index 7019d4424360e150cb8962bab64077d3ce9c0ba8..2f01b47b9aa669bff551a3966a5a2caf0fee0de7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -330,6 +330,13 @@ public class CraftBlock implements Block {
+@@ -333,6 +333,13 @@ public class CraftBlock implements Block {
          return CraftBlockStates.getBlockState(this);
      }
  

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -91,10 +91,10 @@ index be2b8c7cf8c36242f4eee12c9f7b8217f31b12ab..efc9b3bf0a63f87f8d1cab57b8f521a3
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ba53c66b4708e7d2efc2563edf8a39b8664b6f4c..c5bf6cd46d72d415cf3581823dd8fa9a4f4699c1 100644
+index d92f7eadf13cdab064a1f2a5c132faeabc2e25cb..5dcbb06370cdf6a5f700ebd09a9a765c9587a688 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2098,7 +2098,7 @@ public final class CraftServer implements Server {
+@@ -2118,7 +2118,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0185-getPlayerUniqueId-API.patch
+++ b/patches/server/0185-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c5bf6cd46d72d415cf3581823dd8fa9a4f4699c1..d43c27328801f1b830f2438fe1d7a11d44c08885 100644
+index 5dcbb06370cdf6a5f700ebd09a9a765c9587a688..cb70820fd96624c2378e98d48ac31a11dc9e25e3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1720,6 +1720,25 @@ public final class CraftServer implements Server {
+@@ -1740,6 +1740,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0196-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0196-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -34,10 +34,10 @@ index d273673978c8270f2e0719412372039406e31f5e..65110445ff8a245742c4f7a7055f544f
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e85189ccf80c166f741eee2ea9bcdd2fd38508d2..06d667c3ab4d4c6902dfc143666b625b306a7782 100644
+index 632cc1e185b61677d42405d212f41833ee1bc9d4..33cd9cb5b048fccd6bf7720aa1249f966f5b1e6d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1854,11 +1854,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1856,11 +1856,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0213-Expand-Explosions-API.patch
+++ b/patches/server/0213-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 32ef1eb646a33a022c0fffcff2a293091288c3e2..82a3240169b5d9a5c8d6cbb17a82e4a7457bf994 100644
+index 33cd9cb5b048fccd6bf7720aa1249f966f5b1e6d..076a97209d9ac90bb89970a6d3a6075c022bd2ef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -709,6 +709,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -711,6 +711,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
          return !this.world.explode(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, breakBlocks ? net.minecraft.world.level.Level.ExplosionInteraction.MOB : net.minecraft.world.level.Level.ExplosionInteraction.NONE).wasCanceled;
      }

--- a/patches/server/0217-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0217-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 82a3240169b5d9a5c8d6cbb17a82e4a7457bf994..c178f57d5e45a6d2c91f0476ccdb3cb690a3200c 100644
+index 076a97209d9ac90bb89970a6d3a6075c022bd2ef..020049ba110ec10d7dfca9117dcc6de190cd6785 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1033,6 +1033,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1035,6 +1035,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return list;
      }
  

--- a/patches/server/0239-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0239-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -33,10 +33,10 @@ index e6826cd0a596f063e8737dcde3c8c6c5b3f71970..1a2607d1b257cea65c82c661a6b3d46c
          com.destroystokyo.paper.Metrics.PaperMetrics.startMetrics();
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d43c27328801f1b830f2438fe1d7a11d44c08885..d351c9076cdc8e6c491e5afeaafda59182c169d6 100644
+index cb70820fd96624c2378e98d48ac31a11dc9e25e3..195b3f20617f9ad1e1fa522d138be3b570aa49a4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -904,6 +904,7 @@ public final class CraftServer implements Server {
+@@ -924,6 +924,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -44,7 +44,7 @@ index d43c27328801f1b830f2438fe1d7a11d44c08885..d351c9076cdc8e6c491e5afeaafda591
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -993,6 +994,7 @@ public final class CraftServer implements Server {
+@@ -1013,6 +1014,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/patches/server/0252-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0252-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c178f57d5e45a6d2c91f0476ccdb3cb690a3200c..c6e8144a9f2b50fec6e9556a4fa22da48895ad2c 100644
+index 020049ba110ec10d7dfca9117dcc6de190cd6785..ba4f1012c2046921c2c48583a5384fd7e4c05af7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -399,7 +399,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -401,7 +401,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0269-Add-sun-related-API.patch
+++ b/patches/server/0269-Add-sun-related-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add sun related API
 public net.minecraft.world.entity.Mob isSunBurnTick()Z
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c6e8144a9f2b50fec6e9556a4fa22da48895ad2c..24b24ed9a2d6b609ece153d49c675b362cdf11dc 100644
+index ba4f1012c2046921c2c48583a5384fd7e4c05af7..4421392702304514c2cb26f32817ed150c9dc947 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -685,6 +685,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -687,6 +687,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
      }
  

--- a/patches/server/0284-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0284-Make-the-default-permission-message-configurable.patch
@@ -18,10 +18,10 @@ index e3467aaf6d0c8d486b84362e3c20b3fe631b50ff..8f16640fc2f1233c10392d7e32a54d78
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d351c9076cdc8e6c491e5afeaafda59182c169d6..d90435e05330a625514fab36fa7195b4d78ab713 100644
+index 195b3f20617f9ad1e1fa522d138be3b570aa49a4..03a175ce27f7d816ce1f157f41674cd4dbcc5fe2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2671,6 +2671,16 @@ public final class CraftServer implements Server {
+@@ -2691,6 +2691,16 @@ public final class CraftServer implements Server {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }
  

--- a/patches/server/0311-Add-Heightmap-API.patch
+++ b/patches/server/0311-Add-Heightmap-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 24b24ed9a2d6b609ece153d49c675b362cdf11dc..159684576b235cf9a01de75c7e274bd6bf3127d0 100644
+index 4421392702304514c2cb26f32817ed150c9dc947..cb0c6578be38187dbc50aac116e70c492196b8e3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -218,6 +218,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -220,6 +220,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return CraftBlock.at(world, new BlockPos(x, y, z));
      }
  

--- a/patches/server/0315-Implement-CraftBlockSoundGroup.patch
+++ b/patches/server/0315-Implement-CraftBlockSoundGroup.patch
@@ -50,10 +50,10 @@ index 0000000000000000000000000000000000000000..c5b07ec346105d1b95c1c938ffca12a2
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 0cd58fd473f8cc6cb61798ceca972caef3f5c4d4..fadf95c9ce9ca1d8e1aba5d7035338939ee010ec 100644
+index 2f01b47b9aa669bff551a3966a5a2caf0fee0de7..97f0f5fac4e1ddf1f39981687d08adf6a5662457 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -646,4 +646,16 @@ public class CraftBlock implements Block {
+@@ -649,4 +649,16 @@ public class CraftBlock implements Block {
      public String getTranslationKey() {
          return this.getNMS().getBlock().getDescriptionId();
      }

--- a/patches/server/0316-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0316-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -200,10 +200,10 @@ index 4d2348df25410a0b5364eec066880326d6667dad..286aad3205ef8a9e21a47ef07893844f
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 159684576b235cf9a01de75c7e274bd6bf3127d0..9d50bd4535989438743b77580018ba9d16e896c8 100644
+index cb0c6578be38187dbc50aac116e70c492196b8e3..901799f0d222b2f1934436467e73ff80c26aef4a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1342,15 +1342,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1344,15 +1344,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/patches/server/0318-Expose-the-internal-current-tick.patch
+++ b/patches/server/0318-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d90435e05330a625514fab36fa7195b4d78ab713..af732bd31dc2cce4e65e01d69a0c366e71439097 100644
+index 03a175ce27f7d816ce1f157f41674cd4dbcc5fe2..ca20401d795af96f6d8b9f1c10c854e8355e6899 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2712,5 +2712,10 @@ public final class CraftServer implements Server {
+@@ -2732,5 +2732,10 @@ public final class CraftServer implements Server {
          profile.getProperties().putAll(((CraftPlayer)player).getHandle().getGameProfile().getProperties());
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }

--- a/patches/server/0319-Fix-World-isChunkGenerated-calls.patch
+++ b/patches/server/0319-Fix-World-isChunkGenerated-calls.patch
@@ -156,10 +156,10 @@ index 8f729134d8f024678f3f5927059791e28ccb5b90..b294ef87fb93e7f4651dc04128124f29
              } catch (Throwable throwable) {
                  if (dataoutputstream != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9d50bd4535989438743b77580018ba9d16e896c8..e95c0d533f518837d5f6000eb919d685c921d302 100644
+index 901799f0d222b2f1934436467e73ff80c26aef4a..87efc9c4d63b7c413b37f1a1a58100bf17615509 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -306,9 +306,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -308,9 +308,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -185,7 +185,7 @@ index 9d50bd4535989438743b77580018ba9d16e896c8..e95c0d533f518837d5f6000eb919d685
              throw new RuntimeException(ex);
          }
      }
-@@ -422,20 +436,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -424,20 +438,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0343-Anti-Xray.patch
+++ b/patches/server/0343-Anti-Xray.patch
@@ -1572,10 +1572,10 @@ index b738e1f7debac7d70910d5ac908ca9d4f60640d5..269ebe8e8826a0c89e471cb59b503900
  
      public CraftChunk(net.minecraft.world.level.chunk.LevelChunk chunk) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index af732bd31dc2cce4e65e01d69a0c366e71439097..5096c8a665343c9b6f8be0e5721e8e3b83fdb122 100644
+index ca20401d795af96f6d8b9f1c10c854e8355e6899..456bb6cf7278a1418b39b9b2094abad3137bb508 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2246,7 +2246,7 @@ public final class CraftServer implements Server {
+@@ -2266,7 +2266,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Validate.notNull(world, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();
@@ -1585,10 +1585,10 @@ index af732bd31dc2cce4e65e01d69a0c366e71439097..5096c8a665343c9b6f8be0e5721e8e3b
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 998bfd1f63fc08067e9cc9fd5ed503e232dd4783..ef9813df00119d3effa48c5d0fb8f07f7ba7da15 100644
+index 87efc9c4d63b7c413b37f1a1a58100bf17615509..ec934c2cb6f183c43c06ba9c4d015890d5992934 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -417,11 +417,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -419,11 +419,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  List<ServerPlayer> playersInRange = playerChunk.playerProvider.getPlayers(playerChunk.getPos(), false);
                  if (playersInRange.isEmpty()) return true; // Paper - rewrite player chunk loader
  

--- a/patches/server/0349-Improve-Block-breakNaturally-API.patch
+++ b/patches/server/0349-Improve-Block-breakNaturally-API.patch
@@ -34,10 +34,10 @@ index 943b5ee11fb066afcfb3717befe4dab35db5b600..5ecf02ce83b7496c977adfeb203b8ead
              if (world.dimensionType().ultraWarm()) {
                  world.removeBlock(pos, false);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index fadf95c9ce9ca1d8e1aba5d7035338939ee010ec..707ee755cb9ebf2a2b61a6079efbc54368beeed0 100644
+index 97f0f5fac4e1ddf1f39981687d08adf6a5662457..cbe5f0a6ba85d2acafa9d0d9b1575d3ccbd11cae 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -476,6 +476,18 @@ public class CraftBlock implements Block {
+@@ -479,6 +479,18 @@ public class CraftBlock implements Block {
  
      @Override
      public boolean breakNaturally(ItemStack item) {
@@ -56,7 +56,7 @@ index fadf95c9ce9ca1d8e1aba5d7035338939ee010ec..707ee755cb9ebf2a2b61a6079efbc543
          // Order matters here, need to drop before setting to air so skulls can get their data
          net.minecraft.world.level.block.state.BlockState iblockdata = this.getNMS();
          net.minecraft.world.level.block.Block block = iblockdata.getBlock();
-@@ -485,11 +497,35 @@ public class CraftBlock implements Block {
+@@ -488,11 +500,35 @@ public class CraftBlock implements Block {
          // Modelled off EntityHuman#hasBlock
          if (block != Blocks.AIR && (item == null || !iblockdata.requiresCorrectToolForDrops() || nmsItem.isCorrectToolForDrops(iblockdata))) {
              net.minecraft.world.level.block.Block.dropResources(iblockdata, this.world.getMinecraftWorld(), position, this.world.getBlockEntity(position), null, nmsItem);

--- a/patches/server/0352-Remove-garbage-Java-version-check.patch
+++ b/patches/server/0352-Remove-garbage-Java-version-check.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Remove garbage Java version check
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 7968b883847877f7ddc11f7a25efbbb71605d2bf..8b03be6babe3052ab351061c0c206c84e26ef705 100644
+index c79afabed432ca9094967ae0e48b04133dc4c51b..77911e26af9ec468c8a0c1fe8161b79c67b2303c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -205,10 +205,6 @@ public class Main {
@@ -16,6 +16,6 @@ index 7968b883847877f7ddc11f7a25efbbb71605d2bf..8b03be6babe3052ab351061c0c206c84
 -                System.err.println("Unsupported Java detected (" + javaVersion + "). Only up to Java 20 is supported.");
 -                return;
 -            }
- 
-             try {
-                 // Paper start - Handled by TerminalConsoleAppender
+             String javaVersionName = System.getProperty("java.version");
+             // J2SE SDK/JRE Version String Naming Convention
+             boolean isPreRelease = javaVersionName.contains("-");

--- a/patches/server/0363-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0363-Add-tick-times-API-and-mspt-command.patch
@@ -184,10 +184,10 @@ index 2e29d1c3e5faf970bfaf3a545ef3553f284d68ef..d00545c31de383470bcb8e4d9c6edad2
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5096c8a665343c9b6f8be0e5721e8e3b83fdb122..42247677468ad3eac34fa1110e3684c2e51268ec 100644
+index 456bb6cf7278a1418b39b9b2094abad3137bb508..dc1cbc8942d80e2975cc8c47d7567941b18148ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2496,6 +2496,16 @@ public final class CraftServer implements Server {
+@@ -2516,6 +2516,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0364-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0364-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 42247677468ad3eac34fa1110e3684c2e51268ec..422413ddd62e19dced2776bb41f73af1ad294f43 100644
+index dc1cbc8942d80e2975cc8c47d7567941b18148ea..b7dc51e29aed83fe40cc4730a1b8448b432ebff8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2727,5 +2727,10 @@ public final class CraftServer implements Server {
+@@ -2747,5 +2747,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0365-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/server/0365-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Raw Byte ItemStack Serialization
 Serializes using NBT which is safer for server data migrations than bukkits format.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 976a8d9019cccd82d8f5cd2cf86202e4076753ed..e50daf4bafa38d92304ffda05326bd335d070422 100644
+index 4aa7969297cfbbbfe4964a3f793d9f11d684a713..f6eae5756dd7919938ca8265bfeba84fba3ec644 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -460,6 +460,52 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -468,6 +468,52 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {
          return new com.destroystokyo.paper.PaperVersionFetcher();
      }

--- a/patches/server/0375-Improved-Watchdog-Support.patch
+++ b/patches/server/0375-Improved-Watchdog-Support.patch
@@ -318,7 +318,7 @@ index 703830416a0483e960643bee269fe01e170112bd..ee1c9f2c8dd30b3f32a6d49aa1c43148
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 5a22fdbcbe2f2eee2140bff87bc402a437792e9f..70d6bfa86a17cd0f12194e397d15db1833638de6 100644
+index 77911e26af9ec468c8a0c1fe8161b79c67b2303c..be1fbe64a5145b25c111ba3b6bb35109e77deb9d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -178,6 +178,36 @@ public class Main {
@@ -358,7 +358,7 @@ index 5a22fdbcbe2f2eee2140bff87bc402a437792e9f..70d6bfa86a17cd0f12194e397d15db18
          try {
              options = parser.parse(args);
          } catch (joptsimple.OptionException ex) {
-@@ -273,8 +303,64 @@ public class Main {
+@@ -280,8 +310,64 @@ public class Main {
              } catch (Throwable t) {
                  t.printStackTrace();
              }

--- a/patches/server/0391-Expose-game-version.patch
+++ b/patches/server/0391-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 422413ddd62e19dced2776bb41f73af1ad294f43..44658126e87eacc042752940685b3f7457ad9d5a 100644
+index b7dc51e29aed83fe40cc4730a1b8448b432ebff8..0dbabab39dddfbc2a11c509e6e7e12814e60c6c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -572,6 +572,13 @@ public final class CraftServer implements Server {
+@@ -577,6 +577,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  

--- a/patches/server/0394-misc-debugging-dumps.patch
+++ b/patches/server/0394-misc-debugging-dumps.patch
@@ -74,10 +74,10 @@ index 0c7f280bae81bbb492d5780a43e5ffda0f58756a..238a7bc87ab49da1f0fa3c733dd512fd
                  this.connection.send(new ClientboundDisconnectPacket(ichatmutablecomponent));
                  this.connection.disconnect(ichatmutablecomponent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 44658126e87eacc042752940685b3f7457ad9d5a..88e93f9daa5d69d858f61baf03724b96b8b5f1d8 100644
+index 0dbabab39dddfbc2a11c509e6e7e12814e60c6c2..9c50a908146b599b79176bd64f6773539db14996 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -995,6 +995,7 @@ public final class CraftServer implements Server {
+@@ -1015,6 +1015,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getFullName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0397-Implement-Mob-Goal-API.patch
+++ b/patches/server/0397-Implement-Mob-Goal-API.patch
@@ -792,10 +792,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 88e93f9daa5d69d858f61baf03724b96b8b5f1d8..164c137ee1cbfa540ec6ce85bfadab4d34e0c038 100644
+index 9c50a908146b599b79176bd64f6773539db14996..ea1f82fd9369c75b1bfdc8f82c70f1bc132afdca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2740,5 +2740,11 @@ public final class CraftServer implements Server {
+@@ -2760,5 +2760,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0404-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0404-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,10 +22,10 @@ index e189de6d2aa94e9bbb20f1477ee2e34431adb324..4a58843f7ce2dd9e50f9daf3065d056a
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 164c137ee1cbfa540ec6ce85bfadab4d34e0c038..e2fd9a4fc9b0879416fe70aa5352327d3a901a4a 100644
+index ea1f82fd9369c75b1bfdc8f82c70f1bc132afdca..d4439eb165cf01f4dd7eb106d14f7b96c1989e63 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1005,6 +1005,31 @@ public final class CraftServer implements Server {
+@@ -1025,6 +1025,31 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0427-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0427-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -102,10 +102,10 @@ index e9902fa67719c4b40fb9524bf77798357e9a97d9..b4f17b9c195081b54d79494d9afaf0da
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e2fd9a4fc9b0879416fe70aa5352327d3a901a4a..01f734e0e4eb51083ae4d80f3423122a98190095 100644
+index d4439eb165cf01f4dd7eb106d14f7b96c1989e63..dfde62de3b59b9c2473e8f320552051a8904d51b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -944,8 +944,8 @@ public final class CraftServer implements Server {
+@@ -964,8 +964,8 @@ public final class CraftServer implements Server {
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
          this.console.paperConfigurations.reloadConfigs(this.console);
          for (ServerLevel world : this.console.getAllLevels()) {
@@ -117,10 +117,10 @@ index e2fd9a4fc9b0879416fe70aa5352327d3a901a4a..01f734e0e4eb51083ae4d80f3423122a
              for (SpawnCategory spawnCategory : SpawnCategory.values()) {
                  if (CraftSpawnCategory.isValidForLimits(spawnCategory)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ef9813df00119d3effa48c5d0fb8f07f7ba7da15..3f1521b4f5a7b76a648fdaf7af9e2753c98ed545 100644
+index ec934c2cb6f183c43c06ba9c4d015890d5992934..6a5405265b2cb2f4e681c5e3a84ffccbac4fc79d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1143,7 +1143,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1145,7 +1145,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setDifficulty(Difficulty difficulty) {

--- a/patches/server/0431-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0431-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,10 +22,10 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 01f734e0e4eb51083ae4d80f3423122a98190095..5a09fa2042adc34d541b24fff12acca382a8f998 100644
+index dfde62de3b59b9c2473e8f320552051a8904d51b..e9c52523142df3a0dd9ae9389c69024eb2fe5386 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -372,7 +372,7 @@ public final class CraftServer implements Server {
+@@ -377,7 +377,7 @@ public final class CraftServer implements Server {
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -34,7 +34,7 @@ index 01f734e0e4eb51083ae4d80f3423122a98190095..5a09fa2042adc34d541b24fff12acca3
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
  
-@@ -924,7 +924,7 @@ public final class CraftServer implements Server {
+@@ -944,7 +944,7 @@ public final class CraftServer implements Server {
          this.console.setMotd(config.motd);
          this.overrideSpawnLimits();
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -44,10 +44,10 @@ index 01f734e0e4eb51083ae4d80f3423122a98190095..5a09fa2042adc34d541b24fff12acca3
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3f1521b4f5a7b76a648fdaf7af9e2753c98ed545..98e2d959aaef16a2249f6701b28c6a038af799d4 100644
+index 6a5405265b2cb2f4e681c5e3a84ffccbac4fc79d..3711c2842d4830b4a7dd0cd9fd5a4dea46f75bd2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -278,7 +278,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -280,7 +280,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -62,7 +62,7 @@ index 3f1521b4f5a7b76a648fdaf7af9e2753c98ed545..98e2d959aaef16a2249f6701b28c6a03
          return new CraftChunk(chunk);
      }
  
-@@ -292,6 +298,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -294,6 +300,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return new CraftChunk(this.getHandle(), x, z);
      }
  
@@ -75,7 +75,7 @@ index 3f1521b4f5a7b76a648fdaf7af9e2753c98ed545..98e2d959aaef16a2249f6701b28c6a03
      @Override
      public Chunk getChunkAt(Block block) {
          Preconditions.checkArgument(block != null, "null block");
-@@ -357,7 +369,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -359,7 +371,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (this.isChunkLoaded(x, z)) {
@@ -84,7 +84,7 @@ index 3f1521b4f5a7b76a648fdaf7af9e2753c98ed545..98e2d959aaef16a2249f6701b28c6a03
          }
  
          return true;
-@@ -443,9 +455,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -445,9 +457,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -98,7 +98,7 @@ index 3f1521b4f5a7b76a648fdaf7af9e2753c98ed545..98e2d959aaef16a2249f6701b28c6a03
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -453,7 +468,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -455,7 +470,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -107,7 +107,7 @@ index 3f1521b4f5a7b76a648fdaf7af9e2753c98ed545..98e2d959aaef16a2249f6701b28c6a03
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -479,7 +494,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -481,7 +496,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -116,7 +116,7 @@ index 3f1521b4f5a7b76a648fdaf7af9e2753c98ed545..98e2d959aaef16a2249f6701b28c6a03
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -2194,6 +2209,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2201,6 +2216,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          io.papermc.paper.chunk.system.ChunkSystem.scheduleChunkLoad(this.getHandle(), x, z, gen, ChunkStatus.FULL, true, priority, (c) -> {
              net.minecraft.server.MinecraftServer.getServer().scheduleOnMain(() -> {
                  net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk)c;

--- a/patches/server/0457-Add-setMaxPlayers-API.patch
+++ b/patches/server/0457-Add-setMaxPlayers-API.patch
@@ -18,10 +18,10 @@ index cfe2dea64104eeaffd6606fdff0d5a1a2c111329..0e22201853ae2befdc6904e194f8bbc6
      private int simulationDistance;
      private boolean allowCheatsForAllPlayers;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5a09fa2042adc34d541b24fff12acca382a8f998..24d0419ac82ee388e8d545b3fb391eea424a53f7 100644
+index e9c52523142df3a0dd9ae9389c69024eb2fe5386..6af883347c259d043cefd73215d9ce263878e23b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -667,6 +667,13 @@ public final class CraftServer implements Server {
+@@ -672,6 +672,13 @@ public final class CraftServer implements Server {
          return this.playerList.getMaxPlayers();
      }
  

--- a/patches/server/0460-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0460-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -21,10 +21,10 @@ index 06d20e9fde26540d1575975345f3d69405f767d0..959a8a170363227bb8ca833d8399f0c4
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig().spawn.keepSpawnLoadedRange * 16, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 51b88f432134e162dd63580ef2c086ad853d5ee9..2f4bdf2128037b06a3d5e7b340f5f888c8777ca8 100644
+index 3711c2842d4830b4a7dd0cd9fd5a4dea46f75bd2..69187c3809369cf2dbe15a0f99e510e762f682d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -258,12 +258,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -260,12 +260,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {

--- a/patches/server/0471-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0471-Add-methods-to-get-translation-keys.patch
@@ -10,10 +10,10 @@ public org.bukkit.craftbukkit.inventory.CraftMetaFirework getNBT(Lorg/bukkit/Fir
 Co-authored-by: MeFisto94 <MeFisto94@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 707ee755cb9ebf2a2b61a6079efbc54368beeed0..5ce19b2dcf9dd2844fe79991fc0260e6141f3394 100644
+index cbe5f0a6ba85d2acafa9d0d9b1575d3ccbd11cae..883734f0092d1f968fb5e29e0c92a77dfa399ab0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -693,5 +693,10 @@ public class CraftBlock implements Block {
+@@ -696,5 +696,10 @@ public class CraftBlock implements Block {
      public org.bukkit.SoundGroup getBlockSoundGroup() {
          return org.bukkit.craftbukkit.CraftSoundGroup.getSoundGroup(this.getNMS().getSoundType());
      }

--- a/patches/server/0478-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0478-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -21,10 +21,10 @@ index f8f0be4ebb097c26461ea0fcbce7914ce84e87ed..7fe47f6158ca78f522685762e1e990ff
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index e50daf4bafa38d92304ffda05326bd335d070422..c4cc2833879d14451be507a59a31c67f13cc8b3d 100644
+index f6eae5756dd7919938ca8265bfeba84fba3ec644..8bd49ffe7e26e6309407830794fae6b7c91c5600 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -506,6 +506,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -514,6 +514,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
          Preconditions.checkArgument(dataVersion <= getDataVersion(), "Newer version! Server downgrades are not supported!");
          return compound;
      }

--- a/patches/server/0493-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0493-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 24d0419ac82ee388e8d545b3fb391eea424a53f7..a6eba94e20b1c134fed45060645d80081a5e2184 100644
+index 6af883347c259d043cefd73215d9ce263878e23b..e7e0059831b19d03da07fbe610a9d20cd1c490ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1811,6 +1811,28 @@ public final class CraftServer implements Server {
+@@ -1831,6 +1831,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0496-Fix-client-lag-on-advancement-loading.patch
+++ b/patches/server/0496-Fix-client-lag-on-advancement-loading.patch
@@ -15,10 +15,10 @@ manually reload the advancement data for all players, which
 normally takes place as a part of the datapack reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index c4cc2833879d14451be507a59a31c67f13cc8b3d..a933d12dabfee67f2c9bb2419f9ede69c354b3c2 100644
+index 8bd49ffe7e26e6309407830794fae6b7c91c5600..289f6fade5f5500867eb75df41df6b8c5465e185 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -345,7 +345,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -347,7 +347,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
                      Bukkit.getLogger().log(Level.SEVERE, "Error saving advancement " + key, ex);
                  }
  

--- a/patches/server/0503-Add-Destroy-Speed-API.patch
+++ b/patches/server/0503-Add-Destroy-Speed-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 4167b665abdae0db1425f50ccf175bc35699abca..32fdb3cf74a2d0c27b9cb572e7c16c7eda400ea7 100644
+index 1cfbe11ba3e82071bad8b723ac781818268414f2..5cca837474205eaa7bffadf31a60bf352ef7365b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -698,5 +698,26 @@ public class CraftBlock implements Block {
+@@ -701,5 +701,26 @@ public class CraftBlock implements Block {
      public String translationKey() {
          return this.getNMS().getBlock().getDescriptionId();
      }

--- a/patches/server/0523-Additional-Block-Material-API-s.patch
+++ b/patches/server/0523-Additional-Block-Material-API-s.patch
@@ -9,10 +9,10 @@ process to do this in the Bukkit API
 Adds API for buildable, replaceable, burnable too.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 32fdb3cf74a2d0c27b9cb572e7c16c7eda400ea7..83d961be2a3527402c2e22aa5809bc8a7029170b 100644
+index 5cca837474205eaa7bffadf31a60bf352ef7365b..86a932d397ca92ab7d6f3b64860ede8adb86c0b5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -464,6 +464,25 @@ public class CraftBlock implements Block {
+@@ -467,6 +467,25 @@ public class CraftBlock implements Block {
          return this.getNMS().getMaterial().isLiquid();
      }
  

--- a/patches/server/0534-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0534-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 4a0321f56ef80aa4991e61f586ddd3f6b45e499b..de713f1ca1d61a6b1fca2b66de916255
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1e28cda1faf145c2b72e0eac095a1b8b0b2b5dba..091e5fae3834dd06527c5dc108d1342f763f93b4 100644
+index 69187c3809369cf2dbe15a0f99e510e762f682d2..5c8270adf72114263d4e7b212201a7ea24bc95ae 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1837,8 +1837,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1839,8 +1839,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index 1e28cda1faf145c2b72e0eac095a1b8b0b2b5dba..091e5fae3834dd06527c5dc108d1342f
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1873,8 +1878,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1875,8 +1880,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0579-Add-Block-isValidTool.patch
+++ b/patches/server/0579-Add-Block-isValidTool.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Block#isValidTool
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 83d961be2a3527402c2e22aa5809bc8a7029170b..9e11a7967799c6f57e7461e22a3bb6f427af8418 100644
+index 86a932d397ca92ab7d6f3b64860ede8adb86c0b5..9a1304103d367e2d7bc552977542b46e9887bcb4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -738,5 +738,9 @@ public class CraftBlock implements Block {
+@@ -741,5 +741,9 @@ public class CraftBlock implements Block {
          }
          return speed;
      }

--- a/patches/server/0581-Expand-world-key-API.patch
+++ b/patches/server/0581-Expand-world-key-API.patch
@@ -20,10 +20,10 @@ index 3ffea505826bbe4151268ed9cffa5f2ddea27b62..287dd68f1aa78bf5f1406f585e4a6575
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a6eba94e20b1c134fed45060645d80081a5e2184..2cdeb4505c02942079fb18cf7af15e63463f550c 100644
+index e7e0059831b19d03da07fbe610a9d20cd1c490ad..5014f7958074591d1eec22c6775d291828ba0560 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1133,9 +1133,15 @@ public final class CraftServer implements Server {
+@@ -1153,9 +1153,15 @@ public final class CraftServer implements Server {
          File folder = new File(this.getWorldContainer(), name);
          World world = this.getWorld(name);
  
@@ -41,7 +41,7 @@ index a6eba94e20b1c134fed45060645d80081a5e2184..2cdeb4505c02942079fb18cf7af15e63
  
          if ((folder.exists()) && (!folder.isDirectory())) {
              throw new IllegalArgumentException("File exists with the name '" + name + "' and isn't a folder");
-@@ -1224,7 +1230,7 @@ public final class CraftServer implements Server {
+@@ -1244,7 +1250,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -50,7 +50,7 @@ index a6eba94e20b1c134fed45060645d80081a5e2184..2cdeb4505c02942079fb18cf7af15e63
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, worlddimension, this.getServer().progressListenerFactory.create(11),
-@@ -1316,6 +1322,15 @@ public final class CraftServer implements Server {
+@@ -1336,6 +1342,15 @@ public final class CraftServer implements Server {
          return null;
      }
  
@@ -67,10 +67,10 @@ index a6eba94e20b1c134fed45060645d80081a5e2184..2cdeb4505c02942079fb18cf7af15e63
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index a933d12dabfee67f2c9bb2419f9ede69c354b3c2..12358f5147172d3a3a4159f2c1c8b650f45e87dd 100644
+index 289f6fade5f5500867eb75df41df6b8c5465e185..a7c73b19f81e30422ef5f145fdd7c64b6e4fd633 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -517,6 +517,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -525,6 +525,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public int nextEntityId() {
          return net.minecraft.world.entity.Entity.nextEntityId();
      }

--- a/patches/server/0583-Item-Rarity-API.patch
+++ b/patches/server/0583-Item-Rarity-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Item Rarity API
 public net.minecraft.world.item.Item rarity
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 12358f5147172d3a3a4159f2c1c8b650f45e87dd..2b262a9dc58f1c7b79f10c44aae016088a34c06f 100644
+index a7c73b19f81e30422ef5f145fdd7c64b6e4fd633..c96665397d08f74b3331f6544d110df5cc1988ef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -522,6 +522,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -530,6 +530,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public String getMainLevelName() {
          return ((net.minecraft.server.dedicated.DedicatedServer) net.minecraft.server.MinecraftServer.getServer()).getProperties().levelName;
      }

--- a/patches/server/0589-Expose-protocol-version.patch
+++ b/patches/server/0589-Expose-protocol-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 2b262a9dc58f1c7b79f10c44aae016088a34c06f..3bfe371eb5f08f9e6fbd4ce186bad42cc3478ccb 100644
+index c96665397d08f74b3331f6544d110df5cc1988ef..451d36303f12d3b6d22baba9d1d17c2a4eba3206 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -536,6 +536,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -544,6 +544,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(org.bukkit.inventory.ItemStack itemStack) {
          return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
      }

--- a/patches/server/0600-More-World-API.patch
+++ b/patches/server/0600-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 091e5fae3834dd06527c5dc108d1342f763f93b4..96f0a04cb36e106eb04e0972b5cfe0ed3767b40f 100644
+index 5c8270adf72114263d4e7b212201a7ea24bc95ae..d997691ab27b94f3eccaa7669922e53396966087 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2079,6 +2079,69 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2081,6 +2081,69 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return new CraftStructureSearchResult(CraftStructure.minecraftToBukkit(found.getSecond().value(), this.getHandle().registryAccess()), CraftLocation.toBukkit(found.getFirst(), this));
      }
  

--- a/patches/server/0615-Add-basic-Datapack-API.patch
+++ b/patches/server/0615-Add-basic-Datapack-API.patch
@@ -92,10 +92,10 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2cdeb4505c02942079fb18cf7af15e63463f550c..acc119434a0510c89250b1c9c13fc99fb74ec302 100644
+index 5014f7958074591d1eec22c6775d291828ba0560..2de98ed395e645111671e6a66b31da9b301f0194 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -294,6 +294,7 @@ public final class CraftServer implements Server {
+@@ -298,6 +298,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -103,7 +103,7 @@ index 2cdeb4505c02942079fb18cf7af15e63463f550c..acc119434a0510c89250b1c9c13fc99f
      public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {
-@@ -380,6 +381,7 @@ public final class CraftServer implements Server {
+@@ -385,6 +386,7 @@ public final class CraftServer implements Server {
          if (this.configuration.getBoolean("settings.use-map-color-cache")) {
              MapPalette.setMapColorCache(new CraftMapColorCache(this.logger));
          }
@@ -111,7 +111,7 @@ index 2cdeb4505c02942079fb18cf7af15e63463f550c..acc119434a0510c89250b1c9c13fc99f
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2815,5 +2817,11 @@ public final class CraftServer implements Server {
+@@ -2835,5 +2837,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0618-ItemStack-repair-check-API.patch
+++ b/patches/server/0618-ItemStack-repair-check-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack repair check API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 3bfe371eb5f08f9e6fbd4ce186bad42cc3478ccb..1aa8ba6ff3263c6d2ef9694ad4e7bafc8215ec43 100644
+index 451d36303f12d3b6d22baba9d1d17c2a4eba3206..a08b404dbf2b6f53b29c7a6e86cac1871976ae4c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -537,6 +537,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -545,6 +545,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
      }
  

--- a/patches/server/0621-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0621-Fix-and-optimise-world-force-upgrading.patch
@@ -359,10 +359,10 @@ index b294ef87fb93e7f4651dc04128124f297575860d..65fd57609e45ccd49ebfc1ba80d25243
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index acc119434a0510c89250b1c9c13fc99fb74ec302..286531263ece5fe3650433445f5e3e7e394371d4 100644
+index 2de98ed395e645111671e6a66b31da9b301f0194..dad38e93aba899b250155a5075fc85fc988d6a8a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1209,12 +1209,7 @@ public final class CraftServer implements Server {
+@@ -1229,12 +1229,7 @@ public final class CraftServer implements Server {
          worlddata.customDimensions = iregistry;
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().shouldReportAsModified());
@@ -376,7 +376,7 @@ index acc119434a0510c89250b1c9c13fc99fb74ec302..286531263ece5fe3650433445f5e3e7e
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1225,6 +1220,13 @@ public final class CraftServer implements Server {
+@@ -1245,6 +1240,13 @@ public final class CraftServer implements Server {
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
  

--- a/patches/server/0625-Attributes-API-for-item-defaults.patch
+++ b/patches/server/0625-Attributes-API-for-item-defaults.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Attributes API for item defaults
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 1aa8ba6ff3263c6d2ef9694ad4e7bafc8215ec43..aa79564d415af3a61978ba72c95a97cc1de05458 100644
+index a08b404dbf2b6f53b29c7a6e86cac1871976ae4c..ec47babe5f34198ae213679d4a4b2bc27bdc1eab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -545,6 +545,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -553,6 +553,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftMagicNumbers.getItem(itemToBeRepaired.getType()).isValidRepairItem(CraftItemStack.asNMSCopy(itemToBeRepaired), CraftItemStack.asNMSCopy(repairMaterial));
      }
  

--- a/patches/server/0626-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0626-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -95,10 +95,10 @@ index 543d578eb87da6ff526cad7e65c8af76b1043e84..936b7f464097c30fe4dfbe4cee1c1490
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4e73e38dcec36b4ab0a03c6bd1b70811233f9a0a..fb4d76aa19033bdf62c45680d622764dbd9b419c 100644
+index d997691ab27b94f3eccaa7669922e53396966087..d2c7730a63118612eb0a60853b3221fab3b6f37e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1179,7 +1179,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1181,7 +1181,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index 4e73e38dcec36b4ab0a03c6bd1b70811233f9a0a..fb4d76aa19033bdf62c45680d622764d
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1201,7 +1201,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1203,7 +1203,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0641-add-per-world-spawn-limits.patch
+++ b/patches/server/0641-add-per-world-spawn-limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add per world spawn limits
 Taken from #2982. Credit to Chasewhip8
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7faaeea9fed2360ca36c28b66eef76b2aa7464ee..eddd86de37290b15e367ae6b4dc4c4514b1157e0 100644
+index d2c7730a63118612eb0a60853b3221fab3b6f37e..0acb97676ad066d474b0290cbbb8555f11d09154 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -211,6 +211,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -213,6 +213,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          this.biomeProvider = biomeProvider;
  
          this.environment = env;

--- a/patches/server/0647-Fix-return-value-of-Block-applyBoneMeal-always-being.patch
+++ b/patches/server/0647-Fix-return-value-of-Block-applyBoneMeal-always-being.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix return value of Block#applyBoneMeal always being false
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 9e11a7967799c6f57e7461e22a3bb6f427af8418..0499699f0a211d83eb3353c00f63baf87147ee7b 100644
+index 9a1304103d367e2d7bc552977542b46e9887bcb4..9fa50da214ad9a134008c91e1e07223904a8e6a3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -582,7 +582,7 @@ public class CraftBlock implements Block {
+@@ -585,7 +585,7 @@ public class CraftBlock implements Block {
              }
          }
  

--- a/patches/server/0659-Add-System.out-err-catcher.patch
+++ b/patches/server/0659-Add-System.out-err-catcher.patch
@@ -105,10 +105,10 @@ index 0000000000000000000000000000000000000000..a8e813ca89b033f061e695288b3383bd
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 286531263ece5fe3650433445f5e3e7e394371d4..826e288f633a2a7cea9fa0022b44947f75fc1163 100644
+index dad38e93aba899b250155a5075fc85fc988d6a8a..a77453e8390d6c9f656c7ae0ea413abfc7381070 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -296,6 +296,7 @@ public final class CraftServer implements Server {
+@@ -300,6 +300,7 @@ public final class CraftServer implements Server {
      public int reloadCount;
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings

--- a/patches/server/0680-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0680-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -31,10 +31,10 @@ index 16b73f0498936a8413f6adedd7f92bab07a4a108..f12d844d422ca4175d4cb2b8e3112b59
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index bf494076f310fb55e42df92acc556db30b8e4808..60ad39ba1cde4d4d1231f43902af4441a944556f 100644
+index 0acb97676ad066d474b0290cbbb8555f11d09154..1c0cf2bb708e4333319fd3355d937a3dcc3c1ade 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -691,6 +691,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -693,6 +693,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0681-Get-entity-default-attributes.patch
+++ b/patches/server/0681-Get-entity-default-attributes.patch
@@ -81,10 +81,10 @@ index 0000000000000000000000000000000000000000..cf9d28ea97d93cec05c9fb768d59e283
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index aa79564d415af3a61978ba72c95a97cc1de05458..bac01b70eadcf76121e6e2f20bd57edaa78fd0f8 100644
+index ec47babe5f34198ae213679d4a4b2bc27bdc1eab..bb0c75d5e2e642576fb19a03e71ac692912d76b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -562,6 +562,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -570,6 +570,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
      public int getProtocolVersion() {
          return net.minecraft.SharedConstants.getCurrentVersion().getProtocolVersion();
      }

--- a/patches/server/0687-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/server/0687-Add-isCollidable-methods-to-various-places.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add isCollidable methods to various places
 public net.minecraft.world.level.block.state.BlockBehaviour hasCollision
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 0499699f0a211d83eb3353c00f63baf87147ee7b..84911c7c6d038aadd3d84ac4797feaa91a556c3e 100644
+index 9fa50da214ad9a134008c91e1e07223904a8e6a3..d0102a0e7cf3a52b5a2a89f2dc0994fa463eb8c8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -481,6 +481,11 @@ public class CraftBlock implements Block {
+@@ -484,6 +484,11 @@ public class CraftBlock implements Block {
      public boolean isSolid() {
          return getNMS().getMaterial().blocksMotion();
      }
@@ -39,10 +39,10 @@ index 9068557ac50cfb26e7e3ec4ac64bac583baa582e..3e1d36a8c65e6567ac3b78903a25d582
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index bac01b70eadcf76121e6e2f20bd57edaa78fd0f8..30dfdbace0f60074d0cb056d2916331882ade295 100644
+index bb0c75d5e2e642576fb19a03e71ac692912d76b1..c47821a81b9367e1c59d8428384bfd4752d0303e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -574,6 +574,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -582,6 +582,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
          var supplier = net.minecraft.world.entity.ai.attributes.DefaultAttributes.getSupplier((net.minecraft.world.entity.EntityType<? extends net.minecraft.world.entity.LivingEntity>) net.minecraft.core.registries.BuiltInRegistries.ENTITY_TYPE.get(CraftNamespacedKey.toMinecraft(bukkitEntityKey)));
          return new io.papermc.paper.attribute.UnmodifiableAttributeMap(supplier);
      }

--- a/patches/server/0690-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0690-Add-Raw-Byte-Entity-Serialization.patch
@@ -45,10 +45,10 @@ index f5b199b3cdccbe7d8a3331555469c622c853fd03..b1a578f23a21303f79f443107e7a9bea
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 30dfdbace0f60074d0cb056d2916331882ade295..7e9b2497f4b8b0f5e55acd6c83593fb42bb4a52d 100644
+index c47821a81b9367e1c59d8428384bfd4752d0303e..707f50536a3915a68ee8ac09a74ecfebbd5a94dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -485,6 +485,29 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -493,6 +493,29 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of(ca.spottedleaf.dataconverter.minecraft.MCDataConverter.convertTag(ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry.ITEM_STACK, compound, dataVersion, getDataVersion())));
      }
  

--- a/patches/server/0695-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0695-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -278,10 +278,10 @@ index a1770e5ae4b3014c3538b52d4912c60864e186a8..906def91bba96bab7c7aea9b87d9ec56
          // Paper start - add parameters and int ret type
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 826e288f633a2a7cea9fa0022b44947f75fc1163..95015ceeb458d44229d7a23bbcb092c07f5d322e 100644
+index a77453e8390d6c9f656c7ae0ea413abfc7381070..084e107e8714c59182d9b4ae73c0c0f01622b191 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2164,6 +2164,11 @@ public final class CraftServer implements Server {
+@@ -2184,6 +2184,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
@@ -294,10 +294,10 @@ index 826e288f633a2a7cea9fa0022b44947f75fc1163..95015ceeb458d44229d7a23bbcb092c0
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 53d1dee6e81697ff2d9d498f27b57882a9418702..ea8a372a13b7729121e084a79540b317a4c028e1 100644
+index 1c0cf2bb708e4333319fd3355d937a3dcc3c1ade..fd428e74e01e0e9da330e7997c684b8e6b2c8c76 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1696,9 +1696,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1698,9 +1698,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(spawnCategory, "SpawnCategory cannot be null");
          Validate.isTrue(CraftSpawnCategory.isValidForLimits(spawnCategory), "SpawnCategory." + spawnCategory + " are not supported.");
  

--- a/patches/server/0755-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0755-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 95015ceeb458d44229d7a23bbcb092c07f5d322e..53a58b6988cd11d37d6cdff6f2699710e3229745 100644
+index 084e107e8714c59182d9b4ae73c0c0f01622b191..df357a207b52b677c5374865a5d19ba616ec605d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2336,6 +2336,90 @@ public final class CraftServer implements Server {
+@@ -2356,6 +2356,90 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registries.BIOME), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0775-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0775-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,10 +18,10 @@ index 24c88555ea85dd2a0656e1f67a4828a5137157b8..cbbb0ff40488c430d15c2ed054d1b288
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 53a58b6988cd11d37d6cdff6f2699710e3229745..fa74b5a331bb33d4ce7205c0fa80faf6eb613081 100644
+index df357a207b52b677c5374865a5d19ba616ec605d..7bd966d497d15a118c36aa9316d6e71757044d75 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1216,7 +1216,7 @@ public final class CraftServer implements Server {
+@@ -1236,7 +1236,7 @@ public final class CraftServer implements Server {
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
          LevelStem worlddimension = iregistry.get(actualDimension);
  
@@ -31,10 +31,10 @@ index 53a58b6988cd11d37d6cdff6f2699710e3229745..fa74b5a331bb33d4ce7205c0fa80faf6
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ea8a372a13b7729121e084a79540b317a4c028e1..0986a740f5b095cc603d67133c684b5224ae66ae 100644
+index fd428e74e01e0e9da330e7997c684b8e6b2c8c76..fafcc9948778a80841975191014aa0435f1cad94 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -201,6 +201,30 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -203,6 +203,30 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getPlayerCount() {
          return world.players().size();
      }

--- a/patches/server/0790-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0790-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fa74b5a331bb33d4ce7205c0fa80faf6eb613081..c0df30bcd8d6c7e56fb4c7b1c7c5e4a56f365a2a 100644
+index 7bd966d497d15a118c36aa9316d6e71757044d75..f1c6983593fe60251ec8ac69f28e91184732f46b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1998,6 +1998,13 @@ public final class CraftServer implements Server {
+@@ -2018,6 +2018,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  

--- a/patches/server/0792-Implement-regenerateChunk.patch
+++ b/patches/server/0792-Implement-regenerateChunk.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement regenerateChunk
 Co-authored-by: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 093fff34682fa59e96a5591a29f38d90c43738d0..fda4f367da3942fdf59a4a34ea73c6107c9ca465 100644
+index fafcc9948778a80841975191014aa0435f1cad94..1d50e5ace7035873523ca16d683b196732176ea5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -140,6 +140,7 @@ import org.jetbrains.annotations.NotNull;
+@@ -142,6 +142,7 @@ import org.jetbrains.annotations.NotNull;
  public class CraftWorld extends CraftRegionAccessor implements World {
      public static final int CUSTOM_DIMENSION_OFFSET = 10;
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
@@ -17,7 +17,7 @@ index 093fff34682fa59e96a5591a29f38d90c43738d0..fda4f367da3942fdf59a4a34ea73c610
  
      private final ServerLevel world;
      private WorldBorder worldBorder;
-@@ -425,27 +426,62 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -427,27 +428,62 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean regenerateChunk(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk regenerate"); // Spigot

--- a/patches/server/0794-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0794-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c0df30bcd8d6c7e56fb4c7b1c7c5e4a56f365a2a..33ae1bf0e904c20626156192d306eb303dc3cdf1 100644
+index f1c6983593fe60251ec8ac69f28e91184732f46b..c0b7a831d371a4a0eac884b08182290deb51ca02 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2172,6 +2172,8 @@ public final class CraftServer implements Server {
+@@ -2192,6 +2192,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start

--- a/patches/server/0795-Add-GameEvent-tags.patch
+++ b/patches/server/0795-Add-GameEvent-tags.patch
@@ -46,10 +46,10 @@ index 0000000000000000000000000000000000000000..e7d9fd2702a1ce96596580fff8f5ee4f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 33ae1bf0e904c20626156192d306eb303dc3cdf1..d4063237f6f3c9e88b90943e09dfef9cf8a69801 100644
+index c0b7a831d371a4a0eac884b08182290deb51ca02..41994b287f7bb5eaacc14473be9e0e500ae88fdf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2582,6 +2582,15 @@ public final class CraftServer implements Server {
+@@ -2602,6 +2602,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(BuiltInRegistries.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -65,7 +65,7 @@ index 33ae1bf0e904c20626156192d306eb303dc3cdf1..d4063237f6f3c9e88b90943e09dfef9c
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2614,6 +2623,13 @@ public final class CraftServer implements Server {
+@@ -2634,6 +2643,13 @@ public final class CraftServer implements Server {
                  net.minecraft.core.Registry<EntityType<?>> entityTags = BuiltInRegistries.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0801-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0801-Put-world-into-worldlist-before-initing-the-world.patch
@@ -23,10 +23,10 @@ index 23fce58a5909c5b01a5f0ef6912f90858cd3302c..a30c61e176501d1cbd2e330f85d5d258
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d4063237f6f3c9e88b90943e09dfef9cf8a69801..1d13a97eba403eb3e21cd8fe5b473d38b8edf5dd 100644
+index 41994b287f7bb5eaacc14473be9e0e500ae88fdf..020984ba63c5e23c6216f8d2f6faa310eae291a4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1245,10 +1245,11 @@ public final class CraftServer implements Server {
+@@ -1265,10 +1265,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0803-Custom-Potion-Mixes.patch
+++ b/patches/server/0803-Custom-Potion-Mixes.patch
@@ -164,10 +164,10 @@ index 424406d2692856cfd82b6f3b7b6228fa3bd20c2f..c57efcb9a79337ec791e4e8f6671612f
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1d13a97eba403eb3e21cd8fe5b473d38b8edf5dd..ec555493b2bacf174cc6fc9924cb9199df442e60 100644
+index 020984ba63c5e23c6216f8d2f6faa310eae291a4..3901a6d9670e3a9b619e54c43af6c1b07a982c97 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -297,6 +297,7 @@ public final class CraftServer implements Server {
+@@ -301,6 +301,7 @@ public final class CraftServer implements Server {
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings
      private final io.papermc.paper.logging.SysoutCatcher sysoutCatcher = new io.papermc.paper.logging.SysoutCatcher(); // Paper
@@ -175,7 +175,7 @@ index 1d13a97eba403eb3e21cd8fe5b473d38b8edf5dd..ec555493b2bacf174cc6fc9924cb9199
  
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
-@@ -323,7 +324,7 @@ public final class CraftServer implements Server {
+@@ -328,7 +329,7 @@ public final class CraftServer implements Server {
          Enchantments.SHARPNESS.getClass();
          org.bukkit.enchantments.Enchantment.stopAcceptingRegistrations();
  
@@ -184,7 +184,7 @@ index 1d13a97eba403eb3e21cd8fe5b473d38b8edf5dd..ec555493b2bacf174cc6fc9924cb9199
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2941,5 +2942,10 @@ public final class CraftServer implements Server {
+@@ -2961,5 +2962,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0805-Fix-falling-block-spawn-methods.patch
+++ b/patches/server/0805-Fix-falling-block-spawn-methods.patch
@@ -24,10 +24,10 @@ index cc3a90a3337b7d59e4377a1e2448f17a23604e57..b69df51f2a1eec62792e193f64a1815a
              if (Snowball.class.isAssignableFrom(clazz)) {
                  entity = new net.minecraft.world.entity.projectile.Snowball(world, x, y, z);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fda4f367da3942fdf59a4a34ea73c6107c9ca465..75a8c83779f97c430815964e09f1c3ea61ff4659 100644
+index 1d50e5ace7035873523ca16d683b196732176ea5..9a0542c06ae30361ac6139bdf02d0464c8a53e7b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1390,7 +1390,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1392,7 +1392,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(material, "Material cannot be null");
          Validate.isTrue(material.isBlock(), "Material must be a block");
  
@@ -41,7 +41,7 @@ index fda4f367da3942fdf59a4a34ea73c6107c9ca465..75a8c83779f97c430815964e09f1c3ea
          return (FallingBlock) entity.getBukkitEntity();
      }
  
-@@ -1399,7 +1404,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1401,7 +1406,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(location, "Location cannot be null");
          Validate.notNull(data, "BlockData cannot be null");
  

--- a/patches/server/0811-Implement-getComputedBiome-API.patch
+++ b/patches/server/0811-Implement-getComputedBiome-API.patch
@@ -23,10 +23,10 @@ index b69df51f2a1eec62792e193f64a1815ad6a87e1f..f4f1150e6be2bff0b856145159469197
      public void setBiome(Location location, Biome biome) {
          this.setBiome(location.getBlockX(), location.getBlockY(), location.getBlockZ(), biome);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 84911c7c6d038aadd3d84ac4797feaa91a556c3e..4aa7ea31c9d0e0bb5522301dc111d6a4a2e421fc 100644
+index d0102a0e7cf3a52b5a2a89f2dc0994fa463eb8c8..e4f2e1371e481201e4d8b471a8f6f87ba0604028 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -342,6 +342,13 @@ public class CraftBlock implements Block {
+@@ -345,6 +345,13 @@ public class CraftBlock implements Block {
          return this.getWorld().getBiome(this.getX(), this.getY(), this.getZ());
      }
  

--- a/patches/server/0814-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0814-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ec555493b2bacf174cc6fc9924cb9199df442e60..ad0b88f32ec9777ca9593c175660a209a45aab4a 100644
+index 3901a6d9670e3a9b619e54c43af6c1b07a982c97..2af02829a4b0096c2ef8b7b54a5dd9c37ad0f9a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1293,7 +1293,7 @@ public final class CraftServer implements Server {
+@@ -1313,7 +1313,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0821-cache-resource-keys.patch
+++ b/patches/server/0821-cache-resource-keys.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] cache resource keys
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 4aa7ea31c9d0e0bb5522301dc111d6a4a2e421fc..a10ca7df7863d76e2b32bf414437cbfc6d35c9b7 100644
+index e4f2e1371e481201e4d8b471a8f6f87ba0604028..e4e4a282a10bde462af1e60aa6be992c636b9726 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -367,12 +367,13 @@ public class CraftBlock implements Block {
+@@ -370,12 +370,13 @@ public class CraftBlock implements Block {
          return (biome == null) ? Biome.CUSTOM : biome;
      }
  

--- a/patches/server/0828-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0828-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -158,10 +158,10 @@ index de713f1ca1d61a6b1fca2b66de9162556d102449..edd2c9d0cf5a81c779011cb4215d496a
              this.onChanged(server);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3e1833c6cb57f6e9da83b90b7aa7fd4c52acb5a4..528530682d718573b72d13c3d92396bf9f049650 100644
+index 9a0542c06ae30361ac6139bdf02d0464c8a53e7b..c13e5b79c0599a9809b6150cfe660fb11bd44cea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1943,7 +1943,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1945,7 +1945,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule));
          handle.deserialize(event.getValue()); // Paper
@@ -170,7 +170,7 @@ index 3e1833c6cb57f6e9da83b90b7aa7fd4c52acb5a4..528530682d718573b72d13c3d92396bf
          return true;
      }
  
-@@ -1983,7 +1983,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1985,7 +1985,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule.getName()));
          handle.deserialize(event.getValue()); // Paper

--- a/patches/server/0830-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0830-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ad0b88f32ec9777ca9593c175660a209a45aab4a..86cdffd1572ab33e61c8ab0ef2e83cf8ca9b5124 100644
+index 2af02829a4b0096c2ef8b7b54a5dd9c37ad0f9a2..cc74d84ba7053163e4910ccac4b6763afa18c218 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1252,6 +1252,7 @@ public final class CraftServer implements Server {
+@@ -1272,6 +1272,7 @@ public final class CraftServer implements Server {
          internal.setSpawnSettings(true, true);
          // Paper - move up
  

--- a/patches/server/0846-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0846-Throw-exception-on-world-create-while-being-ticked.patch
@@ -45,10 +45,10 @@ index 3e59620c84b3aa93d8ce41b0e9901a1621bb48df..682005e4b19ba3959d4e3a66475487da
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 86cdffd1572ab33e61c8ab0ef2e83cf8ca9b5124..e23023859248fa7fa3aa01a5eccdc3599f54256a 100644
+index cc74d84ba7053163e4910ccac4b6763afa18c218..03084affd2f7cadb06d038569374e16c2d13686f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -848,6 +848,11 @@ public final class CraftServer implements Server {
+@@ -868,6 +868,11 @@ public final class CraftServer implements Server {
          return new ArrayList<World>(this.worlds.values());
      }
  
@@ -60,7 +60,7 @@ index 86cdffd1572ab33e61c8ab0ef2e83cf8ca9b5124..e23023859248fa7fa3aa01a5eccdc359
      public DedicatedPlayerList getHandle() {
          return this.playerList;
      }
-@@ -1129,6 +1134,7 @@ public final class CraftServer implements Server {
+@@ -1149,6 +1154,7 @@ public final class CraftServer implements Server {
      @Override
      public World createWorld(WorldCreator creator) {
          Preconditions.checkState(this.console.getAllLevels().iterator().hasNext(), "Cannot create additional worlds on STARTUP");
@@ -68,7 +68,7 @@ index 86cdffd1572ab33e61c8ab0ef2e83cf8ca9b5124..e23023859248fa7fa3aa01a5eccdc359
          Validate.notNull(creator, "Creator may not be null");
  
          String name = creator.name();
-@@ -1267,6 +1273,7 @@ public final class CraftServer implements Server {
+@@ -1287,6 +1293,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {

--- a/patches/server/0853-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0853-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index 7c7e5f3c0f9cd1f16192a8fc8163da9b2d9519d5..888936385196a178ab8b730fd5e4fff4
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e23023859248fa7fa3aa01a5eccdc3599f54256a..a06eb05470b145b4d4001b957ec6252b3744eeb5 100644
+index 03084affd2f7cadb06d038569374e16c2d13686f..06cd518e7ca037ed6f347c2666b3a252306368a9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1771,7 +1771,7 @@ public final class CraftServer implements Server {
+@@ -1791,7 +1791,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {

--- a/patches/server/0867-Warn-on-plugins-accessing-faraway-chunks.patch
+++ b/patches/server/0867-Warn-on-plugins-accessing-faraway-chunks.patch
@@ -18,10 +18,10 @@ index 4ace5a32e8d17303a4b5d9e8935a803d7c0df409..174f5ff8f827dab2d85cee525429d46b
  
      private static boolean isOutsideSpawnableHeight(int y) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 528530682d718573b72d13c3d92396bf9f049650..dafd2c85f89d8822e50db63c21631199c69a97a0 100644
+index c13e5b79c0599a9809b6150cfe660fb11bd44cea..8f0234296397ca2d4a607dcea6093c6c606dc7d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -309,9 +309,24 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -311,9 +311,24 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean setSpawnLocation(int x, int y, int z) {
          return this.setSpawnLocation(x, y, z, 0.0F);
      }
@@ -46,7 +46,7 @@ index 528530682d718573b72d13c3d92396bf9f049650..dafd2c85f89d8822e50db63c21631199
          // Paper start - add ticket to hold chunk for a little while longer if plugin accesses it
          net.minecraft.world.level.chunk.LevelChunk chunk = this.world.getChunkSource().getChunkAtIfLoadedImmediately(x, z);
          if (chunk == null) {
-@@ -426,6 +441,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -428,6 +443,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean regenerateChunk(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk regenerate"); // Spigot
@@ -54,7 +54,7 @@ index 528530682d718573b72d13c3d92396bf9f049650..dafd2c85f89d8822e50db63c21631199
          // Paper start - implement regenerateChunk method
          final ServerLevel serverLevel = this.world;
          final net.minecraft.server.level.ServerChunkCache serverChunkCache = serverLevel.getChunkSource();
-@@ -522,6 +538,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -524,6 +540,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
@@ -62,7 +62,7 @@ index 528530682d718573b72d13c3d92396bf9f049650..dafd2c85f89d8822e50db63c21631199
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
          ChunkAccess immediate = world.getChunkSource().getChunkAtIfLoadedImmediately(x, z); // Paper
-@@ -585,6 +602,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -587,6 +604,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean addPluginChunkTicket(int x, int z, Plugin plugin) {
@@ -70,7 +70,7 @@ index 528530682d718573b72d13c3d92396bf9f049650..dafd2c85f89d8822e50db63c21631199
          Preconditions.checkArgument(plugin != null, "null plugin");
          Preconditions.checkArgument(plugin.isEnabled(), "plugin is not enabled");
  
-@@ -653,6 +671,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -655,6 +673,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setChunkForceLoaded(int x, int z, boolean forced) {
@@ -78,7 +78,7 @@ index 528530682d718573b72d13c3d92396bf9f049650..dafd2c85f89d8822e50db63c21631199
          this.getHandle().setChunkForced(x, z, forced);
      }
  
-@@ -959,6 +978,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -961,6 +980,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public int getHighestBlockYAt(int x, int z, org.bukkit.HeightMap heightMap) {
@@ -86,7 +86,7 @@ index 528530682d718573b72d13c3d92396bf9f049650..dafd2c85f89d8822e50db63c21631199
          // Transient load for this tick
          return this.world.getChunk(x >> 4, z >> 4).getHeight(CraftHeightMap.toNMS(heightMap), x, z);
      }
-@@ -2363,6 +2383,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2370,6 +2390,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot end
      // Paper start
      public java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent) {

--- a/patches/server/0873-Block-Ticking-API.patch
+++ b/patches/server/0873-Block-Ticking-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Block Ticking API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index a10ca7df7863d76e2b32bf414437cbfc6d35c9b7..b6c4f3d34603929a56073444be5f25fda15ff0c7 100644
+index e4e4a282a10bde462af1e60aa6be992c636b9726..3a201bb68ef34d53aee75ca248248c11c4a77c2c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -755,5 +755,21 @@ public class CraftBlock implements Block {
+@@ -758,5 +758,21 @@ public class CraftBlock implements Block {
      public boolean isValidTool(ItemStack itemStack) {
          return getDrops(itemStack).size() != 0;
      }

--- a/patches/server/0874-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0874-Add-Velocity-IP-Forwarding-Support.patch
@@ -213,10 +213,10 @@ index 3fcd7bfdb8945b276c94a263e9da6b85ce470366..3431b1132e55c53cda7cf47f021f2306
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a06eb05470b145b4d4001b957ec6252b3744eeb5..894c0d5bfa001def4374b657e3eb8f15a0caa1e9 100644
+index 06cd518e7ca037ed6f347c2666b3a252306368a9..9f2536d9a73bdb15b5b3004d4da79ca32cee205b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -777,7 +777,7 @@ public final class CraftServer implements Server {
+@@ -797,7 +797,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0876-Add-NamespacedKey-biome-methods.patch
+++ b/patches/server/0876-Add-NamespacedKey-biome-methods.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add NamespacedKey biome methods
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 7e9b2497f4b8b0f5e55acd6c83593fb42bb4a52d..64c50c52c11214740de7903e5592b8b6b2c170b3 100644
+index 707f50536a3915a68ee8ac09a74ecfebbd5a94dd..1179e9fbff93ec8ff82aa3aae477f6bf4ce9b885 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -603,6 +603,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -611,6 +611,19 @@ public final class CraftMagicNumbers implements UnsafeValues {
          Preconditions.checkArgument(material.isBlock(), material + " is not a block");
          return getBlock(material).hasCollision;
      }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
5dbedae1 PR-864: Fix Registry#match() failing namespaced inputs
49256865 PR-863: Fix boolean PersistentDataType
9f15450b SPIGOT-7195, SPIGOT-7197: Add DataPack API
ebef5b6a Disable InterfaceIsType Checkstyle check
01d577f5 Slight tweak to boolean PersistentDataType javadoc
d2b99e56 PR-857: Add boolean PersistentDataType

CraftBukkit Changes:
2270366cd PR-1196: Test Registry instances more thoroughly
863dacb7a PR-1191: Do not start on pre-release Java 17
1f2dd8e12 SPIGOT-7362: Properly handle null in CraftBlock#blockFaceToNotch()
dbc70bed5 SPIGOT-7195, SPIGOT-7197: Add DataPack API