### PR TITLE
Add option to disable chorus plant and mushroom block updates

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -440,10 +440,10 @@ index 0000000000000000000000000000000000000000..9ef6712c70fcd8912a79f3f61e351aac
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5cfd0bd7c09aacd7313575e30cf0a171c597e2bd
+index 0000000000000000000000000000000000000000..269d646dab4c87910392d9ebd08c50d5fd42476b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,291 @@
+@@ -0,0 +1,285 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -733,6 +733,8 @@ index 0000000000000000000000000000000000000000..5cfd0bd7c09aacd7313575e30cf0a171
 +    public class BlockUpdates extends ConfigurationPart {
 +        public boolean disableNoteblockUpdates = false;
 +        public boolean disableTripwireUpdates = false;
++        public boolean disableChorusPlantUpdates = false;
++        public boolean disableMushroomBlockUpdates = false;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java b/src/main/java/io/papermc/paper/configuration/InnerClassFieldDiscoverer.java

--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -440,10 +440,10 @@ index 0000000000000000000000000000000000000000..9ef6712c70fcd8912a79f3f61e351aac
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..269d646dab4c87910392d9ebd08c50d5fd42476b
+index 0000000000000000000000000000000000000000..0083b66889bfb6d3c4e4219fc73f410477109e37
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,285 @@
+@@ -0,0 +1,293 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;

--- a/patches/server/0019-Rewrite-chunk-system.patch
+++ b/patches/server/0019-Rewrite-chunk-system.patch
@@ -15686,7 +15686,7 @@ index 0000000000000000000000000000000000000000..962d3cae6340fc11607b59355e291629
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 5cfd0bd7c09aacd7313575e30cf0a171c597e2bd..115c44d6f064049270f1fae07683da1da974b08e 100644
+index 269d646dab4c87910392d9ebd08c50d5fd42476b..b7289cf05270c316a3ec069ef0f5e1cf35a61736 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 @@ -116,21 +116,6 @@ public class GlobalConfiguration extends ConfigurationPart {
@@ -15711,9 +15711,9 @@ index 5cfd0bd7c09aacd7313575e30cf0a171c597e2bd..115c44d6f064049270f1fae07683da1d
      public UnsupportedSettings unsupportedSettings;
  
      public class UnsupportedSettings extends ConfigurationPart {
-@@ -288,4 +273,43 @@ public class GlobalConfiguration extends ConfigurationPart {
-         public boolean disableNoteblockUpdates = false;
-         public boolean disableTripwireUpdates = false;
+@@ -282,4 +267,43 @@ public class GlobalConfiguration extends ConfigurationPart {
+         public boolean disableChorusPlantUpdates = false;
+         public boolean disableMushroomBlockUpdates = false;
      }
 +
 +    public ChunkLoadingBasic chunkLoadingBasic;

--- a/patches/server/0019-Rewrite-chunk-system.patch
+++ b/patches/server/0019-Rewrite-chunk-system.patch
@@ -15686,34 +15686,12 @@ index 0000000000000000000000000000000000000000..962d3cae6340fc11607b59355e291629
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 269d646dab4c87910392d9ebd08c50d5fd42476b..b7289cf05270c316a3ec069ef0f5e1cf35a61736 100644
+index 0083b66889bfb6d3c4e4219fc73f410477109e37..499b7e84a42517c9a82e27e425a8aefd9ad614ee 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -116,21 +116,6 @@ public class GlobalConfiguration extends ConfigurationPart {
-         public int incomingPacketThreshold = 300;
-     }
- 
--    public ChunkLoading chunkLoading;
--
--    public class ChunkLoading extends ConfigurationPart {
--        public int minLoadRadius = 2;
--        public int maxConcurrentSends = 2;
--        public boolean autoconfigSendDistance = true;
--        public double targetPlayerChunkSendRate = 100.0;
--        public double globalMaxChunkSendRate = -1.0;
--        public boolean enableFrustumPriority = false;
--        public double globalMaxChunkLoadRate = -1.0;
--        public double playerMaxConcurrentLoads = 20.0;
--        public double globalMaxConcurrentLoads = 500.0;
--        public double playerMaxChunkLoadRate = -1.0;
--    }
--
-     public UnsupportedSettings unsupportedSettings;
- 
-     public class UnsupportedSettings extends ConfigurationPart {
-@@ -282,4 +267,43 @@ public class GlobalConfiguration extends ConfigurationPart {
-         public boolean disableChorusPlantUpdates = false;
-         public boolean disableMushroomBlockUpdates = false;
+@@ -24,6 +24,45 @@ public class GlobalConfiguration extends ConfigurationPart {
+     public static GlobalConfiguration get() {
+         return instance;
      }
 +
 +    public ChunkLoadingBasic chunkLoadingBasic;
@@ -15754,7 +15732,31 @@ index 269d646dab4c87910392d9ebd08c50d5fd42476b..b7289cf05270c316a3ec069ef0f5e1cf
 +        )
 +        public int playerMaxConcurrentChunkGenerates = 0;
 +    }
- }
+     static void set(GlobalConfiguration instance) {
+         GlobalConfiguration.instance = instance;
+     }
+@@ -116,21 +155,6 @@ public class GlobalConfiguration extends ConfigurationPart {
+         public int incomingPacketThreshold = 300;
+     }
+ 
+-    public ChunkLoading chunkLoading;
+-
+-    public class ChunkLoading extends ConfigurationPart {
+-        public int minLoadRadius = 2;
+-        public int maxConcurrentSends = 2;
+-        public boolean autoconfigSendDistance = true;
+-        public double targetPlayerChunkSendRate = 100.0;
+-        public double globalMaxChunkSendRate = -1.0;
+-        public boolean enableFrustumPriority = false;
+-        public double globalMaxChunkLoadRate = -1.0;
+-        public double playerMaxConcurrentLoads = 20.0;
+-        public double globalMaxConcurrentLoads = 500.0;
+-        public double playerMaxChunkLoadRate = -1.0;
+-    }
+-
+     public UnsupportedSettings unsupportedSettings;
+ 
+     public class UnsupportedSettings extends ConfigurationPart {
 diff --git a/src/main/java/io/papermc/paper/threadedregions/TickRegions.java b/src/main/java/io/papermc/paper/threadedregions/TickRegions.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..d5d39e9c1f326e91010237b0db80d527ac52f4d6
@@ -15846,7 +15848,7 @@ index cea9c098ade00ee87b8efc8164ab72f5279758f0..197224e31175252d8438a8df585bbb65
 +    }
  }
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
-index 7afb13b7457755fac3aed4b0260413a280ed29e6..5e17a83df2f3606aff375fe054266d03f9a0b3b6 100644
+index 9572294a50110f2452090da1f32e0a73edc3db05..dc2ab968ed010289125ac08f0a9ea85af6f6e8bb 100644
 --- a/src/main/java/io/papermc/paper/util/MCUtil.java
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
 @@ -4,17 +4,30 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;

--- a/patches/server/0866-Configurable-chat-thread-limit.patch
+++ b/patches/server/0866-Configurable-chat-thread-limit.patch
@@ -22,10 +22,10 @@ is actually processed, this is honestly really just exposed for the misnomers or
 who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
 
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 115c44d6f064049270f1fae07683da1da974b08e..d7f541d94941a341a70dfac025a3d3601dd1aca8 100644
+index 499b7e84a42517c9a82e27e425a8aefd9ad614ee..d225c35b8a91296d007b92d112639ff76948391e 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -246,13 +246,26 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -285,13 +285,26 @@ public class GlobalConfiguration extends ConfigurationPart {
      public Misc misc;
  
      public class Misc extends ConfigurationPart {

--- a/patches/server/0976-Add-option-to-disable-block-updates.patch
+++ b/patches/server/0976-Add-option-to-disable-block-updates.patch
@@ -4,6 +4,74 @@ Date: Sun, 18 Jun 2023 17:45:33 +0200
 Subject: [PATCH] Add option to disable block updates
 
 
+diff --git a/src/main/java/net/minecraft/world/level/block/ChorusPlantBlock.java b/src/main/java/net/minecraft/world/level/block/ChorusPlantBlock.java
+index a6c25647fb37f59307de0d390f8e8cf55504d7d3..2e8bf4463b8da8da50cd14d3f84aba5e930e5710 100644
+--- a/src/main/java/net/minecraft/world/level/block/ChorusPlantBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/ChorusPlantBlock.java
+@@ -21,6 +21,7 @@ public class ChorusPlantBlock extends PipeBlock {
+ 
+     @Override
+     public BlockState getStateForPlacement(BlockPlaceContext ctx) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableChorusPlantUpdates) return this.defaultBlockState(); // Paper - add option to disable block updates
+         return this.getStateForPlacement(ctx.getLevel(), ctx.getClickedPos());
+     }
+ 
+@@ -36,6 +37,7 @@ public class ChorusPlantBlock extends PipeBlock {
+ 
+     @Override
+     public BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor world, BlockPos pos, BlockPos neighborPos) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableChorusPlantUpdates) return state; // Paper - add option to disable block updates
+         if (!state.canSurvive(world, pos)) {
+             world.scheduleTick(pos, this, 1);
+             return super.updateShape(state, direction, neighborState, world, pos, neighborPos);
+@@ -47,6 +49,7 @@ public class ChorusPlantBlock extends PipeBlock {
+ 
+     @Override
+     public void tick(BlockState state, ServerLevel world, BlockPos pos, RandomSource random) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableChorusPlantUpdates) return; // Paper - add option to disable block updates
+         if (!state.canSurvive(world, pos)) {
+             world.destroyBlock(pos, true);
+         }
+@@ -55,6 +58,7 @@ public class ChorusPlantBlock extends PipeBlock {
+ 
+     @Override
+     public boolean canSurvive(BlockState state, LevelReader world, BlockPos pos) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableChorusPlantUpdates) return true; // Paper - add option to disable block updates
+         BlockState blockState = world.getBlockState(pos.below());
+         boolean bl = !world.getBlockState(pos.above()).isAir() && !blockState.isAir();
+ 
+diff --git a/src/main/java/net/minecraft/world/level/block/HugeMushroomBlock.java b/src/main/java/net/minecraft/world/level/block/HugeMushroomBlock.java
+index 3c6d97b51c6fec130b80e5965afa2c49d48843c9..1dd44eb0ab977093660e8fe6f49338e7f5ef7b28 100644
+--- a/src/main/java/net/minecraft/world/level/block/HugeMushroomBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/HugeMushroomBlock.java
+@@ -27,6 +27,7 @@ public class HugeMushroomBlock extends Block {
+ 
+     @Override
+     public BlockState getStateForPlacement(BlockPlaceContext ctx) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableMushroomBlockUpdates) return this.defaultBlockState(); // Paper - add option to disable block updates
+         BlockGetter blockGetter = ctx.getLevel();
+         BlockPos blockPos = ctx.getClickedPos();
+         return this.defaultBlockState().setValue(DOWN, Boolean.valueOf(!blockGetter.getBlockState(blockPos.below()).is(this))).setValue(UP, Boolean.valueOf(!blockGetter.getBlockState(blockPos.above()).is(this))).setValue(NORTH, Boolean.valueOf(!blockGetter.getBlockState(blockPos.north()).is(this))).setValue(EAST, Boolean.valueOf(!blockGetter.getBlockState(blockPos.east()).is(this))).setValue(SOUTH, Boolean.valueOf(!blockGetter.getBlockState(blockPos.south()).is(this))).setValue(WEST, Boolean.valueOf(!blockGetter.getBlockState(blockPos.west()).is(this)));
+@@ -34,16 +35,19 @@ public class HugeMushroomBlock extends Block {
+ 
+     @Override
+     public BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor world, BlockPos pos, BlockPos neighborPos) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableMushroomBlockUpdates) return state; // Paper - add option to disable block updates
+         return neighborState.is(this) ? state.setValue(PROPERTY_BY_DIRECTION.get(direction), Boolean.valueOf(false)) : super.updateShape(state, direction, neighborState, world, pos, neighborPos);
+     }
+ 
+     @Override
+     public BlockState rotate(BlockState state, Rotation rotation) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableMushroomBlockUpdates) return state; // Paper - add option to disable block updates
+         return state.setValue(PROPERTY_BY_DIRECTION.get(rotation.rotate(Direction.NORTH)), state.getValue(NORTH)).setValue(PROPERTY_BY_DIRECTION.get(rotation.rotate(Direction.SOUTH)), state.getValue(SOUTH)).setValue(PROPERTY_BY_DIRECTION.get(rotation.rotate(Direction.EAST)), state.getValue(EAST)).setValue(PROPERTY_BY_DIRECTION.get(rotation.rotate(Direction.WEST)), state.getValue(WEST)).setValue(PROPERTY_BY_DIRECTION.get(rotation.rotate(Direction.UP)), state.getValue(UP)).setValue(PROPERTY_BY_DIRECTION.get(rotation.rotate(Direction.DOWN)), state.getValue(DOWN));
+     }
+ 
+     @Override
+     public BlockState mirror(BlockState state, Mirror mirror) {
++        if (io.papermc.paper.configuration.GlobalConfiguration.get().blockUpdates.disableMushroomBlockUpdates) return state; // Paper - add option to disable block updates
+         return state.setValue(PROPERTY_BY_DIRECTION.get(mirror.mirror(Direction.NORTH)), state.getValue(NORTH)).setValue(PROPERTY_BY_DIRECTION.get(mirror.mirror(Direction.SOUTH)), state.getValue(SOUTH)).setValue(PROPERTY_BY_DIRECTION.get(mirror.mirror(Direction.EAST)), state.getValue(EAST)).setValue(PROPERTY_BY_DIRECTION.get(mirror.mirror(Direction.WEST)), state.getValue(WEST)).setValue(PROPERTY_BY_DIRECTION.get(mirror.mirror(Direction.UP)), state.getValue(UP)).setValue(PROPERTY_BY_DIRECTION.get(mirror.mirror(Direction.DOWN)), state.getValue(DOWN));
+     }
+ 
 diff --git a/src/main/java/net/minecraft/world/level/block/NoteBlock.java b/src/main/java/net/minecraft/world/level/block/NoteBlock.java
 index 910864cfeac085648e6c671b0f9480417324d36e..e46d84750bdd7c940f400efda226e12a3fdc3848 100644
 --- a/src/main/java/net/minecraft/world/level/block/NoteBlock.java


### PR DESCRIPTION
Added option to disable chorus plant and mushroom block updates. These blocks are very useful in plugins that are adding custom blocks through resourcepack.

Video: https://youtu.be/yef93ZCbxM4