### PR TITLE
Force sync inventory after PrepareResultEvent

### DIFF
--- a/patches/server/0402-Add-PrepareResultEvent.patch
+++ b/patches/server/0402-Add-PrepareResultEvent.patch
@@ -123,7 +123,7 @@ index 0a169b4cf47ff3d05555af6c0e0b0cdb30ba9e45..67bfd38bd08c30eae597a4875ea4a8b2
          PrepareGrindstoneEvent event = new PrepareGrindstoneEvent(view, CraftItemStack.asCraftMirror(item).clone());
          event.getView().getPlayer().getServer().getPluginManager().callEvent(event);
          event.getInventory().setItem(2, event.getResult());
-@@ -1661,12 +1673,39 @@ public class CraftEventFactory {
+@@ -1661,12 +1673,40 @@ public class CraftEventFactory {
      }
  
      public static PrepareSmithingEvent callPrepareSmithingEvent(InventoryView view, ItemStack item) {
@@ -156,7 +156,8 @@ index 0a169b4cf47ff3d05555af6c0e0b0cdb30ba9e45..67bfd38bd08c30eae597a4875ea4a8b2
 +        }
 +        event.callEvent();
 +        event.getInventory().setItem(resultSlot, event.getResult());
-+        container.broadcastChanges();;
++        container.sendAllDataToRemote();
++        container.broadcastChanges();
 +    }
 +    // Paper end - Add PrepareResultEvent
 +

--- a/patches/server/0488-Add-BlockFailedDispenseEvent.patch
+++ b/patches/server/0488-Add-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 913ed110d8402d377152753325901eb7f3ac82d6..1d13f8a1009d6eda351c697052d499d5
              } else {
                  ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 430d54feb4224fb73d31aa205b883af66f29b226..0a44f7f2ab9c824f1a32d9dc5feb6a96eb00d8de 100644
+index 0ef24b4df5f6c99016f0986bbf53f9a8a5c14138..e109f155a65e748600b9ff029a95d41400aed739 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2033,4 +2033,12 @@ public class CraftEventFactory {
+@@ -2034,4 +2034,12 @@ public class CraftEventFactory {
          return org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getPotion());
      }
      // Paper end - WitchReadyPotionEvent

--- a/patches/server/0503-Add-BlockPreDispenseEvent.patch
+++ b/patches/server/0503-Add-BlockPreDispenseEvent.patch
@@ -29,10 +29,10 @@ index 1d13f8a1009d6eda351c697052d499d594a6aaa8..9a8a0fb958e8ec782111507bae957f85
                      } else {
                          // CraftBukkit start - Fire event when pushing items into other inventories
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0a44f7f2ab9c824f1a32d9dc5feb6a96eb00d8de..4b3e246475821b71fe023fea602d68c0e2f84964 100644
+index e109f155a65e748600b9ff029a95d41400aed739..b0c4fe6b1cf5fd241778a4477ec9dcecbd8d6376 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2040,5 +2040,11 @@ public class CraftEventFactory {
+@@ -2041,5 +2041,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0847-Add-EntityFertilizeEggEvent.patch
+++ b/patches/server/0847-Add-EntityFertilizeEggEvent.patch
@@ -69,10 +69,10 @@ index 0e85e3ab58d848b119212fa7d2eb4f92d3efe29b..0a5b953bd8c0c7f181da4090b950e9e6
          this.playSound(SoundEvents.SNIFFER_EGG_PLOP, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 0.5F);
          } // Paper - Call EntityDropItemEvent
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b04cf7cb05adcef205f84decf3564f85de0c8e2d..6c5908eecaaf2f2b41bc0074e183a2259fe4a9b2 100644
+index d00192c642e2f30b19144d39b855059e65adbb6d..dcd6394a2a8b99549fed65c8321c5a9b61d2247b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2108,4 +2108,28 @@ public class CraftEventFactory {
+@@ -2109,4 +2109,28 @@ public class CraftEventFactory {
          return event.callEvent();
      }
      // Paper end

--- a/patches/server/0884-Call-missing-BlockDispenseEvent.patch
+++ b/patches/server/0884-Call-missing-BlockDispenseEvent.patch
@@ -50,10 +50,10 @@ index b83af374a33a66a6ceeca119b961eea883bba41c..175b965c92b8b8be9c671e1ee478afa9
                              for (int k = 0; k < 5; ++k) {
                                  worldserver.sendParticles(ParticleTypes.SPLASH, (double) blockposition.getX() + worldserver.random.nextDouble(), (double) (blockposition.getY() + 1), (double) blockposition.getZ() + worldserver.random.nextDouble(), 1, 0.0D, 0.0D, 0.0D, 1.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 52c1d39f494ba441bc93382d895679bcd15fcbde..cd6ee371910328d4ab6f4a018fa0e4a48dbc7982 100644
+index ad95e952e87f7f7e392ea479927d4df13f7733ba..06f0a75d0be193c87b8650dde211bf9c6bd2d9dc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2109,6 +2109,32 @@ public class CraftEventFactory {
+@@ -2110,6 +2110,32 @@ public class CraftEventFactory {
      }
      // Paper end
  


### PR DESCRIPTION
This is required because when changing the result for an anvil (when the event is called because of AnvilMenu.setRenameText method) to an invalid result the item is not synced back to the client