### PR TITLE
Remove sign ticking

### DIFF
--- a/patches/server/0006-MC-Dev-fixes.patch
+++ b/patches/server/0006-MC-Dev-fixes.patch
@@ -226,6 +226,23 @@ index 91bb294be2cd8ab3467a62006a5a2751e0bec4ba..5ab7df0042391cb621ed78a187dc2033
              if (!world.isClientSide) {
                  boolean bl2 = signBlockEntity.isFacingFrontText(player);
                  SignText signText = signBlockEntity.getText(bl2);
+diff --git a/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java b/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java
+index db48010e633165972d2eac339dd7d1fd5a2f5bd8..d818d3ea6d28aa6ffb62127d4efd585d6f2935d1 100644
+--- a/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java
+@@ -52,8 +52,10 @@ public class WallHangingSignBlock extends SignBlock {
+     public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
+         BlockEntity itemStack = world.getBlockEntity(pos);
+         if (itemStack instanceof SignBlockEntity signBlockEntity) {
+-            ItemStack itemStack = player.getItemInHand(hand);
+-            if (this.shouldTryToChainAnotherHangingSign(state, player, hit, signBlockEntity, itemStack)) {
++            // Paper start - decompile fixes
++            ItemStack itemStack0 = player.getItemInHand(hand);
++            if (this.shouldTryToChainAnotherHangingSign(state, player, hit, signBlockEntity, itemStack0)) {
++            // Paper end
+                 return InteractionResult.PASS;
+             }
+         }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java b/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
 index b445f90b70d5a74f5bdc1b081500da4742e1c093..afba733824d84d650e669eda028bf4d28cf006b4 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java

--- a/patches/server/0006-MC-Dev-fixes.patch
+++ b/patches/server/0006-MC-Dev-fixes.patch
@@ -184,6 +184,23 @@ index 4d2d23ff118e9307d50ca2a5194b83450c91a752..ab6dc3449a1d3b7acf1d7bf5ac1c2422
          }));
          this.byName = Maps.newHashMap(builder.build()); // CraftBukkit
          RecipeManager.LOGGER.info("Loaded {} recipes", map1.size());
+diff --git a/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java b/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java
+index 769614aeb4ca914abcf0f770240a3d4c916f08cd..6c9d163b9f857806461dc72e54713f1a4f3a5c31 100644
+--- a/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java
+@@ -53,8 +53,10 @@ public class CeilingHangingSignBlock extends SignBlock {
+     public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
+         BlockEntity itemStack = world.getBlockEntity(pos);
+         if (itemStack instanceof SignBlockEntity signBlockEntity) {
+-            ItemStack itemStack = player.getItemInHand(hand);
+-            if (this.shouldTryToChainAnotherHangingSign(player, hit, signBlockEntity, itemStack)) {
++            // Paper start - decompile fixes
++            ItemStack itemStack0 = player.getItemInHand(hand);
++            if (this.shouldTryToChainAnotherHangingSign(player, hit, signBlockEntity, itemStack0)) {
++            // Paper end - decompile fixes
+                 return InteractionResult.PASS;
+             }
+         }
 diff --git a/src/main/java/net/minecraft/world/level/block/SignBlock.java b/src/main/java/net/minecraft/world/level/block/SignBlock.java
 index 91bb294be2cd8ab3467a62006a5a2751e0bec4ba..5ab7df0042391cb621ed78a187dc20333e344186 100644
 --- a/src/main/java/net/minecraft/world/level/block/SignBlock.java

--- a/patches/server/0985-Don-t-tick-signs.patch
+++ b/patches/server/0985-Don-t-tick-signs.patch
@@ -42,7 +42,7 @@ index d818d3ea6d28aa6ffb62127d4efd585d6f2935d1..ae232311f12c72ff62d3d18f25e3ebf4
      }
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
-index f356196aaeb498a6d2c9ad2112329cef5a3103d6..a7b0d3f44fed4ac7eda1c187e97e7e5d982cd97c 100644
+index f356196aaeb498a6d2c9ad2112329cef5a3103d6..c7a0e9a8ff4adbc4f46c5b21f2d2ff0c7a8dd80a 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
 @@ -44,7 +44,7 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
@@ -67,7 +67,13 @@ index f356196aaeb498a6d2c9ad2112329cef5a3103d6..a7b0d3f44fed4ac7eda1c187e97e7e5d
          return this.playerWhoMayEdit;
      }
  
-@@ -401,7 +407,7 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+@@ -396,12 +402,12 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+     }
+ 
+     public static void tick(Level world, BlockPos pos, BlockState state, SignBlockEntity blockEntity) {
+-        UUID uuid = blockEntity.getPlayerWhoMayEdit();
++        UUID uuid = blockEntity.playerWhoMayEdit; // Paper - Refer directly
+ 
          if (uuid != null) {
              blockEntity.clearInvalidPlayerWhoMayEdit(blockEntity, world, uuid);
          }

--- a/patches/server/0985-Don-t-tick-signs.patch
+++ b/patches/server/0985-Don-t-tick-signs.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Wed, 12 Jul 2023 17:38:26 -0400
+Subject: [PATCH] Don't tick signs
+
+Minecraft now ticks signs in order to validate the playerWhoMayEdit field. This is a horrible idea, as this means that even waxed signs are ticked for essentially no reason. This moves the logic lazily onto the getter.
+
+diff --git a/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java b/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java
+index 6c9d163b9f857806461dc72e54713f1a4f3a5c31..0bd8ea3143b2e9755d492af4596622d1dca1afaf 100644
+--- a/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java
+@@ -144,6 +144,6 @@ public class CeilingHangingSignBlock extends SignBlock {
+     @Nullable
+     @Override
+     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level world, BlockState state, BlockEntityType<T> type) {
+-        return createTickerHelper(type, BlockEntityType.HANGING_SIGN, SignBlockEntity::tick);
++        return null; // Paper
+     }
+ }
+diff --git a/src/main/java/net/minecraft/world/level/block/SignBlock.java b/src/main/java/net/minecraft/world/level/block/SignBlock.java
+index f7fda6fb4e908869310c783e68f7ad7025840592..14e393e252ffe7d04e0aafb85bd319bed76c330d 100644
+--- a/src/main/java/net/minecraft/world/level/block/SignBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/SignBlock.java
+@@ -166,6 +166,6 @@ public abstract class SignBlock extends BaseEntityBlock implements SimpleWaterlo
+     @Nullable
+     @Override
+     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level world, BlockState state, BlockEntityType<T> type) {
+-        return createTickerHelper(type, BlockEntityType.SIGN, SignBlockEntity::tick);
++        return null; // Paper
+     }
+ }
+diff --git a/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java b/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java
+index db48010e633165972d2eac339dd7d1fd5a2f5bd8..c92dfc3acd81d3bd0b3d9e9d1ba78c9795fd3f8d 100644
+--- a/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java
+@@ -165,6 +165,6 @@ public class WallHangingSignBlock extends SignBlock {
+     @Nullable
+     @Override
+     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level world, BlockState state, BlockEntityType<T> type) {
+-        return createTickerHelper(type, BlockEntityType.HANGING_SIGN, SignBlockEntity::tick);
++        return null; // Paper
+     }
+ }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
+index f356196aaeb498a6d2c9ad2112329cef5a3103d6..674b6738be256447742f8eb3a63b404316ed9c95 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
+@@ -367,6 +367,12 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+ 
+     @Nullable
+     public UUID getPlayerWhoMayEdit() {
++        // Paper start
++        if (this.hasLevel()) {
++            // Manually invalidate the value lazily.
++            tick(this.getLevel(), this.getBlockPos(), this.getBlockState(), this);
++        }
++        // Paper end
+         return this.playerWhoMayEdit;
+     }
+ 
+@@ -401,7 +407,7 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+         if (uuid != null) {
+             blockEntity.clearInvalidPlayerWhoMayEdit(blockEntity, world, uuid);
+         }
+-
++        // Paper - Diff on change
+     }
+ 
+     private void clearInvalidPlayerWhoMayEdit(SignBlockEntity blockEntity, Level world, UUID uuid) {

--- a/patches/server/0985-Don-t-tick-signs.patch
+++ b/patches/server/0985-Don-t-tick-signs.patch
@@ -42,9 +42,18 @@ index d818d3ea6d28aa6ffb62127d4efd585d6f2935d1..ae232311f12c72ff62d3d18f25e3ebf4
      }
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
-index f356196aaeb498a6d2c9ad2112329cef5a3103d6..674b6738be256447742f8eb3a63b404316ed9c95 100644
+index f356196aaeb498a6d2c9ad2112329cef5a3103d6..a7b0d3f44fed4ac7eda1c187e97e7e5d982cd97c 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
+@@ -44,7 +44,7 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
+     private static final int MAX_TEXT_LINE_WIDTH = 90;
+     private static final int TEXT_LINE_HEIGHT = 10;
+     @Nullable
+-    public UUID playerWhoMayEdit;
++    private UUID playerWhoMayEdit; // Paper - private
+     private SignText frontText;
+     private SignText backText;
+     private boolean isWaxed;
 @@ -367,6 +367,12 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
  
      @Nullable

--- a/patches/server/0985-Don-t-tick-signs.patch
+++ b/patches/server/0985-Don-t-tick-signs.patch
@@ -30,10 +30,10 @@ index f7fda6fb4e908869310c783e68f7ad7025840592..14e393e252ffe7d04e0aafb85bd319be
      }
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java b/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java
-index db48010e633165972d2eac339dd7d1fd5a2f5bd8..c92dfc3acd81d3bd0b3d9e9d1ba78c9795fd3f8d 100644
+index d818d3ea6d28aa6ffb62127d4efd585d6f2935d1..ae232311f12c72ff62d3d18f25e3ebf46ce1ace2 100644
 --- a/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/WallHangingSignBlock.java
-@@ -165,6 +165,6 @@ public class WallHangingSignBlock extends SignBlock {
+@@ -167,6 +167,6 @@ public class WallHangingSignBlock extends SignBlock {
      @Nullable
      @Override
      public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level world, BlockState state, BlockEntityType<T> type) {

--- a/patches/server/0990-Don-t-tick-signs.patch
+++ b/patches/server/0990-Don-t-tick-signs.patch
@@ -5,6 +5,9 @@ Subject: [PATCH] Don't tick signs
 
 Minecraft now ticks signs in order to validate the playerWhoMayEdit field. This is a horrible idea, as this means that even waxed signs are ticked for essentially no reason. This moves the logic lazily onto the getter.
 
+== AT ==
+private net.minecraft.world.level.block.entity.SignBlockEntity playerWhoMayEdit
+
 diff --git a/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java b/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java
 index 6c9d163b9f857806461dc72e54713f1a4f3a5c31..0bd8ea3143b2e9755d492af4596622d1dca1afaf 100644
 --- a/src/main/java/net/minecraft/world/level/block/CeilingHangingSignBlock.java
@@ -42,43 +45,19 @@ index d818d3ea6d28aa6ffb62127d4efd585d6f2935d1..ae232311f12c72ff62d3d18f25e3ebf4
      }
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
-index f356196aaeb498a6d2c9ad2112329cef5a3103d6..c7a0e9a8ff4adbc4f46c5b21f2d2ff0c7a8dd80a 100644
+index 9eea2982e92e9bc7a53962dc6b21de60f9e5a4c7..38cde466714e5663cd416b6afd5d2558e139ec09 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/SignBlockEntity.java
-@@ -44,7 +44,7 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
-     private static final int MAX_TEXT_LINE_WIDTH = 90;
-     private static final int TEXT_LINE_HEIGHT = 10;
-     @Nullable
--    public UUID playerWhoMayEdit;
-+    private UUID playerWhoMayEdit; // Paper - private
-     private SignText frontText;
-     private SignText backText;
-     private boolean isWaxed;
 @@ -367,6 +367,12 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
  
      @Nullable
      public UUID getPlayerWhoMayEdit() {
 +        // Paper start
-+        if (this.hasLevel()) {
++        if (this.hasLevel() && this.playerWhoMayEdit != null) {
 +            // Manually invalidate the value lazily.
-+            tick(this.getLevel(), this.getBlockPos(), this.getBlockState(), this);
++            this.clearInvalidPlayerWhoMayEdit(this, this.getLevel(), this.playerWhoMayEdit);
 +        }
 +        // Paper end
          return this.playerWhoMayEdit;
      }
  
-@@ -396,12 +402,12 @@ public class SignBlockEntity extends BlockEntity implements CommandSource { // C
-     }
- 
-     public static void tick(Level world, BlockPos pos, BlockState state, SignBlockEntity blockEntity) {
--        UUID uuid = blockEntity.getPlayerWhoMayEdit();
-+        UUID uuid = blockEntity.playerWhoMayEdit; // Paper - Refer directly
- 
-         if (uuid != null) {
-             blockEntity.clearInvalidPlayerWhoMayEdit(blockEntity, world, uuid);
-         }
--
-+        // Paper - Diff on change
-     }
- 
-     private void clearInvalidPlayerWhoMayEdit(SignBlockEntity blockEntity, Level world, UUID uuid) {


### PR DESCRIPTION
As of 1.20, every single sign is now ticked on a server, usually for no reason. This moves the invalidation logic onto the getter. 

This field is only used on interaction/sign editing essentially, so, whenever it tries to check it will do the validation there instead.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9478.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/819249044.zip)