### PR TITLE
Fix DEFAULT getEntitySpawnReason for /summon

### DIFF
--- a/patches/server/0300-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0300-Entity-getEntitySpawnReason.patch
@@ -9,6 +9,18 @@ Pre existing entities will return NATURAL if it was a non
 persistenting Living Entity, SPAWNER for spawners,
 or DEFAULT since data was not stored.
 
+diff --git a/src/main/java/net/minecraft/server/commands/SummonCommand.java b/src/main/java/net/minecraft/server/commands/SummonCommand.java
+index 2eddeb8d5239bbfeefbf4d3bd363f1ad083299b6..a7c89cdf20cb63792c76de81c1ff9f2cbbfcea84 100644
+--- a/src/main/java/net/minecraft/server/commands/SummonCommand.java
++++ b/src/main/java/net/minecraft/server/commands/SummonCommand.java
+@@ -57,6 +57,7 @@ public class SummonCommand {
+             ServerLevel worldserver = source.getLevel();
+             Entity entity = EntityType.loadEntityRecursive(nbttagcompound1, worldserver, (entity1) -> {
+                 entity1.moveTo(pos.x, pos.y, pos.z, entity1.getYRot(), entity1.getXRot());
++                entity1.spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.COMMAND; // Paper
+                 return entity1;
+             });
+ 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
 index 6b157b362cffedae26133fc0f0af1094655ee11f..986a509998d217228eb1dc2b5815787599e02d6b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java


### PR DESCRIPTION
Fixes an issue where summoned entities wouldn't have the spawn reason of COMMAND, but instead defaulted to default/natural/spawner inside the Entity#load method before the command reason could be set.