### PR TITLE
Cache map ids on item frames

### DIFF
--- a/patches/server/0997-Cache-map-ids-on-item-frames.patch
+++ b/patches/server/0997-Cache-map-ids-on-item-frames.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Warrior <50800980+Warriorrrr@users.noreply.github.com>
+Date: Mon, 7 Aug 2023 12:58:28 +0200
+Subject: [PATCH] Cache map ids on item frames
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
+index d934d07ad761319f338d4386536f68fde211c041..196280f54e397c69d32bd4d1f6ae666efdd93773 100644
+--- a/src/main/java/net/minecraft/server/level/ServerEntity.java
++++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
+@@ -115,7 +115,7 @@ public class ServerEntity {
+                 ItemStack itemstack = entityitemframe.getItem();
+ 
+                 if (this.level.paperConfig().maps.itemFrameCursorUpdateInterval > 0 && this.tickCount % this.level.paperConfig().maps.itemFrameCursorUpdateInterval == 0 && itemstack.getItem() instanceof MapItem) { // CraftBukkit - Moved this.tickCounter % 10 logic here so item frames do not enter the other blocks // Paper - Make item frame map cursor update interval configurable
+-                    Integer integer = MapItem.getMapId(itemstack);
++                    Integer integer = entityitemframe.cachedMapId; // Paper
+                     MapItemSavedData worldmap = MapItem.getSavedData(integer, this.level);
+ 
+                     if (worldmap != null) {
+diff --git a/src/main/java/net/minecraft/world/entity/decoration/ItemFrame.java b/src/main/java/net/minecraft/world/entity/decoration/ItemFrame.java
+index dcf245387f59ce730cb2cfb5fc0e837a20d3dfe5..759ecd79534a7706f7d4a63eb9dacbefcfe54674 100644
+--- a/src/main/java/net/minecraft/world/entity/decoration/ItemFrame.java
++++ b/src/main/java/net/minecraft/world/entity/decoration/ItemFrame.java
+@@ -50,6 +50,7 @@ public class ItemFrame extends HangingEntity {
+     public static final int NUM_ROTATIONS = 8;
+     public float dropChance;
+     public boolean fixed;
++    public Integer cachedMapId; // Paper
+ 
+     public ItemFrame(EntityType<? extends ItemFrame> type, Level world) {
+         super(type, world);
+@@ -393,6 +394,7 @@ public class ItemFrame extends HangingEntity {
+     }
+ 
+     private void onItemChanged(ItemStack stack) {
++        this.cachedMapId = MapItem.getMapId(stack); // Paper
+         if (!stack.isEmpty() && stack.getFrame() != this) {
+             stack.setEntityRepresentation(this);
+         }


### PR DESCRIPTION
This patch reduces the cost of broadcasting framed map changes to players by caching the map ID on the item frame itself, instead of reading it from the framed map's tag each time. Also reduces a bit of the logic done in tickCarriedBy for framed maps, since framed maps aren't going to have player decorations on them.

In a lot of spark reports I've seen the call to MapItem#getMapId(ItemStack) take up a few percent of the tick, which seems pretty weird despite it being a simple method, so if that was fixed then this PR probably wouldn't even be necessary.

Closes #9531
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9584.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/858460673.zip)