### PR TITLE
1.20: Remove Experimental API status where upstream forgot

### DIFF
--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -332,6 +332,19 @@ index 631cbf2be51040eee00aa39a39c5ec4003f91843..3147e278eac674ed21d714bbe318b135
      void setData(@NotNull MaterialData data);
  
      /**
+diff --git a/src/main/java/org/bukkit/block/DecoratedPot.java b/src/main/java/org/bukkit/block/DecoratedPot.java
+index 210f4be510c2074db3938d604937dae0270dd994..59b98f411f62e16fafb0efb489562847a090c733 100644
+--- a/src/main/java/org/bukkit/block/DecoratedPot.java
++++ b/src/main/java/org/bukkit/block/DecoratedPot.java
+@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Represents a captured state of a decorated pot.
+  */
+-@ApiStatus.Experimental
++//@ApiStatus.Experimental // Paper
+ public interface DecoratedPot extends TileState {
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/entity/Enderman.java b/src/main/java/org/bukkit/entity/Enderman.java
 index 821c690f8a32918bdb284ffec4af98f411f76ccc..94f3a8c4bf8cf14263d34d866db66728e98dfdb0 100644
 --- a/src/main/java/org/bukkit/entity/Enderman.java
@@ -874,6 +887,19 @@ index 597a18a767b68b47e81454b7d44613c7178c1366..bc3440eb72127824b3961fbdae583bb6
      @NotNull
      public ItemStack getInput() {
          return this.ingredient.getItemStack();
+diff --git a/src/main/java/org/bukkit/inventory/meta/ColorableArmorMeta.java b/src/main/java/org/bukkit/inventory/meta/ColorableArmorMeta.java
+index 5ccae862dbac393805a47fe26c18a2f33f1e140d..72281899817c5c140cdca2afff75fbcebd942532 100644
+--- a/src/main/java/org/bukkit/inventory/meta/ColorableArmorMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/ColorableArmorMeta.java
+@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Represents armor that an entity can equip and can also be colored.
+  */
+-@ApiStatus.Experimental
++//@ApiStatus.Experimental // Paper
+ public interface ColorableArmorMeta extends ArmorMeta, LeatherArmorMeta {
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 index 55e9dc5d1d87fbc9d0dabbb7bd59584fe2c5f379..5c1ca0e47f0ac1525c3d37b55f52874878f44c28 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java


### PR DESCRIPTION
Title, missed these on the first PR. Purposefully left the InventoryType at experimental as discussed in vc since we aren't sure what to do with that yet.