### PR TITLE
Add Adventure InventoryView title methods

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -3957,10 +3957,10 @@ index 5adbe0514129abf3cfbc4b29a213f522359fe2e1..72ebc29db42d08d1d0361dba462fc8a5
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/InventoryView.java b/src/main/java/org/bukkit/inventory/InventoryView.java
-index e12996492c1558fed9fab30de9f8018e0ed7fac3..002acfbdce1db10f7ba1b6a013e678f504ac6e69 100644
+index e12996492c1558fed9fab30de9f8018e0ed7fac3..f67dc7a242cf7ecf5815ed1ae455442fbe09e62c 100644
 --- a/src/main/java/org/bukkit/inventory/InventoryView.java
 +++ b/src/main/java/org/bukkit/inventory/InventoryView.java
-@@ -447,12 +447,26 @@ public abstract class InventoryView {
+@@ -447,12 +447,51 @@ public abstract class InventoryView {
          return getPlayer().setWindowProperty(prop, value);
      }
  
@@ -3973,6 +3973,31 @@ index e12996492c1558fed9fab30de9f8018e0ed7fac3..002acfbdce1db10f7ba1b6a013e678f5
      @NotNull
 +    public /*abstract*/ net.kyori.adventure.text.Component title() {
 +        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(this.getTitle());
++    }
++
++    /**
++     * Get the original title of this inventory window, before any changes were
++     * made using {@link #title(net.kyori.adventure.text.Component)}.
++     *
++     * @return the original title
++     */
++    public /*abstract*/ net.kyori.adventure.text.@NotNull Component originalTitle() {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(this.getOriginalTitle());
++    }
++
++    /**
++     * Sets the title of this inventory window to the specified title if the
++     * inventory window supports it.
++     * <p>
++     * Note if the inventory does not support titles that can be changed (ie, it
++     * is not creatable or viewed by a player), then this method will throw an
++     * exception.
++     *
++     * @param title The new title.
++     * @throws IllegalArgumentException if you cannot set the title of this inventory
++     */
++    public /*abstract*/ void title(net.kyori.adventure.text.@NotNull Component title) {
++        this.setTitle(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(title));
 +    }
 +    // Paper end
 +
@@ -3987,6 +4012,25 @@ index e12996492c1558fed9fab30de9f8018e0ed7fac3..002acfbdce1db10f7ba1b6a013e678f5
      public abstract String getTitle();
  
      /**
+@@ -460,7 +499,9 @@ public abstract class InventoryView {
+      * made using {@link #setTitle(String)}.
+      *
+      * @return the original title
++     * @deprecated in favour of {@link #originalTitle()}
+      */
++    @Deprecated // Paper
+     @NotNull
+     public abstract String getOriginalTitle();
+ 
+@@ -473,6 +514,8 @@ public abstract class InventoryView {
+      * exception.
+      *
+      * @param title The new title.
++     * @deprecated in favour of {@link #title(net.kyori.adventure.text.Component)}
+      */
++    @Deprecated // Paper
+     public abstract void setTitle(@NotNull String title);
+ }
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
 index a66bec33fffd4e11d859efd8d17d274a5fa75f69..9578d6b0fa54feac75fa9a0727d878bd13b9e19e 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -4196,20 +4196,59 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java 
 index bfaa48cfda08c2716f61032b71d38285a9f715e8..1b526fff47e5a3d9a5325c73966dd2bf3dbbdc19 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
-@@ -72,6 +72,13 @@ public class CraftContainer extends AbstractContainerMenu {
+@@ -49,8 +49,8 @@ public class CraftContainer extends AbstractContainerMenu {
+     public CraftContainer(final Inventory inventory, final Player player, int id) {
+         this(new InventoryView() {
+ 
+-            private final String originalTitle = (inventory instanceof CraftInventoryCustom) ? ((CraftInventoryCustom.MinecraftInventory) ((CraftInventory) inventory).getInventory()).getTitle() : inventory.getType().getDefaultTitle();
+-            private String title = this.originalTitle;
++            private final net.kyori.adventure.text.Component originalTitle = (inventory instanceof CraftInventoryCustom) ? ((CraftInventoryCustom.MinecraftInventory) ((CraftInventory) inventory).getInventory()).title() : inventory.getType().defaultTitle(); // Paper - Adventure
++            private net.kyori.adventure.text.Component title = this.originalTitle; // Paper - Adventure
+ 
+             @Override
+             public Inventory getTopInventory() {
+@@ -72,20 +72,37 @@ public class CraftContainer extends AbstractContainerMenu {
                  return inventory.getType();
              }
  
-+            // Paper start
++            // Paper start - Adventure
 +            @Override
 +            public net.kyori.adventure.text.Component title() {
-+                return inventory instanceof CraftInventoryCustom ? ((CraftInventoryCustom.MinecraftInventory) ((CraftInventory) inventory).getInventory()).title() : net.kyori.adventure.text.Component.text(inventory.getType().getDefaultTitle());
++                return this.title;
 +            }
-+            // Paper end
++
++            @Override
++            public net.kyori.adventure.text.Component originalTitle() {
++                return this.originalTitle;
++            }
++
++            @Override
++            public void title(final net.kyori.adventure.text.Component title) {
++                CraftInventoryView.sendInventoryTitleChange(this, title);
++                this.title = title;
++            }
++            // Paper end - Adventure
 +
              @Override
              public String getTitle() {
-                 return title;
+-                return title;
++                return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.title); // Paper - Adventure
+             }
+ 
+             @Override
+             public String getOriginalTitle() {
+-                return originalTitle;
++                return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.originalTitle); // Paper - Adventure
+             }
+ 
+             @Override
+             public void setTitle(String title) {
+-                CraftInventoryView.sendInventoryTitleChange(this, title);
+-                this.title = title;
++                this.title(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(title)); // Paper - Adventure
+             }
+ 
+         }, player, id);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryCustom.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryCustom.java
 index c9cc23757a9fcc58d30b2915d4c5cfbc7d1c767a..fc0e1212022d1aa3506699b60ef338196eb54eba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryCustom.java
@@ -4297,23 +4336,91 @@ index c9cc23757a9fcc58d30b2915d4c5cfbc7d1c767a..fc0e1212022d1aa3506699b60ef33819
              return this.title;
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryView.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryView.java
-index 4dd9a80af9901287ab6740b072f2b89678c3d0cb..b2586684295b295a3196a2a9cf724cec975b5a40 100644
+index 4dd9a80af9901287ab6740b072f2b89678c3d0cb..9eb5bf7e906fd31f6bf5d47441d3a411c7bdb661 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryView.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryView.java
-@@ -73,6 +73,13 @@ public class CraftInventoryView extends InventoryView {
+@@ -19,15 +19,15 @@ public class CraftInventoryView extends InventoryView {
+     private final AbstractContainerMenu container;
+     private final CraftHumanEntity player;
+     private final CraftInventory viewing;
+-    private final String originalTitle;
+-    private String title;
++    private final net.kyori.adventure.text.Component originalTitle; // Paper - Adventure
++    private net.kyori.adventure.text.Component title; // Paper - Adventure
+ 
+     public CraftInventoryView(HumanEntity player, Inventory viewing, AbstractContainerMenu container) {
+         // TODO: Should we make sure it really IS a CraftHumanEntity first? And a CraftInventory?
+         this.player = (CraftHumanEntity) player;
+         this.viewing = (CraftInventory) viewing;
+         this.container = container;
+-        this.originalTitle = CraftChatMessage.fromComponent(container.getTitle());
++        this.originalTitle = io.papermc.paper.adventure.PaperAdventure.asAdventure(container.getTitle()); // Paper - Adventure
+         this.title = this.originalTitle;
+     }
+ 
+@@ -73,20 +73,37 @@ public class CraftInventoryView extends InventoryView {
          return CraftItemStack.asCraftMirror(this.container.getSlot(slot).getItem());
      }
  
-+    // Paper start
++    // Paper start - Adventure
 +    @Override
 +    public net.kyori.adventure.text.Component title() {
-+        return io.papermc.paper.adventure.PaperAdventure.asAdventure(this.container.getTitle());
++        return this.title; // use component
 +    }
-+    // Paper end
++
++    @Override
++    public net.kyori.adventure.text.Component originalTitle() {
++        return this.originalTitle; // use component
++    }
++
++    @Override
++    public void title(final net.kyori.adventure.text.Component title) {
++        CraftInventoryView.sendInventoryTitleChange(this, title);
++        this.title = title; // use component
++    }
++    // Paper end - Adventure
 +
      @Override
      public String getTitle() {
-         return this.title;
+-        return this.title;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.title); // Paper - Adventure
+     }
+ 
+     @Override
+     public String getOriginalTitle() {
+-        return this.originalTitle;
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.originalTitle); // Paper - Adventure
+     }
+ 
+     @Override
+     public void setTitle(String title) {
+-        CraftInventoryView.sendInventoryTitleChange(this, title);
+-        this.title = title;
++        this.title(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(title)); // Paper - Adventure
+     }
+ 
+     public boolean isInTop(int rawSlot) {
+@@ -98,6 +115,11 @@ public class CraftInventoryView extends InventoryView {
+     }
+ 
+     public static void sendInventoryTitleChange(InventoryView view, String title) {
++        // Paper start - Adventure
++        sendInventoryTitleChange(view, net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(title));
++    }
++    public static void sendInventoryTitleChange(InventoryView view, net.kyori.adventure.text.Component title) {
++        // Paper end - Adventure
+         Preconditions.checkArgument(view != null, "InventoryView cannot be null");
+         Preconditions.checkArgument(title != null, "Title cannot be null");
+         Preconditions.checkArgument(view.getPlayer() instanceof Player, "NPCs are not currently supported for this function");
+@@ -106,7 +128,7 @@ public class CraftInventoryView extends InventoryView {
+         final ServerPlayer entityPlayer = (ServerPlayer) ((CraftHumanEntity) view.getPlayer()).getHandle();
+         final int containerId = entityPlayer.containerMenu.containerId;
+         final MenuType<?> windowType = CraftContainer.getNotchInventoryType(view.getTopInventory());
+-        entityPlayer.connection.send(new ClientboundOpenScreenPacket(containerId, windowType, CraftChatMessage.fromString(title)[0]));
++        entityPlayer.connection.send(new ClientboundOpenScreenPacket(containerId, windowType, io.papermc.paper.adventure.PaperAdventure.asVanilla(title))); // Paper - Adventure
+         ((Player) view.getPlayer()).updateInventory();
+     }
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 index 87f57266d4cb3a89a38cf7871e5872d29f6d15b9..45872e28cabc655c170bee163d471acf5d913c00 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java

--- a/patches/server/0277-Restore-custom-InventoryHolder-support.patch
+++ b/patches/server/0277-Restore-custom-InventoryHolder-support.patch
@@ -161,28 +161,19 @@ index 0000000000000000000000000000000000000000..224d4b2cc45b0d02230a76caee9c8857
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
-index 1b526fff47e5a3d9a5325c73966dd2bf3dbbdc19..633e6f4922ccaf59979a22885162f42c65bf628a 100644
+index dca58258cef48d2812a02a98cedb61f86e15503a..60b28cacb38f622e04ac47323a88f80d40961e19 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
 @@ -49,7 +49,7 @@ public class CraftContainer extends AbstractContainerMenu {
      public CraftContainer(final Inventory inventory, final Player player, int id) {
          this(new InventoryView() {
  
--            private final String originalTitle = (inventory instanceof CraftInventoryCustom) ? ((CraftInventoryCustom.MinecraftInventory) ((CraftInventory) inventory).getInventory()).getTitle() : inventory.getType().getDefaultTitle();
-+            private final String originalTitle = inventory instanceof CraftInventoryCustom ? ((CraftInventoryCustom) inventory).getTitle() : inventory.getType().getDefaultTitle(); // Paper
-             private String title = this.originalTitle;
+-            private final net.kyori.adventure.text.Component originalTitle = (inventory instanceof CraftInventoryCustom) ? ((CraftInventoryCustom.MinecraftInventory) ((CraftInventory) inventory).getInventory()).title() : inventory.getType().defaultTitle(); // Paper - Adventure
++            private final net.kyori.adventure.text.Component originalTitle = (inventory instanceof CraftInventoryCustom custom) ? custom.title() : inventory.getType().defaultTitle(); // Paper - Adventure
+             private net.kyori.adventure.text.Component title = this.originalTitle; // Paper - Adventure
  
              @Override
-@@ -75,7 +75,7 @@ public class CraftContainer extends AbstractContainerMenu {
-             // Paper start
-             @Override
-             public net.kyori.adventure.text.Component title() {
--                return inventory instanceof CraftInventoryCustom ? ((CraftInventoryCustom.MinecraftInventory) ((CraftInventory) inventory).getInventory()).title() : net.kyori.adventure.text.Component.text(inventory.getType().getDefaultTitle());
-+                return inventory instanceof CraftInventoryCustom custom ? custom.title() : inventory.getType().defaultTitle(); // Paper
-             }
-             // Paper end
- 
-@@ -247,6 +247,10 @@ public class CraftContainer extends AbstractContainerMenu {
+@@ -257,6 +257,10 @@ public class CraftContainer extends AbstractContainerMenu {
              this.lastSlots = delegate.lastSlots;
              this.slots = delegate.slots;
              this.remoteSlots = delegate.remoteSlots;


### PR DESCRIPTION
Adds in `Compontent` methods for the new title methods in `InventoryView` - wasn't 100% sure on the [custom inventoryholder rebased patch changes](https://github.com/PaperMC/Paper/compare/master...TheRealRyGuy:Paper:feat/invtitle?expand=1#diff-f324938383e32d7ae067b48d303501fffb5096b1ef52d413b0861c3fb950bb57), but everything else should be alright
Partially fixes #9189, however, I just carbon copied Spigot's implementation, unsure if Paper wanted a better implementation