### PR TITLE
Add OfflinePlayer#isConnected

### DIFF
--- a/patches/api/0438-Add-OfflinePlayer-isConnected.patch
+++ b/patches/api/0438-Add-OfflinePlayer-isConnected.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aeltumn <daniel@goossens.ch>
+Date: Thu, 24 Aug 2023 13:05:07 +0200
+Subject: [PATCH] Add OfflinePlayer#isConnected
+
+This adds an alternative to OfflinePlayer#isOnline that returns true only if the same instance of the player is still online. This is generally more useful than isOnline as it allows you to determine if you have an instance of a Player that still exists. If a player relogs an old Player instance becomes unlinked leading to e.g. messages sent to the old player no longer arriving despite isOnline returning true. Checking against isConnected is more useful there to discard invalid instances.
+
+diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
+index 9b84cb5abdf3db55cbc7ba19c8cd6955bf4fc5ec..066a9eced460b9699669ad8995f754bf3c7487be 100644
+--- a/src/main/java/org/bukkit/OfflinePlayer.java
++++ b/src/main/java/org/bukkit/OfflinePlayer.java
+@@ -24,10 +24,25 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+     /**
+      * Checks if this player is currently online
+      *
++     * It should be noted that this will return true if any instance of this player is
++     * online! This instance may have disconnected. If you wish to check if this specific
++     * instance of the player is still online, see {@link OfflinePlayer#isConnected()}
++     *
+      * @return true if they are online
+      */
+     public boolean isOnline();
+ 
++    // Paper start
++    /**
++     * Checks whether the connection to this player is still valid. This will return
++     * true as long as this specific instance of the player is still connected. This
++     * will return false even if another instance exists due to the player reconnecting.
++     *
++     * @return true if this player instance is connected
++     */
++    public boolean isConnected();
++    // Paper end
++
+     /**
+      * Returns the name of this player
+      * <p>

--- a/patches/api/0438-Add-OfflinePlayer-isConnected.patch
+++ b/patches/api/0438-Add-OfflinePlayer-isConnected.patch
@@ -6,16 +6,16 @@ Subject: [PATCH] Add OfflinePlayer#isConnected
 This adds an alternative to OfflinePlayer#isOnline that returns true only if the same instance of the player is still online. This is generally more useful than isOnline as it allows you to determine if you have an instance of a Player that still exists. If a player relogs an old Player instance becomes unlinked leading to e.g. messages sent to the old player no longer arriving despite isOnline returning true. Checking against isConnected is more useful there to discard invalid instances.
 
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
-index 9b84cb5abdf3db55cbc7ba19c8cd6955bf4fc5ec..066a9eced460b9699669ad8995f754bf3c7487be 100644
+index 9b84cb5abdf3db55cbc7ba19c8cd6955bf4fc5ec..bce07d84cafca677bb6fad78c21b82097f06430c 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
-@@ -24,10 +24,25 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -24,10 +24,26 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      /**
       * Checks if this player is currently online
       *
 +     * It should be noted that this will return true if any instance of this player is
 +     * online! This instance may have disconnected. If you wish to check if this specific
-+     * instance of the player is still online, see {@link OfflinePlayer#isConnected()}
++     * instance of the player is still online, see {@link OfflinePlayer#isConnected()}.
 +     *
       * @return true if they are online
       */
@@ -25,7 +25,8 @@ index 9b84cb5abdf3db55cbc7ba19c8cd6955bf4fc5ec..066a9eced460b9699669ad8995f754bf
 +    /**
 +     * Checks whether the connection to this player is still valid. This will return
 +     * true as long as this specific instance of the player is still connected. This
-+     * will return false even if another instance exists due to the player reconnecting.
++     * will return false after this instance has disconnected, even if the same player
++     * has reconnected since.
 +     *
 +     * @return true if this player instance is connected
 +     */

--- a/patches/server/1025-Implement-OfflinePlayer-isConnected.patch
+++ b/patches/server/1025-Implement-OfflinePlayer-isConnected.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aeltumn <daniel@goossens.ch>
+Date: Thu, 24 Aug 2023 13:05:30 +0200
+Subject: [PATCH] Implement OfflinePlayer#isConnected
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+index c6129dc565b8f874b73e2fefcabd4be1c221fd73..c1b874cd6e0498fce3cd53fdbaca30d290e004d7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+@@ -53,6 +53,13 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
+         return this.getPlayer() != null;
+     }
+ 
++    // Paper start
++    @Override
++    public boolean isConnected() {
++        return false;
++    }
++    // Paper end
++
+     @Override
+     public String getName() {
+         Player player = this.getPlayer();
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 472705e92cef5802f377637d8ea5c8001d7a185c..4e6fea7cf11b1e29ae7c7098a6f5d06bb5f93cc2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -272,6 +272,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         return server.getPlayer(getUniqueId()) != null;
+     }
+ 
++    // Paper start
++    @Override
++    public boolean isConnected() {
++        return !this.getHandle().hasDisconnected();
++    }
++    // Paper end
++
+     @Override
+     public InetSocketAddress getAddress() {
+         if (this.getHandle().connection == null) return null;


### PR DESCRIPTION
This adds a method called isConnected to the OfflinePlayer which allows for beter checking if an instance of Player is still representing an actual online player. When a player reconnects isOnline on the old instance will still return true, but isConnected returns false. This way you can distinguish stale Player instances so offline Player instances.

More information in the comments on the paper-api patch.