### PR TITLE
Expand open container api on HumanEntity to support custom titles

### DIFF
--- a/patches/api/0209-Add-additional-open-container-api-to-HumanEntity.patch
+++ b/patches/api/0209-Add-additional-open-container-api-to-HumanEntity.patch
@@ -3,16 +3,137 @@ From: JRoy <joshroy126@gmail.com>
 Date: Wed, 26 Aug 2020 02:11:58 -0400
 Subject: [PATCH] Add additional open container api to HumanEntity
 
+Expand existing methods to also allow for title overrides
+
+Co-authored-by: Lukas Planz <me@md5lukas.de>
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 2557ddcc0528d4f9d811883b3ddc61148ebc3998..5ecfb98540c00da05b13bc5370debb89c52cc76f 100644
+index 2557ddcc0528d4f9d811883b3ddc61148ebc3998..48f5934f1e4e570606c7cd57e9fc349cc8763f68 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
-@@ -174,6 +174,92 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -123,7 +123,26 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      *     opened.
+      */
      @Nullable
-     public InventoryView openMerchant(@NotNull Merchant merchant, boolean force);
+-    public InventoryView openWorkbench(@Nullable Location location, boolean force);
++    // Paper start - Add additional open container api
++    default InventoryView openWorkbench(@Nullable Location location, boolean force) {
++        return openWorkbench(location, force, null);
++    }
++
++    /**
++     * Opens an empty workbench inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no workbench block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @param title The title to use instead of the default one
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    InventoryView openWorkbench(@Nullable Location location, boolean force, @Nullable net.kyori.adventure.text.Component title);
++    // Paper end - Add additional open container api
  
-+    // Paper start - Add additional containers
+     /**
+      * Opens an empty enchanting inventory window with the player's inventory
+@@ -137,7 +156,26 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      *     opened.
+      */
+     @Nullable
+-    public InventoryView openEnchanting(@Nullable Location location, boolean force);
++    // Paper start - Add additional open container api
++    default InventoryView openEnchanting(@Nullable Location location, boolean force) {
++        return openEnchanting(location, force, null);
++    }
++
++    /**
++     * Opens an empty enchanting inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no enchanting table at the
++     *     location, no inventory will be opened and null will be returned.
++     * @param title The title to use instead of the default one
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    InventoryView openEnchanting(@Nullable Location location, boolean force, @Nullable net.kyori.adventure.text.Component title);
++    // Paper end - Add additional open container api
+ 
+     /**
+      * Opens an inventory window to the specified inventory view.
+@@ -158,7 +196,46 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      * opened.
+      */
+     @Nullable
+-    public InventoryView openMerchant(@NotNull Villager trader, boolean force);
++    // Paper start - Add additional open container api
++    default InventoryView openMerchant(@NotNull Villager trader, boolean force) {
++        return openMerchant(trader, force, null);
++    }
++
++    /**
++     * Starts a trade between the player and the villager.
++     *
++     * Note that only one player may trade with a villager at once. You must use
++     * the force parameter for this.
++     *
++     * <p>Keep in mind when using this method, that after the overridden name of the villager a suffix
++     * is appended in the client depending on the level of it, for example " - Novice" for the lowest level.</p>
++     *
++     * @param trader The merchant to trade with. Cannot be null.
++     * @param force whether to force the trade even if another player is trading
++     * @param name The name to use instead of the default one.
++     * @return The newly opened inventory view, or null if it could not be
++     * opened.
++     */
++    @Nullable
++    InventoryView openMerchant(@NotNull Villager trader, boolean force, @Nullable net.kyori.adventure.text.Component name);
++    // Paper end - Add additional open container api
++
++    /**
++     * Starts a trade between the player and the merchant.
++     *
++     * Note that only one player may trade with a merchant at once. You must use
++     * the force parameter for this.
++     *
++     * @param merchant The merchant to trade with. Cannot be null.
++     * @param force whether to force the trade even if another player is trading
++     * @return The newly opened inventory view, or null if it could not be
++     * opened.
++     */
++    @Nullable
++    // Paper start - Add additional open container api
++    default InventoryView openMerchant(@NotNull Merchant merchant, boolean force) {
++        return openMerchant(merchant, force, null);
++    }
+ 
+     /**
+      * Starts a trade between the player and the merchant.
+@@ -166,13 +243,206 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      * Note that only one player may trade with a merchant at once. You must use
+      * the force parameter for this.
+      *
++     * <p>Keep in mind when using this method, that after the overridden name of the villager a suffix
++     * is appended in the client depending on the level of it, for example " - Novice" for the lowest level.</p>
++     *
+      * @param merchant The merchant to trade with. Cannot be null.
+      * @param force whether to force the trade even if another player is trading
++     * @param name The name to use instead of the default one
+      * @return The newly opened inventory view, or null if it could not be
+      * opened.
+      */
+     @Nullable
+-    public InventoryView openMerchant(@NotNull Merchant merchant, boolean force);
++    InventoryView openMerchant(@NotNull Merchant merchant, boolean force, @Nullable net.kyori.adventure.text.Component name);
++    // Paper end - Add additional open container api
++
++    // Paper start - Add additional open container api
 +    /**
 +     * Opens an empty anvil inventory window with the player's inventory
 +     * on the bottom.
@@ -25,7 +146,24 @@ index 2557ddcc0528d4f9d811883b3ddc61148ebc3998..5ecfb98540c00da05b13bc5370debb89
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openAnvil(@Nullable Location location, boolean force);
++    default InventoryView openAnvil(@Nullable Location location, boolean force) {
++        return openAnvil(location, force, null);
++    }
++
++    /**
++     * Opens an empty anvil inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no anvil block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @param title The title to use instead of the default one
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    InventoryView openAnvil(@Nullable Location location, boolean force, @Nullable net.kyori.adventure.text.Component title);
 +
 +    /**
 +     * Opens an empty cartography table inventory window with the player's inventory
@@ -39,7 +177,24 @@ index 2557ddcc0528d4f9d811883b3ddc61148ebc3998..5ecfb98540c00da05b13bc5370debb89
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openCartographyTable(@Nullable Location location, boolean force);
++    default InventoryView openCartographyTable(@Nullable Location location, boolean force) {
++        return openCartographyTable(location, force, null);
++    }
++
++    /**
++     * Opens an empty cartography table inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no cartography table block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @param title The title to use instead of the default one
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    InventoryView openCartographyTable(@Nullable Location location, boolean force, @Nullable net.kyori.adventure.text.Component title);
 +
 +    /**
 +     * Opens an empty grindstone inventory window with the player's inventory
@@ -53,7 +208,24 @@ index 2557ddcc0528d4f9d811883b3ddc61148ebc3998..5ecfb98540c00da05b13bc5370debb89
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openGrindstone(@Nullable Location location, boolean force);
++    default InventoryView openGrindstone(@Nullable Location location, boolean force) {
++        return openGrindstone(location, force, null);
++    }
++
++    /**
++     * Opens an empty grindstone inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no grindstone block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @param title The title to use instead of the default one
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    InventoryView openGrindstone(@Nullable Location location, boolean force, @Nullable net.kyori.adventure.text.Component title);
 +
 +    /**
 +     * Opens an empty loom inventory window with the player's inventory
@@ -67,7 +239,24 @@ index 2557ddcc0528d4f9d811883b3ddc61148ebc3998..5ecfb98540c00da05b13bc5370debb89
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openLoom(@Nullable Location location, boolean force);
++    default InventoryView openLoom(@Nullable Location location, boolean force) {
++        return openLoom(location, force, null);
++    }
++
++    /**
++     * Opens an empty loom inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no loom block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @param title The title to use instead of the default one
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    InventoryView openLoom(@Nullable Location location, boolean force, @Nullable net.kyori.adventure.text.Component title);
 +
 +    /**
 +     * Opens an empty smithing table inventory window with the player's inventory
@@ -81,7 +270,24 @@ index 2557ddcc0528d4f9d811883b3ddc61148ebc3998..5ecfb98540c00da05b13bc5370debb89
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openSmithingTable(@Nullable Location location, boolean force);
++    default InventoryView openSmithingTable(@Nullable Location location, boolean force) {
++        return openSmithingTable(location, force, null);
++    }
++
++    /**
++     * Opens an empty smithing table inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no smithing table block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @param title The title to use instead of the default one
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    InventoryView openSmithingTable(@Nullable Location location, boolean force, @Nullable net.kyori.adventure.text.Component title);
 +
 +    /**
 +     * Opens an empty stonecutter inventory window with the player's inventory
@@ -95,9 +301,25 @@ index 2557ddcc0528d4f9d811883b3ddc61148ebc3998..5ecfb98540c00da05b13bc5370debb89
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openStonecutter(@Nullable Location location, boolean force);
-+    // Paper end
++    default InventoryView openStonecutter(@Nullable Location location, boolean force) {
++        return openStonecutter(location, force, null);
++    }
 +
++    /**
++     * Opens an empty stonecutter inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no stonecutter block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @param title The title to use instead of the default one
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    InventoryView openStonecutter(@Nullable Location location, boolean force, @Nullable net.kyori.adventure.text.Component title);
++    // Paper end - Add additional open container api
+ 
      /**
       * Force-closes the currently open inventory view for this player, if any.
-      */

--- a/patches/api/0225-Expose-LivingEntity-hurt-direction.patch
+++ b/patches/api/0225-Expose-LivingEntity-hurt-direction.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose LivingEntity hurt direction
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 5ecfb98540c00da05b13bc5370debb89c52cc76f..083d5798ccc7f37c6df5e234c7ef233202102b8f 100644
+index 48f5934f1e4e570606c7cd57e9fc349cc8763f68..e6e6b8f038a720ea7375d50a9cbbaef02a23056f 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
-@@ -348,6 +348,16 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -532,6 +532,16 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       */
      public void setCooldown(@NotNull Material material, int ticks);
  

--- a/patches/api/0261-add-isDeeplySleeping-to-HumanEntity.patch
+++ b/patches/api/0261-add-isDeeplySleeping-to-HumanEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add isDeeplySleeping to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 083d5798ccc7f37c6df5e234c7ef233202102b8f..a47ea595c2a23b361a56f13877b67892ecfed826 100644
+index e6e6b8f038a720ea7375d50a9cbbaef02a23056f..f7a67b370de1dd09a0f456632b420030358990c3 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
-@@ -358,6 +358,15 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -542,6 +542,15 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
      void setHurtDirection(float hurtDirection);
      // Paper end
  

--- a/patches/api/0358-Add-Player-getFishHook.patch
+++ b/patches/api/0358-Add-Player-getFishHook.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player#getFishHook
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index a47ea595c2a23b361a56f13877b67892ecfed826..ee866f3497ed56708d4062685f5585ca06a03955 100644
+index f7a67b370de1dd09a0f456632b420030358990c3..43a8ac32ec783d16a82818ad1b635ea2d5978170 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
-@@ -386,6 +386,13 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -570,6 +570,13 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
      @Nullable
      public Location getPotentialBedLocation();
      // Paper end

--- a/patches/server/0418-Add-additional-open-container-api-to-HumanEntity.patch
+++ b/patches/server/0418-Add-additional-open-container-api-to-HumanEntity.patch
@@ -3,80 +3,130 @@ From: JRoy <joshroy126@gmail.com>
 Date: Wed, 26 Aug 2020 02:12:31 -0400
 Subject: [PATCH] Add additional open container api to HumanEntity
 
-== AT ==
-public net/minecraft/world/level/block/state/BlockBehaviour getMenuProvider(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/MenuProvider;
+Expand existing methods to also allow for title overrides
+
+Co-authored-by: Lukas Planz <me@md5lukas.de>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index bbd3f0981eb95348ef12c9af8fa1712c022ed869..9393e9d21fcc41cb0f20b98d9f28c95b0e523f62 100644
+index bbd3f0981eb95348ef12c9af8fa1712c022ed869..7fddf1b492f17d7ed68b3de2db9f465470d08646 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -462,6 +462,70 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -349,7 +349,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+     }
+ 
+     @Override
+-    public InventoryView openWorkbench(Location location, boolean force) {
++    public InventoryView openWorkbench(Location location, boolean force, net.kyori.adventure.text.Component title) { // Paper - Add additional open container api
+         if (location == null) {
+             location = this.getLocation();
+         }
+@@ -359,7 +359,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+                 return null;
+             }
+         }
+-        this.getHandle().openMenu(Blocks.CRAFTING_TABLE.defaultBlockState().getMenuProvider(this.getHandle().level(), CraftLocation.toBlockPosition(location)));
++        this.getHandle().openMenu(overrideTitle(Blocks.CRAFTING_TABLE.defaultBlockState().getMenuProvider(this.getHandle().level(), CraftLocation.toBlockPosition(location)), title)); // Paper - Add additional open container api
+         if (force) {
+             this.getHandle().containerMenu.checkReachable = false;
+         }
+@@ -367,7 +367,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+     }
+ 
+     @Override
+-    public InventoryView openEnchanting(Location location, boolean force) {
++    public InventoryView openEnchanting(Location location, boolean force, net.kyori.adventure.text.Component title) { // Paper - Add additional open container api
+         if (location == null) {
+             location = this.getLocation();
+         }
+@@ -380,7 +380,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+ 
+         // If there isn't an enchant table we can force create one, won't be very useful though.
+         BlockPos pos = CraftLocation.toBlockPosition(location);
+-        this.getHandle().openMenu(Blocks.ENCHANTING_TABLE.defaultBlockState().getMenuProvider(this.getHandle().level(), pos));
++        this.getHandle().openMenu(overrideTitle(Blocks.ENCHANTING_TABLE.defaultBlockState().getMenuProvider(this.getHandle().level(), pos), title)); // Paper - Add additional open container api
+ 
+         if (force) {
+             this.getHandle().containerMenu.checkReachable = false;
+@@ -423,14 +423,14 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+     }
+ 
+     @Override
+-    public InventoryView openMerchant(Villager villager, boolean force) {
++    public InventoryView openMerchant(Villager villager, boolean force, net.kyori.adventure.text.Component name) { // Paper - Add additional open container api
+         Preconditions.checkNotNull(villager, "villager cannot be null");
+ 
+-        return this.openMerchant((Merchant) villager, force);
++        return this.openMerchant((Merchant) villager, force, name); // Paper - Add additional open container api
+     }
+ 
+     @Override
+-    public InventoryView openMerchant(Merchant merchant, boolean force) {
++    public InventoryView openMerchant(Merchant merchant, boolean force, net.kyori.adventure.text.Component nameOverride) { // Paper - Add additional open container api
+         Preconditions.checkNotNull(merchant, "merchant cannot be null");
+ 
+         if (!force && merchant.isTrading()) {
+@@ -457,11 +457,64 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+         }
+ 
+         mcMerchant.setTradingPlayer(this.getHandle());
+-        mcMerchant.openTradingScreen(this.getHandle(), name, level);
++        mcMerchant.openTradingScreen(this.getHandle(), nameOverride == null ? name : io.papermc.paper.adventure.PaperAdventure.asVanilla(nameOverride), level); // Paper - Add additional open container api
+ 
          return this.getHandle().containerMenu.getBukkitView();
      }
  
-+    // Paper start - Add additional containers
++    // Paper start - Add additional open container api
 +    @Override
-+    public InventoryView openAnvil(Location location, boolean force) {
-+        return this.openInventory(location, force, Material.ANVIL);
++    public InventoryView openAnvil(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Blocks.ANVIL, title);
 +    }
 +
 +    @Override
-+    public InventoryView openCartographyTable(Location location, boolean force) {
-+        return this.openInventory(location, force, Material.CARTOGRAPHY_TABLE);
++    public InventoryView openCartographyTable(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Blocks.CARTOGRAPHY_TABLE, title);
 +    }
 +
 +    @Override
-+    public InventoryView openGrindstone(Location location, boolean force) {
-+        return this.openInventory(location, force, Material.GRINDSTONE);
++    public InventoryView openGrindstone(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Blocks.GRINDSTONE, title);
 +    }
 +
 +    @Override
-+    public InventoryView openLoom(Location location, boolean force) {
-+        return this.openInventory(location, force, Material.LOOM);
++    public InventoryView openLoom(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Blocks.LOOM, title);
 +    }
 +
 +    @Override
-+    public InventoryView openSmithingTable(Location location, boolean force) {
-+        return this.openInventory(location, force, Material.SMITHING_TABLE);
++    public InventoryView openSmithingTable(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Blocks.SMITHING_TABLE, title);
 +    }
 +
 +    @Override
-+    public InventoryView openStonecutter(Location location, boolean force) {
-+        return this.openInventory(location, force, Material.STONECUTTER);
++    public InventoryView openStonecutter(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Blocks.STONECUTTER, title);
 +    }
 +
-+    private InventoryView openInventory(Location location, boolean force, Material material) {
-+        org.spigotmc.AsyncCatcher.catchOp("open" + material);
++    private InventoryView openInventory(Location location, boolean force, net.minecraft.world.level.block.Block block, net.kyori.adventure.text.Component title) {
++        org.spigotmc.AsyncCatcher.catchOp("open" + block);
 +        if (location == null) {
 +            location = this.getLocation();
 +        }
-+        if (!force) {
-+            Block block = location.getBlock();
-+            if (block.getType() != material) {
-+                return null;
-+            }
++        if (!force && block != ((org.bukkit.craftbukkit.block.CraftBlock) location.getBlock()).getNMS().getBlock()) {
++            return null;
 +        }
-+        net.minecraft.world.level.block.Block block;
-+        if (material == Material.ANVIL) {
-+            block = Blocks.ANVIL;
-+        } else if (material == Material.CARTOGRAPHY_TABLE) {
-+            block = Blocks.CARTOGRAPHY_TABLE;
-+        } else if (material == Material.GRINDSTONE) {
-+            block = Blocks.GRINDSTONE;
-+        } else if (material == Material.LOOM) {
-+            block = Blocks.LOOM;
-+        } else if (material == Material.SMITHING_TABLE) {
-+            block = Blocks.SMITHING_TABLE;
-+        } else if (material == Material.STONECUTTER) {
-+            block = Blocks.STONECUTTER;
-+        } else {
-+            throw new IllegalArgumentException("Unsupported inventory type: " + material);
-+        }
-+        this.getHandle().openMenu(block.getMenuProvider(null, this.getHandle().level(), new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ())));
++        this.getHandle().openMenu(overrideTitle(block.defaultBlockState().getMenuProvider(this.getHandle().level(), new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ())), title));
 +        this.getHandle().containerMenu.checkReachable = !force;
 +        return this.getHandle().containerMenu.getBukkitView();
 +    }
-+    // Paper end
++
++    private MenuProvider overrideTitle(MenuProvider original, net.kyori.adventure.text.Component titleOverride) {
++        if (original == null || titleOverride == null) {
++            return original;
++        } else {
++            return new net.minecraft.world.SimpleMenuProvider(original, io.papermc.paper.adventure.PaperAdventure.asVanilla(titleOverride));
++        }
++    }
++    // Paper end - Add additional open container api
 +
      @Override
      public void closeInventory() {

--- a/patches/server/0814-Fix-force-opening-enchantment-tables.patch
+++ b/patches/server/0814-Fix-force-opening-enchantment-tables.patch
@@ -5,15 +5,15 @@ Subject: [PATCH] Fix force-opening enchantment tables
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 79faf3c64891899bf5d6d119154aba02d4665b3b..e1150d36de56466ad9fdd5f2cdb4c30855d4af70 100644
+index 8097edefeb9c7f28043ba96c0284c52ef6fb22da..9fa8bbb599a133a9eec07b2c52dd75e76b38e138 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -403,7 +403,18 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
  
          // If there isn't an enchant table we can force create one, won't be very useful though.
          BlockPos pos = CraftLocation.toBlockPosition(location);
--        this.getHandle().openMenu(Blocks.ENCHANTING_TABLE.defaultBlockState().getMenuProvider(this.getHandle().level(), pos));
-+        // Paper start
+-        this.getHandle().openMenu(overrideTitle(Blocks.ENCHANTING_TABLE.defaultBlockState().getMenuProvider(this.getHandle().level(), pos), title)); // Paper - Add additional open container api
++        // Paper start - Fix force-opening enchantment tables
 +        MenuProvider menuProvider = Blocks.ENCHANTING_TABLE.defaultBlockState().getMenuProvider(this.getHandle().level(), pos);
 +        if (menuProvider == null) {
 +            if (!force) {
@@ -23,8 +23,8 @@ index 79faf3c64891899bf5d6d119154aba02d4665b3b..e1150d36de56466ad9fdd5f2cdb4c308
 +                return new net.minecraft.world.inventory.EnchantmentMenu(syncId, inventory, net.minecraft.world.inventory.ContainerLevelAccess.create(this.getHandle().level(), pos));
 +            }, Component.translatable("container.enchant"));
 +        }
-+        this.getHandle().openMenu(menuProvider);
-+        // Paper end
++        this.getHandle().openMenu(overrideTitle(menuProvider, title)); // Paper - Add additional open container api
++        // Paper end - Fix force-opening enchantment tables
  
          if (force) {
              this.getHandle().containerMenu.checkReachable = false;

--- a/patches/server/0818-Fix-HumanEntity-drop-not-updating-the-client-inv.patch
+++ b/patches/server/0818-Fix-HumanEntity-drop-not-updating-the-client-inv.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Fix HumanEntity#drop not updating the client inv
 public net.minecraft.server.level.ServerPlayer containerSynchronizer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index e1150d36de56466ad9fdd5f2cdb4c30855d4af70..3d36d79a4e7f16f6face3465cdf54656984f3ebc 100644
+index 9fa8bbb599a133a9eec07b2c52dd75e76b38e138..1a43e1c9b92e967a139e2dc19c589bdcd2c78032 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -750,8 +750,15 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -739,8 +739,15 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
      // Paper end
      @Override
      public boolean dropItem(boolean dropAll) {


### PR DESCRIPTION
The methods now take an optional component that overrides the title of the container.

I tested these changes with every method and every container type accepts the new overridden title just fine with the villager / merchant being the exception because the level of the villager is appended to the name