### PR TITLE
Fix mobs not spawning when using an older config

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -4600,12 +4600,13 @@ index 0000000000000000000000000000000000000000..5833c06b0707906ab7d10786ecd115f2
 +
 diff --git a/src/main/java/io/papermc/paper/configuration/type/number/IntOr.java b/src/main/java/io/papermc/paper/configuration/type/number/IntOr.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c43bc4d013b48ee367160be6514af1a574c2390c
+index 0000000000000000000000000000000000000000..09f16e5dde565801b153bd6705637c5f71427c8a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/type/number/IntOr.java
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,81 @@
 +package io.papermc.paper.configuration.type.number;
 +
++import com.google.common.base.Preconditions;
 +import com.mojang.logging.LogUtils;
 +import java.util.OptionalInt;
 +import java.util.function.Function;
@@ -4669,7 +4670,8 @@ index 0000000000000000000000000000000000000000..c43bc4d013b48ee367160be6514af1a5
 +
 +        @Override
 +        protected boolean belowZero(final OptionalInt value) {
-+            return false;
++            Preconditions.checkArgument(value.isPresent());
++            return value.getAsInt() < 0;
 +        }
 +
 +        @Override


### PR DESCRIPTION
Closes #9791

The monsterSpawnMaxLightLevel is annotated with BelowZeroToEmpty, but I noticed that the belowZero method wasn't fully implemented for IntOr which meant it wasn't doing anything.

An alternative solution would be to add a migration, but with this anyone who has the old -1 default will have it changed to default in the file.