### PR TITLE
Determine lava and water fluid explosion resistance by their block explosion resistance

### DIFF
--- a/patches/server/0985-Determine-lava-and-water-fluid-explosion-resistance-.patch
+++ b/patches/server/0985-Determine-lava-and-water-fluid-explosion-resistance-.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: galacticwarrior9 <zareef1@yahoo.com>
+Date: Thu, 13 Jul 2023 21:32:13 +0100
+Subject: [PATCH] Determine lava and water fluid explosion resistance by their
+ block explosion resistance
+
+When selecting which explosion resistance to use for lava and water, vanilla selects the highest value between their block explosion resistance and fluid explosion resistance.
+
+Problems emerge when we want to reduce the explosion resistance of water or lava, since the fluid explosion resistance is hardcoded to return 100.0F and can't be changed by a plugin. This simply makes the fluid explosion resistance the same as the block explosion resistance, which allows plugin to change the value. Since both are the same in vanilla, this has no side effects on servers that do not need to do this.
+
+diff --git a/src/main/java/net/minecraft/world/level/material/LavaFluid.java b/src/main/java/net/minecraft/world/level/material/LavaFluid.java
+index 72f8b72c6436ca3b8eaeb39c7d3efe2c1462ae1d..c3f8e1e2dd89c168b8b4a15b589109db486bc8d7 100644
+--- a/src/main/java/net/minecraft/world/level/material/LavaFluid.java
++++ b/src/main/java/net/minecraft/world/level/material/LavaFluid.java
+@@ -232,7 +232,7 @@ public abstract class LavaFluid extends FlowingFluid {
+ 
+     @Override
+     protected float getExplosionResistance() {
+-        return 100.0F;
++        return Blocks.LAVA.getExplosionResistance(); // Paper
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/world/level/material/WaterFluid.java b/src/main/java/net/minecraft/world/level/material/WaterFluid.java
+index 82e85fbbd45244d02df90fa00c9046e7f51275a2..d280c98aed5262c4ce39526c917de884f25a8584 100644
+--- a/src/main/java/net/minecraft/world/level/material/WaterFluid.java
++++ b/src/main/java/net/minecraft/world/level/material/WaterFluid.java
+@@ -109,7 +109,7 @@ public abstract class WaterFluid extends FlowingFluid {
+ 
+     @Override
+     protected float getExplosionResistance() {
+-        return 100.0F;
++        return Blocks.WATER.getExplosionResistance(); // Paper
+     }
+ 
+     @Override


### PR DESCRIPTION
This simple PR changes the fluid explosion resistance of water/lava to be the same as their block's explosion resistance. In short, this makes it possible for servers to lower the explosion resistances of water and lava (it is *impossible* otherwise), while having no effect on servers which do not need to do this. 

Explanation: In vanilla, both the fluid and block explosion resistances of water/lava are 100. The latter is defined in a field which allows plugins to override it via reflection. The former is not, so plugins cannot change it: 

```java
    // How fluid explosion resistances are returned
    @Override
    protected float getExplosionResistance() {
        return 100.0F;
    }
```

That's not a problem - until you want to lower the explosion resistance of water/lava, e.g. to enable underwater explosions. In `ExplosionDamageCalculator#getBlockExplosionResistance`, we find that the effective explosion resistance of water/lava will always be the highest value between the fluid and block explosion resistances. In other words, it can never be lower than 100 since plugins cannot override the fluid explosion resistance. This PR resolves that. 


