### PR TITLE
Migrate Gradle dependencies to version catalog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
       - name: JDK ${{ matrix.java }}
         uses: actions/setup-java@v3.6.0
         with:

--- a/Paper-MojangAPI/build.gradle.kts
+++ b/Paper-MojangAPI/build.gradle.kts
@@ -10,14 +10,14 @@ java {
 
 dependencies {
     implementation(project(":paper-api"))
-    api("com.mojang:brigadier:1.0.18")
+    api(libs.brigadier)
 
-    compileOnly("it.unimi.dsi:fastutil:8.5.6")
-    compileOnly("org.jetbrains:annotations:23.0.0")
+    compileOnly(libs.fastutil)
+    compileOnly(libs.annotations)
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("org.hamcrest:hamcrest-library:1.3")
-    testImplementation("org.ow2.asm:asm-tree:9.2")
+    testImplementation(libs.junit)
+    testImplementation(libs.hamcrest)
+    testImplementation(libs.asm.tree)
 }
 
 configure<PublishingExtension> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,12 +90,12 @@ netty-codec-haproxy = {group = "io.netty", name = "netty-codec-haproxy", version
 annotations-java5 = {group = "org.jetbrains", name = "annotations-java5", version.ref = "annotations"}
 
 adventure-bom = {group = "net.kyori", name = "adventure-bom", version.ref = "adventure"}
-adventure-api = {group = "net.kyori", name = "adventure-api"}
-adventure-text-minimessage = {group = "net.kyori", name = "adventure-text-minimessage"}
-adventure-text-serializer-gson = {group = "net.kyori", name = "adventure-text-serializer-gson"}
-adventure-text-serializer-legacy = {group = "net.kyori", name = "adventure-text-serializer-legacy"}
-adventure-text-serializer-plain = {group = "net.kyori", name = "adventure-text-serializer-plain"}
-adventure-text-logger-slf4j = {group = "net.kyori", name = "adventure-text-logger-slf4j"}
+adventure-api = {group = "net.kyori", name = "adventure-api", version.ref = "adventure"}
+adventure-text-minimessage = {group = "net.kyori", name = "adventure-text-minimessage", version.ref = "adventure"}
+adventure-text-serializer-gson = {group = "net.kyori", name = "adventure-text-serializer-gson", version.ref = "adventure"}
+adventure-text-serializer-legacy = {group = "net.kyori", name = "adventure-text-serializer-legacy", version.ref = "adventure"}
+adventure-text-serializer-plain = {group = "net.kyori", name = "adventure-text-serializer-plain", version.ref = "adventure"}
+adventure-text-logger-slf4j = {group = "net.kyori", name = "adventure-text-logger-slf4j", version.ref = "adventure"}
 adventure-text-serializer-ansi = {group = "net.kyori", name = "adventure-text-serializer-ansi", version.ref = "adventure"}
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,111 @@
+[versions]
+junit = "4.13.2"
+hamcrest = "1.3"
+asm-tree = "9.5"
+asm = "9.4"
+annotations = "24.0.1"
+apache-commons = "3.12.0"
+commons-lang = "2.6"
+fastutil = "8.5.6"
+brigadier = "1.0.18"
+maven-resolver-provider = "3.8.5"
+maven-resolver-connector-basic = "1.7.3"
+maven-resolver-transport-http = "1.7.3"
+guava = "31.1-jre"
+gson = "2.10"
+bungeecordchat = "1.16-R0.4-deprecated+build.9"
+snakeyaml = "2.0"
+joml = "1.10.5"
+jline = "2.12.1"
+log4j-iostreams = "2.19.0"
+log4j-api = "2.17.1"
+log4j-core = "2.14.1"
+slf4j-api = "1.8.0-beta4"
+sqlite = "3.42.0.0"
+mysqlconnector = "8.0.33"
+checkerqual = "3.21.0"
+jsr305 = "1.3.9"
+jsonsimple = "1.1.1"
+adventure = "4.14.0"
+netty = "4.1.87.Final"
+mockito = "4.9.0"
+configurate = "4.1.2"
+jline-terminal = "3.21.0"
+terminalconsoleappender = "1.3.0"
+ansi = "1.0.1"
+disruptor = "3.4.4"
+mappingio = "0.3.0"
+classgraph = "4.8.47"
+velocity = "3.1.2-SNAPSHOT"
+
+yarn = "1.20.1+build.1:mergedv2"
+tinyremapper = "0.8.6:fat"
+forgeflower = "2.0.627.2"
+fernflower = "0.1+build.6"
+paperclip = "3.0.3"
+
+shadow = "8.1.1"
+paperweight = "1.5.5"
+
+[libraries]
+junit = {group = "junit", name = "junit", version.ref = "junit"}
+hamcrest = {group = "org.hamcrest", name = "hamcrest-library", version.ref = "hamcrest"}
+asm-tree = {group = "org.ow2.asm", name = "asm-tree", version.ref = "asm-tree"}
+asm = {group = "org.ow2.asm", name = "asm", version.ref = "asm"}
+asm-commons = {group = "org.ow2.asm", name = "asm-commons", version.ref = "asm"}
+annotations = {group = "org.jetbrains", name = "annotations", version.ref = "annotations"}
+apache-commons = {group = "org.apache.commons", name = "commons-lang3", version.ref = "apache-commons"}
+commons-lang = {group = "commons-lang", name = "commons-lang", version.ref = "commons-lang"}
+fastutil = {group = "it.unimi.dsi", name = "fastutil", version.ref = "fastutil"}
+brigadier = {group = "com.mojang", name = "brigadier", version.ref = "brigadier"}
+maven-resolver-provider = {group = "org.apache.maven", name = "maven-resolver-provider", version.ref = "maven-resolver-provider"}
+maven-resolver-connector-basic = {group = "org.apache.maven.resolver", name = "maven-resolver-connector-basic", version.ref = "maven-resolver-connector-basic"}
+maven-resolver-transport-http = {group = "org.apache.maven.resolver", name = "maven-resolver-transport-http", version.ref = "maven-resolver-transport-http"}
+guava = {group = "com.google.guava", name = "guava", version.ref = "guava"}
+gson = {group = "com.google.code.gson", name = "gson", version.ref = "gson"}
+bungeecordchat = {group = "net.md-5", name = "bungeecord-chat", version.ref = "bungeecordchat"}
+snakeyaml = {group = "org.yaml", name = "snakeyaml", version.ref = "snakeyaml"}
+joml = {group = "org.joml", name = "joml", version.ref = "joml"}
+jline = {group = "jline", name = "jline", version.ref = "jline"}
+log4j-iostreams = {group = "org.apache.logging.log4j", name = "log4j-iostreams", version.ref = "log4j-iostreams"}
+sqlite = {group = "org.xerial", name = "sqlite-jdbc", version.ref = "sqlite"}
+mysqlconnector = {group = "com.mysql", name = "mysql-connector-j", version.ref = "mysqlconnector"}
+checkerqual = {group = "org.checkerframework", name = "checker-qual", version.ref = "checkerqual"}
+jsr305 = {group = "com.google.code.findbugs", name = "jsr305", version.ref = "jsr305"}
+jsonsimple = {group = "com.googlecode.json-simple", name = "json-simple", version.ref = "jsonsimple"}
+log4j-api = {group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j-api"}
+log4j-core = {group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j-core"}
+slf4j-api = {group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j-api"}
+netty-all = {group = "io.netty", name = "netty-all", version.ref = "netty"}
+mockito = {group = "org.mockito", name = "mockito-core", version.ref = "mockito"}
+configurate = {group = "org.spongepowered", name = "configurate-yaml", version.ref = "configurate"}
+jline-terminal = {group = "org.jline", name = "jline-terminal-jansi", version.ref = "jline-terminal"}
+terminalconsoleappender = {group = "net.minecrell", name = "terminalconsoleappender", version.ref = "terminalconsoleappender"}
+ansi = {group = "net.kyori", name = "ansi", version.ref = "ansi"}
+disruptor = {group = "com.lmax", name = "disruptor", version.ref = "disruptor"}
+mappingio = {group = "net.fabricmc", name = "mapping-io", version.ref = "mappingio"}
+classgraph = {group = "io.github.classgraph", name = "classgraph", version.ref = "classgraph"}
+velocity = {group = "com.velocitypowered", name = "velocity-native", version.ref = "velocity"}
+netty-codec-haproxy = {group = "io.netty", name = "netty-codec-haproxy", version.ref = "netty"}
+annotations-java5 = {group = "org.jetbrains", name = "annotations-java5", version.ref = "annotations"}
+
+adventure-bom = {group = "net.kyori", name = "adventure-bom", version.ref = "adventure"}
+adventure-api = {group = "net.kyori", name = "adventure-api"}
+adventure-text-minimessage = {group = "net.kyori", name = "adventure-text-minimessage"}
+adventure-text-serializer-gson = {group = "net.kyori", name = "adventure-text-serializer-gson"}
+adventure-text-serializer-legacy = {group = "net.kyori", name = "adventure-text-serializer-legacy"}
+adventure-text-serializer-plain = {group = "net.kyori", name = "adventure-text-serializer-plain"}
+adventure-text-logger-slf4j = {group = "net.kyori", name = "adventure-text-logger-slf4j"}
+adventure-text-serializer-ansi = {group = "net.kyori", name = "adventure-text-serializer-ansi", version.ref = "adventure"}
+
+
+
+yarn = {group = "net.fabricmc", name = "yarn", version.ref = "yarn"}
+tinyremapper = {group = "net.fabricmc", name = "tiny-remapper", version.ref = "tinyremapper"}
+forgeflower = {group = "net.minecraftforge", name = "forgeflower", version.ref = "forgeflower"}
+fernflower = {group = "io.papermc", name = "patched-spigot-fernflower", version.ref = "fernflower"}
+paperclip = {group = "io.papermc", name = "paperclip", version.ref = "paperclip"}
+
+[plugins]
+shadow = {id = "com.github.johnrengelman.shadow", version.ref = "shadow"}
+paperweight = {id = "io.papermc.paperweight.core", version.ref = "paperweight"}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/patches/api/0001-Convert-project-to-Gradle.patch
+++ b/patches/api/0001-Convert-project-to-Gradle.patch
@@ -27,7 +27,7 @@ index 11038da2e071699d6561a331565db0c8d7850d0e..317acfec5894101294a55abff6181943
 +/.factorypath
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..6658ab9e9e05df5bd735127a22f17bf1c01d1bea
+index 0000000000000000000000000000000000000000..98fc174313ddbb3fb15354e228c95cd86e812848
 --- /dev/null
 +++ b/build.gradle.kts
 @@ -0,0 +1,82 @@
@@ -97,7 +97,7 @@ index 0000000000000000000000000000000000000000..6658ab9e9e05df5bd735127a22f17bf1
 +    options.links(
 +        "https://guava.dev/releases/31.1-jre/api/docs/",
 +        "https://javadoc.io/doc/org.yaml/snakeyaml/2.0/",
-+        "https://javadoc.io/doc/org.jetbrains/annotations-java5/${libs.versions.annotations}/",
++        "https://javadoc.io/doc/org.jetbrains/annotations-java5/${libs.versions.annotations.get()}/",
 +        "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
 +    )
 +    options.tags("apiNote:a:API Note:")

--- a/patches/api/0001-Convert-project-to-Gradle.patch
+++ b/patches/api/0001-Convert-project-to-Gradle.patch
@@ -27,10 +27,10 @@ index 11038da2e071699d6561a331565db0c8d7850d0e..317acfec5894101294a55abff6181943
 +/.factorypath
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..232cc8fafb1d7d9730cf2f58777e8977995ec28b
+index 0000000000000000000000000000000000000000..6658ab9e9e05df5bd735127a22f17bf1c01d1bea
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,85 @@
+@@ -0,0 +1,82 @@
 +plugins {
 +    `java-library`
 +    `maven-publish`
@@ -41,28 +41,25 @@ index 0000000000000000000000000000000000000000..232cc8fafb1d7d9730cf2f58777e8977
 +    withJavadocJar()
 +}
 +
-+val annotationsVersion = "24.0.1"
-+
 +dependencies {
 +    // api dependencies are listed transitively to API consumers
-+    api("com.google.guava:guava:31.1-jre")
-+    api("com.google.code.gson:gson:2.10")
-+    api("net.md-5:bungeecord-chat:1.16-R0.4")
-+    api("org.yaml:snakeyaml:2.0")
-+    api("org.joml:joml:1.10.5")
++    api(libs.guava)
++    api(libs.gson)
++    api(libs.bungeecordchat)
++    api(libs.snakeyaml)
++    api(libs.joml)
 +
-+    compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")
-+    compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
-+    compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
++    compileOnly(libs.maven.resolver.provider)
++    compileOnly(libs.maven.resolver.connector.basic)
++    compileOnly(libs.maven.resolver.transport.http)
 +
-+    val annotations = "org.jetbrains:annotations-java5:$annotationsVersion"
-+    compileOnly(annotations)
-+    testCompileOnly(annotations)
++    compileOnly(libs.annotations.java5)
++    testCompileOnly(libs.annotations.java5)
 +
-+    testImplementation("org.apache.commons:commons-lang3:3.12.0")
-+    testImplementation("junit:junit:4.13.2")
-+    testImplementation("org.hamcrest:hamcrest-library:1.3")
-+    testImplementation("org.ow2.asm:asm-tree:9.5")
++    testImplementation(libs.apache.commons)
++    testImplementation(libs.junit)
++    testImplementation(libs.hamcrest)
++    testImplementation(libs.asm.tree)
 +}
 +
 +configure<PublishingExtension> {
@@ -100,7 +97,7 @@ index 0000000000000000000000000000000000000000..232cc8fafb1d7d9730cf2f58777e8977
 +    options.links(
 +        "https://guava.dev/releases/31.1-jre/api/docs/",
 +        "https://javadoc.io/doc/org.yaml/snakeyaml/2.0/",
-+        "https://javadoc.io/doc/org.jetbrains/annotations-java5/$annotationsVersion/",
++        "https://javadoc.io/doc/org.jetbrains/annotations-java5/${libs.versions.annotations}/",
 +        "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
 +    )
 +    options.tags("apiNote:a:API Note:")

--- a/patches/api/0002-Build-system-changes.patch
+++ b/patches/api/0002-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 6658ab9e9e05df5bd735127a22f17bf1c01d1bea..be7fee376fbac4551ea11d5cf7140a11b47c3a2f 100644
+index 98fc174313ddbb3fb15354e228c95cd86e812848..1f8c4fcaeccaa259765968cce9e2faf6b31f6acf 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -15,13 +15,24 @@ dependencies {
@@ -39,8 +39,8 @@ index 6658ab9e9e05df5bd735127a22f17bf1c01d1bea..be7fee376fbac4551ea11d5cf7140a11
      options.links(
          "https://guava.dev/releases/31.1-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/2.0/",
--        "https://javadoc.io/doc/org.jetbrains/annotations-java5/${libs.versions.annotations}/",
-+        "https://javadoc.io/doc/org.jetbrains/annotations/${libs.versions.annotations}/", // Paper - we don't want Java 5 annotations
+-        "https://javadoc.io/doc/org.jetbrains/annotations-java5/${libs.versions.annotations.get()}/",
++        "https://javadoc.io/doc/org.jetbrains/annotations/${libs.versions.annotations.get()}/", // Paper - we don't want Java 5 annotations
          "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
      )
      options.tags("apiNote:a:API Note:")

--- a/patches/api/0002-Build-system-changes.patch
+++ b/patches/api/0002-Build-system-changes.patch
@@ -5,48 +5,46 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 232cc8fafb1d7d9730cf2f58777e8977995ec28b..3faf250d59eeefb8477a6e1454914bdd88ff11d6 100644
+index 6658ab9e9e05df5bd735127a22f17bf1c01d1bea..be7fee376fbac4551ea11d5cf7140a11b47c3a2f 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -17,15 +17,27 @@ dependencies {
-     api("net.md-5:bungeecord-chat:1.16-R0.4")
-     api("org.yaml:snakeyaml:2.0")
-     api("org.joml:joml:1.10.5")
+@@ -15,13 +15,24 @@ dependencies {
+     api(libs.bungeecordchat)
+     api(libs.snakeyaml)
+     api(libs.joml)
 +    // Paper start
-+    api("com.googlecode.json-simple:json-simple:1.1.1") {
-+        isTransitive = false // includes junit
++    api(libs.jsonsimple) {
++        isTransitive = false; //includes junit
 +    }
 +    // Paper end
  
-     compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")
-     compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
-     compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
-+    compileOnly("com.google.code.findbugs:jsr305:1.3.9") // Paper
- 
--    val annotations = "org.jetbrains:annotations-java5:$annotationsVersion"
-+    val annotations = "org.jetbrains:annotations:$annotationsVersion" // Paper - we don't want Java 5 annotations...
-     compileOnly(annotations)
-     testCompileOnly(annotations)
- 
-+    // Paper start - add checker
-+    val checkerQual = "org.checkerframework:checker-qual:3.21.0"
-+    compileOnlyApi(checkerQual)
-+    testCompileOnly(checkerQual)
-+    // Paper end
+     compileOnly(libs.maven.resolver.provider)
+     compileOnly(libs.maven.resolver.connector.basic)
+     compileOnly(libs.maven.resolver.transport.http)
++    compileOnly(libs.jsr305)
 +
-     testImplementation("org.apache.commons:commons-lang3:3.12.0")
-     testImplementation("junit:junit:4.13.2")
-     testImplementation("org.hamcrest:hamcrest-library:1.3")
-@@ -67,7 +79,7 @@ tasks.withType<Javadoc> {
++    compileOnly(libs.annotations) // Paper - we don't want Java 5 annotations...
++    testCompileOnly(libs.annotations) // Paper - we don't want Java 5 annotations...
+ 
+-    compileOnly(libs.annotations.java5)
+-    testCompileOnly(libs.annotations.java5)
++    // Paper start - add checker
++    compileOnlyApi(libs.checkerqual)
++    testCompileOnly(libs.checkerqual)
++    // Paper end
+ 
+     testImplementation(libs.apache.commons)
+     testImplementation(libs.junit)
+@@ -64,7 +75,7 @@ tasks.withType<Javadoc> {
      options.links(
          "https://guava.dev/releases/31.1-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/2.0/",
--        "https://javadoc.io/doc/org.jetbrains/annotations-java5/$annotationsVersion/",
-+        "https://javadoc.io/doc/org.jetbrains/annotations/$annotationsVersion/", // Paper - we don't want Java 5 annotations
+-        "https://javadoc.io/doc/org.jetbrains/annotations-java5/${libs.versions.annotations}/",
++        "https://javadoc.io/doc/org.jetbrains/annotations/${libs.versions.annotations}/", // Paper - we don't want Java 5 annotations
          "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
      )
      options.tags("apiNote:a:API Note:")
-@@ -83,3 +95,14 @@ tasks.withType<Javadoc> {
+@@ -80,3 +91,14 @@ tasks.withType<Javadoc> {
          }
      }
  }

--- a/patches/api/0003-Test-changes.patch
+++ b/patches/api/0003-Test-changes.patch
@@ -13,17 +13,17 @@ Co-authored-by: Riley Park <rileysebastianpark@gmail.com>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 3faf250d59eeefb8477a6e1454914bdd88ff11d6..4a5f1737910c1c87838baf01366f20c814a39a8f 100644
+index be7fee376fbac4551ea11d5cf7140a11b47c3a2f..fc62836ca4bccec40abe4c45d952fbbb8e25ffc8 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -37,6 +37,7 @@ dependencies {
-     compileOnlyApi(checkerQual)
-     testCompileOnly(checkerQual)
+@@ -33,6 +33,7 @@ dependencies {
+     compileOnlyApi(libs.checkerqual)
+     testCompileOnly(libs.checkerqual)
      // Paper end
-+    testImplementation("org.mockito:mockito-core:4.9.0") // Paper - add mockito
++    testImplementation(libs.mockito) // Paper - add mockito
  
-     testImplementation("org.apache.commons:commons-lang3:3.12.0")
-     testImplementation("junit:junit:4.13.2")
+     testImplementation(libs.apache.commons)
+     testImplementation(libs.junit)
 diff --git a/src/test/java/io/papermc/paper/testing/EmptyRegistry.java b/src/test/java/io/papermc/paper/testing/EmptyRegistry.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..ba9ddce87a9f385e729a5c2cf7c5eec120e388a7

--- a/patches/api/0004-Add-FastUtil-to-Bukkit.patch
+++ b/patches/api/0004-Add-FastUtil-to-Bukkit.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Add FastUtil to Bukkit
 Doesn't expose to plugins, just allows Paper-API to use it for optimization
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 4a5f1737910c1c87838baf01366f20c814a39a8f..3dec6ab39000edd3e90d1bf734d24cc779ce0e3b 100644
+index fc62836ca4bccec40abe4c45d952fbbb8e25ffc8..cb1d9ae1a215a0cb98a5f8ba869af9ccc1778a20 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -21,6 +21,7 @@ dependencies {
-     api("com.googlecode.json-simple:json-simple:1.1.1") {
-         isTransitive = false // includes junit
+@@ -19,6 +19,7 @@ dependencies {
+     api(libs.jsonsimple) {
+         isTransitive = false; //includes junit
      }
-+    api("it.unimi.dsi:fastutil:8.5.6")
++    api(libs.fastutil)
      // Paper end
  
-     compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")
+     compileOnly(libs.maven.resolver.provider)

--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -7,7 +7,7 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index cb1d9ae1a215a0cb98a5f8ba869af9ccc1778a20..e8a931594c7db7d542b34dda8568831cb313dc37 100644
+index f3f4e4b1cbcc5c352d023a094330d8eb418dca39..7249c2dd9a3db8239063af08574e20a0375a17bf 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -8,6 +8,18 @@ java {
@@ -48,16 +48,16 @@ index cb1d9ae1a215a0cb98a5f8ba869af9ccc1778a20..e8a931594c7db7d542b34dda8568831c
 @@ -78,10 +98,26 @@ tasks.withType<Javadoc> {
          "https://guava.dev/releases/31.1-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/2.0/",
-         "https://javadoc.io/doc/org.jetbrains/annotations/${libs.versions.annotations}/", // Paper - we don't want Java 5 annotations
+         "https://javadoc.io/doc/org.jetbrains/annotations/${libs.versions.annotations.get()}/", // Paper - we don't want Java 5 annotations
 -        "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
 +        // Paper start
 +        //"https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/", // don't link to bungee chat
-+        "https://jd.advntr.dev/api/${libs.versions.adventure}/",
-+        "https://jd.advntr.dev/text-minimessage/${libs.versions.adventure}/",
-+        "https://jd.advntr.dev/text-serializer-gson/${libs.versions.adventure}/",
-+        "https://jd.advntr.dev/text-serializer-legacy/${libs.versions.adventure}/",
-+        "https://jd.advntr.dev/text-serializer-plain/${libs.versions.adventure}/",
-+        "https://jd.advntr.dev/text-logger-slf4j/${libs.versions.adventure}/"
++        "https://jd.advntr.dev/api/${libs.versions.adventure.get()}/",
++        "https://jd.advntr.dev/text-minimessage/${libs.versions.adventure.get()}/",
++        "https://jd.advntr.dev/text-serializer-gson/${libs.versions.adventure.get()}/",
++        "https://jd.advntr.dev/text-serializer-legacy/${libs.versions.adventure.get()}/",
++        "https://jd.advntr.dev/text-serializer-plain/${libs.versions.adventure.get()}/",
++        "https://jd.advntr.dev/text-logger-slf4j/${libs.versions.adventure.get()}/"
 +        // Paper end
      )
      options.tags("apiNote:a:API Note:")

--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -7,14 +7,13 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 3dec6ab39000edd3e90d1bf734d24cc779ce0e3b..cbab63d2f3b045f6193f5a3422ae4b5509d3003b 100644
+index cb1d9ae1a215a0cb98a5f8ba869af9ccc1778a20..e8a931594c7db7d542b34dda8568831cb313dc37 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -8,13 +8,26 @@ java {
+@@ -8,6 +8,18 @@ java {
      withJavadocJar()
  }
  
-+val adventureVersion = "4.14.0"
 +val apiAndDocs: Configuration by configurations.creating {
 +    attributes {
 +        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
@@ -27,44 +26,38 @@ index 3dec6ab39000edd3e90d1bf734d24cc779ce0e3b..cbab63d2f3b045f6193f5a3422ae4b55
 +    extendsFrom(apiAndDocs)
 +}
 +
- val annotationsVersion = "24.0.1"
- 
  dependencies {
      // api dependencies are listed transitively to API consumers
-     api("com.google.guava:guava:31.1-jre")
-     api("com.google.code.gson:gson:2.10")
--    api("net.md-5:bungeecord-chat:1.16-R0.4")
-+    api("net.md-5:bungeecord-chat:1.16-R0.4-deprecated+build.9") // Paper
-     api("org.yaml:snakeyaml:2.0")
-     api("org.joml:joml:1.10.5")
-     // Paper start
-@@ -22,6 +35,13 @@ dependencies {
-         isTransitive = false // includes junit
+     api(libs.guava)
+@@ -19,7 +31,15 @@ dependencies {
+     api(libs.jsonsimple) {
+         isTransitive = false; //includes junit
      }
-     api("it.unimi.dsi:fastutil:8.5.6")
-+    apiAndDocs(platform("net.kyori:adventure-bom:$adventureVersion"))
-+    apiAndDocs("net.kyori:adventure-api")
-+    apiAndDocs("net.kyori:adventure-text-minimessage")
-+    apiAndDocs("net.kyori:adventure-text-serializer-gson")
-+    apiAndDocs("net.kyori:adventure-text-serializer-legacy")
-+    apiAndDocs("net.kyori:adventure-text-serializer-plain")
-+    apiAndDocs("net.kyori:adventure-text-logger-slf4j")
++
+     api(libs.fastutil)
++    apiAndDocs(platform(libs.adventure.bom))
++    apiAndDocs(libs.adventure.api)
++    apiAndDocs(libs.adventure.text.minimessage)
++    apiAndDocs(libs.adventure.text.serializer.gson)
++    apiAndDocs(libs.adventure.text.serializer.legacy)
++    apiAndDocs(libs.adventure.text.serializer.plain)
++    apiAndDocs(libs.adventure.text.logger.slf4j)
      // Paper end
  
-     compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")
-@@ -82,10 +102,26 @@ tasks.withType<Javadoc> {
+     compileOnly(libs.maven.resolver.provider)
+@@ -78,10 +98,26 @@ tasks.withType<Javadoc> {
          "https://guava.dev/releases/31.1-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/2.0/",
-         "https://javadoc.io/doc/org.jetbrains/annotations/$annotationsVersion/", // Paper - we don't want Java 5 annotations
+         "https://javadoc.io/doc/org.jetbrains/annotations/${libs.versions.annotations}/", // Paper - we don't want Java 5 annotations
 -        "https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/",
 +        // Paper start
 +        //"https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/", // don't link to bungee chat
-+        "https://jd.advntr.dev/api/$adventureVersion/",
-+        "https://jd.advntr.dev/text-minimessage/$adventureVersion/",
-+        "https://jd.advntr.dev/text-serializer-gson/$adventureVersion/",
-+        "https://jd.advntr.dev/text-serializer-legacy/$adventureVersion/",
-+        "https://jd.advntr.dev/text-serializer-plain/$adventureVersion/",
-+        "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/"
++        "https://jd.advntr.dev/api/${libs.versions.adventure}/",
++        "https://jd.advntr.dev/text-minimessage/${libs.versions.adventure}/",
++        "https://jd.advntr.dev/text-serializer-gson/${libs.versions.adventure}/",
++        "https://jd.advntr.dev/text-serializer-legacy/${libs.versions.adventure}/",
++        "https://jd.advntr.dev/text-serializer-plain/${libs.versions.adventure}/",
++        "https://jd.advntr.dev/text-logger-slf4j/${libs.versions.adventure}/"
 +        // Paper end
      )
      options.tags("apiNote:a:API Note:")

--- a/patches/api/0007-Use-ASM-for-event-executors.patch
+++ b/patches/api/0007-Use-ASM-for-event-executors.patch
@@ -6,19 +6,29 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index cbab63d2f3b045f6193f5a3422ae4b5509d3003b..ba6f0a70ba2442dbe60ed6cc92e4fb91a48d9f3b 100644
+index e8a931594c7db7d542b34dda8568831cb313dc37..cb571fd55d76d9462896cbdad5b94185f3dc4fde 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -42,6 +42,9 @@ dependencies {
-     apiAndDocs("net.kyori:adventure-text-serializer-legacy")
-     apiAndDocs("net.kyori:adventure-text-serializer-plain")
-     apiAndDocs("net.kyori:adventure-text-logger-slf4j")
+@@ -31,8 +31,8 @@ dependencies {
+     api(libs.jsonsimple) {
+         isTransitive = false; //includes junit
+     }
+-
+     api(libs.fastutil)
++    
+     apiAndDocs(platform(libs.adventure.bom))
+     apiAndDocs(libs.adventure.api)
+     apiAndDocs(libs.adventure.text.minimessage)
+@@ -40,6 +40,9 @@ dependencies {
+     apiAndDocs(libs.adventure.text.serializer.legacy)
+     apiAndDocs(libs.adventure.text.serializer.plain)
+     apiAndDocs(libs.adventure.text.logger.slf4j)
 +
-+    implementation("org.ow2.asm:asm:9.4")
-+    implementation("org.ow2.asm:asm-commons:9.4")
++    implementation(libs.asm)
++    implementation(libs.asm.commons)
      // Paper end
  
-     compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")
+     compileOnly(libs.maven.resolver.provider)
 diff --git a/src/main/java/com/destroystokyo/paper/event/executor/MethodHandleEventExecutor.java b/src/main/java/com/destroystokyo/paper/event/executor/MethodHandleEventExecutor.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..5b28e9b1daba7834af67dbc193dd656bedd9a994

--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] Paper Plugins
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ba6f0a70ba2442dbe60ed6cc92e4fb91a48d9f3b..22b65c3ad4ed6e19b88a51a2e001f0e5846d9ae6 100644
+index cb571fd55d76d9462896cbdad5b94185f3dc4fde..544e89fc5e460ec8ac57c17b5a3d0fa36836aa65 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -47,7 +47,7 @@ dependencies {
-     implementation("org.ow2.asm:asm-commons:9.4")
+@@ -45,7 +45,7 @@ dependencies {
+     implementation(libs.asm.commons)
      // Paper end
  
--    compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")
-+    api("org.apache.maven:maven-resolver-provider:3.8.5")
-     compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
-     compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
-     compileOnly("com.google.code.findbugs:jsr305:1.3.9") // Paper
+-    compileOnly(libs.maven.resolver.provider)
++    api(libs.maven.resolver.provider)
+     compileOnly(libs.maven.resolver.connector.basic)
+     compileOnly(libs.maven.resolver.transport.http)
+     compileOnly(libs.jsr305)
 diff --git a/src/main/java/io/papermc/paper/plugin/PermissionManager.java b/src/main/java/io/papermc/paper/plugin/PermissionManager.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..cdbc93b317b3bab47bf6552c29cfbb2c27846933

--- a/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,7 +14,7 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 544e89fc5e460ec8ac57c17b5a3d0fa36836aa65..53071c7095a2b55ed56e0ce8e2108c2568be7e38 100644
+index 48fff1c1dd7f77f8451b541d75fdb7adeda8312d..b82dc32ddd22195830badf674396dfebf4775942 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -40,6 +40,8 @@ dependencies {
@@ -27,13 +27,13 @@ index 544e89fc5e460ec8ac57c17b5a3d0fa36836aa65..53071c7095a2b55ed56e0ce8e2108c25
      implementation(libs.asm)
      implementation(libs.asm.commons)
 @@ -108,7 +110,9 @@ tasks.withType<Javadoc> {
-         "https://jd.advntr.dev/text-serializer-gson/${libs.versions.adventure}/",
-         "https://jd.advntr.dev/text-serializer-legacy/${libs.versions.adventure}/",
-         "https://jd.advntr.dev/text-serializer-plain/${libs.versions.adventure}/",
--        "https://jd.advntr.dev/text-logger-slf4j/${libs.versions.adventure}/"
-+        "https://jd.advntr.dev/text-logger-slf4j/${libs.versions.adventure}/",
-+        "https://javadoc.io/doc/org.slf4j/slf4j-api/${libs.versions.slf4j.api}/",
-+        "https://javadoc.io/doc/org.apache.logging.log4j/log4j-api/${libs.versions.log4j.api}/"
+         "https://jd.advntr.dev/text-serializer-gson/${libs.versions.adventure.get()}/",
+         "https://jd.advntr.dev/text-serializer-legacy/${libs.versions.adventure.get()}/",
+         "https://jd.advntr.dev/text-serializer-plain/${libs.versions.adventure.get()}/",
+-        "https://jd.advntr.dev/text-logger-slf4j/${libs.versions.adventure.get()}/"
++        "https://jd.advntr.dev/text-logger-slf4j/${libs.versions.adventure.get()}/",
++        "https://javadoc.io/doc/org.slf4j/slf4j-api/${libs.versions.slf4j.api.get()}/",
++        "https://javadoc.io/doc/org.apache.logging.log4j/log4j-api/${libs.versions.log4j.api.get()}/"
          // Paper end
      )
      options.tags("apiNote:a:API Note:")

--- a/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,35 +14,26 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 22b65c3ad4ed6e19b88a51a2e001f0e5846d9ae6..149f9088fe806467656e8b1c4157df60fda69ba7 100644
+index 544e89fc5e460ec8ac57c17b5a3d0fa36836aa65..53071c7095a2b55ed56e0ce8e2108c2568be7e38 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -9,6 +9,8 @@ java {
- }
+@@ -40,6 +40,8 @@ dependencies {
+     apiAndDocs(libs.adventure.text.serializer.legacy)
+     apiAndDocs(libs.adventure.text.serializer.plain)
+     apiAndDocs(libs.adventure.text.logger.slf4j)
++    api(libs.log4j.api)
++    api(libs.slf4j.api)
  
- val adventureVersion = "4.14.0"
-+val slf4jVersion = "1.8.0-beta4"
-+val log4jVersion = "2.17.1"
- val apiAndDocs: Configuration by configurations.creating {
-     attributes {
-         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-@@ -42,6 +44,8 @@ dependencies {
-     apiAndDocs("net.kyori:adventure-text-serializer-legacy")
-     apiAndDocs("net.kyori:adventure-text-serializer-plain")
-     apiAndDocs("net.kyori:adventure-text-logger-slf4j")
-+    api("org.apache.logging.log4j:log4j-api:$log4jVersion")
-+    api("org.slf4j:slf4j-api:$slf4jVersion")
- 
-     implementation("org.ow2.asm:asm:9.4")
-     implementation("org.ow2.asm:asm-commons:9.4")
-@@ -112,7 +116,9 @@ tasks.withType<Javadoc> {
-         "https://jd.advntr.dev/text-serializer-gson/$adventureVersion/",
-         "https://jd.advntr.dev/text-serializer-legacy/$adventureVersion/",
-         "https://jd.advntr.dev/text-serializer-plain/$adventureVersion/",
--        "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/"
-+        "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/",
-+        "https://javadoc.io/doc/org.slf4j/slf4j-api/$slf4jVersion/",
-+        "https://javadoc.io/doc/org.apache.logging.log4j/log4j-api/$log4jVersion/"
+     implementation(libs.asm)
+     implementation(libs.asm.commons)
+@@ -108,7 +110,9 @@ tasks.withType<Javadoc> {
+         "https://jd.advntr.dev/text-serializer-gson/${libs.versions.adventure}/",
+         "https://jd.advntr.dev/text-serializer-legacy/${libs.versions.adventure}/",
+         "https://jd.advntr.dev/text-serializer-plain/${libs.versions.adventure}/",
+-        "https://jd.advntr.dev/text-logger-slf4j/${libs.versions.adventure}/"
++        "https://jd.advntr.dev/text-logger-slf4j/${libs.versions.adventure}/",
++        "https://javadoc.io/doc/org.slf4j/slf4j-api/${libs.versions.slf4j.api}/",
++        "https://javadoc.io/doc/org.apache.logging.log4j/log4j-api/${libs.versions.log4j.api}/"
          // Paper end
      )
      options.tags("apiNote:a:API Note:")

--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -28,35 +28,36 @@ index 3df8c60ab5cd1454660980883f80668d535b742b..37c3a00659ce21623be07317f4f6a45b
 +/.factorypath
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..f7d5f785f659aa905000d974f573e43f841e7fc0
+index 0000000000000000000000000000000000000000..c34a00cc647299d2a16868601c0af84b581e903a
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,138 @@
+@@ -0,0 +1,139 @@
 +import io.papermc.paperweight.util.*
 +
++@Suppress("DSL_SCOPE_VIOLATION") //https://github.com/gradle/gradle/issues/22797
 +plugins {
 +    java
 +    `maven-publish`
-+    id("com.github.johnrengelman.shadow")
++    alias(libs.plugins.shadow)
 +}
 +
 +dependencies {
 +    implementation(project(":paper-api"))
-+    implementation("jline:jline:2.12.1")
-+    implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") {
++    implementation(libs.jline)
++    implementation(libs.log4j.iostreams) {
 +        exclude(group = "org.apache.logging.log4j", module = "log4j-api")
 +    }
-+    implementation("org.ow2.asm:asm:9.4")
-+    implementation("commons-lang:commons-lang:2.6")
-+    runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
-+    runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
++    implementation(libs.asm)
++    implementation(libs.commons.lang)
++    runtimeOnly(libs.sqlite)
++    runtimeOnly(libs.mysqlconnector)
 +
-+    runtimeOnly("org.apache.maven:maven-resolver-provider:3.8.5")
-+    runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
-+    runtimeOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
++    runtimeOnly(libs.maven.resolver.provider)
++    runtimeOnly(libs.maven.resolver.connector.basic)
++    runtimeOnly(libs.maven.resolver.transport.http)
 +
-+    testImplementation("junit:junit:4.13.2")
-+    testImplementation("org.hamcrest:hamcrest-library:1.3")
++    testImplementation(libs.junit)
++    testImplementation(libs.hamcrest)
 +}
 +
 +val craftbukkitPackageVersion = "1_20_R1" // Paper

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -5,32 +5,32 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ca692b4758172cb139938f28457cf5639a4411cf..592d2cd1114ee9fbf7b16068ef729f7db4de83d1 100644
+index c34a00cc647299d2a16868601c0af84b581e903a..772a53bd7af41c1a2bceb5d059b5dacceeb0a10b 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -9,10 +9,9 @@ plugins {
+@@ -10,10 +10,9 @@ plugins {
  dependencies {
      implementation(project(":paper-api"))
-     implementation("jline:jline:2.12.1")
--    implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") {
+     implementation(libs.jline)
+-    implementation(libs.log4j.iostreams) {
 -        exclude(group = "org.apache.logging.log4j", module = "log4j-api")
 -    }
-+    implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
-     implementation("org.ow2.asm:asm:9.4")
-+    implementation("org.ow2.asm:asm-commons:9.4") // Paper - ASM event executor generation
-     implementation("commons-lang:commons-lang:2.6")
-     runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
-     runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
-@@ -23,6 +22,8 @@ dependencies {
++    implementation(libs.log4j.iostreams) // Paper - remove exclusion
+     implementation(libs.asm)
++    implementation(libs.asm.commons) // Paper - ASM event executor generation
+     implementation(libs.commons.lang)
+     runtimeOnly(libs.sqlite)
+     runtimeOnly(libs.mysqlconnector)
+@@ -24,6 +23,8 @@ dependencies {
  
-     testImplementation("junit:junit:4.13.2")
-     testImplementation("org.hamcrest:hamcrest-library:1.3")
+     testImplementation(libs.junit)
+     testImplementation(libs.hamcrest)
 +
-+    implementation("io.netty:netty-all:4.1.87.Final"); // Paper - Bump netty
++    implementation(libs.netty.all); // Paper - Bump netty
  }
  
  val craftbukkitPackageVersion = "1_20_R1" // Paper
-@@ -34,6 +35,7 @@ tasks.jar {
+@@ -35,6 +36,7 @@ tasks.jar {
          val gitHash = git("rev-parse", "--short=7", "HEAD").getText().trim()
          val implementationVersion = System.getenv("BUILD_NUMBER") ?: "\"$gitHash\""
          val date = git("show", "-s", "--format=%ci", gitHash).getText().trim() // Paper
@@ -38,7 +38,7 @@ index ca692b4758172cb139938f28457cf5639a4411cf..592d2cd1114ee9fbf7b16068ef729f7d
          attributes(
              "Main-Class" to "org.bukkit.craftbukkit.Main",
              "Implementation-Title" to "CraftBukkit",
-@@ -42,6 +44,9 @@ tasks.jar {
+@@ -43,6 +45,9 @@ tasks.jar {
              "Specification-Title" to "Bukkit",
              "Specification-Version" to project.version,
              "Specification-Vendor" to "Bukkit Team",
@@ -48,7 +48,7 @@ index ca692b4758172cb139938f28457cf5639a4411cf..592d2cd1114ee9fbf7b16068ef729f7d
          )
          for (tld in setOf("net", "com", "org")) {
              attributes("$tld/bukkit", "Sealed" to true)
-@@ -75,6 +80,17 @@ tasks.shadowJar {
+@@ -76,6 +81,17 @@ tasks.shadowJar {
      }
  }
  

--- a/patches/server/0004-Test-changes.patch
+++ b/patches/server/0004-Test-changes.patch
@@ -5,17 +5,17 @@ Subject: [PATCH] Test changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 592d2cd1114ee9fbf7b16068ef729f7db4de83d1..f3f20b34a3ebcbb75004003892e903ee4fd0edd3 100644
+index 772a53bd7af41c1a2bceb5d059b5dacceeb0a10b..526c90b8748f0fafca04cc842f8a654b48087b83 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -12,6 +12,7 @@ dependencies {
-     implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
-     implementation("org.ow2.asm:asm:9.4")
-     implementation("org.ow2.asm:asm-commons:9.4") // Paper - ASM event executor generation
-+    testImplementation("org.mockito:mockito-core:4.9.0") // Paper - switch to mockito
-     implementation("commons-lang:commons-lang:2.6")
-     runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
-     runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
+@@ -13,6 +13,7 @@ dependencies {
+     implementation(libs.log4j.iostreams) // Paper - remove exclusion
+     implementation(libs.asm)
+     implementation(libs.asm.commons) // Paper - ASM event executor generation
++    testImplementation(libs.mockito) // Paper - switch to mockito
+     implementation(libs.commons.lang)
+     runtimeOnly(libs.sqlite)
+     runtimeOnly(libs.mysqlconnector)
 diff --git a/src/test/java/io/papermc/paper/testing/DummyServer.java b/src/test/java/io/papermc/paper/testing/DummyServer.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..e944e9dca13883c57e93e480ae5adfe51c342532

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -14,17 +14,17 @@ public org.spigotmc.SpigotWorldConfig getString(Ljava/lang/String;Ljava/lang/Str
 public net.minecraft.world.level.NaturalSpawner SPAWNING_CATEGORIES
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index cf7f17724f09606eccf040713965a51e72a9c9df..2cabc6126afe4ad83eed4c423ffa67b77fde7c2a 100644
+index 526c90b8748f0fafca04cc842f8a654b48087b83..695ca2741b0b4643366be8147fb174e9f0c3a6c0 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -13,6 +13,7 @@ dependencies {
-     implementation("org.ow2.asm:asm:9.4")
-     implementation("org.ow2.asm:asm-commons:9.4") // Paper - ASM event executor generation
-     testImplementation("org.mockito:mockito-core:4.9.0") // Paper - switch to mockito
-+    implementation("org.spongepowered:configurate-yaml:4.1.2") // Paper - config files
-     implementation("commons-lang:commons-lang:2.6")
-     runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
-     runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
+@@ -14,6 +14,7 @@ dependencies {
+     implementation(libs.asm)
+     implementation(libs.asm.commons) // Paper - ASM event executor generation
+     testImplementation(libs.mockito) // Paper - switch to mockito
++    implementation(libs.configurate) // Paper - config files
+     implementation(libs.commons.lang)
+     runtimeOnly(libs.sqlite)
+     runtimeOnly(libs.mysqlconnector)
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..ef41cf3a7d1e6f2bfe81e0fb865d2f969bbc77c1

--- a/patches/server/0134-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0134-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -25,31 +25,31 @@ Other changes:
 Co-Authored-By: Emilia Kond <emilia@rymiel.space>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 2cabc6126afe4ad83eed4c423ffa67b77fde7c2a..ab46f9cb3bb94af0c418a5d39f2f63a6d3a0e07c 100644
+index 695ca2741b0b4643366be8147fb174e9f0c3a6c0..226b3440c8a734c6db7f30debeee41a8eebf1b04 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -8,7 +8,20 @@ plugins {
+@@ -9,7 +9,20 @@ plugins {
  
  dependencies {
      implementation(project(":paper-api"))
--    implementation("jline:jline:2.12.1")
+-    implementation(libs.jline)
 +    // Paper start
-+    implementation("org.jline:jline-terminal-jansi:3.21.0")
-+    implementation("net.minecrell:terminalconsoleappender:1.3.0")
-+    implementation("net.kyori:adventure-text-serializer-ansi:4.14.0") // Keep in sync with adventureVersion from Paper-API build file
-+    implementation("net.kyori:ansi:1.0.1") // Manually bump beyond above transitive dep
++    implementation(libs.jline.terminal)
++    implementation(libs.terminalconsoleappender)
++    implementation(libs.adventure.text.serializer.ansi) // Keep in sync with adventureVersion from Paper-API build file
++    implementation(libs.ansi) // Manually bump beyond above transitive dep
 +    /*
 +          Required to add the missing Log4j2Plugins.dat file from log4j-core
 +          which has been removed by Mojang. Without it, log4j has to classload
 +          all its classes to check if they are plugins.
 +          Scanning takes about 1-2 seconds so adding this speeds up the server start.
 +     */
-+    runtimeOnly("org.apache.logging.log4j:log4j-core:2.14.1")
-+    annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - Needed to generate meta for our Log4j plugins
++    runtimeOnly(libs.log4j.core)
++    annotationProcessor(libs.log4j.core) // Paper - Needed to generate meta for our Log4j plugins
 +    // Paper end
-     implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
-     implementation("org.ow2.asm:asm:9.4")
-     implementation("org.ow2.asm:asm-commons:9.4") // Paper - ASM event executor generation
+     implementation(libs.log4j.iostreams) // Paper - remove exclusion
+     implementation(libs.asm)
+     implementation(libs.asm.commons) // Paper - ASM event executor generation
 diff --git a/src/main/java/com/destroystokyo/paper/console/PaperConsole.java b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..a4070b59e261f0f1ac4beec47b11492f4724bf27

--- a/patches/server/0155-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/patches/server/0155-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -15,18 +15,18 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ab46f9cb3bb94af0c418a5d39f2f63a6d3a0e07c..a06b75a78ab96229a6e9b97de913df9050325c04 100644
+index 226b3440c8a734c6db7f30debeee41a8eebf1b04..19aac11b20313357b9ed9c8236191e50361667a2 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -19,7 +19,7 @@ dependencies {
+@@ -20,7 +20,7 @@ dependencies {
            all its classes to check if they are plugins.
            Scanning takes about 1-2 seconds so adding this speeds up the server start.
       */
--    runtimeOnly("org.apache.logging.log4j:log4j-core:2.14.1")
-+    implementation("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - implementation
-     annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - Needed to generate meta for our Log4j plugins
+-    runtimeOnly(libs.log4j.core)
++    implementation(libs.log4j.core) // Paper - implementation
+     annotationProcessor(libs.log4j.core) // Paper - Needed to generate meta for our Log4j plugins
      // Paper end
-     implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
+     implementation(libs.log4j.iostreams) // Paper - remove exclusion
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
 index 0a0aa6de31a94a701074cc5f43c94be7515a185c..489ce6f439778b26eb33ede9432681d4bf9e0116 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java

--- a/patches/server/0219-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
+++ b/patches/server/0219-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
@@ -5,17 +5,17 @@ Subject: [PATCH] Use AsyncAppender to keep logging IO off main thread
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a06b75a78ab96229a6e9b97de913df9050325c04..d5602e9020ff233b93987140d143ff5d00154b1c 100644
+index 19aac11b20313357b9ed9c8236191e50361667a2..1a0223bb30c7491f8027a28c1eab008451dd6303 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -30,6 +30,7 @@ dependencies {
-     implementation("commons-lang:commons-lang:2.6")
-     runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
-     runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
-+    runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
+@@ -31,6 +31,7 @@ dependencies {
+     implementation(libs.commons.lang)
+     runtimeOnly(libs.sqlite)
+     runtimeOnly(libs.mysqlconnector)
++    runtimeOnly(libs.disruptor) // Paper
  
-     runtimeOnly("org.apache.maven:maven-resolver-provider:3.8.5")
-     runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
+     runtimeOnly(libs.maven.resolver.provider)
+     runtimeOnly(libs.maven.resolver.connector.basic)
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
 index 88957220d5574e5590e8a545605d76c0c7b0a10e..ea4e2161c0bd43884055cc6b8d70b2139f70e720 100644
 --- a/src/main/resources/log4j2.xml

--- a/patches/server/0295-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0295-Implement-Brigadier-Mojang-API.patch
@@ -10,17 +10,17 @@ Adds CommandRegisteredEvent
   - Allows manipulating the CommandNode to add more children/metadata for the client
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 41485437cdf438cfb837a9fcd276c2dd70b84b42..9617477e8ef0ef5b1af4733ce4e87ddd796a7be2 100644
+index 1a0223bb30c7491f8027a28c1eab008451dd6303..4e4f64f4df3fdf50d23e63c97c04e8575a027a9f 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -8,6 +8,7 @@ plugins {
+@@ -9,6 +9,7 @@ plugins {
  
  dependencies {
      implementation(project(":paper-api"))
 +    implementation(project(":paper-mojangapi"))
      // Paper start
-     implementation("org.jline:jline-terminal-jansi:3.21.0")
-     implementation("net.minecrell:terminalconsoleappender:1.3.0")
+     implementation(libs.jline.terminal)
+     implementation(libs.terminalconsoleappender)
 diff --git a/src/main/java/com/mojang/brigadier/exceptions/CommandSyntaxException.java b/src/main/java/com/mojang/brigadier/exceptions/CommandSyntaxException.java
 index 3370731ee064d2693b972a0765c13dd4fd69f66a..614eba6cc55d1eb7755cac35c671cb6f6cacca13 100644
 --- a/src/main/java/com/mojang/brigadier/exceptions/CommandSyntaxException.java
@@ -131,7 +131,7 @@ index b7f1569c662df13f278fc704cabec0400ba7c382..87ce129e1d592bcf68169feb559f44d5
  
              if (commandnode2.canUse(source)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ee150e432cb8ca69749dc20c8d2140c2b49bcdc2..0222181b0dddffc3b0e91dc53b5424317bb191c7 100644
+index 2b29f260c23121da1ab3a14b843f0500281b373b..b4eaa5142e70e9ba16f0386c10dae30b4a3da31b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -840,8 +840,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic

--- a/patches/server/0392-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0392-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,18 +6,18 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index f339777554b5917f69170d1bc89ff14b89e8f1e3..24cc85285f221cee63eb6feb2aabc3e193d76dd7 100644
+index 4e4f64f4df3fdf50d23e63c97c04e8575a027a9f..48c874a74fb5165597a4be3876c5c41f3b5299b0 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -29,6 +29,7 @@ dependencies {
-     testImplementation("org.mockito:mockito-core:4.9.0") // Paper - switch to mockito
-     implementation("org.spongepowered:configurate-yaml:4.1.2") // Paper - config files
-     implementation("commons-lang:commons-lang:2.6")
-+    implementation("net.fabricmc:mapping-io:0.3.0") // Paper - needed to read mappings for stacktrace deobfuscation
-     runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
-     runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
-     runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
-@@ -108,6 +109,18 @@ tasks.check {
+@@ -30,6 +30,7 @@ dependencies {
+     testImplementation(libs.mockito) // Paper - switch to mockito
+     implementation(libs.configurate) // Paper - config files
+     implementation(libs.commons.lang)
++    implementation(libs.mappingio) // Paper - needed to read mappings for stacktrace deobfuscation
+     runtimeOnly(libs.sqlite)
+     runtimeOnly(libs.mysqlconnector)
+     runtimeOnly(libs.disruptor) // Paper
+@@ -109,6 +110,18 @@ tasks.check {
  }
  // Paper end
  

--- a/patches/server/0393-Implement-Mob-Goal-API.patch
+++ b/patches/server/0393-Implement-Mob-Goal-API.patch
@@ -5,16 +5,16 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 24cc85285f221cee63eb6feb2aabc3e193d76dd7..e3e6318e0c83ae6f6ff699918ab0faff9f84c63d 100644
+index 48c874a74fb5165597a4be3876c5c41f3b5299b0..e73773492180185f963d01d097cd404b08384dd7 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -38,6 +38,7 @@ dependencies {
-     runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
-     runtimeOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
+@@ -39,6 +39,7 @@ dependencies {
+     runtimeOnly(libs.maven.resolver.connector.basic)
+     runtimeOnly(libs.maven.resolver.transport.http)
  
-+    testImplementation("io.github.classgraph:classgraph:4.8.47") // Paper - mob goal test
-     testImplementation("junit:junit:4.13.2")
-     testImplementation("org.hamcrest:hamcrest-library:1.3")
++    testImplementation(libs.classgraph) // Paper - mob goal test
+     testImplementation(libs.junit)
+     testImplementation(libs.hamcrest)
  
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
 new file mode 100644

--- a/patches/server/0709-Use-Velocity-compression-and-cipher-natives.patch
+++ b/patches/server/0709-Use-Velocity-compression-and-cipher-natives.patch
@@ -5,21 +5,21 @@ Subject: [PATCH] Use Velocity compression and cipher natives
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index e3e6318e0c83ae6f6ff699918ab0faff9f84c63d..5df3ca7173cf27eb01475b6dc2e5aad38cd5a324 100644
+index e73773492180185f963d01d097cd404b08384dd7..bd533842f3db6f910a361d7e7a8fd22a92252aa1 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -33,6 +33,11 @@ dependencies {
-     runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
-     runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
-     runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
+@@ -34,6 +34,11 @@ dependencies {
+     runtimeOnly(libs.sqlite)
+     runtimeOnly(libs.mysqlconnector)
+     runtimeOnly(libs.disruptor) // Paper
 +    // Paper start - Use Velocity cipher
-+    implementation("com.velocitypowered:velocity-native:3.1.2-SNAPSHOT") {
++    implementation(libs.velocity) {
 +        isTransitive = false
 +    }
 +    // Paper end
  
-     runtimeOnly("org.apache.maven:maven-resolver-provider:3.8.5")
-     runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
+     runtimeOnly(libs.maven.resolver.provider)
+     runtimeOnly(libs.maven.resolver.connector.basic)
 diff --git a/src/main/java/net/minecraft/network/CipherDecoder.java b/src/main/java/net/minecraft/network/CipherDecoder.java
 index 778beb445eac5769b9e4e07b4d1294c50ae2602b..c712fb8193115e1ab71b5e40fb0ccb9413062b03 100644
 --- a/src/main/java/net/minecraft/network/CipherDecoder.java

--- a/patches/server/0826-Add-support-for-Proxy-Protocol.patch
+++ b/patches/server/0826-Add-support-for-Proxy-Protocol.patch
@@ -5,17 +5,17 @@ Subject: [PATCH] Add support for Proxy Protocol
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 5df3ca7173cf27eb01475b6dc2e5aad38cd5a324..6d3d573ffc118e7f4d76422dc014a7df0384bb49 100644
+index bd533842f3db6f910a361d7e7a8fd22a92252aa1..4d086aee82bbced1680b79929348f4a48d03be5e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -22,6 +22,7 @@ dependencies {
+@@ -23,6 +23,7 @@ dependencies {
       */
-     implementation("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - implementation
-     annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - Needed to generate meta for our Log4j plugins
-+    implementation("io.netty:netty-codec-haproxy:4.1.87.Final") // Paper - Add support for proxy protocol
+     implementation(libs.log4j.core) // Paper - implementation
+     annotationProcessor(libs.log4j.core) // Paper - Needed to generate meta for our Log4j plugins
++    implementation(libs.netty.codec.haproxy) // Paper - Add support for proxy protocol
      // Paper end
-     implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
-     implementation("org.ow2.asm:asm:9.4")
+     implementation(libs.log4j.iostreams) // Paper - remove exclusion
+     implementation(libs.asm)
 diff --git a/src/main/java/net/minecraft/server/network/ServerConnectionListener.java b/src/main/java/net/minecraft/server/network/ServerConnectionListener.java
 index 2beddfc0532c3835d50724551e3d46cb0d7d2290..44d99e89226adb6234b9405f25ac9dab9bd84297 100644
 --- a/src/main/java/net/minecraft/server/network/ServerConnectionListener.java


### PR DESCRIPTION
Still todo - however I wanted to start a conversation about dependency updates
- Review diff properly, didn't have time (marking this as a draft)
- Sort version catalog (by sub project)

All this essentially does is migrate to use a gradle version catalog, to help group dependency versions and aide in ease of updating deps. This does sync up some dependencies (most notably asm), however I tried not to touch too many current dep versions. This also ensures on build workflow we use the `gradle/wrapper-validation-action` git action 
The only testing done with this is making sure it builds 

<i>Note, fully aware some of these strictly can't be updated, this was a generated list</i>

- Gradle: 8.02 -> 8.1.1 (done)

<details>
<summary>Paper-API dependency updates</summary>

 - com.google.code.findbugs:jsr305 [1.3.9 -> 3.0.2]
     http://findbugs.sourceforge.net/
 - com.google.code.gson:gson [2.10 -> 2.10.1]
     https://github.com/google/gson
 - com.google.guava:guava [31.1-jre -> 32.0.1-jre]
     https://github.com/google/guava
 - it.unimi.dsi:fastutil [8.5.6 -> 8.5.12]
     http://fastutil.di.unimi.it/
 - net.md-5:bungeecord-chat [1.16-R0.4-deprecated+build.9 -> 1.16-R0.4]
     https://github.com/SpigotMC/BungeeCord
 - org.apache.logging.log4j:log4j-api [2.17.1 -> 3.0.0-alpha1]
     https://logging.apache.org/log4j/3.x/
 - org.apache.maven:maven-resolver-provider [3.8.5 -> 4.0.0-alpha-5]
     https://maven.apache.org/ref/${project.version}/
 - org.apache.maven.resolver:maven-resolver-connector-basic [1.7.3 -> 1.9.12]
     https://maven.apache.org/resolver/
 - org.apache.maven.resolver:maven-resolver-transport-http [1.7.3 -> 1.9.12]
     https://maven.apache.org/resolver/
 - org.checkerframework:checker-qual [3.21.0 -> 3.35.0]
     https://checkerframework.org/
 - org.hamcrest:hamcrest-library [1.3 -> 2.2]
     http://hamcrest.org/JavaHamcrest/
 - org.mockito:mockito-core [4.9.0 -> 5.4.0]
     https://github.com/mockito/mockito
 - org.ow2.asm:asm [9.4 -> 9.5]
     http://asm.ow2.io/
 - org.ow2.asm:asm-commons [9.4 -> 9.5]
     http://asm.ow2.io/
 - org.slf4j:slf4j-api [1.8.0-beta4 -> 2.0.7]
     http://www.slf4j.org
</details>

<details>
<summary>Paper-MojangAPI Dependency Updates</summary>

 - com.mojang:brigadier [1.0.18 -> 1.0.500]
 - it.unimi.dsi:fastutil [8.5.6 -> 8.5.12]
     http://fastutil.di.unimi.it/
 - org.hamcrest:hamcrest-library [1.3 -> 2.2]
     http://hamcrest.org/JavaHamcrest/
 </details>
 
 <details>
 <summary>Paper-Server Dependency Updates</summary>
 
 - com.lmax:disruptor [3.4.4 -> 4.0.0.RC1]
     https://lmax-exchange.github.io/disruptor
 - io.github.classgraph:classgraph [4.8.47 -> 4.8.160]
     https://github.com/classgraph/classgraph
 - io.netty:netty-all [4.1.87.Final -> 5.0.0.Alpha2]
     http://netty.io/
 - io.netty:netty-codec-haproxy [4.1.87.Final -> 5.0.0.Alpha2]
     http://netty.io/
 - net.fabricmc:mapping-io [0.3.0 -> 0.4.2]
     https://github.com/FabricMC/mapping-io
 - org.apache.logging.log4j:log4j-core [2.19.0 -> 3.0.0-alpha1]
     https://logging.apache.org/log4j/3.x/
 - org.apache.logging.log4j:log4j-iostreams [2.19.0 -> 3.0.0-alpha1]
     https://logging.apache.org/log4j/3.x/
 - org.apache.maven:maven-resolver-provider [3.8.5 -> 4.0.0-alpha-5]
     https://maven.apache.org/ref/${project.version}/
 - org.apache.maven.resolver:maven-resolver-connector-basic [1.7.3 -> 1.9.12]
     https://maven.apache.org/resolver/
 - org.apache.maven.resolver:maven-resolver-transport-http [1.7.3 -> 1.9.12]
     https://maven.apache.org/resolver/
 - org.hamcrest:hamcrest-library [1.3 -> 2.2]
     http://hamcrest.org/JavaHamcrest/
 - org.jline:jline-terminal-jansi [3.21.0 -> 3.23.0]
 - org.mockito:mockito-core [4.9.0 -> 5.4.0]
     https://github.com/mockito/mockito
 - org.ow2.asm:asm [9.4 -> 9.5]
     http://asm.ow2.io/
 - org.ow2.asm:asm-commons [9.4 -> 9.5]
     http://asm.ow2.io/
</details>

