### PR TITLE
Fix replenishable container entities save/load existing contents

### DIFF
--- a/patches/server/0095-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0095-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -490,7 +490,7 @@ index 0000000000000000000000000000000000000000..9cfa5d36a6991067a3866e0d437749fa
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 713052e936d75173cd038b0565d94f9ff451168f..b7b7500c580548fcdcfa2ba36137abf45b43ddf9 100644
+index 9fadfb41a41b575aa1ca1c28e34118708eded498..fbd28a3f571766e6ed4ba73f337b2e835ef50453 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -235,6 +235,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -582,28 +582,34 @@ index d88a6501917306eab57f46cb0d10dc03164a94da..e88c39d405fc7068db64ad34a03dec8d
      public List<HumanEntity> transaction = new java.util.ArrayList<HumanEntity>();
      private int maxStack = MAX_STACK;
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java b/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
-index e0fbacd574e0c83c2e1d164ded8e9ccf4af30480..94252d346c4f8dfbd1501b142ea0b6985dc8e19a 100644
+index e0fbacd574e0c83c2e1d164ded8e9ccf4af30480..7529751afa2932fd16bc4591189b0358268a7b14 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
-@@ -59,7 +59,7 @@ public interface ContainerEntity extends Container, MenuProvider {
+@@ -59,10 +59,9 @@ public interface ContainerEntity extends Container, MenuProvider {
              if (this.getLootTableSeed() != 0L) {
                  nbt.putLong("LootTableSeed", this.getLootTableSeed());
              }
 -        } else {
-+        } else if (true) { // Paper - always load the items, table may still remain
-             ContainerHelper.saveAllItems(nbt, this.getItemStacks());
+-            ContainerHelper.saveAllItems(nbt, this.getItemStacks());
          }
  
-@@ -70,7 +70,7 @@ public interface ContainerEntity extends Container, MenuProvider {
++        ContainerHelper.saveAllItems(nbt, this.getItemStacks()); // Paper - always save the items, table may still remain
+     }
+ 
+     default void readChestVehicleSaveData(CompoundTag nbt) {
+@@ -70,10 +69,9 @@ public interface ContainerEntity extends Container, MenuProvider {
          if (nbt.contains("LootTable", 8)) {
              this.setLootTable(new ResourceLocation(nbt.getString("LootTable")));
              this.setLootTableSeed(nbt.getLong("LootTableSeed"));
 -        } else {
-+        } else if (true) { // Paper - always load the items, table may still remain
-             ContainerHelper.loadAllItems(nbt, this.getItemStacks());
+-            ContainerHelper.loadAllItems(nbt, this.getItemStacks());
          }
  
-@@ -96,13 +96,13 @@ public interface ContainerEntity extends Container, MenuProvider {
++        ContainerHelper.loadAllItems(nbt, this.getItemStacks()); // Paper - always load the items, table may still remain
+     }
+ 
+     default void chestVehicleDestroyed(DamageSource source, Level world, Entity vehicle) {
+@@ -96,13 +94,13 @@ public interface ContainerEntity extends Container, MenuProvider {
  
      default void unpackChestVehicleLootTable(@Nullable Player player) {
          MinecraftServer minecraftServer = this.level().getServer();
@@ -619,7 +625,7 @@ index e0fbacd574e0c83c2e1d164ded8e9ccf4af30480..94252d346c4f8dfbd1501b142ea0b698
              LootParams.Builder builder = (new LootParams.Builder((ServerLevel)this.level())).withParameter(LootContextParams.ORIGIN, this.position());
              if (player != null) {
                  builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
-@@ -176,4 +176,13 @@ public interface ContainerEntity extends Container, MenuProvider {
+@@ -176,4 +174,13 @@ public interface ContainerEntity extends Container, MenuProvider {
      default boolean isChestVehicleStillValid(Player player) {
          return !this.isRemoved() && this.position().closerThan(player.position(), 8.0D);
      }


### PR DESCRIPTION
During some update, the diff was mangled. The save/load items should be run every time due to the loot table possibly persistent across multiple uses.