### PR TITLE
Add method to remove all active potion effects

### DIFF
--- a/patches/api/0418-Add-method-to-remove-all-active-potion-effects.patch
+++ b/patches/api/0418-Add-method-to-remove-all-active-potion-effects.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 17 Jun 2023 13:17:20 -0700
+Subject: [PATCH] Add method to remove all active potion effects
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index ffca32ae2464ea5a669029079a50585ca259a4f8..f08fc7a2f533753fe0d3726362d6411ca6dc44fb 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -565,6 +565,15 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+     @NotNull
+     public Collection<PotionEffect> getActivePotionEffects();
+ 
++    // Paper start - LivingEntity#removeAllActivePotionEffects();
++    /**
++     * Removes all active potion effects for this entity.
++     *
++     * @return true if any were removed
++     */
++    boolean removeAllActivePotionEffects();
++    // Paper end
++
+     /**
+      * Checks whether the living entity has block line of sight to another.
+      * <p>

--- a/patches/api/0418-Add-method-to-remove-all-active-potion-effects.patch
+++ b/patches/api/0418-Add-method-to-remove-all-active-potion-effects.patch
@@ -5,20 +5,20 @@ Subject: [PATCH] Add method to remove all active potion effects
 
 
 diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
-index ffca32ae2464ea5a669029079a50585ca259a4f8..f08fc7a2f533753fe0d3726362d6411ca6dc44fb 100644
+index ffca32ae2464ea5a669029079a50585ca259a4f8..9712f7140933d7fc87c5838c173e2d818b70cfde 100644
 --- a/src/main/java/org/bukkit/entity/LivingEntity.java
 +++ b/src/main/java/org/bukkit/entity/LivingEntity.java
 @@ -565,6 +565,15 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
      @NotNull
      public Collection<PotionEffect> getActivePotionEffects();
  
-+    // Paper start - LivingEntity#removeAllActivePotionEffects();
++    // Paper start - LivingEntity#clearActivePotionEffects();
 +    /**
 +     * Removes all active potion effects for this entity.
 +     *
 +     * @return true if any were removed
 +     */
-+    boolean removeAllActivePotionEffects();
++    boolean clearActivePotionEffects();
 +    // Paper end
 +
      /**

--- a/patches/server/0976-Add-method-to-remove-all-active-potion-effects.patch
+++ b/patches/server/0976-Add-method-to-remove-all-active-potion-effects.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 17 Jun 2023 13:17:25 -0700
+Subject: [PATCH] Add method to remove all active potion effects
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index 7880631fe8a4b06f29ef69ab850129737a99521b..6ba15b31b28fc7a861f195b422eb400d8c5869b4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -490,6 +490,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         return effects;
+     }
+ 
++    // Paper start - LivingEntity#removeAllActivePotionEffects();
++    @Override
++    public boolean removeAllActivePotionEffects() {
++        return this.getHandle().removeAllEffects(EntityPotionEffectEvent.Cause.PLUGIN);
++    }
++    // Paper end
++
+     @Override
+     public <T extends Projectile> T launchProjectile(Class<? extends T> projectile) {
+         return this.launchProjectile(projectile, null);

--- a/patches/server/0976-Add-method-to-remove-all-active-potion-effects.patch
+++ b/patches/server/0976-Add-method-to-remove-all-active-potion-effects.patch
@@ -5,16 +5,16 @@ Subject: [PATCH] Add method to remove all active potion effects
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 7880631fe8a4b06f29ef69ab850129737a99521b..6ba15b31b28fc7a861f195b422eb400d8c5869b4 100644
+index 7880631fe8a4b06f29ef69ab850129737a99521b..19212795df4024cfb2b9f56e1efcd4c9f20d1d83 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -490,6 +490,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          return effects;
      }
  
-+    // Paper start - LivingEntity#removeAllActivePotionEffects();
++    // Paper start - LivingEntity#clearActivePotionEffects();
 +    @Override
-+    public boolean removeAllActivePotionEffects() {
++    public boolean clearActivePotionEffects() {
 +        return this.getHandle().removeAllEffects(EntityPotionEffectEvent.Cause.PLUGIN);
 +    }
 +    // Paper end


### PR DESCRIPTION
Adds a new API method to `LivingEntity` called `removeAllActivePotionEffects` which calls the same logic the milk bucket does. The method name was chosen because of the existing method called `getActivePotionEffects`.