### PR TITLE
Minimise EntityFertilizeEggEvent and add sniffer

### DIFF
--- a/patches/api/0410-Add-EntityFertilizeEggEvent.patch
+++ b/patches/api/0410-Add-EntityFertilizeEggEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add EntityFertilizeEggEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityFertilizeEggEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityFertilizeEggEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..159b3b541991be34a5db856e3706a97afc8afb3d
+index 0000000000000000000000000000000000000000..adc596cae5e4a6e52c51eba16b5aa37410d30e5c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityFertilizeEggEvent.java
-@@ -0,0 +1,128 @@
+@@ -0,0 +1,140 @@
 +package io.papermc.paper.event.entity;
 +
 +import com.google.common.base.Preconditions;
@@ -23,8 +23,18 @@ index 0000000000000000000000000000000000000000..159b3b541991be34a5db856e3706a97a
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
-+ * Called when a mating occurs that results in a pregnancy.
-+ * After a bit of time, the mother will lay an egg.
++ * Called when two entities mate and the mating process results in a fertilization.
++ * Fertilization differs from normal breeding, as represented by the {@link org.bukkit.event.entity.EntityBreedEvent}, as
++ * it does not result in the immediate creation of the child entity in the world.
++ * <p>
++ * An example of this would be:
++ * <ul>
++ * <li>A frog being marked as "is_pregnant" and laying {@link org.bukkit.Material#FROGSPAWN} later.</li>
++ * <li>Sniffers producing the {@link org.bukkit.Material#SNIFFER_EGG} item, which needs to be placed before it can begin to hatch.</li>
++ * <li>A turtle being marked with "HasEgg" and laying a {@link org.bukkit.Material#TURTLE_EGG} later.</li>
++ * </ul>
++ *
++ * The event hence only exposes the two parent entities in the fertilization process and cannot provide the child entity, as it will only exist at a later point in time.
 + */
 +public class EntityFertilizeEggEvent extends EntityEvent implements Cancellable {
 +
@@ -58,9 +68,10 @@ index 0000000000000000000000000000000000000000..159b3b541991be34a5db856e3706a97a
 +    }
 +
 +    /**
-+     * Gets the parent creating this entity.
++     * Provides the entity in the fertilization process that will eventually be responsible for "creating" offspring,
++     * may that be by setting a block that later hatches or dropping an egg that has to be placed.
 +     *
-+     * @return The "birth" parent
++     * @return The "mother" entity.
 +     */
 +    @NotNull
 +    public LivingEntity getMother() {
@@ -68,7 +79,8 @@ index 0000000000000000000000000000000000000000..159b3b541991be34a5db856e3706a97a
 +    }
 +
 +    /**
-+     * Gets the other parent of the newly born entity.
++     * Provides the "father" entity in the fertilization process that is not responsible for initiating the offspring
++     * creation.
 +     *
 +     * @return the other parent
 +     */

--- a/patches/server/0939-Add-EntityFertilizeEggEvent.patch
+++ b/patches/server/0939-Add-EntityFertilizeEggEvent.patch
@@ -69,7 +69,7 @@ index c0f19138c6a00ce6ae837c972ae4af522ddd2895..a6d98f64910c816a5c11867d12698f5c
          world.addFreshEntity(entityitem);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 86b0fe7b6feeef0e085e577954f869e020cc0f04..97808ee1c087b44cacbaebf0bc9450ddca911008 100644
+index 86b0fe7b6feeef0e085e577954f869e020cc0f04..576e982ac53fe6cdc6ca921ad46c36e895509f84 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1981,4 +1981,29 @@ public class CraftEventFactory {
@@ -92,7 +92,7 @@ index 86b0fe7b6feeef0e085e577954f869e020cc0f04..97808ee1c087b44cacbaebf0bc9450dd
 +        if (serverPlayer == null) serverPlayer = other.getLoveCause();
 +        final int experience = breeding.getRandom().nextInt(7) + 1; // From Animal#spawnChildFromBreeding(ServerLevel, Animal)
 +
-+        final var event = new io.papermc.paper.event.entity.EntityFertilizeEggEvent((org.bukkit.entity.LivingEntity) breeding.getBukkitEntity(), (org.bukkit.entity.LivingEntity) other.getBukkitEntity(), serverPlayer == null ? null : serverPlayer.getBukkitEntity(), breeding.breedItem == null ? null : org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(breeding.breedItem).clone(), experience);
++        final io.papermc.paper.event.entity.EntityFertilizeEggEvent event = new io.papermc.paper.event.entity.EntityFertilizeEggEvent((org.bukkit.entity.LivingEntity) breeding.getBukkitEntity(), (org.bukkit.entity.LivingEntity) other.getBukkitEntity(), serverPlayer == null ? null : serverPlayer.getBukkitEntity(), breeding.breedItem == null ? null : org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(breeding.breedItem).clone(), experience);
 +        if (!event.callEvent()) {
 +            breeding.resetLove();
 +            other.resetLove(); // stop the pathfinding to avoid infinite loop

--- a/patches/server/0939-Add-EntityFertilizeEggEvent.patch
+++ b/patches/server/0939-Add-EntityFertilizeEggEvent.patch
@@ -5,37 +5,100 @@ Subject: [PATCH] Add EntityFertilizeEggEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Turtle.java b/src/main/java/net/minecraft/world/entity/animal/Turtle.java
-index c48bf4ca76f70d878378fc43c8270de5c3332824..9f7fa132997829e9a34aaae7aac7a6f7d529eee2 100644
+index c48bf4ca76f70d878378fc43c8270de5c3332824..098ae9d8fa3e7cad8473a877decba771f6bd1b36 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Turtle.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Turtle.java
-@@ -441,6 +441,17 @@ public class Turtle extends Animal {
+@@ -441,6 +441,10 @@ public class Turtle extends Animal {
              if (entityplayer == null && this.partner.getLoveCause() != null) {
                  entityplayer = this.partner.getLoveCause();
              }
-+            // Paper start
-+            RandomSource randomsource = this.animal.getRandom();
-+            int experience = randomsource.nextInt(7) + 1;
-+            io.papermc.paper.event.entity.EntityFertilizeEggEvent event = new io.papermc.paper.event.entity.EntityFertilizeEggEvent((org.bukkit.entity.LivingEntity) turtle.getBukkitEntity(), (org.bukkit.entity.LivingEntity) partner.getBukkitEntity(), entityplayer == null ? null : entityplayer.getBukkitEntity(), turtle.breedItem == null ? null : org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(turtle.breedItem).clone(), experience);
-+            if (!event.callEvent()) {
-+                animal.resetLove();
-+                partner.resetLove(); // stop the pathfinding to avoid infinite loop
-+                return;
-+            }
-+            experience = event.getExperience();
-+            // Paper end
++            // Paper start - Add EntityFertilizeEggEvent event
++            io.papermc.paper.event.entity.EntityFertilizeEggEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityFertilizeEggEvent(this.animal, this.partner);
++            if (event.isCancelled()) return;
++            // Paper end - Add EntityFertilizeEggEvent event
  
              if (entityplayer != null) {
                  entityplayer.awardStat(Stats.ANIMALS_BRED);
-@@ -452,10 +463,9 @@ public class Turtle extends Animal {
-             this.partner.setAge(6000);
-             this.animal.resetLove();
-             this.partner.resetLove();
--            RandomSource randomsource = this.animal.getRandom();
+@@ -455,7 +459,7 @@ public class Turtle extends Animal {
+             RandomSource randomsource = this.animal.getRandom();
  
--            if (this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
+             if (this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
 -                this.level.addFreshEntity(new ExperienceOrb(this.level, this.animal.getX(), this.animal.getY(), this.animal.getZ(), randomsource.nextInt(7) + 1, org.bukkit.entity.ExperienceOrb.SpawnReason.BREED, entityplayer)); // Paper;
-+            if (experience > 0 && this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) { // Paper
-+                this.level.addFreshEntity(new ExperienceOrb(this.level, this.animal.getX(), this.animal.getY(), this.animal.getZ(), experience, org.bukkit.entity.ExperienceOrb.SpawnReason.BREED, entityplayer)); // Paper
++                if(event.getExperience() > 0) this.level.addFreshEntity(new ExperienceOrb(this.level, this.animal.getX(), this.animal.getY(), this.animal.getZ(), event.getExperience(), org.bukkit.entity.ExperienceOrb.SpawnReason.BREED, entityplayer)); // Paper - Add EntityFertilizeEggEvent event
              }
  
          }
+diff --git a/src/main/java/net/minecraft/world/entity/animal/frog/Frog.java b/src/main/java/net/minecraft/world/entity/animal/frog/Frog.java
+index 22eb0a8fc35baa04b34265b62aa29a71f3cc7343..203691417e208b9e023e5f8c3b76993db2747ba8 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/frog/Frog.java
++++ b/src/main/java/net/minecraft/world/entity/animal/frog/Frog.java
+@@ -242,7 +242,12 @@ public class Frog extends Animal implements VariantHolder<FrogVariant> {
+ 
+     @Override
+     public void spawnChildFromBreeding(ServerLevel world, Animal other) {
+-        this.finalizeSpawnChildFromBreeding(world, other, (AgeableMob)null);
++        // Paper start - Add EntityFertilizeEggEvent event
++        final io.papermc.paper.event.entity.EntityFertilizeEggEvent result = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityFertilizeEggEvent(this, other);
++        if (result.isCancelled()) return;
++
++        this.finalizeSpawnChildFromBreeding(world, other, (AgeableMob)null, result.getExperience()); // Paper - use craftbukkit call that takes experience amount
++        // Paper end - Add EntityFertilizeEggEvent event
+         this.getBrain().setMemory(MemoryModuleType.IS_PREGNANT, Unit.INSTANCE);
+     }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java b/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java
+index c0f19138c6a00ce6ae837c972ae4af522ddd2895..a6d98f64910c816a5c11867d12698f5cd63c751a 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java
++++ b/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java
+@@ -350,11 +350,16 @@ public class Sniffer extends Animal {
+ 
+     @Override
+     public void spawnChildFromBreeding(ServerLevel world, Animal other) {
++        // Paper start - Add EntityFertilizeEggEvent event
++        final io.papermc.paper.event.entity.EntityFertilizeEggEvent result = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityFertilizeEggEvent(this, other);
++        if (result.isCancelled()) return;
++        // Paper end - Add EntityFertilizeEggEvent event
++
+         ItemStack itemstack = new ItemStack(Items.SNIFFER_EGG);
+         ItemEntity entityitem = new ItemEntity(world, this.position().x(), this.position().y(), this.position().z(), itemstack);
+ 
+         entityitem.setDefaultPickUpDelay();
+-        this.finalizeSpawnChildFromBreeding(world, other, (AgeableMob) null);
++        this.finalizeSpawnChildFromBreeding(world, other, (AgeableMob) null, result.getExperience()); // Paper - Add EntityFertilizeEggEvent event
+         this.playSound(SoundEvents.SNIFFER_EGG_PLOP, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 0.5F);
+         world.addFreshEntity(entityitem);
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 86b0fe7b6feeef0e085e577954f869e020cc0f04..97808ee1c087b44cacbaebf0bc9450ddca911008 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1981,4 +1981,29 @@ public class CraftEventFactory {
+         return event.callEvent();
+     }
+     // Paper end
++
++    // Paper start - add EntityFertilizeEggEvent
++    /**
++     * Calls the io.papermc.paper.event.entity.EntityFertilizeEggEvent.
++     * If the event is cancelled, this method also resets the love on both the {@code breeding} and {@code other} entity.
++     *
++     * @param breeding the entity on which #spawnChildFromBreeding was called.
++     * @param other    the partner of the entity.
++     * @return the event after it was called. The instance may be used to retrieve the experience of the event.
++     */
++    public static io.papermc.paper.event.entity.EntityFertilizeEggEvent callEntityFertilizeEggEvent(net.minecraft.world.entity.animal.Animal breeding,
++                                                                                                    net.minecraft.world.entity.animal.Animal other) {
++        net.minecraft.server.level.ServerPlayer serverPlayer = breeding.getLoveCause();
++        if (serverPlayer == null) serverPlayer = other.getLoveCause();
++        final int experience = breeding.getRandom().nextInt(7) + 1; // From Animal#spawnChildFromBreeding(ServerLevel, Animal)
++
++        final var event = new io.papermc.paper.event.entity.EntityFertilizeEggEvent((org.bukkit.entity.LivingEntity) breeding.getBukkitEntity(), (org.bukkit.entity.LivingEntity) other.getBukkitEntity(), serverPlayer == null ? null : serverPlayer.getBukkitEntity(), breeding.breedItem == null ? null : org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(breeding.breedItem).clone(), experience);
++        if (!event.callEvent()) {
++            breeding.resetLove();
++            other.resetLove(); // stop the pathfinding to avoid infinite loop
++        }
++
++        return event;
++    }
++    // Paper end - add EntityFertilizeEggEvent
+ }

--- a/patches/server/0962-Fix-DamageCause-for-Falling-Blocks.patch
+++ b/patches/server/0962-Fix-DamageCause-for-Falling-Blocks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix DamageCause for Falling Blocks
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 86b0fe7b6feeef0e085e577954f869e020cc0f04..cc1a7ac6e2123758a8d74b14363265a9040b5ad4 100644
+index 97808ee1c087b44cacbaebf0bc9450ddca911008..20cdce9720c19925e5154f44cab36a7c7cc40ea2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1030,6 +1030,11 @@ public class CraftEventFactory {

--- a/patches/server/0968-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0968-Expand-PlayerItemMendEvent.patch
@@ -51,7 +51,7 @@ index 991f3f947810ebd7e4f2c51a4012115fee8a34ec..548eddde8b0558b780f672d321507cfc
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cc1a7ac6e2123758a8d74b14363265a9040b5ad4..1ced79cf92fe0b01a42f097794dacc3ce74518f3 100644
+index 20cdce9720c19925e5154f44cab36a7c7cc40ea2..49e3715b6648e7c44127030930e06dc9432a8374 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1262,10 +1262,10 @@ public class CraftEventFactory {


### PR DESCRIPTION
Minimises the EntityFertilizeEggEvent by moving the duplicate code out into the CraftEventFactory utility.
Additionally, this adds sniffers as a fertilising entity by calling the event for them breeding and producing the sniffer egg item.