### PR TITLE
Fix unbreakable flint and steel being consumed when igniting creepers

### DIFF
--- a/patches/server/0873-Fix-a-bunch-of-vanilla-bugs.patch
+++ b/patches/server/0873-Fix-a-bunch-of-vanilla-bugs.patch
@@ -48,6 +48,9 @@ https://bugs.mojang.com/browse/MC-123848
   by: BillyGalbreath <blake.galbreath@gmail.com>
   Fixes item frames dropping items above when pointing down
 
+https://bugs.mojang.com/browse/MC-264285
+  Fix unbreakable flint and steel being consumed when igniting creepers
+
 Co-authored-by: William Blake Galbreath <blake.galbreath@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
@@ -248,6 +251,19 @@ index a86472cce8e8fcde16d761842fe443a619f6e305..b42c060a5d8d68b5773a8a5e38c59707
      private void removeFramedMap(ItemStack itemstack) {
          this.getFramedMapId().ifPresent((i) -> {
              MapItemSavedData worldmap = MapItem.getSavedData(i, this.level());
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Creeper.java b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
+index 7fe90ebc8eced53f72c7f935e40745075f02421b..fd1b5a1beea7594fa65decfdcccfa15781fc005b 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Creeper.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
+@@ -248,7 +248,7 @@ public class Creeper extends Monster implements PowerableMob {
+             this.level().playSound(player, this.getX(), this.getY(), this.getZ(), soundeffect, this.getSoundSource(), 1.0F, this.random.nextFloat() * 0.4F + 0.8F);
+             if (!this.level().isClientSide) {
+                 this.ignite();
+-                if (!itemstack.isDamageableItem()) {
++                if (itemstack.getItem().getMaxDamage() == 0) { // Paper - fix MC-264285, only shrink the stack if the item type actually has no durability
+                     itemstack.shrink(1);
+                 } else {
+                     itemstack.hurtAndBreak(1, player, (entityhuman1) -> {
 diff --git a/src/main/java/net/minecraft/world/entity/npc/CatSpawner.java b/src/main/java/net/minecraft/world/entity/npc/CatSpawner.java
 index f174094febfdfdc309f1b50877be60bae8a98156..5f407535298a31a34cfe114dd863fd6a9b977707 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/CatSpawner.java


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/9508

----

Mojang's (and originally ours since we fixed it before) fix for https://bugs.mojang.com/browse/MC-257875 didn't take into account the `Unbreakable` nbt tag for damageable items. We can bypass that by just directly checking if the itemstack's item type has durability. If it does not, we shrink by 1. If it does, you call the ItemStack#hurtAndBreak method which has it's own check for damageable items.