### PR TITLE
Deprecate extra ban methods with raw BanEntry

### DIFF
--- a/patches/api/0096-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0096-Add-Ban-Methods-to-Player-Objects.patch
@@ -11,19 +11,20 @@ diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/buk
 index abbf3d6f11350ab2dd47a277771d9f46221036bd..d8a3b6cb2d0cb035b2ab09e0327bc4f0be457ff7 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
-@@ -67,6 +67,61 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -67,6 +67,73 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       * @return true if banned, otherwise false
       */
      public boolean isBanned();
 +    // Paper start
-+
 +    /**
 +     * Permanently Bans this player from the server
 +     *
 +     * @param reason Reason for Ban
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)}
 +     */
 +    @NotNull
++    @Deprecated
 +    public default BanEntry banPlayer(@Nullable String reason) {
 +        return banPlayer(reason, null, null);
 +    }
@@ -33,8 +34,10 @@ index abbf3d6f11350ab2dd47a277771d9f46221036bd..d8a3b6cb2d0cb035b2ab09e0327bc4f0
 +     * @param reason Reason for Ban
 +     * @param source Source of the ban, or null for default
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)}
 +     */
 +    @NotNull
++    @Deprecated
 +    public default BanEntry banPlayer(@Nullable String reason, @Nullable String source) {
 +        return banPlayer(reason, null, source);
 +    }
@@ -44,8 +47,10 @@ index abbf3d6f11350ab2dd47a277771d9f46221036bd..d8a3b6cb2d0cb035b2ab09e0327bc4f0
 +     * @param reason Reason for Ban
 +     * @param expires When to expire the ban
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)}
 +     */
 +    @NotNull
++    @Deprecated
 +    public default BanEntry banPlayer(@Nullable String reason, @Nullable java.util.Date expires) {
 +        return banPlayer(reason, expires, null);
 +    }
@@ -56,12 +61,19 @@ index abbf3d6f11350ab2dd47a277771d9f46221036bd..d8a3b6cb2d0cb035b2ab09e0327bc4f0
 +     * @param expires When to expire the ban
 +     * @param source Source of the ban or null for default
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)}
 +     */
 +    @NotNull
++    @Deprecated
 +    public default BanEntry banPlayer(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source) {
 +        return banPlayer(reason, expires, source, true);
 +    }
++
++    /**
++     * @deprecated use {@link #ban(String, Date, String)}
++     */
 +    @NotNull
++    @Deprecated
 +    public default BanEntry banPlayer(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source, boolean kickIfOnline) {
 +        BanEntry banEntry = Bukkit.getServer().getBanList(BanList.Type.NAME).addBan(getName(), reason, expires, source);
 +        if (kickIfOnline && isOnline()) {
@@ -74,10 +86,10 @@ index abbf3d6f11350ab2dd47a277771d9f46221036bd..d8a3b6cb2d0cb035b2ab09e0327bc4f0
      /**
       * Adds this user to the {@link ProfileBanList}. If a previous ban exists, this will
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb4ee4a128 100644
+index b1d93f16c55d3fa9a157cf26286936a799ca8025..0c13a41b442b441cba322e03a6cd4da7efb40902 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1173,6 +1173,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1173,6 +1173,186 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start
@@ -86,9 +98,11 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     *
 +     * @param reason Reason for ban
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    // For reference, Bukkit defines this as nullable, while they impl isn't, we'll follow API.
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason) {
 +        return banPlayerFull(reason, null, null);
 +    }
@@ -99,8 +113,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     * @param reason Reason for ban
 +     * @param source Source of ban, or null for default
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason, @Nullable String source) {
 +        return banPlayerFull(reason, null, source);
 +    }
@@ -111,8 +127,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     * @param reason Reason for Ban
 +     * @param expires When to expire the ban
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason, @Nullable java.util.Date expires) {
 +        return banPlayerFull(reason, expires, null);
 +    }
@@ -124,8 +142,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     * @param expires When to expire the ban
 +     * @param source Source of the ban, or null for default
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerFull(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source) {
 +        banPlayer(reason, expires, source);
 +        return banPlayerIP(reason, expires, source, true);
@@ -138,8 +158,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     * @param reason Reason for ban
 +     * @param kickPlayer Whether or not to kick the player afterwards
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, boolean kickPlayer) {
 +        return banPlayerIP(reason, null, null, kickPlayer);
 +    }
@@ -151,8 +173,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     * @param source Source of ban, or null for default
 +     * @param kickPlayer Whether or not to kick the player afterwards
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable String source, boolean kickPlayer) {
 +        return banPlayerIP(reason, null, source, kickPlayer);
 +    }
@@ -164,8 +188,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     * @param expires When to expire the ban
 +     * @param kickPlayer Whether or not to kick the player afterwards
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires, boolean kickPlayer) {
 +        return banPlayerIP(reason, expires, null, kickPlayer);
 +    }
@@ -176,8 +202,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     *
 +     * @param reason Reason for ban
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason) {
 +        return banPlayerIP(reason, null, null);
 +    }
@@ -188,8 +216,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     * @param reason Reason for ban
 +     * @param source Source of ban, or null for default
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable String source) {
 +        return banPlayerIP(reason, null, source);
 +    }
@@ -200,8 +230,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     * @param reason Reason for Ban
 +     * @param expires When to expire the ban
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires) {
 +        return banPlayerIP(reason, expires, null);
 +    }
@@ -213,8 +245,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     * @param expires When to expire the ban
 +     * @param source Source of the ban or null for default
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source) {
 +        return banPlayerIP(reason, expires, source, true);
 +    }
@@ -227,8 +261,10 @@ index d06f9b4d0117515fb8fcf78d416dcd2b4ef6fb4b..07dde016220eef654901e3d78e2d37fb
 +     * @param source Source of the ban or null for default
 +     * @param kickPlayer if the targeted player should be kicked
 +     * @return Ban Entry
++     * @deprecated use {@link #ban(String, Date, String)} and {@link #banIp(String, Date, String, boolean)}
 +     */
 +    @Nullable
++    @Deprecated
 +    public default org.bukkit.BanEntry banPlayerIP(@Nullable String reason, @Nullable java.util.Date expires, @Nullable String source, boolean kickPlayer) {
 +        org.bukkit.BanEntry banEntry = org.bukkit.Bukkit.getServer().getBanList(org.bukkit.BanList.Type.IP).addBan(getAddress().getAddress().getHostAddress(), reason, expires, source);
 +        if (kickPlayer && isOnline()) {

--- a/patches/api/0145-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0145-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 07dde016220eef654901e3d78e2d37fb4ee4a128..7fe44fd8a1e93551365ea434e750f7dece9088de 100644
+index 3b80cb874dccf2ed4fde4c621f0f022ba1112bcd..5e17bab05276de4340c5f06866f2efce81a9ab65 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3195,6 +3195,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3219,6 +3219,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void setPlayerProfile(com.destroystokyo.paper.profile.@NotNull PlayerProfile profile);
      // Paper end - Player Profile API
  

--- a/patches/api/0166-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/api/0166-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,10 +16,10 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
-index d8a3b6cb2d0cb035b2ab09e0327bc4f0be457ff7..634629d8c591d0477dfa6af91fa99caf17ffa9b0 100644
+index ef85e57f812c501fac7abe7dd27c93702f66646f..f5d3e5c5d79910580b6202e7aee01341d09f6225 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
-@@ -211,7 +211,9 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -223,7 +223,9 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       * UTC.
       *
       * @return Date of last log-in for this player, or 0
@@ -29,7 +29,7 @@ index d8a3b6cb2d0cb035b2ab09e0327bc4f0be457ff7..634629d8c591d0477dfa6af91fa99caf
      public long getLastPlayed();
  
      /**
-@@ -234,6 +236,30 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -246,6 +248,30 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      @Nullable
      @Deprecated
      public Location getBedSpawnLocation();

--- a/patches/api/0173-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0173-Fix-Spigot-annotation-mistakes.patch
@@ -857,10 +857,10 @@ index 95c79c5fa0c4e30201f887da6467ce5f81c8a255..7f9c4d4b430a3f0276461346ff2621ba
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7fe44fd8a1e93551365ea434e750f7dece9088de..2778f72af5de5cd339a8648c5631ff94d5ee1352 100644
+index 5e17bab05276de4340c5f06866f2efce81a9ab65..8f2a6f8ac70a7d5c2b8f9c17199b6eb88750a703 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1567,11 +1567,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1591,11 +1591,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
  
      /**
       * Forces an update of the player's entire inventory.

--- a/patches/api/0190-Add-Player-Client-Options-API.patch
+++ b/patches/api/0190-Add-Player-Client-Options-API.patch
@@ -231,10 +231,10 @@ index 0000000000000000000000000000000000000000..1757055d821d9ec7c728aa6c1b52fa6a
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2778f72af5de5cd339a8648c5631ff94d5ee1352..06872dcef2d7f158ca3f25fb69b56511a0a1a90e 100644
+index 8f2a6f8ac70a7d5c2b8f9c17199b6eb88750a703..962cfd7b81a38e8e0bf4371d7c3aca80f40636af 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3214,6 +3214,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3238,6 +3238,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void resetCooldown();
      // Paper end - attack cooldown API
  

--- a/patches/api/0208-Brand-support.patch
+++ b/patches/api/0208-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 06872dcef2d7f158ca3f25fb69b56511a0a1a90e..74dd447e74bae93a568acce75a7e3818ab6e5568 100644
+index 962cfd7b81a38e8e0bf4371d7c3aca80f40636af..219a819731ec081fea4fe3ac75e617f8cd6afbbf 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3327,6 +3327,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3351,6 +3351,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0218-Player-elytra-boost-API.patch
+++ b/patches/api/0218-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 74dd447e74bae93a568acce75a7e3818ab6e5568..3f9cdf1cfd19e61e3568af536b195f08b26418ab 100644
+index 219a819731ec081fea4fe3ac75e617f8cd6afbbf..f52f35902cc6a8af5ee60cf815caef7a43372158 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3221,6 +3221,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3245,6 +3245,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      <T> @NotNull T getClientOption(com.destroystokyo.paper.@NotNull ClientOption<T> option);
      // Paper end - client option API
  

--- a/patches/api/0245-Add-sendOpLevel-API.patch
+++ b/patches/api/0245-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3f9cdf1cfd19e61e3568af536b195f08b26418ab..59821aba66edbef2644bdd21646f556e773a898b 100644
+index f52f35902cc6a8af5ee60cf815caef7a43372158..d735ed635022d170c6b1080ed87f3c2a799202f6 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3240,6 +3240,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3264,6 +3264,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      }
      // Paper end - elytra boost API
  

--- a/patches/api/0365-More-Teleport-API.patch
+++ b/patches/api/0365-More-Teleport-API.patch
@@ -158,10 +158,10 @@ index e1fe5d93eb7a1f96954d907dbbe0758f25bd1ce7..948d6a08ff459afd5d4d5b151c41d94d
       * Teleports this entity to the given location. If this entity is riding a
       * vehicle, it will be dismounted prior to teleportation.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c8a50647d34c70bc927c33c602f938a01bf6e7a9..14b744bd1a0595260c65d3870be5f3985fb95ccb 100644
+index 2501533048e4de25672d9cc0a52fa1150e6d8adb..d598eb27f131a265c163ea96ab5fb56d4cf6ecb9 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3400,6 +3400,45 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3424,6 +3424,45 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      String getClientBrandName();
      // Paper end
  

--- a/patches/api/0367-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0367-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 14b744bd1a0595260c65d3870be5f3985fb95ccb..87d20d238071dabdbebf745d28e87b210b2436ca 100644
+index d598eb27f131a265c163ea96ab5fb56d4cf6ecb9..f7c1b6380389d81ac94005408429ac5bd79f19a6 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3284,6 +3284,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3308,6 +3308,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void sendOpLevel(byte level);
      // Paper end - sendOpLevel API
  

--- a/patches/api/0377-Elder-Guardian-appearance-API.patch
+++ b/patches/api/0377-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 87d20d238071dabdbebf745d28e87b210b2436ca..ada7cfe2070eae77591b3138b88d389fbaab281a 100644
+index f7c1b6380389d81ac94005408429ac5bd79f19a6..deea445fe7b69d36de61e001f617a837c9a0eb2d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3464,6 +3464,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3488,6 +3488,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
      // Paper end - Teleport API
  

--- a/patches/api/0385-Add-Player-Warden-Warning-API.patch
+++ b/patches/api/0385-Add-Player-Warden-Warning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player Warden Warning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ada7cfe2070eae77591b3138b88d389fbaab281a..8a862dbf093ca0812aa1ce8def1e650380c303d0 100644
+index deea445fe7b69d36de61e001f617a837c9a0eb2d..e855cddf37c453ea3f8f0f4fc21dd2358258e28d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3480,6 +3480,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3504,6 +3504,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param silent whether sound should be silenced
       */
      void showElderGuardian(boolean silent);

--- a/patches/api/0398-Flying-Fall-Damage-API.patch
+++ b/patches/api/0398-Flying-Fall-Damage-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Flying Fall Damage API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index bfa5a218576c9db147da75ec39cf8a8f6e9f6157..9d81aec1346d07faa47745a3cb79bac4a8a4ffa3 100644
+index 6afced1da637e4162972b0ff1f6c9cf42c256a02..6fc27c35f8533b37d82f0db5605d4d06e70af18b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1835,6 +1835,23 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1859,6 +1859,23 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void setAllowFlight(boolean flight);
  

--- a/patches/api/0415-Fix-BanList-API.patch
+++ b/patches/api/0415-Fix-BanList-API.patch
@@ -36,10 +36,10 @@ index 548f6d28c28d74bed8b58ee82875909354afe132..a77c0411a68a9bad33ddfb335b7a996a
      /**
       * Gets if a {@link BanEntry} exists for the target, indicating an active
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
-index 634629d8c591d0477dfa6af91fa99caf17ffa9b0..ef6cb124adc98cb5231dc44e243450a2340f74af 100644
+index f5d3e5c5d79910580b6202e7aee01341d09f6225..6a84c3d0d15251694bb7a05393b9ff7a4d8e0617 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
-@@ -135,7 +135,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -147,7 +147,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       *     (updated) previous ban
       */
      @Nullable
@@ -48,7 +48,7 @@ index 634629d8c591d0477dfa6af91fa99caf17ffa9b0..ef6cb124adc98cb5231dc44e243450a2
  
      /**
       * Adds this user to the {@link ProfileBanList}. If a previous ban exists, this will
-@@ -149,7 +149,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -161,7 +161,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       *     (updated) previous ban
       */
      @Nullable
@@ -57,7 +57,7 @@ index 634629d8c591d0477dfa6af91fa99caf17ffa9b0..ef6cb124adc98cb5231dc44e243450a2
  
      /**
       * Adds this user to the {@link ProfileBanList}. If a previous ban exists, this will
-@@ -163,7 +163,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -175,7 +175,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       *     (updated) previous ban
       */
      @Nullable
@@ -130,7 +130,7 @@ index e805e629cede1c4c0674282c930cb67852718c3e..5248cf08ef83c7304dd76c42a2f646bb
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b49294027712e8d0b8aaaee1c041bc731b4cb184..8a765921b7e9ed047cfce2577408e420762f16bb 100644
+index 0966eb33f0a1cf74a2f2fc3cbb74c756848e2eeb..cc84581276a793bb8c4851ab55591f8251b6403b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -301,7 +301,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0423-Add-Listing-API-for-Player.patch
+++ b/patches/api/0423-Add-Listing-API-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Listing API for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8a765921b7e9ed047cfce2577408e420762f16bb..8839ccf9515ebc3d2962e5dd17e948a2a83a5241 100644
+index cc84581276a793bb8c4851ab55591f8251b6403b..0d6401cd26424c971b137c968467e29f47c03d8b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1965,6 +1965,32 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1989,6 +1989,32 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public boolean canSee(@NotNull Entity entity);
  

--- a/patches/api/0437-Add-player-idle-duration-API.patch
+++ b/patches/api/0437-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8839ccf9515ebc3d2962e5dd17e948a2a83a5241..5bad312df63eb6dea705c35e0f7e4dd980f526d7 100644
+index 0d6401cd26424c971b137c968467e29f47c03d8b..0d585390066966f3afd6b88c6d80806292a3cd31 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3621,6 +3621,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3645,6 +3645,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void increaseWardenWarningLevel();
      // Paper end
  

--- a/patches/api/0448-Add-experience-points-API.patch
+++ b/patches/api/0448-Add-experience-points-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add experience points API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5bad312df63eb6dea705c35e0f7e4dd980f526d7..254a02ddb5dc867c9dd6c2086791f7ab94247fd3 100644
+index 0d585390066966f3afd6b88c6d80806292a3cd31..c6cb4f17469a8f2e60dd3e28d41402851ce5fb21 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1834,6 +1834,45 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1858,6 +1858,45 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param exp New total experience points
       */
      public void setTotalExperience(int exp);


### PR DESCRIPTION
All these methods use the raw version of BanEntry and have conflicting nullability contracts.

While the raw BanEntry could be fixed, the conflicting nullability contracts would require larger changes that I'm not sure we want to make. 