### PR TITLE
Fire entity death event for ender dragon

### DIFF
--- a/patches/server/0989-Fire-entity-death-event-for-ender-dragon.patch
+++ b/patches/server/0989-Fire-entity-death-event-for-ender-dragon.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Trevor Bedson <78997566+Prorickey@users.noreply.github.com>
+Date: Fri, 14 Jul 2023 20:47:02 -0400
+Subject: [PATCH] Fire entity death event for ender dragon
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+index 92666c48620078623a451fbf68f673cb9f81c4b5..9d86aacd569cdbb502d495b61d6dd7abdbad8942 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
++++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+@@ -657,7 +657,7 @@ public class EnderDragon extends Mob implements Enemy {
+             this.dragonFight.updateDragon(this);
+             this.dragonFight.setDragonKilled(this);
+         }
+-
++        org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, this.drops); // Paper - Call Death Event
+     }
+ 
+     // CraftBukkit start - SPIGOT-2420: Special case, the ender dragon drops 12000 xp for the first kill and 500 xp for every other kill and this over time.


### PR DESCRIPTION
EntityDeathEvent isn't called for the ender dragon when it's killed with the kill() method. This fixes the EntityDeathEvent not being called when killing the ender dragon with that method.