### PR TITLE
Improve command function perm level checks

### DIFF
--- a/patches/server/0982-Improve-command-function-perm-level-checks.patch
+++ b/patches/server/0982-Improve-command-function-perm-level-checks.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 27 Jun 2023 16:32:39 -0700
+Subject: [PATCH] Improve command function perm level checks
+
+
+diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
+index 43c71d9bf2eac98023057b4483fdd143a8343e98..0de2eae2d448ac9e269a4edf48406d5ea8af8059 100644
+--- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
++++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
+@@ -216,8 +216,14 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
+ 
+     // CraftBukkit start
+     public boolean hasPermission(int i, String bukkitPermission) {
+-        // World is null when loading functions
+-        return ((this.getLevel() == null || !this.getLevel().getCraftServer().ignoreVanillaPermissions) && this.permissionLevel >= i) || this.getBukkitSender().hasPermission(bukkitPermission);
++        // Paper start
++        boolean hasPermissionLevel = this.permissionLevel >= i;
++        if (this.source == CommandSource.NULL) {
++            return hasPermissionLevel;
++        } else {
++            return (!this.getLevel().getCraftServer().ignoreVanillaPermissions && hasPermissionLevel) || this.getBukkitSender().hasPermission(bukkitPermission);
++        }
++        // Paper end
+     }
+     // CraftBukkit end
+ 


### PR DESCRIPTION
Previously if a command function tried to check the perm level of a parsed command, if the `function-permission-level` in `server.properties` was too low, it would throw an UOE trying to fallback to check the bukkit permission. This isn't desirable, it should fail in the expected way, returning `false` in the permission check instead of throwing an exception.

----

This PR changes the check to first check if the `CommandSource` is the `NULL` instance (which will throw the UOE on a bukkit perm check). If it is that instance, it just uses the perm level comparison. Otherwise it falls back to the regular logic.