### PR TITLE
Fix SmithingInventory helper slot methods for 1.20

### DIFF
--- a/patches/api/0192-Add-item-slot-convenience-methods.patch
+++ b/patches/api/0192-Add-item-slot-convenience-methods.patch
@@ -178,51 +178,66 @@ index 4a0c43acc2714e095973eb78536041bb1a179ddc..acf2244f77133df53eb5f862c8e713c8
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/SmithingInventory.java b/src/main/java/org/bukkit/inventory/SmithingInventory.java
-index 96d526b7b153e56c9a97de42ce3270b6638510e4..a41ca6bd2672db2810dd70c4925b84a4f081af05 100644
+index 96d526b7b153e56c9a97de42ce3270b6638510e4..5ed72b7305428f6be98a86fa9aa174d1b8ad4c17 100644
 --- a/src/main/java/org/bukkit/inventory/SmithingInventory.java
 +++ b/src/main/java/org/bukkit/inventory/SmithingInventory.java
-@@ -30,4 +30,44 @@ public interface SmithingInventory extends Inventory {
+@@ -30,4 +30,59 @@ public interface SmithingInventory extends Inventory {
       */
      @Nullable
      Recipe getRecipe();
 +
 +    // Paper start
 +    /**
-+     * Gets the input equipment (first slot).
++     * Gets the input template (first slot).
 +     *
-+     * @return input equipment item
++     * @return input template item
 +     */
-+    @Nullable
-+    default ItemStack getInputEquipment() {
-+        return getItem(0);
++    default @Nullable ItemStack getInputTemplate() {
++        return this.getItem(0);
 +    }
 +
 +    /**
-+     * Sets the input equipment (first slot).
++     * Sets the input template (first slot).
++     *
++     * @param itemStack item to set
++     */
++    default void setInputTemplate(@Nullable ItemStack itemStack) {
++        this.setItem(0, itemStack);
++    }
++    /**
++     * Gets the input equipment (second slot).
++     *
++     * @return input equipment item
++     */
++    default @Nullable ItemStack getInputEquipment() {
++        return this.getItem(1);
++    }
++
++    /**
++     * Sets the input equipment (second slot).
 +     *
 +     * @param itemStack item to set
 +     */
 +    default void setInputEquipment(@Nullable ItemStack itemStack) {
-+        setItem(0, itemStack);
++        this.setItem(1, itemStack);
 +    }
 +
 +    /**
-+     * Gets the input mineral (second slot).
++     * Gets the input mineral (third slot).
 +     *
 +     * @return input mineral item
 +     */
-+    @Nullable
-+    default ItemStack getInputMineral() {
-+        return getItem(1);
++    default @Nullable ItemStack getInputMineral() {
++        return this.getItem(2);
 +    }
 +
 +    /**
-+     * Sets the input mineral (second slot).
++     * Sets the input mineral (third slot).
 +     *
 +     * @param itemStack item to set
 +     */
 +    default void setInputMineral(@Nullable ItemStack itemStack) {
-+        setItem(1, itemStack);
++        this.setItem(2, itemStack);
 +    }
 +    // Paper end
  }


### PR DESCRIPTION
Corrects the slots for the SmithingInventory for 1.20 adding an additional get/set pair for the `template item`.

Closes https://github.com/PaperMC/Paper/issues/9320