### PR TITLE
add predicate recipe choice only for potion mixes

### DIFF
--- a/patches/api/0351-Custom-Potion-Mixes.patch
+++ b/patches/api/0351-Custom-Potion-Mixes.patch
@@ -6,17 +6,19 @@ Subject: [PATCH] Custom Potion Mixes
 
 diff --git a/src/main/java/io/papermc/paper/potion/PotionMix.java b/src/main/java/io/papermc/paper/potion/PotionMix.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad3096781113
+index 0000000000000000000000000000000000000000..ae1f30e88fc5048627295187214aa7a288f4c184
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/potion/PotionMix.java
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,105 @@
 +package io.papermc.paper.potion;
 +
++import java.util.function.Predicate;
 +import org.bukkit.Keyed;
 +import org.bukkit.NamespacedKey;
 +import org.bukkit.inventory.ItemStack;
 +import org.bukkit.inventory.RecipeChoice;
 +import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.Contract;
 +import org.jetbrains.annotations.NotNull;
 +
 +import java.util.Objects;
@@ -79,6 +81,18 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +        return this.ingredient;
 +    }
 +
++    /**
++     * Create a {@link RecipeChoice} based on a Predicate. These RecipeChoices are only
++     * valid for {@link PotionMix}, not anywhere else RecipeChoices may be used.
++     *
++     * @param stackPredicate a predicate for an itemstack.
++     * @return a new RecipeChoice
++     */
++    @Contract(value = "_ -> new", pure = true)
++    public static @NotNull RecipeChoice createPredicateChoice(@NotNull Predicate<ItemStack> stackPredicate) {
++        return new PredicateRecipeChoice(stackPredicate);
++    }
++
 +    @Override
 +    public String toString() {
 +        return "PotionMix{" +
@@ -99,6 +113,45 @@ index 0000000000000000000000000000000000000000..cb6d93526b637946aec311bef103ad30
 +    @Override
 +    public int hashCode() {
 +        return Objects.hash(this.key, this.result, this.input, this.ingredient);
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/potion/PredicateRecipeChoice.java b/src/main/java/io/papermc/paper/potion/PredicateRecipeChoice.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..1bf964605f681469fb364baaa18381c090260a94
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/potion/PredicateRecipeChoice.java
+@@ -0,0 +1,33 @@
++package io.papermc.paper.potion;
++
++import java.util.function.Predicate;
++import org.bukkit.inventory.ItemStack;
++import org.bukkit.inventory.RecipeChoice;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
++import org.jetbrains.annotations.ApiStatus;
++
++@ApiStatus.Internal
++@DefaultQualifier(NonNull.class)
++record PredicateRecipeChoice(Predicate<ItemStack> itemStackPredicate) implements RecipeChoice, Cloneable {
++
++    @Override
++    @Deprecated
++    public ItemStack getItemStack() {
++        throw new UnsupportedOperationException("PredicateRecipeChoice does not support this");
++    }
++
++    @Override
++    public RecipeChoice clone() {
++        try {
++            return (PredicateRecipeChoice) super.clone();
++        } catch (CloneNotSupportedException ex) {
++            throw new AssertionError(ex);
++        }
++    }
++
++    @Override
++    public boolean test(final ItemStack itemStack) {
++        return this.itemStackPredicate.test(itemStack);
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java

--- a/patches/server/0774-Custom-Potion-Mixes.patch
+++ b/patches/server/0774-Custom-Potion-Mixes.patch
@@ -6,21 +6,29 @@ Subject: [PATCH] Custom Potion Mixes
 
 diff --git a/src/main/java/io/papermc/paper/potion/PaperPotionMix.java b/src/main/java/io/papermc/paper/potion/PaperPotionMix.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6b0bed550763f34e18c9e92f9a47ec0c945b2c8b
+index 0000000000000000000000000000000000000000..7ea357ac2f3a93db4ebdf24b5072be7d1cad3e33
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/potion/PaperPotionMix.java
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,21 @@
 +package io.papermc.paper.potion;
 +
++import java.util.function.Predicate;
 +import net.minecraft.world.item.ItemStack;
-+import net.minecraft.world.item.crafting.Ingredient;
 +import org.bukkit.craftbukkit.inventory.CraftItemStack;
 +import org.bukkit.craftbukkit.inventory.CraftRecipe;
++import org.bukkit.inventory.RecipeChoice;
 +
-+public record PaperPotionMix(ItemStack result, Ingredient input, Ingredient ingredient) {
++public record PaperPotionMix(ItemStack result, Predicate<ItemStack> input, Predicate<ItemStack> ingredient) {
 +
 +    public PaperPotionMix(PotionMix potionMix) {
-+        this(CraftItemStack.asNMSCopy(potionMix.getResult()), CraftRecipe.toIngredient(potionMix.getInput(), true), CraftRecipe.toIngredient(potionMix.getIngredient(), true));
++        this(CraftItemStack.asNMSCopy(potionMix.getResult()), convert(potionMix.getInput()), convert(potionMix.getIngredient()));
++    }
++
++    static Predicate<ItemStack> convert(final RecipeChoice choice) {
++        if (choice instanceof PredicateRecipeChoice predicateRecipeChoice) {
++            return stack -> predicateRecipeChoice.test(CraftItemStack.asBukkitCopy(stack));
++        }
++        return CraftRecipe.toIngredient(choice, true);
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java


### PR DESCRIPTION
Way simpler to implement just for potion mixes as it doesn't require any messing with recipe books or StackedContents. Made it clear its only use is for potion mixes.