### PR TITLE
Add SpawnerPlayerSearchEvent

### DIFF
--- a/patches/api/0484-Add-SpawnerPlayerSearchEvent.patch
+++ b/patches/api/0484-Add-SpawnerPlayerSearchEvent.patch
@@ -1,0 +1,135 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TreemanKing <67459602+TreemanKing@users.noreply.github.com>
+Date: Wed, 16 Aug 2023 11:59:08 +1000
+Subject: [PATCH] Add SpawnerPlayerSearchEvent
+
+This patch introduces a new event, SpawnerPlayerSearchEvent. This event is designed to be fired when a mob spawner searches for nearby players to activate. It provides the ability to control and customize the activation logic of mob spawners, preventing them from searching and spawning mobs if desired
+
+diff --git a/src/main/java/io/papermc/paper/event/block/SpawnerPlayerSearchEvent.java b/src/main/java/io/papermc/paper/event/block/SpawnerPlayerSearchEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..3ab3ebdfc560aafd043bef23006ee19d8cd67ed3
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/block/SpawnerPlayerSearchEvent.java
+@@ -0,0 +1,122 @@
++package io.papermc.paper.event.block;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.Location;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Range;
++import org.jetbrains.annotations.Unmodifiable;
++import java.util.Collection;
++import java.util.Collections;
++
++/**
++ * Represents an event that is fired when a mob spawner searches for nearby players to activate.
++ * This event occurs before any of the spawner logic, allowing cancellation to prevent the spawner 
++ * from searching and spawning any mobs. It can also bypass the nearby player check if required.
++ */
++public class SpawnerPlayerSearchEvent extends Event {
++    @NotNull private final Location spawnerLocation;
++    @NotNull private final Collection<Player> activatingPlayers;
++    private int backoffTicks;
++    @NotNull private Result searchResult = Result.DEFAULT;
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    @ApiStatus.Internal
++    public SpawnerPlayerSearchEvent(@NotNull Location spawnerLocation, @NotNull Collection<Player> activatingPlayers, int backoffTicks) {
++        this.spawnerLocation = Preconditions.checkNotNull(spawnerLocation, "Spawner Location can not be null");
++        this.activatingPlayers = Preconditions.checkNotNull(activatingPlayers, "Activating players list cannot be null");
++        this.backoffTicks = backoffTicks;
++    }
++
++    /**
++     * Retrieves the location of the mob spawner associated with the event
++     *
++     * @return The location of the spawner
++     */
++    @NotNull
++    public Location getSpawnerLocation() {
++        return spawnerLocation.clone();
++    }
++
++    /**
++     * Retrieves an immutable collection of players who are close enough to activate the spawner
++     *
++     * @return A collection of activating players
++     */
++    @NotNull @Unmodifiable
++    public Collection<Player> getActivatingPlayers() {
++        return Collections.unmodifiableCollection(activatingPlayers);
++    }
++
++    /**
++     * Retrieves the number of backoff ticks before the mob spawner proceeds with spawner logic
++     *
++     * <p>Backoff ticks determine the duration the spawner pauses for before it proceeds with the spawner logic
++     * and searches for players. A higher value means a longer delay before the spawner attempts to search for
++     * activating players again. It's important to note that negative backoff ticks do not make sense and will be
++     * corrected to 0 automatically.</p>
++     *
++     * <p>While backoff ticks are active, the spawner suspends the spawner logic and hence the search for players.
++     * This means it will not trigger the spawning of monsters. This effectively postpones the activation of the spawner until
++     * the backoff ticks expire.</p>
++     *
++     * @return The amount of backoff ticks before the spawner proceeds with spawner logic
++     */
++    @Range(from = 0, to = Integer.MAX_VALUE)
++    public int getBackoffTicks() {
++        return backoffTicks;
++    }
++
++    /**
++     * Sets the number of backoff ticks before the mob spawner proceeds with the spawner's logic again.
++     * <p>{@link SpawnerPlayerSearchEvent#getBackoffTicks} on an explanation of how backoff ticks function<p>
++     *
++     * @param ticks sets the amount of ticks before the spawner proceeds with the spawner's logic
++     * @throws IllegalArgumentException If the provided backoff ticks value is negative.
++     * @see SpawnerPlayerSearchEvent#getBackoffTicks
++     */
++    public void setBackoffTicks(@Range(from = 0, to = Integer.MAX_VALUE) int ticks) {
++        Preconditions.checkArgument(ticks >= 0, "Backoff Ticks cannot be less than 0");
++        this.backoffTicks = ticks;
++    }
++
++    /**
++     * Gets the result of the spawner event.
++     * <p>See {@link SpawnerPlayerSearchEvent#setSearchResult(Result)} for a description of each result</p>
++     *
++     * @return The result of the event
++     * @see SpawnerPlayerSearchEvent#setSearchResult(Result)
++     */
++    public @NotNull Result getSearchResult() {
++        return this.searchResult;
++    }
++
++    /**
++     * Sets the result of the spawner search event
++     * <ul>
++     *          <li>{@link org.bukkit.event.Event.Result#ALLOW}: Proceed with spawner logic, regardless of activating players </li>
++     *          <li>{@link org.bukkit.event.Event.Result#DENY}: Skip spawner logic, even with activating players</li>
++     *          <li>{@link org.bukkit.event.Event.Result#DEFAULT}: Use default behaviour based on activating players </li>
++     * </ul>
++     *
++     * @param result The result to set for the event
++     */
++    public void setSearchResult(@NotNull org.bukkit.event.Event.Result result) {
++        Preconditions.checkArgument(result != null, "Result cannot be null");
++        this.searchResult = result;
++    }
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}
++

--- a/patches/server/1020-Optimise-nearby-player-retrieval.patch
+++ b/patches/server/1020-Optimise-nearby-player-retrieval.patch
@@ -8,10 +8,10 @@ we can instead use the nearby player tracking system to reduce
 the number of tests per search.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d4376ed215d97066a21e462fae2a0e25ad8a16a1..aab652174a8175765cad548f7c61ce353ca74803 100644
+index d4376ed215d97066a21e462fae2a0e25ad8a16a1..9755ad4b7ab94e94b7765fcb88bb21273ae64eb4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -581,6 +581,115 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -581,6 +581,157 @@ public class ServerLevel extends Level implements WorldGenLevel {
          this.lagCompensationTick = (System.nanoTime() - net.minecraft.server.MinecraftServer.SERVER_INIT) / (java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(50L));
      }
      // Paper end - lag compensation
@@ -21,6 +21,48 @@ index d4376ed215d97066a21e462fae2a0e25ad8a16a1..aab652174a8175765cad548f7c61ce35
 +                                                                                     net.minecraft.world.entity.LivingEntity entity,
 +                                                                                     net.minecraft.world.phys.AABB box) {
 +        return this.getNearbyEntities(Player.class, targetPredicate, entity, box);
++    }
++
++    public List<ServerPlayer> getNearbyPlayers(double sourceX, double sourceY, double sourceZ, double maxDistance, @Nullable Predicate<Entity> targetPredicate) {
++
++        List<ServerPlayer> nearbyPlayers = new ArrayList<>();
++
++        if (maxDistance > 0) {
++
++            io.papermc.paper.util.player.NearbyPlayers players = this.chunkSource.chunkMap.getNearbyPlayers();
++
++            com.destroystokyo.paper.util.maplist.ReferenceList<ServerPlayer> nearby = players.getPlayersByBlock(
++                io.papermc.paper.util.CoordinateUtils.getBlockCoordinate(sourceX),
++                io.papermc.paper.util.CoordinateUtils.getBlockCoordinate(sourceZ),
++                io.papermc.paper.util.player.NearbyPlayers.NearbyMapType.GENERAL
++            );
++
++            if (nearby == null) return nearbyPlayers;
++
++            double maxDistanceSqr = maxDistance * maxDistance;
++            Object[] rawData = nearby.getRawData();
++            for (int i = 0, len = nearby.size(); i < len; ++i) {
++                ServerPlayer player = (ServerPlayer) rawData[i];
++                double distanceSquared = player.distanceToSqr(sourceX, sourceY, sourceZ);
++                if (distanceSquared > maxDistanceSqr) {
++                    continue;
++                }
++
++                if (targetPredicate == null || targetPredicate.test(player)) {
++                    nearbyPlayers.add(player);
++                }
++            }
++
++            return nearbyPlayers;
++        } else {
++            for (ServerPlayer player : this.players()) {
++                if (targetPredicate == null || targetPredicate.test(player)) {
++                    nearbyPlayers.add(player);
++                }
++            }
++
++            return nearbyPlayers;
++        }
 +    }
 +
 +    @Override

--- a/patches/server/1029-Write-SavedData-IO-async.patch
+++ b/patches/server/1029-Write-SavedData-IO-async.patch
@@ -24,10 +24,10 @@ index 36caf354634d6675a3f1ec6829f4778e1d0623bc..b99f50604bafecbc68835974c9ed0caa
  
      // CraftBukkit start - modelled on below
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index aab652174a8175765cad548f7c61ce353ca74803..ca56a0b596976448da6bb2a0e82b3d5cd4133e12 100644
+index 9755ad4b7ab94e94b7765fcb88bb21273ae64eb4..b4c3fb8d8ec7cdb2548da0b4dc50eeab27e4b760 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1492,7 +1492,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1534,7 +1534,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          try (co.aikar.timings.Timing ignored = this.timings.worldSave.startTiming()) {
              if (doFull) {
@@ -36,7 +36,7 @@ index aab652174a8175765cad548f7c61ce353ca74803..ca56a0b596976448da6bb2a0e82b3d5c
              }
  
              this.timings.worldSaveChunks.startTiming(); // Paper
-@@ -1528,7 +1528,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1570,7 +1570,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  progressListener.progressStartNoAbort(Component.translatable("menu.savingLevel"));
              }
  
@@ -45,7 +45,7 @@ index aab652174a8175765cad548f7c61ce353ca74803..ca56a0b596976448da6bb2a0e82b3d5c
              if (progressListener != null) {
                  progressListener.progressStage(Component.translatable("menu.savingChunks"));
              }
-@@ -1551,12 +1551,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1593,12 +1593,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
          // CraftBukkit end
      }
  

--- a/patches/server/1053-feat-Add-SpawnerPlayerSearchEvent.patch
+++ b/patches/server/1053-feat-Add-SpawnerPlayerSearchEvent.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TreemanK <tristankrst@gmail.com>
+Date: Tue, 4 Jun 2024 14:17:55 +1000
+Subject: [PATCH] feat: Add SpawnerPlayerSearchEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
+index f57e1b78204dff661ad5d3ee93a88a00330af2dc..cdf261955d69220ec9f1b12c297030b0f7b0940f 100644
+--- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
++++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
+@@ -59,7 +59,7 @@ public abstract class BaseSpawner {
+     }
+ 
+     public boolean isNearPlayer(Level world, BlockPos pos) {
+-        return world.hasNearbyAlivePlayerThatAffectsSpawning((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, (double) this.requiredPlayerRange); // Paper - Affects Spawning API
++        return world.hasNearbyAlivePlayerThatAffectsSpawning((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, (double) this.requiredPlayerRange); // Paper - Affects Spawning API // diff on change (activatingPlayers)
+     }
+ 
+     public void clientTick(Level world, BlockPos pos) {
+@@ -87,10 +87,41 @@ public abstract class BaseSpawner {
+         if (spawnCount <= 0 || maxNearbyEntities <= 0) return; // Paper - Ignore impossible spawn tick
+         // Paper start - Configurable mob spawner tick rate
+         if (spawnDelay > 0 && --tickDelay > 0) return;
++
+         tickDelay = world.paperConfig().tickRates.mobSpawner;
+         if (tickDelay == -1) { return; } // If disabled
+         // Paper end - Configurable mob spawner tick rate
+-        if (this.isNearPlayer(world, pos)) {
++
++        // Paper start - SpawnerSearchPlayerEvent
++        java.util.function.Supplier<java.util.Collection<org.bukkit.entity.Player>> lazyActivatingPlayersSup = com.google.common.base.Suppliers.memoize(() ->
++            com.google.common.collect.Collections2.transform(
++                world.getNearbyPlayers(
++                    (double) pos.getX() + 0.5D,
++                    (double) pos.getY() + 0.5D,
++                    (double) pos.getZ() + 0.5D,
++                    (double) this.requiredPlayerRange,
++                    net.minecraft.world.entity.EntitySelector.PLAYER_AFFECTS_SPAWNING),
++                net.minecraft.server.level.ServerPlayer::getBukkitEntity)
++        );
++
++        java.util.Collection<org.bukkit.entity.Player> activatingPlayers = new com.google.common.collect.ForwardingCollection<>() {
++            @Override
++            protected java.util.Collection<org.bukkit.entity.Player> delegate() {
++                return lazyActivatingPlayersSup.get();
++            }
++        };
++
++        io.papermc.paper.event.block.SpawnerPlayerSearchEvent spawnerPlayerSearchEvent =
++            new io.papermc.paper.event.block.SpawnerPlayerSearchEvent(io.papermc.paper.util.MCUtil.toLocation(world, pos), activatingPlayers, Math.max(0, tickDelay));
++
++        spawnerPlayerSearchEvent.callEvent();
++        org.bukkit.event.Event.Result result = spawnerPlayerSearchEvent.getSearchResult();
++        tickDelay = Math.max(tickDelay, spawnerPlayerSearchEvent.getBackoffTicks());
++
++        if (result == org.bukkit.event.Event.Result.DENY) return;
++
++        if (result == org.bukkit.event.Event.Result.ALLOW || !activatingPlayers.isEmpty()) {
++        // Paper end - SpawnerSearchPlayerEvent
+             if (this.spawnDelay < -tickDelay) { // Paper - Configurable mob spawner tick rate
+                 this.delay(world, pos);
+             }


### PR DESCRIPTION
Hopefully second try is the charm. With the feedback of lynxplay from my previous pull, I created a new Event which would act before the Spawner searches for nearby spawners.

This would:
a) allow to remove specific players from specific spawners in regards to their activation
b) allow spawners to skip player searching for n ticks (as specified by the backoff cooldown)
c) completely exclude players from affecting spawning on spawners.

I was also going to add NotNulls to the event but I wasn't sure so your feedback would be highly appreciated!


