### PR TITLE
Add `Material#getPlacedType` API

### DIFF
--- a/patches/api/0426-Add-Material-getPlacedType-API.patch
+++ b/patches/api/0426-Add-Material-getPlacedType-API.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aya <31237389+tal5@users.noreply.github.com>
+Date: Tue, 15 Aug 2023 10:05:01 +0100
+Subject: [PATCH] Add Material#getPlacedType API
+
+
+diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
+index 03b47012447430a350e152920f754d993d4023db..ba087077f948bcdfa18708dc1804badb9cebc6b0 100644
+--- a/src/main/java/org/bukkit/Material.java
++++ b/src/main/java/org/bukkit/Material.java
+@@ -11047,4 +11047,23 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
+     public boolean isEnabledByFeature(@NotNull World world) {
+         return Bukkit.getDataPackManager().isEnabledByFeature(this, world);
+     }
++
++    // Paper start
++    /**
++     * Gets the material that would be placed down by this item.
++     * For most placeable items this is the same type as the item, but it is different for some.
++     * <p>
++     * Some examples include:
++     * <pre>
++     *     {@link #REDSTONE} -> {@link #REDSTONE_WIRE}
++     *     {@link #PUMPKIN_SEEDS} -> {@link #PUMPKIN_STEM}
++     * </pre>
++     * @return The material that would be placed down by this item, or {@code null} if it can't be placed.
++     * @throws IllegalArgumentException if {@link #isItem()} is {@code false}
++     */
++    @Nullable
++    public Material getPlacedType() {
++        return Bukkit.getUnsafe().getPlacedType(this);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
+index de36dab37d3af249cf51573d163731c12346066a..b3d524e9f366b254d89d901fe99c827825f0ea9c 100644
+--- a/src/main/java/org/bukkit/UnsafeValues.java
++++ b/src/main/java/org/bukkit/UnsafeValues.java
+@@ -252,4 +252,22 @@ public interface UnsafeValues {
+ 
+     String getStatisticCriteriaKey(@NotNull org.bukkit.Statistic statistic);
+     // Paper end
++
++    // Paper start
++    /**
++     * Gets the material that would be placed down by {@code item}.
++     * For most placeable items this is the same type as the item, but it is different for some.
++     * <p>
++     * Some examples include:
++     * <pre>
++     *     {@link Material#REDSTONE} -> {@link Material#REDSTONE_WIRE}
++     *     {@link Material#PUMPKIN_SEEDS} -> {@link Material#PUMPKIN_STEM}
++     * </pre>
++     * @param item An item material.
++     * @return The material that would be placed down by {@code item}, or {@code null} if it can't be placed.
++     * @throws IllegalArgumentException if {@code item} isn't an item ({@link Material#isItem()} is {@code false})
++     */
++    @org.jetbrains.annotations.Nullable
++    Material getPlacedType(Material item);
++    // Paper end
+ }

--- a/patches/server/1006-Add-Material-getPlacedType-API.patch
+++ b/patches/server/1006-Add-Material-getPlacedType-API.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aya <31237389+tal5@users.noreply.github.com>
+Date: Tue, 15 Aug 2023 10:05:42 +0100
+Subject: [PATCH] Add Material#getPlacedType API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index 719e7103f7dfdc30f1cefd24a3fa572fa0ac8b1e..abaed7df0b50df94fab82a751fa68376325a5b4d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -56,7 +56,6 @@ import org.bukkit.craftbukkit.CraftEquipmentSlot;
+ import org.bukkit.craftbukkit.CraftFeatureFlag;
+ import org.bukkit.craftbukkit.attribute.CraftAttributeInstance;
+ import org.bukkit.craftbukkit.attribute.CraftAttributeMap;
+-import org.bukkit.craftbukkit.block.CraftBlock;
+ import org.bukkit.craftbukkit.block.data.CraftBlockData;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.craftbukkit.legacy.CraftLegacy;
+@@ -630,6 +629,15 @@ public final class CraftMagicNumbers implements UnsafeValues {
+     }
+     // Paper end
+ 
++    // Paper Start
++    @Override
++    public Material getPlacedType(Material item) {
++        Item nmsItem = getItem(item);
++        Preconditions.checkArgument(nmsItem != null, "%s is not an item", item);
++        return nmsItem instanceof net.minecraft.world.item.BlockItem nmsBlockItem ? getMaterial(nmsBlockItem.getBlock()) : null;
++    }
++    // Paper end
++
+     /**
+      * This helper class represents the different NBT Tags.
+      * <p>

--- a/patches/server/1006-Add-Material-getPlacedType-API.patch
+++ b/patches/server/1006-Add-Material-getPlacedType-API.patch
@@ -5,18 +5,10 @@ Subject: [PATCH] Add Material#getPlacedType API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 719e7103f7dfdc30f1cefd24a3fa572fa0ac8b1e..abaed7df0b50df94fab82a751fa68376325a5b4d 100644
+index 719e7103f7dfdc30f1cefd24a3fa572fa0ac8b1e..93be6a0160d5da9068c9fe7dbb766b9e6374f431 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -56,7 +56,6 @@ import org.bukkit.craftbukkit.CraftEquipmentSlot;
- import org.bukkit.craftbukkit.CraftFeatureFlag;
- import org.bukkit.craftbukkit.attribute.CraftAttributeInstance;
- import org.bukkit.craftbukkit.attribute.CraftAttributeMap;
--import org.bukkit.craftbukkit.block.CraftBlock;
- import org.bukkit.craftbukkit.block.data.CraftBlockData;
- import org.bukkit.craftbukkit.inventory.CraftItemStack;
- import org.bukkit.craftbukkit.legacy.CraftLegacy;
-@@ -630,6 +629,15 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -630,6 +630,15 @@ public final class CraftMagicNumbers implements UnsafeValues {
      }
      // Paper end
  


### PR DESCRIPTION
## Additions

- `Material#getPlacedType` - returns the type an item would be placed as (usually the same, but is different in some cases, e.g. pumpkin seeds -> pumpkin stem).
- `UnsafeValues#getPlacedType(Material)` - bridge method for `Material#getPlacedType`.

## Notes

- Currently it returns a `Material`, as that's what's stored internally - might make sense to return `BlockData` to avoid potential issues with more complex data being added in the future/as it might make sense to represent it as `BlockData`?
- `BlockData#getPlacementMaterial` (other way around from this) seems to return `AIR` when a block doesn't have an item equivalent, while this returns `null` for items that can't be placed.
`null` makes more sense imo, but either is fine I guess - let me know if that should be changed to match.