### PR TITLE
Add javadoc-fix-plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "8.1.1" apply false
     id("io.papermc.paperweight.core") version "1.5.5"
+    id("com.jeff-media.fix-javadoc-plugin") version("1.4")
 }
 
 allprojects {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven("https://repo.papermc.io/repository/maven-public/")
+        maven("https://repo.jeff-media.com/public") // fix-javadoc-plugin
     }
 }
 


### PR DESCRIPTION
Hi, this pull requests adds the fix-javadoc-plugin to the "root" build file. It automatically adds a "finalizedBy" task for each task of the Javadoc type to get rid of the annoying "double annotations".

Before:
![image](https://github.com/PaperMC/Paper/assets/1122571/b89576a1-9eb0-4145-8d98-6dbc4d65c5b0)

After:
![image](https://github.com/PaperMC/Paper/assets/1122571/faec3671-e3f4-4d51-ba38-82454df0a7d8)
