### PR TITLE
Fix endgateway teleportation offset

### DIFF
--- a/patches/server/0123-PlayerTeleportEndGatewayEvent.patch
+++ b/patches/server/0123-PlayerTeleportEndGatewayEvent.patch
@@ -4,20 +4,18 @@ Date: Sat, 31 Dec 2016 21:44:50 -0500
 Subject: [PATCH] PlayerTeleportEndGatewayEvent
 
 Allows you to access the Gateway being used in a teleport event
+Fix the offset used for player teleportation
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index 97c57619ebcf31f17f8430ffb68043771d1377f9..9f685b4fe6d57d921e9e7a4d817e0913b863c0ad 100644
+index 97c57619ebcf31f17f8430ffb68043771d1377f9..020314dded2c6305bd5e9013b108bc74be25ccc1 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-@@ -12,6 +12,7 @@ import net.minecraft.data.worldgen.features.EndFeatures;
- import net.minecraft.nbt.CompoundTag;
- import net.minecraft.nbt.NbtUtils;
- import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
-+import io.papermc.paper.util.MCUtil;
- import net.minecraft.server.level.ServerLevel;
- import net.minecraft.server.level.ServerPlayer;
- import net.minecraft.util.Mth;
-@@ -211,7 +212,7 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
+@@ -207,11 +207,11 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
+                 // CraftBukkit start - Fire PlayerTeleportEvent
+                 if (entity1 instanceof ServerPlayer) {
+                     org.bukkit.craftbukkit.entity.CraftPlayer player = (CraftPlayer) entity1.getBukkitEntity();
+-                    org.bukkit.Location location = CraftLocation.toBukkit(blockposition1, world.getWorld()).add(0.5D, 0.5D, 0.5D);
++                    org.bukkit.Location location = CraftLocation.toBukkit(blockposition1, world.getWorld()).add(0.5D, 0, 0.5D); // Paper - use the right Y offset
                      location.setPitch(player.getLocation().getPitch());
                      location.setYaw(player.getLocation().getYaw());
  
@@ -26,3 +24,12 @@ index 97c57619ebcf31f17f8430ffb68043771d1377f9..9f685b4fe6d57d921e9e7a4d817e0913
                      Bukkit.getPluginManager().callEvent(teleEvent);
                      if (teleEvent.isCancelled()) {
                          return;
+@@ -226,7 +226,7 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
+                 // CraftBukkit end
+ 
+                 entity1.setPortalCooldown();
+-                entity1.teleportToWithTicket((double) blockposition1.getX() + 0.5D, (double) blockposition1.getY(), (double) blockposition1.getZ() + 0.5D);
++                entity1.teleportToWithTicket((double) blockposition1.getX() + 0.5D, (double) blockposition1.getY(), (double) blockposition1.getZ() + 0.5D); // Paper - diff on change
+             }
+ 
+             TheEndGatewayBlockEntity.triggerCooldown(world, pos, state, blockEntity);

--- a/patches/server/0201-Implement-EntityTeleportEndGatewayEvent.patch
+++ b/patches/server/0201-Implement-EntityTeleportEndGatewayEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement EntityTeleportEndGatewayEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index 020314dded2c6305bd5e9013b108bc74be25ccc1..d3e2a78f4e562fac7f42687629a4807aec85037f 100644
+index 020314dded2c6305bd5e9013b108bc74be25ccc1..85914124014b4e6f0a561cf560918af68682b6f5 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 @@ -224,9 +224,20 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
@@ -13,11 +13,11 @@ index 020314dded2c6305bd5e9013b108bc74be25ccc1..d3e2a78f4e562fac7f42687629a4807a
                  }
                  // CraftBukkit end
 +                // Paper start - EntityTeleportEndGatewayEvent
-+                org.bukkit.Location location = new org.bukkit.Location(world.getWorld(), (double) blockposition1.getX() + 0.5D, (double) blockposition1.getY(), (double) blockposition1.getZ() + 0.5D);
-+                location.setPitch(entity.getXRot());
-+                location.setYaw(entity.getBukkitYaw());
++                org.bukkit.Location location = new org.bukkit.Location(world.getWorld(), blockposition1.getX() + 0.5D, blockposition1.getY(), blockposition1.getZ() + 0.5D);
++                location.setPitch(entity1.getXRot());
++                location.setYaw(entity1.getBukkitYaw());
 +
-+                org.bukkit.entity.Entity bukkitEntity = entity.getBukkitEntity();
++                org.bukkit.entity.Entity bukkitEntity = entity1.getBukkitEntity();
 +                com.destroystokyo.paper.event.entity.EntityTeleportEndGatewayEvent event = new com.destroystokyo.paper.event.entity.EntityTeleportEndGatewayEvent(bukkitEntity, bukkitEntity.getLocation(), location, new org.bukkit.craftbukkit.block.CraftEndGateway(world.getWorld(), blockEntity));
 +                if (!event.callEvent()) {
 +                    return;

--- a/patches/server/0201-Implement-EntityTeleportEndGatewayEvent.patch
+++ b/patches/server/0201-Implement-EntityTeleportEndGatewayEvent.patch
@@ -5,19 +5,19 @@ Subject: [PATCH] Implement EntityTeleportEndGatewayEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index 9f685b4fe6d57d921e9e7a4d817e0913b863c0ad..11f9b40d0cfb77d69ecd2c7ef71dc409d1d79eba 100644
+index 020314dded2c6305bd5e9013b108bc74be25ccc1..d3e2a78f4e562fac7f42687629a4807aec85037f 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-@@ -225,9 +225,20 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
+@@ -224,9 +224,20 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
  
                  }
                  // CraftBukkit end
-+                // Paper start - EntityTeleportEndGatewayEvent - replicated from above
-+                org.bukkit.craftbukkit.entity.CraftEntity bukkitEntity = entity.getBukkitEntity();
-+                org.bukkit.Location location = new org.bukkit.Location(world.getWorld(), (double) blockposition1.getX() + 0.5D, (double) blockposition1.getY() + 0.5D, (double) blockposition1.getZ() + 0.5D);
-+                location.setPitch(bukkitEntity.getLocation().getPitch());
-+                location.setYaw(bukkitEntity.getLocation().getYaw());
++                // Paper start - EntityTeleportEndGatewayEvent
++                org.bukkit.Location location = new org.bukkit.Location(world.getWorld(), (double) blockposition1.getX() + 0.5D, (double) blockposition1.getY(), (double) blockposition1.getZ() + 0.5D);
++                location.setPitch(entity.getXRot());
++                location.setYaw(entity.getBukkitYaw());
 +
++                org.bukkit.entity.Entity bukkitEntity = entity.getBukkitEntity();
 +                com.destroystokyo.paper.event.entity.EntityTeleportEndGatewayEvent event = new com.destroystokyo.paper.event.entity.EntityTeleportEndGatewayEvent(bukkitEntity, bukkitEntity.getLocation(), location, new org.bukkit.craftbukkit.block.CraftEndGateway(world.getWorld(), blockEntity));
 +                if (!event.callEvent()) {
 +                    return;
@@ -25,7 +25,7 @@ index 9f685b4fe6d57d921e9e7a4d817e0913b863c0ad..11f9b40d0cfb77d69ecd2c7ef71dc409
 +                // Paper end
  
                  entity1.setPortalCooldown();
--                entity1.teleportToWithTicket((double) blockposition1.getX() + 0.5D, (double) blockposition1.getY(), (double) blockposition1.getZ() + 0.5D);
+-                entity1.teleportToWithTicket((double) blockposition1.getX() + 0.5D, (double) blockposition1.getY(), (double) blockposition1.getZ() + 0.5D); // Paper - diff on change
 +                entity1.teleportToWithTicket(event.getTo().getX(), event.getTo().getY(), event.getTo().getZ()); // Paper
              }
  

--- a/patches/server/0403-Ensure-safe-gateway-teleport.patch
+++ b/patches/server/0403-Ensure-safe-gateway-teleport.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure safe gateway teleport
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index 11f9b40d0cfb77d69ecd2c7ef71dc409d1d79eba..d9baa85962236c42219cf09d4f3129be93ff069c 100644
+index d3e2a78f4e562fac7f42687629a4807aec85037f..115553877c222c101bdea0978e1fa6ec8322702e 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-@@ -106,7 +106,14 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
+@@ -105,7 +105,14 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
              List<Entity> list = world.getEntitiesOfClass(Entity.class, new AABB(pos), TheEndGatewayBlockEntity::canEntityTeleport);
  
              if (!list.isEmpty()) {


### PR DESCRIPTION
The endgateway teleport the entity normally at the center of the found block in the horizontal axis (X+0.5 Y+0 Z+0.5) however on Spigot/Paper the offset is at the center of the block for both axis (X+0.5 Y+0.5 Z+0.5). On Paper it's even worst than Spigot since it affect all entities and so the teleportation is done in mid-air unlike vanilla.