### PR TITLE
Respect randomizeData on more entities when spawning

### DIFF
--- a/patches/server/0198-Allow-spawning-Item-entities-with-World.spawnEntity.patch
+++ b/patches/server/0198-Allow-spawning-Item-entities-with-World.spawnEntity.patch
@@ -8,7 +8,7 @@ This API has more capabilities than .dropItem with the Consumer function
 Item can be set inside of the Consumer pre spawn function.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index 3dd759d030411420f93eb5ac51f2087ecbf2dc49..4dc5c75d1fa0748b6e7e95d90b92a865b2f6362e 100644
+index 3dd759d030411420f93eb5ac51f2087ecbf2dc49..91fbc67eefea473211b99e4338f6464f58dc5592 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 @@ -592,6 +592,10 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
@@ -17,7 +17,7 @@ index 3dd759d030411420f93eb5ac51f2087ecbf2dc49..4dc5c75d1fa0748b6e7e95d90b92a865
              entity.moveTo(x, y, z, yaw, pitch);
 +            // Paper start
 +        } else if (org.bukkit.entity.Item.class.isAssignableFrom(clazz)) {
-+            entity = new net.minecraft.world.entity.item.ItemEntity(world, x, y, z, new net.minecraft.world.item.ItemStack(net.minecraft.world.item.Item.byBlock(net.minecraft.world.level.block.Blocks.DIRT)));
++            entity = new net.minecraft.world.entity.item.ItemEntity(world, x, y, z, new net.minecraft.world.item.ItemStack(net.minecraft.world.item.Items.DIRT));
 +            // Paper end
          } else if (FallingBlock.class.isAssignableFrom(clazz)) {
              BlockPos pos = BlockPos.containing(x, y, z);

--- a/patches/server/0999-Respect-randomizeData-on-more-entities-when-spawning.patch
+++ b/patches/server/0999-Respect-randomizeData-on-more-entities-when-spawning.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 13 Jul 2023 16:10:07 -0700
+Subject: [PATCH] Respect randomizeData on more entities when spawning
+
+* ItemEntity
+* PrimedTNT
+* FireworkRocketEntity
+* ExperienceOrb
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+index 602b09323e0f1fda64ced1c285bfe2dbd854bb54..be6dc2b7a0dfc57853d26c0cd5e4a9a4cf987879 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
+@@ -603,6 +603,11 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+         } else if (org.bukkit.entity.Item.class.isAssignableFrom(clazz)) {
+             entity = new net.minecraft.world.entity.item.ItemEntity(world, x, y, z, new net.minecraft.world.item.ItemStack(net.minecraft.world.item.Items.DIRT));
+             // Paper end
++            // Paper start - respect randomizeData
++            if (!randomizeData) {
++                entity.setDeltaMovement(net.minecraft.world.phys.Vec3.ZERO);
++            }
++            // Paper end - respect randomizeData
+         } else if (FallingBlock.class.isAssignableFrom(clazz)) {
+             BlockPos pos = BlockPos.containing(x, y, z);
+             entity = new FallingBlockEntity(world, x, y, z, this.getHandle().getBlockState(pos)); // Paper
+@@ -658,6 +663,14 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+                 entity.moveTo(x, y, z, yaw, pitch);
+             } else if (Firework.class.isAssignableFrom(clazz)) {
+                 entity = new FireworkRocketEntity(world, x, y, z, net.minecraft.world.item.ItemStack.EMPTY);
++                // Paper start - respect randomizeData
++                if (!randomizeData) {
++                    // logic below was taken from FireworkRocketEntity constructor
++                    entity.setDeltaMovement(0, 0.05, 0);
++                    //noinspection PointlessArithmeticExpression
++                    ((FireworkRocketEntity) entity).lifetime = 10 * 1 + 6;
++                }
++                // Paper end - respect randomizeData
+             }
+         } else if (Minecart.class.isAssignableFrom(clazz)) {
+             if (PoweredMinecart.class.isAssignableFrom(clazz)) {
+@@ -959,8 +972,19 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
+             }
+         } else if (TNTPrimed.class.isAssignableFrom(clazz)) {
+             entity = new PrimedTnt(world, x, y, z, null);
++            // Paper start - respect randomizeData
++            if (!randomizeData) {
++                entity.setDeltaMovement(net.minecraft.world.phys.Vec3.ZERO);
++            }
++            // Paper end - respect randomizeData
+         } else if (ExperienceOrb.class.isAssignableFrom(clazz)) {
+             entity = new net.minecraft.world.entity.ExperienceOrb(world, x, y, z, 0, org.bukkit.entity.ExperienceOrb.SpawnReason.CUSTOM, null, null); // Paper
++            // Paper start - respect randomizeData
++            if (!randomizeData) {
++                entity.setDeltaMovement(net.minecraft.world.phys.Vec3.ZERO);
++                entity.setYRot(0);
++            }
++            // Paper end - respect randomizeData
+         } else if (LightningStrike.class.isAssignableFrom(clazz)) {
+             entity = net.minecraft.world.entity.EntityType.LIGHTNING_BOLT.create(world);
+             entity.moveTo(location.getX(), location.getY(), location.getZ());


### PR DESCRIPTION
Obey the `randomizeData` boolean param when spawning primed TNT and itemstacks, not applying the random movements that the constructors add.