### PR TITLE
Fire entity death event for ender dragon

### DIFF
--- a/patches/server/0989-Fire-entity-death-event-for-ender-dragon.patch
+++ b/patches/server/0989-Fire-entity-death-event-for-ender-dragon.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Trevor Bedson <78997566+Prorickey@users.noreply.github.com>
+Date: Fri, 14 Jul 2023 20:47:02 -0400
+Subject: [PATCH] Fire entity death event for ender dragon
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+index 92666c48620078623a451fbf68f673cb9f81c4b5..11d096b3200e5ccf7b6c7370b9706855915dee80 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
++++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+@@ -657,7 +657,8 @@ public class EnderDragon extends Mob implements Enemy {
+             this.dragonFight.updateDragon(this);
+             this.dragonFight.setDragonKilled(this);
+         }
+-
++        this.silentDeath = true; // Paper - Silence the dragon death sound
++        org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, new ArrayList<>()); // Paper - Call Death Event
+     }
+ 
+     // CraftBukkit start - SPIGOT-2420: Special case, the ender dragon drops 12000 xp for the first kill and 500 xp for every other kill and this over time.

--- a/patches/server/0989-Fire-entity-death-event-for-ender-dragon.patch
+++ b/patches/server/0989-Fire-entity-death-event-for-ender-dragon.patch
@@ -5,16 +5,26 @@ Subject: [PATCH] Fire entity death event for ender dragon
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 92666c48620078623a451fbf68f673cb9f81c4b5..11d096b3200e5ccf7b6c7370b9706855915dee80 100644
+index 92666c48620078623a451fbf68f673cb9f81c4b5..91fe39f5710415c9536886eb7a990692b7d8caf9 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -657,7 +657,8 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -651,13 +651,18 @@ public class EnderDragon extends Mob implements Enemy {
+ 
+     @Override
+     public void kill() {
++        // Paper start
++        this.silentDeath = true;
++        org.bukkit.event.entity.EntityDeathEvent deathEvent =  org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, new java.util.ArrayList<>())
++        if(deathEvent.isCancelled()) return;
++        // Paper end
++
+         this.remove(Entity.RemovalReason.KILLED);
+         this.gameEvent(GameEvent.ENTITY_DIE);
+         if (this.dragonFight != null) {
              this.dragonFight.updateDragon(this);
              this.dragonFight.setDragonKilled(this);
          }
 -
-+        this.silentDeath = true; // Paper - Silence the dragon death sound
-+        org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, new ArrayList<>()); // Paper - Call Death Event
      }
  
      // CraftBukkit start - SPIGOT-2420: Special case, the ender dragon drops 12000 xp for the first kill and 500 xp for every other kill and this over time.

--- a/patches/server/0989-Fire-entity-death-event-for-ender-dragon.patch
+++ b/patches/server/0989-Fire-entity-death-event-for-ender-dragon.patch
@@ -14,7 +14,7 @@ index 92666c48620078623a451fbf68f673cb9f81c4b5..91fe39f5710415c9536886eb7a990692
      public void kill() {
 +        // Paper start
 +        this.silentDeath = true;
-+        org.bukkit.event.entity.EntityDeathEvent deathEvent =  org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, new java.util.ArrayList<>())
++        org.bukkit.event.entity.EntityDeathEvent deathEvent =  org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, new java.util.ArrayList<>());
 +        if(deathEvent.isCancelled()) return;
 +        // Paper end
 +

--- a/patches/server/1011-Fire-entity-death-event-for-ender-dragon.patch
+++ b/patches/server/1011-Fire-entity-death-event-for-ender-dragon.patch
@@ -5,26 +5,22 @@ Subject: [PATCH] Fire entity death event for ender dragon
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 92666c48620078623a451fbf68f673cb9f81c4b5..91fe39f5710415c9536886eb7a990692b7d8caf9 100644
+index 92666c48620078623a451fbf68f673cb9f81c4b5..a24ae93efcdb2da5782d342c7697a1bb253400c7 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-@@ -651,13 +651,18 @@ public class EnderDragon extends Mob implements Enemy {
+@@ -651,6 +651,15 @@ public class EnderDragon extends Mob implements Enemy {
  
      @Override
      public void kill() {
 +        // Paper start
 +        this.silentDeath = true;
-+        org.bukkit.event.entity.EntityDeathEvent deathEvent =  org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, new java.util.ArrayList<>());
-+        if(deathEvent.isCancelled()) return;
++        org.bukkit.event.entity.EntityDeathEvent deathEvent =  org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this);
++        if (deathEvent.isCancelled()) {
++            this.silentDeath = false; // Reset to default if event was cancelled
++            return;
++        }
 +        // Paper end
 +
          this.remove(Entity.RemovalReason.KILLED);
          this.gameEvent(GameEvent.ENTITY_DIE);
          if (this.dragonFight != null) {
-             this.dragonFight.updateDragon(this);
-             this.dragonFight.setDragonKilled(this);
-         }
--
-     }
- 
-     // CraftBukkit start - SPIGOT-2420: Special case, the ender dragon drops 12000 xp for the first kill and 500 xp for every other kill and this over time.


### PR DESCRIPTION
EntityDeathEvent isn't called for the ender dragon when it's killed with the kill() method. This fixes the EntityDeathEvent not being called when killing the ender dragon with that method. Fixes #8836