### PR TITLE
Add Owner UUID api for AreaEffectCloud

### DIFF
--- a/patches/api/0299-Missing-Entity-API.patch
+++ b/patches/api/0299-Missing-Entity-API.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 Date: Fri, 28 May 2021 21:06:59 -0400
-Subject: [PATCH] Missing Entity Behavior API
+Subject: [PATCH] Missing Entity API
 
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
@@ -150,6 +150,31 @@ index 0d88dce9978243a1f995c5fb448c5d71b01136eb..8b1048c94dffd058eb9fd9144f7f59fc
 +     */
 +    public void setEating(boolean eating);
 +    // Paper end - Horse API
+ }
+diff --git a/src/main/java/org/bukkit/entity/AreaEffectCloud.java b/src/main/java/org/bukkit/entity/AreaEffectCloud.java
+index c2096b5344d48d855d031538ec32e0154bd9054d..f3180f6a4910984fc324f4a69eac59e036e32f2b 100644
+--- a/src/main/java/org/bukkit/entity/AreaEffectCloud.java
++++ b/src/main/java/org/bukkit/entity/AreaEffectCloud.java
+@@ -239,4 +239,20 @@ public interface AreaEffectCloud extends Entity {
+      * @param source the {@link ProjectileSource} that threw the LingeringPotion
+      */
+     public void setSource(@Nullable ProjectileSource source);
++
++    // Paper start - owner API
++    /**
++     * Get the entity UUID for the owner of this area effect cloud.
++     *
++     * @return the entity owner uuid or null
++     */
++    @Nullable java.util.UUID getOwnerUniqueId();
++
++    /**
++     * Sets the entity UUID for the owner of this area effect cloud.
++     *
++     * @param ownerUuid the entity owner uuid or null to clear
++     */
++    void setOwnerUniqueId(@Nullable java.util.UUID ownerUuid);
++    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Bat.java b/src/main/java/org/bukkit/entity/Bat.java
 index bd73f22ef7e79e1ade69e860e7ae1d3dcd6fc858..b9f8b14d90a758672642222675d2f5664d4f67b4 100644

--- a/patches/server/0631-Missing-Entity-API.patch
+++ b/patches/server/0631-Missing-Entity-API.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 Date: Mon, 21 Jun 2021 23:56:07 -0400
-Subject: [PATCH] Missing Entity Behavior API
+Subject: [PATCH] Missing Entity API
 
 == AT ==
 public net.minecraft.world.entity.animal.Fox isDefending()Z
@@ -30,6 +30,7 @@ public net.minecraft.world.entity.npc.WanderingTrader getWanderTarget()Lnet/mine
 public net.minecraft.world.entity.animal.AbstractSchoolingFish leader
 public net.minecraft.world.entity.animal.AbstractSchoolingFish schoolSize
 public net.minecraft.world.entity.animal.Rabbit moreCarrotTicks
+public net.minecraft.world.entity.AreaEffectCloud ownerUUID
 
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
@@ -427,6 +428,28 @@ index 3f1f4d65525562b3117fdc21c8a7f535b12c3c46..90a989c7c9de6f9ba55ab640761915e9
 +       this.getHandle().setMouthOpen(eating);
 +    }
 +    // Paper end - Horse API
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
+index 3034a3902a946162f48840682d434e554de4eae9..c73a9c930c6fa3a7b85986048dca8dc11aa05238 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
+@@ -228,4 +228,17 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
+             this.getHandle().setOwner(null);
+         }
+     }
++
++    // Paper start - owner API
++    @Override
++    public java.util.UUID getOwnerUniqueId() {
++        return this.getHandle().ownerUUID;
++    }
++
++    @Override
++    public void setOwnerUniqueId(final java.util.UUID ownerUuid) {
++        this.getHandle().setOwner(null);
++        this.getHandle().ownerUUID = ownerUuid;
++    }
++    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftBat.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftBat.java
 index 3b960a832df1fe496ea036962083f1ac507a7db7..e405488ba5e0159ff84a72fac1d2da6e9c45238e 100644


### PR DESCRIPTION
Can maybe be merged into Owen's big "missing entity API" patch?

I followed the name convention for other "get owner uuid" methods with `getOwnerUniqueId`, but things are less clear for "set owner uuid" method. There is "setOwner(UUID)" in some places, but it feels weird to not use the same pattern for a get/set pair.