### PR TITLE
Dont resend blocks on interactions

### DIFF
--- a/patches/server/0176-Extend-Player-Interact-cancellation.patch
+++ b/patches/server/0176-Extend-Player-Interact-cancellation.patch
@@ -16,19 +16,7 @@ diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java 
 index 16468dfd657501f6fd5eefa4c32682e24eaba22d..7adf7d1248680e591638298f13f5ae88788f5e4c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -186,6 +186,11 @@ public class ServerPlayerGameMode {
-                 PlayerInteractEvent event = CraftEventFactory.callPlayerInteractEvent(this.player, Action.LEFT_CLICK_BLOCK, pos, direction, this.player.getInventory().getSelected(), InteractionHand.MAIN_HAND);
-                 if (event.isCancelled()) {
-                     // Let the client know the block still exists
-+                    // Paper start - brute force neighbor blocks for any attached blocks
-+                    for (Direction dir : Direction.values()) {
-+                        this.player.connection.send(new ClientboundBlockUpdatePacket(level, pos.relative(dir)));
-+                    }
-+                    // Paper end
-                     this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
-                     // Update any tile entity data for this block
-                     BlockEntity tileentity = this.level.getBlockEntity(pos);
-@@ -519,7 +524,13 @@ public class ServerPlayerGameMode {
+@@ -519,7 +519,13 @@ public class ServerPlayerGameMode {
  
                  // send a correcting update to the client for the block above as well, this because of replaceable blocks (such as grass, sea grass etc)
                  player.connection.send(new ClientboundBlockUpdatePacket(world, blockposition.above()));

--- a/patches/server/0281-Don-t-allow-digging-into-unloaded-chunks.patch
+++ b/patches/server/0281-Don-t-allow-digging-into-unloaded-chunks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Don't allow digging into unloaded chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 3273448ebb2db3fa8eb3f45262f5497dbb31a5ba..58277908737a1f3da89e5df827e108e2381396ff 100644
+index 4dac6b03e39be78071df1688ce61b3fc05d336df..56f391cef4bd85e67eb1f687e3febb18fa27831b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -119,8 +119,8 @@ public class ServerPlayerGameMode {
@@ -42,7 +42,7 @@ index 3273448ebb2db3fa8eb3f45262f5497dbb31a5ba..58277908737a1f3da89e5df827e108e2
              this.debugLogging(pos, false, sequence, "too far");
          } else if (pos.getY() >= worldHeight) {
              this.player.connection.send(new ClientboundBlockUpdatePacket(pos, this.level.getBlockState(pos)));
-@@ -304,10 +311,12 @@ public class ServerPlayerGameMode {
+@@ -299,10 +306,12 @@ public class ServerPlayerGameMode {
                  this.debugLogging(pos, true, sequence, "stopped destroying");
              } else if (action == ServerboundPlayerActionPacket.Action.ABORT_DESTROY_BLOCK) {
                  this.isDestroyingBlock = false;

--- a/patches/server/0342-Anti-Xray.patch
+++ b/patches/server/0342-Anti-Xray.patch
@@ -1129,7 +1129,7 @@ index 58277908737a1f3da89e5df827e108e2381396ff..f47fcae72d48cd410a4ac3e0a4bd21f4
      protected final ServerPlayer player;
      private GameType gameModeForPlayer;
      @Nullable
-@@ -326,6 +326,8 @@ public class ServerPlayerGameMode {
+@@ -321,6 +321,8 @@ public class ServerPlayerGameMode {
              }
  
          }

--- a/patches/server/0417-Add-permission-for-command-blocks.patch
+++ b/patches/server/0417-Add-permission-for-command-blocks.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java 
 index f47fcae72d48cd410a4ac3e0a4bd21f42fae7eec..345bae8d145abd8357f4b71f4977e5850b980ff4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -404,7 +404,7 @@ public class ServerPlayerGameMode {
+@@ -399,7 +399,7 @@ public class ServerPlayerGameMode {
              BlockEntity tileentity = this.level.getBlockEntity(pos);
              Block block = iblockdata.getBlock();
  

--- a/patches/server/0464-Extend-block-drop-capture-to-capture-all-items-added.patch
+++ b/patches/server/0464-Extend-block-drop-capture-to-capture-all-items-added.patch
@@ -26,7 +26,7 @@ diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java 
 index 345bae8d145abd8357f4b71f4977e5850b980ff4..40ac674da09a5d28c3b691d8979b228b9c6a8a84 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -436,10 +436,12 @@ public class ServerPlayerGameMode {
+@@ -431,10 +431,12 @@ public class ServerPlayerGameMode {
                      // return true; // CraftBukkit
                  }
                  // CraftBukkit start

--- a/patches/server/0514-Implement-PlayerFlowerPotManipulateEvent.patch
+++ b/patches/server/0514-Implement-PlayerFlowerPotManipulateEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement PlayerFlowerPotManipulateEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/FlowerPotBlock.java b/src/main/java/net/minecraft/world/level/block/FlowerPotBlock.java
-index 9a8fc69de43fcfeebcb31c895fa4b5868952fa0a..db05c1ea847d60ad45d33cd798cb34ad3f5cfd75 100644
+index 9a8fc69de43fcfeebcb31c895fa4b5868952fa0a..b229b21b4a9b953983e743f345e46e4235e2809d 100644
 --- a/src/main/java/net/minecraft/world/level/block/FlowerPotBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FlowerPotBlock.java
-@@ -52,6 +52,26 @@ public class FlowerPotBlock extends Block {
+@@ -52,6 +52,25 @@ public class FlowerPotBlock extends Block {
          boolean bl = blockState.is(Blocks.AIR);
          boolean bl2 = this.isEmpty();
          if (bl != bl2) {
@@ -26,7 +26,6 @@ index 9a8fc69de43fcfeebcb31c895fa4b5868952fa0a..db05c1ea847d60ad45d33cd798cb34ad
 +
 +            if (event.isCancelled()) {
 +                // Update client
-+                player1.sendBlockChange(bukkitblock.getLocation(), bukkitblock.getBlockData());
 +                player1.updateInventory();
 +
 +                return InteractionResult.PASS;

--- a/patches/server/0761-Fix-cancelled-powdered-snow-bucket-placement.patch
+++ b/patches/server/0761-Fix-cancelled-powdered-snow-bucket-placement.patch
@@ -7,18 +7,6 @@ Cancelling the placement of powdered snow from the powdered
 snow bucket didn't revert grass that became snowy because of the
 placement.
 
-diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
-index e581dc10f3c805f7f8b6e4c842092609e7e1a0f8..b0204af850ee182773ad458208cccd946ad148d5 100644
---- a/src/main/java/net/minecraft/world/item/BlockItem.java
-+++ b/src/main/java/net/minecraft/world/item/BlockItem.java
-@@ -117,6 +117,7 @@ public class BlockItem extends Item {
-                                 blockstate.update(true, false);
- 
-                                 if (this instanceof SolidBucketItem) {
-+                                    ((ServerPlayer) entityhuman).connection.send(new net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket(world, blockposition.below())); // Paper - update block below
-                                     ((ServerPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
-                                 }
-                                 return InteractionResult.FAIL;
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
 index 9eb6ad597a0e2605eae367038d7541fe538f9a86..e615c8b5c1142f547af77dafb33a8772ab5e13c3 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java

--- a/patches/server/0800-Trigger-bee_nest_destroyed-trigger-in-the-correct-pl.patch
+++ b/patches/server/0800-Trigger-bee_nest_destroyed-trigger-in-the-correct-pl.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java 
 index 8a8b766d91d9e2328486e3156bd6a408808dc1e3..3fe747fdc4500bd65029446f63e314031d71ed4a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -428,12 +428,16 @@ public class ServerPlayerGameMode {
+@@ -423,12 +423,16 @@ public class ServerPlayerGameMode {
                      block.destroy(this.level, pos, iblockdata);
                  }
  
@@ -25,7 +25,7 @@ index 8a8b766d91d9e2328486e3156bd6a408808dc1e3..3fe747fdc4500bd65029446f63e31403
  
                      itemstack.mineBlock(this.level, iblockdata, pos, this.player);
                      if (flag && flag1 && event.isDropItems()) { // CraftBukkit - Check if block should drop items
-@@ -454,6 +458,13 @@ public class ServerPlayerGameMode {
+@@ -449,6 +453,13 @@ public class ServerPlayerGameMode {
                  if (flag && event != null) {
                      iblockdata.getBlock().popExperience(this.level, pos, event.getExpToDrop(), this.player); // Paper
                  }

--- a/patches/server/0833-Send-block-entities-after-destroy-prediction.patch
+++ b/patches/server/0833-Send-block-entities-after-destroy-prediction.patch
@@ -31,8 +31,8 @@ index 3fe747fdc4500bd65029446f63e314031d71ed4a..19573bfb05d7f9641964c76e6670e4a7
                      // CraftBukkit end
                      return;
                  }
-@@ -207,10 +206,7 @@ public class ServerPlayerGameMode {
-                     // Paper end
+@@ -202,10 +201,7 @@ public class ServerPlayerGameMode {
+                     // Let the client know the block still exists
                      this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
                      // Update any tile entity data for this block
 -                    BlockEntity tileentity = this.level.getBlockEntity(pos);
@@ -43,7 +43,7 @@ index 3fe747fdc4500bd65029446f63e314031d71ed4a..19573bfb05d7f9641964c76e6670e4a7
                      return;
                  }
                  // CraftBukkit end
-@@ -394,10 +390,12 @@ public class ServerPlayerGameMode {
+@@ -389,10 +385,12 @@ public class ServerPlayerGameMode {
                  }
  
                  // Update any tile entity data for this block

--- a/patches/server/0860-Correctly-handle-interactions-with-items-on-cooldown.patch
+++ b/patches/server/0860-Correctly-handle-interactions-with-items-on-cooldown.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java 
 index 25cbbc714e86c11dcf05329430a83bba2cd05364..4b1af7bba3ce10a1247bb61535456510e18da2d9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -521,6 +521,7 @@ public class ServerPlayerGameMode {
+@@ -516,6 +516,7 @@ public class ServerPlayerGameMode {
          BlockState iblockdata = world.getBlockState(blockposition);
          InteractionResult enuminteractionresult = InteractionResult.PASS;
          boolean cancelledBlock = false;
@@ -16,7 +16,7 @@ index 25cbbc714e86c11dcf05329430a83bba2cd05364..4b1af7bba3ce10a1247bb61535456510
  
          if (!iblockdata.getBlock().isEnabled(world.enabledFeatures())) {
              return InteractionResult.FAIL;
-@@ -530,10 +531,10 @@ public class ServerPlayerGameMode {
+@@ -525,10 +526,10 @@ public class ServerPlayerGameMode {
          }
  
          if (player.getCooldowns().isOnCooldown(stack.getItem())) {

--- a/patches/server/0944-Fix-block-place-logic.patch
+++ b/patches/server/0944-Fix-block-place-logic.patch
@@ -9,10 +9,10 @@ Fix several issues when a player interact with a block:
 * poi can desync when the BlockPhysicsEvent is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
-index b0204af850ee182773ad458208cccd946ad148d5..ebee8de2ed831755b6fd154f6cc77ac993839bb9 100644
+index e581dc10f3c805f7f8b6e4c842092609e7e1a0f8..6819cea2858f0035a4fbf3671612d43fead883b6 100644
 --- a/src/main/java/net/minecraft/world/item/BlockItem.java
 +++ b/src/main/java/net/minecraft/world/item/BlockItem.java
-@@ -131,7 +131,7 @@ public class BlockItem extends Item {
+@@ -130,7 +130,7 @@ public class BlockItem extends Item {
  
                      SoundType soundeffecttype = iblockdata1.getSoundType();
  

--- a/patches/server/0954-Properly-Cancel-Usable-Items.patch
+++ b/patches/server/0954-Properly-Cancel-Usable-Items.patch
@@ -10,10 +10,10 @@ The underlying issue of this is that the client modifies their synced data value
 them in order for the client to reset their using item state.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 4b1af7bba3ce10a1247bb61535456510e18da2d9..76cef8f2861af8fcb88b4dad294a8853dd3f3e01 100644
+index e8ad6a1e497f399c5d8cd6a6ec192ddc932e3fb9..1a895a511d8bb20bcaf6ae5534ca70529d65951e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -562,6 +562,7 @@ public class ServerPlayerGameMode {
+@@ -557,6 +557,7 @@ public class ServerPlayerGameMode {
              }
              // Paper end - extend Player Interact cancellation
              player.getBukkitEntity().updateInventory(); // SPIGOT-2867
@@ -21,7 +21,7 @@ index 4b1af7bba3ce10a1247bb61535456510e18da2d9..76cef8f2861af8fcb88b4dad294a8853
              enuminteractionresult = (event.useItemInHand() != Event.Result.ALLOW) ? InteractionResult.SUCCESS : InteractionResult.PASS;
          } else if (this.gameModeForPlayer == GameType.SPECTATOR) {
              MenuProvider itileinventory = iblockdata.getMenuProvider(world, blockposition);
-@@ -605,6 +606,11 @@ public class ServerPlayerGameMode {
+@@ -600,6 +601,11 @@ public class ServerPlayerGameMode {
  
                  return enuminteractionresult1;
              }

--- a/patches/server/0992-Properly-handle-BlockBreakEvent-isDropItems.patch
+++ b/patches/server/0992-Properly-handle-BlockBreakEvent-isDropItems.patch
@@ -9,10 +9,10 @@ food consumption, turtle egg count decreases, ice to water
 conversions and beehive releases
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 76cef8f2861af8fcb88b4dad294a8853dd3f3e01..ee12ca53c7919d6d424c4306b90d25660eb14af6 100644
+index 1a895a511d8bb20bcaf6ae5534ca70529d65951e..282dcf4c1b2de40810832dbdd3ff1ba1ce444fd6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -438,8 +438,8 @@ public class ServerPlayerGameMode {
+@@ -433,8 +433,8 @@ public class ServerPlayerGameMode {
                      isCorrectTool = flag1; // Paper
  
                      itemstack.mineBlock(this.level, iblockdata, pos, this.player);

--- a/patches/server/0997-Expose-clicked-BlockFace-during-BlockDamageEvent.patch
+++ b/patches/server/0997-Expose-clicked-BlockFace-during-BlockDamageEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose clicked BlockFace during BlockDamageEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index ee12ca53c7919d6d424c4306b90d25660eb14af6..cd57234a5f1131f48c9726f89262f253e61b9811 100644
+index 282dcf4c1b2de40810832dbdd3ff1ba1ce444fd6..25f7adf194a165fa28488f80b87382c08111f896 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-@@ -258,7 +258,7 @@ public class ServerPlayerGameMode {
+@@ -253,7 +253,7 @@ public class ServerPlayerGameMode {
                      }
                      return;
                  }

--- a/patches/server/1005-Expose-hand-during-BlockCanBuildEvent.patch
+++ b/patches/server/1005-Expose-hand-during-BlockCanBuildEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose hand during BlockCanBuildEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
-index ebee8de2ed831755b6fd154f6cc77ac993839bb9..65c69432da4bc042cd975e01fcf62b09843cf202 100644
+index 6819cea2858f0035a4fbf3671612d43fead883b6..ce0a22b5084cb382b7c1036960793e3a8314a26f 100644
 --- a/src/main/java/net/minecraft/world/item/BlockItem.java
 +++ b/src/main/java/net/minecraft/world/item/BlockItem.java
-@@ -215,7 +215,7 @@ public class BlockItem extends Item {
+@@ -214,7 +214,7 @@ public class BlockItem extends Item {
          boolean defaultReturn = (!this.mustSurvive() || state.canSurvive(context.getLevel(), context.getClickedPos())) && world.checkEntityCollision(state, entityhuman, voxelshapecollision, context.getClickedPos(), true); // Paper
          org.bukkit.entity.Player player = (context.getPlayer() instanceof ServerPlayer) ? (org.bukkit.entity.Player) context.getPlayer().getBukkitEntity() : null;
  

--- a/patches/server/1008-Fix-inventory-desync.patch
+++ b/patches/server/1008-Fix-inventory-desync.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix inventory desync
 
 
 diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
-index 65c69432da4bc042cd975e01fcf62b09843cf202..e483186a5292b3b53bfb1af4d56f55fcc1a6106c 100644
+index ce0a22b5084cb382b7c1036960793e3a8314a26f..efdf56044396b4ce486948d2c993971f99174a5e 100644
 --- a/src/main/java/net/minecraft/world/item/BlockItem.java
 +++ b/src/main/java/net/minecraft/world/item/BlockItem.java
 @@ -116,7 +116,7 @@ public class BlockItem extends Item {
@@ -14,6 +14,6 @@ index 65c69432da4bc042cd975e01fcf62b09843cf202..e483186a5292b3b53bfb1af4d56f55fc
  
 -                                if (this instanceof SolidBucketItem) {
 +                                if (true) { // Paper - if the event is called here, the inventory should be updated
-                                     ((ServerPlayer) entityhuman).connection.send(new net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket(world, blockposition.below())); // Paper - update block below
                                      ((ServerPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
                                  }
+                                 return InteractionResult.FAIL;

--- a/patches/server/1055-Dont-resend-blocks-on-interactions.patch
+++ b/patches/server/1055-Dont-resend-blocks-on-interactions.patch
@@ -1,0 +1,171 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Tue, 27 Jun 2023 21:09:11 -0400
+Subject: [PATCH] Dont resend blocks on interactions
+
+In general, the client now has an acknowledgment system which will prevent block changes made by the client to be reverted correctly.
+
+It should be noted that this system does not yet support block entities, so those still need to resynced when needed.
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
+index 346912d854a176a410920e69d063919f5d34626a..3706e94108f68a16fea63e734f3e3b6871dcb0b8 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
+@@ -199,7 +199,7 @@ public class ServerPlayerGameMode {
+                 PlayerInteractEvent event = CraftEventFactory.callPlayerInteractEvent(this.player, Action.LEFT_CLICK_BLOCK, pos, direction, this.player.getInventory().getSelected(), InteractionHand.MAIN_HAND);
+                 if (event.isCancelled()) {
+                     // Let the client know the block still exists
+-                    this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
++                    // this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos)); // Paper - Don't resync blocks
+                     // Update any tile entity data for this block
+                     capturedBlockEntity = true; // Paper - send block entity after predicting
+                     return;
+@@ -214,7 +214,7 @@ public class ServerPlayerGameMode {
+                 // Spigot start - handle debug stick left click for non-creative
+                 if (this.player.getMainHandItem().is(net.minecraft.world.item.Items.DEBUG_STICK)
+                         && ((net.minecraft.world.item.DebugStickItem) net.minecraft.world.item.Items.DEBUG_STICK).handleInteraction(this.player, this.level.getBlockState(pos), this.level, pos, false, this.player.getMainHandItem())) {
+-                    this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
++                    // this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos)); // Paper - Don't resync block
+                     return;
+                 }
+                 // Spigot end
+@@ -232,15 +232,17 @@ public class ServerPlayerGameMode {
+                 // CraftBukkit start - Swings at air do *NOT* exist.
+                 if (event.useInteractedBlock() == Event.Result.DENY) {
+                     // If we denied a door from opening, we need to send a correcting update to the client, as it already opened the door.
+-                    BlockState data = this.level.getBlockState(pos);
+-                    if (data.getBlock() instanceof DoorBlock) {
+-                        // For some reason *BOTH* the bottom/top part have to be marked updated.
+-                        boolean bottom = data.getValue(DoorBlock.HALF) == DoubleBlockHalf.LOWER;
+-                        this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
+-                        this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, bottom ? pos.above() : pos.below()));
+-                    } else if (data.getBlock() instanceof TrapDoorBlock) {
+-                        this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
+-                    }
++                    // Paper start - Don't resync blocks
++                    //BlockState data = this.level.getBlockState(pos);
++                    //if (data.getBlock() instanceof DoorBlock) {
++                    //    // For some reason *BOTH* the bottom/top part have to be marked updated.
++                    //    boolean bottom = data.getValue(DoorBlock.HALF) == DoubleBlockHalf.LOWER;
++                    //    this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
++                    //    this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, bottom ? pos.above() : pos.below()));
++                    //} else if (data.getBlock() instanceof TrapDoorBlock) {
++                    //    this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
++                    //}
++                    // Paper end
+                 } else if (!iblockdata.isAir()) {
+                     iblockdata.attack(this.level, pos, this.player);
+                     f = iblockdata.getDestroyProgress(this.player, this.player.level(), pos);
+@@ -249,7 +251,7 @@ public class ServerPlayerGameMode {
+                 if (event.useItemInHand() == Event.Result.DENY) {
+                     // If we 'insta destroyed' then the client needs to be informed.
+                     if (f > 1.0f) {
+-                        this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
++                        // this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos)); // Paper - Don't resync blocks
+                     }
+                     return;
+                 }
+@@ -257,7 +259,7 @@ public class ServerPlayerGameMode {
+ 
+                 if (blockEvent.isCancelled()) {
+                     // Let the client know the block still exists
+-                    this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
++                    // this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos)); // Paper - Don't resync block
+                     return;
+                 }
+ 
+@@ -350,7 +352,7 @@ public class ServerPlayerGameMode {
+ 
+             // Tell client the block is gone immediately then process events
+             // Don't tell the client if its a creative sword break because its not broken!
+-            if (this.level.getBlockEntity(pos) == null && !isSwordNoBreak) {
++            if (false && this.level.getBlockEntity(pos) == null && !isSwordNoBreak) { // Paper - Don't resync block
+                 ClientboundBlockUpdatePacket packet = new ClientboundBlockUpdatePacket(pos, Blocks.AIR.defaultBlockState());
+                 this.player.connection.send(packet);
+             }
+@@ -376,13 +378,15 @@ public class ServerPlayerGameMode {
+                 if (isSwordNoBreak) {
+                     return false;
+                 }
++                // Paper start - Dont resync blocks
+                 // Let the client know the block still exists
+-                this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
++                //this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos));
+ 
+                 // Brute force all possible updates
+-                for (Direction dir : Direction.values()) {
+-                    this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos.relative(dir)));
+-                }
++                //for (Direction dir : Direction.values()) {
++                //    this.player.connection.send(new ClientboundBlockUpdatePacket(this.level, pos.relative(dir)));
++                //}
++                // Paper end
+ 
+                 // Update any tile entity data for this block
+                 if (!captureSentBlockEntities) { // Paper - Toggle this location for capturing as this is used for api
+@@ -539,16 +543,18 @@ public class ServerPlayerGameMode {
+         if (event.useInteractedBlock() == Event.Result.DENY) {
+             // If we denied a door from opening, we need to send a correcting update to the client, as it already opened the door.
+             if (iblockdata.getBlock() instanceof DoorBlock) {
+-                boolean bottom = iblockdata.getValue(DoorBlock.HALF) == DoubleBlockHalf.LOWER;
+-                player.connection.send(new ClientboundBlockUpdatePacket(world, bottom ? blockposition.above() : blockposition.below()));
++                // Paper start - Don't resync blocks
++                // boolean bottom = iblockdata.getValue(DoorBlock.HALF) == DoubleBlockHalf.LOWER;
++                // player.connection.send(new ClientboundBlockUpdatePacket(world, bottom ? blockposition.above() : blockposition.below()));
++                // Paper end
+             } else if (iblockdata.getBlock() instanceof CakeBlock) {
+                 player.getBukkitEntity().sendHealthUpdate(); // SPIGOT-1341 - reset health for cake
+             } else if (this.interactItemStack.getItem() instanceof DoubleHighBlockItem) {
+                 // send a correcting update to the client, as it already placed the upper half of the bisected item
+-                player.connection.send(new ClientboundBlockUpdatePacket(world, blockposition.relative(hitResult.getDirection()).above()));
++                //player.connection.send(new ClientboundBlockUpdatePacket(world, blockposition.relative(hitResult.getDirection()).above())); // Paper - don't resync blocks
+ 
+                 // send a correcting update to the client for the block above as well, this because of replaceable blocks (such as grass, sea grass etc)
+-                player.connection.send(new ClientboundBlockUpdatePacket(world, blockposition.above()));
++                //player.connection.send(new ClientboundBlockUpdatePacket(world, blockposition.above())); // Paper - don't resync blocks
+             // Paper start  - extend Player Interact cancellation // TODO: consider merging this into the extracted method
+             } else if (iblockdata.getBlock() instanceof net.minecraft.world.level.block.StructureBlock) {
+                 player.connection.send(new net.minecraft.network.protocol.game.ClientboundContainerClosePacket(this.player.containerMenu.containerId));
+diff --git a/src/main/java/net/minecraft/world/item/BucketItem.java b/src/main/java/net/minecraft/world/item/BucketItem.java
+index 277555a26e8281dd1a626e572794b08cf51d00c5..aa0f09a18ea781e027ea70928b30d3e93061120f 100644
+--- a/src/main/java/net/minecraft/world/item/BucketItem.java
++++ b/src/main/java/net/minecraft/world/item/BucketItem.java
+@@ -77,7 +77,7 @@ public class BucketItem extends Item implements DispensibleContainerItem {
+                         PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent((ServerLevel) world, user, blockposition, blockposition, movingobjectpositionblock.getDirection(), itemstack, dummyFluid.getItem(), hand);
+ 
+                         if (event.isCancelled()) {
+-                            ((ServerPlayer) user).connection.send(new ClientboundBlockUpdatePacket(world, blockposition)); // SPIGOT-5163 (see PlayerInteractManager)
++                            // ((ServerPlayer) user).connection.send(new ClientboundBlockUpdatePacket(world, blockposition)); // SPIGOT-5163 (see PlayerInteractManager) // Paper - Don't resend blocks
+                             ((ServerPlayer) user).getBukkitEntity().updateInventory(); // SPIGOT-4541
+                             return InteractionResultHolder.fail(itemstack);
+                         }
+@@ -186,7 +186,7 @@ public class BucketItem extends Item implements DispensibleContainerItem {
+             if (flag2 && entityhuman != null) {
+                 PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent((ServerLevel) world, entityhuman, blockposition, clicked, enumdirection, itemstack, enumhand);
+                 if (event.isCancelled()) {
+-                    ((ServerPlayer) entityhuman).connection.send(new ClientboundBlockUpdatePacket(world, blockposition)); // SPIGOT-4238: needed when looking through entity
++                    // ((ServerPlayer) entityhuman).connection.send(new ClientboundBlockUpdatePacket(world, blockposition)); // SPIGOT-4238: needed when looking through entity // Paper - Don't resend blocks
+                     ((ServerPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
+                     return false;
+                 }
+diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
+index 4697df75fdee2023c41260bed211e3e3d90d2b9b..d0f7baa80cb7d0883304abe2ed990c258a0d92b6 100644
+--- a/src/main/java/net/minecraft/world/item/ItemStack.java
++++ b/src/main/java/net/minecraft/world/item/ItemStack.java
+@@ -436,10 +436,12 @@ public final class ItemStack {
+                     world.preventPoiUpdated = false;
+ 
+                     // Brute force all possible updates
+-                    BlockPos placedPos = ((CraftBlock) placeEvent.getBlock()).getPosition();
+-                    for (Direction dir : Direction.values()) {
+-                        ((ServerPlayer) entityhuman).connection.send(new ClientboundBlockUpdatePacket(world, placedPos.relative(dir)));
+-                    }
++                    // Paper start - don't resync blocks
++                    // BlockPos placedPos = ((CraftBlock) placeEvent.getBlock()).getPosition();
++                    // for (Direction dir : Direction.values()) {
++                    //     ((ServerPlayer) entityhuman).connection.send(new ClientboundBlockUpdatePacket(world, placedPos.relative(dir)));
++                    // }
++                    // Paper end
+                     SignItem.openSign = null; // SPIGOT-6758 - Reset on early return
+                 } else {
+                     // Change the stack to its new contents if it hasn't been tampered with.


### PR DESCRIPTION
In general, the client now has an acknowledgment system that will cause block changes made by the client to be reverted correctly.

Essentially: 
1. The client enters a "prediction" stage, where any block changes made will have its old blockstate captured (this is referred to as "server state"). 
2. If you update blocks during this stage, the client will update this captured server state as long as they're still currently predicting. 
3. After prediction is done (via an ack packet) all captured blockstates are reverted to their captured server state. 

This means that if the server *actually updated* a block and send a block update packet, it's correctly set, while if a block wasn't updated on the server but WAS updated on the client (server state wasn't updated), that change will be reverted.

It should be noted that this system does not yet support block entities, so those still need to be resynced when needed.

I discovered this when noticing that blocks broken outside of the player's valid interaction distance are still properly reverted, even though the server doesn't send any block updates, only an ack packet.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9413.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1088613506.zip)