### PR TITLE
[ci skip] Use Nullable annotation for Entity source

### DIFF
--- a/patches/api/0114-Expand-Explosions-API.patch
+++ b/patches/api/0114-Expand-Explosions-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 6693e3d8dc2519facb12db981a6b6325faa095bf..5a6b33c6d9a68affdbd02c13fdb0854e011e327d 100644
+index 6693e3d8dc2519facb12db981a6b6325faa095bf..b7ff09ffdd3aecc1843d175bc76fe5fae1f48dde 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -7,6 +7,7 @@ import java.util.HashMap;
@@ -17,10 +17,11 @@ index 6693e3d8dc2519facb12db981a6b6325faa095bf..5a6b33c6d9a68affdbd02c13fdb0854e
  import org.bukkit.util.NumberConversions;
  import org.bukkit.util.Vector;
  import org.jetbrains.annotations.NotNull;
-@@ -568,6 +569,87 @@ public class Location implements Cloneable, ConfigurationSerializable, io.paperm
+@@ -568,6 +569,89 @@ public class Location implements Cloneable, ConfigurationSerializable, io.paperm
          return centerLoc;
      }
  
++    // Paper start - Expand Explosions API
 +    /**
 +     * Creates explosion at this location with given power
 +     *
@@ -98,9 +99,10 @@ index 6693e3d8dc2519facb12db981a6b6325faa095bf..5a6b33c6d9a68affdbd02c13fdb0854e
 +     * @param breakBlocks Whether or not to have blocks be destroyed
 +     * @return false if explosion was canceled, otherwise true
 +     */
-+    public boolean createExplosion(@NotNull Entity source, float power, boolean setFire, boolean breakBlocks) {
++    public boolean createExplosion(@Nullable Entity source, float power, boolean setFire, boolean breakBlocks) {
 +        return this.getWorld().createExplosion(source, this, power, setFire, breakBlocks);
 +    }
++    // Paper end - Expand Explosions API
 +
      /**
       * Returns a list of entities within a bounding box centered around a Location.

--- a/patches/api/0175-Add-Heightmap-API.patch
+++ b/patches/api/0175-Add-Heightmap-API.patch
@@ -51,15 +51,14 @@ index 0000000000000000000000000000000000000000..1c832d69bb3717dcfccf21e45f6f060a
 +    SOLID_OR_LIQUID_NO_LEAVES;
 +}
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 2b9a117804a8ca54b47e51e23359bd6e01087641..1a60a18e15780128a1914826daa952ffacb92e9e 100644
+index f7564581c18425c903e54f949728dd3742ca7bf2..1bfe465b9aaeea7d3c871140145b7de1b8f1d93d 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
-@@ -640,6 +640,47 @@ public class Location implements Cloneable, ConfigurationSerializable, io.paperm
+@@ -640,6 +640,46 @@ public class Location implements Cloneable, ConfigurationSerializable, io.paperm
          return centerLoc;
      }
  
 +    // Paper start - Add heightmap api
-+
 +    /**
 +     * Returns a copy of this location except with y = getWorld().getHighestBlockYAt(this.getBlockX(), this.getBlockZ())
 +     * @return A copy of this location except with y = getWorld().getHighestBlockYAt(this.getBlockX(), this.getBlockZ())
@@ -97,11 +96,11 @@ index 2b9a117804a8ca54b47e51e23359bd6e01087641..1a60a18e15780128a1914826daa952ff
 +        ret.setY(this.getWorld().getHighestBlockYAt(this, heightMap));
 +        return ret;
 +    }
-+    // Paper end
++    // Paper end - Add heightmap api
 +
+     // Paper start - Expand Explosions API
      /**
       * Creates explosion at this location with given power
-      *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
 index 31fc272b0e82e4eef6d9bf01dd25d39513d354b3..0c5ce79c04e8193db248a221f519d80a944ef6ba 100644
 --- a/src/main/java/org/bukkit/World.java


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/9434

The Entity source parameter on World is marked as Nullable but the method on Location isn't