### PR TITLE
Fix startup and runtime crashes (experimental branch)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -60,4 +60,5 @@ Luke Chambers <consolelogluke@gmail.com>
 Emily <emilia.lopezf.1999@gmail.com>
 dawon <dawon@dawon.eu>
 Ollie <69084614+olijeffers0n@users.noreply.github.com>
+BlockyTheDev <86119630+BlockyTheDev@users.noreply.github.com>
 ```

--- a/patches/api/0010-Timings-v2.patch
+++ b/patches/api/0010-Timings-v2.patch
@@ -717,10 +717,10 @@ index 0000000000000000000000000000000000000000..199789d56d22fcb1b77ebd56805cc28a
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingHistory.java b/src/main/java/co/aikar/timings/TimingHistory.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bf9f5d7a46c08c3352468cf738a9605bfe777b35
+index 0000000000000000000000000000000000000000..0a0e6308923f466ca96786b74811b9beeca83d73
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingHistory.java
-@@ -0,0 +1,359 @@
+@@ -0,0 +1,358 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -750,13 +750,6 @@ index 0000000000000000000000000000000000000000..bf9f5d7a46c08c3352468cf738a9605b
 +import com.google.common.base.Function;
 +import com.google.common.collect.Sets;
 +
-+import java.util.Collection;
-+import java.util.HashMap;
-+import java.util.List;
-+import java.util.Locale;
-+import java.util.Map;
-+import java.util.Set;
-+
 +import org.bukkit.Bukkit;
 +import org.bukkit.Chunk;
 +import org.bukkit.World;
@@ -769,6 +762,12 @@ index 0000000000000000000000000000000000000000..bf9f5d7a46c08c3352468cf738a9605b
 +import co.aikar.util.MRUMapCache;
 +
 +import java.lang.management.ManagementFactory;
++import java.util.Collection;
++import java.util.HashMap;
++import java.util.List;
++import java.util.Locale;
++import java.util.Map;
++import java.util.Set;
 +
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;

--- a/patches/api/0010-Timings-v2.patch
+++ b/patches/api/0010-Timings-v2.patch
@@ -717,10 +717,10 @@ index 0000000000000000000000000000000000000000..199789d56d22fcb1b77ebd56805cc28a
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingHistory.java b/src/main/java/co/aikar/timings/TimingHistory.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b9544c6f2adb0a8b32abd8ab3f1bdc5e00ee7679
+index 0000000000000000000000000000000000000000..9d9a9b47b743d66af74725298fac3256dfadb601
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingHistory.java
-@@ -0,0 +1,356 @@
+@@ -0,0 +1,354 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -749,12 +749,14 @@ index 0000000000000000000000000000000000000000..b9544c6f2adb0a8b32abd8ab3f1bdc5e
 +import co.aikar.timings.TimingHistory.RegionData.RegionId;
 +import com.google.common.base.Function;
 +import com.google.common.collect.Sets;
-+import java.util.HashMap;
++
++import java.util.*;
++
 +import org.bukkit.Bukkit;
 +import org.bukkit.Chunk;
-+import org.bukkit.Material;
 +import org.bukkit.World;
 +import org.bukkit.block.BlockState;
++import org.bukkit.block.BlockType;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.entity.EntityType;
 +import org.bukkit.entity.Player;
@@ -762,11 +764,7 @@ index 0000000000000000000000000000000000000000..b9544c6f2adb0a8b32abd8ab3f1bdc5e
 +import co.aikar.util.MRUMapCache;
 +
 +import java.lang.management.ManagementFactory;
-+import java.util.Collection;
-+import java.util.EnumMap;
-+import java.util.List;
-+import java.util.Map;
-+import java.util.Set;
++
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -798,7 +796,7 @@ index 0000000000000000000000000000000000000000..b9544c6f2adb0a8b32abd8ab3f1bdc5e
 +    private final MinuteReport[] minuteReports;
 +
 +    private final TimingHistoryEntry[] entries;
-+    final Set<Material> tileEntityTypeSet = Sets.newHashSet();
++    final Set<BlockType> tileEntityTypeSet = Sets.newHashSet();
 +    final Set<EntityType> entityTypeSet = Sets.newHashSet();
 +    private final Map<Object, Object> worlds;
 +
@@ -869,20 +867,20 @@ index 0000000000000000000000000000000000000000..b9544c6f2adb0a8b32abd8ab3f1bdc5e
 +                                        public JSONPair apply(Map.Entry<EntityType, Counter> entry) {
 +                                            entityTypeSet.add(entry.getKey());
 +                                            return pair(
-+                                                    String.valueOf(entry.getKey().ordinal()),
++                                                    entry.getKey().getKey().getKey().toUpperCase(Locale.ROOT),
 +                                                    entry.getValue().count()
 +                                            );
 +                                        }
 +                                    }
 +                                ),
 +                                toObjectMapper(input.tileEntityCounts.entrySet(),
-+                                    new Function<Map.Entry<Material, Counter>, JSONPair>() {
++                                    new Function<Map.Entry<BlockType, Counter>, JSONPair>() {
 +                                        @NotNull
 +                                        @Override
-+                                        public JSONPair apply(Map.Entry<Material, Counter> entry) {
++                                        public JSONPair apply(Map.Entry<BlockType, Counter> entry) {
 +                                            tileEntityTypeSet.add(entry.getKey());
 +                                            return pair(
-+                                                    String.valueOf(entry.getKey().ordinal()),
++                                                    entry.getKey().getKey().getKey().toUpperCase(Locale.ROOT),
 +                                                    entry.getValue().count()
 +                                            );
 +                                        }
@@ -934,7 +932,7 @@ index 0000000000000000000000000000000000000000..b9544c6f2adb0a8b32abd8ab3f1bdc5e
 +                new HashMap<>(), k -> new Counter()
 +        ));
 +        @SuppressWarnings("unchecked")
-+        final Map<Material, Counter> tileEntityCounts = MRUMapCache.of(LoadingMap.of(
++        final Map<BlockType, Counter> tileEntityCounts = MRUMapCache.of(LoadingMap.of(
 +                new HashMap<>(), k -> new Counter()
 +        ));
 +
@@ -2898,7 +2896,7 @@ index 437d59ddf6a6859afc052257ba3f574929071522..c8a8305e41a55e98c99ed9df07f57630
           * Sends the component to the player
           *
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 628fae98b17cd7dd1a5358562225cefefeb5051b..c84dc62c7383deeb00106c2e672af2018c4acadc 100644
+index e800b6abb43fcb95937f1a8719761b4e2da84318..1a4212141fae926950a95e7bb584b28b21e20ba1 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
 @@ -39,6 +39,7 @@ public interface UnsafeValues {
@@ -3457,7 +3455,7 @@ index 516d7fc7812aac343782861d0d567f54aa578c2a..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9d8ddb2656d22c287ee1338fe4ab79fac0e8488a..6de23a9dbaf012dd8a95bab55835bb406b59a012 100644
+index 5b5802be082f70a015b4a20c0ccdec1ee6f479f6..e7d6559f7a1e4cf88042a31e16d5b3370c2a0eb7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2187,7 +2187,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0010-Timings-v2.patch
+++ b/patches/api/0010-Timings-v2.patch
@@ -717,10 +717,10 @@ index 0000000000000000000000000000000000000000..199789d56d22fcb1b77ebd56805cc28a
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingHistory.java b/src/main/java/co/aikar/timings/TimingHistory.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9d9a9b47b743d66af74725298fac3256dfadb601
+index 0000000000000000000000000000000000000000..bf9f5d7a46c08c3352468cf738a9605bfe777b35
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingHistory.java
-@@ -0,0 +1,354 @@
+@@ -0,0 +1,359 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -750,7 +750,12 @@ index 0000000000000000000000000000000000000000..9d9a9b47b743d66af74725298fac3256
 +import com.google.common.base.Function;
 +import com.google.common.collect.Sets;
 +
-+import java.util.*;
++import java.util.Collection;
++import java.util.HashMap;
++import java.util.List;
++import java.util.Locale;
++import java.util.Map;
++import java.util.Set;
 +
 +import org.bukkit.Bukkit;
 +import org.bukkit.Chunk;

--- a/patches/api/0134-Don-t-use-snapshots-for-Timings-Tile-Entity-reports.patch
+++ b/patches/api/0134-Don-t-use-snapshots-for-Timings-Tile-Entity-reports.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't use snapshots for Timings Tile Entity reports
 
 
 diff --git a/src/main/java/co/aikar/timings/TimingHistory.java b/src/main/java/co/aikar/timings/TimingHistory.java
-index 9d9a9b47b743d66af74725298fac3256dfadb601..60446ba8cb154a4589fc456da583e6a1758f9842 100644
+index bf9f5d7a46c08c3352468cf738a9605bfe777b35..6454b005d57689ae1c227b1e00c00ac138bb2440 100644
 --- a/src/main/java/co/aikar/timings/TimingHistory.java
 +++ b/src/main/java/co/aikar/timings/TimingHistory.java
-@@ -119,7 +119,7 @@ public class TimingHistory {
+@@ -124,7 +124,7 @@ public class TimingHistory {
                          data.entityCounts.get(entity.getType()).increment();
                      }
  

--- a/patches/api/0134-Don-t-use-snapshots-for-Timings-Tile-Entity-reports.patch
+++ b/patches/api/0134-Don-t-use-snapshots-for-Timings-Tile-Entity-reports.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't use snapshots for Timings Tile Entity reports
 
 
 diff --git a/src/main/java/co/aikar/timings/TimingHistory.java b/src/main/java/co/aikar/timings/TimingHistory.java
-index b9544c6f2adb0a8b32abd8ab3f1bdc5e00ee7679..0632618965df58effe4f62e0fdb3d558c99ab698 100644
+index 9d9a9b47b743d66af74725298fac3256dfadb601..60446ba8cb154a4589fc456da583e6a1758f9842 100644
 --- a/src/main/java/co/aikar/timings/TimingHistory.java
 +++ b/src/main/java/co/aikar/timings/TimingHistory.java
-@@ -121,7 +121,7 @@ public class TimingHistory {
+@@ -119,7 +119,7 @@ public class TimingHistory {
                          data.entityCounts.get(entity.getType()).increment();
                      }
  

--- a/patches/api/0134-Don-t-use-snapshots-for-Timings-Tile-Entity-reports.patch
+++ b/patches/api/0134-Don-t-use-snapshots-for-Timings-Tile-Entity-reports.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't use snapshots for Timings Tile Entity reports
 
 
 diff --git a/src/main/java/co/aikar/timings/TimingHistory.java b/src/main/java/co/aikar/timings/TimingHistory.java
-index bf9f5d7a46c08c3352468cf738a9605bfe777b35..6454b005d57689ae1c227b1e00c00ac138bb2440 100644
+index 0a0e6308923f466ca96786b74811b9beeca83d73..e1b52eeecc1baf02c3e5d4bdf24ade769b2c3c75 100644
 --- a/src/main/java/co/aikar/timings/TimingHistory.java
 +++ b/src/main/java/co/aikar/timings/TimingHistory.java
-@@ -124,7 +124,7 @@ public class TimingHistory {
+@@ -123,7 +123,7 @@ public class TimingHistory {
                          data.entityCounts.get(entity.getType()).increment();
                      }
  

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -181,10 +181,10 @@ index 0000000000000000000000000000000000000000..59affb62cb487d60e8c3e32decf89d6c
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..38f01952153348d937e326da0ec102cd9b0f80af
+index 0000000000000000000000000000000000000000..12fde004221de66cf1c0f0de1fbcee1ac3b5732d
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -0,0 +1,386 @@
+@@ -0,0 +1,387 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -218,7 +218,7 @@ index 0000000000000000000000000000000000000000..38f01952153348d937e326da0ec102cd
 +import net.minecraft.server.MinecraftServer;
 +import org.apache.commons.lang.StringUtils;
 +import org.bukkit.Bukkit;
-+import org.bukkit.Material;
++import org.bukkit.block.BlockType;
 +import org.bukkit.configuration.ConfigurationSection;
 +import org.bukkit.configuration.MemorySection;
 +import org.bukkit.entity.EntityType;
@@ -238,6 +238,7 @@ index 0000000000000000000000000000000000000000..38f01952153348d937e326da0ec102cd
 +import java.net.InetAddress;
 +import java.net.URL;
 +import java.util.List;
++import java.util.Locale;
 +import java.util.Map;
 +import java.util.Set;
 +import java.util.logging.Level;
@@ -354,7 +355,7 @@ index 0000000000000000000000000000000000000000..38f01952153348d937e326da0ec102cd
 +            ));
 +        }));
 +
-+        Set<Material> tileEntityTypeSet = Sets.newHashSet();
++        Set<BlockType> tileEntityTypeSet = Sets.newHashSet();
 +        Set<EntityType> entityTypeSet = Sets.newHashSet();
 +
 +        int size = HISTORY.size();
@@ -403,9 +404,9 @@ index 0000000000000000000000000000000000000000..38f01952153348d937e326da0ec102cd
 +            pair("handlers", handlers),
 +            pair("worlds", toObjectMapper(TimingHistory.worldMap.entrySet(), input -> pair(input.getValue(), input.getKey()))),
 +            pair("tileentity",
-+                toObjectMapper(tileEntityTypeSet, input -> pair(input.ordinal(), input.name()))),
++                toObjectMapper(tileEntityTypeSet, input -> pair(input.getKey().getKey().toUpperCase(Locale.ROOT), input.getKey().getKey().toUpperCase(Locale.ROOT)))),
 +            pair("entity",
-+                toObjectMapper(entityTypeSet, input -> pair(input.ordinal(), input.name())))
++                toObjectMapper(entityTypeSet, input -> pair(input.getKey().getKey().toUpperCase(Locale.ROOT), input.getKey().getKey().toUpperCase(Locale.ROOT))))
 +        ));
 +
 +        // Information about loaded plugins

--- a/patches/server/0019-Rewrite-chunk-system.patch
+++ b/patches/server/0019-Rewrite-chunk-system.patch
@@ -907,10 +907,10 @@ index 146c78a333e47cb4d8aa97700e19a12ca176ce76..691239e65b0870ceb0d071b57793cff9
  
      protected static final class LightQueue {
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index 38f01952153348d937e326da0ec102cd9b0f80af..1080e1f67afe5574baca0df50cdb1d029a7a586a 100644
+index 12fde004221de66cf1c0f0de1fbcee1ac3b5732d..b85eb07e6409648391abe97d51c73d22d61bcbf8 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -163,7 +163,11 @@ public class TimingsExport extends Thread {
+@@ -164,7 +164,11 @@ public class TimingsExport extends Thread {
                  pair("gamerules", toObjectMapper(world.getWorld().getGameRules(), rule -> {
                      return pair(rule, world.getWorld().getGameRuleValue(rule));
                  })),

--- a/patches/server/0726-Configurable-feature-seeds.patch
+++ b/patches/server/0726-Configurable-feature-seeds.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable feature seeds
 Co-authored-by: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
 
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index 1080e1f67afe5574baca0df50cdb1d029a7a586a..a2f71a6d1a9e98133dff6cd0f625da9435a8af14 100644
+index b85eb07e6409648391abe97d51c73d22d61bcbf8..ebb6bd6f875bd9caab94b3642812444f970e4fb2 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
-@@ -288,7 +288,7 @@ public class TimingsExport extends Thread {
+@@ -289,7 +289,7 @@ public class TimingsExport extends Thread {
          JSONObject object = new JSONObject();
          for (String key : config.getKeys(false)) {
              String fullKey = (parentKey != null ? parentKey + "." + key : key);

--- a/patches/server/0789-Custom-Potion-Mixes.patch
+++ b/patches/server/0789-Custom-Potion-Mixes.patch
@@ -164,7 +164,7 @@ index 424406d2692856cfd82b6f3b7b6228fa3bd20c2f..c57efcb9a79337ec791e4e8f6671612f
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3d3bff31befbfd5b730e47485a5d814a1065549b..e9d3a817071774cf60b8fd04227382569d8cd3f8 100644
+index 3d3bff31befbfd5b730e47485a5d814a1065549b..b5f8cac05b00550ff26ac3e470d11708d829ed23 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -300,6 +300,7 @@ public final class CraftServer implements Server {
@@ -175,15 +175,16 @@ index 3d3bff31befbfd5b730e47485a5d814a1065549b..e9d3a817071774cf60b8fd0422738256
  
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
-@@ -324,6 +325,7 @@ public final class CraftServer implements Server {
+@@ -323,7 +324,7 @@ public final class CraftServer implements Server {
+ 
          Bukkit.setServer(this);
  
-         Potion.setPotionBrewer(new CraftPotionBrewer());
+-        Potion.setPotionBrewer(new CraftPotionBrewer());
 +        Potion.setPotionBrewer(this.potionBrewer); // Paper
          // Ugly hack :(
  
          if (!Main.useConsole) {
-@@ -2988,5 +2990,10 @@ public final class CraftServer implements Server {
+@@ -2988,5 +2989,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0800-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0800-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e9d3a817071774cf60b8fd04227382569d8cd3f8..a34cbc27c41f073ed473be39d41867ac2b9a7cd9 100644
+index b5f8cac05b00550ff26ac3e470d11708d829ed23..7dbb0acda9fff69a850c72eb88ad69a1584569be 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1326,7 +1326,7 @@ public final class CraftServer implements Server {
+@@ -1325,7 +1325,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0816-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0816-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a34cbc27c41f073ed473be39d41867ac2b9a7cd9..659367b869509ecfcc16d6e9088368b0dec7e098 100644
+index 7dbb0acda9fff69a850c72eb88ad69a1584569be..68a218152d3ac11732ee873d00c184a4fa5a88df 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1285,6 +1285,7 @@ public final class CraftServer implements Server {
+@@ -1284,6 +1284,7 @@ public final class CraftServer implements Server {
          internal.setSpawnSettings(true, true);
          // Paper - move up
  

--- a/patches/server/0831-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0831-Throw-exception-on-world-create-while-being-ticked.patch
@@ -45,10 +45,10 @@ index 910523399b1fae64808b292cfb45bed56719fcb3..66bb92ca535b559d3bca89b9bc841f8f
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 659367b869509ecfcc16d6e9088368b0dec7e098..408c4c1a6da5c393b98a2a81f15e20029b08283b 100644
+index 68a218152d3ac11732ee873d00c184a4fa5a88df..f496d10cb8b5fe311c8cf6c6fa98972ac22b3953 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -880,6 +880,11 @@ public final class CraftServer implements Server {
+@@ -879,6 +879,11 @@ public final class CraftServer implements Server {
          return new ArrayList<World>(this.worlds.values());
      }
  
@@ -60,7 +60,7 @@ index 659367b869509ecfcc16d6e9088368b0dec7e098..408c4c1a6da5c393b98a2a81f15e2002
      public DedicatedPlayerList getHandle() {
          return this.playerList;
      }
-@@ -1161,6 +1166,7 @@ public final class CraftServer implements Server {
+@@ -1160,6 +1165,7 @@ public final class CraftServer implements Server {
      @Override
      public World createWorld(WorldCreator creator) {
          Preconditions.checkState(this.console.getAllLevels().iterator().hasNext(), "Cannot create additional worlds on STARTUP");
@@ -68,7 +68,7 @@ index 659367b869509ecfcc16d6e9088368b0dec7e098..408c4c1a6da5c393b98a2a81f15e2002
          Preconditions.checkArgument(creator != null, "WorldCreator cannot be null");
  
          String name = creator.name();
-@@ -1300,6 +1306,7 @@ public final class CraftServer implements Server {
+@@ -1299,6 +1305,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {

--- a/patches/server/0838-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0838-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index e05eb08a9c229b371887676da510df948b896a85..ceeedbd88c56c08ec8b047c9ca2f14cc
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 408c4c1a6da5c393b98a2a81f15e20029b08283b..1f7f9c2fb99c8c035f0ac87727582b58c158cdb3 100644
+index f496d10cb8b5fe311c8cf6c6fa98972ac22b3953..cb6425a458f4ae5ec9e54a108b76061493160a54 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1802,7 +1802,7 @@ public final class CraftServer implements Server {
+@@ -1801,7 +1801,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {

--- a/patches/server/0858-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0858-Add-Velocity-IP-Forwarding-Support.patch
@@ -213,10 +213,10 @@ index 3fcd7bfdb8945b276c94a263e9da6b85ce470366..3431b1132e55c53cda7cf47f021f2306
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1f7f9c2fb99c8c035f0ac87727582b58c158cdb3..a29320e9c4f139afce472da7190a3798a61e9506 100644
+index cb6425a458f4ae5ec9e54a108b76061493160a54..41e5204b13c0a5455c3e79ca36cfe2790f542a48 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -809,7 +809,7 @@ public final class CraftServer implements Server {
+@@ -808,7 +808,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0970-Don-t-enforce-icanhasbukkit-default-if-alias-block-e.patch
+++ b/patches/server/0970-Don-t-enforce-icanhasbukkit-default-if-alias-block-e.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't enforce icanhasbukkit default if alias block exists
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a29320e9c4f139afce472da7190a3798a61e9506..db59e9c82d6ab0e9822220f22515bf869a773e23 100644
+index 41e5204b13c0a5455c3e79ca36cfe2790f542a48..9179459da2da38d3e211030d10d1375c47c5e72b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -346,7 +346,11 @@ public final class CraftServer implements Server {
+@@ -345,7 +345,11 @@ public final class CraftServer implements Server {
          }
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
          this.commandsConfiguration.options().copyDefaults(true);


### PR DESCRIPTION
Like written on Discord with @Machine-Maker , here the pull request to fix a startup crash and the runtime crash occuring around three minutes after startup, found while wanting to experiment with the `experimental` Paper branch.

Changes following things:
- An erroneous change in the Custom-Potion-Mixes-Patch leading to a server crash at startup
- A server crash occuring around three minutes after startup, coming from the timings system because of an unexpected exception of the type `java.lang.ClassCastException`. While doing this I also migrated the code away from using the deprecated class `OldEnum`, introduced in the (Craft-)Bukkit pull request for enum to class migration for backwards compatibility, used in the `EntityType` related code of the timings system.

All the code changes were successfully tested through several server startups and several created timings reports (with different worlds and situations).

If i should post pictures of the exceptions, just write and I will post them here.