### PR TITLE
Add getHighestMapId method

### DIFF
--- a/patches/api/0419-add-getHighestMapId-method.patch
+++ b/patches/api/0419-add-getHighestMapId-method.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: chmodsayshello <chmodsayshello@hotmail.com>
+Date: Mon, 12 Jun 2023 18:33:43 +0200
+Subject: [PATCH] add getHighestMapId method
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index b0bc2df41506770e2854a287813f1c53f003eda1..410c965d4e663fc085c2fe00905b8a8802d85806 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -2483,4 +2483,17 @@ public final class Bukkit {
+     public static Server.Spigot spigot() {
+         return server.spigot();
+     }
++
++    // Paper start
++
++    /**
++     * Gets the highest map ID currently created
++     *
++     * @return the map ID (-1 if no maps were created yet)
++     */
++    @NotNull
++    public static int getHighestMapId() {
++        return server.getHighestMapId();
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 1d1a1d087dabc9794e0062a064da2cced4062309..84dd347b8ab275e28341635a2626b19765fcaa1a 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -2161,5 +2161,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @return the potion brewer
+      */
+     @NotNull org.bukkit.potion.PotionBrewer getPotionBrewer();
++
++    /**
++     * Gets the highest map ID currently created
++     *
++     * @return the map ID (-1 if no maps were created yet)
++     */
++    int getHighestMapId();
+     // Paper end
+ }

--- a/patches/server/0978-add-getHighestMapId-method.patch
+++ b/patches/server/0978-add-getHighestMapId-method.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: chmodsayshello <chmodsayshello@hotmail.com>
+Date: Mon, 12 Jun 2023 18:56:48 +0200
+Subject: [PATCH] add getHighestMapId method
+
+
+diff --git a/src/main/java/net/minecraft/world/level/saveddata/maps/MapIndex.java b/src/main/java/net/minecraft/world/level/saveddata/maps/MapIndex.java
+index 9b2948b5150c8f039ca667a50765109721b93947..9f69db46239d3e8055d5793a6a9ba62d321b5e4f 100644
+--- a/src/main/java/net/minecraft/world/level/saveddata/maps/MapIndex.java
++++ b/src/main/java/net/minecraft/world/level/saveddata/maps/MapIndex.java
+@@ -40,4 +40,10 @@ public class MapIndex extends SavedData {
+         this.setDirty();
+         return i;
+     }
++
++    // Paper start - get value without writing
++    public int getCurrentValueForMap() {
++        return this.usedAuxIds.getInt("map");
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index ffa27c9c02dc4d12411fc089de3af8e8e12ba06e..2a32560d0e09dc9a93e17b7d13b612ef4a4bd803 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -2971,5 +2971,11 @@ public final class CraftServer implements Server {
+         return this.potionBrewer;
+     }
+ 
++    @Override
++    public int getHighestMapId(){
++        // Paper - all map IDs are meant for the overworld, this line is more or less copied from NMS
++        // Paper - for additional info, view getFreeMapId() in ServerLevel.java and getFreeAuxValueForMap() in MapIndex.java
++        return (this.getServer().overworld().getDataStorage().computeIfAbsent(net.minecraft.world.level.saveddata.maps.MapIndex::load, net.minecraft.world.level.saveddata.maps.MapIndex::new, "idcounts")).getCurrentValueForMap();
++    }
+     // Paper end
+ }


### PR DESCRIPTION
This small pull request adds a method to get the highest Map ID currently generated via the bukkit api. Prior to this, plugin developers would need to keep track of this themselves, using some sort of external database...