### PR TITLE
Fix some beacon event issues

### DIFF
--- a/patches/server/0589-Introduce-beacon-activation-deactivation-events.patch
+++ b/patches/server/0589-Introduce-beacon-activation-deactivation-events.patch
@@ -4,19 +4,51 @@ Date: Thu, 25 Mar 2021 20:28:04 +0200
 Subject: [PATCH] Introduce beacon activation/deactivation events
 
 
+diff --git a/src/main/java/net/minecraft/world/level/block/BeaconBlock.java b/src/main/java/net/minecraft/world/level/block/BeaconBlock.java
+index 1dc9af04113364f37b6351dd01f542aa22c59767..bec36de3e4c4b4bb154f9b4ffc9f2ae08f299223 100644
+--- a/src/main/java/net/minecraft/world/level/block/BeaconBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/BeaconBlock.java
+@@ -69,4 +69,16 @@ public class BeaconBlock extends BaseEntityBlock implements BeaconBeamBlock {
+         }
+ 
+     }
++
++    // Paper start - BeaconDeactivatedEvent
++    @Override
++    public void onRemove(BlockState state, Level world, BlockPos pos, BlockState newState, boolean moved) {
++        if (!state.is(newState.getBlock()) && world.getBlockEntity(pos) instanceof BeaconBlockEntity beacon && beacon.levels > 0 && !beacon.getBeamSections().isEmpty()) {
++            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(world, pos);
++            new io.papermc.paper.event.block.BeaconDeactivatedEvent(block).callEvent();
++        }
++
++        super.onRemove(state, world, pos, newState, moved);
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
-index f3fb7e07ca65cb1c948b110b7f7edc8b0bd83b21..147e808c7e2b3ed16861c989c1ba4a0b99a5be38 100644
+index f3fb7e07ca65cb1c948b110b7f7edc8b0bd83b21..c63e4dfa6d65c6ce2e1d6ca19c32d266a11bd096 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
-@@ -212,6 +212,15 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name
+@@ -98,6 +98,7 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name
+         this.effectRange = -1;
+     }
+     // Paper end
++    public boolean justLoadedAndPreviouslyActive; // Paper - consider beacon previously active for first tick to skip activate event/sound
+ 
+     public BeaconBlockEntity(BlockPos pos, BlockState state) {
+         super(BlockEntityType.BEACON, pos, state);
+@@ -212,6 +213,18 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name
                  BeaconBlockEntity.playSound(world, pos, SoundEvents.BEACON_AMBIENT);
              }
          }
 +        // Paper start - beacon activation/deactivation events
-+        if (i1 <= 0 && blockEntity.levels > 0) {
++        final boolean prevActive = i1 > 0 && (!blockEntity.beamSections.isEmpty() || (blockEntity.justLoadedAndPreviouslyActive && !blockEntity.checkingBeamSections.isEmpty()));
++        blockEntity.justLoadedAndPreviouslyActive = false;
++        final boolean newActive = blockEntity.levels > 0 && !blockEntity.checkingBeamSections.isEmpty();
++        if (!prevActive && newActive) {
 +            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(world, pos);
 +            new io.papermc.paper.event.block.BeaconActivatedEvent(block).callEvent();
-+        } else if (i1 > 0 && blockEntity.levels <= 0) {
++        } else if (prevActive && !newActive) {
 +            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(world, pos);
 +            new io.papermc.paper.event.block.BeaconDeactivatedEvent(block).callEvent();
 +        }
@@ -24,14 +56,11 @@ index f3fb7e07ca65cb1c948b110b7f7edc8b0bd83b21..147e808c7e2b3ed16861c989c1ba4a0b
  
          if (blockEntity.lastCheckY >= l) {
              blockEntity.lastCheckY = world.getMinBuildHeight() - 1;
-@@ -269,6 +278,10 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name
- 
-     @Override
-     public void setRemoved() {
-+        // Paper start - BeaconDeactivatedEvent
-+        org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(level, worldPosition);
-+        new io.papermc.paper.event.block.BeaconDeactivatedEvent(block).callEvent();
-+        // Paper end
-         BeaconBlockEntity.playSound(this.level, this.worldPosition, SoundEvents.BEACON_DEACTIVATE);
-         super.setRemoved();
-     }
+@@ -396,6 +409,7 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name
+         this.secondaryPower = MobEffect.byId(nbt.getInt("Secondary"));
+         this.levels = nbt.getInt("Levels"); // SPIGOT-5053, use where available
+         // CraftBukkit end
++        this.justLoadedAndPreviouslyActive = this.levels > 0; // Paper
+         if (nbt.contains("CustomName", 8)) {
+             this.name = io.papermc.paper.util.MCUtil.getBaseComponentFromNbt("CustomName", nbt); // Paper - Catch ParseException
+         }

--- a/patches/server/0871-Fix-a-bunch-of-vanilla-bugs.patch
+++ b/patches/server/0871-Fix-a-bunch-of-vanilla-bugs.patch
@@ -57,6 +57,9 @@ https://bugs.mojang.com/browse/MC-84789
 https://bugs.mojang.com/browse/MC-225381
   Fix overfilled bundles duplicating items / being filled with air
 
+https://bugs.mojang.com/browse/MC-183981
+  Fix beacons not playing (de)activation sounds when losing sky access
+
 Co-authored-by: William Blake Galbreath <blake.galbreath@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
@@ -405,3 +408,21 @@ index 436290eaa0dab05a642b67b265117dbe5eceb8b7..5ccc419b904aec590c5624438da61ca6
  
      }
  }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
+index c63e4dfa6d65c6ce2e1d6ca19c32d266a11bd096..80f03ecd35408d02bd660e1ee8b7b44b7d24aa3d 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
+@@ -228,11 +228,11 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name
+ 
+         if (blockEntity.lastCheckY >= l) {
+             blockEntity.lastCheckY = world.getMinBuildHeight() - 1;
+-            boolean flag = i1 > 0;
++            boolean flag = prevActive; // Paper - Fix MC-183981
+ 
+             blockEntity.beamSections = blockEntity.checkingBeamSections;
+             if (!world.isClientSide) {
+-                boolean flag1 = blockEntity.levels > 0;
++                boolean flag1 = newActive; // Paper - Fix MC-183981
+ 
+                 if (!flag && flag1) {
+                     BeaconBlockEntity.playSound(world, pos, SoundEvents.BEACON_ACTIVATE);

--- a/patches/server/0911-Add-BlockLockCheckEvent.patch
+++ b/patches/server/0911-Add-BlockLockCheckEvent.patch
@@ -56,10 +56,10 @@ index f1acd19432877a833f0d4339f9de4830a0f7b890..8d38ebfdc976b9695ed367591e58de8c
  
      @Nullable
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
-index 147e808c7e2b3ed16861c989c1ba4a0b99a5be38..59246e24558569f7f50b4d4d508616798091c888 100644
+index 80f03ecd35408d02bd660e1ee8b7b44b7d24aa3d..33694cb33ebb228691ad9c1e6088e579313d03f9 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
-@@ -444,7 +444,7 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name
+@@ -445,7 +445,7 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider, Name
      @Nullable
      @Override
      public AbstractContainerMenu createMenu(int syncId, Inventory playerInventory, Player player) {


### PR DESCRIPTION
Closes #8947

Moves the deactivate event call into the onRemove method for the beacon block itself to prevent it from running when the block entity is unloaded. Also fixes an issue where the events were not being called when the beacon beam gets blocked.

The field I added feels a bit wrong but it works, it's to prevent the activation event being called immediately after loading, can't see any better way to differentiate between a newly placed beacon and a newly loaded one.