### PR TITLE
Fix multiple spectator bugs

### DIFF
--- a/patches/server/0977-Fix-multiple-spectator-bugs.patch
+++ b/patches/server/0977-Fix-multiple-spectator-bugs.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Fritz Windisch <friwidev@gmail.com>
+Date: Thu, 15 Jun 2023 17:10:22 +0200
+Subject: [PATCH] Fix multiple spectator bugs
+
+Fixes MC-261799: Spectator mode not teleporting viewers to targets in other worlds or viewers bug around (stuck) when a target changes world
+Fixes MC-107113: Spectator mode viewers stuck when target is teleported more than viewing distance
+Fixes untracked: Chunks go invisible when target moves too far over time while viewing (render POI on client is not updated)
+
+diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
+index 9209b598d7168b82574e4800056b8b9f84265dd0..2b37ccc8e2619677179b17a6c5bd758bd5f95150 100644
+--- a/src/main/java/net/minecraft/server/level/ChunkMap.java
++++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
+@@ -1535,6 +1535,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+                 double d1 = vec3d_dx * vec3d_dx + vec3d_dz * vec3d_dz; // Paper
+                 double d2 = d0 * d0;
+                 boolean flag = d1 <= d2 && this.entity.broadcastToPlayer(player);
++                flag |= player.getCamera() == this.entity; // Paper - Make entities always visible for spectators, even when teleported far away (MC-107113)
+ 
+                 // CraftBukkit start - respect vanish API
+                 if (!player.getBukkitEntity().canSee(this.entity.getBukkitEntity())) {
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 9d46536f80b5b3e6641fd377c02166a431edfd77..bfe4d87835a4979fa03abac532b82f5f65dae5d7 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -732,8 +732,25 @@ public class ServerPlayer extends Player {
+ 
+         if (entity != this) {
+             if (entity.isAlive()) {
+-                this.absMoveTo(entity.getX(), entity.getY(), entity.getZ(), entity.getYRot(), entity.getXRot());
+-                this.serverLevel().getChunkSource().move(this);
++                // Paper start - Fix spectator on cross-world teleports (MC-261799)
++                if (entity.level() != this.level()) {
++                    // Teleport ourselves to our camera
++                    this.getBukkitEntity().teleport(entity.getBukkitEntity().getLocation(), TeleportCause.SPECTATE);
++                    // Update the tracker of the other dimension for our cross-dimension teleport
++                    ChunkMap.TrackedEntity tracker = ((ServerLevel) entity.level()).getChunkSource().chunkMap.entityMap.get(entity.getId());
++                    if (tracker != null) {
++                        tracker.updatePlayer(this);
++                    }
++                    // Advise the client to start spectating again
++                    this.connection.send(new ClientboundSetCameraPacket(entity));
++                }else {
++                    // Paper: We send the player an additional teleport packet here to indicate that the position of itself has been moved.
++                    // Without this packet, if a player travels a too far distance, chunks will start to become invisible for our spectator.
++                    this.connection.teleport(entity.getX(), entity.getY(), entity.getZ(), entity.getYRot(), entity.getXRot(), TeleportCause.SPECTATE);
++                    this.absMoveTo(entity.getX(), entity.getY(), entity.getZ(), entity.getYRot(), entity.getXRot());
++                    this.serverLevel().getChunkSource().move(this);
++                }
++                // Paper end
+                 if (this.wantsToStopRiding()) {
+                     this.setCamera(this);
+                 }


### PR DESCRIPTION
This is a small contribution from the PlayLegend server team with multiple issues resolved we had concerning player spectating. We started using this patch in production in 1.19.3. It is already in use for a long time and tested to be working flawlessly.

Fixes MC-261799: Spectator mode not teleporting viewers to targets in other worlds or viewers bug around (stuck) when a target changes world
Fixes MC-107113: Spectator mode viewers stuck when target is teleported more than viewing distance
Fixes MC-148993: Chunks go invisible when target moves too far over time while viewing (render POI on client is not updated)