### PR TITLE
[ci skip] add 'accepted' to Done project category

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -65,6 +65,7 @@ jobs:
           # include "status: needs triage" below to catch any closed issues without setting a resolution
           label-to-column-map: |
             {
+              "status: accepted": "Done",
               "status: needs triage": "Invalid",
               "resolution: works-as-intended": "Invalid",
               "resolution: invalid": "Invalid",


### PR DESCRIPTION
This second action only runs when a label modification happens on a closed issue, and if the accepted label is added after an issue is closed, it should be moved to the Done category rather than stay in the Invalid category.