### PR TITLE
Added GrindstoneExtractEvent

### DIFF
--- a/patches/api/0441-Added-GrindstoneExtractEvent.patch
+++ b/patches/api/0441-Added-GrindstoneExtractEvent.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tamion <70228790+notTamion@users.noreply.github.com>
+Date: Mon, 25 Sep 2023 17:06:47 +0200
+Subject: [PATCH] Added GrindstoneExtractEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/inventory/GrindstoneExtractEvent.java b/src/main/java/io/papermc/paper/event/inventory/GrindstoneExtractEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..0df17f7df5daf9a8646db16b5485dfbee51dd66b
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/inventory/GrindstoneExtractEvent.java
+@@ -0,0 +1,40 @@
++package io.papermc.paper.event.inventory;
++
++import org.bukkit.block.Block;
++import org.bukkit.entity.Player;
++import org.bukkit.event.block.BlockExpEvent;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * This event is called when a player takes an item out of a grindstone
++ */
++public class GrindstoneExtractEvent extends BlockExpEvent {
++    private final Player player;
++    private final ItemStack itemStack;
++
++    public GrindstoneExtractEvent(@NotNull Player player, @NotNull Block block, @NotNull ItemStack itemStack, int exp) {
++        super(block, exp);
++        this.player = player;
++        this.itemStack = itemStack;
++    }
++
++    /**
++     * Get the player that triggered the event
++     *
++     * @return the relevant player
++     */
++    @NotNull
++    public Player getPlayer() {
++        return player;
++    }
++
++    /**
++     * Get a copy of the ItemStack that is being retrieved
++     *
++     * @return copy of the ItemStack
++     */
++    public ItemStack getItemStack() {
++        return itemStack;
++    }
++}

--- a/patches/server/1035-Added-GrindstoneExtractEvent.patch
+++ b/patches/server/1035-Added-GrindstoneExtractEvent.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tamion <70228790+notTamion@users.noreply.github.com>
+Date: Mon, 25 Sep 2023 17:06:21 +0200
+Subject: [PATCH] Added GrindstoneExtractEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
+index a21eadcdfbdc4be803c5793bc97996db3e706071..c346e6972f9c1dff24a3060c843f193fa9af0b13 100644
+--- a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
+@@ -4,6 +4,12 @@ import java.util.Iterator;
+ import java.util.Map;
+ import java.util.Map.Entry;
+ import java.util.stream.Collectors;
++// Paper start
++import io.papermc.paper.event.inventory.GrindstoneExtractEvent;
++import org.bukkit.Bukkit;
++import org.bukkit.craftbukkit.block.CraftBlock;
++import org.bukkit.event.block.BlockExpEvent;
++// Paper end
+ import net.minecraft.server.level.ServerLevel;
+ import net.minecraft.world.Container;
+ import net.minecraft.world.SimpleContainer;
+@@ -96,8 +102,12 @@ public class GrindstoneMenu extends AbstractContainerMenu {
+             @Override
+             public void onTake(net.minecraft.world.entity.player.Player player, ItemStack stack) {
+                 context.execute((world, blockposition) -> {
++                    // Paper start
++                    BlockExpEvent event = new GrindstoneExtractEvent((Player) player.getBukkitEntity(), CraftBlock.at(world, blockposition), stack.asBukkitCopy(),this.getExperienceAmount(world));
++                    Bukkit.getServer().getPluginManager().callEvent(event);
++                    // Paper end
+                     if (world instanceof ServerLevel) {
+-                        ExperienceOrb.award((ServerLevel) world, Vec3.atCenterOf(blockposition), this.getExperienceAmount(world), org.bukkit.entity.ExperienceOrb.SpawnReason.GRINDSTONE, player); // Paper
++                        ExperienceOrb.award((ServerLevel) world, Vec3.atCenterOf(blockposition), event.getExpToDrop(), org.bukkit.entity.ExperienceOrb.SpawnReason.GRINDSTONE, player); // Paper
+                     }
+ 
+                     world.levelEvent(1042, blockposition, 0);
+@@ -327,7 +337,7 @@ public class GrindstoneMenu extends AbstractContainerMenu {
+                 return ItemStack.EMPTY;
+             }
+ 
+-            slot1.onTake(player, itemstack1);
++            slot1.onTake(player, itemstack); // Paper - itemstack1 is AIR on shift-click
+         }
+ 
+         return itemstack;


### PR DESCRIPTION
Adds an event that gets called before the ExperienceOrb is spawned because of using a Grindstone. Allows you to get a copy of the ItemStack, modify/get the amount of Experience and get the Player involved

Calling onTake with itemstack instead of itemstack1 should not be an issue since it is not used anywhere except in the onTake method of the resultslot (Calling the event). Though someone should probably double check that.