### PR TITLE
API for an entity's scoreboard name

### DIFF
--- a/patches/api/0426-API-for-an-entity-s-scoreboard-name.patch
+++ b/patches/api/0426-API-for-an-entity-s-scoreboard-name.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 9 Jul 2023 11:54:54 -0700
+Subject: [PATCH] API for an entity's scoreboard name
+
+Was obtainable through different methods, but you had to use different
+methods depending on the implementation of Entity you were working with.
+
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 6b842453589cf148ab32c1507cf374056826316e..75664470303a6e0cbd393c0db32b78b3af818cb6 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -965,4 +965,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+      */
+     @NotNull io.papermc.paper.threadedregions.scheduler.EntityScheduler getScheduler();
+     // Paper end - Folia schedulers
++
++    // Paper start - entity scoreboard name
++    /**
++     * Gets the string name of the entity used to track it in {@link org.bukkit.scoreboard.Scoreboard Scoreboards}.
++     *
++     * @return the scoreboard entry name
++     * @see org.bukkit.scoreboard.Scoreboard#getScores(String)
++     * @see org.bukkit.scoreboard.Scoreboard#getEntries()
++     */
++    @NotNull String getScoreboardEntryName();
++    // Paper end - entity scoreboard name
+ }

--- a/patches/server/1004-API-for-an-entity-s-scoreboard-name.patch
+++ b/patches/server/1004-API-for-an-entity-s-scoreboard-name.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 9 Jul 2023 11:55:02 -0700
+Subject: [PATCH] API for an entity's scoreboard name
+
+Was obtainable through different methods, but you had to use different
+methods depending on the implementation of Entity you were working with.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index 6e600f9d81178f4ad10967a1aba802c9ac853d82..975e2402cd1a2910043084957210c352329d42ae 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -1461,4 +1461,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+         return !this.getHandle().level().noCollision(this.getHandle(), aabb);
+     }
+     // Paper End - Collision API
++
++    // Paper start - entity scoreboard name
++    @Override
++    public String getScoreboardEntryName() {
++        return this.getHandle().getScoreboardName();
++    }
++    // Paper end - entity scoreboard name
+ }


### PR DESCRIPTION
Was obtainable through different methods, but you had to use different methods depending on the implementation of Entity you were working with.

----

It might not be worth exposing this directly since you can deal with the Entity type directly in scoreboards methods with the api now, and if not, we can just close this quickly.