### PR TITLE
Fix BanList API

### DIFF
--- a/patches/api/0421-Fix-BanList-API.patch
+++ b/patches/api/0421-Fix-BanList-API.patch
@@ -1,0 +1,113 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 4 Jul 2023 11:27:18 -0700
+Subject: [PATCH] Fix BanList API
+
+
+diff --git a/src/main/java/org/bukkit/BanList.java b/src/main/java/org/bukkit/BanList.java
+index c229d3bc37c4e454a4b5a93eda1fe6466a4f4e8b..adeff14586351edad412a85a5797c28a43aaa9de 100644
+--- a/src/main/java/org/bukkit/BanList.java
++++ b/src/main/java/org/bukkit/BanList.java
+@@ -46,7 +46,7 @@ public interface BanList<T> {
+      */
+     @Deprecated
+     @Nullable
+-    public BanEntry<T> getBanEntry(@NotNull String target);
++    public <E extends BanEntry<? super T>> E getBanEntry(@NotNull String target); // Paper
+ 
+     /**
+      * Gets a {@link BanEntry} by target.
+@@ -75,7 +75,7 @@ public interface BanList<T> {
+      */
+     @Deprecated
+     @Nullable
+-    public BanEntry<T> addBan(@NotNull String target, @Nullable String reason, @Nullable Date expires, @Nullable String source);
++    public <E extends BanEntry<? super T>> E addBan(@NotNull String target, @Nullable String reason, @Nullable Date expires, @Nullable String source); // Paper
+ 
+     /**
+      * Adds a ban to this list. If a previous ban exists, this will
+@@ -108,7 +108,7 @@ public interface BanList<T> {
+      * @return an immutable set containing every entry tracked by this list
+      */
+     @NotNull
+-    public Set<BanEntry<T>> getEntries();
++    public <E extends BanEntry<? super T>> Set<E> getEntries(); // Paper
+ 
+     /**
+      * Gets if a {@link BanEntry} exists for the target, indicating an active
+diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
+index 4d014215dce2c2ff09a2701accf2db144603c55a..08ae501e97ae2a3f22b1994c9616fc7134cfc0c3 100644
+--- a/src/main/java/org/bukkit/OfflinePlayer.java
++++ b/src/main/java/org/bukkit/OfflinePlayer.java
+@@ -133,7 +133,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+      *     (updated) previous ban
+      */
+     @Nullable
+-    public BanEntry<PlayerProfile> ban(@Nullable String reason, @Nullable Date expires, @Nullable String source);
++    public <E extends BanEntry<? super com.destroystokyo.paper.profile.PlayerProfile>> E ban(@Nullable String reason, @Nullable Date expires, @Nullable String source);
+ 
+     /**
+      * Checks if this player is whitelisted or not
+diff --git a/src/main/java/org/bukkit/ban/ProfileBanList.java b/src/main/java/org/bukkit/ban/ProfileBanList.java
+index e805e629cede1c4c0674282c930cb67852718c3e..429b6e3730118660585c84319ef09e2e5bb32fd5 100644
+--- a/src/main/java/org/bukkit/ban/ProfileBanList.java
++++ b/src/main/java/org/bukkit/ban/ProfileBanList.java
+@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
+ /**
+  * A {@link BanList} targeting player profile bans.
+  */
+-public interface ProfileBanList extends BanList<PlayerProfile> {
++public interface ProfileBanList extends BanList<com.destroystokyo.paper.profile.PlayerProfile> { // Paper
+ 
+     /**
+      * {@inheritDoc}
+@@ -23,8 +23,35 @@ public interface ProfileBanList extends BanList<PlayerProfile> {
+      * @return the entry for the newly created ban, or the entry for the
+      *     (updated) previous ban
+      * @throws IllegalArgumentException if ProfilePlayer has an invalid UUID
++     * @deprecated use {@link #addBan(com.destroystokyo.paper.profile.PlayerProfile, String, Date, String)}
+      */
+     @Nullable
+-    public BanEntry<PlayerProfile> addBan(@NotNull PlayerProfile target, @Nullable String reason, @Nullable Date expires, @Nullable String source);
++    // Paper start
++    @Deprecated
++    public <E extends BanEntry<? super com.destroystokyo.paper.profile.PlayerProfile>> E addBan(@NotNull PlayerProfile target, @Nullable String reason, @Nullable Date expires, @Nullable String source);
+ 
++    /**
++     * @throws IllegalArgumentException if ProfilePlayer has an invalid UUID
++     */
++    @Nullable BanEntry<com.destroystokyo.paper.profile.PlayerProfile> addBan(com.destroystokyo.paper.profile.@NotNull PlayerProfile target, @Nullable String reason, @Nullable Date expires, @Nullable String source);
++
++    // the 3 methods below are added to maintain compat for the PlayerProfile parameter type
++    /**
++     * @deprecated use {@link #getBanEntry(Object)}
++     */
++    @Deprecated
++    @Nullable <E extends BanEntry<? super com.destroystokyo.paper.profile.PlayerProfile>> E getBanEntry(@NotNull PlayerProfile target);
++
++    /**
++     * @deprecated use {@link #isBanned(Object)}
++     */
++    @Deprecated
++    boolean isBanned(@NotNull PlayerProfile target);
++
++    /**
++     * @deprecated use {@link #pardon(Object)}
++     */
++    @Deprecated
++    void pardon(@NotNull PlayerProfile target);
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index d0297f47f18cabf857cf4ce04c529b46525c0f75..06b2b925de745850816d9ce0cf6316412c8d2b49 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -296,7 +296,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      *     (updated) previous ban
+      */
+     @Nullable
+-    public BanEntry<PlayerProfile> ban(@Nullable String reason, @Nullable Date expires, @Nullable String source, boolean kickPlayer);
++    public <E extends BanEntry<? super com.destroystokyo.paper.profile.PlayerProfile>> E ban(@Nullable String reason, @Nullable Date expires, @Nullable String source, boolean kickPlayer); // Paper
+ 
+     /**
+      * Adds this user's current IP address to the {@link IpBanList}. If a previous ban exists, this will

--- a/patches/server/0986-Fix-BanList-API.patch
+++ b/patches/server/0986-Fix-BanList-API.patch
@@ -1,0 +1,288 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 4 Jul 2023 11:27:10 -0700
+Subject: [PATCH] Fix BanList API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+index 2856b861a1207ef94ae5671c5898f08fedd14475..0857c22236080df80d06e2c50eb43c9e05cc8d24 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+@@ -112,7 +112,7 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
+     }
+ 
+     @Override
+-    public BanEntry<PlayerProfile> ban(String reason, Date expires, String source) {
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> ban(String reason, Date expires, String source) { // Paper
+         return ((ProfileBanList) this.server.getBanList(BanList.Type.PROFILE)).addBan(this.getPlayerProfile(), reason, expires, source);
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/ban/CraftProfileBanEntry.java b/src/main/java/org/bukkit/craftbukkit/ban/CraftProfileBanEntry.java
+index 13e5e44b069121e51b9486c445902937f1d6c6d8..4a37c8172b42b10472bb90c9310c7ae3eeaa3481 100644
+--- a/src/main/java/org/bukkit/craftbukkit/ban/CraftProfileBanEntry.java
++++ b/src/main/java/org/bukkit/craftbukkit/ban/CraftProfileBanEntry.java
+@@ -9,7 +9,7 @@ import org.bukkit.BanEntry;
+ import org.bukkit.craftbukkit.profile.CraftPlayerProfile;
+ import org.bukkit.profile.PlayerProfile;
+ 
+-public final class CraftProfileBanEntry implements BanEntry<PlayerProfile> {
++public final class CraftProfileBanEntry implements BanEntry<com.destroystokyo.paper.profile.PlayerProfile> { // Paper
+     private static final Date minorDate = Date.from(Instant.parse("1899-12-31T04:00:00Z"));
+     private final UserBanList list;
+     private final GameProfile profile;
+@@ -33,8 +33,8 @@ public final class CraftProfileBanEntry implements BanEntry<PlayerProfile> {
+     }
+ 
+     @Override
+-    public PlayerProfile getBanTarget() {
+-        return new CraftPlayerProfile(this.profile);
++    public com.destroystokyo.paper.profile.PlayerProfile getBanTarget() { // Paper
++        return new com.destroystokyo.paper.profile.CraftPlayerProfile(this.profile); // Paper
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/ban/CraftProfileBanList.java b/src/main/java/org/bukkit/craftbukkit/ban/CraftProfileBanList.java
+index b143b6a43da875caf938865a062e2f30019f7788..6b479a11cb15b7d1d468b2ea1eff547b9e5661de 100644
+--- a/src/main/java/org/bukkit/craftbukkit/ban/CraftProfileBanList.java
++++ b/src/main/java/org/bukkit/craftbukkit/ban/CraftProfileBanList.java
+@@ -22,32 +22,58 @@ public class CraftProfileBanList implements ProfileBanList {
+     }
+ 
+     @Override
+-    public BanEntry<PlayerProfile> getBanEntry(String target) {
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> getBanEntry(String target) { // Paper
+         Preconditions.checkArgument(target != null, "Target cannot be null");
+ 
+         return this.getBanEntry(CraftProfileBanList.getProfile(target));
+     }
+ 
+     @Override
+-    public BanEntry<PlayerProfile> getBanEntry(PlayerProfile target) {
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> getBanEntry(PlayerProfile target) { // Paper
+         Preconditions.checkArgument(target != null, "Target cannot be null");
+ 
+-        return this.getBanEntry(((CraftPlayerProfile) target).buildGameProfile());
++        return this.getBanEntry(((com.destroystokyo.paper.profile.SharedPlayerProfile) target).buildGameProfile()); // Paper
++    }
++    // Paper start
++    @Override
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> getBanEntry(final com.destroystokyo.paper.profile.PlayerProfile target) {
++        Preconditions.checkArgument(target != null, "target cannot be null");
++
++        return this.getBanEntry(((com.destroystokyo.paper.profile.SharedPlayerProfile) target).buildGameProfile());
++    }
++
++    @Override
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> addBan(final com.destroystokyo.paper.profile.PlayerProfile target, final String reason, final Date expires, final String source) {
++        Preconditions.checkArgument(target != null, "PlayerProfile cannot be null");
++        Preconditions.checkArgument(target.getId() != null, "The PlayerProfile UUID cannot be null");
++
++        return this.addBan(((com.destroystokyo.paper.profile.SharedPlayerProfile) target).buildGameProfile(), reason, expires, source);
+     }
+ 
+     @Override
+-    public BanEntry<PlayerProfile> addBan(String target, String reason, Date expires, String source) {
++    public boolean isBanned(final com.destroystokyo.paper.profile.PlayerProfile target) {
++        return this.isBanned((com.destroystokyo.paper.profile.SharedPlayerProfile) target);
++    }
++
++    @Override
++    public void pardon(final com.destroystokyo.paper.profile.PlayerProfile target) {
++        this.pardon((com.destroystokyo.paper.profile.SharedPlayerProfile) target);
++    }
++    // Paper end
++
++    @Override
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> addBan(String target, String reason, Date expires, String source) { // Paper
+         Preconditions.checkArgument(target != null, "Ban target cannot be null");
+ 
+         return this.addBan(CraftProfileBanList.getProfileByName(target), reason, expires, source);
+     }
+ 
+     @Override
+-    public BanEntry<PlayerProfile> addBan(PlayerProfile target, String reason, Date expires, String source) {
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> addBan(PlayerProfile target, String reason, Date expires, String source) { // Paper
+         Preconditions.checkArgument(target != null, "PlayerProfile cannot be null");
+         Preconditions.checkArgument(target.getUniqueId() != null, "The PlayerProfile UUID cannot be null");
+ 
+-        return this.addBan(((CraftPlayerProfile) target).buildGameProfile(), reason, expires, source);
++        return this.addBan(((com.destroystokyo.paper.profile.SharedPlayerProfile) target).buildGameProfile(), reason, expires, source); // Paper
+     }
+ 
+     @Override
+@@ -62,8 +88,8 @@ public class CraftProfileBanList implements ProfileBanList {
+     }
+ 
+     @Override
+-    public Set<BanEntry<PlayerProfile>> getEntries() {
+-        ImmutableSet.Builder<BanEntry<PlayerProfile>> builder = ImmutableSet.builder();
++    public Set<BanEntry<com.destroystokyo.paper.profile.PlayerProfile>> getEntries() { // Paper
++        ImmutableSet.Builder<BanEntry<com.destroystokyo.paper.profile.PlayerProfile>> builder = ImmutableSet.builder(); // Paper
+         for (UserBanListEntry entry : this.list.getEntries()) {
+             GameProfile profile = entry.getUser();
+             builder.add(new CraftProfileBanEntry(profile, entry, this.list));
+@@ -74,9 +100,14 @@ public class CraftProfileBanList implements ProfileBanList {
+ 
+     @Override
+     public boolean isBanned(PlayerProfile target) {
++        // Paper start
++        return this.isBanned((com.destroystokyo.paper.profile.SharedPlayerProfile) target);
++    }
++    private boolean isBanned(com.destroystokyo.paper.profile.SharedPlayerProfile target) {
++        // Paper end
+         Preconditions.checkArgument(target != null, "Target cannot be null");
+ 
+-        return this.isBanned(((CraftPlayerProfile) target).buildGameProfile());
++        return this.isBanned(target.buildGameProfile()); // Paper
+     }
+ 
+     @Override
+@@ -88,9 +119,14 @@ public class CraftProfileBanList implements ProfileBanList {
+ 
+     @Override
+     public void pardon(PlayerProfile target) {
++        // Paper start
++        this.pardon((com.destroystokyo.paper.profile.SharedPlayerProfile) target);
++    }
++    private void pardon(com.destroystokyo.paper.profile.SharedPlayerProfile target) {
++        // Paper end
+         Preconditions.checkArgument(target != null, "Target cannot be null");
+ 
+-        this.pardon(((CraftPlayerProfile) target).buildGameProfile());
++        this.pardon(target.buildGameProfile()); // Paper
+     }
+ 
+     @Override
+@@ -100,7 +136,7 @@ public class CraftProfileBanList implements ProfileBanList {
+         this.pardon(CraftProfileBanList.getProfile(target));
+     }
+ 
+-    public BanEntry<PlayerProfile> getBanEntry(GameProfile profile) {
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> getBanEntry(GameProfile profile) { // Paper
+         if (profile == null) {
+             return null;
+         }
+@@ -113,7 +149,7 @@ public class CraftProfileBanList implements ProfileBanList {
+         return new CraftProfileBanEntry(profile, entry, this.list);
+     }
+ 
+-    public BanEntry<PlayerProfile> addBan(GameProfile profile, String reason, Date expires, String source) {
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> addBan(GameProfile profile, String reason, Date expires, String source) { // Paper
+         if (profile == null) {
+             return null;
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 5b201d2c21f04e0223970035e0631f8f92ea0d3a..dbdeb913e228651cadf5dbd7ec98afc738c80522 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1632,13 +1632,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+ 
+     @Override
+-    public BanEntry<PlayerProfile> ban(String reason, Date expires, String source) {
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> ban(String reason, Date expires, String source) { // Paper
+         return this.ban(reason, expires, source, true);
+     }
+ 
+     @Override
+-    public BanEntry<PlayerProfile> ban(String reason, Date expires, String source, boolean kickPlayer) {
+-        BanEntry<PlayerProfile> banEntry = ((ProfileBanList) server.getBanList(BanList.Type.PROFILE)).addBan(this.getPlayerProfile(), reason, expires, source);
++    public BanEntry<com.destroystokyo.paper.profile.PlayerProfile> ban(String reason, Date expires, String source, boolean kickPlayer) { // Paper
++        BanEntry<com.destroystokyo.paper.profile.PlayerProfile> banEntry = ((ProfileBanList) server.getBanList(BanList.Type.PROFILE)).addBan(this.getPlayerProfile(), reason, expires, source); // Paper
+         if (kickPlayer) {
+             this.kickPlayer(reason);
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
+index d1aab4742b605e8807b0e4ca148abe0ed95039f4..58ea78d3917d2f264515c41f4df2f9ff6f8e4667 100644
+--- a/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
++++ b/src/main/java/org/bukkit/craftbukkit/profile/CraftPlayerProfile.java
+@@ -27,7 +27,7 @@ import org.bukkit.profile.PlayerProfile;
+ import org.bukkit.profile.PlayerTextures;
+ 
+ @SerializableAs("PlayerProfile")
+-public final class CraftPlayerProfile implements PlayerProfile, com.destroystokyo.paper.profile.SharedPlayerProfile { // Paper
++public final class CraftPlayerProfile implements PlayerProfile, com.destroystokyo.paper.profile.SharedPlayerProfile, com.destroystokyo.paper.profile.PlayerProfile { // Paper
+ 
+     @Nonnull
+     public static GameProfile validateSkullProfile(@Nonnull GameProfile gameProfile) {
+@@ -122,7 +122,7 @@ public final class CraftPlayerProfile implements PlayerProfile, com.destroystoky
+     }
+ 
+     @Override
+-    public CompletableFuture<PlayerProfile> update() {
++    public CompletableFuture update() { // Paper - have to remove generic to avoid clashing between bukkit.PlayerProfile and paper.PlayerProfile
+         return CompletableFuture.supplyAsync(this::getUpdatedProfile, Util.PROFILE_EXECUTOR); // Paper - not a good idea to use BLOCKING OPERATIONS on the worldgen executor
+     }
+ 
+@@ -276,4 +276,71 @@ public final class CraftPlayerProfile implements PlayerProfile, com.destroystoky
+         // Paper - diff on change
+         return profile;
+     }
++
++    // Paper start - This must implement our PlayerProfile so generic casts succeed from cb.CraftPlayerProfile to paper.PlayerProfile
++    // The methods don't actually have to be implemented, because the profile should immediately be cast to SharedPlayerProfile
++    @Override
++    public String setName(final String name) {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public UUID getId() {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public UUID setId(final UUID uuid) {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public java.util.Set<com.destroystokyo.paper.profile.ProfileProperty> getProperties() {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public boolean hasProperty(final String property) {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public void setProperty(final com.destroystokyo.paper.profile.ProfileProperty property) {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public void setProperties(final java.util.Collection<com.destroystokyo.paper.profile.ProfileProperty> properties) {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public void clearProperties() {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public boolean completeFromCache() {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public boolean completeFromCache(final boolean onlineMode) {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public boolean completeFromCache(final boolean lookupUUID, final boolean onlineMode) {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public boolean complete(final boolean textures) {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
++
++    @Override
++    public boolean complete(final boolean textures, final boolean onlineMode) {
++        throw new UnsupportedOperationException("Do not cast to com.destroystokyo.paper.profile.PlayerProfile");
++    }
+ }


### PR DESCRIPTION
Fixes BanList API with paper's PlayerProfile.

----

~~Still requires a fix to the broken and bad `BanList.Type` enum being used in place of a class that should have a generic to make sure that *this* doesn't compile.

`BanList<ItemStack> banList = server.getBanList(BanList.Type.PROFILE);`~~ Will handle in a separate PR.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9450.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/803148760.zip)