### PR TITLE
Add clicked position to PlayerUseUnknownEntityEvent

### DIFF
--- a/patches/api/0036-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/api/0036-Add-PlayerUseUnknownEntityEvent.patch
@@ -10,7 +10,7 @@ Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ffd2250dcf9041566381abc1d5e4fd3eebd3781b
+index 0000000000000000000000000000000000000000..c7d853121becd8f6980173aff6322e327f4037a1
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java
 @@ -0,0 +1,82 @@
@@ -48,7 +48,7 @@ index 0000000000000000000000000000000000000000..ffd2250dcf9041566381abc1d5e4fd3e
 +    }
 +
 +    /**
-+     * Returns the location of the unknown entity that was interacted with.
++     * Returns the entity id of the unknown entity that was interacted with.
 +     *
 +     * @return the entity id of the entity that was interacted with
 +     */

--- a/patches/api/0036-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/api/0036-Add-PlayerUseUnknownEntityEvent.patch
@@ -3,56 +3,96 @@ From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sat, 2 Apr 2016 05:08:36 -0400
 Subject: [PATCH] Add PlayerUseUnknownEntityEvent
 
+Adds the PlayerUseUnknownEntityEvent to be used by plugins dealing with
+virtual entities/entities that are not actually known to the server.
+
+Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..09cfdf48ead8f03f3497646537292174241b0868
+index 0000000000000000000000000000000000000000..ffd2250dcf9041566381abc1d5e4fd3eebd3781b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,82 @@
 +package com.destroystokyo.paper.event.player;
 +
++import io.papermc.paper.math.Position;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.EquipmentSlot;
 +import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
 +
++/**
++ * Represents an event that is called when a player right-clicks an unknown entity.
++ * Useful for plugins dealing with virtual entities (entities that don't actually spawned on the server).
++ * <br>
++ * This event may be called multiple times per interaction with different interaction hands
++ * and with or without the clicked position.
++ */
 +public class PlayerUseUnknownEntityEvent extends PlayerEvent {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLERS = new HandlerList();
 +    private final int entityId;
 +    private final boolean attack;
-+    @NotNull private final EquipmentSlot hand;
++    private final @NotNull EquipmentSlot hand;
++    private final @Nullable Position clickedPosition;
 +
-+    public PlayerUseUnknownEntityEvent(@NotNull Player who, int entityId, boolean attack, @NotNull EquipmentSlot hand) {
++    public PlayerUseUnknownEntityEvent(@NotNull Player who, int entityId, boolean attack, @NotNull EquipmentSlot hand, @Nullable Position clickedPosition) {
 +        super(who);
 +        this.entityId = entityId;
 +        this.attack = attack;
 +        this.hand = hand;
++        this.clickedPosition = clickedPosition;
 +    }
 +
++    /**
++     * Returns the location of the unknown entity that was interacted with.
++     *
++     * @return the entity id of the entity that was interacted with
++     */
 +    public int getEntityId() {
 +        return this.entityId;
 +    }
 +
++    /**
++     * Returns whether the interaction was an attack.
++     *
++     * @return true if the player is attacking the entity, false if the player is interacting with the entity
++     */
 +    public boolean isAttack() {
 +        return this.attack;
 +    }
 +
-+    @NotNull
-+    public EquipmentSlot getHand() {
++    /**
++     * Returns the hand used to perform this interaction.
++     *
++     * @return the hand used to interact
++     */
++    public @NotNull EquipmentSlot getHand() {
 +        return this.hand;
++    }
++
++    /**
++     * Returns the exact position that was clicked, or null if not available.
++     * See {@link org.bukkit.event.player.PlayerInteractAtEntityEvent} for more details.
++     *
++     * @return the exact position that was clicked, or null if not available
++     * @see org.bukkit.event.player.PlayerInteractAtEntityEvent
++     */
++    public @Nullable Position getClickedPosition() {
++        return clickedPosition;
 +    }
 +
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLERS;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLERS;
 +    }
 +}

--- a/patches/api/0036-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/api/0036-Add-PlayerUseUnknownEntityEvent.patch
@@ -26,7 +26,7 @@ index 0000000000000000000000000000000000000000..c7d853121becd8f6980173aff6322e32
 +
 +/**
 + * Represents an event that is called when a player right-clicks an unknown entity.
-+ * Useful for plugins dealing with virtual entities (entities that don't actually spawned on the server).
++ * Useful for plugins dealing with virtual entities (entities that aren't actually spawned on the server).
 + * <br>
 + * This event may be called multiple times per interaction with different interaction hands
 + * and with or without the clicked position.

--- a/patches/api/0036-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/api/0036-Add-PlayerUseUnknownEntityEvent.patch
@@ -10,23 +10,23 @@ Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c7d853121becd8f6980173aff6322e327f4037a1
+index 0000000000000000000000000000000000000000..16291c34a87fb0c610a8b2fef10a1899693cb3b8
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerUseUnknownEntityEvent.java
 @@ -0,0 +1,82 @@
 +package com.destroystokyo.paper.event.player;
 +
-+import io.papermc.paper.math.Position;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.EquipmentSlot;
++import org.bukkit.util.Vector;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Represents an event that is called when a player right-clicks an unknown entity.
-+ * Useful for plugins dealing with virtual entities (entities that aren't actually spawned on the server).
++ * Useful for plugins dealing with virtual entities (entities that don't actually spawned on the server).
 + * <br>
 + * This event may be called multiple times per interaction with different interaction hands
 + * and with or without the clicked position.
@@ -37,9 +37,9 @@ index 0000000000000000000000000000000000000000..c7d853121becd8f6980173aff6322e32
 +    private final int entityId;
 +    private final boolean attack;
 +    private final @NotNull EquipmentSlot hand;
-+    private final @Nullable Position clickedPosition;
++    private final @Nullable Vector clickedPosition;
 +
-+    public PlayerUseUnknownEntityEvent(@NotNull Player who, int entityId, boolean attack, @NotNull EquipmentSlot hand, @Nullable Position clickedPosition) {
++    public PlayerUseUnknownEntityEvent(@NotNull Player who, int entityId, boolean attack, @NotNull EquipmentSlot hand, @Nullable Vector clickedPosition) {
 +        super(who);
 +        this.entityId = entityId;
 +        this.attack = attack;
@@ -75,14 +75,14 @@ index 0000000000000000000000000000000000000000..c7d853121becd8f6980173aff6322e32
 +    }
 +
 +    /**
-+     * Returns the exact position that was clicked, or null if not available.
++     * Returns the position relative to the entity that was clicked, or null if not available.
 +     * See {@link org.bukkit.event.player.PlayerInteractAtEntityEvent} for more details.
 +     *
-+     * @return the exact position that was clicked, or null if not available
++     * @return the position relative to the entity that was clicked, or null if not available
 +     * @see org.bukkit.event.player.PlayerInteractAtEntityEvent
 +     */
-+    public @Nullable Position getClickedPosition() {
-+        return clickedPosition;
++    public @Nullable Vector getClickedRelativePosition() {
++        return clickedPosition.clone();
 +    }
 +
 +    @NotNull

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -3480,7 +3480,7 @@ index 0000000000000000000000000000000000000000..cea9c098ade00ee87b8efc8164ab72f5
 +}
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7afb13b7457755fac3aed4b0260413a280ed29e6
+index 0000000000000000000000000000000000000000..9572294a50110f2452090da1f32e0a73edc3db05
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
 @@ -0,0 +1,534 @@
@@ -3964,11 +3964,11 @@ index 0000000000000000000000000000000000000000..7afb13b7457755fac3aed4b0260413a2
 +        return new BlockPos(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
 +    }
 +
-+    public FinePosition toPosition(Vec3 vector) {
++    public static FinePosition toPosition(Vec3 vector) {
 +        return Position.fine(vector.x, vector.y, vector.z);
 +    }
 +
-+    public BlockPosition toPosition(Vec3i vector) {
++    public static BlockPosition toPosition(Vec3i vector) {
 +        return Position.block(vector.getX(), vector.getY(), vector.getZ());
 +    }
 +

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -3480,24 +3480,28 @@ index 0000000000000000000000000000000000000000..cea9c098ade00ee87b8efc8164ab72f5
 +}
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6779a0cc401231c53545dd22827b404be80b2ad0
+index 0000000000000000000000000000000000000000..7afb13b7457755fac3aed4b0260413a280ed29e6
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
-@@ -0,0 +1,522 @@
+@@ -0,0 +1,534 @@
 +package io.papermc.paper.util;
 +
 +import com.google.common.util.concurrent.ThreadFactoryBuilder;
++import io.papermc.paper.math.BlockPosition;
++import io.papermc.paper.math.FinePosition;
 +import io.papermc.paper.math.Position;
 +import it.unimi.dsi.fastutil.objects.ObjectRBTreeSet;
 +import java.lang.ref.Cleaner;
 +import net.minecraft.core.BlockPos;
 +import net.minecraft.core.Direction;
++import net.minecraft.core.Vec3i;
 +import net.minecraft.server.MinecraftServer;
 +import net.minecraft.server.level.ServerLevel;
 +import net.minecraft.world.entity.Entity;
 +import net.minecraft.world.level.ChunkPos;
 +import net.minecraft.world.level.ClipContext;
 +import net.minecraft.world.level.Level;
++import net.minecraft.world.phys.Vec3;
 +import org.apache.commons.lang.exception.ExceptionUtils;
 +import org.bukkit.Location;
 +import org.bukkit.block.BlockFace;
@@ -3958,6 +3962,14 @@ index 0000000000000000000000000000000000000000..6779a0cc401231c53545dd22827b404b
 +
 +    public static BlockPos toBlockPosition(Vector vec) {
 +        return new BlockPos(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
++    }
++
++    public FinePosition toPosition(Vec3 vector) {
++        return Position.fine(vector.x, vector.y, vector.z);
++    }
++
++    public BlockPosition toPosition(Vec3i vector) {
++        return Position.block(vector.getX(), vector.getY(), vector.getZ());
 +    }
 +
 +    public static boolean isEdgeOfChunk(BlockPos pos) {

--- a/patches/server/0019-Rewrite-chunk-system.patch
+++ b/patches/server/0019-Rewrite-chunk-system.patch
@@ -15847,12 +15847,12 @@ index cea9c098ade00ee87b8efc8164ab72f5279758f0..197224e31175252d8438a8df585bbb65
 +    }
  }
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
-index 6779a0cc401231c53545dd22827b404be80b2ad0..750ed5844b16dcee6c4dda7a7422777ed1bd3f5c 100644
+index 7afb13b7457755fac3aed4b0260413a280ed29e6..5e17a83df2f3606aff375fe054266d03f9a0b3b6 100644
 --- a/src/main/java/io/papermc/paper/util/MCUtil.java
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
-@@ -2,16 +2,29 @@ package io.papermc.paper.util;
- 
- import com.google.common.util.concurrent.ThreadFactoryBuilder;
+@@ -4,17 +4,30 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
+ import io.papermc.paper.math.BlockPosition;
+ import io.papermc.paper.math.FinePosition;
  import io.papermc.paper.math.Position;
 +import com.google.gson.JsonArray;
 +import com.google.gson.JsonObject;
@@ -15864,6 +15864,7 @@ index 6779a0cc401231c53545dd22827b404be80b2ad0..750ed5844b16dcee6c4dda7a7422777e
 +import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
  import net.minecraft.core.BlockPos;
  import net.minecraft.core.Direction;
+ import net.minecraft.core.Vec3i;
  import net.minecraft.server.MinecraftServer;
 +import net.minecraft.server.level.ChunkHolder;
 +import net.minecraft.server.level.ChunkMap;
@@ -15877,10 +15878,10 @@ index 6779a0cc401231c53545dd22827b404be80b2ad0..750ed5844b16dcee6c4dda7a7422777e
  import net.minecraft.world.level.Level;
 +import net.minecraft.world.level.chunk.ChunkAccess;
 +import net.minecraft.world.level.chunk.ChunkStatus;
+ import net.minecraft.world.phys.Vec3;
  import org.apache.commons.lang.exception.ExceptionUtils;
  import org.bukkit.Location;
- import org.bukkit.block.BlockFace;
-@@ -22,8 +35,11 @@ import org.spigotmc.AsyncCatcher;
+@@ -26,8 +39,11 @@ import org.spigotmc.AsyncCatcher;
  
  import javax.annotation.Nonnull;
  import javax.annotation.Nullable;
@@ -15892,7 +15893,7 @@ index 6779a0cc401231c53545dd22827b404be80b2ad0..750ed5844b16dcee6c4dda7a7422777e
  import java.util.concurrent.CompletableFuture;
  import java.util.concurrent.ExecutionException;
  import java.util.concurrent.LinkedBlockingQueue;
-@@ -516,6 +532,100 @@ public final class MCUtil {
+@@ -528,6 +544,100 @@ public final class MCUtil {
          }
      }
  
@@ -20638,7 +20639,7 @@ index ca788f0dcec4a117b410fe8348969e056b138b1e..a6ac76707da39cf86113003b1f326433
      public boolean remove(Object object) {
          int i = this.findIndex((T)object);
 diff --git a/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java b/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java
-index 12e72ad737b1219fcdf88d344d41621d9fd5feec..e0bfeebeaac1aaea64bc07cdfdf7790e3e43ca7b 100644
+index 495b52bfab14478f8285cc5471335a41244c199e..e16ef1b7c0bfe6d6194c09f6787a50fd9b28f55e 100644
 --- a/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java
 +++ b/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java
 @@ -186,7 +186,11 @@ public class WorldUpgrader {
@@ -22796,7 +22797,7 @@ index d01388bbadf3069357cf52463f4104a1be4d2b56..b3dfa35bc41191883814c78693a0d958
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cf87f197d860567746dcae2a15946fed0b1a1d85..3b1dbfe6f03e62ac9e12066d41516de157f99719 100644
+index f76db40188007b6ab475d259b4cbe0c7ef804677..49ca3592012cca981b96434c9807440672a8c165 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -195,6 +195,48 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
@@ -28,7 +28,7 @@ index 644a0fdea6576647539b96528717dbaeab498d93..221e64a66ff12a8de5c75992fc26a54a
 +    // Paper end - PlayerUseUnknownEntityEvent
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index cad7df80d4914b533ce9db1a10b5923b5ffe578b..def0e05568bd5e1c3e9a6dfb95784d808bc109da 100644
+index cad7df80d4914b533ce9db1a10b5923b5ffe578b..39f2db938edad3db6fa83d9f8431a28176d4011a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2543,8 +2543,38 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -57,13 +57,13 @@ index cad7df80d4914b533ce9db1a10b5923b5ffe578b..def0e05568bd5e1c3e9a6dfb95784d80
 +
 +    }
  
-+    private void callPlayerUseUnknownEntityEvent(ServerboundInteractPacket packet, InteractionHand hand, @Nullable net.minecraft.world.phys.Vec3 pos) {
++    private void callPlayerUseUnknownEntityEvent(ServerboundInteractPacket packet, InteractionHand hand, @Nullable net.minecraft.world.phys.Vec3 vector) {
 +        this.cserver.getPluginManager().callEvent(new com.destroystokyo.paper.event.player.PlayerUseUnknownEntityEvent(
 +            this.getCraftPlayer(),
 +            packet.getEntityId(),
 +            packet.isAttack(),
 +            hand == InteractionHand.MAIN_HAND ? EquipmentSlot.HAND : EquipmentSlot.OFF_HAND,
-+            pos != null ? io.papermc.paper.util.MCUtil.toPosition(pos) : null)
++            vector != null ? new org.bukkit.util.Vector(vector.x, vector.y, vector.z) : null)
 +        );
      }
 +    // Paper end - PlayerUseUnknownEntityEvent

--- a/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
@@ -28,7 +28,7 @@ index 644a0fdea6576647539b96528717dbaeab498d93..221e64a66ff12a8de5c75992fc26a54a
 +    // Paper end - PlayerUseUnknownEntityEvent
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index cad7df80d4914b533ce9db1a10b5923b5ffe578b..c2bcf734f5829d7ea2af05deafc3dbc715fd11ba 100644
+index cad7df80d4914b533ce9db1a10b5923b5ffe578b..def0e05568bd5e1c3e9a6dfb95784d808bc109da 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2543,8 +2543,38 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -63,7 +63,7 @@ index cad7df80d4914b533ce9db1a10b5923b5ffe578b..c2bcf734f5829d7ea2af05deafc3dbc7
 +            packet.getEntityId(),
 +            packet.isAttack(),
 +            hand == InteractionHand.MAIN_HAND ? EquipmentSlot.HAND : EquipmentSlot.OFF_HAND,
-+            pos != null ? io.papermc.paper.math.Position.fine(pos.x, pos.y, pos.z) : null)
++            pos != null ? io.papermc.paper.util.MCUtil.toPosition(pos) : null)
 +        );
      }
 +    // Paper end - PlayerUseUnknownEntityEvent

--- a/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
@@ -3,63 +3,70 @@ From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sat, 2 Apr 2016 05:09:16 -0400
 Subject: [PATCH] Add PlayerUseUnknownEntityEvent
 
-== AT ==
-public net.minecraft.network.protocol.game.ServerboundInteractPacket$ActionType
+Adds the PlayerUseUnknownEntityEvent to be used by plugins dealing with
+virtual entities/entities that are not actually known to the server.
+
+Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/src/main/java/net/minecraft/network/protocol/game/ServerboundInteractPacket.java b/src/main/java/net/minecraft/network/protocol/game/ServerboundInteractPacket.java
-index a5d57cc862036012d83b090bb1b3ccf4115a88b3..21068f766b75c414d5818073b7dca083d8ff4409 100644
+index 644a0fdea6576647539b96528717dbaeab498d93..221e64a66ff12a8de5c75992fc26a54a03b317e7 100644
 --- a/src/main/java/net/minecraft/network/protocol/game/ServerboundInteractPacket.java
 +++ b/src/main/java/net/minecraft/network/protocol/game/ServerboundInteractPacket.java
-@@ -10,8 +10,8 @@ import net.minecraft.world.entity.Entity;
- import net.minecraft.world.phys.Vec3;
- 
- public class ServerboundInteractPacket implements Packet<ServerGamePacketListener> {
--    private final int entityId;
--    private final ServerboundInteractPacket.Action action;
-+    private final int entityId; public final int getEntityId() { return this.entityId; } // Paper - add accessor
-+    private final ServerboundInteractPacket.Action action; public final ServerboundInteractPacket.ActionType getActionType() { return this.action.getType(); } // Paper - add accessor
-     private final boolean usingSecondaryAction;
-     static final ServerboundInteractPacket.Action ATTACK_ACTION = new ServerboundInteractPacket.Action() {
-         @Override
+@@ -169,4 +169,14 @@ public class ServerboundInteractPacket implements Packet<ServerGamePacketListene
+             buf.writeEnum(this.hand);
+         }
+     }
++
++    // Paper start - PlayerUseUnknownEntityEvent
++    public int getEntityId() {
++        return this.entityId;
++    }
++
++    public boolean isAttack() {
++        return this.action.getType() == ActionType.ATTACK;
++    }
++    // Paper end - PlayerUseUnknownEntityEvent
+ }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index cad7df80d4914b533ce9db1a10b5923b5ffe578b..ae66a8a222bc27986bab0f7896e0eacfd6044b31 100644
+index cad7df80d4914b533ce9db1a10b5923b5ffe578b..c2bcf734f5829d7ea2af05deafc3dbc715fd11ba 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2543,8 +2543,37 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2543,8 +2543,38 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  });
              }
          }
-+        // Paper start - fire event
++        // Paper start - PlayerUseUnknownEntityEvent
 +        else {
 +            packet.dispatch(new net.minecraft.network.protocol.game.ServerboundInteractPacket.Handler() {
 +                @Override
 +                public void onInteraction(net.minecraft.world.InteractionHand hand) {
-+                    ServerGamePacketListenerImpl.this.callPlayerUseUnknownEntityEvent(packet, hand);
++                    ServerGamePacketListenerImpl.this.callPlayerUseUnknownEntityEvent(packet, hand, null);
 +                }
 +
 +                @Override
 +                public void onInteraction(net.minecraft.world.InteractionHand hand, net.minecraft.world.phys.Vec3 pos) {
-+                    ServerGamePacketListenerImpl.this.callPlayerUseUnknownEntityEvent(packet, hand);
++                    ServerGamePacketListenerImpl.this.callPlayerUseUnknownEntityEvent(packet, hand, pos);
 +                }
 +
 +                @Override
 +                public void onAttack() {
-+                    ServerGamePacketListenerImpl.this.callPlayerUseUnknownEntityEvent(packet, net.minecraft.world.InteractionHand.MAIN_HAND);
++                    ServerGamePacketListenerImpl.this.callPlayerUseUnknownEntityEvent(packet, net.minecraft.world.InteractionHand.MAIN_HAND, null);
 +                }
 +            });
 +        }
 +
 +    }
  
-+    private void callPlayerUseUnknownEntityEvent(ServerboundInteractPacket packet, InteractionHand hand) {
++    private void callPlayerUseUnknownEntityEvent(ServerboundInteractPacket packet, InteractionHand hand, @Nullable net.minecraft.world.phys.Vec3 pos) {
 +        this.cserver.getPluginManager().callEvent(new com.destroystokyo.paper.event.player.PlayerUseUnknownEntityEvent(
 +            this.getCraftPlayer(),
 +            packet.getEntityId(),
-+            packet.getActionType() == ServerboundInteractPacket.ActionType.ATTACK,
-+            hand == InteractionHand.MAIN_HAND ? EquipmentSlot.HAND : EquipmentSlot.OFF_HAND
-+        ));
++            packet.isAttack(),
++            hand == InteractionHand.MAIN_HAND ? EquipmentSlot.HAND : EquipmentSlot.OFF_HAND,
++            pos != null ? io.papermc.paper.math.Position.fine(pos.x, pos.y, pos.z) : null)
++        );
      }
-+    // Paper end
++    // Paper end - PlayerUseUnknownEntityEvent
  
      @Override
      public void handleClientCommand(ServerboundClientCommandPacket packet) {

--- a/patches/server/0121-Properly-fix-item-duplication-bug.patch
+++ b/patches/server/0121-Properly-fix-item-duplication-bug.patch
@@ -19,10 +19,10 @@ index 9e182c4cdf54c9ca7701660df72052d5c8936a55..5c855a15f7847ca37c263755f643eeb1
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 631eaf856daa09151e62e192296ba143213d6f29..12ce6ef8163fa46c1f5bc1f88011cd862b8bad89 100644
+index 512129382123d0c06eb308a98a9ee1b268e3b486..c7870a1a81f9c2d84066a39d2606c96f4e4df0bf 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3160,7 +3160,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3161,7 +3161,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      }
  
      public final boolean isDisconnected() {

--- a/patches/server/0140-Basic-PlayerProfile-API.patch
+++ b/patches/server/0140-Basic-PlayerProfile-API.patch
@@ -565,7 +565,7 @@ index 0000000000000000000000000000000000000000..7ac27392a8647ef7d0dc78efe78703e9
 +    @NotNull GameProfile buildGameProfile();
 +}
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
-index 750ed5844b16dcee6c4dda7a7422777ed1bd3f5c..39b19310eece90fa5398fbb160593fd4f966627a 100644
+index 5e17a83df2f3606aff375fe054266d03f9a0b3b6..5448dce87bb5934d4192ce2eb0b99a7b8e1f1ecc 100644
 --- a/src/main/java/io/papermc/paper/util/MCUtil.java
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
 @@ -1,5 +1,7 @@
@@ -574,17 +574,17 @@ index 750ed5844b16dcee6c4dda7a7422777ed1bd3f5c..39b19310eece90fa5398fbb160593fd4
 +import com.destroystokyo.paper.profile.CraftPlayerProfile;
 +import com.destroystokyo.paper.profile.PlayerProfile;
  import com.google.common.util.concurrent.ThreadFactoryBuilder;
- import io.papermc.paper.math.Position;
- import com.google.gson.JsonArray;
-@@ -26,6 +28,7 @@ import net.minecraft.world.level.Level;
- import net.minecraft.world.level.chunk.ChunkAccess;
+ import io.papermc.paper.math.BlockPosition;
+ import io.papermc.paper.math.FinePosition;
+@@ -30,6 +32,7 @@ import net.minecraft.world.level.chunk.ChunkAccess;
  import net.minecraft.world.level.chunk.ChunkStatus;
+ import net.minecraft.world.phys.Vec3;
  import org.apache.commons.lang.exception.ExceptionUtils;
 +import com.mojang.authlib.GameProfile;
  import org.bukkit.Location;
  import org.bukkit.block.BlockFace;
  import org.bukkit.craftbukkit.CraftWorld;
-@@ -374,6 +377,10 @@ public final class MCUtil {
+@@ -378,6 +381,10 @@ public final class MCUtil {
          return run.get();
      }
  

--- a/patches/server/0157-handle-ServerboundKeepAlivePacket-async.patch
+++ b/patches/server/0157-handle-ServerboundKeepAlivePacket-async.patch
@@ -15,10 +15,10 @@ also adding some additional logging in order to help work out what is causing
 random disconnections for clients.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 79769e770e04f0852fabed7dc7367e87bd5be310..924f520702723b3f44ac990f6222102119d16e9c 100644
+index 1f52d3cdb63319b0fe7aa29c34f502f4368646c2..9fdde607ee51da69371cce114c15074beb2d611a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3119,14 +3119,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3120,14 +3120,18 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      @Override
      public void handleKeepAlive(ServerboundKeepAlivePacket packet) {

--- a/patches/server/0215-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0215-InventoryCloseEvent-Reason-API.patch
@@ -75,7 +75,7 @@ index 3842caf61e388aa65b3a18c587480a7dabb8341b..bd7b8ede44a5971b034ffb75fbddbadd
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3580ce27843ab4e379360e2f63c8783e66384956..b87df5c04ad2c9abe112cccfde27c04f7e3a78e7 100644
+index ba1d752653b3a8111a96012a51f2e4d8048c3516..d9f392623ec3527e1e481d890748c5eeb3e3fadb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -222,6 +222,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -86,7 +86,7 @@ index 3580ce27843ab4e379360e2f63c8783e66384956..b87df5c04ad2c9abe112cccfde27c04f
  import org.bukkit.event.inventory.InventoryCreativeEvent;
  import org.bukkit.event.inventory.InventoryType.SlotType;
  import org.bukkit.event.inventory.SmithItemEvent;
-@@ -2681,10 +2682,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2682,10 +2683,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      @Override
      public void handleContainerClose(ServerboundContainerClosePacket packet) {
@@ -173,7 +173,7 @@ index 74f1af3dccddf52965e5c91277be3592649e8cfa..552fb0be2f31bd52a5ae43526d55aa29
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d8ec0ee64f0d322caa2fc9bf0c3680e6e6481a18..f9fc3b1dc6a134a22393e90de242aca0eb2e8dff 100644
+index 91eb7f4fb65fcaa4c953f9567971df243387816a..ef566466afb9665824e3f5c5c16a411cdf1abadc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1189,7 +1189,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0266-Catch-JsonParseException-in-Entity-and-TE-names.patch
+++ b/patches/server/0266-Catch-JsonParseException-in-Entity-and-TE-names.patch
@@ -13,19 +13,19 @@ Shulkers) may need to be changed in order for it to re-save properly
 No more crashing though.
 
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
-index 39b19310eece90fa5398fbb160593fd4f966627a..cb4379268b191d331c71be44642baac381ffaaf6 100644
+index 5448dce87bb5934d4192ce2eb0b99a7b8e1f1ecc..b842ff5c28c202a079cf6f626c6f7aca3ef1acf3 100644
 --- a/src/main/java/io/papermc/paper/util/MCUtil.java
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
-@@ -15,6 +15,8 @@ import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
- import net.minecraft.core.BlockPos;
+@@ -18,6 +18,8 @@ import net.minecraft.core.BlockPos;
  import net.minecraft.core.Direction;
+ import net.minecraft.core.Vec3i;
  import net.minecraft.server.MinecraftServer;
 +import net.minecraft.nbt.CompoundTag;
 +import net.minecraft.network.chat.Component;
  import net.minecraft.server.level.ChunkHolder;
  import net.minecraft.server.level.ChunkMap;
  import net.minecraft.server.level.DistanceManager;
-@@ -539,6 +541,21 @@ public final class MCUtil {
+@@ -551,6 +553,21 @@ public final class MCUtil {
          }
      }
  

--- a/patches/server/0296-Limit-Client-Sign-length-more.patch
+++ b/patches/server/0296-Limit-Client-Sign-length-more.patch
@@ -22,7 +22,7 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9a134d65ebb4d004cc1a92fd832975e307667a03..9358e4edc7265326c0ec32e60f596b0f61ee690f 100644
+index 9b59c97776a3843a94afff58261238246ac364c5..a979050827dc28c19b650c873a768580d1c14252 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -302,6 +302,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -33,7 +33,7 @@ index 9a134d65ebb4d004cc1a92fd832975e307667a03..9358e4edc7265326c0ec32e60f596b0f
  
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
          this.lastChatTimeStamp = new AtomicReference(Instant.EPOCH);
-@@ -3209,7 +3210,19 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3210,7 +3211,19 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      @Override
      public void handleSignUpdate(ServerboundSignUpdatePacket packet) {

--- a/patches/server/0416-Add-and-implement-PlayerRecipeBookClickEvent.patch
+++ b/patches/server/0416-Add-and-implement-PlayerRecipeBookClickEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add and implement PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 7e2f2c503f0af6b63ae496beb7cd9b34e61b16c9..dbae4102766837af9b173773c3d1a09439a1d606 100644
+index b197d5cc1b6abbeea22d3c941d54421d2e83cccd..45b6fd88d12d1f42164c6149fb8779edda478041 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3116,16 +3116,40 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3117,16 +3117,40 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              if (!this.player.containerMenu.stillValid(this.player)) {
                  ServerGamePacketListenerImpl.LOGGER.debug("Player {} interacted with invalid menu {}", this.player, this.player.containerMenu);
              } else {

--- a/patches/server/0420-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0420-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -89,10 +89,10 @@ index 15a70bad66eb2508f58ff184061c2d19e45297e1..f80645fe0e1f9ad2a70ea33c5dc6a8c0
  
                  playerlist.sendPlayerPermissionLevel(this);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f7c21abf2a783dc69c7fbe5719b4ca563a9deb65..a3d7f9cc074ce83815938a77c6119af95790d7e7 100644
+index 457c2b1e3db83c17c5282ad64eaccf3e534eafdb..6f3cd16845d5ea265666f5535b7f893e0a9d0fcf 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3381,7 +3381,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3382,7 +3382,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      public void handleChangeDifficulty(ServerboundChangeDifficultyPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (this.player.hasPermissions(2) || this.isSingleplayerOwner()) {

--- a/patches/server/0448-Brand-support.patch
+++ b/patches/server/0448-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a3d7f9cc074ce83815938a77c6119af95790d7e7..6f43de26f3d757dc14572c2d42dd8b6694e9fb0a 100644
+index 6f3cd16845d5ea265666f5535b7f893e0a9d0fcf..a37a29d771511b960c6c033b649833c223f40990 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -304,6 +304,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -17,7 +17,7 @@ index a3d7f9cc074ce83815938a77c6119af95790d7e7..6f43de26f3d757dc14572c2d42dd8b66
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player) {
          this.lastChatTimeStamp = new AtomicReference(Instant.EPOCH);
          this.lastSeenMessages = new LastSeenMessagesValidator(20);
-@@ -3336,6 +3338,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3337,6 +3339,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      private static final ResourceLocation CUSTOM_REGISTER = new ResourceLocation("register");
      private static final ResourceLocation CUSTOM_UNREGISTER = new ResourceLocation("unregister");
  
@@ -26,7 +26,7 @@ index a3d7f9cc074ce83815938a77c6119af95790d7e7..6f43de26f3d757dc14572c2d42dd8b66
      @Override
      public void handleCustomPayload(ServerboundCustomPayloadPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
-@@ -3363,6 +3367,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3364,6 +3368,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              try {
                  byte[] data = new byte[packet.data.readableBytes()];
                  packet.data.readBytes(data);
@@ -42,7 +42,7 @@ index a3d7f9cc074ce83815938a77c6119af95790d7e7..6f43de26f3d757dc14572c2d42dd8b66
                  this.cserver.getMessenger().dispatchIncomingMessage(this.player.getBukkitEntity(), packet.identifier.toString(), data);
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
-@@ -3372,6 +3385,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3373,6 +3386,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      }
  

--- a/patches/server/0503-Limit-recipe-packets.patch
+++ b/patches/server/0503-Limit-recipe-packets.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Limit recipe packets
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c6a1e8246ac22e83121cb17eee8e00ab1dd48306..c1636c313994dc4b3ae4c19fc66137bd080a501c 100644
+index 25a01e0a6dc87bc5785d1ede6a7344fcdc9daf7e..e1999066bb12d39a03dca00f99618045b2cee471 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -268,6 +268,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -24,7 +24,7 @@ index c6a1e8246ac22e83121cb17eee8e00ab1dd48306..c1636c313994dc4b3ae4c19fc66137bd
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -3135,6 +3137,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3136,6 +3138,15 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      @Override
      public void handlePlaceRecipe(ServerboundPlaceRecipePacket packet) {

--- a/patches/server/0591-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/server/0591-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add RespawnFlags to PlayerRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 25eefd856fb228b939b6ee4ae87f676e7419d9f4..e95574ecd4cee2515920f1445d8812b0fba7dc5e 100644
+index 89478496379ee8cf1653670a74e16201e030419b..aef114a256e048cd6c0c20a861d6fbfe61a7d1cf 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2789,7 +2789,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2790,7 +2790,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              case PERFORM_RESPAWN:
                  if (this.player.wonGame) {
                      this.player.wonGame = false;

--- a/patches/server/0603-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0603-additions-to-PlayerGameModeChangeEvent.patch
@@ -131,10 +131,10 @@ index c256423e9dc9d1837b847da44fb2920c58842c8b..0cb9803e30702de1cc530c1205fe9bbb
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e95574ecd4cee2515920f1445d8812b0fba7dc5e..363e16f3d8069d2828cd7437c7aed4cccccd9002 100644
+index aef114a256e048cd6c0c20a861d6fbfe61a7d1cf..14d8f37af21f2d7fb892c705c9da38ade0c88c41 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2798,7 +2798,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2799,7 +2799,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
                      this.player = this.server.getPlayerList().respawn(this.player, false, RespawnReason.DEATH);
                      if (this.server.isHardcore()) {
@@ -144,7 +144,7 @@ index e95574ecd4cee2515920f1445d8812b0fba7dc5e..363e16f3d8069d2828cd7437c7aed4cc
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d27c4b7a9db3b3970858eeacecabcc7926ff3ed8..155e39b55efeb72e8b92b68bc1183d8e842cf1e8 100644
+index f4ac6130d1112fb908cfd61698207b81d182b492..270521550d0349af64b01eb0d12c09c557341baa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1562,7 +1562,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0615-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0615-Add-PlayerKickEvent-causes.patch
@@ -88,7 +88,7 @@ index c68bac4727f6b2ca95fc8c438303097af14286f2..bb629ec263959c8268de88ca807bddb6
                  return Component.translatable("commands.kick.success", serverPlayer.getDisplayName(), reason);
              }, true);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0f8c29375790599f75d3d4535a417bafba916396..bc609a16fed44f0a96025fb3b75eec039107338c 100644
+index 5bca0a32de3355dd472fde02b0ddf3055a42ab0c..63aa0a4bc2fe0011c7e4e9736993dec52fc4e43e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -364,7 +364,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -370,7 +370,7 @@ index 0f8c29375790599f75d3d4535a417bafba916396..bc609a16fed44f0a96025fb3b75eec03
                              ServerGamePacketListenerImpl.LOGGER.warn("Player {} tried to attack an invalid entity", ServerGamePacketListenerImpl.this.player.getName().getString());
                          }
                      }
-@@ -3159,7 +3169,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3160,7 +3170,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          // Paper start
          if (!org.bukkit.Bukkit.isPrimaryThread()) {
              if (this.recipeSpamPackets.addAndGet(io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamIncrement) > io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamLimit) {
@@ -379,7 +379,7 @@ index 0f8c29375790599f75d3d4535a417bafba916396..bc609a16fed44f0a96025fb3b75eec03
                  return;
              }
          }
-@@ -3357,7 +3367,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3358,7 +3368,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          } else if (!this.isSingleplayerOwner()) {
              // Paper start - This needs to be handled on the main thread for plugins
              server.submit(() -> {
@@ -388,7 +388,7 @@ index 0f8c29375790599f75d3d4535a417bafba916396..bc609a16fed44f0a96025fb3b75eec03
              });
              // Paper end
          }
-@@ -3403,7 +3413,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3404,7 +3414,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  }
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t register custom payload", ex);
@@ -397,7 +397,7 @@ index 0f8c29375790599f75d3d4535a417bafba916396..bc609a16fed44f0a96025fb3b75eec03
              }
          } else if (packet.identifier.equals(CUSTOM_UNREGISTER)) {
              try {
-@@ -3413,7 +3423,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3414,7 +3424,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  }
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t unregister custom payload", ex);
@@ -406,7 +406,7 @@ index 0f8c29375790599f75d3d4535a417bafba916396..bc609a16fed44f0a96025fb3b75eec03
              }
          } else {
              try {
-@@ -3431,7 +3441,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3432,7 +3442,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  this.cserver.getMessenger().dispatchIncomingMessage(this.player.getBukkitEntity(), packet.identifier.toString(), data);
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
@@ -415,7 +415,7 @@ index 0f8c29375790599f75d3d4535a417bafba916396..bc609a16fed44f0a96025fb3b75eec03
              }
          }
  
-@@ -3473,7 +3483,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3474,7 +3484,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
          if (!Objects.equals(profilepublickey_a, profilepublickey_a1)) {
              if (profilepublickey_a != null && profilepublickey_a1.expiresAt().isBefore(profilepublickey_a.expiresAt())) {
@@ -424,7 +424,7 @@ index 0f8c29375790599f75d3d4535a417bafba916396..bc609a16fed44f0a96025fb3b75eec03
              } else {
                  try {
                      SignatureValidator signaturevalidator = this.server.getProfileKeySignatureValidator();
-@@ -3486,7 +3496,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3487,7 +3497,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                      this.resetPlayerChatState(remotechatsession_a.validate(this.player.getGameProfile(), signaturevalidator, Duration.ZERO));
                  } catch (ProfilePublicKey.ValidationException profilepublickey_b) {
                      ServerGamePacketListenerImpl.LOGGER.error("Failed to validate profile key: {}", profilepublickey_b.getMessage());
@@ -491,7 +491,7 @@ index 984c288abf94d9fe47fada33722fea035b832f3b..addd20237b87c9a87bb09fd7addb101a
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 155e39b55efeb72e8b92b68bc1183d8e842cf1e8..f94fa71039ebd0e638745a0cd7ca86b98ecb9b5e 100644
+index 270521550d0349af64b01eb0d12c09c557341baa..04979441a1e654d978b858acb2219da6615ed8a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -584,7 +584,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0809-Prevent-tile-entity-copies-loading-chunks.patch
+++ b/patches/server/0809-Prevent-tile-entity-copies-loading-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent tile entity copies loading chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 655dc1cda9a498466ffef68d41bde5030dfe53c3..4700a1f41a1ff97076bb837fd2b3bc226512b3e2 100644
+index 1ccd169ceb0e90eeb5debd1d7e6a00a0b7d8578e..842f9e9b1e1f1026f78fb69c6941896e565fde02 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3344,7 +3344,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3345,7 +3345,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  BlockPos blockposition = BlockEntity.getPosFromTag(nbttagcompound);
  
                  if (this.player.level().isLoaded(blockposition)) {

--- a/patches/server/0812-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0812-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -18,10 +18,10 @@ index 9a45921cbb1e7a39e6ef46cc93c14766ee8229ad..8115cf64a30b6438721769df6045e1b7
  
              if (dedicatedserverproperties.enableQuery) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4700a1f41a1ff97076bb837fd2b3bc226512b3e2..92f9ee5897045e052c51805112c8478d32380c08 100644
+index 842f9e9b1e1f1026f78fb69c6941896e565fde02..569dcb7175dd0269c5ab7ea48fe7a56115f1281c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2907,7 +2907,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2908,7 +2908,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                      this.player = this.server.getPlayerList().respawn(this.player, false, RespawnReason.DEATH);
                      if (this.server.isHardcore()) {
                          this.player.setGameMode(GameType.SPECTATOR, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.HARDCORE_DEATH, null); // Paper

--- a/patches/server/0822-Do-not-accept-invalid-client-settings.patch
+++ b/patches/server/0822-Do-not-accept-invalid-client-settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Do not accept invalid client settings
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 92f9ee5897045e052c51805112c8478d32380c08..aae750e2b6067a8fccff7e70b3b0422bd609904a 100644
+index 569dcb7175dd0269c5ab7ea48fe7a56115f1281c..595735875e8ffba672d17f08df11c101e640c807 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3486,6 +3486,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3487,6 +3487,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      @Override
      public void handleClientInformation(ServerboundClientInformationPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());

--- a/patches/server/0914-Improve-logging-and-errors.patch
+++ b/patches/server/0914-Improve-logging-and-errors.patch
@@ -22,10 +22,10 @@ index f6e423a76d4c9cf639f1d44af80d33cf3072f6b5..135fc81414446f24c3adad71f5199c78
              Properties properties;
              Properties properties1;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index afdef7501e6071932d569657d60a39305f5ca4be..3d2ca3ae49a85a91773510ca93d60b9b098e39ba 100644
+index 4aa5ff559cbb46b7badbc960f782ed4035a5e495..4d13bfc159ad5cdf60db25ad19ff6f37c6d16924 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3621,7 +3621,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3622,7 +3622,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
                      this.resetPlayerChatState(remotechatsession_a.validate(this.player.getGameProfile(), signaturevalidator, Duration.ZERO));
                  } catch (ProfilePublicKey.ValidationException profilepublickey_b) {

--- a/patches/server/0923-Use-single-player-info-update-packet-on-join.patch
+++ b/patches/server/0923-Use-single-player-info-update-packet-on-join.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use single player info update packet on join
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4947265c3b7a9da8782be3ae8d35ef99c5836e81..c072cccb0a80019ce2f6c9e73f965ca26f8bc42c 100644
+index d05c4c34777a33240e4e8f985d6bca76ed45d7f3..460baa53e365b1da3680ba3e0e8b8f4b94a75fc4 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3636,7 +3636,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3637,7 +3637,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          this.signedMessageDecoder = session.createMessageDecoder(this.player.getUUID());
          this.chatMessageChain.append((executor) -> {
              this.player.setChatSession(session);

--- a/patches/server/0946-Prevent-causing-expired-keys-from-impacting-new-join.patch
+++ b/patches/server/0946-Prevent-causing-expired-keys-from-impacting-new-join.patch
@@ -24,7 +24,7 @@ index 23e0e6937e28f09271a4ec7c35e0076a576cf3d3..4aa8b483841028fbcc43f9ed47730881
          UPDATE_GAME_MODE((serialized, buf) -> {
              serialized.gameMode = GameType.byId(buf.readVarInt());
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 54ea5cfdb6fba3c66349b80e21e66b44c4dbba53..7ee70536cfb621702388bd13dddf08f0224ba6bb 100644
+index 82a63452e73ac146d2a8d9bfdd030d6aa4d42080..4e0bef1456cbeee6574b7581576cbb882878722e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -298,6 +298,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -49,7 +49,7 @@ index 54ea5cfdb6fba3c66349b80e21e66b44c4dbba53..7ee70536cfb621702388bd13dddf08f0
      }
  
      public void resetPosition() {
-@@ -3634,6 +3642,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3635,6 +3643,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      private void resetPlayerChatState(RemoteChatSession session) {
          this.chatSession = session;


### PR DESCRIPTION
Fixes the event being called 4 times (2 per hand) when a player right clicks with no difference to the event data. Also adds some javadoc and removes an unnecessary access transformer