### PR TITLE
Fix sign update desync

### DIFF
--- a/patches/server/1029-Fix-sign-update-desync.patch
+++ b/patches/server/1029-Fix-sign-update-desync.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ScriptLineStudios <scriptlinestudios@protonmail.com>
+Date: Sat, 9 Sep 2023 16:18:05 +0200
+Subject: [PATCH] Fix sign update desync
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 3c0651fa5a5db880202c9a3805a6455269c5f16d..b51bb9c1da063c953d009d0df83aeee0097d0acb 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -3531,6 +3531,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+             BlockEntity tileentity = worldserver.getBlockEntity(blockposition);
+ 
+             if (!(tileentity instanceof SignBlockEntity)) {
++                // Paper start - Fix sign update desync
++                this.player.connection.send(tileentity.getUpdatePacket());
++                // Paper end
+                 return;
+             }
+ 
+@@ -3538,7 +3541,6 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+ 
+             tileentitysign.updateSignText(this.player, packet.isFrontText(), signText);
+         }
+-
+     }
+ 
+     @Override


### PR DESCRIPTION
Stops desync (most likely caused by latency) in the event of a player updating a block which the server hasn't recognized as a sign.