### PR TITLE
Add Barrel to LootableBlockInventory

### DIFF
--- a/patches/api/0040-LootTable-API.patch
+++ b/patches/api/0040-LootTable-API.patch
@@ -239,7 +239,7 @@ index 0000000000000000000000000000000000000000..fd184f13f5e8ee5cf829fff4f44696e1
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/block/Barrel.java b/src/main/java/org/bukkit/block/Barrel.java
-index aa1bb7a1a1c94b0b029bb60026efbc7f55584dd7..7ca177ff9d1c4a6b9b5d006a2f1ff1968259c92b 100644
+index aa1bb7a1a1c94b0b029bb60026efbc7f55584dd7..d3789b2b7dd71d7c1872a0d84698d35a1884101b 100644
 --- a/src/main/java/org/bukkit/block/Barrel.java
 +++ b/src/main/java/org/bukkit/block/Barrel.java
 @@ -5,4 +5,4 @@ import org.bukkit.loot.Lootable;
@@ -247,7 +247,7 @@ index aa1bb7a1a1c94b0b029bb60026efbc7f55584dd7..7ca177ff9d1c4a6b9b5d006a2f1ff196
   * Represents a captured state of a Barrel.
   */
 -public interface Barrel extends Container, Lootable, Lidded { }
-+public interface Barrel extends Container, com.destroystokyo.paper.loottable.LootableBlockInventory, Lidded { } //Paper
++public interface Barrel extends Container, com.destroystokyo.paper.loottable.LootableBlockInventory, Lidded { } // Paper
 diff --git a/src/main/java/org/bukkit/block/Chest.java b/src/main/java/org/bukkit/block/Chest.java
 index b451191312e4fb19f2131c2d0a0c0337953f6c7c..db6affbc78106b2d93b41953b624a0bca0ca1d72 100644
 --- a/src/main/java/org/bukkit/block/Chest.java

--- a/patches/api/0040-LootTable-API.patch
+++ b/patches/api/0040-LootTable-API.patch
@@ -239,14 +239,10 @@ index 0000000000000000000000000000000000000000..fd184f13f5e8ee5cf829fff4f44696e1
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/block/Barrel.java b/src/main/java/org/bukkit/block/Barrel.java
-index aa1bb7a1a1c94b0b029bb60026efbc7f55584dd7..b4430cb7bb8e33016a1af5fcb1cf4f671f364717 100644
+index aa1bb7a1a1c94b0b029bb60026efbc7f55584dd7..7ca177ff9d1c4a6b9b5d006a2f1ff1968259c92b 100644
 --- a/src/main/java/org/bukkit/block/Barrel.java
 +++ b/src/main/java/org/bukkit/block/Barrel.java
-@@ -1,8 +1,6 @@
- package org.bukkit.block;
- 
--import org.bukkit.loot.Lootable;
--
+@@ -5,4 +5,4 @@ import org.bukkit.loot.Lootable;
  /**
   * Represents a captured state of a Barrel.
   */

--- a/patches/api/0040-LootTable-API.patch
+++ b/patches/api/0040-LootTable-API.patch
@@ -238,6 +238,20 @@ index 0000000000000000000000000000000000000000..fd184f13f5e8ee5cf829fff4f44696e1
 +        cancelled = cancel;
 +    }
 +}
+diff --git a/src/main/java/org/bukkit/block/Barrel.java b/src/main/java/org/bukkit/block/Barrel.java
+index aa1bb7a1a1c94b0b029bb60026efbc7f55584dd7..b4430cb7bb8e33016a1af5fcb1cf4f671f364717 100644
+--- a/src/main/java/org/bukkit/block/Barrel.java
++++ b/src/main/java/org/bukkit/block/Barrel.java
+@@ -1,8 +1,6 @@
+ package org.bukkit.block;
+ 
+-import org.bukkit.loot.Lootable;
+-
+ /**
+  * Represents a captured state of a Barrel.
+  */
+-public interface Barrel extends Container, Lootable, Lidded { }
++public interface Barrel extends Container, com.destroystokyo.paper.loottable.LootableBlockInventory, Lidded { } //Paper
 diff --git a/src/main/java/org/bukkit/block/Chest.java b/src/main/java/org/bukkit/block/Chest.java
 index b451191312e4fb19f2131c2d0a0c0337953f6c7c..db6affbc78106b2d93b41953b624a0bca0ca1d72 100644
 --- a/src/main/java/org/bukkit/block/Chest.java


### PR DESCRIPTION
Adds Barrel to the LootableBlockInventory Interface as it is currently missing.