### PR TITLE
Add ExplosionPower methods to LargeFireball

### DIFF
--- a/patches/api/0299-Missing-Entity-API.patch
+++ b/patches/api/0299-Missing-Entity-API.patch
@@ -511,6 +511,33 @@ index 6b3c9bef9a8a34ddc6ff42cf358541a2665bf5e3..9c618a27d590f186f29c5d9094fc565e
 +    void setExplosionPower(int explosionPower);
 +    // Paper end
  }
+diff --git a/src/main/java/org/bukkit/entity/LargeFireball.java b/src/main/java/org/bukkit/entity/LargeFireball.java
+index b5f3cc9de70baa9b51b62977f1ff38dfc0cec717..e5108c367c10a4fee624bf4d80f7f79f0df8c34e 100644
+--- a/src/main/java/org/bukkit/entity/LargeFireball.java
++++ b/src/main/java/org/bukkit/entity/LargeFireball.java
+@@ -4,4 +4,22 @@ package org.bukkit.entity;
+  * Represents a large {@link Fireball}
+  */
+ public interface LargeFireball extends SizedFireball {
++
++    // Paper start
++    /**
++     * Returns the explosion power of the fireball.
++     *
++     * @return explosion power of the fireball
++     */
++    int getExplosionPower();
++
++    /**
++     * Sets the explosion power of the fireball.
++     *
++     * @param explosionPower explosion power of the fireball
++     * @throws IllegalArgumentException if the explosion power is less than 0 or greater than 127
++     */
++    void setExplosionPower(int explosionPower);
++    // Paper end
++
+ }
 diff --git a/src/main/java/org/bukkit/entity/Llama.java b/src/main/java/org/bukkit/entity/Llama.java
 index d23226ccb0f6c25028f000ce31346cd0a8898e6a..bc84b892cae5fe7019a3ad481e9da79956efa1fe 100644
 --- a/src/main/java/org/bukkit/entity/Llama.java

--- a/patches/server/0631-Missing-Entity-API.patch
+++ b/patches/server/0631-Missing-Entity-API.patch
@@ -359,7 +359,7 @@ index 61d4877b4f74362e38104bfeacb7d66534ad798e..454dd67920826b8b62c2654abfd43fc0
      @Override
      protected EntityHitResult findHitEntity(Vec3 currentPosition, Vec3 nextPosition) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index bb383c090ea6948a19cf8609b76ba517689b1562..49d6ae8465397c4210a6f9599d14008518c30cd0 100644
+index 76195cfe2be5931401fd66454013b829ddf265ff..2732b952ab18b49f72efcc22facef4f9b2b4fa4d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 @@ -828,14 +828,19 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
@@ -743,6 +743,28 @@ index 9e7a9520737f56a20a130b624ae66f3ee90fa3e7..814cded47a04c25391575af036f53dc4
 +    public void setExplosionPower(int explosionPower) {
 +        com.google.common.base.Preconditions.checkArgument(explosionPower >= 0 && explosionPower <= 127, "The explosion power has to be between 0 and 127");
 +        this.getHandle().setExplosionPower(explosionPower);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLargeFireball.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLargeFireball.java
+index 4bf68ae4c7417d2b97d2da93dffe2e0c3291129f..f961dc0a4cfe87b0de7d1855e57199435560cec5 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLargeFireball.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLargeFireball.java
+@@ -29,4 +29,17 @@ public class CraftLargeFireball extends CraftSizedFireball implements LargeFireb
+     public EntityType getType() {
+         return EntityType.FIREBALL;
+     }
++
++    // Paper start
++    @Override
++    public int getExplosionPower() {
++        return this.getHandle().explosionPower;
++    }
++
++    @Override
++    public void setExplosionPower(int explosionPower) {
++        com.google.common.base.Preconditions.checkArgument(explosionPower >= 0 && explosionPower <= 127, "The explosion power has to be between 0 and 127");
++        this.getHandle().explosionPower = explosionPower;
 +    }
 +    // Paper end
  }


### PR DESCRIPTION
This PR add the get/set method to LargeFireball to the explosion power, if not wrong the only way to get that value is if the shooter is a Ghast but this not apply to custom LargeFireball generated.

~~This PR starts because wanna get the radius.. in another entites are more hardcoded..~~