### PR TITLE
fix ugly java logger format for paper plugin dependency loader

### DIFF
--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -754,7 +754,7 @@ index 0000000000000000000000000000000000000000..3327595d154700890c862a2ced5eff93
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/loader/library/impl/MavenLibraryResolver.java b/src/main/java/io/papermc/paper/plugin/loader/library/impl/MavenLibraryResolver.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e3e902a708a760be167cb1bba8e845c5fa5b9141
+index 0000000000000000000000000000000000000000..9af07d168beadaa77e4965819200eeb94fe3e092
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/loader/library/impl/MavenLibraryResolver.java
 @@ -0,0 +1,132 @@
@@ -784,12 +784,12 @@ index 0000000000000000000000000000000000000000..e3e902a708a760be167cb1bba8e845c5
 +import org.eclipse.aether.transfer.TransferEvent;
 +import org.eclipse.aether.transport.http.HttpTransporterFactory;
 +import org.jetbrains.annotations.NotNull;
++import org.slf4j.Logger;
++import org.slf4j.LoggerFactory;
 +
 +import java.io.File;
 +import java.util.ArrayList;
 +import java.util.List;
-+import java.util.logging.Level;
-+import java.util.logging.Logger;
 +
 +/**
 + * The maven library resolver acts as a resolver for yet to be resolved jar libraries that may be pulled from a
@@ -810,7 +810,7 @@ index 0000000000000000000000000000000000000000..e3e902a708a760be167cb1bba8e845c5
 + */
 +public class MavenLibraryResolver implements ClassPathLibrary {
 +
-+    private static final Logger logger = Logger.getLogger("MavenLibraryResolver");
++    private static final Logger logger = LoggerFactory.getLogger("MavenLibraryResolver");
 +
 +    private final RepositorySystem repository;
 +    private final DefaultRepositorySystemSession session;
@@ -838,7 +838,7 @@ index 0000000000000000000000000000000000000000..e3e902a708a760be167cb1bba8e845c5
 +        this.session.setTransferListener(new AbstractTransferListener() {
 +            @Override
 +            public void transferInitiated(@NotNull TransferEvent event) throws TransferCancelledException {
-+                logger.log(Level.INFO, "Downloading {0}", event.getResource().getRepositoryUrl() + event.getResource().getResourceName());
++                logger.info("Downloading {}", event.getResource().getRepositoryUrl() + event.getResource().getResourceName());
 +            }
 +        });
 +        this.session.setReadOnly();

--- a/test-plugin/src/main/java/io/papermc/testplugin/TestPluginLoader.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/TestPluginLoader.java
@@ -2,21 +2,10 @@ package io.papermc.testplugin;
 
 import io.papermc.paper.plugin.loader.PluginClasspathBuilder;
 import io.papermc.paper.plugin.loader.PluginLoader;
-import io.papermc.paper.plugin.loader.library.impl.MavenLibraryResolver;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.repository.RemoteRepository;
 import org.jetbrains.annotations.NotNull;
 
 public class TestPluginLoader implements PluginLoader {
     @Override
     public void classloader(@NotNull PluginClasspathBuilder classpathBuilder) {
-        final MavenLibraryResolver resolver = new MavenLibraryResolver();
-        classpathBuilder.getContext().getLogger().info("TESTING LOGGING IN LOADER");
-        resolver.addDependency(new Dependency(new DefaultArtifact("cloud.commandframework:cloud-paper:1.8.3"), null));
-        resolver.addDependency(new Dependency(new DefaultArtifact("org.spongepowered:configurate-gson:4.1.2"), null));
-        resolver.addRepository(new RemoteRepository.Builder("paper", "default", "https://repo.papermc.io/repository/maven-public/").build());
-
-        classpathBuilder.addLibrary(resolver);
     }
 }

--- a/test-plugin/src/main/java/io/papermc/testplugin/TestPluginLoader.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/TestPluginLoader.java
@@ -2,10 +2,21 @@ package io.papermc.testplugin;
 
 import io.papermc.paper.plugin.loader.PluginClasspathBuilder;
 import io.papermc.paper.plugin.loader.PluginLoader;
+import io.papermc.paper.plugin.loader.library.impl.MavenLibraryResolver;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.jetbrains.annotations.NotNull;
 
 public class TestPluginLoader implements PluginLoader {
     @Override
     public void classloader(@NotNull PluginClasspathBuilder classpathBuilder) {
+        final MavenLibraryResolver resolver = new MavenLibraryResolver();
+        classpathBuilder.getContext().getLogger().info("TESTING LOGGING IN LOADER");
+        resolver.addDependency(new Dependency(new DefaultArtifact("cloud.commandframework:cloud-paper:1.8.3"), null));
+        resolver.addDependency(new Dependency(new DefaultArtifact("org.spongepowered:configurate-gson:4.1.2"), null));
+        resolver.addRepository(new RemoteRepository.Builder("paper", "default", "https://repo.papermc.io/repository/maven-public/").build());
+
+        classpathBuilder.addLibrary(resolver);
     }
 }


### PR DESCRIPTION
after: ![after](https://i.imgur.com/9i0IG3H.png)

before ![before](https://i.imgur.com/x72Scg8.png)