### PR TITLE
Add MiniMessage motd option

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -440,15 +440,16 @@ index 0000000000000000000000000000000000000000..9ef6712c70fcd8912a79f3f61e351aac
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5cfd0bd7c09aacd7313575e30cf0a171c597e2bd
+index 0000000000000000000000000000000000000000..81d816bba5580664a05a71f0c6c6478835a91cfa
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,291 @@
+@@ -0,0 +1,293 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
 +import io.papermc.paper.configuration.constraint.Constraint;
 +import io.papermc.paper.configuration.constraint.Constraints;
++import io.papermc.paper.configuration.type.ComponentOrDefault;
 +import net.kyori.adventure.text.Component;
 +import net.kyori.adventure.text.format.NamedTextColor;
 +import net.minecraft.network.protocol.Packet;
@@ -490,6 +491,7 @@ index 0000000000000000000000000000000000000000..5cfd0bd7c09aacd7313575e30cf0a171
 +        }
 +
 +        public Component noPermission = Component.text("I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.", NamedTextColor.RED);
++        public ComponentOrDefault motd = ComponentOrDefault.USE_DEFAULT;
 +        public boolean useDisplayNameInQuitMessage = false;
 +    }
 +
@@ -948,10 +950,10 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e471960e0443392f6f54732b052a4debf2a8fd97
+index 0000000000000000000000000000000000000000..8df7344a632bcb954fccaa911061525e0aeb0128
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
-@@ -0,0 +1,442 @@
+@@ -0,0 +1,445 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.base.Suppliers;
@@ -976,6 +978,7 @@ index 0000000000000000000000000000000000000000..e471960e0443392f6f54732b052a4deb
 +import io.papermc.paper.configuration.transformation.world.versioned.V29_ZeroWorldHeight;
 +import io.papermc.paper.configuration.transformation.world.versioned.V30_RenameFilterNbtFromSpawnEgg;
 +import io.papermc.paper.configuration.type.BooleanOrDefault;
++import io.papermc.paper.configuration.type.ComponentOrDefault;
 +import io.papermc.paper.configuration.type.DoubleOrDefault;
 +import io.papermc.paper.configuration.type.Duration;
 +import io.papermc.paper.configuration.type.DurationOrDisabled;
@@ -1128,7 +1131,9 @@ index 0000000000000000000000000000000000000000..e471960e0443392f6f54732b052a4deb
 +    private static ConfigurationOptions defaultGlobalOptions(ConfigurationOptions options) {
 +        return options
 +            .header(GLOBAL_HEADER)
-+            .serializers(builder -> builder.register(new PacketClassSerializer()));
++            .serializers(builder -> builder
++                .register(new PacketClassSerializer())
++                .register(ComponentOrDefault.SERIALIZER));
 +    }
 +
 +    @Override
@@ -3861,6 +3866,61 @@ index 0000000000000000000000000000000000000000..33ae915b2462faf1705be3b195e113c1
 +            final @Nullable Boolean value = item.value;
 +            if (value != null) {
 +                return value.toString();
++            } else {
++                return DEFAULT_VALUE;
++            }
++        }
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/configuration/type/ComponentOrDefault.java b/src/main/java/io/papermc/paper/configuration/type/ComponentOrDefault.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..b367bc19bb3666768cba3af56b103dad81df1bca
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/configuration/type/ComponentOrDefault.java
+@@ -0,0 +1,49 @@
++package io.papermc.paper.configuration.type;
++
++import io.papermc.paper.configuration.serializer.ComponentSerializer;
++import net.kyori.adventure.text.Component;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++import org.spongepowered.configurate.serialize.ScalarSerializer;
++import org.spongepowered.configurate.serialize.SerializationException;
++
++import java.lang.reflect.Type;
++import java.util.function.Predicate;
++
++public record ComponentOrDefault(@Nullable Component value, @NotNull String input) {
++    private static final String DEFAULT_VALUE = "default";
++    public static final ComponentOrDefault USE_DEFAULT = new ComponentOrDefault(null, DEFAULT_VALUE);
++    public static final ScalarSerializer<ComponentOrDefault> SERIALIZER = new Serializer();
++
++    public Component or(Component fallback) {
++        return this.value == null ? fallback : this.value;
++    }
++
++    private static final class Serializer extends ScalarSerializer<ComponentOrDefault> {
++        private static final ComponentSerializer COMPONENT_SERIALIZER = new ComponentSerializer();
++
++        Serializer() {
++            super(ComponentOrDefault.class);
++        }
++
++        @Override
++        public ComponentOrDefault deserialize(Type type, Object obj) throws SerializationException {
++            final String string = obj.toString();
++
++            if (DEFAULT_VALUE.equalsIgnoreCase(string))
++                return USE_DEFAULT;
++            else
++                return new ComponentOrDefault(COMPONENT_SERIALIZER.deserialize(type, obj), string);
++        }
++
++        @Override
++        protected Object serialize(ComponentOrDefault item, Predicate<Class<?>> typeSupported) {
++            final @Nullable Component value = item.value;
++            if (value != null) {
++                return item.input;
 +            } else {
 +                return DEFAULT_VALUE;
 +            }

--- a/patches/server/0019-Rewrite-chunk-system.patch
+++ b/patches/server/0019-Rewrite-chunk-system.patch
@@ -15687,10 +15687,10 @@ index 0000000000000000000000000000000000000000..962d3cae6340fc11607b59355e291629
 +
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 5cfd0bd7c09aacd7313575e30cf0a171c597e2bd..115c44d6f064049270f1fae07683da1da974b08e 100644
+index 81d816bba5580664a05a71f0c6c6478835a91cfa..495624dccb4cbae77c008e7db4bd514a0ea525db 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -116,21 +116,6 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -118,21 +118,6 @@ public class GlobalConfiguration extends ConfigurationPart {
          public int incomingPacketThreshold = 300;
      }
  
@@ -15712,7 +15712,7 @@ index 5cfd0bd7c09aacd7313575e30cf0a171c597e2bd..115c44d6f064049270f1fae07683da1d
      public UnsupportedSettings unsupportedSettings;
  
      public class UnsupportedSettings extends ConfigurationPart {
-@@ -288,4 +273,43 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -290,4 +275,43 @@ public class GlobalConfiguration extends ConfigurationPart {
          public boolean disableNoteblockUpdates = false;
          public boolean disableTripwireUpdates = false;
      }
@@ -15847,7 +15847,7 @@ index cea9c098ade00ee87b8efc8164ab72f5279758f0..197224e31175252d8438a8df585bbb65
 +    }
  }
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
-index 7afb13b7457755fac3aed4b0260413a280ed29e6..5e17a83df2f3606aff375fe054266d03f9a0b3b6 100644
+index 9572294a50110f2452090da1f32e0a73edc3db05..dc2ab968ed010289125ac08f0a9ea85af6f6e8bb 100644
 --- a/src/main/java/io/papermc/paper/util/MCUtil.java
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
 @@ -4,17 +4,30 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;

--- a/patches/server/0867-Configurable-chat-thread-limit.patch
+++ b/patches/server/0867-Configurable-chat-thread-limit.patch
@@ -22,10 +22,10 @@ is actually processed, this is honestly really just exposed for the misnomers or
 who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
 
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 115c44d6f064049270f1fae07683da1da974b08e..d7f541d94941a341a70dfac025a3d3601dd1aca8 100644
+index 495624dccb4cbae77c008e7db4bd514a0ea525db..fa9ab6195e104f2b67d4b33b08c2396cb9318816 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -246,13 +246,26 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -248,13 +248,26 @@ public class GlobalConfiguration extends ConfigurationPart {
      public Misc misc;
  
      public class Misc extends ConfigurationPart {

--- a/patches/server/1005-Add-MiniMessage-motd-option.patch
+++ b/patches/server/1005-Add-MiniMessage-motd-option.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Warrior <50800980+Warriorrrr@users.noreply.github.com>
+Date: Fri, 18 Aug 2023 19:23:29 +0200
+Subject: [PATCH] Add MiniMessage motd option
+
+
+diff --git a/src/main/java/io/papermc/paper/command/subcommands/ReloadCommand.java b/src/main/java/io/papermc/paper/command/subcommands/ReloadCommand.java
+index bd68139ae635f2ad7ec8e7a21e0056a139c4c62e..7763e4d78c2cd351646388452ce7313bb29978b1 100644
+--- a/src/main/java/io/papermc/paper/command/subcommands/ReloadCommand.java
++++ b/src/main/java/io/papermc/paper/command/subcommands/ReloadCommand.java
+@@ -27,6 +27,7 @@ public final class ReloadCommand implements PaperSubcommand {
+         MinecraftServer server = ((CraftServer) sender.getServer()).getServer();
+         server.paperConfigurations.reloadConfigs(server);
+         server.server.reloadCount++;
++        server.motd(io.papermc.paper.configuration.GlobalConfiguration.get().messages.motd.or(server.motd())); // Paper - add MiniMessage motd option
+ 
+         Command.broadcastCommandMessage(sender, text("Paper config reload complete.", GREEN));
+     }
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index 9f422cbeaa52b3e6a0a27af4f8ad4ddb7808483f..cf7ff0841d59ebe8e61e4e53081ae52bd250f222 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -225,6 +225,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         this.setPvpAllowed(dedicatedserverproperties.pvp);
+         this.setFlightAllowed(dedicatedserverproperties.allowFlight);
+         this.setMotd(dedicatedserverproperties.motd);
++        this.motd(io.papermc.paper.configuration.GlobalConfiguration.get().messages.motd.or(this.motd())); // Paper - add MiniMessage motd option
+         super.setPlayerIdleTimeout((Integer) dedicatedserverproperties.playerIdleTimeout.get());
+         this.setEnforceWhitelist(dedicatedserverproperties.enforceWhitelist);
+         // this.worldData.setGameType(dedicatedserverproperties.gamemode); // CraftBukkit - moved to world loading
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 249d76acac9a91cd46f0b8a477511974a75d6f4a..9503dfffda68f6679fb2d876473ea61d06e972c2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1057,6 +1057,7 @@ public final class CraftServer implements Server {
+ 
+         org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
+         this.console.paperConfigurations.reloadConfigs(this.console);
++        this.console.motd(io.papermc.paper.configuration.GlobalConfiguration.get().messages.motd.or(this.console.motd())); // Paper - add MiniMessage motd option
+         for (ServerLevel world : this.console.getAllLevels()) {
+             // world.serverLevelData.setDifficulty(config.difficulty); // Paper - per level difficulty
+             world.setSpawnSettings(world.serverLevelData.getDifficulty() != Difficulty.PEACEFUL && config.spawnMonsters, config.spawnAnimals); // Paper - per level difficulty (from MinecraftServer#setDifficulty(ServerLevel, Difficulty, boolean))


### PR DESCRIPTION
Closes #8230, supersedes #8242

By default, the option will have a value of "default" which will fallback to the motd set in the server.properties. Adds a new ComponentOrDefault class which uses the already existing ComponentSerializer to (de)serialize the component.