### PR TITLE
Fix/improve destroy speed API

### DIFF
--- a/patches/api/0223-Add-Destroy-Speed-API.patch
+++ b/patches/api/0223-Add-Destroy-Speed-API.patch
@@ -6,36 +6,72 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 5ae85ddc2cff3145dcba877a7bf55abd818f6881..546c6709383edb0007b9a8a560af0b64f498dadd 100644
+index 5ae85ddc2cff3145dcba877a7bf55abd818f6881..89bd97153d874c2710304d163f7c46062d8c8bab 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -680,5 +680,29 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
-     @NotNull
+@@ -681,4 +681,31 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
      @Deprecated(forRemoval = true)
      String getTranslationKey();
+     // Paper end
 +
++    // Paper start - destroy speed API
 +    /**
 +     * Gets the speed at which this block will be destroyed by a given {@link ItemStack}
-+     *
-+     * <p>Default value is 1.0</p>
++     * <p>
++     * Default value is 1.0
 +     *
 +     * @param itemStack {@link ItemStack} used to mine this Block
 +     * @return the speed that this Block will be mined by the given {@link ItemStack}
 +     */
-+    @NotNull
-+    public default float getDestroySpeed(@NotNull ItemStack itemStack) {
-+        return getDestroySpeed(itemStack, false);
++    default float getDestroySpeed(final @NotNull ItemStack itemStack) {
++        return this.getBlockData().getDestroySpeed(itemStack);
 +    }
 +
 +    /**
-+     * Gets the speed at which this blook will be destroyed by a given {@link org.bukkit.inventory.ItemStack}
++     * Gets the speed at which this block will be destroyed by a given {@link ItemStack}
 +     * <p>
 +     * Default value is 1.0
-+     * @param itemStack {@link org.bukkit.inventory.ItemStack} used to mine this Block
++     *
++     * @param itemStack {@link ItemStack} used to mine this Block
 +     * @param considerEnchants true to look at enchants on the itemstack
-+     * @return the speed that this Block will be mined by the given {@link org.bukkit.inventory.ItemStack}
++     * @return the speed that this Block will be mined by the given {@link ItemStack}
 +     */
-+    @NotNull
++    default float getDestroySpeed(@NotNull ItemStack itemStack, boolean considerEnchants) {
++        return this.getBlockData().getDestroySpeed(itemStack, considerEnchants);
++    }
++    // Paper end - destroy speed API
+ }
+diff --git a/src/main/java/org/bukkit/block/data/BlockData.java b/src/main/java/org/bukkit/block/data/BlockData.java
+index 869fa47a13fbcb128228963bf53cc72da4499a01..1f475424cc04d90f437cf0e38e07f5ae4020fb54 100644
+--- a/src/main/java/org/bukkit/block/data/BlockData.java
++++ b/src/main/java/org/bukkit/block/data/BlockData.java
+@@ -247,4 +247,29 @@ public interface BlockData extends Cloneable {
+     @NotNull
+     @ApiStatus.Experimental
+     BlockState createBlockState();
++
++    // Paper start - destroy speed API
++    /**
++     * Gets the speed at which this block will be destroyed by a given {@link ItemStack}
++     * <p>
++     * Default value is 1.0
++     *
++     * @param itemStack {@link ItemStack} used to mine this Block
++     * @return the speed that this Block will be mined by the given {@link ItemStack}
++     */
++    default float getDestroySpeed(final @NotNull ItemStack itemStack) {
++        return this.getDestroySpeed(itemStack, false);
++    }
++
++    /**
++     * Gets the speed at which this block will be destroyed by a given {@link ItemStack}
++     * <p>
++     * Default value is 1.0
++     *
++     * @param itemStack {@link ItemStack} used to mine this Block
++     * @param considerEnchants true to look at enchants on the itemstack
++     * @return the speed that this Block will be mined by the given {@link ItemStack}
++     */
 +    float getDestroySpeed(@NotNull ItemStack itemStack, boolean considerEnchants);
-     // Paper end
++    // Paper end - destroy speed API
  }

--- a/patches/api/0373-Block-Ticking-API.patch
+++ b/patches/api/0373-Block-Ticking-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Block Ticking API
 
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 921864e748407291b7fa153381e7d9701e1c4608..1c3f54382d66549dc881d4577c7104be6673a274 100644
+index 49fd2f54d2051553bd2df1c53f6b229ffa64892e..0b2a927b3500be5e6583a6d1ae90fe68473ff786 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -589,6 +589,21 @@ public interface Block extends Metadatable, Translatable, net.kyori.adventure.tr
@@ -31,13 +31,13 @@ index 921864e748407291b7fa153381e7d9701e1c4608..1c3f54382d66549dc881d4577c7104be
  
      /**
 diff --git a/src/main/java/org/bukkit/block/data/BlockData.java b/src/main/java/org/bukkit/block/data/BlockData.java
-index 869fa47a13fbcb128228963bf53cc72da4499a01..c6b17605090f2f284e6536567ddf0e0977eeaaf8 100644
+index 1f475424cc04d90f437cf0e38e07f5ae4020fb54..31111cea5ffd018c3c011c1f3b8befbbd33db5e5 100644
 --- a/src/main/java/org/bukkit/block/data/BlockData.java
 +++ b/src/main/java/org/bukkit/block/data/BlockData.java
-@@ -247,4 +247,14 @@ public interface BlockData extends Cloneable {
-     @NotNull
-     @ApiStatus.Experimental
-     BlockState createBlockState();
+@@ -272,4 +272,14 @@ public interface BlockData extends Cloneable {
+      */
+     float getDestroySpeed(@NotNull ItemStack itemStack, boolean considerEnchants);
+     // Paper end - destroy speed API
 +
 +    // Paper start - Tick API
 +    /**
@@ -47,5 +47,5 @@ index 869fa47a13fbcb128228963bf53cc72da4499a01..c6b17605090f2f284e6536567ddf0e09
 +     * @return is ticked randomly
 +     */
 +    boolean isRandomlyTicked();
-+    // Paper end
++    // Paper end - Tick API
  }

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -7423,6 +7423,27 @@ index b5544bbfcf4449bdf588a14a9afe518f272e8261..5e8ec70a58c047969a144355782da58a
 +    }
 +    // Paper end
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+index 34a54a99e7484b2934e1d174c1b55f0472ff3812..40aad6a209fbded448e3db21207a85d9f2875e71 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+@@ -23,6 +23,16 @@ import org.bukkit.material.MaterialData;
+ @DelegateDeserialization(ItemStack.class)
+ public final class CraftItemStack extends ItemStack {
+ 
++    // Paper start - MC Utils
++    public static net.minecraft.world.item.ItemStack unwrap(ItemStack bukkit) {
++        if (bukkit instanceof CraftItemStack craftItemStack) {
++            return craftItemStack.handle != null ? craftItemStack.handle : net.minecraft.world.item.ItemStack.EMPTY;
++        } else {
++            return asNMSCopy(bukkit);
++        }
++    }
++    // Paper end - MC Utils
++
+     public static net.minecraft.world.item.ItemStack asNMSCopy(ItemStack original) {
+         if (original instanceof CraftItemStack) {
+             CraftItemStack stack = (CraftItemStack) original;
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 index 07249989e6f0f76f8408363d7f20e7335b7a8e06..4d94c3a19f98f78476ecc403f410d75a6ea57c2d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java

--- a/patches/server/0069-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0069-Handle-Item-Meta-Inconsistencies.patch
@@ -70,10 +70,10 @@ index 3f18fb61a47dda559a6997af9c6c043423dd206a..c33660718c0ea281d7bcdb15df0568d4
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 34a54a99e7484b2934e1d174c1b55f0472ff3812..b75c8549e9484a2e6167d0bbb9fd64ae8b422931 100644
+index 40aad6a209fbded448e3db21207a85d9f2875e71..4dcbd1ed61070c12adf5871a595875ca60110c5d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -178,28 +178,11 @@ public final class CraftItemStack extends ItemStack {
+@@ -188,28 +188,11 @@ public final class CraftItemStack extends ItemStack {
      public void addUnsafeEnchantment(Enchantment ench, int level) {
          Preconditions.checkArgument(ench != null, "Enchantment cannot be null");
  
@@ -107,7 +107,7 @@ index 34a54a99e7484b2934e1d174c1b55f0472ff3812..b75c8549e9484a2e6167d0bbb9fd64ae
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -225,57 +208,40 @@ public final class CraftItemStack extends ItemStack {
+@@ -235,57 +218,40 @@ public final class CraftItemStack extends ItemStack {
          if (this.handle == null) {
              return 0;
          }

--- a/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0200-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 7fd9a3a7f4cb98d89b7c4cbfda756d581963e5bf..0ac686e880f0f87ab3f6dbed77e553d7568b3305 100644
+index 4dcbd1ed61070c12adf5871a595875ca60110c5d..00bdaff22deab7a9f328670917fe2bae01e37a73 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -174,6 +174,13 @@ public final class CraftItemStack extends ItemStack {
+@@ -184,6 +184,13 @@ public final class CraftItemStack extends ItemStack {
          return (this.handle == null) ? Material.AIR.getMaxStackSize() : this.handle.getItem().getMaxStackSize();
      }
  

--- a/patches/server/0228-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0228-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 3afb5e9e9c40031d9a8afe9460ebae81bbad58a9..0588f33b59e95ad660c07332ab31d253e240c9b8 100644
+index 00bdaff22deab7a9f328670917fe2bae01e37a73..cee7a93cd516ed8f483fd29dfcd6a54f4c37e348 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -668,7 +668,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -678,7 +678,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {

--- a/patches/server/0492-Add-Destroy-Speed-API.patch
+++ b/patches/server/0492-Add-Destroy-Speed-API.patch
@@ -5,27 +5,20 @@ Subject: [PATCH] Add Destroy Speed API
 
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
-diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 2749f81fd74e466fa6b7c1c5f08d8defc5203b3e..d035ff8390f2181fb81baec1b0287ead6da0a912 100644
---- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-+++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -699,5 +699,26 @@ public class CraftBlock implements Block {
-     public String translationKey() {
-         return this.getNMS().getBlock().getDescriptionId();
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+index 68ffdb2140bdf8d00ed86db19d316735d9a6b2d1..f4e37764f714419a614a7e40718924788a204d28 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+@@ -688,4 +688,19 @@ public class CraftBlockData implements BlockData {
+     public BlockState createBlockState() {
+         return CraftBlockStates.getBlockState(this.state, null);
      }
 +
++    // Paper start - destroy speed API
 +    @Override
-+    public float getDestroySpeed(ItemStack itemStack, boolean considerEnchants) {
-+        net.minecraft.world.item.ItemStack nmsItemStack;
-+        if (itemStack instanceof CraftItemStack) {
-+            nmsItemStack = ((CraftItemStack) itemStack).handle;
-+            if (nmsItemStack == null) {
-+                nmsItemStack = net.minecraft.world.item.ItemStack.EMPTY;
-+            }
-+        } else {
-+            nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
-+        }
-+        float speed = nmsItemStack.getDestroySpeed(this.getNMS().getBlock().defaultBlockState());
++    public float getDestroySpeed(final ItemStack itemStack, final boolean considerEnchants) {
++        net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.unwrap(itemStack);
++        float speed = nmsItemStack.getDestroySpeed(this.state);
 +        if (speed > 1.0F && considerEnchants) {
 +            int enchantLevel = net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.BLOCK_EFFICIENCY, nmsItemStack);
 +            if (enchantLevel > 0) {
@@ -34,5 +27,5 @@ index 2749f81fd74e466fa6b7c1c5f08d8defc5203b3e..d035ff8390f2181fb81baec1b0287ead
 +        }
 +        return speed;
 +    }
-     // Paper end
++    // Paper end - destroy speed API
  }

--- a/patches/server/0565-Add-Block-isValidTool.patch
+++ b/patches/server/0565-Add-Block-isValidTool.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Add Block#isValidTool
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 8958a54d1a9d6e9ad6ab09f3a587ba89ae2d817d..582f1c07da8edc88dda9463992bb8503fcb9e163 100644
+index 5e0f16acbd892f815cc504e03cd186070598b530..7dcc1fa9c058adf2d55b1ccc6f7abf468752e116 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -739,5 +739,9 @@ public class CraftBlock implements Block {
-         }
-         return speed;
+@@ -718,5 +718,9 @@ public class CraftBlock implements Block {
+     public String translationKey() {
+         return this.getNMS().getBlock().getDescriptionId();
      }
 +
 +    public boolean isValidTool(ItemStack itemStack) {

--- a/patches/server/0791-More-Projectile-API.patch
+++ b/patches/server/0791-More-Projectile-API.patch
@@ -492,10 +492,10 @@ index c628594b981f276acae7b9337100d811f919631b..c8b65210d2416b5a293cb4bcc1b71f56
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 0588f33b59e95ad660c07332ab31d253e240c9b8..3f0c1edcc6bf57a72942b4680fccf27c68ea0a44 100644
+index cee7a93cd516ed8f483fd29dfcd6a54f4c37e348..28e6933e5b02d1d2f983968692bffa2b9e572051 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -290,12 +290,20 @@ public final class CraftItemStack extends ItemStack {
+@@ -300,12 +300,20 @@ public final class CraftItemStack extends ItemStack {
      public ItemMeta getItemMeta() {
          return CraftItemStack.getItemMeta(this.handle);
      }

--- a/patches/server/0855-Block-Ticking-API.patch
+++ b/patches/server/0855-Block-Ticking-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Block Ticking API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index c04397cc60154ef55027c90be990b9dfb818fd2f..5401ab9f8f6ce12e1c5368dbc3acc78a250b3822 100644
+index df104b1f7753d98318a5cc511c6e0e1c68e5c277..f3ac362b7b65a5273ff5fdad1d8065c5f654a53a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -756,5 +756,21 @@ public class CraftBlock implements Block {
+@@ -735,5 +735,21 @@ public class CraftBlock implements Block {
      public boolean isValidTool(ItemStack itemStack) {
          return getDrops(itemStack).size() != 0;
      }
@@ -31,18 +31,18 @@ index c04397cc60154ef55027c90be990b9dfb818fd2f..5401ab9f8f6ce12e1c5368dbc3acc78a
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-index 68ffdb2140bdf8d00ed86db19d316735d9a6b2d1..78dc524549be9373a04df905deab85d41e7f7870 100644
+index f4e37764f714419a614a7e40718924788a204d28..86fb50f946ff57d66c561ba0ee6f1116f63479fb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-@@ -688,4 +688,11 @@ public class CraftBlockData implements BlockData {
-     public BlockState createBlockState() {
-         return CraftBlockStates.getBlockState(this.state, null);
+@@ -703,4 +703,11 @@ public class CraftBlockData implements BlockData {
+         return speed;
      }
+     // Paper end - destroy speed API
 +
 +    // Paper start - Block tick API
 +    @Override
 +    public boolean isRandomlyTicked() {
 +        return this.state.isRandomlyTicking();
 +    }
-+    // Paper end
++    // Paper end - Block tick API
  }

--- a/patches/server/0926-Remove-CraftItemStack-setAmount-null-assignment.patch
+++ b/patches/server/0926-Remove-CraftItemStack-setAmount-null-assignment.patch
@@ -16,10 +16,10 @@ with less than zero amounts, so this code doesn't create
 a problem with operations on the vanilla ItemStack.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index d6b9897dcb4715decd4dd0b1b96995e25d789482..8657736cdfe2d5d2a1c0851ca54dd26ce17e0a83 100644
+index 28e6933e5b02d1d2f983968692bffa2b9e572051..ce82f313007762b6d1d9f006f21a8858e2976efb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -147,7 +147,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -157,7 +157,7 @@ public final class CraftItemStack extends ItemStack {
          }
  
          this.handle.setCount(amount);

--- a/patches/server/0983-fix-item-meta-for-tadpole-buckets.patch
+++ b/patches/server/0983-fix-item-meta-for-tadpole-buckets.patch
@@ -17,10 +17,10 @@ index 4c0b250bb9e3cf52173b563b36fd27d9e893e154..3f4e55bb9a4134e54adddca3c6622851
          case GLOW_ITEM_FRAME:
          case PAINTING:
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index dc524fd22ce5f9298e3d73b05d72c1ef7459d9ea..3e8cd6a892155c1eda34424d87bd426ace26f3cd 100644
+index ce82f313007762b6d1d9f006f21a8858e2976efb..0e5abd2a8694b24d4077a602a544e9c2b4c31822 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -590,6 +590,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -600,6 +600,7 @@ public final class CraftItemStack extends ItemStack {
              case COD_BUCKET:
              case PUFFERFISH_BUCKET:
              case SALMON_BUCKET:


### PR DESCRIPTION
PR adding methods to `BlockData` that are currently just on `Block` which either never should have been there in the first place or should have been in both places.

----

Am splitting this up cause they are kind of annoying PRs to review cause the diff is ugly.