### PR TITLE
Fix javac api compile errors (experimental branch)

### DIFF
--- a/patches/api/0418-Temporary-fix-API-compile-errors-with-javac.patch
+++ b/patches/api/0418-Temporary-fix-API-compile-errors-with-javac.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BlockyTheDev <86119630+BlockyTheDev@users.noreply.github.com>
+Date: Mon, 21 Aug 2023 00:22:26 +0200
+Subject: [PATCH] Temporary fix API compile errors with javac
+
+
+diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
+index 10b9a61e08912cf866c1695dd55ae4054254da6f..024dffe5ae6bf310e329bc331e157177c8c08f9b 100644
+--- a/src/main/java/org/bukkit/Registry.java
++++ b/src/main/java/org/bukkit/Registry.java
+@@ -82,7 +82,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      *
+      * @see BlockType
+      */
+-    Registry<BlockType<?>> BLOCK = Objects.requireNonNull(Bukkit.getRegistry(BlockType.class), "No registry present for BlockType. This is a bug.");
++    Registry<BlockType<?>> BLOCK = (Registry<BlockType<?>>) Objects.requireNonNull(Bukkit.getRegistry(BlockType.class), "No registry present for BlockType. This is a bug.");
+     /**
+      * Server pattern types.
+      *
+@@ -126,7 +126,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      *
+      * @see EntityType
+      */
+-    Registry<EntityType<?>> ENTITY_TYPE = Objects.requireNonNull(Bukkit.getRegistry(EntityType.class), "No registry present for EntityType. This is a bug.");
++    Registry<EntityType<?>> ENTITY_TYPE = (Registry<EntityType<?>>) Objects.requireNonNull(Bukkit.getRegistry(EntityType.class), "No registry present for EntityType. This is a bug.");
+     /**
+      * Server instruments.
+      *
+@@ -158,7 +158,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      *
+      * @see Particle
+      */
+-    Registry<Particle<?>> PARTICLE_TYPE = Objects.requireNonNull(Bukkit.getRegistry(Particle.class), "No registry present for Particle. This is a bug.");
++    Registry<Particle<?>> PARTICLE_TYPE = (Registry<Particle<?>>) Objects.requireNonNull(Bukkit.getRegistry(Particle.class), "No registry present for Particle. This is a bug.");
+     /**
+      * Server potion types.
+      *


### PR DESCRIPTION
I hope this pull request is welcome...

This PR fixes compile errors related to the javac compiler in the experimental branch until upstream fixes it (if they do).


All the code changes were successfully tested.


Before/After this PR gets merged an upstream update would be great because md_5 updated the experimental branch two days ago.