### PR TITLE
Only erase allay memory on non-item targets

### DIFF
--- a/patches/server/0707-Remove-streams-for-villager-AI.patch
+++ b/patches/server/0707-Remove-streams-for-villager-AI.patch
@@ -112,7 +112,7 @@ index 731ef21dbbd25d6924717de42f4569a9b5935643..fe3ab3d388f0481fb0db06b7f730f868
      private final boolean isUnsafe; // Paper
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/sensing/NearestItemSensor.java b/src/main/java/net/minecraft/world/entity/ai/sensing/NearestItemSensor.java
-index 1dfcc5cba6ffb463acf161a23fff1ca452184290..2c4517850a9692f1c2b1332b58e8312fe1166772 100644
+index 1dfcc5cba6ffb463acf161a23fff1ca452184290..61a164c5bfc86faa3f4d04a66e0257016cfd937d 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/sensing/NearestItemSensor.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/sensing/NearestItemSensor.java
 @@ -25,13 +25,16 @@ public class NearestItemSensor extends Sensor<Mob> {
@@ -120,7 +120,7 @@ index 1dfcc5cba6ffb463acf161a23fff1ca452184290..2c4517850a9692f1c2b1332b58e8312f
          Brain<?> brain = entity.getBrain();
          List<ItemEntity> list = world.getEntitiesOfClass(ItemEntity.class, entity.getBoundingBox().inflate(32.0D, 16.0D, 32.0D), (itemEntity) -> {
 -            return true;
-+            return itemEntity.closerThan(entity, 9.0D) && entity.wantsToPickUp(itemEntity.getItem()); // Paper - move predicate into getEntities
++            return itemEntity.closerThan(entity, MAX_DISTANCE_TO_WANTED_ITEM) && entity.wantsToPickUp(itemEntity.getItem()); // Paper - move predicate into getEntities
          });
 -        list.sort(Comparator.comparingDouble(entity::distanceToSqr));
 +        list.sort((e1, e2) -> Double.compare(entity.distanceToSqr(e1), entity.distanceToSqr(e2))); // better to take the sort perf hit than using line of sight more than we need to.

--- a/patches/server/0994-Only-erase-allay-memory-on-non-item-targets.patch
+++ b/patches/server/0994-Only-erase-allay-memory-on-non-item-targets.patch
@@ -13,24 +13,17 @@ This commit fixes the faulty behaviour by instance performing a check
 against the CraftItem type.
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java b/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java
-index bd9aa4a5443da862be3403c1941113373741a87c..cdd8a4bb43054063fc14d3d8c82c75e80f2cfc13 100644
+index bd9aa4a5443da862be3403c1941113373741a87c..73b49261499d9faf4e4e0e9322c17834ab128025 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java
-@@ -35,11 +35,15 @@ public class GoToWantedItem {
+@@ -35,8 +35,9 @@ public class GoToWantedItem {
                              if (event.isCancelled()) {
                                  return false;
                              }
 -                            if (!(event.getTarget() instanceof ItemEntity)) {
-+                            // Paper start - only erase allay memory on non-item targets
-+                            final org.bukkit.entity.Entity target = event.getTarget();
-+                            if (!(target instanceof final org.bukkit.craftbukkit.entity.CraftItem craftTarget)) {
++                            if (!(event.getTarget() instanceof org.bukkit.craftbukkit.entity.CraftItem)) { // Paper - only erase allay memory on non-item targets
                                  memoryaccessor2.erase();
-+                                return false;
++                                return false; // Paper - only erase allay memory onnon-item targets
                              }
  
--                            entityitem = (ItemEntity) ((org.bukkit.craftbukkit.entity.CraftEntity) event.getTarget()).getHandle();
-+                            entityitem = (ItemEntity) craftTarget.getHandle();
-+                            // Paper end - only erase allay memory on non-item targets
-                         }
-                         // CraftBukkit end
-                         WalkTarget memorytarget = new WalkTarget(new EntityTracker(entityitem, false), speed, 0);
+                             entityitem = (ItemEntity) ((org.bukkit.craftbukkit.entity.CraftEntity) event.getTarget()).getHandle();

--- a/patches/server/0994-Only-erase-allay-memory-on-non-item-targets.patch
+++ b/patches/server/0994-Only-erase-allay-memory-on-non-item-targets.patch
@@ -13,7 +13,7 @@ This commit fixes the faulty behaviour by instance performing a check
 against the CraftItem type.
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java b/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java
-index bd9aa4a5443da862be3403c1941113373741a87c..73b49261499d9faf4e4e0e9322c17834ab128025 100644
+index bd9aa4a5443da862be3403c1941113373741a87c..2f92eb39cde7b30a894db347ca85a506d880411e 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java
 @@ -35,8 +35,9 @@ public class GoToWantedItem {
@@ -23,7 +23,7 @@ index bd9aa4a5443da862be3403c1941113373741a87c..73b49261499d9faf4e4e0e9322c17834
 -                            if (!(event.getTarget() instanceof ItemEntity)) {
 +                            if (!(event.getTarget() instanceof org.bukkit.craftbukkit.entity.CraftItem)) { // Paper - only erase allay memory on non-item targets
                                  memoryaccessor2.erase();
-+                                return false; // Paper - only erase allay memory onnon-item targets
++                                return false; // Paper - only erase allay memory on non-item targets
                              }
  
                              entityitem = (ItemEntity) ((org.bukkit.craftbukkit.entity.CraftEntity) event.getTarget()).getHandle();

--- a/patches/server/0994-Only-erase-allay-memory-on-non-item-targets.patch
+++ b/patches/server/0994-Only-erase-allay-memory-on-non-item-targets.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <lynxplay101@gmail.com>
+Date: Fri, 4 Aug 2023 15:53:36 +0200
+Subject: [PATCH] Only erase allay memory on non-item targets
+
+Spigot incorrectly instanceOf checks the EntityTargetEvent#getTarget
+against the internal ItemEntity type and removes the nearest wanted item
+memory if said instanceOf check fails, (which is always the case)
+causing allays to behave differently as they constantly loose their
+target item.
+
+This commit fixes the faulty behaviour by instance performing a check
+against the CraftItem type.
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java b/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java
+index bd9aa4a5443da862be3403c1941113373741a87c..cdd8a4bb43054063fc14d3d8c82c75e80f2cfc13 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java
++++ b/src/main/java/net/minecraft/world/entity/ai/behavior/GoToWantedItem.java
+@@ -35,11 +35,15 @@ public class GoToWantedItem {
+                             if (event.isCancelled()) {
+                                 return false;
+                             }
+-                            if (!(event.getTarget() instanceof ItemEntity)) {
++                            // Paper start - only erase allay memory on non-item targets
++                            final org.bukkit.entity.Entity target = event.getTarget();
++                            if (!(target instanceof final org.bukkit.craftbukkit.entity.CraftItem craftTarget)) {
+                                 memoryaccessor2.erase();
++                                return false;
+                             }
+ 
+-                            entityitem = (ItemEntity) ((org.bukkit.craftbukkit.entity.CraftEntity) event.getTarget()).getHandle();
++                            entityitem = (ItemEntity) craftTarget.getHandle();
++                            // Paper end - only erase allay memory on non-item targets
+                         }
+                         // CraftBukkit end
+                         WalkTarget memorytarget = new WalkTarget(new EntityTracker(entityitem, false), speed, 0);


### PR DESCRIPTION
Spigot incorrectly instanceOf checks the EntityTargetEvent#getTarget against the internal ItemEntity type and removes the nearest wanted item memory if said instanceOf check fails, (which is always the case) causing allays to behave differently as they constantly loose their target item.

This commit fixes the faulty behaviour by instance performing a check against the CraftItem type.

Resolves: #9567

Additionally also resolves a not updated distance variable that was wrongly ported to 1.19.