### PR TITLE
Fix ThrownEggHatchEvent#setHatching

### DIFF
--- a/patches/server/0348-Add-ThrownEggHatchEvent.patch
+++ b/patches/server/0348-Add-ThrownEggHatchEvent.patch
@@ -7,10 +7,10 @@ Adds a new event similar to PlayerEggThrowEvent, but without the Player requirem
 (dispensers can throw eggs to hatch them, too).
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java
-index 88e8ce770ddc61702fc87cd8dcee498183dc1032..4aca131fe774c54b5cc274000d825687a1373b3f 100644
+index 88e8ce770ddc61702fc87cd8dcee498183dc1032..97e6d07db5b0c5c4710605cc0fee8468583d109b 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java
-@@ -82,6 +82,12 @@ public class ThrownEgg extends ThrowableItemProjectile {
+@@ -82,6 +82,17 @@ public class ThrownEgg extends ThrowableItemProjectile {
                      }
                  }
                  // CraftBukkit end
@@ -18,7 +18,12 @@ index 88e8ce770ddc61702fc87cd8dcee498183dc1032..4aca131fe774c54b5cc274000d825687
 +                com.destroystokyo.paper.event.entity.ThrownEggHatchEvent event = new com.destroystokyo.paper.event.entity.ThrownEggHatchEvent((org.bukkit.entity.Egg) getBukkitEntity(), hatching, b0, hatchingType);
 +                event.callEvent();
 +                b0 = event.getNumHatches();
++                hatching = event.isHatching();
 +                hatchingType = event.getHatchingType();
++                // If hatching is set to false, ensure child count is 0
++                if (!hatching) {
++                    b0 = 0;
++                }
 +                // Paper end
  
                  for (int i = 0; i < b0; ++i) {

--- a/patches/server/0348-Add-ThrownEggHatchEvent.patch
+++ b/patches/server/0348-Add-ThrownEggHatchEvent.patch
@@ -7,23 +7,19 @@ Adds a new event similar to PlayerEggThrowEvent, but without the Player requirem
 (dispensers can throw eggs to hatch them, too).
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java
-index 88e8ce770ddc61702fc87cd8dcee498183dc1032..97e6d07db5b0c5c4710605cc0fee8468583d109b 100644
+index 88e8ce770ddc61702fc87cd8dcee498183dc1032..588e5ac6fc9b2d12be3bb80bc3fe50d81470c441 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownEgg.java
-@@ -82,6 +82,17 @@ public class ThrownEgg extends ThrowableItemProjectile {
+@@ -82,6 +82,13 @@ public class ThrownEgg extends ThrowableItemProjectile {
                      }
                  }
                  // CraftBukkit end
 +                // Paper start
 +                com.destroystokyo.paper.event.entity.ThrownEggHatchEvent event = new com.destroystokyo.paper.event.entity.ThrownEggHatchEvent((org.bukkit.entity.Egg) getBukkitEntity(), hatching, b0, hatchingType);
 +                event.callEvent();
-+                b0 = event.getNumHatches();
 +                hatching = event.isHatching();
++                b0 = hatching ? event.getNumHatches() : 0; // If hatching is set to false, ensure child count is 0
 +                hatchingType = event.getHatchingType();
-+                // If hatching is set to false, ensure child count is 0
-+                if (!hatching) {
-+                    b0 = 0;
-+                }
 +                // Paper end
  
                  for (int i = 0; i < b0; ++i) {


### PR DESCRIPTION
When a plugin change the hatching boolean in the event without changing the number of mobs the boolean will be ignored.
The recent upstream update removed that diff.