### PR TITLE
Optimize nearest structure border iteration

### DIFF
--- a/patches/server/1024-Optimize-nearest-structure-border-iteration.patch
+++ b/patches/server/1024-Optimize-nearest-structure-border-iteration.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martijn Muijsers <martijnmuijsers@live.nl>
+Date: Mon, 21 Aug 2023 21:05:09 +0200
+Subject: [PATCH] Optimize nearest structure border iteration
+
+Getting the nearest generated structure contains a nested set of loops that
+iterates over all chunks at a specific chessboard distance. It does this by
+iterating over the entire square of chunks within that distance, and checking
+if the coordinates are at exactly the right distance to be on the border.
+
+This patch optimizes the iteration by only iterating over the border chunks.
+This evaluated chunks are the same, and in the same order, as before, to
+ensure that the returned found structure (which may for example be a buried
+treasure that will be marked on a treasure map) is the same as in vanilla.
+
+diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
+index 8bab3fcfc6aa6c0b37621474a69f15e94bda2113..d5c2a608e1b4c8099c96b33d9d758e968350a46d 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
++++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
+@@ -260,12 +260,15 @@ public abstract class ChunkGenerator {
+         int i1 = placement.spacing();
+ 
+         for (int j1 = -radius; j1 <= radius; ++j1) {
+-            boolean flag1 = j1 == -radius || j1 == radius;
++            // Paper start - iterate over border chunks instead of entire square chunk area
++            boolean flag1 = j1 == -radius || j1 == radius; final boolean onBorderAlongZAxis = flag1; // Paper - OBFHELPER
+ 
+-            for (int k1 = -radius; k1 <= radius; ++k1) {
+-                boolean flag2 = k1 == -radius || k1 == radius;
++            for (int k1 = -radius; k1 <= radius; k1 += onBorderAlongZAxis ? 1 : radius * 2) {
++                // boolean flag2 = k1 == -radius || k1 == radius;
+ 
+-                if (flag1 || flag2) {
++                // if (flag1 || flag2) {
++                if (true) {
++                    // Paper end
+                     int l1 = centerChunkX + i1 * j1;
+                     int i2 = centerChunkZ + i1 * k1;
+                     ChunkPos chunkcoordintpair = placement.getPotentialStructureChunk(seed, l1, i2);


### PR DESCRIPTION
Getting the nearest generated structure calls `ChunkGenerator.getNearestGeneratedStructure`, which contains a nested set of loops that iterate over all chunks at a specific chessboard distance. It does this by iterating over the entire square of chunks within that distance, and checking if the coordinates are at exactly the right distance to be on the border.

This patch optimizes the iteration by only iterating over the border chunks. This evaluated chunks are the same, and in the same order, as before, to ensure that the returned found structure (which may for example be a buried treasure that will be marked on a treasure map) is the same as in vanilla.

Since the radius may be quite large (50 for buried treasure maps in chests, 100 for cartographer treasure maps, or any arbitrary value for plugin calls or data pack functions) this effect is noticeable.
For example, for a cartographer treasure map, where the call to `ChunkGenerator.getNearestGeneratedStructure` is made from `ChunkGenerator.findNearestMapStructure` with an increasing radius, this effect can cause $\sum_\limits{i=1}^{100} (2i+1)^2-8i = 1\,333\,300$ unnecessary loop iterations, of which the bookkeeping can easily take half a millisecond, which is 1/100th of the main thread tick time already, spent just on pointless variable incrementing.