### PR TITLE
Fix possible NPE on painting creation

### DIFF
--- a/patches/server/0987-Fix-possible-NPE-on-painting-creation.patch
+++ b/patches/server/0987-Fix-possible-NPE-on-painting-creation.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 24 Jun 2023 09:42:53 -0700
+Subject: [PATCH] Fix possible NPE on painting creation
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+index b305941aaf50b417bb054a9327c67a0891f2fe9e..995b3e31c5725f3d8879df349351eae3bcdfdddf 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+@@ -916,6 +916,7 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+                         AABB bb = (ItemFrame.class.isAssignableFrom(clazz))
+                                 ? net.minecraft.world.entity.decoration.ItemFrame.calculateBoundingBox(null, pos, CraftBlock.blockFaceToNotch(dir).getOpposite(), width, height)
+                                 : HangingEntity.calculateBoundingBox(null, pos, CraftBlock.blockFaceToNotch(dir).getOpposite(), width, height);
++                        if (!this.getHandle().noCollision(bb)) continue; // Paper - add collision check
+                         List<net.minecraft.world.entity.Entity> list = (List<net.minecraft.world.entity.Entity>) this.getHandle().getEntities(null, bb);
+                         for (Iterator<net.minecraft.world.entity.Entity> it = list.iterator(); !taken && it.hasNext(); ) {
+                             net.minecraft.world.entity.Entity e = it.next();
+@@ -942,7 +943,8 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+                 if (Painting.class.isAssignableFrom(clazz)) {
+                     if (this.isNormalWorld() && randomizeData) {
+                         entity = net.minecraft.world.entity.decoration.Painting.create(world, pos, dir).orElse(null);
+-                    } else {
++                    } // Paper
++                    if (entity == null) { // Paper - if randomizeData fails, force it
+                         entity = new net.minecraft.world.entity.decoration.Painting(net.minecraft.world.entity.EntityType.PAINTING, this.getHandle().getMinecraftWorld());
+                         entity.absMoveTo(x, y, z, yaw, pitch);
+                         ((net.minecraft.world.entity.decoration.Painting) entity).setDirection(dir);


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/9374

This should go back to the original behavior of spawning the painting in, if only for a few seconds until it breaks because it can't exist at that location.

Can be tested by trying to spawn a painting at the same location as a ladder. 