### PR TITLE
Make the cursor limit option apply to banners

### DIFF
--- a/patches/server/0614-Limit-item-frame-cursors-on-maps.patch
+++ b/patches/server/0614-Limit-item-frame-cursors-on-maps.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Limit item frame cursors on maps
 
 
 diff --git a/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java b/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
-index 7a6fbd4be33e93c7f09b1ed146ae25fe6c6b503c..3b12030b49b1c539684d75ca3896eb498400ef99 100644
+index 7a6fbd4be33e93c7f09b1ed146ae25fe6c6b503c..50713f03c783c63f93710d986d94af544be0615a 100644
 --- a/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
 +++ b/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
 @@ -295,8 +295,10 @@ public class MapItemSavedData extends SavedData {
@@ -19,3 +19,12 @@ index 7a6fbd4be33e93c7f09b1ed146ae25fe6c6b503c..3b12030b49b1c539684d75ca3896eb49
          }
  
          CompoundTag nbttagcompound = stack.getTag();
+@@ -478,7 +480,7 @@ public class MapItemSavedData extends SavedData {
+                 return true;
+             }
+ 
+-            if (!this.isTrackedCountOverLimit(256)) {
++            if (!this.isTrackedCountOverLimit(((Level) world).paperConfig().maps.itemFrameCursorLimit)) { // Paper
+                 this.bannerMarkers.put(mapiconbanner.getId(), mapiconbanner);
+                 this.addDecoration(mapiconbanner.getDecoration(), world, mapiconbanner.getId(), d0, d1, 180.0D, mapiconbanner.getName());
+                 return true;


### PR DESCRIPTION
This PR makes the decoration limit for banners use the config's cursor limit instead of the vanilla limit of 256

Closes #9553