### PR TITLE
[ci skip] Update Repo style and change project url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ High-performance Spigot fork that aims to fix gameplay and mechanics inconsisten
 
 
 **Support and Project Discussion:**
- - [Our forums](https://forums.papermc.io/), [Discord](https://discord.gg/papermc), or [IRC](https://webchat.esper.net/?channels=paper)
+- [Our forums](https://forums.papermc.io/), [Discord](https://discord.gg/papermc), or [IRC](https://webchat.esper.net/?channels=paper)
 
 How To (Server Admins)
 ------
@@ -18,22 +18,24 @@ Download Paper from our [downloads page](https://papermc.io/downloads/paper).
 
 Run the Paperclip jar directly from your server. Just like old times
 
-  * Documentation on using Paper: [docs.papermc.io](https://docs.papermc.io)
-  * For a sneak peek at upcoming features, [see here](https://github.com/PaperMC/Paper/projects)
+* Documentation on using Paper: [docs.papermc.io](https://docs.papermc.io)
+* For a sneak peek at upcoming features, [see here](https://github.com/PaperMC/Paper/projects)
 
 How To (Plugin Developers)
 ------
- * See our API patches [here](patches/api)
- * See upcoming, pending, and recently added API [here](https://github.com/PaperMC/Paper/projects/6)
- * Paper API javadocs here: [papermc.io/javadocs](https://papermc.io/javadocs/)
- * Maven Repo (for paper-api):
+* See our API patches [here](patches/api)
+* See upcoming, pending, and recently added API [here](https://github.com/orgs/PaperMC/projects/2/views/4)
+* Paper API javadocs here: [papermc.io/javadocs](https://papermc.io/javadocs/)
+#### Repository (for paper-api)
+##### Maven
+
 ```xml
 <repository>
     <id>papermc</id>
     <url>https://repo.papermc.io/repository/maven-public/</url>
 </repository>
 ```
- * Artifact Information:
+
 ```xml
 <dependency>
     <groupId>io.papermc.paper</groupId>
@@ -41,11 +43,8 @@ How To (Plugin Developers)
     <version>1.20.1-R0.1-SNAPSHOT</version>
     <scope>provided</scope>
 </dependency>
- ```
-
-**Or alternatively, with Gradle:**
-
- * Repository:
+```
+##### Gradle
 ```kotlin
 repositories {
     maven {
@@ -76,9 +75,9 @@ See [Contributing](CONTRIBUTING.md)
 
 Support Us
 ------
-First of all, thank you for considering helping out, we really appreciate that!  
+First of all, thank you for considering helping out, we really appreciate that!
 
-PaperMC has various recurring expenses, mostly related to infrastructure. Paper uses [Open Collective](https://opencollective.com/) via the [Open Source Collective fiscal host](https://opencollective.com/opensource) to manage expenses. Open Collective allows us to be extremely transparent, so you can always see how your donations are used. You can read more about financially supporting PaperMC [on our website](https://papermc.io/sponsors).  
+PaperMC has various recurring expenses, mostly related to infrastructure. Paper uses [Open Collective](https://opencollective.com/) via the [Open Source Collective fiscal host](https://opencollective.com/opensource) to manage expenses. Open Collective allows us to be extremely transparent, so you can always see how your donations are used. You can read more about financially supporting PaperMC [on our website](https://papermc.io/sponsors).
 
 You can find our collective [here](https://opencollective.com/papermc), or you can donate via GitHub Sponsors [here](https://github.com/sponsors/PaperMC), which will also go towards the collective.
 


### PR DESCRIPTION
This PR aims two things in the README
- Change the url in the "See upcoming, pending, and recently added API" to the project PR queue, mostly because the current URL are in read-only mode
- Touch a little how to show the repository thing.. i think use list for the maven/gradle not looks good.. this PR replace this with headers for make this works in the URL

Note: not sure why the IDE remove empty things...