### PR TITLE
Print warning if people try to call JavaPlugin#getCommand with paper plugins

### DIFF
--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Paper Plugins
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ba6f0a70ba2442dbe60ed6cc92e4fb91a48d9f3b..22b65c3ad4ed6e19b88a51a2e001f0e5846d9ae6 100644
+index b6b86e41b42a2e205ce2e74faea3f005529229fe..8c93ff28273ef9ddce2fb7a62ac50701fa3cd9a2 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -47,7 +47,7 @@ dependencies {
@@ -1882,10 +1882,18 @@ index a80251eff75430863b37db1c131e22593f3fcd5e..310c4041963a3f1e0a26e39a6da12a9b
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d8a25b6ff 100644
+index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7fe3ea5495 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -40,6 +40,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -14,6 +14,7 @@ import java.net.URLConnection;
+ import java.util.List;
+ import java.util.logging.Level;
+ import java.util.logging.Logger;
++import io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage;
+ import org.bukkit.Server;
+ import org.bukkit.command.Command;
+ import org.bukkit.command.CommandSender;
+@@ -40,6 +41,7 @@ public abstract class JavaPlugin extends PluginBase {
      private Server server = null;
      private File file = null;
      private PluginDescriptionFile description = null;
@@ -1893,7 +1901,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
      private File dataFolder = null;
      private ClassLoader classLoader = null;
      private boolean naggable = true;
-@@ -48,13 +49,16 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -48,13 +50,16 @@ public abstract class JavaPlugin extends PluginBase {
      private PluginLogger logger = null;
  
      public JavaPlugin() {
@@ -1914,7 +1922,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
      protected JavaPlugin(@NotNull final JavaPluginLoader loader, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file) {
          final ClassLoader classLoader = this.getClass().getClassLoader();
          if (classLoader instanceof PluginClassLoader) {
-@@ -79,9 +83,12 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -79,9 +84,12 @@ public abstract class JavaPlugin extends PluginBase {
       * Gets the associated PluginLoader responsible for this plugin
       *
       * @return PluginLoader that controls this plugin
@@ -1927,7 +1935,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
      public final PluginLoader getPluginLoader() {
          return loader;
      }
-@@ -122,13 +129,20 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -122,13 +130,20 @@ public abstract class JavaPlugin extends PluginBase {
       * Returns the plugin.yaml file containing the details for this plugin
       *
       * @return Contents of the plugin.yaml file
@@ -1948,7 +1956,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
      @NotNull
      @Override
      public FileConfiguration getConfig() {
-@@ -258,7 +272,8 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -258,7 +273,8 @@ public abstract class JavaPlugin extends PluginBase {
       *
       * @param enabled true if enabled, otherwise false
       */
@@ -1958,7 +1966,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
          if (isEnabled != enabled) {
              isEnabled = enabled;
  
-@@ -270,9 +285,18 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -270,9 +286,18 @@ public abstract class JavaPlugin extends PluginBase {
          }
      }
  
@@ -1980,7 +1988,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
          this.server = server;
          this.file = file;
          this.description = description;
-@@ -280,6 +304,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -280,6 +305,7 @@ public abstract class JavaPlugin extends PluginBase {
          this.classLoader = classLoader;
          this.configFile = new File(dataFolder, "config.yml");
          this.logger = new PluginLogger(this);
@@ -1988,7 +1996,26 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
      }
  
      /**
-@@ -396,10 +421,10 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -309,6 +335,18 @@ public abstract class JavaPlugin extends PluginBase {
+      */
+     @Nullable
+     public PluginCommand getCommand(@NotNull String name) {
++        // Paper start - print warning if paper plugin
++        if (!(pluginMeta instanceof PluginDescriptionFile)) {
++            this.logger.warning("---------------------------------WARNING--------------------------------");
++            this.logger.warning("         Defining commands in paper-plugin.yml is unsupported!          ");
++            this.logger.warning("      Please refer to the docs for proper command initialization!       ");
++            this.logger.warning("https://docs.papermc.io/paper/dev/getting-started/paper-plugins#commands");
++            this.logger.warning("                    Command will not be initialized!                    ");
++            this.logger.warning("---------------------------------WARNING--------------------------------");
++            throw new RuntimeException("Defining commands in paper-plugin.yml is unsupported! - Please refer to the warning above for further details.");
++        }
++        // Paper end
++        
+         String alias = name.toLowerCase(java.util.Locale.ENGLISH);
+         PluginCommand command = getServer().getPluginCommand(alias);
+ 
+@@ -396,10 +434,10 @@ public abstract class JavaPlugin extends PluginBase {
              throw new IllegalArgumentException(clazz + " does not extend " + JavaPlugin.class);
          }
          final ClassLoader cl = clazz.getClassLoader();
@@ -2002,7 +2029,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..f594913e6b94f77b26a4a758c447a42d
          if (plugin == null) {
              throw new IllegalStateException("Cannot get plugin for " + clazz + " from a static initializer");
          }
-@@ -422,10 +447,10 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -422,10 +460,10 @@ public abstract class JavaPlugin extends PluginBase {
      public static JavaPlugin getProvidingPlugin(@NotNull Class<?> clazz) {
          Preconditions.checkArgument(clazz != null, "Null class cannot have a plugin");
          final ClassLoader cl = clazz.getClassLoader();

--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -1882,18 +1882,10 @@ index a80251eff75430863b37db1c131e22593f3fcd5e..310c4041963a3f1e0a26e39a6da12a9b
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7fe3ea5495 100644
+index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..b7191597f5d442ebc56c20366fba633fc2541856 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -14,6 +14,7 @@ import java.net.URLConnection;
- import java.util.List;
- import java.util.logging.Level;
- import java.util.logging.Logger;
-+import io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage;
- import org.bukkit.Server;
- import org.bukkit.command.Command;
- import org.bukkit.command.CommandSender;
-@@ -40,6 +41,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -40,6 +40,7 @@ public abstract class JavaPlugin extends PluginBase {
      private Server server = null;
      private File file = null;
      private PluginDescriptionFile description = null;
@@ -1901,7 +1893,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7f
      private File dataFolder = null;
      private ClassLoader classLoader = null;
      private boolean naggable = true;
-@@ -48,13 +50,16 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -48,13 +49,16 @@ public abstract class JavaPlugin extends PluginBase {
      private PluginLogger logger = null;
  
      public JavaPlugin() {
@@ -1922,7 +1914,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7f
      protected JavaPlugin(@NotNull final JavaPluginLoader loader, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file) {
          final ClassLoader classLoader = this.getClass().getClassLoader();
          if (classLoader instanceof PluginClassLoader) {
-@@ -79,9 +84,12 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -79,9 +83,12 @@ public abstract class JavaPlugin extends PluginBase {
       * Gets the associated PluginLoader responsible for this plugin
       *
       * @return PluginLoader that controls this plugin
@@ -1935,7 +1927,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7f
      public final PluginLoader getPluginLoader() {
          return loader;
      }
-@@ -122,13 +130,20 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -122,13 +129,20 @@ public abstract class JavaPlugin extends PluginBase {
       * Returns the plugin.yaml file containing the details for this plugin
       *
       * @return Contents of the plugin.yaml file
@@ -1956,7 +1948,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7f
      @NotNull
      @Override
      public FileConfiguration getConfig() {
-@@ -258,7 +273,8 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -258,7 +272,8 @@ public abstract class JavaPlugin extends PluginBase {
       *
       * @param enabled true if enabled, otherwise false
       */
@@ -1966,7 +1958,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7f
          if (isEnabled != enabled) {
              isEnabled = enabled;
  
-@@ -270,9 +286,18 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -270,9 +285,18 @@ public abstract class JavaPlugin extends PluginBase {
          }
      }
  
@@ -1988,7 +1980,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7f
          this.server = server;
          this.file = file;
          this.description = description;
-@@ -280,6 +305,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -280,6 +304,7 @@ public abstract class JavaPlugin extends PluginBase {
          this.classLoader = classLoader;
          this.configFile = new File(dataFolder, "config.yml");
          this.logger = new PluginLogger(this);
@@ -1996,7 +1988,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7f
      }
  
      /**
-@@ -309,6 +335,18 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -309,6 +334,18 @@ public abstract class JavaPlugin extends PluginBase {
       */
      @Nullable
      public PluginCommand getCommand(@NotNull String name) {
@@ -2015,7 +2007,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7f
          String alias = name.toLowerCase(java.util.Locale.ENGLISH);
          PluginCommand command = getServer().getPluginCommand(alias);
  
-@@ -396,10 +434,10 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -396,10 +433,10 @@ public abstract class JavaPlugin extends PluginBase {
              throw new IllegalArgumentException(clazz + " does not extend " + JavaPlugin.class);
          }
          final ClassLoader cl = clazz.getClassLoader();
@@ -2029,7 +2021,7 @@ index ee100b7ad89ce1eccef0c3bc55885cd78aadd1ec..688beae38ddc8837150764bb4f79fa7f
          if (plugin == null) {
              throw new IllegalStateException("Cannot get plugin for " + clazz + " from a static initializer");
          }
-@@ -422,10 +460,10 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -422,10 +459,10 @@ public abstract class JavaPlugin extends PluginBase {
      public static JavaPlugin getProvidingPlugin(@NotNull Class<?> clazz) {
          Preconditions.checkArgument(clazz != null, "Null class cannot have a plugin");
          final ClassLoader cl = clazz.getClassLoader();

--- a/patches/api/0070-Handle-plugin-prefixes-in-implementation-logging-con.patch
+++ b/patches/api/0070-Handle-plugin-prefixes-in-implementation-logging-con.patch
@@ -17,10 +17,10 @@ The implementation should handle plugin prefixes by displaying
 logger names when appropriate.
 
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index 688beae38ddc8837150764bb4f79fa7fe3ea5495..1ac9a3dc7a1fb506cbe743c53a034166aa4711be 100644
+index b7191597f5d442ebc56c20366fba633fc2541856..d946ad5490d208a83b447f84a6fe6bdfe6913cef 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -47,7 +47,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -46,7 +46,7 @@ public abstract class JavaPlugin extends PluginBase {
      private boolean naggable = true;
      private FileConfiguration newConfig = null;
      private File configFile = null;
@@ -29,7 +29,7 @@ index 688beae38ddc8837150764bb4f79fa7fe3ea5495..1ac9a3dc7a1fb506cbe743c53a034166
  
      public JavaPlugin() {
          // Paper start
-@@ -304,8 +304,8 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -303,8 +303,8 @@ public abstract class JavaPlugin extends PluginBase {
          this.dataFolder = dataFolder;
          this.classLoader = classLoader;
          this.configFile = new File(dataFolder, "config.yml");

--- a/patches/api/0070-Handle-plugin-prefixes-in-implementation-logging-con.patch
+++ b/patches/api/0070-Handle-plugin-prefixes-in-implementation-logging-con.patch
@@ -17,10 +17,10 @@ The implementation should handle plugin prefixes by displaying
 logger names when appropriate.
 
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index f594913e6b94f77b26a4a758c447a42d8a25b6ff..7cd9f98c042dc2bb80876af35c755f81bef34651 100644
+index 688beae38ddc8837150764bb4f79fa7fe3ea5495..1ac9a3dc7a1fb506cbe743c53a034166aa4711be 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -46,7 +46,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -47,7 +47,7 @@ public abstract class JavaPlugin extends PluginBase {
      private boolean naggable = true;
      private FileConfiguration newConfig = null;
      private File configFile = null;
@@ -29,7 +29,7 @@ index f594913e6b94f77b26a4a758c447a42d8a25b6ff..7cd9f98c042dc2bb80876af35c755f81
  
      public JavaPlugin() {
          // Paper start
-@@ -303,8 +303,8 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -304,8 +304,8 @@ public abstract class JavaPlugin extends PluginBase {
          this.dataFolder = dataFolder;
          this.classLoader = classLoader;
          this.configFile = new File(dataFolder, "config.yml");

--- a/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
+++ b/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
@@ -67,10 +67,10 @@ index 0000000000000000000000000000000000000000..087ee57fe5485bc760fadd45a176d4d9
 +
 +}
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index 1ac9a3dc7a1fb506cbe743c53a034166aa4711be..29d41b34e856d9708dd8cfae7a22f8f1a2ff3ce5 100644
+index d946ad5490d208a83b447f84a6fe6bdfe6913cef..296a319d10e399fa27b8fca7b5c05a7e16aa0b52 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -292,10 +292,10 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -291,10 +291,10 @@ public abstract class JavaPlugin extends PluginBase {
              .orElseThrow();
      }
      public final void init(@NotNull PluginLoader loader, @NotNull Server server, @NotNull PluginDescriptionFile description, @NotNull File dataFolder, @NotNull File file, @NotNull ClassLoader classLoader) {
@@ -83,7 +83,7 @@ index 1ac9a3dc7a1fb506cbe743c53a034166aa4711be..29d41b34e856d9708dd8cfae7a22f8f1
      // Paper end
          this.loader = DummyPluginLoaderImplHolder.INSTANCE; // Paper
          this.server = server;
-@@ -305,7 +305,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -304,7 +304,7 @@ public abstract class JavaPlugin extends PluginBase {
          this.classLoader = classLoader;
          this.configFile = new File(dataFolder, "config.yml");
          this.pluginMeta = configuration; // Paper

--- a/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
+++ b/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
@@ -67,10 +67,10 @@ index 0000000000000000000000000000000000000000..087ee57fe5485bc760fadd45a176d4d9
 +
 +}
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-index 7cd9f98c042dc2bb80876af35c755f81bef34651..5cd236965de12392d8c7aa81307c0ff1cc8673b1 100644
+index 1ac9a3dc7a1fb506cbe743c53a034166aa4711be..29d41b34e856d9708dd8cfae7a22f8f1a2ff3ce5 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
-@@ -291,10 +291,10 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -292,10 +292,10 @@ public abstract class JavaPlugin extends PluginBase {
              .orElseThrow();
      }
      public final void init(@NotNull PluginLoader loader, @NotNull Server server, @NotNull PluginDescriptionFile description, @NotNull File dataFolder, @NotNull File file, @NotNull ClassLoader classLoader) {
@@ -83,7 +83,7 @@ index 7cd9f98c042dc2bb80876af35c755f81bef34651..5cd236965de12392d8c7aa81307c0ff1
      // Paper end
          this.loader = DummyPluginLoaderImplHolder.INSTANCE; // Paper
          this.server = server;
-@@ -304,7 +304,7 @@ public abstract class JavaPlugin extends PluginBase {
+@@ -305,7 +305,7 @@ public abstract class JavaPlugin extends PluginBase {
          this.classLoader = classLoader;
          this.configFile = new File(dataFolder, "config.yml");
          this.pluginMeta = configuration; // Paper

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -4748,10 +4748,10 @@ index 0000000000000000000000000000000000000000..e3430f535e8e9c3b8b44bf2daece8c47
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..489a1737516eead7e11eaa226d60dd647228cbdb
+index 0000000000000000000000000000000000000000..45bd29b70782e29eb11c36eaca0f940aee49799b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
-@@ -0,0 +1,252 @@
+@@ -0,0 +1,248 @@
 +package io.papermc.paper.plugin.provider.configuration;
 +
 +import com.google.common.base.Preconditions;
@@ -4857,10 +4857,6 @@ index 0000000000000000000000000000000000000000..489a1737516eead7e11eaa226d60dd64
 +                .build();
 +        }
 +
-+        if (!node.node("commands").virtual()) {
-+            org.slf4j.LoggerFactory.getLogger(pluginConfiguration.getName()).warn("Defining commands in paper-plugin.yml is not supported! - Commands will not be available!");
-+        }
-+        
 +        return pluginConfiguration;
 +    }
 +

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -4748,10 +4748,10 @@ index 0000000000000000000000000000000000000000..e3430f535e8e9c3b8b44bf2daece8c47
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..45bd29b70782e29eb11c36eaca0f940aee49799b
+index 0000000000000000000000000000000000000000..489a1737516eead7e11eaa226d60dd647228cbdb
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
-@@ -0,0 +1,248 @@
+@@ -0,0 +1,252 @@
 +package io.papermc.paper.plugin.provider.configuration;
 +
 +import com.google.common.base.Preconditions;
@@ -4857,6 +4857,10 @@ index 0000000000000000000000000000000000000000..45bd29b70782e29eb11c36eaca0f940a
 +                .build();
 +        }
 +
++        if (!node.node("commands").virtual()) {
++            org.slf4j.LoggerFactory.getLogger(pluginConfiguration.getName()).warn("Defining commands in paper-plugin.yml is not supported! - Commands will not be available!");
++        }
++        
 +        return pluginConfiguration;
 +    }
 +

--- a/patches/server/0013-Paper-Plugins.patch
+++ b/patches/server/0013-Paper-Plugins.patch
@@ -4748,10 +4748,10 @@ index 0000000000000000000000000000000000000000..e3430f535e8e9c3b8b44bf2daece8c47
 +}
 diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..45bd29b70782e29eb11c36eaca0f940aee49799b
+index 0000000000000000000000000000000000000000..705ea6f2ddee0b38aa33ca219f0bb695cc3fafad
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
-@@ -0,0 +1,248 @@
+@@ -0,0 +1,253 @@
 +package io.papermc.paper.plugin.provider.configuration;
 +
 +import com.google.common.base.Preconditions;
@@ -4771,6 +4771,7 @@ index 0000000000000000000000000000000000000000..45bd29b70782e29eb11c36eaca0f940a
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +import org.jetbrains.annotations.TestOnly;
++import org.slf4j.LoggerFactory;
 +import org.spongepowered.configurate.CommentedConfigurationNode;
 +import org.spongepowered.configurate.ConfigurateException;
 +import org.spongepowered.configurate.loader.HeaderMode;
@@ -4857,6 +4858,10 @@ index 0000000000000000000000000000000000000000..45bd29b70782e29eb11c36eaca0f940a
 +                .build();
 +        }
 +
++        if (!node.node("commands").virtual()) {
++            LoggerFactory.getLogger(pluginConfiguration.getName()).warn("Defining commands in paper-plugin.yml is not supported! - Commands will not be available!");
++        }
++        
 +        return pluginConfiguration;
 +    }
 +


### PR DESCRIPTION
This PR adds a simple warning if a `commands` section has been found in the `paper-plugin.yml` file.

I am taking suggestions for the warning message since I don't know if I should include how to register commands with Paper Plugins. 
I also did not know which logger I should use since I don't think a plugin logger has already been created at the time where the warning is printed. 

Which brings me to the next point:
Currently the warning is printed before the server is started: 

```.sv
Loading libraries, please wait...
2023-09-04 17:30:38,271 main WARN Advanced terminal features are not available in this environment
[17:30:38 WARN]: [Paper-Test-Plugin] Defining commands in paper-plugin.yml is not supported! <-------
[17:30:41 INFO]: Environment: authHost='https://authserver.mojang.com', accountsHost='https://api.mojang.com', sessionHost='https://sessionserver.mojang.com', servicesHost='https://api.minecraftservices.com', name='PROD'
[17:30:42 INFO]: Loaded 7 recipes
[17:30:42 INFO]: Starting minecraft server version 1.20.1
```
I don't think there is a way of printing the warning during the plugin load period (unless we add a boolean or something) since I don't think it is not possible to get the node after the `PaperPluginMeta#create()` method. 


Closes #9669