### PR TITLE
Bump net.kyori:ansi to 1.0.3

### DIFF
--- a/patches/server/0133-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0133-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -25,7 +25,7 @@ Other changes:
 Co-Authored-By: Emilia Kond <emilia@rymiel.space>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index d67bfb162d122f6944aa16219b754d8d6ee40fb8..9f2068920183b6aca8ea6d8c6f6c433716b886c4 100644
+index d67bfb162d122f6944aa16219b754d8d6ee40fb8..df0c787a6e3cff522dc540aab3986692b4fc4cc3 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -6,9 +6,30 @@ plugins {
@@ -45,7 +45,7 @@ index d67bfb162d122f6944aa16219b754d8d6ee40fb8..9f2068920183b6aca8ea6d8c6f6c4337
 +    implementation("org.jline:jline-terminal-jansi:3.21.0")
 +    implementation("net.minecrell:terminalconsoleappender:1.3.0")
 +    implementation("net.kyori:adventure-text-serializer-ansi:4.14.0") // Keep in sync with adventureVersion from Paper-API build file
-+    implementation("net.kyori:ansi:1.0.2") // Manually bump beyond above transitive dep
++    implementation("net.kyori:ansi:1.0.3") // Manually bump beyond above transitive dep
 +    /*
 +          Required to add the missing Log4j2Plugins.dat file from log4j-core
 +          which has been removed by Mojang. Without it, log4j has to classload


### PR DESCRIPTION
net.kyori:ansi 1.0.3 introduces detection for Windows Terminal usage (via `WT_SESSION` env variable) and relies on jansi's presence to potentially detect other settings (such as Windows conhost)