### PR TITLE
Add InventoryCloseEvent safety doc comment, similar to InventoryClickEvent

### DIFF
--- a/patches/api/0423-Add-InventoryCloseEvent-safety-doc-comment-similar-t.patch
+++ b/patches/api/0423-Add-InventoryCloseEvent-safety-doc-comment-similar-t.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gameoholic <viner.atmic@gmail.com>
+Date: Mon, 24 Jul 2023 20:05:09 +0300
+Subject: [PATCH] Add InventoryCloseEvent safety doc comment, similar to
+ InventoryClickEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryCloseEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryCloseEvent.java
+index 21ad8888c0e403bfc63518502577d651c02dda05..0ecccd041c4c5ee82165983c3169954f03e7f646 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryCloseEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryCloseEvent.java
+@@ -7,7 +7,25 @@ import org.bukkit.inventory.InventoryView;
+ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+- * Represents a player related inventory event
++ * This event is called when a player closes an inventory.
++ * <p>
++ * Because InventoryCloseEvent occurs within a modification of the Inventory,
++ * not all Inventory related methods are safe to use.
++ * <p>
++ * The following should never be invoked by an EventHandler for
++ * InventoryCloseEvent using the HumanEntity or InventoryView associated with
++ * this event:
++ * <ul>
++ * <li>{@link HumanEntity#closeInventory()}
++ * <li>{@link HumanEntity#openInventory(Inventory)}
++ * <li>{@link HumanEntity#openWorkbench(Location, boolean)}
++ * <li>{@link HumanEntity#openEnchanting(Location, boolean)}
++ * <li>{@link InventoryView#close()}
++ * </ul>
++ * To invoke one of these methods, schedule a task using
++ * {@link BukkitScheduler#runTask(Plugin, Runnable)}, which will run the task
++ * on the next tick. Also be aware that this is not an exhaustive list, and
++ * other methods could potentially create issues as well.
+  */
+ public class InventoryCloseEvent extends InventoryEvent {
+     private static final HandlerList handlers = new HandlerList();


### PR DESCRIPTION
When invoking `HumanEntity.openInventory()` by an EventHandler for `InventoryCloseEvent`, clicking on inventory menus after invoking it does not fire the event `InventoryClickEvent`.
Scheduling a task for it fixed the issue.

`InventoryClickEvent` has the following doc:
```
... 
The following should never be invoked by an EventHandler for InventoryClickEvent using the HumanEntity or InventoryView associated with this event:
HumanEntity.openInventory(Inventory)
...
```
However, the comment for `InventoryCloseEvent` doesn't state that, even though it should.