### PR TITLE
Added LootTableRollEvent

### DIFF
--- a/patches/api/0440-Added-LootTableRollEvent.patch
+++ b/patches/api/0440-Added-LootTableRollEvent.patch
@@ -1,0 +1,109 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: aerulion <aerulion@gmail.com>
+Date: Tue, 29 Aug 2023 04:51:53 +0200
+Subject: [PATCH] Added LootTableRollEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/server/LootTableRollEvent.java b/src/main/java/io/papermc/paper/event/server/LootTableRollEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..bf87658239ea84a74df875ccda1b52a0dcaa9231
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/server/LootTableRollEvent.java
+@@ -0,0 +1,97 @@
++package io.papermc.paper.event.server;
++
++import java.util.Collection;
++import java.util.List;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.server.ServerEvent;
++import org.bukkit.inventory.ItemStack;
++import org.bukkit.loot.LootContext;
++import org.bukkit.loot.LootTable;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.Contract;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when a {@link LootTable} is rolled to generate loot for a specific context.
++ */
++public class LootTableRollEvent extends ServerEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final @NotNull LootTable lootTable;
++    private final @NotNull LootContext lootContext;
++    private final @NotNull List<ItemStack> loot;
++
++    /**
++     * Represents an event that is fired when a loot table roll occurs.
++     *
++     * @param lootTable   The loot table that was rolled.
++     * @param lootContext The context of the loot roll.
++     * @param loot        The list of loot items obtained from the roll.
++     */
++    @ApiStatus.Internal
++    public LootTableRollEvent(final @NotNull LootTable lootTable,
++        final @NotNull LootContext lootContext, final @NotNull List<ItemStack> loot) {
++        super();
++        this.lootTable = lootTable;
++        this.lootContext = lootContext;
++        this.loot = loot;
++    }
++
++    /**
++     * Gets the loot table that was rolled.
++     *
++     * @return The loot table that was rolled.
++     */
++    public @NotNull LootTable getLootTable() {
++        return this.lootTable;
++    }
++
++    /**
++     * Gets the loot context for the current loot table roll.
++     *
++     * @return The loot context for the current loot table roll.
++     */
++    public @NotNull LootContext getLootContext() {
++        return this.lootContext;
++    }
++
++    /**
++     * Get a mutable list of all {@link ItemStack}s generated in this loot table roll.
++     * <p>
++     * Any items added or removed from the returned list will be reflected in the loot generation.
++     *
++     * @return The list of generated items.
++     */
++    public @NotNull List<ItemStack> getLoot() {
++        return this.loot;
++    }
++
++    /**
++     * Set the loot for this loot table roll.
++     * <p>
++     * Any existing loot will be cleared, and the new loot will be added to the loot roll.
++     * <p>
++     * Can be set to null to clear.
++     *
++     * @param loot The collection of ItemStacks to set as the loot.
++     */
++    public void setLoot(final @Nullable Collection<ItemStack> loot) {
++        this.loot.clear();
++        if (loot != null) {
++            this.loot.addAll(loot);
++        }
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @Contract(pure = true)
++    public static @NotNull HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++}

--- a/patches/server/1029-Added-LootTableRollEvent.patch
+++ b/patches/server/1029-Added-LootTableRollEvent.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: aerulion <aerulion@gmail.com>
+Date: Tue, 29 Aug 2023 04:52:12 +0200
+Subject: [PATCH] Added LootTableRollEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/level/storage/loot/LootTable.java b/src/main/java/net/minecraft/world/level/storage/loot/LootTable.java
+index e46a0afa45ee771a0114703acc314d7cf8e8ffed..cd22641f3d229bdc209735ab60fbd2d26e175602 100644
+--- a/src/main/java/net/minecraft/world/level/storage/loot/LootTable.java
++++ b/src/main/java/net/minecraft/world/level/storage/loot/LootTable.java
+@@ -132,7 +132,10 @@ public class LootTable {
+ 
+         Objects.requireNonNull(objectarraylist);
+         this.getRandomItems(context, objectarraylist::add);
+-        return objectarraylist;
++        // Paper start - LootTableRollEvent
++        final io.papermc.paper.event.server.LootTableRollEvent lootTableRollEvent = CraftEventFactory.callLootTableRollEvent(this, context, objectarraylist);
++        return lootTableRollEvent.getLoot().stream().map(CraftItemStack::asNMSCopy).collect(ObjectArrayList.toList());
++        // Paper start - LootTableRollEvent
+     }
+ 
+     public LootContextParamSet getParamSet() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 090b1ee57ddef58ca71469ad860960f66da7d5a2..8d8d02a10d36cc5b9862f17cb581f7cae2ff0e43 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1946,6 +1946,16 @@ public class CraftEventFactory {
+         RaidSpawnWaveEvent event = new RaidSpawnWaveEvent(new CraftRaid(raid), raid.getLevel().getWorld(), craftLeader, craftRaiders);
+         Bukkit.getPluginManager().callEvent(event);
+     }
++    // Paper start - LootTableRollEvent
++    public static io.papermc.paper.event.server.LootTableRollEvent callLootTableRollEvent(final LootTable lootTable, final LootContext lootContext, final List<ItemStack> loot) {
++        final NamespacedKey key = CraftNamespacedKey.fromMinecraft(lootContext.getLevel().getServer().getLootData().lootTableToKey.get(lootTable));
++        final CraftLootTable craftLootTable = new CraftLootTable(key, lootTable);
++        final List<org.bukkit.inventory.ItemStack> bukkitLoot = loot.stream().map(CraftItemStack::asCraftMirror).collect(Collectors.toCollection(ArrayList::new));
++        final io.papermc.paper.event.server.LootTableRollEvent lootTableRollEvent = new io.papermc.paper.event.server.LootTableRollEvent(craftLootTable, CraftLootTable.convertContext(lootContext), bukkitLoot);
++        Bukkit.getPluginManager().callEvent(lootTableRollEvent);
++        return lootTableRollEvent;
++    }
++    // Paper end - LootTableRollEvent
+ 
+     public static LootGenerateEvent callLootGenerateEvent(Container inventory, LootTable lootTable, LootContext lootInfo, List<ItemStack> loot, boolean plugin) {
+         CraftWorld world = lootInfo.getLevel().getWorld();


### PR DESCRIPTION
Adds an event that gets called whenever a LootTable rolls any loot.
There are two aspects I'm not sure about:
- Whether this should be a ServerEvent, or a WorldEvent like the LootGenerateEvent (but just forwarding the world from the LootContext location seems a bit pointless)?
- If this is the best way to implement / call such an event. The goal was to have a general event for all loot table rolls, but this implementation only covers loot generated via LootTable#getRandomItems method returning an ObjectArrayList of the generated items. That for example excludes the loot generated by a LivingEntity, since it calls the void method with a consumer consuming the generated items, and I couldn't think of any good way to implement the event call in the consumer method.

Nonetheless this implementation allows for modifying the loot of Brushable Blocks, which wouldn't be possible otherwise (apart from replacing the item during the BlockDropItemEvent, but that leads to the "old item" sticking out the brushable block during brushing).