### PR TITLE
Add allowDirectConnection to Velocity proxy config

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -440,10 +440,10 @@ index 0000000000000000000000000000000000000000..9ef6712c70fcd8912a79f3f61e351aac
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..58cdb70c0b9de45ca28811416d871099eefec2ce
+index 0000000000000000000000000000000000000000..e80d752eb40edf7a30c50cf0840232a6f4e2ef14
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,283 @@
+@@ -0,0 +1,284 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -530,6 +530,7 @@ index 0000000000000000000000000000000000000000..58cdb70c0b9de45ca28811416d871099
 +            public boolean enabled = false;
 +            public boolean onlineMode = false;
 +            public String secret = "";
++            public boolean allowDirectConnection = false;
 +        }
 +        public boolean proxyProtocol = false;
 +        public boolean isProxyOnlineMode() {

--- a/patches/server/0019-Rewrite-chunk-system.patch
+++ b/patches/server/0019-Rewrite-chunk-system.patch
@@ -15673,10 +15673,10 @@ index 0000000000000000000000000000000000000000..962d3cae6340fc11607b59355e291629
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 58cdb70c0b9de45ca28811416d871099eefec2ce..6a0560b1b0972f90b5260115e81f2baa84cfb40d 100644
+index e80d752eb40edf7a30c50cf0840232a6f4e2ef14..ff393a9873f67de3df811608b8cc0fc2e2c3e490 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -116,21 +116,6 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -117,21 +117,6 @@ public class GlobalConfiguration extends ConfigurationPart {
          public int incomingPacketThreshold = 300;
      }
  
@@ -15698,7 +15698,7 @@ index 58cdb70c0b9de45ca28811416d871099eefec2ce..6a0560b1b0972f90b5260115e81f2baa
      public UnsupportedSettings unsupportedSettings;
  
      public class UnsupportedSettings extends ConfigurationPart {
-@@ -280,4 +265,43 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -281,4 +266,43 @@ public class GlobalConfiguration extends ConfigurationPart {
          public boolean disableNoteblockUpdates = false;
          public boolean disableTripwireUpdates = false;
      }

--- a/patches/server/0868-Configurable-chat-thread-limit.patch
+++ b/patches/server/0868-Configurable-chat-thread-limit.patch
@@ -22,10 +22,10 @@ is actually processed, this is honestly really just exposed for the misnomers or
 who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
 
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 6a0560b1b0972f90b5260115e81f2baa84cfb40d..4ac3fa45cd155ae8a852e26d4d4d1f16b28efdc2 100644
+index ff393a9873f67de3df811608b8cc0fc2e2c3e490..06080c21f40c895f2e2e67faf93e51457c1e3c58 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -238,13 +238,26 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -239,13 +239,26 @@ public class GlobalConfiguration extends ConfigurationPart {
      public Misc misc;
  
      public class Misc extends ConfigurationPart {

--- a/patches/server/0989-Add-allowDirectConnection-to-Velocity-proxy-config.patch
+++ b/patches/server/0989-Add-allowDirectConnection-to-Velocity-proxy-config.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: No-Eul <noeul1243@gmail.com>
+Date: Mon, 17 Jul 2023 14:39:15 +0900
+Subject: [PATCH] Add allowDirectConnection to Velocity proxy config
+
+Each Paper server can enable or disable this feature, which allows clients to connect to the server without having to connect to the Velocity proxy server.
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
+index 2ff578e4a953ffcf5176815ba8e3f06f73499989..a81982f92b462803f71e3f56606e6ca7758a391c 100644
+--- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
+@@ -432,7 +432,10 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener,
+         if (io.papermc.paper.configuration.GlobalConfiguration.get().proxies.velocity.enabled && packet.getTransactionId() == this.velocityLoginMessageId) {
+             net.minecraft.network.FriendlyByteBuf buf = packet.getData();
+             if (buf == null) {
+-                this.disconnect("This server requires you to connect with Velocity.");
++                if (io.papermc.paper.configuration.GlobalConfiguration.get().proxies.velocity.allowDirectConnection && !this.connection.isMemoryConnection()) {
++                    this.state = ServerLoginPacketListenerImpl.State.KEY;
++                    this.connection.send(new ClientboundHelloPacket("", this.server.getKeyPair().getPublic().getEncoded(), this.challenge));
++                } else this.disconnect("This server requires you to connect with Velocity.");
+                 return;
+             }
+ 


### PR DESCRIPTION
Each Paper server can enable or disable this feature, which allows clients to connect to the server without having to connect to the Velocity proxy server.

The content of pull request is same to [this](https://github.com/PaperMC/Paper/issues/9438).