### PR TITLE
Add Foiled/Glow NBT + API

### DIFF
--- a/patches/api/0148-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-Values.patch
+++ b/patches/api/0148-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-Values.patch
@@ -226,10 +226,10 @@ index a42f1d53340e4073038d46b7fabf5d44248d5b32..dbc22807a33606f8fe326cc2f5f755fe
          return key;
      }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index f78714c2a6d9da162c9802552984cbfad76ff728..55e9dc5d1d87fbc9d0dabbb7bd59584fe2c5f379 100644
+index f78714c2a6d9da162c9802552984cbfad76ff728..32c05427858d19a70df40381ee2238f1d34d7190 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -444,4 +444,87 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -444,4 +444,101 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @SuppressWarnings("javadoc")
      @NotNull
      ItemMeta clone();
@@ -315,5 +315,19 @@ index f78714c2a6d9da162c9802552984cbfad76ff728..55e9dc5d1d87fbc9d0dabbb7bd59584f
 +     * @return true if this item has destroyable keys
 +     */
 +    boolean hasDestroyableKeys();
++
++    /**
++     * Return if the foiled tag is true. A foiled item will glow
++     *
++     * @return true if the foiled tag is true
++     */
++    boolean isFoiled();
++
++    /**
++     * Sets the foiled tag. A foiled item will glow.
++     *
++     * @param foiled true if set foiled
++     */
++    void setFoiled(boolean foiled);
 +    // Paper end
  }

--- a/patches/server/0255-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
+++ b/patches/server/0255-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
@@ -4,8 +4,464 @@ Date: Wed, 12 Sep 2018 18:53:55 +0300
 Subject: [PATCH] Implement an API for CanPlaceOn and CanDestroy NBT values
 
 
+diff --git a/src/main/java/net/minecraft/world/item/Item.java b/src/main/java/net/minecraft/world/item/Item.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9ffce5e5940a55bc06a61ac8733d8735a0004b70
+--- /dev/null
++++ b/src/main/java/net/minecraft/world/item/Item.java
+@@ -0,0 +1,429 @@
++package net.minecraft.world.item;
++
++import com.google.common.collect.ImmutableMultimap;
++import com.google.common.collect.Maps;
++import com.google.common.collect.Multimap;
++import com.mojang.logging.LogUtils;
++import java.util.List;
++import java.util.Map;
++import java.util.Optional;
++import java.util.UUID;
++import javax.annotation.Nullable;
++import net.minecraft.SharedConstants;
++import net.minecraft.Util;
++import net.minecraft.core.BlockPos;
++import net.minecraft.core.Holder;
++import net.minecraft.core.registries.BuiltInRegistries;
++import net.minecraft.nbt.CompoundTag;
++import net.minecraft.network.chat.Component;
++import net.minecraft.sounds.SoundEvent;
++import net.minecraft.sounds.SoundEvents;
++import net.minecraft.tags.DamageTypeTags;
++import net.minecraft.util.Mth;
++import net.minecraft.world.InteractionHand;
++import net.minecraft.world.InteractionResult;
++import net.minecraft.world.InteractionResultHolder;
++import net.minecraft.world.damagesource.DamageSource;
++import net.minecraft.world.entity.Entity;
++import net.minecraft.world.entity.EquipmentSlot;
++import net.minecraft.world.entity.LivingEntity;
++import net.minecraft.world.entity.SlotAccess;
++import net.minecraft.world.entity.ai.attributes.Attribute;
++import net.minecraft.world.entity.ai.attributes.AttributeModifier;
++import net.minecraft.world.entity.item.ItemEntity;
++import net.minecraft.world.entity.player.Player;
++import net.minecraft.world.flag.FeatureElement;
++import net.minecraft.world.flag.FeatureFlag;
++import net.minecraft.world.flag.FeatureFlagSet;
++import net.minecraft.world.flag.FeatureFlags;
++import net.minecraft.world.food.FoodProperties;
++import net.minecraft.world.inventory.ClickAction;
++import net.minecraft.world.inventory.Slot;
++import net.minecraft.world.inventory.tooltip.TooltipComponent;
++import net.minecraft.world.item.context.UseOnContext;
++import net.minecraft.world.level.ClipContext;
++import net.minecraft.world.level.ItemLike;
++import net.minecraft.world.level.Level;
++import net.minecraft.world.level.block.Block;
++import net.minecraft.world.level.block.state.BlockState;
++import net.minecraft.world.phys.BlockHitResult;
++import net.minecraft.world.phys.Vec3;
++import org.slf4j.Logger;
++
++public class Item implements FeatureElement, ItemLike {
++    private static final Logger LOGGER = LogUtils.getLogger();
++    public static final Map<Block, Item> BY_BLOCK = Maps.newHashMap();
++    protected static final UUID BASE_ATTACK_DAMAGE_UUID = UUID.fromString("CB3F55D3-645C-4F38-A497-9C13A33DB5CF");
++    protected static final UUID BASE_ATTACK_SPEED_UUID = UUID.fromString("FA233E1C-4180-4865-B01B-BCCE9785ACA3");
++    public static final int MAX_STACK_SIZE = 64;
++    public static final int EAT_DURATION = 32;
++    public static final int MAX_BAR_WIDTH = 13;
++    private final Holder.Reference<Item> builtInRegistryHolder = BuiltInRegistries.ITEM.createIntrusiveHolder(this);
++    public final Rarity rarity;
++    private final int maxStackSize;
++    private final int maxDamage;
++    private final boolean isFireResistant;
++    @Nullable
++    private final Item craftingRemainingItem;
++    @Nullable
++    private String descriptionId;
++    @Nullable
++    private final FoodProperties foodProperties;
++    private final FeatureFlagSet requiredFeatures;
++
++    public static int getId(Item item) {
++        return item == null ? 0 : BuiltInRegistries.ITEM.getId(item);
++    }
++
++    public static Item byId(int id) {
++        return BuiltInRegistries.ITEM.byId(id);
++    }
++
++    /** @deprecated */
++    @Deprecated
++    public static Item byBlock(Block block) {
++        return BY_BLOCK.getOrDefault(block, Items.AIR);
++    }
++
++    public Item(Item.Properties settings) {
++        this.rarity = settings.rarity;
++        this.craftingRemainingItem = settings.craftingRemainingItem;
++        this.maxDamage = settings.maxDamage;
++        this.maxStackSize = settings.maxStackSize;
++        this.foodProperties = settings.foodProperties;
++        this.isFireResistant = settings.isFireResistant;
++        this.requiredFeatures = settings.requiredFeatures;
++        if (SharedConstants.IS_RUNNING_IN_IDE) {
++            String string = this.getClass().getSimpleName();
++            if (!string.endsWith("Item")) {
++                LOGGER.error("Item classes should end with Item and {} doesn't.", (Object)string);
++            }
++        }
++
++    }
++
++    /** @deprecated */
++    @Deprecated
++    public Holder.Reference<Item> builtInRegistryHolder() {
++        return this.builtInRegistryHolder;
++    }
++
++    public void onUseTick(Level world, LivingEntity user, ItemStack stack, int remainingUseTicks) {
++    }
++
++    public void onDestroyed(ItemEntity entity) {
++    }
++
++    public void verifyTagAfterLoad(CompoundTag nbt) {
++    }
++
++    public boolean canAttackBlock(BlockState state, Level world, BlockPos pos, Player miner) {
++        return true;
++    }
++
++    @Override
++    public Item asItem() {
++        return this;
++    }
++
++    public InteractionResult useOn(UseOnContext context) {
++        return InteractionResult.PASS;
++    }
++
++    public float getDestroySpeed(ItemStack stack, BlockState state) {
++        return 1.0F;
++    }
++
++    public InteractionResultHolder<ItemStack> use(Level world, Player user, InteractionHand hand) {
++        if (this.isEdible()) {
++            ItemStack itemStack = user.getItemInHand(hand);
++            if (user.canEat(this.getFoodProperties().canAlwaysEat())) {
++                user.startUsingItem(hand);
++                return InteractionResultHolder.consume(itemStack);
++            } else {
++                return InteractionResultHolder.fail(itemStack);
++            }
++        } else {
++            return InteractionResultHolder.pass(user.getItemInHand(hand));
++        }
++    }
++
++    public ItemStack finishUsingItem(ItemStack stack, Level world, LivingEntity user) {
++        return this.isEdible() ? user.eat(world, stack) : stack;
++    }
++
++    public final int getMaxStackSize() {
++        return this.maxStackSize;
++    }
++
++    public final int getMaxDamage() {
++        return this.maxDamage;
++    }
++
++    public boolean canBeDepleted() {
++        return this.maxDamage > 0;
++    }
++
++    public boolean isBarVisible(ItemStack stack) {
++        return stack.isDamaged();
++    }
++
++    public int getBarWidth(ItemStack stack) {
++        return Math.round(13.0F - (float)stack.getDamageValue() * 13.0F / (float)this.maxDamage);
++    }
++
++    public int getBarColor(ItemStack stack) {
++        float f = Math.max(0.0F, ((float)this.maxDamage - (float)stack.getDamageValue()) / (float)this.maxDamage);
++        return Mth.hsvToRgb(f / 3.0F, 1.0F, 1.0F);
++    }
++
++    public boolean overrideStackedOnOther(ItemStack stack, Slot slot, ClickAction clickType, Player player) {
++        return false;
++    }
++
++    public boolean overrideOtherStackedOnMe(ItemStack stack, ItemStack otherStack, Slot slot, ClickAction clickType, Player player, SlotAccess cursorStackReference) {
++        return false;
++    }
++
++    public boolean hurtEnemy(ItemStack stack, LivingEntity target, LivingEntity attacker) {
++        return false;
++    }
++
++    public boolean mineBlock(ItemStack stack, Level world, BlockState state, BlockPos pos, LivingEntity miner) {
++        return false;
++    }
++
++    public boolean isCorrectToolForDrops(BlockState state) {
++        return false;
++    }
++
++    public InteractionResult interactLivingEntity(ItemStack stack, Player user, LivingEntity entity, InteractionHand hand) {
++        return InteractionResult.PASS;
++    }
++
++    public Component getDescription() {
++        return Component.translatable(this.getDescriptionId());
++    }
++
++    @Override
++    public String toString() {
++        return BuiltInRegistries.ITEM.getKey(this).getPath();
++    }
++
++    protected String getOrCreateDescriptionId() {
++        if (this.descriptionId == null) {
++            this.descriptionId = Util.makeDescriptionId("item", BuiltInRegistries.ITEM.getKey(this));
++        }
++
++        return this.descriptionId;
++    }
++
++    public String getDescriptionId() {
++        return this.getOrCreateDescriptionId();
++    }
++
++    public String getDescriptionId(ItemStack stack) {
++        return this.getDescriptionId();
++    }
++
++    public boolean shouldOverrideMultiplayerNbt() {
++        return true;
++    }
++
++    @Nullable
++    public final Item getCraftingRemainingItem() {
++        return this.craftingRemainingItem;
++    }
++
++    public boolean hasCraftingRemainingItem() {
++        return this.craftingRemainingItem != null;
++    }
++
++    public void inventoryTick(ItemStack stack, Level world, Entity entity, int slot, boolean selected) {
++    }
++
++    public void onCraftedBy(ItemStack stack, Level world, Player player) {
++    }
++
++    public boolean isComplex() {
++        return false;
++    }
++
++    public UseAnim getUseAnimation(ItemStack stack) {
++        return stack.getItem().isEdible() ? UseAnim.EAT : UseAnim.NONE;
++    }
++
++    public int getUseDuration(ItemStack stack) {
++        if (stack.getItem().isEdible()) {
++            return this.getFoodProperties().isFastFood() ? 16 : 32;
++        } else {
++            return 0;
++        }
++    }
++
++    public void releaseUsing(ItemStack stack, Level world, LivingEntity user, int remainingUseTicks) {
++    }
++
++    public void appendHoverText(ItemStack stack, @Nullable Level world, List<Component> tooltip, TooltipFlag context) {
++    }
++
++    public Optional<TooltipComponent> getTooltipImage(ItemStack stack) {
++        return Optional.empty();
++    }
++
++    public Component getName(ItemStack stack) {
++        return Component.translatable(this.getDescriptionId(stack));
++    }
++
++    // Paper Start - Add Glow API
++    public boolean isFoil(ItemStack stack) {
++        return stack.isEnchanted() || stack.isFoiled();
++    }
++    // Paper End
++
++    public Rarity getRarity(ItemStack stack) {
++        if (!stack.isEnchanted()) {
++            return this.rarity;
++        } else {
++            switch (this.rarity) {
++                case COMMON:
++                case UNCOMMON:
++                    return Rarity.RARE;
++                case RARE:
++                    return Rarity.EPIC;
++                case EPIC:
++                default:
++                    return this.rarity;
++            }
++        }
++    }
++
++    public boolean isEnchantable(ItemStack stack) {
++        return this.getMaxStackSize() == 1 && this.canBeDepleted();
++    }
++
++    protected static BlockHitResult getPlayerPOVHitResult(Level world, Player player, ClipContext.Fluid fluidHandling) {
++        float f = player.getXRot();
++        float g = player.getYRot();
++        Vec3 vec3 = player.getEyePosition();
++        float h = Mth.cos(-g * ((float)Math.PI / 180F) - (float)Math.PI);
++        float i = Mth.sin(-g * ((float)Math.PI / 180F) - (float)Math.PI);
++        float j = -Mth.cos(-f * ((float)Math.PI / 180F));
++        float k = Mth.sin(-f * ((float)Math.PI / 180F));
++        float l = i * j;
++        float n = h * j;
++        double d = 5.0D;
++        Vec3 vec32 = vec3.add((double)l * 5.0D, (double)k * 5.0D, (double)n * 5.0D);
++        return world.clip(new ClipContext(vec3, vec32, ClipContext.Block.OUTLINE, fluidHandling, player));
++    }
++
++    public int getEnchantmentValue() {
++        return 0;
++    }
++
++    public boolean isValidRepairItem(ItemStack stack, ItemStack ingredient) {
++        return false;
++    }
++
++    public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot slot) {
++        return ImmutableMultimap.of();
++    }
++
++    public boolean useOnRelease(ItemStack stack) {
++        return false;
++    }
++
++    public ItemStack getDefaultInstance() {
++        return new ItemStack(this);
++    }
++
++    public boolean isEdible() {
++        return this.foodProperties != null;
++    }
++
++    @Nullable
++    public FoodProperties getFoodProperties() {
++        return this.foodProperties;
++    }
++
++    public SoundEvent getDrinkingSound() {
++        return SoundEvents.GENERIC_DRINK;
++    }
++
++    public SoundEvent getEatingSound() {
++        return SoundEvents.GENERIC_EAT;
++    }
++
++    public boolean isFireResistant() {
++        return this.isFireResistant;
++    }
++
++    public boolean canBeHurtBy(DamageSource source) {
++        return !this.isFireResistant || !source.is(DamageTypeTags.IS_FIRE);
++    }
++
++    public boolean canFitInsideContainerItems() {
++        return true;
++    }
++
++    @Override
++    public FeatureFlagSet requiredFeatures() {
++        return this.requiredFeatures;
++    }
++
++    public static class Properties {
++        int maxStackSize = 64;
++        int maxDamage;
++        @Nullable
++        Item craftingRemainingItem;
++        Rarity rarity = Rarity.COMMON;
++        @Nullable
++        FoodProperties foodProperties;
++        boolean isFireResistant;
++        FeatureFlagSet requiredFeatures = FeatureFlags.VANILLA_SET;
++
++        public Item.Properties food(FoodProperties foodComponent) {
++            this.foodProperties = foodComponent;
++            return this;
++        }
++
++        public Item.Properties stacksTo(int maxCount) {
++            if (this.maxDamage > 0) {
++                throw new RuntimeException("Unable to have damage AND stack.");
++            } else {
++                this.maxStackSize = maxCount;
++                return this;
++            }
++        }
++
++        public Item.Properties defaultDurability(int maxDamage) {
++            return this.maxDamage == 0 ? this.durability(maxDamage) : this;
++        }
++
++        public Item.Properties durability(int maxDamage) {
++            this.maxDamage = maxDamage;
++            this.maxStackSize = 1;
++            return this;
++        }
++
++        public Item.Properties craftRemainder(Item recipeRemainder) {
++            this.craftingRemainingItem = recipeRemainder;
++            return this;
++        }
++
++        public Item.Properties rarity(Rarity rarity) {
++            this.rarity = rarity;
++            return this;
++        }
++
++        public Item.Properties fireResistant() {
++            this.isFireResistant = true;
++            return this;
++        }
++
++        public Item.Properties requiredFeatures(FeatureFlag... features) {
++            this.requiredFeatures = FeatureFlags.REGISTRY.subset(features);
++            return this;
++        }
++    }
++}
+diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
+index 0caf3eeb7984e842f7a0bdfed3021d0b231a0dd0..1de2416a293d0e8214e281aa7f5de032bcf6ef4b 100644
+--- a/src/main/java/net/minecraft/world/item/ItemStack.java
++++ b/src/main/java/net/minecraft/world/item/ItemStack.java
+@@ -1135,9 +1135,15 @@ public final class ItemStack {
+     }
+ 
+     public boolean isEnchanted() {
+-        return this.tag != null && this.tag.contains("Enchantments", 9) ? !this.tag.getList("Enchantments", 10).isEmpty() : false;
++        return this.tag != null && this.tag.contains("Enchantments", 9) ? !this.tag.getList("Enchantments", 10).isEmpty() : false; // diff on change isFoiled
+     }
+ 
++    // Paper Start
++    public boolean isFoiled() {
++        return this.tag != null && this.tag.contains("Foiled") && this.tag.getBoolean("Foiled");
++    }
++    // Paper End
++
+     public void addTagElement(String key, Tag element) {
+         this.getOrCreateTag().put(key, element);
+     }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..d7102d83bb781b6cf296cf9c637f8270f4ee8b14 100644
+index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..b93fa4d5e2d8e590b585ed359eb990622a151935 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -83,6 +83,12 @@ import org.bukkit.persistence.PersistentDataContainer;
@@ -21,33 +477,35 @@ index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..d7102d83bb781b6cf296cf9c637f8270
  /**
   * Children must include the following:
   *
-@@ -271,6 +277,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -271,6 +277,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      @Specific(Specific.To.NBT)
      static final ItemMetaKey BLOCK_DATA = new ItemMetaKey("BlockStateTag");
      static final ItemMetaKey BUKKIT_CUSTOM_TAG = new ItemMetaKey("PublicBukkitValues");
-+    // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++    // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +    static final ItemMetaKey CAN_DESTROY = new ItemMetaKey("CanDestroy");
 +    static final ItemMetaKey CAN_PLACE_ON = new ItemMetaKey("CanPlaceOn");
++    static final ItemMetaKey FOILED = new ItemMetaKey("Foiled");
 +    // Paper end
  
      // We store the raw original JSON representation of all text data. See SPIGOT-5063, SPIGOT-5656, SPIGOT-5304
      private String displayName;
-@@ -284,6 +294,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -284,6 +295,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private int hideFlag;
      private boolean unbreakable;
      private int damage;
-+    // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++    // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +    private Set<Namespaced> placeableKeys = Sets.newHashSet();
 +    private Set<Namespaced> destroyableKeys = Sets.newHashSet();
++    private boolean foiled;
 +    // Paper end
  
      private static final Set<String> HANDLED_TAGS = Sets.newHashSet();
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
-@@ -321,6 +335,15 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -321,6 +337,17 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          this.hideFlag = meta.hideFlag;
          this.unbreakable = meta.unbreakable;
          this.damage = meta.damage;
-+        // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++        // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +        if (meta.hasPlaceableKeys()) {
 +            this.placeableKeys = new java.util.HashSet<>(meta.placeableKeys);
 +        }
@@ -55,15 +513,17 @@ index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..d7102d83bb781b6cf296cf9c637f8270
 +        if (meta.hasDestroyableKeys()) {
 +            this.destroyableKeys = new java.util.HashSet<>(meta.destroyableKeys);
 +        }
++
++        this.foiled = meta.foiled;
 +        // Paper end
          this.unhandledTags.putAll(meta.unhandledTags);
          this.persistentDataContainer.putAll(meta.persistentDataContainer.getRaw());
  
-@@ -384,6 +407,31 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -384,6 +411,35 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  this.persistentDataContainer.put(key, compound.get(key).copy());
              }
          }
-+        // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++        // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +        if (tag.contains(CAN_DESTROY.NBT)) {
 +            ListTag list = tag.getList(CAN_DESTROY.NBT, CraftMagicNumbers.NBT.TAG_STRING);
 +            for (int i = 0; i < list.size(); i++) {
@@ -87,15 +547,19 @@ index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..d7102d83bb781b6cf296cf9c637f8270
 +                this.placeableKeys.add(namespaced);
 +            }
 +        }
++
++        if (tag.contains(FOILED.NBT)) {
++            this.foiled = tag.getBoolean(FOILED.NBT);
++        }
 +        // Paper end
  
          Set<String> keys = tag.getAllKeys();
          for (String key : keys) {
-@@ -522,6 +570,34 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -522,6 +578,39 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              this.setDamage(damage);
          }
  
-+        // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++        // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +        Iterable<?> canPlaceOnSerialized = SerializableMeta.getObject(Iterable.class, map, CAN_PLACE_ON.BUKKIT, true);
 +        if (canPlaceOnSerialized != null) {
 +            for (Object canPlaceOnElement : canPlaceOnSerialized) {
@@ -121,16 +585,21 @@ index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..d7102d83bb781b6cf296cf9c637f8270
 +                this.destroyableKeys.add(value);
 +            }
 +        }
++
++        Boolean foiled = SerializableMeta.getObject(Boolean.class, map, FOILED.BUKKIT, true);
++        if (foiled != null) {
++            this.setFoiled(foiled);
++        }
 +        // Paper end
 +
          String internal = SerializableMeta.getString(map, "internal", true);
          if (internal != null) {
              ByteArrayInputStream buf = new ByteArrayInputStream(Base64.getDecoder().decode(internal));
-@@ -650,6 +726,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -650,6 +739,27 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          if (this.hasDamage()) {
              itemTag.putInt(DAMAGE.NBT, damage);
          }
-+        // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++        // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +        if (hasPlaceableKeys()) {
 +            List<String> items = this.placeableKeys.stream()
 +                .map(this::serializeNamespaced)
@@ -146,14 +615,20 @@ index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..d7102d83bb781b6cf296cf9c637f8270
 +
 +            itemTag.put(CAN_DESTROY.NBT, createNonComponentStringList(items));
 +        }
++
++        if (this.isFoiled()) {
++            itemTag.putBoolean(FOILED.NBT, foiled);
++        }
 +        // Paper end
  
          for (Map.Entry<String, Tag> e : this.unhandledTags.entrySet()) {
              itemTag.put(e.getKey(), e.getValue());
-@@ -666,6 +759,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -666,6 +776,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
++
++
 +    // Paper start
 +    static ListTag createNonComponentStringList(List<String> list) {
 +        if (list == null || list.isEmpty()) {
@@ -172,59 +647,62 @@ index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..d7102d83bb781b6cf296cf9c637f8270
      ListTag createStringList(List<String> list) {
          if (list == null) {
              return null;
-@@ -749,7 +857,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -749,7 +876,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
 -        return !(this.hasDisplayName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isUnbreakable() || this.hasDamage() || this.hasAttributeModifiers());
-+        return !(this.hasDisplayName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isUnbreakable() || this.hasDamage() || this.hasAttributeModifiers() || this.hasPlaceableKeys() || this.hasDestroyableKeys()); // Paper - Implement an API for CanPlaceOn and CanDestroy NBT values
++        return !(this.hasDisplayName() || this.hasLocalizedName() || this.hasEnchants() || (this.lore != null) || this.hasCustomModelData() || this.hasBlockData() || this.hasRepairCost() || !this.unhandledTags.isEmpty() || !this.persistentDataContainer.isEmpty() || this.hideFlag != 0 || this.isUnbreakable() || this.hasDamage() || this.hasAttributeModifiers() || this.hasPlaceableKeys() || this.hasDestroyableKeys() || this.isFoiled()); // Paper - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
      }
  
      // Paper start
-@@ -1181,7 +1289,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1181,7 +1308,12 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hideFlag == that.hideFlag)
                  && (this.isUnbreakable() == that.isUnbreakable())
                  && (this.hasDamage() ? that.hasDamage() && this.damage == that.damage : !that.hasDamage())
 -                && (this.version == that.version);
 +                && (this.version == that.version)
-+                // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++                // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +                && (this.hasPlaceableKeys() ? that.hasPlaceableKeys() && this.placeableKeys.equals(that.placeableKeys) : !that.hasPlaceableKeys())
-+                && (this.hasDestroyableKeys() ? that.hasDestroyableKeys() && this.destroyableKeys.equals(that.destroyableKeys) : !that.hasDestroyableKeys());
++                && (this.hasDestroyableKeys() ? that.hasDestroyableKeys() && this.destroyableKeys.equals(that.destroyableKeys) : !that.hasDestroyableKeys())
++                && (this.foiled == that.isFoiled());
 +                // Paper end
      }
  
      /**
-@@ -1216,6 +1328,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1216,6 +1348,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (this.hasDamage() ? this.damage : 0);
          hash = 61 * hash + (this.hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
          hash = 61 * hash + this.version;
-+        // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++        // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +        hash = 61 * hash + (this.hasPlaceableKeys() ? this.placeableKeys.hashCode() : 0);
 +        hash = 61 * hash + (this.hasDestroyableKeys() ? this.destroyableKeys.hashCode() : 0);
++        hash = 61 * hash + (this.isFoiled() ? 1231 : 1237);
 +        // Paper end
          return hash;
      }
  
-@@ -1240,6 +1356,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1240,6 +1377,15 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.unbreakable = this.unbreakable;
              clone.damage = this.damage;
              clone.version = this.version;
-+            // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++            // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +            if (this.placeableKeys != null) {
 +                clone.placeableKeys = Sets.newHashSet(this.placeableKeys);
 +            }
 +            if (this.destroyableKeys != null) {
 +                clone.destroyableKeys = Sets.newHashSet(this.destroyableKeys);
 +            }
++            clone.foiled = this.foiled;
 +            // Paper end
              return clone;
          } catch (CloneNotSupportedException e) {
              throw new Error(e);
-@@ -1297,6 +1421,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1297,6 +1443,26 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              builder.put(DAMAGE.BUKKIT, damage);
          }
  
-+        // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++        // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +        if (this.hasPlaceableKeys()) {
 +            List<String> cerealPlaceable = this.placeableKeys.stream()
 +                .map(this::serializeNamespaced)
@@ -240,24 +718,28 @@ index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..d7102d83bb781b6cf296cf9c637f8270
 +
 +            builder.put(CAN_DESTROY.BUKKIT, cerealDestroyable);
 +        }
++        if (this.isFoiled()) {
++            builder.put(FOILED.BUKKIT, foiled);
++        }
 +        // Paper end
          final Map<String, Tag> internalTags = new HashMap<String, Tag>(this.unhandledTags);
          this.serializeInternal(internalTags);
          if (!internalTags.isEmpty()) {
-@@ -1469,6 +1610,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1469,6 +1635,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaArmorStand.SHOW_ARMS.NBT,
                          CraftMetaArmorStand.SMALL.NBT,
                          CraftMetaArmorStand.MARKER.NBT,
 +                        CAN_DESTROY.NBT,
 +                        CAN_PLACE_ON.NBT,
++                        FOILED.NBT,
                          // Paper end
                          CraftMetaCompass.LODESTONE_DIMENSION.NBT,
                          CraftMetaCompass.LODESTONE_POS.NBT,
-@@ -1498,4 +1641,146 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1498,4 +1667,157 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
      // Paper end
  
-+    // Paper start - Implement an API for CanPlaceOn and CanDestroy NBT values
++    // Paper start - Implement an API for CanPlaceOn, CanDestroy and Foiled NBT values
 +    @Override
 +    @SuppressWarnings("deprecation")
 +    public Set<Material> getCanDestroy() {
@@ -318,6 +800,16 @@ index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..d7102d83bb781b6cf296cf9c637f8270
 +    @Override
 +    public boolean hasDestroyableKeys() {
 +        return this.destroyableKeys != null && !this.destroyableKeys.isEmpty();
++    }
++
++    @Override
++    public boolean isFoiled() {
++        return this.foiled;
++    }
++
++    @Override
++    public void setFoiled(boolean foiled) {
++        this.foiled = foiled;
 +    }
 +
 +    @Deprecated
@@ -398,5 +890,6 @@ index 8ada3a7c5539293d4e2c1a5b83e00fc2542f10ff..d7102d83bb781b6cf296cf9c637f8270
 +
 +        return true;
 +    }
++
 +    // Paper end
  }

--- a/patches/server/0427-Convert-legacy-attributes-in-Item-Meta.patch
+++ b/patches/server/0427-Convert-legacy-attributes-in-Item-Meta.patch
@@ -30,10 +30,10 @@ index fac4097be2ee3d0bffbc92fb217f98831e78d6b3..233e372ba5d785352c9ac12dac37395b
      public CraftAttributeMap(AttributeMap handle) {
          this.handle = handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index d7102d83bb781b6cf296cf9c637f8270f4ee8b14..d1f21b5f5600dba41a93378853aadacd24f4a1f3 100644
+index b93fa4d5e2d8e590b585ed359eb990622a151935..95cc1f8c49f2f7c851e0a52b632d9bc99dc4ad35 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -483,7 +483,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -491,7 +491,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
              AttributeModifier attribMod = CraftAttributeInstance.convert(nmsModifier);
  

--- a/patches/server/0430-Support-components-in-ItemMeta.patch
+++ b/patches/server/0430-Support-components-in-ItemMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index d1f21b5f5600dba41a93378853aadacd24f4a1f3..b34f364f8580ae900e25ef3f31f58f4e8fee88e0 100644
+index 95cc1f8c49f2f7c851e0a52b632d9bc99dc4ad35..c533b4ccc1292c8001364db8ffd71457fe10c35b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -877,11 +877,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -896,11 +896,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return CraftChatMessage.fromJSONComponent(displayName);
      }
  
@@ -32,7 +32,7 @@ index d1f21b5f5600dba41a93378853aadacd24f4a1f3..b34f364f8580ae900e25ef3f31f58f4e
      @Override
      public boolean hasDisplayName() {
          return this.displayName != null;
-@@ -1024,6 +1036,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1043,6 +1055,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromJSONComponent));
      }
  
@@ -47,7 +47,7 @@ index d1f21b5f5600dba41a93378853aadacd24f4a1f3..b34f364f8580ae900e25ef3f31f58f4e
      @Override
      public void setLore(List<String> lore) {
          if (lore == null || lore.isEmpty()) {
-@@ -1038,6 +1058,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1057,6 +1077,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -69,7 +69,7 @@ index d1f21b5f5600dba41a93378853aadacd24f4a1f3..b34f364f8580ae900e25ef3f31f58f4e
      @Override
      public boolean hasCustomModelData() {
          return this.customModelData != null;
-@@ -1506,6 +1541,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1531,6 +1566,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Object object : addFrom) {

--- a/patches/server/0624-Make-item-validations-configurable.patch
+++ b/patches/server/0624-Make-item-validations-configurable.patch
@@ -32,10 +32,10 @@ index 5d72d2c6fcab478121eb9b4216cf79532b58299e..88c899e323eb554febe191ac7df678bb
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index b34f364f8580ae900e25ef3f31f58f4e8fee88e0..1481c8ca684eddca3eb5db3aceac4877043b9fcd 100644
+index c533b4ccc1292c8001364db8ffd71457fe10c35b..703cd430a80695177923fcce07029bc8326df64f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -360,7 +360,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -364,7 +364,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              CompoundTag display = tag.getCompound(DISPLAY.NBT);
  
              if (display.contains(NAME.NBT)) {
@@ -44,7 +44,7 @@ index b34f364f8580ae900e25ef3f31f58f4e8fee88e0..1481c8ca684eddca3eb5db3aceac4877
              }
  
              if (display.contains(LOCNAME.NBT)) {
-@@ -371,7 +371,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -375,7 +375,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  ListTag list = display.getList(LORE.NBT, CraftMagicNumbers.NBT.TAG_STRING);
                  this.lore = new ArrayList<String>(list.size());
                  for (int index = 0; index < list.size(); index++) {

--- a/patches/server/0983-Suppress-Item-Meta-Validation-Checks.patch
+++ b/patches/server/0983-Suppress-Item-Meta-Validation-Checks.patch
@@ -47,10 +47,10 @@ index c92981aedebe934cefa1c96a0328fb91fe17acbc..80138632e5216c71fe7060a59dbb2915
      CraftMetaArmor(Map<String, Object> map) {
          super(map);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 1481c8ca684eddca3eb5db3aceac4877043b9fcd..076e06908a0cf97f86a64a15ca0231c5b0f06fec 100644
+index 703cd430a80695177923fcce07029bc8326df64f..0e17984296ca4a8b7b3390da0dd3d289606f78ac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -488,7 +488,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -496,7 +496,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  continue;
              }
  

--- a/patches/server/1018-Deep-clone-unhandled-nbt-tags.patch
+++ b/patches/server/1018-Deep-clone-unhandled-nbt-tags.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deep clone unhandled nbt tags
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 076e06908a0cf97f86a64a15ca0231c5b0f06fec..3df1822b55358a9bdf41bcacd5b7fecfd8f05dfa 100644
+index 0e17984296ca4a8b7b3390da0dd3d289606f78ac..23465b48b1adacc6a8e65b3c360600a46327ea84 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -303,7 +303,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -305,7 +305,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
  
      private CompoundTag internalTag;
@@ -17,9 +17,9 @@ index 076e06908a0cf97f86a64a15ca0231c5b0f06fec..3df1822b55358a9bdf41bcacd5b7fecf
      private CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftMetaItem.DATA_TYPE_REGISTRY);
  
      private int version = CraftMagicNumbers.INSTANCE.getDataVersion(); // Internal use only
-@@ -344,8 +344,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
-             this.destroyableKeys = new java.util.HashSet<>(meta.destroyableKeys);
-         }
+@@ -348,8 +348,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+         this.foiled = meta.foiled;
          // Paper end
 -        this.unhandledTags.putAll(meta.unhandledTags);
 -        this.persistentDataContainer.putAll(meta.persistentDataContainer.getRaw());
@@ -30,7 +30,7 @@ index 076e06908a0cf97f86a64a15ca0231c5b0f06fec..3df1822b55358a9bdf41bcacd5b7fecf
  
          this.internalTag = meta.internalTag;
          if (this.internalTag != null) {
-@@ -1393,7 +1395,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1414,7 +1416,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
              }


### PR DESCRIPTION
Adds Foiled/Glow API using NBT. 

Possibly can add the API to the Overrides for the default items that are foiled. Follows most of the logic of the unbreakable tag.

Relevant:
#5274 

Also not sure if this is going to be relevant due to #8711.

P.S. For some reason Patch 1018 was edited and it says it removed something? I also can't rebuild or apply new patches after rebuilding the first time which is confusing to me. 

