### PR TITLE
Use correct seed on api world load

### DIFF
--- a/patches/server/1000-Use-correct-seed-on-api-world-load.patch
+++ b/patches/server/1000-Use-correct-seed-on-api-world-load.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Florian Schmidt <florian@f012.dev>
+Date: Fri, 28 Jul 2023 14:14:35 +0200
+Subject: [PATCH] Use correct seed on api world load
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 54f27d91f941235a99e341ed84531ad7f0840728..249d76acac9a91cd46f0b8a477511974a75d6f4a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1330,7 +1330,7 @@ public final class CraftServer implements Server {
+ 
+         // Paper - move down
+ 
+-        long j = BiomeManager.obfuscateSeed(creator.seed());
++        long j = BiomeManager.obfuscateSeed(worlddata.worldGenOptions().seed()); // Paper - use world seed
+         List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
+         LevelStem worlddimension = iregistry.get(actualDimension);
+ 


### PR DESCRIPTION
When loading an existing world using a `WorldCreator`, there is potential for two different seeds to be used. The seed used by the generator is the one loaded from the `level.dat` while the seed that gets provided to the `BiomeManager` (aka. `biomeZoomSeed`) is the one that the `WorldCreator` instance provides (which is random when not explicitly provided).

With this PR the seed from `WorldOptions` will be taken which will be the seed loaded from the `level.dat` in case the world already exists. In case a new world is being created the seed will be the one from `WorldCreator` as that is used to create `WorldOptions` in that case.

The new behavior would be the same as in `MinecraftServer#loadWorld0`

## Biome Changes

The impact of this PR on existing worlds is minor. Since the seed only seems responsible for biome borders. That is probably also the reason why this bug hasn't been noticed yet. For illustration, I've extracted a 1000x1000 area of the biomes as images:

| / | World Create | World load | Diff | 
|--|:------------------:|:----------------:|:------:|
|**Without fix** | ![worldCreate](https://github.com/PaperMC/Paper/assets/7030787/3c57e749-26f4-4af4-b6ba-80a42caecc12) | ![before](https://github.com/PaperMC/Paper/assets/7030787/a776c07f-3bc1-4b8e-b46b-ba2983d0a134) | ![create-before-diff](https://github.com/PaperMC/Paper/assets/7030787/6e28d51a-dcf3-4b97-8eec-50887adc36b2)
|**With fix** | ![worldCreate](https://github.com/PaperMC/Paper/assets/7030787/3c57e749-26f4-4af4-b6ba-80a42caecc12) | ![after](https://github.com/PaperMC/Paper/assets/7030787/2db0043f-84ea-491d-994d-8040c107a16b) | ![create-after-diff](https://github.com/PaperMC/Paper/assets/7030787/d5c48850-b81e-48a4-9610-86c78d71e099)


