### PR TITLE
Fix sniffer #removeExploredLocation and javadoc

### DIFF
--- a/patches/api/0055-Fix-upstream-javadocs.patch
+++ b/patches/api/0055-Fix-upstream-javadocs.patch
@@ -494,6 +494,29 @@ index a5ad3250cebfeb302c58e0bfd6db1295913c927e..bfac874840cf1f36afba16ae4d176c58
       * @param sz The new size of the slime.
       */
      public void setSize(int sz);
+diff --git a/src/main/java/org/bukkit/entity/Sniffer.java b/src/main/java/org/bukkit/entity/Sniffer.java
+index af5110b4160979c39cc1e5de6fa3bd7957b21403..15a0a733b0e5804655b5957cbf20831290d52a08 100644
+--- a/src/main/java/org/bukkit/entity/Sniffer.java
++++ b/src/main/java/org/bukkit/entity/Sniffer.java
+@@ -12,8 +12,6 @@ public interface Sniffer extends Animals {
+ 
+     /**
+      * Gets the locations explored by the sniffer.
+-     * <br>
+-     * <b>Note:</b> the returned locations use sniffer's current world.
+      *
+      * @return a collection of locations
+      */
+@@ -22,9 +20,6 @@ public interface Sniffer extends Animals {
+ 
+     /**
+      * Remove a location of the explored locations.
+-     * <br>
+-     * <b>Note:</b> the location must be in the sniffer's current world for this
+-     * method to have any effect.
+      *
+      * @param location the location to remove
+      * @see #getExploredLocations()
 diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
 index 6bf3af3ed81b66f61e53105d3591165ea74dba0e..a91400cd8bb4c72d1f3200a17f6de025540fe09d 100644
 --- a/src/main/java/org/bukkit/entity/Villager.java

--- a/patches/server/0977-Fix-sniffer-removeExploredLocation.patch
+++ b/patches/server/0977-Fix-sniffer-removeExploredLocation.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com>
+Date: Sun, 11 Jun 2023 19:02:46 +0200
+Subject: [PATCH] Fix sniffer removeExploredLocation
+
+Add support to remove explored location in different world
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftSniffer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftSniffer.java
+index ca3bffd07e0e8f3b2409917cf561d4755c8fba21..e9e8ee8c87285705366d54c23a59c136c612aaff 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftSniffer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftSniffer.java
+@@ -40,12 +40,13 @@ public class CraftSniffer extends CraftAnimals implements Sniffer {
+     @Override
+     public void removeExploredLocation(Location location) {
+         Preconditions.checkArgument(location != null, "location cannot be null");
+-        if (location.getWorld() != getWorld()) {
+-            return;
+-        }
+ 
+         BlockPos blockPosition = CraftLocation.toBlockPosition(location);
+-        this.getHandle().getBrain().setMemory(MemoryModuleType.SNIFFER_EXPLORED_POSITIONS, this.getHandle().getExploredPositions().filter(blockPositionExplored -> !blockPositionExplored.equals(blockPosition)).collect(Collectors.toList()));
++        // Paper start
++        net.minecraft.world.level.Level level = location.getWorld() != null ? ((org.bukkit.craftbukkit.CraftWorld) location.getWorld()).getHandle() : this.getHandle().level();
++        net.minecraft.core.GlobalPos globalPos = net.minecraft.core.GlobalPos.of(level.dimension(), blockPosition);
++        this.getHandle().getBrain().setMemory(MemoryModuleType.SNIFFER_EXPLORED_POSITIONS, this.getHandle().getExploredPositions().filter(blockPositionExplored -> !blockPositionExplored.equals(globalPos)).collect(Collectors.toList()));
++        // Paper end
+     }
+ 
+     @Override


### PR DESCRIPTION
Sniffer can now explore a position in different worlds but spigot hasn't updated their methods
The removeExploredLocation is useless since it compare a blockPos and a globalpos and so it will always fail