### PR TITLE
Fix breaking tripwires with shears

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -440,10 +440,10 @@ index 0000000000000000000000000000000000000000..9ef6712c70fcd8912a79f3f61e351aac
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5cfd0bd7c09aacd7313575e30cf0a171c597e2bd
+index 0000000000000000000000000000000000000000..fc513278f2e410551f70b11f95138f960941cb34
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,291 @@
+@@ -0,0 +1,294 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -597,6 +597,9 @@ index 0000000000000000000000000000000000000000..5cfd0bd7c09aacd7313575e30cf0a171
 +            ZLIB,
 +            NONE
 +        }
++
++        @Comment("This setting controls if shears should be able to leave behind disarmed tripwire.")
++        public boolean allowShearsDisarmedTripwire = false;
 +    }
 +
 +    public Commands commands;

--- a/patches/server/0019-Rewrite-chunk-system.patch
+++ b/patches/server/0019-Rewrite-chunk-system.patch
@@ -15687,7 +15687,7 @@ index 0000000000000000000000000000000000000000..962d3cae6340fc11607b59355e291629
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 5cfd0bd7c09aacd7313575e30cf0a171c597e2bd..115c44d6f064049270f1fae07683da1da974b08e 100644
+index fc513278f2e410551f70b11f95138f960941cb34..4274b43069d9aca4d6018b96e5446dcdd2eb225f 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 @@ -116,21 +116,6 @@ public class GlobalConfiguration extends ConfigurationPart {
@@ -15712,7 +15712,7 @@ index 5cfd0bd7c09aacd7313575e30cf0a171c597e2bd..115c44d6f064049270f1fae07683da1d
      public UnsupportedSettings unsupportedSettings;
  
      public class UnsupportedSettings extends ConfigurationPart {
-@@ -288,4 +273,43 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -291,4 +276,43 @@ public class GlobalConfiguration extends ConfigurationPart {
          public boolean disableNoteblockUpdates = false;
          public boolean disableTripwireUpdates = false;
      }
@@ -20638,7 +20638,7 @@ index ca788f0dcec4a117b410fe8348969e056b138b1e..a6ac76707da39cf86113003b1f326433
      public boolean remove(Object object) {
          int i = this.findIndex((T)object);
 diff --git a/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java b/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java
-index 12e72ad737b1219fcdf88d344d41621d9fd5feec..e0bfeebeaac1aaea64bc07cdfdf7790e3e43ca7b 100644
+index 495b52bfab14478f8285cc5471335a41244c199e..e16ef1b7c0bfe6d6194c09f6787a50fd9b28f55e 100644
 --- a/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java
 +++ b/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java
 @@ -186,7 +186,11 @@ public class WorldUpgrader {
@@ -22796,7 +22796,7 @@ index d01388bbadf3069357cf52463f4104a1be4d2b56..b3dfa35bc41191883814c78693a0d958
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cf87f197d860567746dcae2a15946fed0b1a1d85..3b1dbfe6f03e62ac9e12066d41516de157f99719 100644
+index f76db40188007b6ab475d259b4cbe0c7ef804677..49ca3592012cca981b96434c9807440672a8c165 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -195,6 +195,48 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0745-Fix-tripwire-state-inconsistency.patch
+++ b/patches/server/0745-Fix-tripwire-state-inconsistency.patch
@@ -1,67 +1,21 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Nassim Jahnke <nassim@njahnke.dev>
-Date: Sun, 19 Dec 2021 21:11:20 +0100
+From: DungeonDev <dungeondevtn@gmail.com>
+Date: Sun, 2 Jul 2023 02:34:54 +0100
 Subject: [PATCH] Fix tripwire state inconsistency
 
-This patch prevents updating and re-setting the tripwire when being removed in certain conditions
+Fixes MC-129055 and thereby infinite string duplication when breaking bugged string
 
-diff --git a/src/main/java/net/minecraft/world/level/block/TripWireBlock.java b/src/main/java/net/minecraft/world/level/block/TripWireBlock.java
-index 4e2fb4ee8e46b3c363992ff23e26f5a648c5f003..7f60175bf671d282c11e9084670d2bb900968255 100644
---- a/src/main/java/net/minecraft/world/level/block/TripWireBlock.java
-+++ b/src/main/java/net/minecraft/world/level/block/TripWireBlock.java
-@@ -74,7 +74,7 @@ public class TripWireBlock extends Block {
-     @Override
-     public void onRemove(BlockState state, Level world, BlockPos pos, BlockState newState, boolean moved) {
-         if (!moved && !state.is(newState.getBlock())) {
--            this.updateSource(world, pos, (BlockState) state.setValue(TripWireBlock.POWERED, true));
-+            this.updateSource(world, pos, (BlockState) state.setValue(TripWireBlock.POWERED, true), true); // Paper - fix state inconsistency
-         }
-     }
- 
-@@ -89,6 +89,12 @@ public class TripWireBlock extends Block {
-     }
- 
-     private void updateSource(Level world, BlockPos pos, BlockState state) {
-+        // Paper start - fix state inconsistency
-+        this.updateSource(world, pos, state, false);
-+    }
-+
-+    private void updateSource(Level world, BlockPos pos, BlockState state, boolean beingRemoved) {
-+        // Paper end
-         Direction[] aenumdirection = new Direction[]{Direction.SOUTH, Direction.WEST};
-         int i = aenumdirection.length;
-         int j = 0;
-@@ -104,7 +110,7 @@ public class TripWireBlock extends Block {
- 
-                     if (iblockdata1.is((Block) this.hook)) {
-                         if (iblockdata1.getValue(TripWireHookBlock.FACING) == enumdirection.getOpposite()) {
--                            this.hook.calculateState(world, blockposition1, iblockdata1, false, true, k, state);
-+                            this.hook.calculateState(world, blockposition1, iblockdata1, false, true, k, state, beingRemoved); // Paper - fix state inconsistency
-                         }
-                     } else if (iblockdata1.is((Block) this)) {
-                         ++k;
 diff --git a/src/main/java/net/minecraft/world/level/block/TripWireHookBlock.java b/src/main/java/net/minecraft/world/level/block/TripWireHookBlock.java
-index 4a516828e5c6abd63511ee7c93fcff11203cf8d0..004dce26ff073f1de52a84cd425c4f60fdab5e50 100644
+index 4a516828e5c6abd63511ee7c93fcff11203cf8d0..162174b386814eba4198cdc45070517626181853 100644
 --- a/src/main/java/net/minecraft/world/level/block/TripWireHookBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/TripWireHookBlock.java
-@@ -108,6 +108,12 @@ public class TripWireHookBlock extends Block {
-     }
+@@ -188,8 +188,8 @@ public class TripWireHookBlock extends Block {
+                 BlockState iblockdata4 = aiblockdata[l];
  
-     public void calculateState(Level world, BlockPos pos, BlockState state, boolean beingRemoved, boolean flag1, int i, @Nullable BlockState iblockdata1) {
-+        // Paper start - fix tripwire inconsistency
-+        this.calculateState(world, pos, state, beingRemoved, flag1, i, iblockdata1, false);
-+    }
-+
-+    public void calculateState(Level world, BlockPos pos, BlockState state, boolean beingRemoved, boolean flag1, int i, @Nullable BlockState iblockdata1, boolean tripWireBeingRemoved) {
-+        // Paper end
-         Direction enumdirection = (Direction) state.getValue(TripWireHookBlock.FACING);
-         boolean flag2 = (Boolean) state.getValue(TripWireHookBlock.ATTACHED);
-         boolean flag3 = (Boolean) state.getValue(TripWireHookBlock.POWERED);
-@@ -141,6 +147,7 @@ public class TripWireHookBlock extends Block {
-                 boolean flag7 = (Boolean) iblockdata2.getValue(TripWireBlock.POWERED);
- 
-                 flag5 |= flag6 && flag7;
-+                if (k != i || !tripWireBeingRemoved || !flag6) // Paper - don't update the tripwire again if being removed and not disarmed
-                 aiblockdata[k] = iblockdata2;
-                 if (k == i) {
-                     world.scheduleTick(pos, (Block) this, 10);
+                 if (iblockdata4 != null) {
++                    if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.allowShearsDisarmedTripwire || world.getBlockState(blockposition2).is(Blocks.TRIPWIRE)) { // Paper - Moved up, validate correct block instead of non-air.
+                     world.setBlock(blockposition2, (BlockState) iblockdata4.setValue(TripWireHookBlock.ATTACHED, flag4), 3);
+-                    if (!world.getBlockState(blockposition2).isAir()) {
+                         ;
+                     }
+                 }

--- a/patches/server/0867-Configurable-chat-thread-limit.patch
+++ b/patches/server/0867-Configurable-chat-thread-limit.patch
@@ -22,10 +22,10 @@ is actually processed, this is honestly really just exposed for the misnomers or
 who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
 
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 115c44d6f064049270f1fae07683da1da974b08e..d7f541d94941a341a70dfac025a3d3601dd1aca8 100644
+index 4274b43069d9aca4d6018b96e5446dcdd2eb225f..ba59c85cfb6fe9d237375a71698e3f80b6bbea3e 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -246,13 +246,26 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -249,13 +249,26 @@ public class GlobalConfiguration extends ConfigurationPart {
      public Misc misc;
  
      public class Misc extends ConfigurationPart {

--- a/patches/server/0977-Add-option-to-disable-block-updates.patch
+++ b/patches/server/0977-Add-option-to-disable-block-updates.patch
@@ -40,7 +40,7 @@ index 910864cfeac085648e6c671b0f9480417324d36e..e46d84750bdd7c940f400efda226e12a
              this.playNote(player, state, world, pos);
              player.awardStat(Stats.TUNE_NOTEBLOCK);
 diff --git a/src/main/java/net/minecraft/world/level/block/TripWireBlock.java b/src/main/java/net/minecraft/world/level/block/TripWireBlock.java
-index 7f60175bf671d282c11e9084670d2bb900968255..cb2ff8d94308c637a498d2737f86f6af4c9c1b83 100644
+index 4e2fb4ee8e46b3c363992ff23e26f5a648c5f003..7200ea0d3644824bbe207d68a2f5ce0429e18c21 100644
 --- a/src/main/java/net/minecraft/world/level/block/TripWireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/TripWireBlock.java
 @@ -53,6 +53,7 @@ public class TripWireBlock extends Block {
@@ -71,7 +71,7 @@ index 7f60175bf671d282c11e9084670d2bb900968255..cb2ff8d94308c637a498d2737f86f6af
      public void onRemove(BlockState state, Level world, BlockPos pos, BlockState newState, boolean moved) {
 +        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent adjacent tripwires from updating
          if (!moved && !state.is(newState.getBlock())) {
-             this.updateSource(world, pos, (BlockState) state.setValue(TripWireBlock.POWERED, true), true); // Paper - fix state inconsistency
+             this.updateSource(world, pos, (BlockState) state.setValue(TripWireBlock.POWERED, true));
          }
 @@ -80,6 +84,7 @@ public class TripWireBlock extends Block {
  
@@ -86,10 +86,10 @@ index 7f60175bf671d282c11e9084670d2bb900968255..cb2ff8d94308c637a498d2737f86f6af
  
      private void updateSource(Level world, BlockPos pos, BlockState state) {
 +        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableTripwireUpdates) return; // Paper - prevent adjacent tripwires from updating
-         // Paper start - fix state inconsistency
-         this.updateSource(world, pos, state, false);
-     }
-@@ -127,6 +133,7 @@ public class TripWireBlock extends Block {
+         Direction[] aenumdirection = new Direction[]{Direction.SOUTH, Direction.WEST};
+         int i = aenumdirection.length;
+         int j = 0;
+@@ -121,6 +127,7 @@ public class TripWireBlock extends Block {
  
      @Override
      public void entityInside(BlockState state, Level world, BlockPos pos, Entity entity) {
@@ -97,7 +97,7 @@ index 7f60175bf671d282c11e9084670d2bb900968255..cb2ff8d94308c637a498d2737f86f6af
          if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(world, pos)).callEvent()) { return; } // Paper
          if (!world.isClientSide) {
              if (!(Boolean) state.getValue(TripWireBlock.POWERED)) {
-@@ -137,6 +144,7 @@ public class TripWireBlock extends Block {
+@@ -131,6 +138,7 @@ public class TripWireBlock extends Block {
  
      @Override
      public void tick(BlockState state, ServerLevel world, BlockPos pos, RandomSource random) {


### PR DESCRIPTION
A bug in vanilla causes tripwires broken by shears to go into a weird state, see https://bugs.mojang.com/browse/MC-129055
In this state, destroying the tripwire will not work, it will instead disconnect from tripwire hooks for 10 ticks before connecting again. Destroying the tripwire during this 10 tick window will actually destroy the tripwire.

Abusing this, and using water to repeatedly destroy the tripwire, an infinite amount of string can be easily duplicated in a fast manner, as the tripwire will drop one string when "destroyed" by water.

It seems tripwire in this bugged state was previously accepted as a feature, see #7259 and #7261
This PR fixes the issue by moving a line of code down one line into an empty if-statement by Mojang...
If bugged "disarmed" tripwire is something we'd like to keep around, a more thorough solution is needed, as the current "unbreakable" behavior is quite unintuitive.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9436.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/861343771.zip)