### PR TITLE
Add and implement PlayerFailMoveEvent

### DIFF
--- a/patches/api/0423-Add-PlayerFailMoveEvent.patch
+++ b/patches/api/0423-Add-PlayerFailMoveEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerFailMoveEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerFailMoveEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerFailMoveEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4525618952907237a037fed36e01768c69e48fd9
+index 0000000000000000000000000000000000000000..bb0be7376d068fa94f68d139c616bd99822e51bb
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerFailMoveEvent.java
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,109 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.Location;
@@ -18,6 +18,9 @@ index 0000000000000000000000000000000000000000..4525618952907237a037fed36e01768c
 +import org.bukkit.event.player.PlayerEvent;
 +import org.jetbrains.annotations.NotNull;
 +
++/**
++ * Runs when a player attempts to move, but is prevented from doing so by the server
++ */
 +public class PlayerFailMoveEvent extends PlayerEvent {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
@@ -28,7 +31,8 @@ index 0000000000000000000000000000000000000000..4525618952907237a037fed36e01768c
 +    private final Location from;
 +    private final Location to;
 +
-+    public PlayerFailMoveEvent(@NotNull Player who, FailReason failReason, boolean allowed, boolean logWarning, Location from, Location to) {
++    public PlayerFailMoveEvent(@NotNull Player who, @NotNull FailReason failReason, boolean allowed,
++                               boolean logWarning, @NotNull Location from, @NotNull Location to) {
 +        super(who);
 +        this.failReason = failReason;
 +        this.allowed = allowed;
@@ -37,19 +41,37 @@ index 0000000000000000000000000000000000000000..4525618952907237a037fed36e01768c
 +        this.to = to;
 +    }
 +
++    /**
++     * Gets the reason this movement was prevented by the server
++     * @return The reason the movement was prevented
++     */
 +    @NotNull
 +    public FailReason getFailReason() {
 +        return failReason;
 +    }
 +
++    /**
++     * Gets the location this player moved from
++     * @return Location the player moved from
++     */
++    @NotNull
 +    public Location getFrom() {
 +        return from;
 +    }
 +
++    /**
++     * Gets the location this player tried to move to
++     * @return Location the player tried to move to
++     */
++    @NotNull
 +    public Location getTo() {
 +        return to;
 +    }
 +
++    /**
++     * Gets if the check should be bypassed, allowing the movement
++     * @return whether to bypass the check
++     */
 +    public boolean isAllowed() {
 +        return allowed;
 +    }
@@ -62,6 +84,10 @@ index 0000000000000000000000000000000000000000..4525618952907237a037fed36e01768c
 +        this.allowed = allowed;
 +    }
 +
++    /**
++     * Gets if warnings will be printed to console. eg. "Player123 moved too quickly!"
++     * @return whether to log warnings
++     */
 +    public boolean getLogWarning() {
 +        return logWarning;
 +    }

--- a/patches/api/0423-Add-PlayerFailMoveEvent.patch
+++ b/patches/api/0423-Add-PlayerFailMoveEvent.patch
@@ -1,0 +1,95 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Moulberry <james.jenour@protonmail.com>
+Date: Wed, 26 Jul 2023 20:57:11 +0800
+Subject: [PATCH] Add PlayerFailMoveEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerFailMoveEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerFailMoveEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..4525618952907237a037fed36e01768c69e48fd9
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerFailMoveEvent.java
+@@ -0,0 +1,83 @@
++package io.papermc.paper.event.player;
++
++import org.bukkit.Location;
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++public class PlayerFailMoveEvent extends PlayerEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final FailReason failReason;
++    private boolean allowed;
++    private boolean logWarning;
++    private final Location from;
++    private final Location to;
++
++    public PlayerFailMoveEvent(@NotNull Player who, FailReason failReason, boolean allowed, boolean logWarning, Location from, Location to) {
++        super(who);
++        this.failReason = failReason;
++        this.allowed = allowed;
++        this.logWarning = logWarning;
++        this.from = from;
++        this.to = to;
++    }
++
++    @NotNull
++    public FailReason getFailReason() {
++        return failReason;
++    }
++
++    public Location getFrom() {
++        return from;
++    }
++
++    public Location getTo() {
++        return to;
++    }
++
++    public boolean isAllowed() {
++        return allowed;
++    }
++
++    /**
++     * Set if the check should be bypassed and the movement should be allowed
++     * @param allowed whether to bypass the check
++     */
++    public void setAllowed(boolean allowed) {
++        this.allowed = allowed;
++    }
++
++    public boolean getLogWarning() {
++        return logWarning;
++    }
++
++    /**
++     * Set if a warning is printed to console. eg. "Player123 moved too quickly!"
++     * @param logWarning whether to log warnings
++     */
++    public void setLogWarning(boolean logWarning) {
++        this.logWarning = logWarning;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++    public enum FailReason {
++        MOVED_INTO_UNLOADED_CHUNK, // Only fired if the world setting prevent-moving-into-unloaded-chunks is true
++        MOVED_TOO_QUICKLY,
++        MOVED_WRONGLY,
++        CLIPPED_INTO_BLOCK
++    }
++
++}

--- a/patches/server/0994-Implement-PlayerFailMoveEvent.patch
+++ b/patches/server/0994-Implement-PlayerFailMoveEvent.patch
@@ -5,16 +5,27 @@ Subject: [PATCH] Implement PlayerFailMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..fa6acce416d3c5fb821dc7da8e37c0adb6738218 100644
+index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..f14f498203169797434a113c73a0dd2660d7cf21 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1404,8 +1404,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                     double d0 = ServerGamePacketListenerImpl.clampHorizontal(packet.getX(this.player.getX())); final double toX = d0; // Paper - OBFHELPER
+                     double d1 = ServerGamePacketListenerImpl.clampVertical(packet.getY(this.player.getY())); final double toY = d1;
+                     double d2 = ServerGamePacketListenerImpl.clampHorizontal(packet.getZ(this.player.getZ())); final double toZ = d2; // Paper - OBFHELPER
+-                    float f = Mth.wrapDegrees(packet.getYRot(this.player.getYRot()));
+-                    float f1 = Mth.wrapDegrees(packet.getXRot(this.player.getXRot()));
++                    float f = Mth.wrapDegrees(packet.getYRot(this.player.getYRot())); final float toYaw = f; // Paper - OBFHELPER
++                    float f1 = Mth.wrapDegrees(packet.getXRot(this.player.getXRot())); final float toPitch = f1; // Paper - OBFHELPER
+ 
+                     if (this.player.isPassenger()) {
+                         this.player.absMoveTo(this.player.getX(), this.player.getY(), this.player.getZ(), f, f1);
 @@ -1471,8 +1471,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                              }
                              // Paper start - Prevent moving into unloaded chunks
                              if (this.player.level().paperConfig().chunks.preventMovingIntoUnloadedChunks && (this.player.getX() != toX || this.player.getZ() != toZ) && !worldserver.areChunksLoadedForMove(this.player.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(this.player.position())))) {
 +                                // Paper start - Add fail move event
 +                                io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_INTO_UNLOADED_CHUNK,
-+                                    toX, toY, toZ, f, f1, false);
++                                    toX, toY, toZ, toYaw, toPitch, false);
 +                                if (!event.isAllowed()) {
                                  this.internalTeleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot(), Collections.emptySet());
                                  return;
@@ -29,7 +40,7 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..fa6acce416d3c5fb821dc7da8e37c0ad
                                  // CraftBukkit end
 +                                    // Paper start - Add fail move event
 +                                    io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_TOO_QUICKLY,
-+                                        toX, toY, toZ, f, f1, true);
++                                        toX, toY, toZ, toYaw, toPitch, true);
 +                                    if (!event.isAllowed()) {
 +                                        if (event.getLogWarning())
                                      ServerGamePacketListenerImpl.LOGGER.warn("{} moved too quickly! {},{},{}", new Object[]{this.player.getName().getString(), d6, d7, d8});
@@ -46,7 +57,7 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..fa6acce416d3c5fb821dc7da8e37c0ad
                              if (!this.player.isChangingDimension() && d10 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
 +                                // Paper start - Add fail move event
 +                                io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_WRONGLY,
-+                                    toX, toY, toZ, f, f1, true);
++                                    toX, toY, toZ, toYaw, toPitch, true);
 +                                if (!event.isAllowed()) {
                                  flag2 = true; // Paper - diff on change, this should be moved wrongly
 +                                    if (event.getLogWarning())
@@ -63,7 +74,7 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..fa6acce416d3c5fb821dc7da8e37c0ad
 +                                    // Paper start - Add fail move event
 +                                    if (teleportBack) {
 +                                        io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
-+                                            toX, toY, toZ, f, f1, false);
++                                            toX, toY, toZ, toYaw, toPitch, false);
 +                                        if (event.isAllowed()) {
 +                                            teleportBack = false;
 +                                        }

--- a/patches/server/0994-Implement-PlayerFailMoveEvent.patch
+++ b/patches/server/0994-Implement-PlayerFailMoveEvent.patch
@@ -1,0 +1,107 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Moulberry <james.jenour@protonmail.com>
+Date: Wed, 26 Jul 2023 20:13:31 +0800
+Subject: [PATCH] Implement PlayerFailMoveEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..e17fea7e89e22bb5e9e3f350be4ec964cadea5cf 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1471,8 +1471,20 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                             }
+                             // Paper start - Prevent moving into unloaded chunks
+                             if (this.player.level().paperConfig().chunks.preventMovingIntoUnloadedChunks && (this.player.getX() != toX || this.player.getZ() != toZ) && !worldserver.areChunksLoadedForMove(this.player.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(this.player.position())))) {
+-                                this.internalTeleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot(), Collections.emptySet());
+-                                return;
++                                // Paper start - Add fail move event
++                                Player player = this.getCraftPlayer();
++                                Location from = player.getLocation().clone();
++                                Location to = new Location(player.getWorld(), toX, toY, toZ, f, f1);
++                                io.papermc.paper.event.player.PlayerFailMoveEvent event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player,
++                                    io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_INTO_UNLOADED_CHUNK,
++                                    false, false, from, to);
++                                event.callEvent();
++
++                                if (!event.isAllowed()) {
++                                    this.internalTeleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot(), Collections.emptySet());
++                                    return;
++                                }
++                                // Paper end
+                             }
+                             // Paper end
+ 
+@@ -1481,9 +1493,23 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+ 
+                                 if (d10 - d9 > Math.max(f2, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
+                                 // CraftBukkit end
+-                                    ServerGamePacketListenerImpl.LOGGER.warn("{} moved too quickly! {},{},{}", new Object[]{this.player.getName().getString(), d6, d7, d8});
+-                                    this.teleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot());
+-                                    return;
++                                    // Paper start - Add fail move event
++                                    Player player = this.getCraftPlayer();
++                                    Location from = player.getLocation().clone();
++                                    Location to = new Location(player.getWorld(), toX, toY, toZ, f, f1);
++                                    io.papermc.paper.event.player.PlayerFailMoveEvent event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player,
++                                        io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_TOO_QUICKLY,
++                                        false, true, from, to);
++                                    event.callEvent();
++
++                                    if (!event.isAllowed()) {
++                                        if (event.getLogWarning()) {
++                                            ServerGamePacketListenerImpl.LOGGER.warn("{} moved too quickly! {},{},{}", new Object[]{this.player.getName().getString(), d6, d7, d8});
++                                        }
++                                        this.teleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot());
++                                        return;
++                                    }
++                                    // Paper end
+                                 }
+                             }
+ 
+@@ -1548,8 +1574,22 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                             boolean flag2 = false;
+ 
+                             if (!this.player.isChangingDimension() && d10 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
+-                                flag2 = true; // Paper - diff on change, this should be moved wrongly
+-                                ServerGamePacketListenerImpl.LOGGER.warn("{} moved wrongly!", this.player.getName().getString());
++                                // Paper start - Add fail move event
++                                Player player = this.getCraftPlayer();
++                                Location from = new Location(player.getWorld(), this.lastPosX, this.lastPosY, this.lastPosZ, this.lastYaw, this.lastPitch);
++                                Location to = new Location(player.getWorld(), toX, toY, toZ, f, f1);
++                                io.papermc.paper.event.player.PlayerFailMoveEvent event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player,
++                                    io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_WRONGLY,
++                                    false, true, from, to);
++                                event.callEvent();
++
++                                if (!event.isAllowed()) {
++                                    flag2 = true; // Paper - diff on change, this should be moved wrongly
++                                    if (event.getLogWarning()) {
++                                        ServerGamePacketListenerImpl.LOGGER.warn("{} moved wrongly!", this.player.getName().getString());
++                                    }
++                                }
++                                // Paper end
+                             }
+ 
+                             // Paper start - optimise out extra getCubes
+@@ -1562,6 +1602,21 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                                 if (didCollide || !axisalignedbb.equals(newBox)) {
+                                     // note: only call after setLocation, or else getBoundingBox is wrong
+                                     teleportBack = this.hasNewCollision(worldserver, this.player, axisalignedbb, newBox);
++                                    // Paper start - Add fail move event
++                                    if (teleportBack) {
++                                        Player player = this.getCraftPlayer();
++                                        Location from = new Location(player.getWorld(), this.lastPosX, this.lastPosY, this.lastPosZ, this.lastYaw, this.lastPitch);
++                                        Location to = new Location(player.getWorld(), toX, toY, toZ, f, f1);
++                                        io.papermc.paper.event.player.PlayerFailMoveEvent event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player,
++                                            io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
++                                            false, false, from, to);
++                                        event.callEvent();
++
++                                        if (event.isAllowed()) {
++                                            teleportBack = false;
++                                        }
++                                    }
++                                    // Paper end
+                                 } // else: no collision at all detected, why do we care?
+                             }
+                             if (!this.player.noPhysics && !this.player.isSleeping() && teleportBack) { // Paper end - optimise out extra getCubes

--- a/patches/server/0994-Implement-PlayerFailMoveEvent.patch
+++ b/patches/server/0994-Implement-PlayerFailMoveEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement PlayerFailMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..60740d54ddbcc06bfa02b1d24cafe5f25aa1ba79 100644
+index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..fa6acce416d3c5fb821dc7da8e37c0adb6738218 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1471,8 +1471,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -34,8 +34,7 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..60740d54ddbcc06bfa02b1d24cafe5f2
 +                                        if (event.getLogWarning())
                                      ServerGamePacketListenerImpl.LOGGER.warn("{} moved too quickly! {},{},{}", new Object[]{this.player.getName().getString(), d6, d7, d8});
                                      this.teleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot());
--                                    return;
-+                                        return;
+                                     return;
 +                                    }
 +                                    // Paper end
                                  }

--- a/patches/server/0994-Implement-PlayerFailMoveEvent.patch
+++ b/patches/server/0994-Implement-PlayerFailMoveEvent.patch
@@ -5,73 +5,65 @@ Subject: [PATCH] Implement PlayerFailMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..c6521916145fce15342570fb415c4d052d09b261 100644
+index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..60740d54ddbcc06bfa02b1d24cafe5f25aa1ba79 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1471,8 +1471,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                              }
                              // Paper start - Prevent moving into unloaded chunks
                              if (this.player.level().paperConfig().chunks.preventMovingIntoUnloadedChunks && (this.player.getX() != toX || this.player.getZ() != toZ) && !worldserver.areChunksLoadedForMove(this.player.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(this.player.position())))) {
--                                this.internalTeleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot(), Collections.emptySet());
--                                return;
 +                                // Paper start - Add fail move event
-+                                var event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_INTO_UNLOADED_CHUNK,
++                                io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_INTO_UNLOADED_CHUNK,
 +                                    toX, toY, toZ, f, f1, false);
 +                                if (!event.isAllowed()) {
-+                                    this.internalTeleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot(), Collections.emptySet());
-+                                    return;
+                                 this.internalTeleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot(), Collections.emptySet());
+                                 return;
 +                                }
 +                                // Paper end
                              }
                              // Paper end
  
-@@ -1481,9 +1487,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1481,9 +1487,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
                                  if (d10 - d9 > Math.max(f2, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
                                  // CraftBukkit end
--                                    ServerGamePacketListenerImpl.LOGGER.warn("{} moved too quickly! {},{},{}", new Object[]{this.player.getName().getString(), d6, d7, d8});
--                                    this.teleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot());
--                                    return;
 +                                    // Paper start - Add fail move event
-+                                    var event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_TOO_QUICKLY,
++                                    io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_TOO_QUICKLY,
 +                                        toX, toY, toZ, f, f1, true);
 +                                    if (!event.isAllowed()) {
-+                                        if (event.getLogWarning()) {
-+                                            ServerGamePacketListenerImpl.LOGGER.warn("{} moved too quickly! {},{},{}", new Object[]{this.player.getName().getString(), d6, d7, d8});
-+                                        }
-+                                        this.teleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot());
++                                        if (event.getLogWarning())
+                                     ServerGamePacketListenerImpl.LOGGER.warn("{} moved too quickly! {},{},{}", new Object[]{this.player.getName().getString(), d6, d7, d8});
+                                     this.teleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot());
+-                                    return;
 +                                        return;
 +                                    }
 +                                    // Paper end
                                  }
                              }
  
-@@ -1548,8 +1562,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1548,8 +1561,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                              boolean flag2 = false;
  
                              if (!this.player.isChangingDimension() && d10 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
--                                flag2 = true; // Paper - diff on change, this should be moved wrongly
--                                ServerGamePacketListenerImpl.LOGGER.warn("{} moved wrongly!", this.player.getName().getString());
 +                                // Paper start - Add fail move event
-+                                var event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_WRONGLY,
++                                io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_WRONGLY,
 +                                    toX, toY, toZ, f, f1, true);
 +                                if (!event.isAllowed()) {
-+                                    flag2 = true; // Paper - diff on change, this should be moved wrongly
-+                                    if (event.getLogWarning()) {
-+                                        ServerGamePacketListenerImpl.LOGGER.warn("{} moved wrongly!", this.player.getName().getString());
-+                                    }
+                                 flag2 = true; // Paper - diff on change, this should be moved wrongly
++                                    if (event.getLogWarning())
+                                 ServerGamePacketListenerImpl.LOGGER.warn("{} moved wrongly!", this.player.getName().getString());
 +                                }
 +                                // Paper end
                              }
  
                              // Paper start - optimise out extra getCubes
-@@ -1562,6 +1584,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1562,6 +1582,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                                  if (didCollide || !axisalignedbb.equals(newBox)) {
                                      // note: only call after setLocation, or else getBoundingBox is wrong
                                      teleportBack = this.hasNewCollision(worldserver, this.player, axisalignedbb, newBox);
 +                                    // Paper start - Add fail move event
 +                                    if (teleportBack) {
-+                                        var event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
++                                        io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
 +                                            toX, toY, toZ, f, f1, false);
 +                                        if (event.isAllowed()) {
 +                                            teleportBack = false;
@@ -81,7 +73,7 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..c6521916145fce15342570fb415c4d05
                                  } // else: no collision at all detected, why do we care?
                              }
                              if (!this.player.noPhysics && !this.player.isSleeping() && teleportBack) { // Paper end - optimise out extra getCubes
-@@ -1650,6 +1681,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1650,6 +1679,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          }
      }
  
@@ -91,7 +83,7 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..c6521916145fce15342570fb415c4d05
 +        Player player = this.getCraftPlayer();
 +        Location from = new Location(player.getWorld(), this.lastPosX, this.lastPosY, this.lastPosZ, this.lastYaw, this.lastPitch);
 +        Location to = new Location(player.getWorld(), toX, toY, toZ, toYaw, toPitch);
-+        var event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player, failReason,
++        io.papermc.paper.event.player.PlayerFailMoveEvent event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player, failReason,
 +            false, logWarning, from, to);
 +        event.callEvent();
 +        return event;

--- a/patches/server/0994-Implement-PlayerFailMoveEvent.patch
+++ b/patches/server/0994-Implement-PlayerFailMoveEvent.patch
@@ -5,24 +5,18 @@ Subject: [PATCH] Implement PlayerFailMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..e17fea7e89e22bb5e9e3f350be4ec964cadea5cf 100644
+index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..c6521916145fce15342570fb415c4d052d09b261 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1471,8 +1471,20 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1471,8 +1471,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                              }
                              // Paper start - Prevent moving into unloaded chunks
                              if (this.player.level().paperConfig().chunks.preventMovingIntoUnloadedChunks && (this.player.getX() != toX || this.player.getZ() != toZ) && !worldserver.areChunksLoadedForMove(this.player.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(this.player.position())))) {
 -                                this.internalTeleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot(), Collections.emptySet());
 -                                return;
 +                                // Paper start - Add fail move event
-+                                Player player = this.getCraftPlayer();
-+                                Location from = player.getLocation().clone();
-+                                Location to = new Location(player.getWorld(), toX, toY, toZ, f, f1);
-+                                io.papermc.paper.event.player.PlayerFailMoveEvent event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player,
-+                                    io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_INTO_UNLOADED_CHUNK,
-+                                    false, false, from, to);
-+                                event.callEvent();
-+
++                                var event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_INTO_UNLOADED_CHUNK,
++                                    toX, toY, toZ, f, f1, false);
 +                                if (!event.isAllowed()) {
 +                                    this.internalTeleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot(), Collections.emptySet());
 +                                    return;
@@ -31,7 +25,7 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..e17fea7e89e22bb5e9e3f350be4ec964
                              }
                              // Paper end
  
-@@ -1481,9 +1493,23 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1481,9 +1487,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
                                  if (d10 - d9 > Math.max(f2, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
                                  // CraftBukkit end
@@ -39,14 +33,8 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..e17fea7e89e22bb5e9e3f350be4ec964
 -                                    this.teleport(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYRot(), this.player.getXRot());
 -                                    return;
 +                                    // Paper start - Add fail move event
-+                                    Player player = this.getCraftPlayer();
-+                                    Location from = player.getLocation().clone();
-+                                    Location to = new Location(player.getWorld(), toX, toY, toZ, f, f1);
-+                                    io.papermc.paper.event.player.PlayerFailMoveEvent event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player,
-+                                        io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_TOO_QUICKLY,
-+                                        false, true, from, to);
-+                                    event.callEvent();
-+
++                                    var event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_TOO_QUICKLY,
++                                        toX, toY, toZ, f, f1, true);
 +                                    if (!event.isAllowed()) {
 +                                        if (event.getLogWarning()) {
 +                                            ServerGamePacketListenerImpl.LOGGER.warn("{} moved too quickly! {},{},{}", new Object[]{this.player.getName().getString(), d6, d7, d8});
@@ -58,21 +46,15 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..e17fea7e89e22bb5e9e3f350be4ec964
                                  }
                              }
  
-@@ -1548,8 +1574,22 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1548,8 +1562,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                              boolean flag2 = false;
  
                              if (!this.player.isChangingDimension() && d10 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
 -                                flag2 = true; // Paper - diff on change, this should be moved wrongly
 -                                ServerGamePacketListenerImpl.LOGGER.warn("{} moved wrongly!", this.player.getName().getString());
 +                                // Paper start - Add fail move event
-+                                Player player = this.getCraftPlayer();
-+                                Location from = new Location(player.getWorld(), this.lastPosX, this.lastPosY, this.lastPosZ, this.lastYaw, this.lastPitch);
-+                                Location to = new Location(player.getWorld(), toX, toY, toZ, f, f1);
-+                                io.papermc.paper.event.player.PlayerFailMoveEvent event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player,
-+                                    io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_WRONGLY,
-+                                    false, true, from, to);
-+                                event.callEvent();
-+
++                                var event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_WRONGLY,
++                                    toX, toY, toZ, f, f1, true);
 +                                if (!event.isAllowed()) {
 +                                    flag2 = true; // Paper - diff on change, this should be moved wrongly
 +                                    if (event.getLogWarning()) {
@@ -83,20 +65,14 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..e17fea7e89e22bb5e9e3f350be4ec964
                              }
  
                              // Paper start - optimise out extra getCubes
-@@ -1562,6 +1602,21 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1562,6 +1584,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                                  if (didCollide || !axisalignedbb.equals(newBox)) {
                                      // note: only call after setLocation, or else getBoundingBox is wrong
                                      teleportBack = this.hasNewCollision(worldserver, this.player, axisalignedbb, newBox);
 +                                    // Paper start - Add fail move event
 +                                    if (teleportBack) {
-+                                        Player player = this.getCraftPlayer();
-+                                        Location from = new Location(player.getWorld(), this.lastPosX, this.lastPosY, this.lastPosZ, this.lastYaw, this.lastPitch);
-+                                        Location to = new Location(player.getWorld(), toX, toY, toZ, f, f1);
-+                                        io.papermc.paper.event.player.PlayerFailMoveEvent event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player,
-+                                            io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
-+                                            false, false, from, to);
-+                                        event.callEvent();
-+
++                                        var event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.CLIPPED_INTO_BLOCK,
++                                            toX, toY, toZ, f, f1, false);
 +                                        if (event.isAllowed()) {
 +                                            teleportBack = false;
 +                                        }
@@ -105,3 +81,22 @@ index 316740b2ba4c85828f544249c8cdd6fa1b525d3f..e17fea7e89e22bb5e9e3f350be4ec964
                                  } // else: no collision at all detected, why do we care?
                              }
                              if (!this.player.noPhysics && !this.player.isSleeping() && teleportBack) { // Paper end - optimise out extra getCubes
+@@ -1650,6 +1681,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+         }
+     }
+ 
++    // Paper start - Add fail move event
++    private io.papermc.paper.event.player.PlayerFailMoveEvent fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason failReason,
++               double toX, double toY, double toZ, float toYaw, float toPitch, boolean logWarning) {
++        Player player = this.getCraftPlayer();
++        Location from = new Location(player.getWorld(), this.lastPosX, this.lastPosY, this.lastPosZ, this.lastYaw, this.lastPitch);
++        Location to = new Location(player.getWorld(), toX, toY, toZ, toYaw, toPitch);
++        var event = new io.papermc.paper.event.player.PlayerFailMoveEvent(player, failReason,
++            false, logWarning, from, to);
++        event.callEvent();
++        return event;
++    }
++    // Paper end
+     // Paper start - optimise out extra getCubes
+     private boolean hasNewCollision(final ServerLevel world, final Entity entity, final AABB oldBox, final AABB newBox) {
+         final List<AABB> collisions = io.papermc.paper.util.CachedLists.getTempCollisionList();


### PR DESCRIPTION
Event runs when the client attempts to move, but is prevented from doing so by the server

The movement can be allowed by calling "setAllowed(true)"
Warning messages can be prevented by calling "setLogWarning(false)"

Event can be used to:
- Prevent lagback when interacting with certain game elements like launchers, double jump, etc.
- Disable movement checks for admins
- Prevent 'moved too quickly' and 'moved wrongly' messages from being logged

Event can also be implemented for vehicle movement, but I've skipped that in this PR.