### PR TITLE
Fix inventory desync

### DIFF
--- a/patches/server/1026-Fix-inventory-desync.patch
+++ b/patches/server/1026-Fix-inventory-desync.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 23 Aug 2023 13:22:09 -0700
+Subject: [PATCH] Fix inventory desync
+
+
+diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
+index 65c69432da4bc042cd975e01fcf62b09843cf202..e483186a5292b3b53bfb1af4d56f55fcc1a6106c 100644
+--- a/src/main/java/net/minecraft/world/item/BlockItem.java
++++ b/src/main/java/net/minecraft/world/item/BlockItem.java
+@@ -116,7 +116,7 @@ public class BlockItem extends Item {
+                             if (placeEvent != null && (placeEvent.isCancelled() || !placeEvent.canBuild())) {
+                                 blockstate.update(true, false);
+ 
+-                                if (this instanceof SolidBucketItem) {
++                                if (true) { // Paper - if the event is called here, the inventory should be updated
+                                     ((ServerPlayer) entityhuman).connection.send(new net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket(world, blockposition.below())); // Paper - update block below
+                                     ((ServerPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
+                                 }


### PR DESCRIPTION
The check for updating the inventory should be run in all cases that the event is fired in BlockItem, not just for solid bucket item. This should cover lilypads and frogspawn, the 2 place on water blocks.

Fixes https://github.com/PaperMC/Paper/issues/9504