### PR TITLE
Re-add dropped patch during 1.20 update

### DIFF
--- a/patches/server/0976-fix-MapLike-spam-for-missing-key-selector.patch
+++ b/patches/server/0976-fix-MapLike-spam-for-missing-key-selector.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 14 Jun 2023 13:17:40 -0700
+Subject: [PATCH] fix MapLike spam for missing key 'selector'
+
+
+diff --git a/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java b/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java
+index 405709bed99bb0ddd3a746f0f7815b59394c1b81..846f0c18c348e30fb5ce73e0efafa30c1b121fec 100644
+--- a/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java
++++ b/src/main/java/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java
+@@ -351,7 +351,7 @@ public interface VibrationSystem {
+         public static Codec<VibrationSystem.Data> CODEC = RecordCodecBuilder.create((instance) -> {
+             return instance.group(VibrationInfo.CODEC.optionalFieldOf("event").forGetter((vibrationsystem_a) -> {
+                 return Optional.ofNullable(vibrationsystem_a.currentVibration);
+-            }), VibrationSelector.CODEC.fieldOf("selector").forGetter(VibrationSystem.Data::getSelectionStrategy), ExtraCodecs.NON_NEGATIVE_INT.fieldOf("event_delay").orElse(0).forGetter(VibrationSystem.Data::getTravelTimeInTicks)).apply(instance, (optional, vibrationselector, integer) -> {
++            }), Codec.optionalField("selector", VibrationSelector.CODEC).xmap(o -> o.orElseGet(VibrationSelector::new), Optional::of).forGetter(VibrationSystem.Data::getSelectionStrategy), ExtraCodecs.NON_NEGATIVE_INT.fieldOf("event_delay").orElse(0).forGetter(VibrationSystem.Data::getTravelTimeInTicks)).apply(instance, (optional, vibrationselector, integer) -> { // Paper - fix MapLike spam for missing "selector" in 1.19.2
+                 return new VibrationSystem.Data((VibrationInfo) optional.orElse(null), vibrationselector, integer, true); // CraftBukkit - decompile error
+             });
+         });


### PR DESCRIPTION
This is still needed for pre-1.19.2 sculk nbt data. Was accidentally dropped during 1.20 update [here](https://github.com/PaperMC/Paper/commit/aa1c25c88d5eadd79e6e05f4963657beccb064cb#diff-0cde6bb11a132e24e0952798e29deb7ac320d4b4afde59624dee2fefdf28ede9).