### PR TITLE
Fix bugs in collision detection when itemframe is outside the worldborder

### DIFF
--- a/patches/server/0727-Collision-optimisations.patch
+++ b/patches/server/0727-Collision-optimisations.patch
@@ -2629,7 +2629,7 @@ index a25497eec004add7408a63b1a0f09e3fa443b324..9f892de55ab03367daed4c30cc44c9dd
  
      // Paper start
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 270ce3995229aa79074e981bb45e5480a5e924d4..627758e4f55283c5dcf23d494efb92bfa9f6b005 100644
+index 270ce3995229aa79074e981bb45e5480a5e924d4..3163058a28092b1708d58cdc54f9ca8614a4d4ac 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -297,6 +297,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -3024,7 +3024,7 @@ index 270ce3995229aa79074e981bb45e5480a5e924d4..627758e4f55283c5dcf23d494efb92bf
 +        if (entity != null) {
 +            flags |= io.papermc.paper.util.CollisionUtil.COLLISION_FLAG_CHECK_BORDER;
 +        }
-+        if (io.papermc.paper.util.CollisionUtil.getCollisionsForBlocksOrWorldBorder(this, entity, box, null, null, flags, null)) {
++        if (!(entity instanceof net.minecraft.world.entity.decoration.ItemFrame) && io.papermc.paper.util.CollisionUtil.getCollisionsForBlocksOrWorldBorder(this, entity, box, null, null, flags, null)) {
 +            return false;
 +        }
 +


### PR DESCRIPTION
repair for https://github.com/PaperMC/Paper/issues/9805
in `net.minecraft.world.entity.decoration.ItemFrame#survives`
```
 @Override
    public boolean survives() {
        if (this.fixed) {
            return true;
        } else if (!this.level().noCollision((Entity) this)) {
            return false;
        } else {
            BlockState iblockdata = this.level().getBlockState(this.pos.relative(this.direction.getOpposite()));

            return !iblockdata.isSolid() && (!this.direction.getAxis().isHorizontal() || !DiodeBlock.isDiode(iblockdata)) ? false : this.level().getEntities((Entity) this, this.getBoundingBox(), ItemFrame.HANGING_ENTITY).isEmpty();
        }
    }
```
the itemframe will detect whether itself collides with other items by calling `noCollision`, but in `net.minecraft.world.level.Level#noCollision(Entity, AABB)`, which has been modified by paper, hasn't consider the situation that itemframe is outside the world border and directly call the func `getCollisionsForBlocksOrWorldBorder`, which return false when entity is outside the world border
```
// Paper start - Prevent armor stands from doing entity lookups
    @Override
    public boolean noCollision(@Nullable Entity entity, AABB box) {
        if (entity instanceof net.minecraft.world.entity.decoration.ArmorStand && !entity.level().paperConfig().entities.armorStands.doCollisionEntityLookups) return false;
        // Paper start - optimise collisions
        int flags = io.papermc.paper.util.CollisionUtil.COLLISION_FLAG_CHECK_ONLY;
        if (entity != null) {
            flags |= io.papermc.paper.util.CollisionUtil.COLLISION_FLAG_CHECK_BORDER;
        }
        if (io.papermc.paper.util.CollisionUtil.getCollisionsForBlocksOrWorldBorder(this, entity, box, null, null, flags, null)) {
            return false;
        }

        return !io.papermc.paper.util.CollisionUtil.getEntityHardCollisions(this, entity, box, null, flags, null);
        // Paper end - optimise collisions
    }
    // Paper end
```
so I change the patch to
```
if (!(entity instanceof net.minecraft.world.entity.decoration.ItemFrame) && io.papermc.paper.util.CollisionUtil.getCollisionsForBlocksOrWorldBorder(this, entity, box, null, null, flags, null)) {
+            return false;
+        }
```
to prevent item frame from killed
