### PR TITLE
Take in account waterlogged blocks for scaffolding

### DIFF
--- a/patches/server/0851-Add-and-fix-missing-BlockFadeEvents.patch
+++ b/patches/server/0851-Add-and-fix-missing-BlockFadeEvents.patch
@@ -1,8 +1,13 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 Date: Thu, 21 Jul 2022 12:07:54 -0400
-Subject: [PATCH] Add missing BlockFadeEvents
+Subject: [PATCH] Add and fix missing BlockFadeEvents
 
+Beyond calling the BlockFadeEvent in more places, this patch also aims
+to pass the proper replacement state to the event, specifically for
+potentially waterlogged block states fading.
+
+Co-authored-by: Lulu13022002 <41980282+Lulu13022002@users.noreply.github.com
 
 diff --git a/src/main/java/net/minecraft/world/level/block/FrogspawnBlock.java b/src/main/java/net/minecraft/world/level/block/FrogspawnBlock.java
 index 834c5e3fbff3819f3f72e95a1072d9b9e57f25b3..294d22b6b27e96b59c77527efcfefa9410b756e4 100644
@@ -20,6 +25,19 @@ index 834c5e3fbff3819f3f72e95a1072d9b9e57f25b3..294d22b6b27e96b59c77527efcfefa94
          this.destroyBlock(world, pos);
          world.playSound((Player)null, pos, SoundEvents.FROGSPAWN_HATCH, SoundSource.BLOCKS, 1.0F, 1.0F);
          this.spawnTadpoles(world, pos, random);
+diff --git a/src/main/java/net/minecraft/world/level/block/ScaffoldingBlock.java b/src/main/java/net/minecraft/world/level/block/ScaffoldingBlock.java
+index f99082c58743e8b73e263655dbebc34e904c45bc..e9358522e526505d5c200e19b193bbcf5ee10826 100644
+--- a/src/main/java/net/minecraft/world/level/block/ScaffoldingBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/ScaffoldingBlock.java
+@@ -96,7 +96,7 @@ public class ScaffoldingBlock extends Block implements SimpleWaterloggedBlock {
+         int i = ScaffoldingBlock.getDistance(world, pos);
+         BlockState iblockdata1 = (BlockState) ((BlockState) state.setValue(ScaffoldingBlock.DISTANCE, i)).setValue(ScaffoldingBlock.BOTTOM, this.isBottom(world, pos, i));
+ 
+-        if ((Integer) iblockdata1.getValue(ScaffoldingBlock.DISTANCE) == 7 && !org.bukkit.craftbukkit.event.CraftEventFactory.callBlockFadeEvent(world, pos, Blocks.AIR.defaultBlockState()).isCancelled()) { // CraftBukkit - BlockFadeEvent
++        if ((Integer) iblockdata1.getValue(ScaffoldingBlock.DISTANCE) == 7 && !org.bukkit.craftbukkit.event.CraftEventFactory.callBlockFadeEvent(world, pos, iblockdata1.getFluidState().createLegacyBlock()).isCancelled()) { // CraftBukkit - BlockFadeEvent // Paper - fix wrong block state
+             if ((Integer) state.getValue(ScaffoldingBlock.DISTANCE) == 7) {
+                 FallingBlockEntity.fall(world, pos, iblockdata1);
+             } else {
 diff --git a/src/main/java/net/minecraft/world/level/block/SnifferEggBlock.java b/src/main/java/net/minecraft/world/level/block/SnifferEggBlock.java
 index 1e115adfcfee518667559100d04050f5e71c8a23..8aaa3cb2248a02b5ee25251cc837a145edd34341 100644
 --- a/src/main/java/net/minecraft/world/level/block/SnifferEggBlock.java


### PR DESCRIPTION
The scaffolding is waterloggable and when the limit of suspended blocks is reached in water, the block fade into air (for the BlockFadeEvent) and into water (for the EntityChangeBlockEvent/BlockDestroyEvent)