### PR TITLE
Fix entity data not being updated when attaching firework to entity

### DIFF
--- a/patches/server/0123-Firework-API-s.patch
+++ b/patches/server/0123-Firework-API-s.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Firework API's
 public net.minecraft.world.entity.projectile.FireworkRocketEntity attachedToEntity
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/FireworkRocketEntity.java b/src/main/java/net/minecraft/world/entity/projectile/FireworkRocketEntity.java
-index b16add0be6ac782a7e40be0cdeea4c1829a19d4e..288910fb168ddc5d3a61971778b8038a56772fa8 100644
+index 36f096001d2df5e3cae921cf1f08473e51e91a19..b2f08889139dc447f7071f1c81456035bf8de31e 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/FireworkRocketEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/FireworkRocketEntity.java
 @@ -38,6 +38,7 @@ public class FireworkRocketEntity extends Projectile implements ItemSupplier {

--- a/patches/server/1035-Update-entity-data-when-attaching-firework-to-entity.patch
+++ b/patches/server/1035-Update-entity-data-when-attaching-firework-to-entity.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: booky10 <boooky10@gmail.com>
+Date: Sun, 27 Aug 2023 16:11:31 +0200
+Subject: [PATCH] Update entity data when attaching firework to entity
+
+== AT ==
+public net.minecraft.world.entity.projectile.FireworkRocketEntity DATA_ATTACHED_TO_TARGET
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftFirework.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftFirework.java
+index 68c5af9b67a2834ee6e2f80ceefa19c3a982b8ed..1605ac0e726accdbd7953ffb95a302c2a21d64ce 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftFirework.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftFirework.java
+@@ -69,6 +69,10 @@ public class CraftFirework extends CraftProjectile implements Firework {
+         }
+ 
+         this.getHandle().attachedToEntity = (entity != null) ? ((CraftLivingEntity) entity).getHandle() : null;
++        // Paper start - update entity data
++        this.getHandle().getEntityData().set(FireworkRocketEntity.DATA_ATTACHED_TO_TARGET,
++            entity != null ? java.util.OptionalInt.of(entity.getEntityId()) : java.util.OptionalInt.empty());
++        // Paper end
+         return true;
+     }
+ 


### PR DESCRIPTION
CraftBukkit's API implementation doesn't update the firework's entitydata, which results in the client not being informed about the attached firework