### PR TITLE
Fix default permission for xp command

### DIFF
--- a/patches/server/0501-Added-missing-default-perms-for-commands.patch
+++ b/patches/server/0501-Added-missing-default-perms-for-commands.patch
@@ -5,14 +5,16 @@ Subject: [PATCH] Added missing default perms for commands
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java b/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java
-index ca30f9c590f792caa8f1b76d7219e9121d932673..55695044da8363c8da040d922fa033c917f341d0 100644
+index ca30f9c590f792caa8f1b76d7219e9121d932673..2959f713ce75a1df9c6c7cf5e021690cfcb6e1e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/permissions/CommandPermissions.java
-@@ -25,12 +25,71 @@ public final class CommandPermissions {
+@@ -24,13 +24,72 @@ public final class CommandPermissions {
+         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "stop", "Allows the user to stop the server", PermissionDefault.OP, commands);
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "list", "Allows the user to list all online players", PermissionDefault.OP, commands);
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "gamemode", "Allows the user to change the gamemode of another player", PermissionDefault.OP, commands);
-         DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "xp", "Allows the user to give themselves or others arbitrary values of experience", PermissionDefault.OP, commands);
+-        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "xp", "Allows the user to give themselves or others arbitrary values of experience", PermissionDefault.OP, commands);
 -        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "toggledownfall", "Allows the user to toggle rain on/off for a given world", PermissionDefault.OP, commands);
++        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "experience", "Allows the user to give themselves or others arbitrary values of experience", PermissionDefault.OP, commands); // Paper - wrong permission; redirects are de-redirected and the root literal name is used, so xp -> experience
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "defaultgamemode", "Allows the user to change the default gamemode of the server", PermissionDefault.OP, commands);
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "seed", "Allows the user to view the seed of the world", PermissionDefault.OP, commands);
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "effect", "Allows the user to add/remove effects on players", PermissionDefault.OP, commands);
@@ -52,7 +54,7 @@ index ca30f9c590f792caa8f1b76d7219e9121d932673..55695044da8363c8da040d922fa033c9
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "ride", "Allows the user to use the /ride command to control passengers", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "recipe", "Allows the user to give or take recipes", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "reload", "Allows the user to reload loot tables, advancements, and functions from disk", PermissionDefault.OP, commands);
-+        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "item", "Allows the user to replace items in inventories", PermissionDefault.OP, commands); // Remove in 1.17 (replaced by /item)
++        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "item", "Allows the user to replace items in inventories", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "save-all", "Allows the user to save the server to disk", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "save-off", "Allows the user disable automatic server saves", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "save-on", "Allows the user enable automatic server saves", PermissionDefault.OP, commands);
@@ -68,7 +70,7 @@ index ca30f9c590f792caa8f1b76d7219e9121d932673..55695044da8363c8da040d922fa033c9
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "summon", "Allows the user to summon an entity", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "tag", "Allows the user to control entity tags", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "team", "Allows the user to control teams", PermissionDefault.OP, commands);
-+        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "teammsg", "Allows the user to specify the message to send to team", PermissionDefault.TRUE, commands);
++        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "teammsg", "Allows the user to specify the message to send to team", PermissionDefault.TRUE, commands); // defaults to all players
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "tellraw", "Allows the user to display a JSON message to players", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "time", "Allows the user to change or query the world's game time", PermissionDefault.OP, commands);
 +        DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "title", "Allows the user to manage screen titles", PermissionDefault.OP, commands);
@@ -83,10 +85,10 @@ index ca30f9c590f792caa8f1b76d7219e9121d932673..55695044da8363c8da040d922fa033c9
  
 diff --git a/src/test/java/io/papermc/paper/permissions/MinecraftCommandPermissionsTest.java b/src/test/java/io/papermc/paper/permissions/MinecraftCommandPermissionsTest.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8665e2740aedcc2895b0e2c44ebaba53d2a40568
+index 0000000000000000000000000000000000000000..4f43882d930ab8816e75b216d9a61a06b79df265
 --- /dev/null
 +++ b/src/test/java/io/papermc/paper/permissions/MinecraftCommandPermissionsTest.java
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,82 @@
 +package io.papermc.paper.permissions;
 +
 +import com.mojang.brigadier.tree.CommandNode;
@@ -154,10 +156,6 @@ index 0000000000000000000000000000000000000000..8665e2740aedcc2895b0e2c44ebaba53
 +        for (Permission perm : Bukkit.getPluginManager().getPermissions()) {
 +            if (perm.getName().startsWith("minecraft.command.")) {
 +                if (TO_SKIP.contains(perm.getName())) {
-+                    continue;
-+                }
-+                if (perm.getName().endsWith(".xp")) {
-+                    perms.add("minecraft.command.experience"); // for the "experience" command, craftbukkit perm is "minecraft.command.xp"
 +                    continue;
 +                }
 +                perms.add(perm.getName());


### PR DESCRIPTION
Should've actually checked that the one special case cb had for the `/experience` command was actually correct. Turns out its been wrong for a long time. CB un-redirects vanilla command nodes, so when checking perms for the `/xp` command node, it uses the `/experience` command node for the literal string (`experience`) and so the permission should be `minecraft.command.experience`. Don't think `minecraft.command.xp` has worked at all recently.

----

Depending on how much we care about permission descriptions being more specific than "Lets you use /somecommand", these could just be completely autogenerated in the future. Using the vanilla perm system to figure out what the default should be, OP or TRUE.