### PR TITLE
Fix custom statistic criteria creation

### DIFF
--- a/patches/api/0424-Fix-custom-statistic-criteria-creation.patch
+++ b/patches/api/0424-Fix-custom-statistic-criteria-creation.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sat, 12 Aug 2023 15:33:55 +0200
+Subject: [PATCH] Fix custom statistic criteria creation
+
+
+diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
+index c661eab343ae76488de701630424e2d589f44fc0..de36dab37d3af249cf51573d163731c12346066a 100644
+--- a/src/main/java/org/bukkit/UnsafeValues.java
++++ b/src/main/java/org/bukkit/UnsafeValues.java
+@@ -249,5 +249,7 @@ public interface UnsafeValues {
+      * @throws IllegalStateException if no biome by the given key is registered.
+      */
+     void setBiomeKey(RegionAccessor accessor, int x, int y, int z, NamespacedKey biomeKey);
++
++    String getStatisticCriteriaKey(@NotNull org.bukkit.Statistic statistic);
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/scoreboard/Criteria.java b/src/main/java/org/bukkit/scoreboard/Criteria.java
+index 7d79d7fadab19bfbefc4797d7e5bbd3e9d733b53..3bc3abaf093d13e22b6ac2ee59ab584c92b4666a 100644
+--- a/src/main/java/org/bukkit/scoreboard/Criteria.java
++++ b/src/main/java/org/bukkit/scoreboard/Criteria.java
+@@ -335,7 +335,7 @@ public interface Criteria {
+     @NotNull
+     public static Criteria statistic(@NotNull Statistic statistic) {
+         Preconditions.checkArgument(statistic != null, "statistic must not be null");
+-        return Bukkit.getScoreboardCriteria("minecraft.custom:minecraft." + statistic.getKey().getKey());
++        return Bukkit.getScoreboardCriteria(org.bukkit.Bukkit.getUnsafe().getStatisticCriteriaKey(statistic)); // Paper
+     }
+ 
+     /**

--- a/patches/server/1003-Fix-custom-statistic-criteria-creation.patch
+++ b/patches/server/1003-Fix-custom-statistic-criteria-creation.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sat, 12 Aug 2023 15:33:49 +0200
+Subject: [PATCH] Fix custom statistic criteria creation
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index 83cef5ec27c31f133a23cd27349f722799c786ea..719e7103f7dfdc30f1cefd24a3fa572fa0ac8b1e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -622,6 +622,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+         net.minecraft.core.Holder<net.minecraft.world.level.biome.Biome> biomeBase = cra.getHandle().registryAccess().registryOrThrow(net.minecraft.core.registries.Registries.BIOME).getHolderOrThrow(net.minecraft.resources.ResourceKey.create(net.minecraft.core.registries.Registries.BIOME, org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(biomeKey)));
+         cra.setBiome(x, y, z, biomeBase);
+     }
++
++    @Override
++    public String getStatisticCriteriaKey(org.bukkit.Statistic statistic) {
++        if (statistic.getType() != org.bukkit.Statistic.Type.UNTYPED) return "minecraft.custom:minecraft." + statistic.getKey().getKey();
++        return org.bukkit.craftbukkit.CraftStatistic.getNMSStatistic(statistic).getName();
++    }
+     // Paper end
+ 
+     /**


### PR DESCRIPTION
When looking into fixing #9507 I noticed a lot more statistic criterion than just the play time were broken by the 'naive' enum -> key conversion. See [the wiki](https://minecraft.fandom.com/wiki/Statistics#List_of_custom_statistic_names) for the full list, everything that doesn't match with the enum is broken.

Rather than having to update the entire enum with the correct names in the way lynx showed [in this comment](https://github.com/PaperMC/Paper/issues/9507#issuecomment-1639815454), I opted for grabbing the correct statistic key from the server itself, using unsafevalues to bridge the gap. This should be easier to maintain and will prevent us missing the enum update should the keys change again.

A proper, long-term solution would be #5691, but until then I believe this is best fix.

Fixes #9507.