### PR TITLE
Add missing javadoc links

### DIFF
--- a/patches/api/0002-Build-system-changes.patch
+++ b/patches/api/0002-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index c2e5d8006420aab5a60e5aaa188223aeb0396483..ffd1c792b0e0fe1ed3da85cf933202c5193734ce 100644
+index c2e5d8006420aab5a60e5aaa188223aeb0396483..394665bf1d4b485bb0cefd24162f1ef4c255f160 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -18,15 +18,27 @@ dependencies {
@@ -37,16 +37,21 @@ index c2e5d8006420aab5a60e5aaa188223aeb0396483..ffd1c792b0e0fe1ed3da85cf933202c5
      testImplementation("org.apache.commons:commons-lang3:3.12.0")
      testImplementation("junit:junit:4.13.2")
      testImplementation("org.hamcrest:hamcrest-library:1.3")
-@@ -68,7 +80,7 @@ tasks.withType<Javadoc> {
+@@ -68,8 +80,12 @@ tasks.withType<Javadoc> {
      options.links(
          "https://guava.dev/releases/31.1-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/2.0/",
 -        "https://javadoc.io/doc/org.jetbrains/annotations-java5/$annotationsVersion/",
 +        "https://javadoc.io/doc/org.jetbrains/annotations/$annotationsVersion/", // Paper - we don't want Java 5 annotations
          "https://javadoc.io/doc/net.md-5/bungeecord-chat/$bungeeCordChatVersion/",
++        // Paper start - add missing javadoc links
++        "https://javadoc.io/doc/org.joml/joml/1.10.5/index.html",
++        "https://www.javadoc.io/doc/com.google.code.gson/gson/2.10",
++        // Paper end
      )
      options.tags("apiNote:a:API Note:")
-@@ -84,3 +96,14 @@ tasks.withType<Javadoc> {
+ 
+@@ -84,3 +100,14 @@ tasks.withType<Javadoc> {
          }
      }
  }

--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -7,7 +7,7 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 19720f73cb8454d6ddd8d75e7d08556d61436505..82310336813b5c2d7c6f708839cb6f3928293445 100644
+index c44e0485ba54b3d15fa4fd7d1250bcbc1ce809d5..1a4512bc5aef7e89dca53f8352e9008b4de537e3 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -10,12 +10,24 @@ java {
@@ -50,13 +50,17 @@ index 19720f73cb8454d6ddd8d75e7d08556d61436505..82310336813b5c2d7c6f708839cb6f39
      // Paper end
  
      compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")
-@@ -83,10 +102,26 @@ tasks.withType<Javadoc> {
+@@ -83,14 +102,30 @@ tasks.withType<Javadoc> {
          "https://guava.dev/releases/31.1-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/2.0/",
          "https://javadoc.io/doc/org.jetbrains/annotations/$annotationsVersion/", // Paper - we don't want Java 5 annotations
 -        "https://javadoc.io/doc/net.md-5/bungeecord-chat/$bungeeCordChatVersion/",
++        // "https://javadoc.io/doc/net.md-5/bungeecord-chat/$bungeeCordChatVersion/", // Paper - don't link to bungee chat
+         // Paper start - add missing javadoc links
+         "https://javadoc.io/doc/org.joml/joml/1.10.5/index.html",
+         "https://www.javadoc.io/doc/com.google.code.gson/gson/2.10",
+         // Paper end
 +        // Paper start
-+        // "https://javadoc.io/doc/net.md-5/bungeecord-chat/$bungeeCordChatVersion/", // don't link to bungee chat
 +        "https://jd.advntr.dev/api/$adventureVersion/",
 +        "https://jd.advntr.dev/text-minimessage/$adventureVersion/",
 +        "https://jd.advntr.dev/text-serializer-gson/$adventureVersion/",

--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Paper Plugins
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ba6f0a70ba2442dbe60ed6cc92e4fb91a48d9f3b..22b65c3ad4ed6e19b88a51a2e001f0e5846d9ae6 100644
+index 85e370ab77b7f3ec6c77c1d6750ce220777dbce5..713f5d73743007d47eca70167058f207626d2298 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -47,7 +47,7 @@ dependencies {
@@ -17,6 +17,14 @@ index ba6f0a70ba2442dbe60ed6cc92e4fb91a48d9f3b..22b65c3ad4ed6e19b88a51a2e001f0e5
      compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
      compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
      compileOnly("com.google.code.findbugs:jsr305:1.3.9") // Paper
+@@ -118,6 +118,7 @@ tasks.withType<Javadoc> {
+         "https://jd.advntr.dev/text-serializer-plain/$adventureVersion/",
+         "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/",
+         // Paper end
++        "https://javadoc.io/doc/org.apache.maven.resolver/maven-resolver-api/1.7.3", // Paper
+     )
+     options.tags("apiNote:a:API Note:")
+ 
 diff --git a/src/main/java/io/papermc/paper/plugin/PermissionManager.java b/src/main/java/io/papermc/paper/plugin/PermissionManager.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..cdbc93b317b3bab47bf6552c29cfbb2c27846933

--- a/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,7 +14,7 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 8c93ff28273ef9ddce2fb7a62ac50701fa3cd9a2..8045f92ffdfb4164bcbef99c41359590c45f9006 100644
+index 713f5d73743007d47eca70167058f207626d2298..460bd4029b5a01e39b2322e69aecc128a073ee3a 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -11,6 +11,8 @@ java {
@@ -35,15 +35,15 @@ index 8c93ff28273ef9ddce2fb7a62ac50701fa3cd9a2..8045f92ffdfb4164bcbef99c41359590
  
      implementation("org.ow2.asm:asm:9.4")
      implementation("org.ow2.asm:asm-commons:9.4")
-@@ -113,6 +117,8 @@ tasks.withType<Javadoc> {
+@@ -117,6 +121,8 @@ tasks.withType<Javadoc> {
          "https://jd.advntr.dev/text-serializer-legacy/$adventureVersion/",
          "https://jd.advntr.dev/text-serializer-plain/$adventureVersion/",
          "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/",
 +        "https://javadoc.io/doc/org.slf4j/slf4j-api/$slf4jVersion/",
 +        "https://javadoc.io/doc/org.apache.logging.log4j/log4j-api/$log4jVersion/",
          // Paper end
+         "https://javadoc.io/doc/org.apache.maven.resolver/maven-resolver-api/1.7.3", // Paper
      )
-     options.tags("apiNote:a:API Note:")
 diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
 index 8c76716249e44ed8bf6be94c1f5c7b6d9bb35be2..4eb639fbb46a0848be207149ea433455550fae1c 100644
 --- a/src/main/java/org/bukkit/plugin/Plugin.java


### PR DESCRIPTION
I know @jpenilla was working on a poc for how we could use version catalogs with patches which would make tracking versions better, but in the meantime, these should be added so any types in the javadocs are linked correctly.