### PR TITLE
Prevent some desync for poi and pistons

### DIFF
--- a/patches/server/0409-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/patches/server/0409-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -59,7 +59,7 @@ index 4f6b7ed4809086811f0460544ba2ec0606f0f5da..9abae63e06c1dde9b8434d32bac87988
 +                }
 +                world.setBlockEntity(MovingPistonBlock.newMovingBlockEntity(blockposition3, iblockdata2, allowDesync ? list1.get(k) : iblockdata1, dir, retract, false));
 +                if (!allowDesync) {
-+                    world.setBlock(oldPos, Blocks.AIR.defaultBlockState(), 2 | 4 | 16 | 1024); // set air to prevent later physics updates from seeing this block
++                    world.setBlock(oldPos, Blocks.AIR.defaultBlockState(), Block.UPDATE_CLIENTS | Block.UPDATE_KNOWN_SHAPE | Block.UPDATE_MOVE_BY_PISTON | 1024); // set air to prevent later physics updates from seeing this block
 +                }
 +                // Paper end - fix a variety of piston desync dupes
                  aiblockdata[j++] = iblockdata1;
@@ -74,7 +74,7 @@ index 17a6327ab7b26dfab38881bbc0689b0b25f8f025..30fafbb26a347b73c72b9f5c30da3b01
                      BlockState blockState = Block.updateFromNeighbourShapes(blockEntity.movedState, world, pos);
                      if (blockState.isAir()) {
 -                        world.setBlock(pos, blockEntity.movedState, 84);
-+                        world.setBlock(pos, blockEntity.movedState, io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.allowPistonDuplication ? 84 : (84 | 2)); // Paper - force notify (flag 2), it's possible the set type by the piston block (which doesn't notify) set this block to air
++                        world.setBlock(pos, blockEntity.movedState, io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.allowPistonDuplication ? 84 : (84 | Block.UPDATE_CLIENTS)); // Paper - force notify (flag 2), it's possible the set type by the piston block (which doesn't notify) set this block to air
                          Block.updateOrDestroy(blockEntity.movedState, blockState, world, pos, 3);
                      } else {
                          if (blockState.hasProperty(BlockStateProperties.WATERLOGGED) && blockState.getValue(BlockStateProperties.WATERLOGGED)) {

--- a/patches/server/0963-Fix-block-place-logic.patch
+++ b/patches/server/0963-Fix-block-place-logic.patch
@@ -3,6 +3,10 @@ From: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com>
 Date: Mon, 3 Apr 2023 18:46:49 +0200
 Subject: [PATCH] Fix block place logic
 
+Fix several issues when a player interact with a block:
+* the place sound isn't played for the dispensed shulker block
+* desync of the jukebox blocks between bukkit handler and the vanilla interaction
+* poi can desync when the BlockPhysicsEvent is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
 index b0204af850ee182773ad458208cccd946ad148d5..ebee8de2ed831755b6fd154f6cc77ac993839bb9 100644
@@ -36,3 +40,29 @@ index 6a25b768ea2e99acdda781cdc0ab7bf80b45912c..5f0e01060e1d8716e7514a25cbe68b73
                              world.gameEvent(GameEvent.BLOCK_CHANGE, blockposition, GameEvent.Context.of(entityhuman, world.getBlockState(blockposition)));
                          }
  
+diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
+index 147d802d9207e358fdb2d1c7806fc2f634dcfd98..f39ab10c5b0b8d86b579a5b683491204c51db70b 100644
+--- a/src/main/java/net/minecraft/world/level/Level.java
++++ b/src/main/java/net/minecraft/world/level/Level.java
+@@ -646,17 +646,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+                 // CraftBukkit start
+                 iblockdata1.updateIndirectNeighbourShapes(this, blockposition, k, j - 1); // Don't call an event for the old block to limit event spam
+                 CraftWorld world = ((ServerLevel) this).getWorld();
++                boolean cancelledUpdates = false; // Paper
+                 if (world != null && ((ServerLevel)this).hasPhysicsEvent) { // Paper
+                     BlockPhysicsEvent event = new BlockPhysicsEvent(world.getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), CraftBlockData.fromData(iblockdata));
+                     this.getCraftServer().getPluginManager().callEvent(event);
+ 
+-                    if (event.isCancelled()) {
+-                        return;
+-                    }
++                    cancelledUpdates = event.isCancelled(); // Paper
+                 }
+                 // CraftBukkit end
++                if (!cancelledUpdates) { // Paper
+                 iblockdata.updateNeighbourShapes(this, blockposition, k, j - 1);
+                 iblockdata.updateIndirectNeighbourShapes(this, blockposition, k, j - 1);
++                } // Paper
+             }
+ 
+             // CraftBukkit start - SPIGOT-5710


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/5561
This fix two issues:
- poi desync when the BlockPhysicsEvent is cancelled
- the set air to prevent further updates doesn't have the UPDATE_MOVE_BY_PISTON flag and so the rail will drop when removed even with all the previous flags.