### PR TITLE
Account for dimension type in portal void damage check

### DIFF
--- a/patches/server/0035-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0035-Configurable-top-of-nether-void-damage.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Configurable top of nether void damage
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c0d19d31aece8abab310b4c7bffa2ffe7a8ac845..d20722a79aa87cae72b1b3b9039d342c9ff9570a 100644
+index 98933377d46b2dd69d5d477e7f1d6ddff96ee2b4..30360e9e8787b893a360ba899d8fac657634de75 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -715,7 +715,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -23,7 +23,7 @@ index c0d19d31aece8abab310b4c7bffa2ffe7a8ac845..d20722a79aa87cae72b1b3b9039d342c
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
-index 02e3322ec41108fe9275510e2daa833d180353dc..3668f9775f377434779a8e519b10a11cf7b14dd5 100644
+index 02e3322ec41108fe9275510e2daa833d180353dc..0762bb248b3bd43a06e89aa1893a6189f0e13866 100644
 --- a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
 +++ b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
 @@ -55,7 +55,7 @@ public class PortalForcer {
@@ -31,7 +31,7 @@ index 02e3322ec41108fe9275510e2daa833d180353dc..3668f9775f377434779a8e519b10a11c
              return holder.is(PoiTypes.NETHER_PORTAL);
          }, blockposition, i, PoiManager.Occupancy.ANY).filter((villageplacerecord) -> {
 -            return worldborder.isWithinBounds(villageplacerecord.getPos());
-+            return worldborder.isWithinBounds(villageplacerecord.getPos()) && !this.level.paperConfig().environment.netherCeilingVoidDamageHeight.test(v -> villageplacerecord.getPos().getY() >= v); // Paper - don't teleport into void damage
++            return worldborder.isWithinBounds(villageplacerecord.getPos()) && !(this.level.getTypeKey() == net.minecraft.world.level.dimension.LevelStem.NETHER && this.level.paperConfig().environment.netherCeilingVoidDamageHeight.test(v -> villageplacerecord.getPos().getY() >= v)); // Paper - don't teleport into void damage
          }).sorted(Comparator.comparingDouble((PoiRecord villageplacerecord) -> { // CraftBukkit - decompile error
              return villageplacerecord.getPos().distSqr(blockposition);
          }).thenComparingInt((villageplacerecord) -> {
@@ -40,7 +40,7 @@ index 02e3322ec41108fe9275510e2daa833d180353dc..3668f9775f377434779a8e519b10a11c
          WorldBorder worldborder = this.level.getWorldBorder();
          int i = Math.min(this.level.getMaxBuildHeight(), this.level.getMinBuildHeight() + this.level.getLogicalHeight()) - 1;
 +        // Paper start - if ceiling void damage is enabled, make sure the max height doesn't exceed the void damage height
-+        if (this.level.paperConfig().environment.netherCeilingVoidDamageHeight.enabled()) {
++        if (this.level.getTypeKey() == net.minecraft.world.level.dimension.LevelStem.NETHER && this.level.paperConfig().environment.netherCeilingVoidDamageHeight.enabled()) {
 +            i = Math.min(i, this.level.paperConfig().environment.netherCeilingVoidDamageHeight.intValue() - 1);
 +        }
 +        // Paper end

--- a/patches/server/0684-Optimise-general-POI-access.patch
+++ b/patches/server/0684-Optimise-general-POI-access.patch
@@ -996,7 +996,7 @@ index 0887cba39bfc4279abec21c6c316abab28beb0a3..5561b8499a0503b850974b1dc309edfb
              return Optional.empty();
          } else {
 diff --git a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
-index 33a6fda1e8f2df61b44f0e3ddda356ffa386f2df..9b38f4c81ca9ef0f91f9d59fc2be4eecc1afc165 100644
+index 08325c055b04355089d75031522c7b74d83c6cca..42212d4533ce25d1cfcf4c58f1fc88791d546cff 100644
 --- a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
 +++ b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
 @@ -51,18 +51,39 @@ public class PortalForcer {
@@ -1007,7 +1007,7 @@ index 33a6fda1e8f2df61b44f0e3ddda356ffa386f2df..9b38f4c81ca9ef0f91f9d59fc2be4eec
 -        Optional<PoiRecord> optional = villageplace.getInSquare((holder) -> {
 -            return holder.is(PoiTypes.NETHER_PORTAL);
 -        }, blockposition, i, PoiManager.Occupancy.ANY).filter((villageplacerecord) -> {
--            return worldborder.isWithinBounds(villageplacerecord.getPos()) && !this.level.paperConfig().environment.netherCeilingVoidDamageHeight.test(v -> villageplacerecord.getPos().getY() >= v); // Paper - don't teleport into void damage
+-            return worldborder.isWithinBounds(villageplacerecord.getPos()) && !(this.level.getTypeKey() == net.minecraft.world.level.dimension.LevelStem.NETHER && this.level.paperConfig().environment.netherCeilingVoidDamageHeight.test(v -> villageplacerecord.getPos().getY() >= v)); // Paper - don't teleport into void damage
 -        }).sorted(Comparator.comparingDouble((PoiRecord villageplacerecord) -> { // CraftBukkit - decompile error
 -            return villageplacerecord.getPos().distSqr(blockposition);
 -        }).thenComparingInt((villageplacerecord) -> {
@@ -1028,7 +1028,7 @@ index 33a6fda1e8f2df61b44f0e3ddda356ffa386f2df..9b38f4c81ca9ef0f91f9d59fc2be4eec
 +                    // why would we generate the chunk?
 +                    return false;
 +                }
-+                if (!worldborder.isWithinBounds(pos) || this.level.paperConfig().environment.netherCeilingVoidDamageHeight.test(v -> pos.getY() >= v)) { // Paper - don't teleport into void damage
++                if (!worldborder.isWithinBounds(pos) || (this.level.getTypeKey() == net.minecraft.world.level.dimension.LevelStem.NETHER && this.level.paperConfig().environment.netherCeilingVoidDamageHeight.test(v -> pos.getY() >= v))) { // Paper - don't teleport into void damage
 +                    return false;
 +                }
 +                return lowest.getBlockState(pos).hasProperty(BlockStateProperties.HORIZONTAL_AXIS);


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/8611

I think this is the best way to check if the world is a nether-like world. I don't really want to use the `World$Environment` enum as that will go away at some point in the future.