### PR TITLE
Remove unused lag-compensate-block-breaking option

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -440,10 +440,10 @@ index 0000000000000000000000000000000000000000..9ef6712c70fcd8912a79f3f61e351aac
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0083b66889bfb6d3c4e4219fc73f410477109e37
+index 0000000000000000000000000000000000000000..45f1436cdd4b81b621ab71e4336c2aa666572105
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,293 @@
+@@ -0,0 +1,292 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -723,7 +723,6 @@ index 0000000000000000000000000000000000000000..0083b66889bfb6d3c4e4219fc73f4104
 +        public int regionFileCacheSize = 256;
 +        @Comment("See https://luckformula.emc.gs")
 +        public boolean useAlternativeLuckFormula = false;
-+        public boolean lagCompensateBlockBreaking = true;
 +        public boolean useDimensionTypeForCustomSpawners = false;
 +        public boolean strictAdvancementDimensionCheck = false;
 +    }


### PR DESCRIPTION
Removes the unused lag-compensate-block-breaking option from the paper configuration file as the patch using it has been dropped in 1.19.