### PR TITLE
Add option to disable NoteBlock and Tripwire updates

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -440,10 +440,10 @@ index 0000000000000000000000000000000000000000..9ef6712c70fcd8912a79f3f61e351aac
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8633fdfa7e8aeac7414c232006fc298b3bfe1b58
+index 0000000000000000000000000000000000000000..58cdb70c0b9de45ca28811416d871099eefec2ce
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,276 @@
+@@ -0,0 +1,283 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -718,6 +718,13 @@ index 0000000000000000000000000000000000000000..8633fdfa7e8aeac7414c232006fc298b
 +        public boolean lagCompensateBlockBreaking = true;
 +        public boolean useDimensionTypeForCustomSpawners = false;
 +        public boolean strictAdvancementDimensionCheck = false;
++    }
++
++    public BlockUpdates blockUpdates;
++
++    public class BlockUpdates extends ConfigurationPart {
++        public boolean disableNoteblockUpdates = false;
++        public boolean disableTripwireUpdates = false;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java b/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java

--- a/patches/server/0019-Rewrite-chunk-system.patch
+++ b/patches/server/0019-Rewrite-chunk-system.patch
@@ -15673,7 +15673,7 @@ index 0000000000000000000000000000000000000000..962d3cae6340fc11607b59355e291629
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 8633fdfa7e8aeac7414c232006fc298b3bfe1b58..eb12227b009b1fb766a5f9e338e5d2394d498376 100644
+index 58cdb70c0b9de45ca28811416d871099eefec2ce..6a0560b1b0972f90b5260115e81f2baa84cfb40d 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 @@ -116,21 +116,6 @@ public class GlobalConfiguration extends ConfigurationPart {
@@ -15698,9 +15698,9 @@ index 8633fdfa7e8aeac7414c232006fc298b3bfe1b58..eb12227b009b1fb766a5f9e338e5d239
      public UnsupportedSettings unsupportedSettings;
  
      public class UnsupportedSettings extends ConfigurationPart {
-@@ -273,4 +258,43 @@ public class GlobalConfiguration extends ConfigurationPart {
-         public boolean useDimensionTypeForCustomSpawners = false;
-         public boolean strictAdvancementDimensionCheck = false;
+@@ -280,4 +265,43 @@ public class GlobalConfiguration extends ConfigurationPart {
+         public boolean disableNoteblockUpdates = false;
+         public boolean disableTripwireUpdates = false;
      }
 +
 +    public ChunkLoadingBasic chunkLoadingBasic;

--- a/patches/server/0983-Add-option-to-disable-block-updates.patch
+++ b/patches/server/0983-Add-option-to-disable-block-updates.patch
@@ -1,0 +1,107 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Boy <sivertpaulsen2@gmail.com>
+Date: Sun, 18 Jun 2023 17:45:33 +0200
+Subject: [PATCH] Add option to disable block updates
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/NoteBlock.java b/src/main/java/net/minecraft/world/level/block/NoteBlock.java
+index 910864cfeac085648e6c671b0f9480417324d36e..e46d84750bdd7c940f400efda226e12a3fdc3848 100644
+--- a/src/main/java/net/minecraft/world/level/block/NoteBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/NoteBlock.java
+@@ -58,11 +58,13 @@ public class NoteBlock extends Block {
+ 
+     @Override
+     public BlockState getStateForPlacement(BlockPlaceContext ctx) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableNoteblockUpdates) return this.defaultBlockState(); // Paper - place without considering instrument
+         return this.setInstrument(ctx.getLevel(), ctx.getClickedPos(), this.defaultBlockState());
+     }
+ 
+     @Override
+     public BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor world, BlockPos pos, BlockPos neighborPos) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableNoteblockUpdates) return state; // Paper - prevent noteblock instrument from updating
+         boolean flag = direction.getAxis() == Direction.Axis.Y;
+ 
+         return flag ? this.setInstrument(world, pos, state) : super.updateShape(state, direction, neighborState, world, pos, neighborPos);
+@@ -70,6 +72,7 @@ public class NoteBlock extends Block {
+ 
+     @Override
+     public void neighborChanged(BlockState state, Level world, BlockPos pos, Block sourceBlock, BlockPos sourcePos, boolean notify) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableNoteblockUpdates) return; // Paper - prevent noteblock powered-state from updating
+         boolean flag1 = world.hasNeighborSignal(pos);
+ 
+         if (flag1 != (Boolean) state.getValue(NoteBlock.POWERED)) {
+@@ -107,7 +110,7 @@ public class NoteBlock extends Block {
+         } else if (world.isClientSide) {
+             return InteractionResult.SUCCESS;
+         } else {
+-            state = (BlockState) state.cycle(NoteBlock.NOTE);
++            if (!io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableNoteblockUpdates) state = (BlockState) state.cycle(NoteBlock.NOTE); // Paper - prevent noteblock note from updating
+             world.setBlock(pos, state, 3);
+             this.playNote(player, state, world, pos);
+             player.awardStat(Stats.TUNE_NOTEBLOCK);
+diff --git a/src/main/java/net/minecraft/world/level/block/TripWireBlock.java b/src/main/java/net/minecraft/world/level/block/TripWireBlock.java
+index 7f60175bf671d282c11e9084670d2bb900968255..cb2ff8d94308c637a498d2737f86f6af4c9c1b83 100644
+--- a/src/main/java/net/minecraft/world/level/block/TripWireBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/TripWireBlock.java
+@@ -53,6 +53,7 @@ public class TripWireBlock extends Block {
+ 
+     @Override
+     public BlockState getStateForPlacement(BlockPlaceContext ctx) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return this.defaultBlockState(); // Paper - place tripwire without updating
+         Level world = ctx.getLevel();
+         BlockPos blockposition = ctx.getClickedPos();
+ 
+@@ -61,11 +62,13 @@ public class TripWireBlock extends Block {
+ 
+     @Override
+     public BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor world, BlockPos pos, BlockPos neighborPos) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return state; // Paper - prevent tripwire from updating
+         return direction.getAxis().isHorizontal() ? (BlockState) state.setValue((Property) TripWireBlock.PROPERTY_BY_DIRECTION.get(direction), this.shouldConnectTo(neighborState, direction)) : super.updateShape(state, direction, neighborState, world, pos, neighborPos);
+     }
+ 
+     @Override
+     public void onPlace(BlockState state, Level world, BlockPos pos, BlockState oldState, boolean notify) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent adjacent tripwires from updating
+         if (!oldState.is(state.getBlock())) {
+             this.updateSource(world, pos, state);
+         }
+@@ -73,6 +76,7 @@ public class TripWireBlock extends Block {
+ 
+     @Override
+     public void onRemove(BlockState state, Level world, BlockPos pos, BlockState newState, boolean moved) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent adjacent tripwires from updating
+         if (!moved && !state.is(newState.getBlock())) {
+             this.updateSource(world, pos, (BlockState) state.setValue(TripWireBlock.POWERED, true), true); // Paper - fix state inconsistency
+         }
+@@ -80,6 +84,7 @@ public class TripWireBlock extends Block {
+ 
+     @Override
+     public void playerWillDestroy(Level world, BlockPos pos, BlockState state, Player player) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent disarming tripwires
+         if (!world.isClientSide && !player.getMainHandItem().isEmpty() && player.getMainHandItem().is(Items.SHEARS)) {
+             world.setBlock(pos, (BlockState) state.setValue(TripWireBlock.DISARMED, true), 4);
+             world.gameEvent((Entity) player, GameEvent.SHEAR, pos);
+@@ -89,6 +94,7 @@ public class TripWireBlock extends Block {
+     }
+ 
+     private void updateSource(Level world, BlockPos pos, BlockState state) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent adjacent tripwires from updating
+         // Paper start - fix state inconsistency
+         this.updateSource(world, pos, state, false);
+     }
+@@ -127,6 +133,7 @@ public class TripWireBlock extends Block {
+ 
+     @Override
+     public void entityInside(BlockState state, Level world, BlockPos pos, Entity entity) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent tripwires from detecting collision
+         if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(world, pos)).callEvent()) { return; } // Paper
+         if (!world.isClientSide) {
+             if (!(Boolean) state.getValue(TripWireBlock.POWERED)) {
+@@ -137,6 +144,7 @@ public class TripWireBlock extends Block {
+ 
+     @Override
+     public void tick(BlockState state, ServerLevel world, BlockPos pos, RandomSource random) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent tripwire pressed check
+         if ((Boolean) world.getBlockState(pos).getValue(TripWireBlock.POWERED)) {
+             this.checkPressed(world, pos);
+         }


### PR DESCRIPTION
Superseeds #9367
Closing that as it was made from an Organization and not a Personal fork.
This also includes tripwires

Moved config stuff to Config patch, and out of "unsupported" and into "blockUpdates"
Figured a section for it was best as there are multiple options now and perhaps more down the line

In addition to preventing noteblock state updates this also prevents tripwires.
Noteblock example: (Config is outdated)

https://github.com/PaperMC/Paper/assets/62521371/85faef6d-4ee9-4907-b739-a4c1f8f0ca87

tripwire example:

https://github.com/PaperMC/Paper/assets/62521371/10977f17-08f2-4125-9d72-5c73a93ff615



