### PR TITLE
[ci skip] Fix incorrect annotation on BrushableBlock#getItem

### DIFF
--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -332,6 +332,19 @@ index 631cbf2be51040eee00aa39a39c5ec4003f91843..3147e278eac674ed21d714bbe318b135
      void setData(@NotNull MaterialData data);
  
      /**
+diff --git a/src/main/java/org/bukkit/block/BrushableBlock.java b/src/main/java/org/bukkit/block/BrushableBlock.java
+index 4bd127b3646307398e0c937c3e36ab671235b72b..f2557a87f468ee20c2d276dbfc0e9a976656c75c 100644
+--- a/src/main/java/org/bukkit/block/BrushableBlock.java
++++ b/src/main/java/org/bukkit/block/BrushableBlock.java
+@@ -15,7 +15,7 @@ public interface BrushableBlock extends Lootable, TileState {
+      *
+      * @return the item
+      */
+-    @Nullable
++    @org.jetbrains.annotations.NotNull // Paper
+     public ItemStack getItem();
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/block/DecoratedPot.java b/src/main/java/org/bukkit/block/DecoratedPot.java
 index 210f4be510c2074db3938d604937dae0270dd994..59b98f411f62e16fafb0efb489562847a090c733 100644
 --- a/src/main/java/org/bukkit/block/DecoratedPot.java


### PR DESCRIPTION
The impl for `BrushableBlock#getItem` actually won't return null for "no item" but an air itemstack. As we want to move away from using "null" to represent itemstack's, It should be fine to change this to `@NotNull` instead.