### PR TITLE
Allow paper-server to incrementally compile

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     java
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "8.1.1" apply false
-    id("io.papermc.paperweight.core") version "1.5.5"
+    id("io.papermc.paperweight.core") version "1.5.6-SNAPSHOT"
 }
 
 allprojects {

--- a/patches/server/0134-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0134-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -25,10 +25,10 @@ Other changes:
 Co-Authored-By: Emilia Kond <emilia@rymiel.space>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 9ab4d3e462c02e4d23b45adb46965eb75eb2178e..a651a41b33cb671e0d0bd7b2f990b2a727d6b15c 100644
+index 9ab4d3e462c02e4d23b45adb46965eb75eb2178e..05a3fb9ee57444a1aeddc47e13c9b965b4f23448 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -8,7 +8,20 @@ plugins {
+@@ -8,7 +8,13 @@ plugins {
  
  dependencies {
      implementation(project(":paper-api"))
@@ -38,18 +38,49 @@ index 9ab4d3e462c02e4d23b45adb46965eb75eb2178e..a651a41b33cb671e0d0bd7b2f990b2a7
 +    implementation("net.minecrell:terminalconsoleappender:1.3.0")
 +    implementation("net.kyori:adventure-text-serializer-ansi:4.14.0") // Keep in sync with adventureVersion from Paper-API build file
 +    implementation("net.kyori:ansi:1.0.1") // Manually bump beyond above transitive dep
-+    /*
-+          Required to add the missing Log4j2Plugins.dat file from log4j-core
-+          which has been removed by Mojang. Without it, log4j has to classload
-+          all its classes to check if they are plugins.
-+          Scanning takes about 1-2 seconds so adding this speeds up the server start.
-+     */
 +    runtimeOnly("org.apache.logging.log4j:log4j-core:2.14.1")
-+    annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - Needed to generate meta for our Log4j plugins
 +    // Paper end
      implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
      implementation("org.ow2.asm:asm:9.4")
      implementation("org.ow2.asm:asm-commons:9.4") // Paper - ASM event executor generation
+@@ -28,6 +34,26 @@ dependencies {
+     implementation("io.netty:netty-all:4.1.87.Final"); // Paper - Bump netty
+ }
+ 
++/*
++    Log4j's annotation processor is preventing gradle from performing
++    incremental compilation. Incremental compilation reduces compile time
++    after the first full compilation. We enable the processor only when
++    building a jar file.
++ */
++gradle.taskGraph.whenReady {
++    if (hasTask(":${project.name}:shadowJar")) {
++        dependencies {
++            /*
++                Required to add the missing Log4j2Plugins.dat file from log4j-core
++                which has been removed by Mojang. Without it, log4j has to classload
++                all its classes to check if they are plugins.
++                Scanning takes about 1-2 seconds so adding this speeds up the server start.
++             */
++            annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - Needed to generate meta for our Log4j plugins
++        }
++    }
++}
++
+ val craftbukkitPackageVersion = "1_20_R1" // Paper
+ tasks.jar {
+     archiveClassifier.set("dev")
+@@ -153,4 +179,10 @@ tasks.registerRunTask("runReobf") {
+ tasks.registerRunTask("runDev") {
+     description = "Spin up a non-relocated Mojang-mapped test server"
+     classpath(sourceSets.main.map { it.runtimeClasspath })
++    /*
++        Add io.papermc.paper package to log4j plugin scanning because we do not have the
++        Log4j2Plugins.dat file since we disable the annotation processor when using runDev
++     */
++    systemProperty("io.papermc.paper.dev.log4j.scanPackages", "io.papermc.paper")
+ }
++
 diff --git a/src/main/java/com/destroystokyo/paper/console/PaperConsole.java b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..a4070b59e261f0f1ac4beec47b11492f4724bf27
@@ -612,12 +643,13 @@ index 0000000000000000000000000000000000000000..0694b21465fb9e4164e71862ff24b622
 @@ -0,0 +1 @@
 +log4j.skipJansi=true
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
-index 722ca84968cbbbdeffd09939abff0cccd0a84010..a994ec0f8621b1f267b40049306f63479c050e2f 100644
+index 722ca84968cbbbdeffd09939abff0cccd0a84010..c7e841bd52aea799265b87bbbabc8669914ea486 100644
 --- a/src/main/resources/log4j2.xml
 +++ b/src/main/resources/log4j2.xml
 @@ -1,17 +1,14 @@
  <?xml version="1.0" encoding="UTF-8"?>
- <Configuration status="WARN" packages="com.mojang.util">
+-<Configuration status="WARN" packages="com.mojang.util">
++<Configuration status="WARN" packages="com.mojang.util,${sys:io.papermc.paper.dev.log4j.scanPackages}">
      <Appenders>
 -        <Console name="SysOut" target="SYSTEM_OUT">
 -            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />

--- a/patches/server/0155-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/patches/server/0155-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -15,18 +15,18 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a651a41b33cb671e0d0bd7b2f990b2a727d6b15c..588d5370a10de25f80022d64abb8af0f16ce943b 100644
+index 1222f55aa7cea8fb72eaf1f4e0442067897c89bf..4e3baa2bca93e092e83baf1eac69cc6c11bfc3e4 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -19,7 +19,7 @@ dependencies {
-           all its classes to check if they are plugins.
-           Scanning takes about 1-2 seconds so adding this speeds up the server start.
-      */
+@@ -13,7 +13,7 @@ dependencies {
+     implementation("net.minecrell:terminalconsoleappender:1.3.0")
+     implementation("net.kyori:adventure-text-serializer-ansi:4.14.0") // Keep in sync with adventureVersion from Paper-API build file
+     implementation("net.kyori:ansi:1.0.1") // Manually bump beyond above transitive dep
 -    runtimeOnly("org.apache.logging.log4j:log4j-core:2.14.1")
 +    implementation("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - implementation
-     annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - Needed to generate meta for our Log4j plugins
      // Paper end
      implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
+     implementation("org.ow2.asm:asm:9.4")
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
 index 0a0aa6de31a94a701074cc5f43c94be7515a185c..489ce6f439778b26eb33ede9432681d4bf9e0116 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java

--- a/patches/server/0219-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
+++ b/patches/server/0219-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
@@ -8,7 +8,7 @@ diff --git a/build.gradle.kts b/build.gradle.kts
 index a06b75a78ab96229a6e9b97de913df9050325c04..d5602e9020ff233b93987140d143ff5d00154b1c 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -30,6 +30,7 @@ dependencies {
+@@ -23,6 +23,7 @@ dependencies {
      implementation("commons-lang:commons-lang:2.6")
      runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.33")

--- a/patches/server/0371-Improved-Watchdog-Support.patch
+++ b/patches/server/0371-Improved-Watchdog-Support.patch
@@ -537,13 +537,13 @@ index b47d043144c499b1499f6b4be5a16a3f75c9fcb8..383c52c62f49b17db2fbf58009d6ea13
                  break;
                  } // Paper end
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
-index ea4e2161c0bd43884055cc6b8d70b2139f70e720..266b4e6fb3988b5848021c83fdc68e342c70b188 100644
+index b0227e1139e426c37da975ce98c2bbb69e2fdba7..9b1619bf1ba96b88b25681171ed2f70787b023c8 100644
 --- a/src/main/resources/log4j2.xml
 +++ b/src/main/resources/log4j2.xml
 @@ -1,5 +1,5 @@
  <?xml version="1.0" encoding="UTF-8"?>
--<Configuration status="WARN" packages="com.mojang.util">
-+<Configuration status="WARN" packages="com.mojang.util" shutdownHook="disable">
+-<Configuration status="WARN" packages="com.mojang.util,${sys:io.papermc.paper.dev.log4j.scanPackages}">
++<Configuration status="WARN" packages="com.mojang.util,${sys:io.papermc.paper.dev.log4j.scanPackages}" shutdownHook="disable">
      <Appenders>
          <Queue name="ServerGuiConsole">
              <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg%n" />

--- a/patches/server/0392-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0392-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 50de0801f88091b8e5587ef797fc2d5fd8621a54..4162d6a040a20a4ef8e1adb90f215a8d80fb48a3 100644
+index fc1530df38d1c6f23f72970ecb9ccee57ecec94f..88f52a9273c970bf2055b9e9b520c94572ba9f95 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -29,6 +29,7 @@ dependencies {
+@@ -22,6 +22,7 @@ dependencies {
      testImplementation("org.mockito:mockito-core:4.9.0") // Paper - switch to mockito
      implementation("org.spongepowered:configurate-yaml:4.1.2") // Paper - config files
      implementation("commons-lang:commons-lang:2.6")
@@ -17,7 +17,7 @@ index 50de0801f88091b8e5587ef797fc2d5fd8621a54..4162d6a040a20a4ef8e1adb90f215a8d
      runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
-@@ -108,6 +109,18 @@ tasks.check {
+@@ -121,6 +122,18 @@ tasks.check {
  }
  // Paper end
  
@@ -635,7 +635,7 @@ index 383c52c62f49b17db2fbf58009d6ea132d124bea..e0a71bfc1498a517456b21747ab6ef3f
              log.log( Level.SEVERE, "\t\t" + stack );
          }
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
-index 266b4e6fb3988b5848021c83fdc68e342c70b188..2b247d55e39246fbef31279b14c45fc40f956bfb 100644
+index 9b1619bf1ba96b88b25681171ed2f70787b023c8..54a64f67413b4b8805bd889b72ec13b72b0ae88b 100644
 --- a/src/main/resources/log4j2.xml
 +++ b/src/main/resources/log4j2.xml
 @@ -30,10 +30,14 @@

--- a/patches/server/0393-Implement-Mob-Goal-API.patch
+++ b/patches/server/0393-Implement-Mob-Goal-API.patch
@@ -8,7 +8,7 @@ diff --git a/build.gradle.kts b/build.gradle.kts
 index 24cc85285f221cee63eb6feb2aabc3e193d76dd7..e3e6318e0c83ae6f6ff699918ab0faff9f84c63d 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -38,6 +38,7 @@ dependencies {
+@@ -31,6 +31,7 @@ dependencies {
      runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
      runtimeOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
  

--- a/patches/server/0709-Use-Velocity-compression-and-cipher-natives.patch
+++ b/patches/server/0709-Use-Velocity-compression-and-cipher-natives.patch
@@ -8,7 +8,7 @@ diff --git a/build.gradle.kts b/build.gradle.kts
 index e3e6318e0c83ae6f6ff699918ab0faff9f84c63d..5df3ca7173cf27eb01475b6dc2e5aad38cd5a324 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -33,6 +33,11 @@ dependencies {
+@@ -26,6 +26,11 @@ dependencies {
      runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper

--- a/patches/server/0826-Add-support-for-Proxy-Protocol.patch
+++ b/patches/server/0826-Add-support-for-Proxy-Protocol.patch
@@ -8,14 +8,19 @@ diff --git a/build.gradle.kts b/build.gradle.kts
 index 5df3ca7173cf27eb01475b6dc2e5aad38cd5a324..6d3d573ffc118e7f4d76422dc014a7df0384bb49 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -22,6 +22,7 @@ dependencies {
-      */
+@@ -15,6 +15,7 @@ dependencies {
+     implementation("net.kyori:adventure-text-serializer-ansi:4.14.0") // Keep in sync with adventureVersion from Paper-API build file
+     implementation("net.kyori:ansi:1.0.1") // Manually bump beyond above transitive dep
      implementation("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - implementation
-     annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - Needed to generate meta for our Log4j plugins
 +    implementation("io.netty:netty-codec-haproxy:4.1.87.Final") // Paper - Add support for proxy protocol
      // Paper end
      implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
      implementation("org.ow2.asm:asm:9.4")
+@@ -206,4 +207,3 @@ tasks.registerRunTask("runDev") {
+      */
+     systemProperty("io.papermc.paper.dev.log4j.scanPackages", "io.papermc.paper")
+ }
+-
 diff --git a/src/main/java/net/minecraft/server/network/ServerConnectionListener.java b/src/main/java/net/minecraft/server/network/ServerConnectionListener.java
 index 2beddfc0532c3835d50724551e3d46cb0d7d2290..44d99e89226adb6234b9405f25ac9dab9bd84297 100644
 --- a/src/main/java/net/minecraft/server/network/ServerConnectionListener.java

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ import java.util.Locale
 
 pluginManagement {
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         maven("https://repo.papermc.io/repository/maven-public/")
     }


### PR DESCRIPTION
With this PR and https://github.com/PaperMC/paperweight/pull/200 paper-server will make use of Gradle's incremental compilation feature.

## Why is this needed?

Currently, every time you want to change some code and start the `runDev` task, Gradle completely recompiles the server project taking a relatively long duration. This is especially annoying if you want to use the hot reload feature of an IDE while debugging paper (i.e. changing some lines of code and hot reloading the changes into the running VM). Waiting ~30 seconds for a single line of code to update is frustrating. And if you're unlucky the VM crashes because something went wrong while trying to reload 10k classes (because it just recompiled every file in the server project) and you have to restart the `runDev` process which triggers another recompile.

## Why is that?

Gradle disables incremental recompilation for several reasons. In this case, it is because the Log4j annotation processor is not marked as incremental:

```
Full recompilation is required because org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor is not incremental.
```

## What does this PR change?

This PR removes Log4j's annotation processor from the default dependencies and only "activates" it when a jar file is built. This allows the `compileJava` task to use incremental compilation (i.e. only recompiling the classes that were changed). This reduces the compile time for consecutive runs down to 2-3 seconds on my machine.

To still load Paper's Log4j plugins, the `io.papermc.paper` package gets added to the `packages` property of the log4j configuration when starting the server using the `runDev` task.

## Paper and Incremental compilation

Since paper patches a lot of classes from external libraries (and Minecraft) but still uses the original jar files as dependencies, incremental compilation would end up in an error (to my understanding the log4j annotation processor is the reason why these errors have not been seen yet). To fix that we need to modify the classpath and add the path of the already compiled classes as the first entry so the compiler loads our patched classes instead of the unpatched classes from the original dependencies. I've opened a PR for paperweight that does that: https://github.com/PaperMC/paperweight/pull/200 (more in-depth info: https://github.com/PaperMC/paperweight/issues/199). **Paperweight needs to be updated before this PR gets merged.**

(The part from paperweight could also be placed directly in paper-server's build config, let me know what you prefer)

## Things to test

1. [x] 1st Build runs cleanly
    - Normal builds (without incremental compilation and caches) should run as expected
2. [x] Subsequent builds without code changes should not perform any compilation
    - When not changing code all the tasks should complete with "UP-TO-DATE" / "FROM-CACHE"
3. [x] Subsequent builds with code changes should trigger incremental compilation on the `compileJava` task
    - Use the `--info` CLI flag to confirm.
4. [x] All the tasks creating server JAR-Files should include the Log4j annotation processor
    - Use the `--info` CLI flag to determine whether a full recompilation was triggered because of the annotation processor
5. [x] The generated server JAR should contain the `Log4jPlugins.dat` file
    - Test if `META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat` is present
6. [x] When running the server using `runDev` log4j should scan `io.papermc.paper` for plugins
    - Set `log4j2.debug` system property to `true` and check if log4j2 scans the package. It should find 3 plugins
       -  Search for `load 3 plugins from package io.papermc.paper`
    - The server log should look "normal" not contain any errors related to log4j (see below for examples)
        - `Uncrecognized format specifier ...`
        - `Unrecognized conversion specifier ...`
        - `Rewrite contains an invalid element or attribute ...`
 7. [x] When running a built jar file, log4j should not scan the `io.papermc.paper `  package for plugins
    - Set `log4j2.debug` system property to `true`. There should be no lines starting with `Checking to see if class io.papermc.paper`
 


