### PR TITLE
Allow passanger retaining teleport via end gateway

### DIFF
--- a/patches/server/0403-Ensure-safe-gateway-teleport.patch
+++ b/patches/server/0403-Ensure-safe-gateway-teleport.patch
@@ -3,24 +3,18 @@ From: kickash32 <kickash32@gmail.com>
 Date: Fri, 15 May 2020 01:10:03 -0400
 Subject: [PATCH] Ensure safe gateway teleport
 
+== AT ==
+public net.minecraft.world.entity.Entity teleportPassengers()V
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index 11f9b40d0cfb77d69ecd2c7ef71dc409d1d79eba..d9baa85962236c42219cf09d4f3129be93ff069c 100644
+index 11f9b40d0cfb77d69ecd2c7ef71dc409d1d79eba..98050655d31c05bc7e761d24a54059b3183b0f61 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-@@ -106,7 +106,14 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
-             List<Entity> list = world.getEntitiesOfClass(Entity.class, new AABB(pos), TheEndGatewayBlockEntity::canEntityTeleport);
+@@ -220,6 +220,7 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
  
-             if (!list.isEmpty()) {
--                TheEndGatewayBlockEntity.teleportEntity(world, pos, state, (Entity) list.get(world.random.nextInt(list.size())), blockEntity);
-+                // Paper start
-+                for (Entity entity : list) {
-+                    if (entity.canChangeDimensions()) {
-+                        TheEndGatewayBlockEntity.teleportEntity(world, pos, state, entity, blockEntity);
-+                        break;
-+                    }
-+                }
-+                // Paper end
-             }
+                     entity1.setPortalCooldown();
+                     ((ServerPlayer) entity1).connection.teleport(teleEvent.getTo());
++                    entity1.teleportPassengers(); // Paper - teleport passangers as well, preventing invisible passangers post teleport.
+                     TheEndGatewayBlockEntity.triggerCooldown(world, pos, state, blockEntity); // CraftBukkit - call at end of method
+                     return;
  
-             if (blockEntity.age % 2400L == 0L) {


### PR DESCRIPTION
Previously paper disabled the abilities for entities to teleport via end gateways if they were being used as a vehicle.

While the behaviour generally worked fine for entities riding other entities, players would quickly end up in an invalid state, not seeing their passanger anymore.

This commit removes the paper introduced limitation by now properly updating the passangers location of a player when they are teleporting through an end gateway.

Resolves: #9172
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9521.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/819270730.zip)