### PR TITLE
Swap some nullable annotations

### DIFF
--- a/patches/api/0073-Add-PlayerArmorChangeEvent.patch
+++ b/patches/api/0073-Add-PlayerArmorChangeEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..faea096dac02d339667c02a0011b6f8313fd8c12
+index 0000000000000000000000000000000000000000..57521010ff0574f1bbc96727948a6185fd37e9ee
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
-@@ -0,0 +1,137 @@
+@@ -0,0 +1,139 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.Material;
@@ -22,6 +22,7 @@ index 0000000000000000000000000000000000000000..faea096dac02d339667c02a0011b6f83
 +import java.util.Collections;
 +import java.util.HashSet;
 +import java.util.Set;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -36,10 +37,11 @@ index 0000000000000000000000000000000000000000..faea096dac02d339667c02a0011b6f83
 +    private static final HandlerList HANDLERS = new HandlerList();
 +
 +    @NotNull private final SlotType slotType;
-+    @Nullable private final ItemStack oldItem;
-+    @Nullable private final ItemStack newItem;
++    @NotNull private final ItemStack oldItem;
++    @NotNull private final ItemStack newItem;
 +
-+    public PlayerArmorChangeEvent(@NotNull Player player, @NotNull SlotType slotType, @Nullable ItemStack oldItem, @Nullable ItemStack newItem) {
++    @ApiStatus.Internal
++    public PlayerArmorChangeEvent(@NotNull Player player, @NotNull SlotType slotType, @NotNull ItemStack oldItem, @NotNull ItemStack newItem) {
 +        super(player);
 +        this.slotType = slotType;
 +        this.oldItem = oldItem;
@@ -61,7 +63,7 @@ index 0000000000000000000000000000000000000000..faea096dac02d339667c02a0011b6f83
 +     *
 +     * @return old item
 +     */
-+    @Nullable
++    @NotNull
 +    public ItemStack getOldItem() {
 +        return this.oldItem;
 +    }
@@ -71,7 +73,7 @@ index 0000000000000000000000000000000000000000..faea096dac02d339667c02a0011b6f83
 +     *
 +     * @return new item
 +     */
-+    @Nullable
++    @NotNull
 +    public ItemStack getNewItem() {
 +        return this.newItem;
 +    }
@@ -137,10 +139,10 @@ index 0000000000000000000000000000000000000000..faea096dac02d339667c02a0011b6f83
 +        }
 +
 +        /**
-+         * Gets whether or not this material can be equipped to a slot
++         * Gets whether this material can be equipped to a slot
 +         *
 +         * @param material material to check
-+         * @return whether or not this material can be equipped
++         * @return whether this material can be equipped
 +         */
 +        public static boolean isEquipable(@NotNull Material material) {
 +            return getByMaterial(material) != null;

--- a/patches/api/0122-EnderDragon-Events.patch
+++ b/patches/api/0122-EnderDragon-Events.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] EnderDragon Events
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFireballHitEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFireballHitEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..118c7b6772a52c250649af2a9286f483f43da385
+index 0000000000000000000000000000000000000000..615bc4c973ff371d87f996e981207fc15b70275b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFireballHitEvent.java
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,77 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.AreaEffectCloud;
@@ -20,17 +20,21 @@ index 0000000000000000000000000000000000000000..118c7b6772a52c250649af2a9286f483
 +import org.bukkit.event.entity.EntityEvent;
 +
 +import java.util.Collection;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
-+import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Fired when a DragonFireball collides with a block/entity and spawns an AreaEffectCloud
 + */
 +public class EnderDragonFireballHitEvent extends EntityEvent implements Cancellable {
-+    @Nullable private final Collection<LivingEntity> targets;
-+    @NotNull private final AreaEffectCloud areaEffectCloud;
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
-+    public EnderDragonFireballHitEvent(@NotNull DragonFireball fireball, @Nullable Collection<LivingEntity> targets, @NotNull AreaEffectCloud areaEffectCloud) {
++    @NotNull private final Collection<LivingEntity> targets;
++    @NotNull private final AreaEffectCloud areaEffectCloud;
++    private boolean cancelled = false;
++
++    @ApiStatus.Internal
++    public EnderDragonFireballHitEvent(@NotNull DragonFireball fireball, @NotNull Collection<LivingEntity> targets, @NotNull AreaEffectCloud areaEffectCloud) {
 +        super(fireball);
 +        this.targets = targets;
 +        this.areaEffectCloud = areaEffectCloud;
@@ -48,11 +52,9 @@ index 0000000000000000000000000000000000000000..118c7b6772a52c250649af2a9286f483
 +    /**
 +     * The living entities hit by fireball
 +     *
-+     * May be null if no entities were hit
-+     *
 +     * @return the targets
 +     */
-+    @Nullable
++    @NotNull
 +    public Collection<LivingEntity> getTargets() {
 +        return targets;
 +    }
@@ -65,20 +67,6 @@ index 0000000000000000000000000000000000000000..118c7b6772a52c250649af2a9286f483
 +        return areaEffectCloud;
 +    }
 +
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    @NotNull
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    @NotNull
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+
-+    private boolean cancelled = false;
-+
 +    @Override
 +    public boolean isCancelled() {
 +        return cancelled;
@@ -87,6 +75,16 @@ index 0000000000000000000000000000000000000000..118c7b6772a52c250649af2a9286f483
 +    @Override
 +    public void setCancelled(boolean cancel) {
 +        cancelled = cancel;
++    }
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFlameEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFlameEvent.java

--- a/patches/api/0130-AnvilDamageEvent.patch
+++ b/patches/api/0130-AnvilDamageEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] AnvilDamageEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/AnvilDamagedEvent.java b/src/main/java/com/destroystokyo/paper/event/block/AnvilDamagedEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a83c286c1c11af25fc4d16af7a42b95ce90b9dee
+index 0000000000000000000000000000000000000000..aa5c3690fb898a7560a9551df91588a0cdc69fe2
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/AnvilDamagedEvent.java
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,151 @@
 +package com.destroystokyo.paper.event.block;
 +
 +import org.bukkit.Material;
@@ -19,6 +19,7 @@ index 0000000000000000000000000000000000000000..a83c286c1c11af25fc4d16af7a42b95c
 +import org.bukkit.event.inventory.InventoryEvent;
 +import org.bukkit.inventory.AnvilInventory;
 +import org.bukkit.inventory.InventoryView;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -26,11 +27,13 @@ index 0000000000000000000000000000000000000000..a83c286c1c11af25fc4d16af7a42b95c
 + * Called when an anvil is damaged from being used
 + */
 +public class AnvilDamagedEvent extends InventoryEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private boolean cancel;
 +    private DamageState damageState;
 +
-+    public AnvilDamagedEvent(@NotNull InventoryView inventory, @NotNull BlockData blockData) {
++    @ApiStatus.Internal
++    public AnvilDamagedEvent(@NotNull InventoryView inventory, @Nullable BlockData blockData) {
 +        super(inventory);
 +        this.damageState = DamageState.getState(blockData);
 +    }
@@ -92,12 +95,12 @@ index 0000000000000000000000000000000000000000..a83c286c1c11af25fc4d16af7a42b95c
 +
 +    @NotNull
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    /**
@@ -109,7 +112,7 @@ index 0000000000000000000000000000000000000000..a83c286c1c11af25fc4d16af7a42b95c
 +        DAMAGED(Material.DAMAGED_ANVIL),
 +        BROKEN(Material.AIR);
 +
-+        private Material material;
++        private final Material material;
 +
 +        DamageState(@NotNull Material material) {
 +            this.material = material;
@@ -154,7 +157,7 @@ index 0000000000000000000000000000000000000000..a83c286c1c11af25fc4d16af7a42b95c
 +                    return state;
 +                }
 +            }
-+            throw new IllegalArgumentException("Material not an anvil");
++            throw new IllegalArgumentException("Material is not an anvil state");
 +        }
 +    }
 +}

--- a/patches/api/0137-Add-PhantomPreSpawnEvent.patch
+++ b/patches/api/0137-Add-PhantomPreSpawnEvent.patch
@@ -6,16 +6,17 @@ Subject: [PATCH] Add PhantomPreSpawnEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/PhantomPreSpawnEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/PhantomPreSpawnEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9022f697ab244df43074e48c9150f39d44217531
+index 0000000000000000000000000000000000000000..d8f3f1c354331bc5e6fc1d9aa013476baf2daf05
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/PhantomPreSpawnEvent.java
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,33 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.Location;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.entity.EntityType;
 +import org.bukkit.event.entity.CreatureSpawnEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -26,6 +27,7 @@ index 0000000000000000000000000000000000000000..9022f697ab244df43074e48c9150f39d
 +public class PhantomPreSpawnEvent extends PreCreatureSpawnEvent {
 +    @NotNull private final Entity entity;
 +
++    @ApiStatus.Internal
 +    public PhantomPreSpawnEvent(@NotNull Location location, @NotNull Entity entity, @NotNull CreatureSpawnEvent.SpawnReason reason) {
 +        super(location, EntityType.PHANTOM, reason);
 +        this.entity = entity;
@@ -36,7 +38,7 @@ index 0000000000000000000000000000000000000000..9022f697ab244df43074e48c9150f39d
 +     *
 +     * @return Entity
 +     */
-+    @Nullable
++    @NotNull
 +    public Entity getSpawningEntity() {
 +        return entity;
 +    }

--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -491,6 +491,19 @@ index e9a6e5be5f33a342f7e5c496f0f1c64b2f302ace..f0db59a556deaefefbdaca121585c0fd
          return offers;
      }
  
+diff --git a/src/main/java/org/bukkit/event/entity/EntityTargetLivingEntityEvent.java b/src/main/java/org/bukkit/event/entity/EntityTargetLivingEntityEvent.java
+index 090ec6f96ca9b7f760389994da988c44c32b9976..e6b4d4c1722bf4a11744a421d09646b22745b138 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityTargetLivingEntityEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityTargetLivingEntityEvent.java
+@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
+  * LivingEntity's.
+  */
+ public class EntityTargetLivingEntityEvent extends EntityTargetEvent {
+-    public EntityTargetLivingEntityEvent(@NotNull final Entity entity, @Nullable final LivingEntity target, @Nullable final TargetReason reason) {
++    public EntityTargetLivingEntityEvent(@NotNull final Entity entity, @Nullable final LivingEntity target, @NotNull final TargetReason reason) { // Paper
+         super(entity, target, reason);
+     }
+ 
 diff --git a/src/main/java/org/bukkit/event/entity/EntityToggleSwimEvent.java b/src/main/java/org/bukkit/event/entity/EntityToggleSwimEvent.java
 index e1123295b9511a2c610a1baf7195638f7f3e64c4..273ae8e5da0a858d3b82d1b0f5992318ff49f145 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityToggleSwimEvent.java
@@ -510,6 +523,75 @@ index e1123295b9511a2c610a1baf7195638f7f3e64c4..273ae8e5da0a858d3b82d1b0f5992318
      @Override
      public void setCancelled(boolean cancel) {
          this.cancel = cancel;
+diff --git a/src/main/java/org/bukkit/event/entity/SpawnerSpawnEvent.java b/src/main/java/org/bukkit/event/entity/SpawnerSpawnEvent.java
+index 9353f0d09272404f42167ab8b7ad83a03620c436..f3ec8f67328b266defb31a44a36d31401d5e9371 100644
+--- a/src/main/java/org/bukkit/event/entity/SpawnerSpawnEvent.java
++++ b/src/main/java/org/bukkit/event/entity/SpawnerSpawnEvent.java
+@@ -12,12 +12,19 @@ import org.jetbrains.annotations.NotNull;
+ public class SpawnerSpawnEvent extends EntitySpawnEvent {
+     private final CreatureSpawner spawner;
+ 
+-    public SpawnerSpawnEvent(@NotNull final Entity spawnee, @NotNull final CreatureSpawner spawner) {
++    public SpawnerSpawnEvent(@NotNull final Entity spawnee, @org.jetbrains.annotations.Nullable final CreatureSpawner spawner) { // Paper
+         super(spawnee);
+         this.spawner = spawner;
+     }
+ 
+-    @NotNull
++    /**
++     * Gets the spawner tile state, or null
++     * when the entity is spawned from a minecart
++     * spawner.
++     *
++     * @return the spawner tile state
++     */
++    @org.jetbrains.annotations.Nullable // Paper
+     public CreatureSpawner getSpawner() {
+         return spawner;
+     }
+diff --git a/src/main/java/org/bukkit/event/hanging/HangingBreakByEntityEvent.java b/src/main/java/org/bukkit/event/hanging/HangingBreakByEntityEvent.java
+index 68517811f63838bdad41073ee26be82f95042a8e..454885e47611edd707358ddfe0a01b7acf9ad5c8 100644
+--- a/src/main/java/org/bukkit/event/hanging/HangingBreakByEntityEvent.java
++++ b/src/main/java/org/bukkit/event/hanging/HangingBreakByEntityEvent.java
+@@ -11,22 +11,21 @@ import org.jetbrains.annotations.Nullable;
+ public class HangingBreakByEntityEvent extends HangingBreakEvent {
+     private final Entity remover;
+ 
+-    public HangingBreakByEntityEvent(@NotNull final Hanging hanging, @Nullable final Entity remover) {
++    public HangingBreakByEntityEvent(@NotNull final Hanging hanging, @NotNull final Entity remover) { // Paper
+         this(hanging, remover, HangingBreakEvent.RemoveCause.ENTITY);
+     }
+ 
+-    public HangingBreakByEntityEvent(@NotNull final Hanging hanging, @Nullable final Entity remover, @NotNull final HangingBreakEvent.RemoveCause cause) {
++    public HangingBreakByEntityEvent(@NotNull final Hanging hanging, @NotNull final Entity remover, @NotNull final HangingBreakEvent.RemoveCause cause) { // Paper
+         super(hanging, cause);
+         this.remover = remover;
+     }
+ 
+     /**
+      * Gets the entity that removed the hanging entity.
+-     * May be null, for example when broken by an explosion.
+      *
+      * @return the entity that removed the hanging entity
+      */
+-    @Nullable
++    @NotNull // Paper
+     public Entity getRemover() {
+         return remover;
+     }
+diff --git a/src/main/java/org/bukkit/event/inventory/HopperInventorySearchEvent.java b/src/main/java/org/bukkit/event/inventory/HopperInventorySearchEvent.java
+index 80a0a4ad813d6453b30273d25942e6612bb05c1b..18bb808e73c7a78f367ccdb44d5fe12bc54672cb 100644
+--- a/src/main/java/org/bukkit/event/inventory/HopperInventorySearchEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/HopperInventorySearchEvent.java
+@@ -34,7 +34,7 @@ public class HopperInventorySearchEvent extends BlockEvent {
+         DESTINATION;
+     }
+ 
+-    public HopperInventorySearchEvent(@NotNull Inventory inventory, @NotNull ContainerType containerType, @NotNull Block hopper, @NotNull Block searchBlock) {
++    public HopperInventorySearchEvent(@Nullable Inventory inventory, @NotNull ContainerType containerType, @NotNull Block hopper, @NotNull Block searchBlock) { // Paper
+         super(hopper);
+         this.inventory = inventory;
+         this.containerType = containerType;
 diff --git a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
 index 1b2267f4e8ebded198773ec80e2bff2c861c7084..1a58734d919fae247eeb85dd785fd59990856505 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
@@ -522,6 +604,28 @@ index 1b2267f4e8ebded198773ec80e2bff2c861c7084..1a58734d919fae247eeb85dd785fd599
 +    @NotNull // Paper
      public Location getTo() {
          return to;
+     }
+diff --git a/src/main/java/org/bukkit/event/raid/RaidSpawnWaveEvent.java b/src/main/java/org/bukkit/event/raid/RaidSpawnWaveEvent.java
+index cd58dd7de781823804701fc023706e805c0142a8..1b8bb5241efcf4a90fd098f2000f8394072dca4a 100644
+--- a/src/main/java/org/bukkit/event/raid/RaidSpawnWaveEvent.java
++++ b/src/main/java/org/bukkit/event/raid/RaidSpawnWaveEvent.java
+@@ -19,7 +19,7 @@ public class RaidSpawnWaveEvent extends RaidEvent {
+     private final List<Raider> raiders;
+     private final Raider leader;
+ 
+-    public RaidSpawnWaveEvent(@NotNull Raid raid, @NotNull World world, @Nullable Raider leader, @NotNull List<Raider> raiders) {
++    public RaidSpawnWaveEvent(@NotNull Raid raid, @NotNull World world, @NotNull Raider leader, @NotNull List<Raider> raiders) { // Paper
+         super(raid, world);
+         this.raiders = raiders;
+         this.leader = leader;
+@@ -30,7 +30,7 @@ public class RaidSpawnWaveEvent extends RaidEvent {
+      *
+      * @return {@link Raider}
+      */
+-    @Nullable
++    @NotNull // Paper
+     public Raider getPatrolLeader() {
+         return leader;
      }
 diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleEntityCollisionEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleEntityCollisionEvent.java
 index 6bafc62e2235a6b783cbf96f4dabeeaf02bd5178..50c762d777ac90a05772501a28cacff8fd3f5126 100644

--- a/patches/api/0237-Add-EntityLoadCrossbowEvent.patch
+++ b/patches/api/0237-Add-EntityLoadCrossbowEvent.patch
@@ -6,33 +6,34 @@ Subject: [PATCH] Add EntityLoadCrossbowEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityLoadCrossbowEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityLoadCrossbowEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..aa9ccd7c806e864455ecd5f15ddb17c0fa8728c4
+index 0000000000000000000000000000000000000000..66e41bfe89f35d3947ea47aedcd36ac8f01ac5b6
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityLoadCrossbowEvent.java
-@@ -0,0 +1,97 @@
+@@ -0,0 +1,98 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.LivingEntity;
-+import org.bukkit.entity.Player;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.bukkit.inventory.EquipmentSlot;
 +import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
-+import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Called when a LivingEntity loads a crossbow with a projectile.
 + */
 +public class EntityLoadCrossbowEvent extends EntityEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private final ItemStack crossbow;
 +    private final EquipmentSlot hand;
 +    private boolean cancelled;
 +    private boolean consumeItem = true;
 +
-+    public EntityLoadCrossbowEvent(@NotNull LivingEntity entity, @Nullable ItemStack crossbow, @NotNull EquipmentSlot hand) {
++    @ApiStatus.Internal
++    public EntityLoadCrossbowEvent(@NotNull LivingEntity entity, @NotNull ItemStack crossbow, @NotNull EquipmentSlot hand) {
 +        super(entity);
 +        this.crossbow = crossbow;
 +        this.hand = hand;
@@ -49,7 +50,7 @@ index 0000000000000000000000000000000000000000..aa9ccd7c806e864455ecd5f15ddb17c0
 +     *
 +     * @return the crossbow involved in this event
 +     */
-+    @Nullable
++    @NotNull
 +    public ItemStack getCrossbow() {
 +        return crossbow;
 +    }
@@ -99,11 +100,11 @@ index 0000000000000000000000000000000000000000..aa9ccd7c806e864455ecd5f15ddb17c0
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0249-Added-PlayerChangeBeaconEffectEvent.patch
+++ b/patches/api/0249-Added-PlayerChangeBeaconEffectEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Added PlayerChangeBeaconEffectEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7646050f4bfc9092afaae9f769b0f7ecb42262ff
+index 0000000000000000000000000000000000000000..812712b3b233c454dfab039fb9f16d6becca2d93
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java
-@@ -0,0 +1,141 @@
+@@ -0,0 +1,143 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.block.Block;
@@ -18,6 +18,7 @@ index 0000000000000000000000000000000000000000..7646050f4bfc9092afaae9f769b0f7ec
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.potion.PotionEffectType;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
@@ -25,7 +26,7 @@ index 0000000000000000000000000000000000000000..7646050f4bfc9092afaae9f769b0f7ec
 + * Called when a player sets the effect for a beacon
 + */
 +public class PlayerChangeBeaconEffectEvent extends PlayerEvent implements Cancellable {
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
 +
 +    private PotionEffectType primary;
 +    private PotionEffectType secondary;
@@ -34,7 +35,8 @@ index 0000000000000000000000000000000000000000..7646050f4bfc9092afaae9f769b0f7ec
 +
 +    private boolean isCancelled;
 +
-+    public PlayerChangeBeaconEffectEvent(@NotNull Player player, @Nullable PotionEffectType primary, @Nullable PotionEffectType secondary, @Nullable Block beacon) {
++    @ApiStatus.Internal
++    public PlayerChangeBeaconEffectEvent(@NotNull Player player, @Nullable PotionEffectType primary, @Nullable PotionEffectType secondary, @NotNull Block beacon) {
 +        super(player);
 +        this.primary = primary;
 +        this.secondary = secondary;
@@ -80,9 +82,9 @@ index 0000000000000000000000000000000000000000..7646050f4bfc9092afaae9f769b0f7ec
 +    }
 +
 +    /**
-+     * @return the beacon block associated with this event, or null if not found
++     * @return the beacon block associated with this event
 +     */
-+    @Nullable
++    @NotNull
 +    public Block getBeacon() {
 +        return beacon;
 +    }
@@ -143,11 +145,11 @@ index 0000000000000000000000000000000000000000..7646050f4bfc9092afaae9f769b0f7ec
 +
 +    @Override
 +    public @NotNull HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}

--- a/patches/api/0301-Add-PlayerSignCommandPreprocessEvent.patch
+++ b/patches/api/0301-Add-PlayerSignCommandPreprocessEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add PlayerSignCommandPreprocessEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerSignCommandPreprocessEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerSignCommandPreprocessEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6e539aee02fd5399e6b8f064a3ea368c12a54a53
+index 0000000000000000000000000000000000000000..dc774403749633a1bf8e8088b8c7b402b0e43863
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerSignCommandPreprocessEvent.java
 @@ -0,0 +1,47 @@
@@ -33,7 +33,7 @@ index 0000000000000000000000000000000000000000..6e539aee02fd5399e6b8f064a3ea368c
 +    private final Side side;
 +
 +    @ApiStatus.Internal
-+    public PlayerSignCommandPreprocessEvent(@NotNull Player player, @NotNull String message, @NotNull Set<Player> recipients, @NotNull Sign sign, final Side side) {
++    public PlayerSignCommandPreprocessEvent(@NotNull Player player, @NotNull String message, @NotNull Set<Player> recipients, @NotNull Sign sign, @NotNull Side side) {
 +        super(player, message, recipients);
 +        this.sign = sign;
 +        this.side = side;

--- a/patches/api/0366-Add-WardenAngerChangeEvent.patch
+++ b/patches/api/0366-Add-WardenAngerChangeEvent.patch
@@ -8,10 +8,10 @@ another entity.
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/WardenAngerChangeEvent.java b/src/main/java/io/papermc/paper/event/entity/WardenAngerChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4fd31d4d8b35f27789f3cd9581e7c17a6bde5373
+index 0000000000000000000000000000000000000000..6da98b535c9ba57942faa62e1172a62b84ab0b6a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/WardenAngerChangeEvent.java
-@@ -0,0 +1,103 @@
+@@ -0,0 +1,105 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.Entity;
@@ -19,8 +19,8 @@ index 0000000000000000000000000000000000000000..4fd31d4d8b35f27789f3cd9581e7c17a
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.ApiStatus;
 +import org.jetbrains.annotations.NotNull;
-+import org.jetbrains.annotations.Nullable;
 +
 +/**
 + * Called when a Warden's anger level has changed due to another entity.
@@ -29,13 +29,15 @@ index 0000000000000000000000000000000000000000..4fd31d4d8b35f27789f3cd9581e7c17a
 + */
 +public class WardenAngerChangeEvent extends EntityEvent implements Cancellable {
 +
-+    private static final HandlerList handlers = new HandlerList();
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
 +    private boolean cancelled;
 +    private final Entity target;
 +    private final int oldAnger;
 +    private int newAnger;
 +
-+    public WardenAngerChangeEvent(@NotNull final Warden warden, @Nullable final Entity target, final int oldAnger, final int newAnger) {
++    @ApiStatus.Internal
++    public WardenAngerChangeEvent(@NotNull final Warden warden, @NotNull final Entity target, final int oldAnger, final int newAnger) {
 +        super(warden);
 +        this.target = target;
 +        this.oldAnger = oldAnger;
@@ -43,11 +45,11 @@ index 0000000000000000000000000000000000000000..4fd31d4d8b35f27789f3cd9581e7c17a
 +    }
 +
 +    /**
-+     * Gets the entity (if any) which triggered this anger update.
++     * Gets the entity which triggered this anger update.
 +     *
-+     * @return triggering entity, or null
++     * @return triggering entity
 +     */
-+    @Nullable
++    @NotNull
 +    public Entity getTarget() {
 +        return target;
 +    }
@@ -107,11 +109,11 @@ index 0000000000000000000000000000000000000000..4fd31d4d8b35f27789f3cd9581e7c17a
 +    @NotNull
 +    @Override
 +    public HandlerList getHandlers() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +
 +    @NotNull
 +    public static HandlerList getHandlerList() {
-+        return handlers;
++        return HANDLER_LIST;
 +    }
 +}


### PR DESCRIPTION
Swap a lot of wrong nullable annotations (only events for now)

Some example:
The SpawnerSpawnEvent#getSpawner can become null when the spawn is done from a minecart spawner
and the HangingBreakByEntityEvent#getRemover doesn't seems to be null even when the entity is damaged by an explosion.