### PR TITLE
Fix missing map initialize event call & missing map id assignment

### DIFF
--- a/patches/server/1034-Fix-missing-map-initialize-event-call.patch
+++ b/patches/server/1034-Fix-missing-map-initialize-event-call.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Warrior <50800980+Warriorrrr@users.noreply.github.com>
+Date: Sun, 24 Sep 2023 18:35:28 +0200
+Subject: [PATCH] Fix missing map initialize event call
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index f502b01b564bd33c449cbe621966ef4076a38cca..868951dc21aff541765b1f58f08cdf3c47446d25 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -2099,7 +2099,23 @@ public class ServerLevel extends Level implements WorldGenLevel {
+     @Nullable
+     @Override
+     public MapItemSavedData getMapData(String id) {
+-        return (MapItemSavedData) this.getServer().overworld().getDataStorage().get(MapItemSavedData.factory(), id);
++        // Paper start - Call missing map initialize event & set id
++        final DimensionDataStorage storage = this.getServer().overworld().getDataStorage();
++
++        final net.minecraft.world.level.saveddata.SavedData existing = storage.cache.get(id);
++        if (existing == null && !storage.cache.containsKey(id)) {
++            final net.minecraft.world.level.saveddata.SavedData.Factory<MapItemSavedData> factory = MapItemSavedData.factory();
++            final MapItemSavedData map = storage.readSavedData(factory.deserializer(), factory.type(), id);
++            if (map != null) {
++                map.id = id;
++                new MapInitializeEvent(map.mapView).callEvent();
++            }
++
++            storage.cache.put(id, map);
++        }
++
++        return existing instanceof MapItemSavedData data ? data : null;
++        // Paper end
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/world/level/storage/DimensionDataStorage.java b/src/main/java/net/minecraft/world/level/storage/DimensionDataStorage.java
+index bd30ebc66484a6c4770cf697a2e9b0a123681b1c..f921f55e815a4da01828e025881a7a03591c3978 100644
+--- a/src/main/java/net/minecraft/world/level/storage/DimensionDataStorage.java
++++ b/src/main/java/net/minecraft/world/level/storage/DimensionDataStorage.java
+@@ -57,7 +57,7 @@ public class DimensionDataStorage {
+     }
+ 
+     @Nullable
+-    private <T extends SavedData> T readSavedData(Function<CompoundTag, T> readFunction, DataFixTypes dataFixTypes, String id) {
++    public <T extends SavedData> T readSavedData(Function<CompoundTag, T> readFunction, DataFixTypes dataFixTypes, String id) { // Paper
+         try {
+             File file = this.getDataFile(id);
+             if (file.exists()) {


### PR DESCRIPTION
Fixes maps not having their id field assigned which causes an NPE when a plugin tries to get the id, also fixes the initialize event not being called in this spot.

If it's possible to replace the private -> public with an AT then let me know, wasn't sure how to handle the generic return type