### PR TITLE
Move Log4j plugins to own source set

### DIFF
--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ca692b4758172cb139938f28457cf5639a4411cf..592d2cd1114ee9fbf7b16068ef729f7db4de83d1 100644
+index f7d5f785f659aa905000d974f573e43f841e7fc0..59579c22db8e028782f284942fb1e4f9791cfe1b 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -9,10 +9,9 @@ plugins {
@@ -48,7 +48,19 @@ index ca692b4758172cb139938f28457cf5639a4411cf..592d2cd1114ee9fbf7b16068ef729f7d
          )
          for (tld in setOf("net", "com", "org")) {
              attributes("$tld/bukkit", "Sealed" to true)
-@@ -75,6 +80,17 @@ tasks.shadowJar {
+@@ -49,6 +54,11 @@ tasks.jar {
+     }
+ }
+ 
++tasks.compileJava {
++    // incremental compilation is currently broken due to patched files having compiled counterparts already on the compile classpath
++    options.setIncremental(false)
++}
++
+ publishing {
+     publications.create<MavenPublication>("maven") {
+         artifact(tasks.shadowJar)
+@@ -75,6 +85,17 @@ tasks.shadowJar {
      }
  }
  

--- a/patches/server/0134-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0134-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -25,10 +25,10 @@ Other changes:
 Co-Authored-By: Emilia Kond <emilia@rymiel.space>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 2cabc6126afe4ad83eed4c423ffa67b77fde7c2a..1c0d6aff62f653044a402f5914bc558c70a3ca46 100644
+index d67bfb162d122f6944aa16219b754d8d6ee40fb8..4e682e084a7f653ccb90756bab884499861f9060 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -6,9 +6,28 @@ plugins {
+@@ -6,9 +6,30 @@ plugins {
      id("com.github.johnrengelman.shadow")
  }
  
@@ -36,6 +36,7 @@ index 2cabc6126afe4ad83eed4c423ffa67b77fde7c2a..1c0d6aff62f653044a402f5914bc558c
 +configurations.named(log4jPlugins.compileClasspathConfigurationName) {
 +    extendsFrom(configurations.compileClasspath.get())
 +}
++val alsoShade: Configuration by configurations.creating
 +
  dependencies {
      implementation(project(":paper-api"))
@@ -54,10 +55,20 @@ index 2cabc6126afe4ad83eed4c423ffa67b77fde7c2a..1c0d6aff62f653044a402f5914bc558c
 +    runtimeOnly("org.apache.logging.log4j:log4j-core:2.19.0")
 +    log4jPlugins.annotationProcessorConfigurationName("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - Needed to generate meta for our Log4j plugins
 +    runtimeOnly(log4jPlugins.output)
++    alsoShade(log4jPlugins.output)
 +    // Paper end
      implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
      implementation("org.ow2.asm:asm:9.4")
      implementation("org.ow2.asm:asm-commons:9.4") // Paper - ASM event executor generation
+@@ -75,7 +96,7 @@ relocation {
+ }
+ 
+ tasks.shadowJar {
+-    configurations = listOf(project.configurations.vanillaServer.get())
++    configurations = listOf(project.configurations.vanillaServer.get(), alsoShade)
+     archiveClassifier.set("mojang-mapped")
+ 
+     for (relocation in relocation.relocations.get()) {
 diff --git a/src/log4jPlugins/java/io/papermc/paper/console/StripANSIConverter.java b/src/log4jPlugins/java/io/papermc/paper/console/StripANSIConverter.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..91547f6e6fe90006713beb2818da634304bdd236

--- a/patches/server/0134-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0134-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -25,11 +25,18 @@ Other changes:
 Co-Authored-By: Emilia Kond <emilia@rymiel.space>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 2cabc6126afe4ad83eed4c423ffa67b77fde7c2a..ab46f9cb3bb94af0c418a5d39f2f63a6d3a0e07c 100644
+index 2cabc6126afe4ad83eed4c423ffa67b77fde7c2a..1c0d6aff62f653044a402f5914bc558c70a3ca46 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -8,7 +8,20 @@ plugins {
+@@ -6,9 +6,28 @@ plugins {
+     id("com.github.johnrengelman.shadow")
+ }
  
++val log4jPlugins = sourceSets.create("log4jPlugins")
++configurations.named(log4jPlugins.compileClasspathConfigurationName) {
++    extendsFrom(configurations.compileClasspath.get())
++}
++
  dependencies {
      implementation(project(":paper-api"))
 -    implementation("jline:jline:2.12.1")
@@ -44,12 +51,70 @@ index 2cabc6126afe4ad83eed4c423ffa67b77fde7c2a..ab46f9cb3bb94af0c418a5d39f2f63a6
 +          all its classes to check if they are plugins.
 +          Scanning takes about 1-2 seconds so adding this speeds up the server start.
 +     */
-+    runtimeOnly("org.apache.logging.log4j:log4j-core:2.14.1")
-+    annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - Needed to generate meta for our Log4j plugins
++    runtimeOnly("org.apache.logging.log4j:log4j-core:2.19.0")
++    log4jPlugins.annotationProcessorConfigurationName("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - Needed to generate meta for our Log4j plugins
++    runtimeOnly(log4jPlugins.output)
 +    // Paper end
      implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
      implementation("org.ow2.asm:asm:9.4")
      implementation("org.ow2.asm:asm-commons:9.4") // Paper - ASM event executor generation
+diff --git a/src/log4jPlugins/java/io/papermc/paper/console/StripANSIConverter.java b/src/log4jPlugins/java/io/papermc/paper/console/StripANSIConverter.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..91547f6e6fe90006713beb2818da634304bdd236
+--- /dev/null
++++ b/src/log4jPlugins/java/io/papermc/paper/console/StripANSIConverter.java
+@@ -0,0 +1,51 @@
++package io.papermc.paper.console;
++
++import org.apache.logging.log4j.core.LogEvent;
++import org.apache.logging.log4j.core.config.Configuration;
++import org.apache.logging.log4j.core.config.plugins.Plugin;
++import org.apache.logging.log4j.core.layout.PatternLayout;
++import org.apache.logging.log4j.core.pattern.ConverterKeys;
++import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
++import org.apache.logging.log4j.core.pattern.PatternConverter;
++import org.apache.logging.log4j.core.pattern.PatternFormatter;
++import org.apache.logging.log4j.core.pattern.PatternParser;
++
++import java.util.List;
++import java.util.regex.Pattern;
++
++@Plugin(name = "stripAnsi", category = PatternConverter.CATEGORY)
++@ConverterKeys({"stripAnsi"})
++public final class StripANSIConverter extends LogEventPatternConverter {
++    final private Pattern ANSI_PATTERN = Pattern.compile("\\e\\[[\\d;]*[^\\d;]");
++
++    private final List<PatternFormatter> formatters;
++
++    private StripANSIConverter(List<PatternFormatter> formatters) {
++        super("stripAnsi", null);
++        this.formatters = formatters;
++    }
++
++    @Override
++    public void format(LogEvent event, StringBuilder toAppendTo) {
++        int start = toAppendTo.length();
++        for (PatternFormatter formatter : formatters) {
++            formatter.format(event, toAppendTo);
++        }
++        String content = toAppendTo.substring(start);
++        content = ANSI_PATTERN.matcher(content).replaceAll("");
++
++        toAppendTo.setLength(start);
++        toAppendTo.append(content);
++    }
++
++    public static StripANSIConverter newInstance(Configuration config, String[] options) {
++        if (options.length != 1) {
++            LOGGER.error("Incorrect number of options on stripAnsi. Expected exactly 1, received " + options.length);
++            return null;
++        }
++
++        PatternParser parser = PatternLayout.createPatternParser(config);
++        List<PatternFormatter> formatters = parser.parse(options[0]);
++        return new StripANSIConverter(formatters);
++    }
++}
 diff --git a/src/main/java/com/destroystokyo/paper/console/PaperConsole.java b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..a4070b59e261f0f1ac4beec47b11492f4724bf27
@@ -175,63 +240,6 @@ index c3631efda9c7fa531a8a9f18fbee7b5f8655382b..769f6489632302627fa1730cc08e77f5
 +        return PaperAdventure.ANSI_SERIALIZER.serialize(GlobalTranslator.render(message, Locale.getDefault()));
      }
  }
-diff --git a/src/main/java/io/papermc/paper/console/StripANSIConverter.java b/src/main/java/io/papermc/paper/console/StripANSIConverter.java
-new file mode 100644
-index 0000000000000000000000000000000000000000..91547f6e6fe90006713beb2818da634304bdd236
---- /dev/null
-+++ b/src/main/java/io/papermc/paper/console/StripANSIConverter.java
-@@ -0,0 +1,51 @@
-+package io.papermc.paper.console;
-+
-+import org.apache.logging.log4j.core.LogEvent;
-+import org.apache.logging.log4j.core.config.Configuration;
-+import org.apache.logging.log4j.core.config.plugins.Plugin;
-+import org.apache.logging.log4j.core.layout.PatternLayout;
-+import org.apache.logging.log4j.core.pattern.ConverterKeys;
-+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
-+import org.apache.logging.log4j.core.pattern.PatternConverter;
-+import org.apache.logging.log4j.core.pattern.PatternFormatter;
-+import org.apache.logging.log4j.core.pattern.PatternParser;
-+
-+import java.util.List;
-+import java.util.regex.Pattern;
-+
-+@Plugin(name = "stripAnsi", category = PatternConverter.CATEGORY)
-+@ConverterKeys({"stripAnsi"})
-+public final class StripANSIConverter extends LogEventPatternConverter {
-+    final private Pattern ANSI_PATTERN = Pattern.compile("\\e\\[[\\d;]*[^\\d;]");
-+
-+    private final List<PatternFormatter> formatters;
-+
-+    private StripANSIConverter(List<PatternFormatter> formatters) {
-+        super("stripAnsi", null);
-+        this.formatters = formatters;
-+    }
-+
-+    @Override
-+    public void format(LogEvent event, StringBuilder toAppendTo) {
-+        int start = toAppendTo.length();
-+        for (PatternFormatter formatter : formatters) {
-+            formatter.format(event, toAppendTo);
-+        }
-+        String content = toAppendTo.substring(start);
-+        content = ANSI_PATTERN.matcher(content).replaceAll("");
-+
-+        toAppendTo.setLength(start);
-+        toAppendTo.append(content);
-+    }
-+
-+    public static StripANSIConverter newInstance(Configuration config, String[] options) {
-+        if (options.length != 1) {
-+            LOGGER.error("Incorrect number of options on stripAnsi. Expected exactly 1, received " + options.length);
-+            return null;
-+        }
-+
-+        PatternParser parser = PatternLayout.createPatternParser(config);
-+        List<PatternFormatter> formatters = parser.parse(options[0]);
-+        return new StripANSIConverter(formatters);
-+    }
-+}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index 72161fef4ff8a469e028d136f71dda86e6220d0a..a6d6652fab0dcb490b4229cbf6a7a63112cbfa26 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java

--- a/patches/server/0155-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/patches/server/0155-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -15,18 +15,18 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ab46f9cb3bb94af0c418a5d39f2f63a6d3a0e07c..a06b75a78ab96229a6e9b97de913df9050325c04 100644
+index 1c0d6aff62f653044a402f5914bc558c70a3ca46..940754907384cf374e29ba31184a2cefa0ee1413 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -19,7 +19,7 @@ dependencies {
+@@ -24,7 +24,7 @@ dependencies {
            all its classes to check if they are plugins.
            Scanning takes about 1-2 seconds so adding this speeds up the server start.
       */
--    runtimeOnly("org.apache.logging.log4j:log4j-core:2.14.1")
-+    implementation("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - implementation
-     annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - Needed to generate meta for our Log4j plugins
+-    runtimeOnly("org.apache.logging.log4j:log4j-core:2.19.0")
++    implementation("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - implementation
+     log4jPlugins.annotationProcessorConfigurationName("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - Needed to generate meta for our Log4j plugins
+     runtimeOnly(log4jPlugins.output)
      // Paper end
-     implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
 index 0a0aa6de31a94a701074cc5f43c94be7515a185c..489ce6f439778b26eb33ede9432681d4bf9e0116 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java

--- a/patches/server/0155-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/patches/server/0155-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -15,10 +15,10 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 1c0d6aff62f653044a402f5914bc558c70a3ca46..940754907384cf374e29ba31184a2cefa0ee1413 100644
+index 4e682e084a7f653ccb90756bab884499861f9060..9013a7218ddf3919e5cddd745d03c73d1b6480ae 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -24,7 +24,7 @@ dependencies {
+@@ -25,7 +25,7 @@ dependencies {
            all its classes to check if they are plugins.
            Scanning takes about 1-2 seconds so adding this speeds up the server start.
       */
@@ -26,7 +26,7 @@ index 1c0d6aff62f653044a402f5914bc558c70a3ca46..940754907384cf374e29ba31184a2cef
 +    implementation("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - implementation
      log4jPlugins.annotationProcessorConfigurationName("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - Needed to generate meta for our Log4j plugins
      runtimeOnly(log4jPlugins.output)
-     // Paper end
+     alsoShade(log4jPlugins.output)
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
 index 0a0aa6de31a94a701074cc5f43c94be7515a185c..489ce6f439778b26eb33ede9432681d4bf9e0116 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java

--- a/patches/server/0219-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
+++ b/patches/server/0219-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use AsyncAppender to keep logging IO off main thread
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a06b75a78ab96229a6e9b97de913df9050325c04..d5602e9020ff233b93987140d143ff5d00154b1c 100644
+index 940754907384cf374e29ba31184a2cefa0ee1413..2826b2c593973d1f2518e71ad0c0623decace6e7 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -30,6 +30,7 @@ dependencies {
+@@ -36,6 +36,7 @@ dependencies {
      implementation("commons-lang:commons-lang:2.6")
      runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.33")

--- a/patches/server/0219-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
+++ b/patches/server/0219-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use AsyncAppender to keep logging IO off main thread
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 940754907384cf374e29ba31184a2cefa0ee1413..2826b2c593973d1f2518e71ad0c0623decace6e7 100644
+index 9013a7218ddf3919e5cddd745d03c73d1b6480ae..cfaa988f64c4b994b918e2f947c58dd8743a9dfb 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -36,6 +36,7 @@ dependencies {
+@@ -38,6 +38,7 @@ dependencies {
      implementation("commons-lang:commons-lang:2.6")
      runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.33")

--- a/patches/server/0295-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0295-Implement-Brigadier-Mojang-API.patch
@@ -10,10 +10,10 @@ Adds CommandRegisteredEvent
   - Allows manipulating the CommandNode to add more children/metadata for the client
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 2826b2c593973d1f2518e71ad0c0623decace6e7..8e04a8a59fa0d242a6ac37cb8fe4f997ec3b50dd 100644
+index cfaa988f64c4b994b918e2f947c58dd8743a9dfb..527e39bcd6aea7560b5d8ef37377c2f37da5c1ca 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -13,6 +13,7 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
+@@ -14,6 +14,7 @@ val alsoShade: Configuration by configurations.creating
  
  dependencies {
      implementation(project(":paper-api"))

--- a/patches/server/0295-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0295-Implement-Brigadier-Mojang-API.patch
@@ -10,10 +10,10 @@ Adds CommandRegisteredEvent
   - Allows manipulating the CommandNode to add more children/metadata for the client
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 41485437cdf438cfb837a9fcd276c2dd70b84b42..9617477e8ef0ef5b1af4733ce4e87ddd796a7be2 100644
+index 2826b2c593973d1f2518e71ad0c0623decace6e7..8e04a8a59fa0d242a6ac37cb8fe4f997ec3b50dd 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -8,6 +8,7 @@ plugins {
+@@ -13,6 +13,7 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
  
  dependencies {
      implementation(project(":paper-api"))
@@ -131,7 +131,7 @@ index b7f1569c662df13f278fc704cabec0400ba7c382..87ce129e1d592bcf68169feb559f44d5
  
              if (commandnode2.canUse(source)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ee150e432cb8ca69749dc20c8d2140c2b49bcdc2..0222181b0dddffc3b0e91dc53b5424317bb191c7 100644
+index 2b29f260c23121da1ab3a14b843f0500281b373b..b4eaa5142e70e9ba16f0386c10dae30b4a3da31b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -840,8 +840,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic

--- a/patches/server/0392-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0392-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index f339777554b5917f69170d1bc89ff14b89e8f1e3..24cc85285f221cee63eb6feb2aabc3e193d76dd7 100644
+index 8e04a8a59fa0d242a6ac37cb8fe4f997ec3b50dd..79d3f2398751fa6660c77b4bdce7425ba492a4e4 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -29,6 +29,7 @@ dependencies {
+@@ -35,6 +35,7 @@ dependencies {
      testImplementation("org.mockito:mockito-core:4.9.0") // Paper - switch to mockito
      implementation("org.spongepowered:configurate-yaml:4.1.2") // Paper - config files
      implementation("commons-lang:commons-lang:2.6")
@@ -17,7 +17,7 @@ index f339777554b5917f69170d1bc89ff14b89e8f1e3..24cc85285f221cee63eb6feb2aabc3e1
      runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
-@@ -108,6 +109,18 @@ tasks.check {
+@@ -114,6 +115,18 @@ tasks.check {
  }
  // Paper end
  
@@ -36,28 +36,17 @@ index f339777554b5917f69170d1bc89ff14b89e8f1e3..24cc85285f221cee63eb6feb2aabc3e1
  tasks.test {
      exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
  }
-diff --git a/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java b/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java
-index 0bb4aaa546939b67a5d22865190f30478a9337c1..d3e619655382e50e9ac9323ed942502d85c9599c 100644
---- a/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java
-+++ b/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java
-@@ -91,7 +91,7 @@ public class SyncLoadFinder {
- 
-                 final JsonArray traces = new JsonArray();
- 
--                for (StackTraceElement element : pair.getFirst().stacktrace) {
-+                for (StackTraceElement element : io.papermc.paper.util.StacktraceDeobfuscator.INSTANCE.deobfuscateStacktrace(pair.getFirst().stacktrace)) {
-                     traces.add(String.valueOf(element));
-                 }
- 
-diff --git a/src/main/java/io/papermc/paper/logging/StacktraceDeobfuscatingRewritePolicy.java b/src/main/java/io/papermc/paper/logging/StacktraceDeobfuscatingRewritePolicy.java
+diff --git a/src/log4jPlugins/java/io/papermc/paper/logging/StacktraceDeobfuscatingRewritePolicy.java b/src/log4jPlugins/java/io/papermc/paper/logging/StacktraceDeobfuscatingRewritePolicy.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c701ef3c287f62aa0ebfbdbd6da6ed82a1c7793c
+index 0000000000000000000000000000000000000000..66b6011ee3684695b2ab9292961c80bf2a420ee9
 --- /dev/null
-+++ b/src/main/java/io/papermc/paper/logging/StacktraceDeobfuscatingRewritePolicy.java
-@@ -0,0 +1,38 @@
++++ b/src/log4jPlugins/java/io/papermc/paper/logging/StacktraceDeobfuscatingRewritePolicy.java
+@@ -0,0 +1,66 @@
 +package io.papermc.paper.logging;
 +
-+import io.papermc.paper.util.StacktraceDeobfuscator;
++import java.lang.invoke.MethodHandle;
++import java.lang.invoke.MethodHandles;
++import java.lang.invoke.VarHandle;
 +import org.apache.logging.log4j.core.Core;
 +import org.apache.logging.log4j.core.LogEvent;
 +import org.apache.logging.log4j.core.appender.rewrite.RewritePolicy;
@@ -73,6 +62,22 @@ index 0000000000000000000000000000000000000000..c701ef3c287f62aa0ebfbdbd6da6ed82
 +    printObject = true
 +)
 +public final class StacktraceDeobfuscatingRewritePolicy implements RewritePolicy {
++    private static final MethodHandle DEOBFUSCATE_THROWABLE;
++
++    static {
++        try {
++            final Class<?> cls = Class.forName("io.papermc.paper.util.StacktraceDeobfuscator");
++            final MethodHandles.Lookup lookup = MethodHandles.lookup();
++            final VarHandle instanceHandle = lookup.findStaticVarHandle(cls, "INSTANCE", cls);
++            final Object deobfuscator = instanceHandle.get();
++            DEOBFUSCATE_THROWABLE = lookup
++                .unreflect(cls.getDeclaredMethod("deobfuscateThrowable", Throwable.class))
++                .bindTo(deobfuscator);
++        } catch (final ReflectiveOperationException ex) {
++            throw new IllegalStateException(ex);
++        }
++    }
++
 +    private StacktraceDeobfuscatingRewritePolicy() {
 +    }
 +
@@ -80,7 +85,7 @@ index 0000000000000000000000000000000000000000..c701ef3c287f62aa0ebfbdbd6da6ed82
 +    public @NonNull LogEvent rewrite(final @NonNull LogEvent rewrite) {
 +        final Throwable thrown = rewrite.getThrown();
 +        if (thrown != null) {
-+            StacktraceDeobfuscator.INSTANCE.deobfuscateThrowable(thrown);
++            deobfuscateThrowable(thrown);
 +            return new Log4jLogEvent.Builder(rewrite)
 +                .setThrownProxy(null)
 +                .build();
@@ -88,11 +93,34 @@ index 0000000000000000000000000000000000000000..c701ef3c287f62aa0ebfbdbd6da6ed82
 +        return rewrite;
 +    }
 +
++    private static void deobfuscateThrowable(final Throwable thrown) {
++        try {
++            DEOBFUSCATE_THROWABLE.invoke(thrown);
++        } catch (final Error e) {
++            throw e;
++        } catch (final Throwable e) {
++            throw new RuntimeException(e);
++        }
++    }
++
 +    @PluginFactory
 +    public static @NonNull StacktraceDeobfuscatingRewritePolicy createPolicy() {
 +        return new StacktraceDeobfuscatingRewritePolicy();
 +    }
 +}
+diff --git a/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java b/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java
+index 0bb4aaa546939b67a5d22865190f30478a9337c1..d3e619655382e50e9ac9323ed942502d85c9599c 100644
+--- a/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java
++++ b/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java
+@@ -91,7 +91,7 @@ public class SyncLoadFinder {
+ 
+                 final JsonArray traces = new JsonArray();
+ 
+-                for (StackTraceElement element : pair.getFirst().stacktrace) {
++                for (StackTraceElement element : io.papermc.paper.util.StacktraceDeobfuscator.INSTANCE.deobfuscateStacktrace(pair.getFirst().stacktrace)) {
+                     traces.add(String.valueOf(element));
+                 }
+ 
 diff --git a/src/main/java/io/papermc/paper/util/ObfHelper.java b/src/main/java/io/papermc/paper/util/ObfHelper.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..b8b17d046f836c8652ab094db00ab1af84971b2c

--- a/patches/server/0392-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0392-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 39ed80f37fcbaf037269847c0f9a1f9f1739c56e..db672c3e4b6af50bfe60c492c8b2de209a3f13bc 100644
+index 527e39bcd6aea7560b5d8ef37377c2f37da5c1ca..e2e7fe74095b83f2ac12f8054dd91b38ffcc32e7 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -35,6 +35,7 @@ dependencies {
+@@ -37,6 +37,7 @@ dependencies {
      testImplementation("org.mockito:mockito-core:4.9.0") // Paper - switch to mockito
      implementation("org.spongepowered:configurate-yaml:4.1.2") // Paper - config files
      implementation("commons-lang:commons-lang:2.6")
@@ -17,7 +17,7 @@ index 39ed80f37fcbaf037269847c0f9a1f9f1739c56e..db672c3e4b6af50bfe60c492c8b2de20
      runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
-@@ -119,6 +120,18 @@ tasks.check {
+@@ -121,6 +122,18 @@ tasks.check {
  }
  // Paper end
  

--- a/patches/server/0392-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0392-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 8e04a8a59fa0d242a6ac37cb8fe4f997ec3b50dd..79d3f2398751fa6660c77b4bdce7425ba492a4e4 100644
+index 39ed80f37fcbaf037269847c0f9a1f9f1739c56e..db672c3e4b6af50bfe60c492c8b2de209a3f13bc 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -35,6 +35,7 @@ dependencies {
@@ -17,7 +17,7 @@ index 8e04a8a59fa0d242a6ac37cb8fe4f997ec3b50dd..79d3f2398751fa6660c77b4bdce7425b
      runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
-@@ -114,6 +115,18 @@ tasks.check {
+@@ -119,6 +120,18 @@ tasks.check {
  }
  // Paper end
  

--- a/patches/server/0393-Implement-Mob-Goal-API.patch
+++ b/patches/server/0393-Implement-Mob-Goal-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 79d3f2398751fa6660c77b4bdce7425ba492a4e4..0795b304593ee7840ba6479f7edc30685a3ed3b9 100644
+index e2e7fe74095b83f2ac12f8054dd91b38ffcc32e7..dcfa0d630286e854474854add012138830aa389f 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -44,6 +44,7 @@ dependencies {
+@@ -46,6 +46,7 @@ dependencies {
      runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
      runtimeOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
  

--- a/patches/server/0393-Implement-Mob-Goal-API.patch
+++ b/patches/server/0393-Implement-Mob-Goal-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 24cc85285f221cee63eb6feb2aabc3e193d76dd7..e3e6318e0c83ae6f6ff699918ab0faff9f84c63d 100644
+index 79d3f2398751fa6660c77b4bdce7425ba492a4e4..0795b304593ee7840ba6479f7edc30685a3ed3b9 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -38,6 +38,7 @@ dependencies {
+@@ -44,6 +44,7 @@ dependencies {
      runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
      runtimeOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
  

--- a/patches/server/0648-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
+++ b/patches/server/0648-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
@@ -4,11 +4,11 @@ Date: Sat, 10 Jul 2021 11:12:30 +0200
 Subject: [PATCH] Rewrite LogEvents to contain the source jars in stack traces
 
 
-diff --git a/src/main/java/io/papermc/paper/logging/DelegateLogEvent.java b/src/main/java/io/papermc/paper/logging/DelegateLogEvent.java
+diff --git a/src/log4jPlugins/java/io/papermc/paper/logging/DelegateLogEvent.java b/src/log4jPlugins/java/io/papermc/paper/logging/DelegateLogEvent.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..6ffd1befe64c6c3036c22e05ed1c44808d64bd28
 --- /dev/null
-+++ b/src/main/java/io/papermc/paper/logging/DelegateLogEvent.java
++++ b/src/log4jPlugins/java/io/papermc/paper/logging/DelegateLogEvent.java
 @@ -0,0 +1,130 @@
 +package io.papermc.paper.logging;
 +
@@ -140,11 +140,11 @@ index 0000000000000000000000000000000000000000..6ffd1befe64c6c3036c22e05ed1c4480
 +        return this.original.getNanoTime();
 +    }
 +}
-diff --git a/src/main/java/io/papermc/paper/logging/ExtraClassInfoLogEvent.java b/src/main/java/io/papermc/paper/logging/ExtraClassInfoLogEvent.java
+diff --git a/src/log4jPlugins/java/io/papermc/paper/logging/ExtraClassInfoLogEvent.java b/src/log4jPlugins/java/io/papermc/paper/logging/ExtraClassInfoLogEvent.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..558427c65b4051923f73d15d85ee519be005060a
 --- /dev/null
-+++ b/src/main/java/io/papermc/paper/logging/ExtraClassInfoLogEvent.java
++++ b/src/log4jPlugins/java/io/papermc/paper/logging/ExtraClassInfoLogEvent.java
 @@ -0,0 +1,48 @@
 +package io.papermc.paper.logging;
 +
@@ -194,11 +194,11 @@ index 0000000000000000000000000000000000000000..558427c65b4051923f73d15d85ee519b
 +        }
 +    }
 +}
-diff --git a/src/main/java/io/papermc/paper/logging/ExtraClassInfoRewritePolicy.java b/src/main/java/io/papermc/paper/logging/ExtraClassInfoRewritePolicy.java
+diff --git a/src/log4jPlugins/java/io/papermc/paper/logging/ExtraClassInfoRewritePolicy.java b/src/log4jPlugins/java/io/papermc/paper/logging/ExtraClassInfoRewritePolicy.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..34734bb969a1a74c7a4f9c17d40ebf007ad5d701
 --- /dev/null
-+++ b/src/main/java/io/papermc/paper/logging/ExtraClassInfoRewritePolicy.java
++++ b/src/log4jPlugins/java/io/papermc/paper/logging/ExtraClassInfoRewritePolicy.java
 @@ -0,0 +1,29 @@
 +package io.papermc.paper.logging;
 +

--- a/patches/server/0709-Use-Velocity-compression-and-cipher-natives.patch
+++ b/patches/server/0709-Use-Velocity-compression-and-cipher-natives.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use Velocity compression and cipher natives
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 0795b304593ee7840ba6479f7edc30685a3ed3b9..ef5b87b994e0e330d732e6867a124b230e4a7d06 100644
+index dcfa0d630286e854474854add012138830aa389f..102955438ce339c403a5c0a7409bcf1894293c44 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -39,6 +39,11 @@ dependencies {
+@@ -41,6 +41,11 @@ dependencies {
      runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper

--- a/patches/server/0709-Use-Velocity-compression-and-cipher-natives.patch
+++ b/patches/server/0709-Use-Velocity-compression-and-cipher-natives.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use Velocity compression and cipher natives
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index e3e6318e0c83ae6f6ff699918ab0faff9f84c63d..5df3ca7173cf27eb01475b6dc2e5aad38cd5a324 100644
+index 0795b304593ee7840ba6479f7edc30685a3ed3b9..ef5b87b994e0e330d732e6867a124b230e4a7d06 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -33,6 +33,11 @@ dependencies {
+@@ -39,6 +39,11 @@ dependencies {
      runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.0")
      runtimeOnly("com.mysql:mysql-connector-j:8.0.33")
      runtimeOnly("com.lmax:disruptor:3.4.4") // Paper

--- a/patches/server/0826-Add-support-for-Proxy-Protocol.patch
+++ b/patches/server/0826-Add-support-for-Proxy-Protocol.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Add support for Proxy Protocol
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ef5b87b994e0e330d732e6867a124b230e4a7d06..6884f438320df020dc5c780d11d50339dc11294e 100644
+index 102955438ce339c403a5c0a7409bcf1894293c44..57f2c414dbfe127c193002fbc8eeb22e94e9cb55 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -28,6 +28,7 @@ dependencies {
-     implementation("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - implementation
+@@ -30,6 +30,7 @@ dependencies {
      log4jPlugins.annotationProcessorConfigurationName("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - Needed to generate meta for our Log4j plugins
      runtimeOnly(log4jPlugins.output)
+     alsoShade(log4jPlugins.output)
 +    implementation("io.netty:netty-codec-haproxy:4.1.87.Final") // Paper - Add support for proxy protocol
      // Paper end
      implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion

--- a/patches/server/0826-Add-support-for-Proxy-Protocol.patch
+++ b/patches/server/0826-Add-support-for-Proxy-Protocol.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Add support for Proxy Protocol
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 5df3ca7173cf27eb01475b6dc2e5aad38cd5a324..6d3d573ffc118e7f4d76422dc014a7df0384bb49 100644
+index ef5b87b994e0e330d732e6867a124b230e4a7d06..6884f438320df020dc5c780d11d50339dc11294e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -22,6 +22,7 @@ dependencies {
-      */
-     implementation("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - implementation
-     annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - Needed to generate meta for our Log4j plugins
+@@ -28,6 +28,7 @@ dependencies {
+     implementation("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - implementation
+     log4jPlugins.annotationProcessorConfigurationName("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - Needed to generate meta for our Log4j plugins
+     runtimeOnly(log4jPlugins.output)
 +    implementation("io.netty:netty-codec-haproxy:4.1.87.Final") // Paper - Add support for proxy protocol
      // Paper end
      implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion


### PR DESCRIPTION
The Log4j AP disables incremental compilation, this change limits the scope of that to what actually needs to be processed. Further changes are needed for incremental compilation to actually work, but this is a good first step, and running the l4j processor less is an improvement regardless.