### PR TITLE
Ensure destination is unloaded when preventing movement into unloaded chunks.

### DIFF
--- a/patches/server/1032-Ensure-final-chunk-is-unloaded-when-preventing-movem.patch
+++ b/patches/server/1032-Ensure-final-chunk-is-unloaded-when-preventing-movem.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pseudospace0 <pseudospace0@proton.me>
+Date: Mon, 11 Sep 2023 21:32:47 +0200
+Subject: [PATCH] Ensure final chunk is unloaded when preventing movement to
+ unloaded chunks
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 3c0651fa5a5db880202c9a3805a6455269c5f16d..291c12fb9c9fb10c654b15ac94c62b139c914fc3 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -649,7 +649,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                 if (this.player.level().paperConfig().chunks.preventMovingIntoUnloadedChunks && (
+                     !worldserver.areChunksLoadedForMove(this.player.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(this.player.position()))) ||
+                         !worldserver.areChunksLoadedForMove(entity.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(entity.position())))
+-                    )) {
++                    ) && worldserver.getChunkSource().getChunkAtIfLoadedImmediately((int)toX >> 4, (int)toZ >> 4) == null) {
+                     this.connection.send(new ClientboundMoveVehiclePacket(entity));
+                     return;
+                 }
+@@ -1484,7 +1484,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                                 speed = this.player.getAbilities().walkingSpeed * 10f;
+                             }
+                             // Paper start - Prevent moving into unloaded chunks
+-                            if (this.player.level().paperConfig().chunks.preventMovingIntoUnloadedChunks && (this.player.getX() != toX || this.player.getZ() != toZ) && !worldserver.areChunksLoadedForMove(this.player.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(this.player.position())))) {
++                            if (this.player.level().paperConfig().chunks.preventMovingIntoUnloadedChunks && (this.player.getX() != toX || this.player.getZ() != toZ) && !worldserver.areChunksLoadedForMove(this.player.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(this.player.position()))) && worldserver.getChunkSource().getChunkAtIfLoadedImmediately((int)toX >> 4, (int)toZ >> 4) == null) {
+                                 // Paper start - Add fail move event
+                                 io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_INTO_UNLOADED_CHUNK,
+                                     toX, toY, toZ, toYaw, toPitch, false);


### PR DESCRIPTION
When preventing players from moving into unloaded chunks; I would argue that if a scenario arises where the player is attempting to move to a chunk which is indeed loaded, but is sandwiched between a one or more unloaded chunks it would be more beneficial for the method to return in a place where a warning message is explicitly logged rather than just silently not allowing the movement. 

This can be done by ensuring that the location of the movement resides in an unloaded chunk.