### PR TITLE
Create 0994-Add-Mob-Spawner-support-to-AffectsSpawning.patch

### DIFF
--- a/patches/server/0994-Add-Mob-Spawner-support-to-AffectsSpawning.patch
+++ b/patches/server/0994-Add-Mob-Spawner-support-to-AffectsSpawning.patch
@@ -1,0 +1,111 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tristan Krstevski <tristankrst@gmail.com>
+Date: Sat, 5 Aug 2023 19:29:57 +1000
+Subject: [PATCH] Add Mob Spawner support to AffectsSpawning
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 18aac3da3c88f33b1a71a5920a8daa27e9723913..ceacb821d11290e6f0d8a624c910666e8a055908 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -565,6 +565,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+ 
+     // Paper start - optimise checkDespawn
+     public final List<ServerPlayer> playersAffectingSpawning = new java.util.ArrayList<>();
++    public final List<ServerPlayer> playersAffectingNaturalSpawning = new java.util.ArrayList<>();
+     // Paper end - optimise checkDespawn
+     // Paper start - optimise get nearest players for entity AI
+     @Override
+diff --git a/src/main/java/net/minecraft/world/entity/EntitySelector.java b/src/main/java/net/minecraft/world/entity/EntitySelector.java
+index 3ff999734d14e2b6e7828e117f5ee32a60c26bc1..430d61bd36197879b13cf592eac9e9c3b3d3025f 100644
+--- a/src/main/java/net/minecraft/world/entity/EntitySelector.java
++++ b/src/main/java/net/minecraft/world/entity/EntitySelector.java
+@@ -45,8 +45,13 @@ public final class EntitySelector {
+     public static final Predicate<Entity> PLAYER_AFFECTS_SPAWNING = (entity) -> {
+         return !entity.isSpectator() && entity.isAlive() && entity instanceof Player player && player.affectsSpawning;
+     };
++
++    public static final Predicate<Entity> PLAYER_AFFECTS_MOB_SPAWNER_SPAWNING = (entity) -> {
++        return !entity.isSpectator() && entity.isAlive() && entity instanceof Player player && player.affectsSpawning;
++    };
+     // Paper end
+ 
++
+     public static Predicate<Entity> withinDistance(double x, double y, double z, double max) {
+         double d4 = max * max;
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
+index 58152160d609d0e9d105153aeb166a56a7955603..499623b2e724fdfd294b2f38f046f2527aa85f8f 100644
+--- a/src/main/java/net/minecraft/world/entity/player/Player.java
++++ b/src/main/java/net/minecraft/world/entity/player/Player.java
+@@ -185,6 +185,7 @@ public abstract class Player extends LivingEntity {
+     public float hurtDir; // Paper - protected -> public
+     // Paper start
+     public boolean affectsSpawning = true;
++    public boolean affectsMobSpawnersSpawning = true;
+     public net.kyori.adventure.util.TriState flyingFallDamage = net.kyori.adventure.util.TriState.NOT_SET;
+     // Paper end
+ 
+diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
+index 633500aefd515df5dadda3802b94079f75a03fa0..72ddc1bf13c7e9599c505d3d9b9a4dbb0f70c653 100644
+--- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
++++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
+@@ -55,7 +55,7 @@ public abstract class BaseSpawner {
+     }
+ 
+     public boolean isNearPlayer(Level world, BlockPos pos) {
+-        return world.hasNearbyAlivePlayerThatAffectsSpawning((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, (double) this.requiredPlayerRange); // Paper - Affects Spawning API
++        return world.hasNearbyAlivePlayerThatAffectsMobSpawnerSpawning((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, (double) this.requiredPlayerRange); // Paper - Affects Spawning API
+     }
+ 
+     public void clientTick(Level world, BlockPos pos) {
+diff --git a/src/main/java/net/minecraft/world/level/EntityGetter.java b/src/main/java/net/minecraft/world/level/EntityGetter.java
+index 3b959f42d958bf0f426853aee56753d6c455fcdb..dc35c8e8bb5977485d3f06b4331e41953cf6aafb 100644
+--- a/src/main/java/net/minecraft/world/level/EntityGetter.java
++++ b/src/main/java/net/minecraft/world/level/EntityGetter.java
+@@ -150,6 +150,18 @@ public interface EntityGetter {
+         }
+         return false;
+     }
++
++    default boolean hasNearbyAlivePlayerThatAffectsMobSpawnerSpawning(double x, double y, double z, double range) {
++        for (Player player : this.players()) {
++            if (EntitySelector.PLAYER_AFFECTS_MOB_SPAWNER_SPAWNING.test(player)) { // combines NO_SPECTATORS and LIVING_ENTITY_STILL_ALIVE with an "affects mob spawner spawning" check
++                double distanceSqr = player.distanceToSqr(x, y, z);
++                if (range < 0.0D || distanceSqr < range * range) {
++                    return true;
++                }
++            }
++        }
++        return false;
++    }
+     // Paper end
+ 
+     default boolean hasNearbyAlivePlayer(double x, double y, double z, double range) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index dbdeb913e228651cadf5dbd7ec98afc738c80522..8aad21384d71dedb4930453f6a9c61c66da4662c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -2682,8 +2682,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+ 
+     // Paper start
+-    public void setAffectsSpawning(boolean affects) {
++    public void setAffectsSpawning(boolean affects, boolean affectsMobSpawners) {
+         this.getHandle().affectsSpawning = affects;
++        this.getHandle().affectsMobSpawnersSpawning = affectsMobSpawners;
+     }
+ 
+     @Override
+@@ -2691,6 +2692,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         return this.getHandle().affectsSpawning;
+     }
+ 
++    @Override
++    public boolean getAffectsMobSpawnerSpawning(){
++        return this.getHandle().affectsMobSpawnersSpawning;
++    }
++
+     @Override
+     public void setResourcePack(@NotNull String url, @NotNull String hash) {
+         this.setResourcePack(url, hash, false, null);


### PR DESCRIPTION
Introduce API for Mob Spawner support for AffectsSpawning to allow different type of spawning types. The reason for this as it would allow for the ability to only prevent natural spawns and keep mob spawns from spawners.

Originally I was just going to create another get/set, however, the code for checkDespawn is quite hard to change without breaking a previous patch hence I opted for editing original API by adding an extra boolean to the get (public void setAffectsSpawning(boolean affects, boolean affectsMobSpawners))

I believe everything should work by common sense but unsure if I've missed or possibly stuffed something up as it's my first time meddling around with this.