### PR TITLE
Fix leashed pets teleporting to owner when loaded

### DIFF
--- a/patches/server/0872-Fix-a-bunch-of-vanilla-bugs.patch
+++ b/patches/server/0872-Fix-a-bunch-of-vanilla-bugs.patch
@@ -57,6 +57,12 @@ https://bugs.mojang.com/browse/MC-84789
 https://bugs.mojang.com/browse/MC-225381
   Fix overfilled bundles duplicating items / being filled with air
 
+https://bugs.mojang.com/browse/MC-173303
+  Fix leashed pets teleporting to owner when loaded
+
+== AT ==
+public net/minecraft/world/entity/Mob leashInfoTag
+
 Co-authored-by: William Blake Galbreath <blake.galbreath@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
@@ -198,6 +204,19 @@ index b0caf52d00d8cd76550ab116291f8e11144a5e59..93bbda61f0eb2dd52573602b1f9cc7b0
          if (this.mob.getRandom().nextInt(this.mob.isBaby() ? 50 : 1000) != 0) {
              return false;
          } else {
+diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java
+index 11cc26954b4e97114b59df35a4f9b75a09132e20..0a3f7dcc0e205a85dbaa6dee1fc9ae2c7fa9e02d 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java
++++ b/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java
+@@ -74,7 +74,7 @@ public class FollowOwnerGoal extends Goal {
+     }
+ 
+     private boolean unableToMove() {
+-        return this.tamable.isOrderedToSit() || this.tamable.isPassenger() || this.tamable.isLeashed();
++        return this.tamable.isOrderedToSit() || this.tamable.isPassenger() || this.tamable.isLeashed() || this.tamable.leashInfoTag != null; // Paper - Fix MC-173303
+     }
+ 
+     @Override
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java
 index 19540fd4a7f992888fadb6501d0c8a5a7e71fcf6..e241ae250f4f04a17ef2c583d00b065a4ca56a4c 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java


### PR DESCRIPTION
Closes #8462

The FollowOwnerGoal is ticked before the re-leashing logic inside Mob#restoreLeashFromSave is, which allows tamables to teleport to their owners in their first tick. This PR fixes that by also checking whether the entity has a "pending" leash before running the goal.