### PR TITLE
Array backed synched entity data

### DIFF
--- a/patches/server/0983-Array-backed-synched-entity-data.patch
+++ b/patches/server/0983-Array-backed-synched-entity-data.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jellysquid3 <jellysquid3@users.noreply.github.com>
+Date: Sat, 8 Jul 2023 21:38:05 +0200
+Subject: [PATCH] Array backed synched entity data
+
+Original code by jellysquid3 in Lithium, licensed under the GNU Lesser General Public License v3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+diff --git a/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java b/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java
+index 15add3f4dfd718ec09bb1db4f22223466936879c..5dfb35117c285e0b202dc9c088ad5848beb8d054 100644
+--- a/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java
++++ b/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java
+@@ -34,6 +34,11 @@ public class SynchedEntityData {
+     private final Int2ObjectMap<SynchedEntityData.DataItem<?>> itemsById = new Int2ObjectOpenHashMap();
+     // private final ReadWriteLock lock = new ReentrantReadWriteLock(); // Spigot - not required
+     private boolean isDirty;
++    // Paper start - array backed synched entity data
++    private static final int DEFAULT_ENTRY_COUNT = 10;
++    private static final int GROW_FACTOR = 8;
++    private SynchedEntityData.DataItem<?>[] itemsArray = new SynchedEntityData.DataItem<?>[DEFAULT_ENTRY_COUNT];
++    // Paper end
+ 
+     public SynchedEntityData(Entity trackedEntity) {
+         this.entity = trackedEntity;
+@@ -103,6 +108,15 @@ public class SynchedEntityData {
+         // this.lock.writeLock().lock(); // Spigot - not required
+         this.itemsById.put(key.getId(), datawatcher_item);
+         // this.lock.writeLock().unlock(); // Spigot - not required
++        // Paper start - array backed synched entity data
++        if (this.itemsArray.length <= key.getId()) {
++            final int newSize = Math.min(key.getId() + GROW_FACTOR, MAX_ID_VALUE);
++
++            this.itemsArray = java.util.Arrays.copyOf(this.itemsArray, newSize);
++        }
++
++        this.itemsArray[key.getId()] = datawatcher_item;
++        // Paper end
+     }
+ 
+     public <T> boolean hasItem(EntityDataAccessor<T> key) {
+@@ -130,7 +144,15 @@ public class SynchedEntityData {
+ 
+         return datawatcher_item;
+         */
+-        return (SynchedEntityData.DataItem) this.itemsById.get(key.getId());
++        // Paper start - array backed synched entity data
++        final int id = key.getId();
++
++        if (id < 0 || id >= this.itemsArray.length) {
++            return null;
++        }
++
++        return (DataItem<T>) this.itemsArray[id];
++        // Paper end
+         // Spigot end
+     }
+ 


### PR DESCRIPTION
Improves the speed of synched entity data lookups by using an array instead of a map. The difference probably isn't too drastic but given how many places it's called from it's still nice. 

This patch is originally from lithium and can be found [here](https://github.com/CaffeineMC/lithium-fabric/blob/ae1bd56556248aceba51f1d27e1317b0958448b1/src/main/java/me/jellysquid/mods/lithium/mixin/entity/data_tracker/use_arrays/DataTrackerMixin.java).