### PR TITLE
Don't let player loot if reloot time is disabled

### DIFF
--- a/patches/server/0095-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0095-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -240,7 +240,7 @@ index 0000000000000000000000000000000000000000..8e6dac2cef7af26ad74928eff631c182
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..87c5f8a43b8643486ba898e1cea33873398f3b1c
+index 0000000000000000000000000000000000000000..5408cbc21fc7577a6100b5a1ca0463e899d2df8b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
 @@ -0,0 +1,188 @@
@@ -419,7 +419,7 @@ index 0000000000000000000000000000000000000000..87c5f8a43b8643486ba898e1cea33873
 +        if (!worldConfiguration.lootables.restrictPlayerReloot || lastLooted == null) return true;
 +
 +        final DurationOrDisabled restrictPlayerRelootTime = worldConfiguration.lootables.restrictPlayerRelootTime;
-+        if (restrictPlayerRelootTime.value().isEmpty()) return true;
++        if (restrictPlayerRelootTime.value().isEmpty()) return false;
 +
 +        return TimeUnit.SECONDS.toMillis(restrictPlayerRelootTime.value().get().seconds()) + lastLooted < System.currentTimeMillis();
 +    }


### PR DESCRIPTION
If the reloot time is disabled while reloot is restricted, the player should not be able to reloot. The previous logic was incorrect and allowed players to reloot explicitly when the reloot time was disabled.

Resolves: #9613