### PR TITLE
Use correct source for mushroom block spread event

### DIFF
--- a/patches/server/0998-Use-correct-source-for-mushroom-block-spread-event.patch
+++ b/patches/server/0998-Use-correct-source-for-mushroom-block-spread-event.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Warrior <50800980+Warriorrrr@users.noreply.github.com>
+Date: Tue, 8 Aug 2023 11:49:32 +0200
+Subject: [PATCH] Use correct source for mushroom block spread event
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/MushroomBlock.java b/src/main/java/net/minecraft/world/level/block/MushroomBlock.java
+index f6f8e155223cba10c4073ddca602d1aa3aa872d7..5238b23cd3bca21e2b14c9be15699b95ad267e24 100644
+--- a/src/main/java/net/minecraft/world/level/block/MushroomBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/MushroomBlock.java
+@@ -56,6 +56,7 @@ public class MushroomBlock extends BushBlock implements BonemealableBlock {
+             }
+ 
+             BlockPos blockposition2 = pos.offset(random.nextInt(3) - 1, random.nextInt(2) - random.nextInt(2), random.nextInt(3) - 1);
++            final BlockPos sourcePos = pos; // Paper
+ 
+             for (int j = 0; j < 4; ++j) {
+                 if (world.isEmptyBlock(blockposition2) && state.canSurvive(world, blockposition2)) {
+@@ -66,7 +67,7 @@ public class MushroomBlock extends BushBlock implements BonemealableBlock {
+             }
+ 
+             if (world.isEmptyBlock(blockposition2) && state.canSurvive(world, blockposition2)) {
+-                org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockSpreadEvent(world, pos, blockposition2, state, 2); // CraftBukkit
++                org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockSpreadEvent(world, sourcePos, blockposition2, state, 2); // CraftBukkit // Paper
+             }
+         }
+ 


### PR DESCRIPTION
The pos variable is reassigned in this method which makes it no longer the position of the source mushroom that's being ticked.

Before:
```
[Paper-Test-Plugin] Source: AIR, at Location{world=CraftWorld{name=world},x=-275.0,y=69.0,z=-223.0,pitch=0.0,yaw=0.0}
[Paper-Test-Plugin] New state: BROWN_MUSHROOM, at Location{world=CraftWorld{name=world},x=-275.0,y=69.0,z=-223.0,pitch=0.0,yaw=0.0}
```
After:
```
[Paper-Test-Plugin] Source: BROWN_MUSHROOM, at Location{world=CraftWorld{name=world},x=-275.0,y=69.0,z=-222.0,pitch=0.0,yaw=0.0}
[Paper-Test-Plugin] New state: BROWN_MUSHROOM, at Location{world=CraftWorld{name=world},x=-275.0,y=69.0,z=-223.0,pitch=0.0,yaw=0.0}
```