### PR TITLE
Add timeDamaged to EntityDamageEvent

### DIFF
--- a/patches/api/0440-Add-timeDamaged-to-EntityDamageEvent.patch
+++ b/patches/api/0440-Add-timeDamaged-to-EntityDamageEvent.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cryptite <cryptite@gmail.com>
+Date: Sun, 10 Sep 2023 08:05:46 -0500
+Subject: [PATCH] Add timeDamaged to EntityDamageEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+index 4773f537dec20d6ebd82e4b145a1cdea0077fe90..2a3a7060200147d7dcf48bfaf5f66f07393b97b5 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityDamageEvent.java
+@@ -27,6 +27,7 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
+     private final Map<DamageModifier, Double> originals;
+     private boolean cancelled;
+     private final DamageCause cause;
++    private long timeDamaged = System.currentTimeMillis(); // Paper
+ 
+     public EntityDamageEvent(@NotNull final Entity damagee, @NotNull final DamageCause cause, final double damage) {
+         this(damagee, cause, new EnumMap<DamageModifier, Double>(ImmutableMap.of(DamageModifier.BASE, damage)), new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, ZERO)));
+@@ -193,6 +194,22 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
+         return cause;
+     }
+ 
++    // Paper start
++    /**
++     * @return Get the time the damage event happened.
++     */
++    public long getTimeDamaged() {
++        return timeDamaged;
++    }
++
++    /**
++     * @param timeDamaged Set the time the damage event happened, if you so choose.
++     */
++    public void setTimeDamaged(long timeDamaged) {
++        this.timeDamaged = timeDamaged;
++    }
++    // Paper end
++
+     @NotNull
+     @Override
+     public HandlerList getHandlers() {


### PR DESCRIPTION
My finest work yet. Just a simple way to fetch the time an EntityDamageEvent happened. 

Unsure if we want to use things like epoch time still or whether we're trying to use things like ticks or other time measurements; happy to update as needed if so.