### PR TITLE
Add support for custom titles to HumanEntity inventory open methods

### DIFF
--- a/patches/api/0441-Add-optional-title-parameters-to-inventory-open-meth.patch
+++ b/patches/api/0441-Add-optional-title-parameters-to-inventory-open-meth.patch
@@ -6,18 +6,10 @@ Subject: [PATCH] Add optional title parameters to inventory open methods in
 
 
 diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
-index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14cedb2cc65 100644
+index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..3132131e294f5880732c77ec5d6757db7e29c0fc 100644
 --- a/src/main/java/org/bukkit/entity/HumanEntity.java
 +++ b/src/main/java/org/bukkit/entity/HumanEntity.java
-@@ -2,6 +2,7 @@ package org.bukkit.entity;
- 
- import java.util.Collection;
- import java.util.Set;
-+import net.kyori.adventure.text.Component;
- import org.bukkit.GameMode;
- import org.bukkit.Location;
- import org.bukkit.Material;
-@@ -122,8 +123,30 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -122,8 +122,30 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       * @return The newly opened inventory view, or null if it could not be
       *     opened.
       */
@@ -44,12 +36,12 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openWorkbench(@Nullable Location location, boolean force, @Nullable Component title);
++    public InventoryView openWorkbench(@Nullable Location location, boolean force, net.kyori.adventure.text.@Nullable Component title);
 +    // Paper end
  
      /**
       * Opens an empty enchanting inventory window with the player's inventory
-@@ -136,8 +159,30 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -136,8 +158,30 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       * @return The newly opened inventory view, or null if it could not be
       *     opened.
       */
@@ -76,12 +68,12 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openEnchanting(@Nullable Location location, boolean force, @Nullable Component title);
++    public InventoryView openEnchanting(@Nullable Location location, boolean force, net.kyori.adventure.text.@Nullable Component title);
 +    // Paper end
  
      /**
       * Opens an inventory window to the specified inventory view.
-@@ -187,7 +232,41 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -187,7 +231,41 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       *     opened.
       */
      @Nullable
@@ -104,7 +96,7 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openAnvil(@Nullable Location location, boolean force, @Nullable Component title);
++    public InventoryView openAnvil(@Nullable Location location, boolean force, net.kyori.adventure.text.@Nullable Component title);
 +
 +    /**
 +     * Opens an empty cartography table inventory window with the player's inventory
@@ -124,7 +116,7 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
  
      /**
       * Opens an empty cartography table inventory window with the player's inventory
-@@ -197,11 +276,29 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -197,11 +275,29 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       *     location is used.
       * @param force If false, and there is no cartography table block at the location,
       *     no inventory will be opened and null will be returned.
@@ -134,7 +126,7 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openCartographyTable(@Nullable Location location, boolean force, @Nullable Component title);
++    public InventoryView openCartographyTable(@Nullable Location location, boolean force, net.kyori.adventure.text.@Nullable Component title);
 +
 +    /**
 +     * Opens an empty grindstone inventory window with the player's inventory
@@ -155,7 +147,7 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
  
      /**
       * Opens an empty grindstone inventory window with the player's inventory
-@@ -211,11 +308,13 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -211,11 +307,13 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       *     location is used.
       * @param force If false, and there is no grindstone block at the location,
       *     no inventory will be opened and null will be returned.
@@ -166,11 +158,11 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
       */
      @Nullable
 -    public InventoryView openGrindstone(@Nullable Location location, boolean force);
-+    public InventoryView openGrindstone(@Nullable Location location, boolean force, @Nullable Component title);
++    public InventoryView openGrindstone(@Nullable Location location, boolean force, net.kyori.adventure.text.@Nullable Component title);
  
      /**
       * Opens an empty loom inventory window with the player's inventory
-@@ -229,7 +328,41 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -229,7 +327,41 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       *     opened.
       */
      @Nullable
@@ -193,7 +185,7 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
 +     *     opened.
 +     */
 +    @Nullable
-+    public InventoryView openLoom(@Nullable Location location, boolean force, @Nullable Component title);
++    public InventoryView openLoom(@Nullable Location location, boolean force, net.kyori.adventure.text.@Nullable Component title);
 +
 +    /**
 +     * Opens an empty smithing table inventory window with the player's inventory
@@ -213,7 +205,7 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
  
      /**
       * Opens an empty smithing table inventory window with the player's inventory
-@@ -239,11 +372,29 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -239,11 +371,29 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       *     location is used.
       * @param force If false, and there is no smithing table block at the location,
       *     no inventory will be opened and null will be returned.
@@ -224,7 +216,7 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
       */
      @Nullable
 -    public InventoryView openSmithingTable(@Nullable Location location, boolean force);
-+    public InventoryView openSmithingTable(@Nullable Location location, boolean force, @Nullable Component title);
++    public InventoryView openSmithingTable(@Nullable Location location, boolean force, net.kyori.adventure.text.@Nullable Component title);
 +
 +    /**
 +     * Opens an empty stonecutter inventory window with the player's inventory
@@ -244,7 +236,7 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
  
      /**
       * Opens an empty stonecutter inventory window with the player's inventory
-@@ -253,11 +404,13 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+@@ -253,11 +403,13 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
       *     location is used.
       * @param force If false, and there is no stonecutter block at the location,
       *     no inventory will be opened and null will be returned.
@@ -255,7 +247,7 @@ index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14c
       */
      @Nullable
 -    public InventoryView openStonecutter(@Nullable Location location, boolean force);
-+    public InventoryView openStonecutter(@Nullable Location location, boolean force, @Nullable Component title);
++    public InventoryView openStonecutter(@Nullable Location location, boolean force, net.kyori.adventure.text.@Nullable Component title);
      // Paper end
  
      /**

--- a/patches/api/0441-Add-optional-title-parameters-to-inventory-open-meth.patch
+++ b/patches/api/0441-Add-optional-title-parameters-to-inventory-open-meth.patch
@@ -1,0 +1,261 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TrollyLoki <trollyloki@gmail.com>
+Date: Thu, 28 Sep 2023 22:47:28 -0400
+Subject: [PATCH] Add optional title parameters to inventory open methods in
+ HumanEntity
+
+
+diff --git a/src/main/java/org/bukkit/entity/HumanEntity.java b/src/main/java/org/bukkit/entity/HumanEntity.java
+index 8b0d04d5b39ee817555a36adddc39b18fc6f0d02..806c2a50a6dba5f9e645498b20d4c14cedb2cc65 100644
+--- a/src/main/java/org/bukkit/entity/HumanEntity.java
++++ b/src/main/java/org/bukkit/entity/HumanEntity.java
+@@ -2,6 +2,7 @@ package org.bukkit.entity;
+ 
+ import java.util.Collection;
+ import java.util.Set;
++import net.kyori.adventure.text.Component;
+ import org.bukkit.GameMode;
+ import org.bukkit.Location;
+ import org.bukkit.Material;
+@@ -122,8 +123,30 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      * @return The newly opened inventory view, or null if it could not be
+      *     opened.
+      */
++    // Paper start - default implementation
+     @Nullable
+-    public InventoryView openWorkbench(@Nullable Location location, boolean force);
++    public default InventoryView openWorkbench(@Nullable Location location, boolean force) {
++        return this.openWorkbench(location, force, null);
++    }
++    // Paper end
++
++    // Paper start
++    /**
++     * Opens an empty workbench inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no workbench block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @param title The title to display at the top of the inventory. If null,
++     *     the default title is used.
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    public InventoryView openWorkbench(@Nullable Location location, boolean force, @Nullable Component title);
++    // Paper end
+ 
+     /**
+      * Opens an empty enchanting inventory window with the player's inventory
+@@ -136,8 +159,30 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      * @return The newly opened inventory view, or null if it could not be
+      *     opened.
+      */
++    // Paper start - default implementation
+     @Nullable
+-    public InventoryView openEnchanting(@Nullable Location location, boolean force);
++    public default InventoryView openEnchanting(@Nullable Location location, boolean force) {
++        return this.openEnchanting(location, force, null);
++    }
++    // Paper end
++
++    // Paper start
++    /**
++     * Opens an empty enchanting inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no enchanting table at the
++     *     location, no inventory will be opened and null will be returned.
++     * @param title The title to display at the top of the inventory. If null,
++     *     the default title is used.
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    public InventoryView openEnchanting(@Nullable Location location, boolean force, @Nullable Component title);
++    // Paper end
+ 
+     /**
+      * Opens an inventory window to the specified inventory view.
+@@ -187,7 +232,41 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      *     opened.
+      */
+     @Nullable
+-    public InventoryView openAnvil(@Nullable Location location, boolean force);
++    public default InventoryView openAnvil(@Nullable Location location, boolean force) {
++        return this.openAnvil(location, force, null);
++    }
++
++    /**
++     * Opens an empty anvil inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no anvil block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @param title The title to display at the top of the inventory. If null,
++     *     the default title is used.
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    public InventoryView openAnvil(@Nullable Location location, boolean force, @Nullable Component title);
++
++    /**
++     * Opens an empty cartography table inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no cartography table block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    public default InventoryView openCartographyTable(@Nullable Location location, boolean force) {
++        return this.openCartographyTable(location, force, null);
++    }
+ 
+     /**
+      * Opens an empty cartography table inventory window with the player's inventory
+@@ -197,11 +276,29 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      *     location is used.
+      * @param force If false, and there is no cartography table block at the location,
+      *     no inventory will be opened and null will be returned.
++     * @param title The title to display at the top of the inventory. If null,
++     *     the default title is used.
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    public InventoryView openCartographyTable(@Nullable Location location, boolean force, @Nullable Component title);
++
++    /**
++     * Opens an empty grindstone inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no grindstone block at the location,
++     *     no inventory will be opened and null will be returned.
+      * @return The newly opened inventory view, or null if it could not be
+      *     opened.
+      */
+     @Nullable
+-    public InventoryView openCartographyTable(@Nullable Location location, boolean force);
++    public default InventoryView openGrindstone(@Nullable Location location, boolean force) {
++        return this.openGrindstone(location, force, null);
++    }
+ 
+     /**
+      * Opens an empty grindstone inventory window with the player's inventory
+@@ -211,11 +308,13 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      *     location is used.
+      * @param force If false, and there is no grindstone block at the location,
+      *     no inventory will be opened and null will be returned.
++     * @param title The title to display at the top of the inventory. If null,
++     *     the default title is used.
+      * @return The newly opened inventory view, or null if it could not be
+      *     opened.
+      */
+     @Nullable
+-    public InventoryView openGrindstone(@Nullable Location location, boolean force);
++    public InventoryView openGrindstone(@Nullable Location location, boolean force, @Nullable Component title);
+ 
+     /**
+      * Opens an empty loom inventory window with the player's inventory
+@@ -229,7 +328,41 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      *     opened.
+      */
+     @Nullable
+-    public InventoryView openLoom(@Nullable Location location, boolean force);
++    public default InventoryView openLoom(@Nullable Location location, boolean force) {
++        return this.openLoom(location, force, null);
++    }
++
++    /**
++     * Opens an empty loom inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no loom block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @param title The title to display at the top of the inventory. If null,
++     *     the default title is used.
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    public InventoryView openLoom(@Nullable Location location, boolean force, @Nullable Component title);
++
++    /**
++     * Opens an empty smithing table inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no smithing table block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    public default InventoryView openSmithingTable(@Nullable Location location, boolean force) {
++        return this.openSmithingTable(location, force, null);
++    }
+ 
+     /**
+      * Opens an empty smithing table inventory window with the player's inventory
+@@ -239,11 +372,29 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      *     location is used.
+      * @param force If false, and there is no smithing table block at the location,
+      *     no inventory will be opened and null will be returned.
++     * @param title The title to display at the top of the inventory. If null,
++     *     the default title is used.
+      * @return The newly opened inventory view, or null if it could not be
+      *     opened.
+      */
+     @Nullable
+-    public InventoryView openSmithingTable(@Nullable Location location, boolean force);
++    public InventoryView openSmithingTable(@Nullable Location location, boolean force, @Nullable Component title);
++
++    /**
++     * Opens an empty stonecutter inventory window with the player's inventory
++     * on the bottom.
++     *
++     * @param location The location to attach it to. If null, the player's
++     *     location is used.
++     * @param force If false, and there is no stonecutter block at the location,
++     *     no inventory will be opened and null will be returned.
++     * @return The newly opened inventory view, or null if it could not be
++     *     opened.
++     */
++    @Nullable
++    public default InventoryView openStonecutter(@Nullable Location location, boolean force) {
++        return this.openStonecutter(location, force, null);
++    }
+ 
+     /**
+      * Opens an empty stonecutter inventory window with the player's inventory
+@@ -253,11 +404,13 @@ public interface HumanEntity extends LivingEntity, AnimalTamer, InventoryHolder
+      *     location is used.
+      * @param force If false, and there is no stonecutter block at the location,
+      *     no inventory will be opened and null will be returned.
++     * @param title The title to display at the top of the inventory. If null,
++     *     the default title is used.
+      * @return The newly opened inventory view, or null if it could not be
+      *     opened.
+      */
+     @Nullable
+-    public InventoryView openStonecutter(@Nullable Location location, boolean force);
++    public InventoryView openStonecutter(@Nullable Location location, boolean force, @Nullable Component title);
+     // Paper end
+ 
+     /**

--- a/patches/server/1036-Add-support-for-custom-titles-to-inventory-open-meth.patch
+++ b/patches/server/1036-Add-support-for-custom-titles-to-inventory-open-meth.patch
@@ -1,0 +1,139 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TrollyLoki <trollyloki@gmail.com>
+Date: Thu, 28 Sep 2023 23:20:20 -0400
+Subject: [PATCH] Add support for custom titles to inventory open methods in
+ CraftHumanEntity
+
+All the relevant methods open instances of SimpleMenuProvider, which has a title field that is now set based on new method parameters.
+
+== AT ==
+public-f net.minecraft.world.SimpleMenuProvider title
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+index 017e97c1618b8ee4640b36a0ec1b07026047bfc3..d31aebe7efdabc48f2a44c25d1ea60fc189aefb5 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+@@ -374,8 +374,22 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+         player.initMenu(container);
+     }
+ 
++    // Paper start - helper method for setting titles
++    private void modifyMenuProviderTitle(MenuProvider menuProvider, net.kyori.adventure.text.Component title) {
++        if (title == null) {
++            return;
++        }
++
++        if (menuProvider instanceof net.minecraft.world.SimpleMenuProvider simple) {
++            simple.title = io.papermc.paper.adventure.PaperAdventure.asVanilla(title);
++        } else {
++            throw new IllegalArgumentException("Unsupported inventory for custom title");
++        }
++    }
++    // Paper end
++
+     @Override
+-    public InventoryView openWorkbench(Location location, boolean force) {
++    public InventoryView openWorkbench(Location location, boolean force, net.kyori.adventure.text.Component title) { // Paper - add title parameter
+         if (location == null) {
+             location = getLocation();
+         }
+@@ -385,7 +399,11 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+                 return null;
+             }
+         }
+-        this.getHandle().openMenu(((CraftingTableBlock) Blocks.CRAFTING_TABLE).getMenuProvider(null, this.getHandle().level(), CraftLocation.toBlockPosition(location)));
++        // Paper start - modify title
++        MenuProvider menuProvider = ((CraftingTableBlock) Blocks.CRAFTING_TABLE).getMenuProvider(null, this.getHandle().level(), CraftLocation.toBlockPosition(location));
++        modifyMenuProviderTitle(menuProvider, title);
++        this.getHandle().openMenu(menuProvider);
++        // Paper end
+         if (force) {
+             this.getHandle().containerMenu.checkReachable = false;
+         }
+@@ -393,7 +411,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+     }
+ 
+     @Override
+-    public InventoryView openEnchanting(Location location, boolean force) {
++    public InventoryView openEnchanting(Location location, boolean force, net.kyori.adventure.text.Component title) { // Paper - add title parameter
+         if (location == null) {
+             location = getLocation();
+         }
+@@ -416,6 +434,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+                 return new net.minecraft.world.inventory.EnchantmentMenu(syncId, inventory, net.minecraft.world.inventory.ContainerLevelAccess.create(this.getHandle().level(), pos));
+             }, Component.translatable("container.enchant"));
+         }
++        modifyMenuProviderTitle(menuProvider, title);
+         this.getHandle().openMenu(menuProvider);
+         // Paper end
+ 
+@@ -464,7 +483,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+     }
+ 
+     @Override
+-    public InventoryView openMerchant(Villager villager, boolean force) {
++    public InventoryView openMerchant(Villager villager, boolean force) { // Paper - add title parameter
+         Preconditions.checkNotNull(villager, "villager cannot be null");
+ 
+         return this.openMerchant((Merchant) villager, force);
+@@ -505,36 +524,36 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+ 
+     // Paper start - Add additional containers
+     @Override
+-    public InventoryView openAnvil(Location location, boolean force) {
+-        return this.openInventory(location, force, Material.ANVIL);
++    public InventoryView openAnvil(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Material.ANVIL, title);
+     }
+ 
+     @Override
+-    public InventoryView openCartographyTable(Location location, boolean force) {
+-        return this.openInventory(location, force, Material.CARTOGRAPHY_TABLE);
++    public InventoryView openCartographyTable(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Material.CARTOGRAPHY_TABLE, title);
+     }
+ 
+     @Override
+-    public InventoryView openGrindstone(Location location, boolean force) {
+-        return this.openInventory(location, force, Material.GRINDSTONE);
++    public InventoryView openGrindstone(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Material.GRINDSTONE, title);
+     }
+ 
+     @Override
+-    public InventoryView openLoom(Location location, boolean force) {
+-        return this.openInventory(location, force, Material.LOOM);
++    public InventoryView openLoom(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Material.LOOM, title);
+     }
+ 
+     @Override
+-    public InventoryView openSmithingTable(Location location, boolean force) {
+-        return this.openInventory(location, force, Material.SMITHING_TABLE);
++    public InventoryView openSmithingTable(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Material.SMITHING_TABLE, title);
+     }
+ 
+     @Override
+-    public InventoryView openStonecutter(Location location, boolean force) {
+-        return this.openInventory(location, force, Material.STONECUTTER);
++    public InventoryView openStonecutter(Location location, boolean force, net.kyori.adventure.text.Component title) {
++        return this.openInventory(location, force, Material.STONECUTTER, title);
+     }
+ 
+-    private InventoryView openInventory(Location location, boolean force, Material material) {
++    private InventoryView openInventory(Location location, boolean force, Material material, net.kyori.adventure.text.Component title) {
+         org.spigotmc.AsyncCatcher.catchOp("open" + material);
+         if (location == null) {
+             location = this.getLocation();
+@@ -561,7 +580,9 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+         } else {
+             throw new IllegalArgumentException("Unsupported inventory type: " + material);
+         }
+-        this.getHandle().openMenu(block.getMenuProvider(null, this.getHandle().level(), new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ())));
++        MenuProvider menuProvider = block.getMenuProvider(null, this.getHandle().level(), new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()));
++        modifyMenuProviderTitle(menuProvider, title);
++        this.getHandle().openMenu(menuProvider);
+         this.getHandle().containerMenu.checkReachable = !force;
+         return this.getHandle().containerMenu.getBukkitView();
+     }


### PR DESCRIPTION
Adds additional overloads to the methods in the HumanEntity interface that open inventories (such as openAnvil, openWorkbench, ect.) allowing for customization of the displayed titles.