### PR TITLE
Fix main thread priority being lowered

### DIFF
--- a/patches/server/0275-Improve-Server-Thread-Pool-and-Thread-Priorities.patch
+++ b/patches/server/0275-Improve-Server-Thread-Pool-and-Thread-Priorities.patch
@@ -79,14 +79,14 @@ index 0f05d26248d8c999048a88796df227a6a1e3755f..7354711e194ab58b11b68f447c1fc795
          return executorService;
      }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9cd0e389deda8d0bc7a551ff9e8b6bcd51184476..ed66f20b38fb6cea0dab020d8ffdde894da86113 100644
+index 9cd0e389deda8d0bc7a551ff9e8b6bcd51184476..3289e2ec79c760ba8c1c47ed1baaba136682d8e8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -319,6 +319,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
-         S s0 = serverFactory.apply(thread); // CraftBukkit - decompile error
- 
-         atomicreference.set(s0);
+@@ -312,6 +312,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         thread.setUncaughtExceptionHandler((thread1, throwable) -> {
+             MinecraftServer.LOGGER.error("Uncaught exception in server thread", throwable);
+         });
 +        thread.setPriority(Thread.NORM_PRIORITY+2); // Paper - boost priority
-         thread.start();
-         return s0;
-     }
+         if (Runtime.getRuntime().availableProcessors() > 4) {
+             thread.setPriority(8);
+         }


### PR DESCRIPTION
This PR fixes vanilla's thread priority of 8 being overridden with 7 (regular priority of 5 + 2). I'm not too sure how much of a difference this makes or if this line is still even needed, but a higher priority seems better than a lower one.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9488.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/863108412.zip)