### PR TITLE
Feat/mushroom spread config

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1479,10 +1479,10 @@ index 0000000000000000000000000000000000000000..f0d4ec73bc8872a85e34f5c6b4d342e7
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d47c57afafc01e25b965f1844938b2516a7bd031
+index 0000000000000000000000000000000000000000..8550600818842fa6c9a934dff8cb3282b8ec7d4f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,484 @@
+@@ -0,0 +1,490 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1841,6 +1841,12 @@ index 0000000000000000000000000000000000000000..d47c57afafc01e25b965f1844938b251
 +        public boolean portalSearchVanillaDimensionScaling = true;
 +        public boolean disableTeleportationSuffocationCheck = false;
 +        public IntOr.Disabled netherCeilingVoidDamageHeight = IntOr.Disabled.DISABLED;
++
++        public Mushroom mushroom;
++        public class Mushroom extends ConfigurationPart {
++            public BooleanOrDefault disableLimit = BooleanOrDefault.USE_DEFAULT;
++            public IntOr.Default spreadLimit = IntOr.Default.USE_DEFAULT;
++        }
 +    }
 +
 +    public Spawn spawn;

--- a/patches/server/1006-Increase-vanilla-Mushroom-spread-limit.patch
+++ b/patches/server/1006-Increase-vanilla-Mushroom-spread-limit.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?L=C3=A9o=20Moriceau?= <thisis41@protonmail.com>
+Date: Sun, 13 Aug 2023 13:18:57 +0200
+Subject: [PATCH] Increase vanilla Mushroom spread limit
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/MushroomBlock.java b/src/main/java/net/minecraft/world/level/block/MushroomBlock.java
+index 5238b23cd3bca21e2b14c9be15699b95ad267e24..746d8001ada3db7417a426e0b70df486bfbb9477 100644
+--- a/src/main/java/net/minecraft/world/level/block/MushroomBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/MushroomBlock.java
+@@ -41,6 +41,14 @@ public class MushroomBlock extends BushBlock implements BonemealableBlock {
+     public void randomTick(BlockState state, ServerLevel world, BlockPos pos, RandomSource random) {
+         if (random.nextFloat() < (world.spigotConfig.mushroomModifier / (100.0f * 25))) { // Spigot - SPIGOT-7159: Better modifier resolution
+             int i = 5;
++            // Paper start - Increase vanilla mushroom spread
++            int mushroomSpreadLimit = world.paperConfig().environment.mushroom.spreadLimit.or(i);
++            if(world.paperConfig().environment.mushroom.disableLimit.or(false)) {
++                mushroomSpreadLimit = 9 * 9 * 3; // Paper - 9x9x3 Vanilla SHAPE sum
++            }
++            i = mushroomSpreadLimit;
++            // Paper end
++
+             boolean flag = true;
+             Iterator iterator = BlockPos.betweenClosed(pos.offset(-4, -1, -4), pos.offset(4, 1, 4)).iterator();
+ 


### PR DESCRIPTION
This update introduces a mushroom configuration to the Paper world, providing users with the ability to bypass the standard vanilla spread limit. This customization allows users to exert more control over mushroom spreading, potentially leading to increased mushroom growth within the designated area.

From: https://github.com/PaperMC/Paper/pull/9592