### PR TITLE
Mark Player.sendSignChange as deprecated

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -2111,7 +2111,7 @@ index f3afe67f0832cb828d25be3654518ff73a80b0e1..598abaa82c634178043a29f6caa6ac52
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc1d7a8ef1 100644
+index 7591d6de16694467b0fa5ab7ee746f3efdafad82..513e48de04a78268d16c924717d64896a23b437f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -49,7 +49,41 @@ import org.jetbrains.annotations.Nullable;
@@ -2302,7 +2302,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
      /**
       * Adds this user to the {@link ProfileBanList}. If a previous ban exists, this will
       * update the entry.
-@@ -671,6 +770,90 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -671,6 +770,106 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull Map<EquipmentSlot, ItemStack> items);
  
@@ -2321,7 +2321,11 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
 +     * @param lines the new text on the sign or null to clear it
 +     * @throws IllegalArgumentException if location is null
 +     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
++     * @deprecated Use {@link #sendBlockUpdate(Location, TileState)} by creating a new virtual
++     * {@link org.bukkit.block.Sign} block state via {@link BlockData#createBlockState()}
++     * (constructed e.g. via {@link Material#createBlockData()})
 +     */
++    @Deprecated
 +    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<? extends net.kyori.adventure.text.Component> lines) throws IllegalArgumentException {
 +        this.sendSignChange(loc, lines, DyeColor.BLACK);
 +    }
@@ -2342,7 +2346,11 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
 +     * @throws IllegalArgumentException if location is null
 +     * @throws IllegalArgumentException if dyeColor is null
 +     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
++     * @deprecated Use {@link #sendBlockUpdate(Location, TileState)} by creating a new virtual
++     * {@link org.bukkit.block.Sign} block state via {@link BlockData#createBlockState()}
++     * (constructed e.g. via {@link Material#createBlockData()})
 +     */
++    @Deprecated
 +    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<? extends net.kyori.adventure.text.Component> lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException {
 +        this.sendSignChange(loc, lines, dyeColor, false);
 +    }
@@ -2363,7 +2371,11 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
 +     * @throws IllegalArgumentException if location is null
 +     * @throws IllegalArgumentException if dyeColor is null
 +     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
++     * @deprecated Use {@link #sendBlockUpdate(Location, TileState)} by creating a new virtual
++     * {@link org.bukkit.block.Sign} block state via {@link BlockData#createBlockState()}
++     * (constructed e.g. via {@link Material#createBlockData()})
 +     */
++    @Deprecated
 +    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<? extends net.kyori.adventure.text.Component> lines, boolean hasGlowingText) throws IllegalArgumentException {
 +        this.sendSignChange(loc, lines, DyeColor.BLACK, hasGlowingText);
 +    }
@@ -2385,7 +2397,11 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
 +     * @throws IllegalArgumentException if location is null
 +     * @throws IllegalArgumentException if dyeColor is null
 +     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
++     * @deprecated Use {@link #sendBlockUpdate(Location, TileState)} by creating a new virtual
++     * {@link org.bukkit.block.Sign} block state via {@link BlockData#createBlockState()}
++     * (constructed e.g. via {@link Material#createBlockData()})
 +     */
++    @Deprecated
 +    void sendSignChange(@NotNull Location loc, @Nullable java.util.List<? extends net.kyori.adventure.text.Component> lines, @NotNull DyeColor dyeColor, boolean hasGlowingText)
 +        throws IllegalArgumentException;
 +    // Paper end
@@ -2393,37 +2409,43 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
      /**
       * Send a sign change. This fakes a sign change packet for a user at
       * a certain location. This will not actually change the world in any way.
-@@ -688,7 +871,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -688,7 +887,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param lines the new text on the sign or null to clear it
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
-+     * @deprecated in favour of {@link #sendSignChange(org.bukkit.Location, java.util.List)}
++     * @deprecated Use {@link #sendBlockUpdate(Location, TileState)} by creating a new virtual
++     * {@link org.bukkit.block.Sign} block state via {@link BlockData#createBlockState()}
++     * (constructed e.g. via {@link Material#createBlockData()})
       */
 +    @Deprecated // Paper
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines) throws IllegalArgumentException;
  
      /**
-@@ -710,7 +895,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -710,7 +913,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
-+     * @deprecated in favour of {@link #sendSignChange(org.bukkit.Location, java.util.List, org.bukkit.DyeColor)}
++     * @deprecated Use {@link #sendBlockUpdate(Location, TileState)} by creating a new virtual
++     * {@link org.bukkit.block.Sign} block state via {@link BlockData#createBlockState()}
++     * (constructed e.g. via {@link Material#createBlockData()})
       */
 +    @Deprecated // Paper
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException;
  
      /**
-@@ -733,7 +920,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -733,7 +940,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
-+     * @deprecated Deprecated in favour of {@link #sendSignChange(Location, java.util.List, DyeColor, boolean)}
++     * @deprecated Use {@link #sendBlockUpdate(Location, TileState)} by creating a new virtual
++     * {@link org.bukkit.block.Sign} block state via {@link BlockData#createBlockState()}
++     * (constructed e.g. via {@link Material#createBlockData()})
       */
 +    @Deprecated // Paper
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException;
  
      /**
-@@ -1249,6 +1438,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1249,6 +1460,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *     pack correctly.
       * </ul>
       *
@@ -2431,7 +2453,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
       * @param url The URL from which the client will download the resource
       *     pack. The string must contain only US-ASCII characters and should
       *     be encoded as per RFC 1738.
-@@ -1305,8 +1495,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1305,8 +1517,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
       *     long.
       */
@@ -2489,7 +2511,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
      /**
       * Request that the player's client download and switch resource packs.
       * <p>
-@@ -1336,6 +1575,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1336,6 +1597,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *     pack correctly.
       * </ul>
       *
@@ -2497,7 +2519,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
       * @param url The URL from which the client will download the resource
       *     pack. The string must contain only US-ASCII characters and should
       *     be encoded as per RFC 1738.
-@@ -1396,8 +1636,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1396,8 +1658,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
       *     long.
       */
@@ -2555,7 +2577,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
      /**
       * Gets the Scoreboard displayed to this player
       *
-@@ -1532,7 +1821,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1532,7 +1843,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param title Title text
       * @param subtitle Subtitle text
@@ -2564,7 +2586,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
       */
      @Deprecated
      public void sendTitle(@Nullable String title, @Nullable String subtitle);
-@@ -1551,7 +1840,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1551,7 +1862,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param fadeIn time in ticks for titles to fade in. Defaults to 10.
       * @param stay time in ticks for titles to stay. Defaults to 70.
       * @param fadeOut time in ticks for titles to fade out. Defaults to 20.
@@ -2574,7 +2596,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
      public void sendTitle(@Nullable String title, @Nullable String subtitle, int fadeIn, int stay, int fadeOut);
  
      /**
-@@ -1778,6 +2069,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1778,6 +2091,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -2589,7 +2611,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1803,8 +2102,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1803,8 +2124,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -2600,7 +2622,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
      public String getLocale();
  
      /**
-@@ -1856,6 +2157,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1856,6 +2179,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public boolean isAllowingServerListings();
  
@@ -2615,7 +2637,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1887,11 +2196,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1887,11 +2218,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -2629,7 +2651,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1902,7 +2213,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1902,7 +2235,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -2639,7 +2661,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1912,7 +2225,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1912,7 +2247,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -2649,7 +2671,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1923,7 +2238,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1923,7 +2260,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -2659,7 +2681,7 @@ index 7591d6de16694467b0fa5ab7ee746f3efdafad82..72b014ebf1a88bf0bf583f570b339ecc
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable java.util.UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1934,7 +2251,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1934,7 +2273,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send

--- a/patches/api/0010-Timings-v2.patch
+++ b/patches/api/0010-Timings-v2.patch
@@ -3455,10 +3455,10 @@ index 516d7fc7812aac343782861d0d567f54aa578c2a..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 72b014ebf1a88bf0bf583f570b339ecc1d7a8ef1..c370100ad6363640368c58a6adec6c8fc6e10ab9 100644
+index 513e48de04a78268d16c924717d64896a23b437f..5e1b013756d506b42c61a0abd25b324461adb9b2 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2256,7 +2256,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2278,7 +2278,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          @Deprecated // Paper
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable java.util.UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");

--- a/patches/api/0012-Player-affects-spawning-API.patch
+++ b/patches/api/0012-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c370100ad6363640368c58a6adec6c8fc6e10ab9..268361f4476baa96aafdbb01e0f2859c010de612 100644
+index 5e1b013756d506b42c61a0abd25b324461adb9b2..2a86cb0a29e89d9dbb43047644c7c857d0abad60 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2108,6 +2108,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2130,6 +2130,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0017-Add-view-distance-API.patch
+++ b/patches/api/0017-Add-view-distance-API.patch
@@ -75,10 +75,10 @@ index 5357291ff0f2f20bd87ab9f6e57f6a4f6ff65226..887aa6217583d224d66f6d238ac269c2
      public class Spigot {
  
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 268361f4476baa96aafdbb01e0f2859c010de612..950ca8562568cb161f6935deeafd8caa716fa33f 100644
+index 2a86cb0a29e89d9dbb43047644c7c857d0abad60..f128512b17ec0079bea6bfd9d7b726b3db578745 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2122,6 +2122,78 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2144,6 +2144,78 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0021-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0021-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -76,10 +76,10 @@ index 124e88e512d24b6ff7ace3cf7d5a6adf4c2bb40d..ccc825a2ea43bb84a5a08dff00c4d8ec
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 950ca8562568cb161f6935deeafd8caa716fa33f..dbdbea106c11136f449b572b9709969c8a9569bd 100644
+index f128512b17ec0079bea6bfd9d7b726b3db578745..4e68f6bc8ed217712b1d9a8990ee97ddfac18869 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -953,6 +953,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -975,6 +975,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  

--- a/patches/api/0025-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/api/0025-Player-Tab-List-and-Title-APIs.patch
@@ -432,10 +432,10 @@ index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb90
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index dbdbea106c11136f449b572b9709969c8a9569bd..48fb241657cd596d467135c067ad793c10f26418 100644
+index 4e68f6bc8ed217712b1d9a8990ee97ddfac18869..64c696a5d0c4177c9f860a25e9901ee2bdb64aee 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -987,6 +987,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1009,6 +1009,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }

--- a/patches/api/0027-Complete-resource-pack-API.patch
+++ b/patches/api/0027-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 48fb241657cd596d467135c067ad793c10f26418..15e289557a85a0b0e62ab4f150a601512ab3f72e 100644
+index 64c696a5d0c4177c9f860a25e9901ee2bdb64aee..d0a9fee7a2fd2a75894ea4acdf47454039406566 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1567,7 +1567,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1589,7 +1589,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the URL is null.
       * @throws IllegalArgumentException Thrown if the URL is too long. The
       *     length restriction is an implementation specific arbitrary value.
@@ -18,7 +18,7 @@ index 48fb241657cd596d467135c067ad793c10f26418..15e289557a85a0b0e62ab4f150a60151
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -2412,6 +2414,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2434,6 +2436,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0046-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0046-Add-String-based-Action-Bar-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 15e289557a85a0b0e62ab4f150a601512ab3f72e..96ca3feb93b949f1b052fc9d85f583e25f87ace7 100644
+index d0a9fee7a2fd2a75894ea4acdf47454039406566..cfa757a782ff592a2f7f998b649edd93052a17ac 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -954,6 +954,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -976,6 +976,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start
@@ -48,7 +48,7 @@ index 15e289557a85a0b0e62ab4f150a601512ab3f72e..96ca3feb93b949f1b052fc9d85f583e2
      /**
       * Sends the component to the player
       *
-@@ -981,9 +1014,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1003,9 +1036,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Sends an array of components as a single message to the specified screen position of this player
       *

--- a/patches/api/0055-Fix-upstream-javadocs.patch
+++ b/patches/api/0055-Fix-upstream-javadocs.patch
@@ -387,7 +387,7 @@ index ae9eaaa8e38e1d9dfc459926c7fc51ddb89de84a..b2ec535bb1b0ce0c114ddd7638b90218
      @Override
      public int getConversionTime();
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 96ca3feb93b949f1b052fc9d85f583e25f87ace7..77b2e935b823b302a7221cd5be6441ec10557908 100644
+index cfa757a782ff592a2f7f998b649edd93052a17ac..49e3e59e369980dd96fec1467cacd88322a0c6ed 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -365,15 +365,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -419,7 +419,7 @@ index 96ca3feb93b949f1b052fc9d85f583e25f87ace7..77b2e935b823b302a7221cd5be6441ec
       * @param loc the location to play the effect at
       * @param effect the {@link Effect}
       * @param data a data bit needed for some effects
-@@ -971,7 +971,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -993,7 +993,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * Use supplied alternative character to the section symbol to represent legacy color codes.
       *
@@ -428,7 +428,7 @@ index 96ca3feb93b949f1b052fc9d85f583e25f87ace7..77b2e935b823b302a7221cd5be6441ec
       * @param message The message to send
       * @deprecated use {@link #sendActionBar(net.kyori.adventure.text.Component)}
       */
-@@ -1437,7 +1437,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1459,7 +1459,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
  
      /**
       * Allows this player to see a player that was previously hidden. If
@@ -437,7 +437,7 @@ index 96ca3feb93b949f1b052fc9d85f583e25f87ace7..77b2e935b823b302a7221cd5be6441ec
       * remain hidden until the other plugin calls this method too.
       *
       * @param plugin Plugin that wants to show the player
-@@ -1466,7 +1466,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1488,7 +1488,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
  
      /**
       * Allows this player to see an entity that was previously hidden. If

--- a/patches/api/0080-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/api/0080-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 4a1c42a55df02b33c144da55b4a01c610217d63c..8916caa53a638f4029ec6293b2ab11ad1bcdb14d 100644
+index 83402738ec9c435b456929ad4d9337e7362f52c2..c742fb537788da58fb8984d588049fff3ba79af1 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1280,6 +1280,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1302,6 +1302,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void resetPlayerWeather();
  
@@ -29,7 +29,7 @@ index 4a1c42a55df02b33c144da55b4a01c610217d63c..8916caa53a638f4029ec6293b2ab11ad
      /**
       * Gets the player's cooldown between picking up experience orbs.
       *
-@@ -1305,8 +1314,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1327,8 +1336,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Gives the player the amount of experience specified.
       *
       * @param amount Exp amount to give

--- a/patches/api/0091-Player.setPlayerProfile-API.patch
+++ b/patches/api/0091-Player.setPlayerProfile-API.patch
@@ -93,10 +93,10 @@ index 016cee903c7179baf711984503d1d0793d40c5c5..064edd612885b2ea4b35001a864503b5
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8916caa53a638f4029ec6293b2ab11ad1bcdb14d..317db645b6459a6ee2c888b7cf2e40fdbb30bdde 100644
+index c742fb537788da58fb8984d588049fff3ba79af1..bbd08acb81fd059a95f2f6e09284e7a0264f548d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2588,6 +2588,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2610,6 +2610,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/api/0094-Add-openSign-method-to-HumanEntity.patch
@@ -36,10 +36,10 @@ index abdca9fe5acc90f167219eb769ece66c35682bb1..b3aa3dc6aa5afbc36cc86741b4cba56f
      /**
       * Make the entity drop the item in their hand.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 317db645b6459a6ee2c888b7cf2e40fdbb30bdde..ee13cbc86cea2892521424df01cceceb6c0b3842 100644
+index bbd08acb81fd059a95f2f6e09284e7a0264f548d..b1d93f16c55d3fa9a157cf26286936a799ca8025 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2433,10 +2433,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2455,10 +2455,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Open a Sign for editing by the Player.
       *

--- a/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0095-Add-Ban-Methods-to-Player-Objects.patch
@@ -74,10 +74,10 @@ index 829077d76ad6b179e6f6abf7fb848353fa53a60a..0666cc126ab3709fd7d59c3902c3ec0e
      /**
       * Adds this user to the {@link ProfileBanList}. If a previous ban exists, this will
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ee13cbc86cea2892521424df01cceceb6c0b3842..03363c3d3a2eb6078eac5d3edff7a33472158f3a 100644
+index b1d93f16c55d3fa9a157cf26286936a799ca8025..24723d089ffc9fc87b1f5dc8ae365b7124dc0e87 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -954,6 +954,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -976,6 +976,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start

--- a/patches/api/0144-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0144-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 03363c3d3a2eb6078eac5d3edff7a33472158f3a..19b8fb15f893445f1e7a30baa3262b1947e869a6 100644
+index 24723d089ffc9fc87b1f5dc8ae365b7124dc0e87..7e304a795d8156c9b1c5ae8a19b71fb116b1b984 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2760,6 +2760,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2782,6 +2782,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull com.destroystokyo.paper.profile.PlayerProfile profile);

--- a/patches/api/0189-Add-Player-Client-Options-API.patch
+++ b/patches/api/0189-Add-Player-Client-Options-API.patch
@@ -229,10 +229,10 @@ index 0000000000000000000000000000000000000000..cf67dc7d465223710adbf2b798109f52
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 19b8fb15f893445f1e7a30baa3262b1947e869a6..c907585e27b6a5103323aa6d199cc8d6f4d43fa4 100644
+index 7e304a795d8156c9b1c5ae8a19b71fb116b1b984..1f559c18d961ba31f723a9664201e5522dd7d14a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2780,6 +2780,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2802,6 +2802,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0206-Brand-support.patch
+++ b/patches/api/0206-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c907585e27b6a5103323aa6d199cc8d6f4d43fa4..a93bd6abd567dcd75d3b119534041d2e19dc3da6 100644
+index 1f559c18d961ba31f723a9664201e5522dd7d14a..eb5fdf0d907f7e6d49cccbf0476ccfd25f578f2d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2889,6 +2889,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2911,6 +2911,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0217-Player-elytra-boost-API.patch
+++ b/patches/api/0217-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index a93bd6abd567dcd75d3b119534041d2e19dc3da6..2fd141ebda1c8aeeab5144e6e83816e137b0c41a 100644
+index eb5fdf0d907f7e6d49cccbf0476ccfd25f578f2d..d5660c021020b9bacd2888e1b526bf2445aad919 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2786,6 +2786,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2808,6 +2808,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull com.destroystokyo.paper.ClientOption<T> option);

--- a/patches/api/0244-Add-sendOpLevel-API.patch
+++ b/patches/api/0244-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2fd141ebda1c8aeeab5144e6e83816e137b0c41a..e5f52cabf9447bb7dba77f1f5bbd4cdbf6fa772d 100644
+index d5660c021020b9bacd2888e1b526bf2445aad919..5eb534d4199a83e94543999a7ae99dd538e1d9aa 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2799,6 +2799,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2821,6 +2821,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0370-More-Teleport-API.patch
+++ b/patches/api/0370-More-Teleport-API.patch
@@ -165,10 +165,10 @@ index ab0ceaba9ddcbe20a8b8a1fc3ed19cb3c64ecd3d..97f0bc6573c8ba09de77061b6312b91c
       * Teleports this entity to the given location. If this entity is riding a
       * vehicle, it will be dismounted prior to teleportation.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 0af6b1ad7d0449354fd0166d1d6e8484ab1bd73f..ba4f9a34b825f8d4700ab5c7ad108f802568a657 100644
+index cd6dd216eb528bf5c0dcf804a2409d852accb78b..5a514111c21f62d1db8b298270088c1705a9e766 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2954,6 +2954,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2976,6 +2976,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      String getClientBrandName();
      // Paper end
  

--- a/patches/api/0372-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0372-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ba4f9a34b825f8d4700ab5c7ad108f802568a657..2018df5aff5042034b8d982844d28e71936700dc 100644
+index 5a514111c21f62d1db8b298270088c1705a9e766..b977f198f7385813006473adf5e50166f0b77d5f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2841,6 +2841,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2863,6 +2863,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException If the level is negative or greater than {@code 4} (i.e. not within {@code [0, 4]}).
       */
      void sendOpLevel(byte level);

--- a/patches/api/0382-Elder-Guardian-appearance-API.patch
+++ b/patches/api/0382-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2018df5aff5042034b8d982844d28e71936700dc..4e43793a57ecf78a04972168b5a9a116ff18e30a 100644
+index b977f198f7385813006473adf5e50166f0b77d5f..e70375b18de9c2c7c09ce13c5d6faadabd3732c1 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3020,6 +3020,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3042,6 +3042,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
      // Paper end - Teleport API
  

--- a/patches/api/0390-Add-Player-Warden-Warning-API.patch
+++ b/patches/api/0390-Add-Player-Warden-Warning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player Warden Warning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 4e43793a57ecf78a04972168b5a9a116ff18e30a..60206aaf1dfec3cf1f8911d7dce41a36a8675375 100644
+index e70375b18de9c2c7c09ce13c5d6faadabd3732c1..b21d2ee776a25d00ed076b0a83562baec4ff2bd3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3036,6 +3036,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3058,6 +3058,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param silent whether sound should be silenced
       */
      void showElderGuardian(boolean silent);

--- a/patches/api/0403-Flying-Fall-Damage-API.patch
+++ b/patches/api/0403-Flying-Fall-Damage-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Flying Fall Damage API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 77b0e632f8fefb9165a5170f8620a117c3b71c04..7e4d541e92d2e1cf47a4a50e451bc9e40dd15049 100644
+index d4d07bb5cab656973b2ee54c8ea85e57718d2746..e2a3effda47e2c2696636398a0ff450d226ef469 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1617,6 +1617,23 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1639,6 +1639,23 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void setAllowFlight(boolean flight);
  

--- a/patches/api/0406-Win-Screen-API.patch
+++ b/patches/api/0406-Win-Screen-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Win Screen API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7e4d541e92d2e1cf47a4a50e451bc9e40dd15049..d0297f47f18cabf857cf4ce04c529b46525c0f75 100644
+index e2a3effda47e2c2696636398a0ff450d226ef469..44f5237406128adde97e43304f8b433032920090 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -984,6 +984,47 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1006,6 +1006,47 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  


### PR DESCRIPTION
As discussed in #9303 this pull request marks the Player.sendSignChange methods as deprecated in favor of Player.sendBlockUpdate.