### PR TITLE
Make setVelocity method of Fireballs change the travel direction to an arbitrary vector

### DIFF
--- a/patches/server/0894-Properly-resend-entities.patch
+++ b/patches/server/0894-Properly-resend-entities.patch
@@ -121,15 +121,14 @@ index 37596c7b65f280be00e8e59ae18bd1aceae21080..eca18540aeb0b0d4098477d73b14c78a
                  return Optional.of(InteractionResult.FAIL);
              }
              entity.playSound(((Bucketable) entity).getPickupSound(), 1.0F, 1.0F);
-
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 315d8260e196709ed9084272aa640f11e327c0a8..f7ebddd35ff5a60a81034fd7de035ebba83e9517 100644
+index 8733255559e63d8709d2502e58f16decdf1714ae..6759dad436d9e82f9c959e2c183e6e95c37abdcb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1299,7 +1299,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1258,7 +1258,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return;
          }
-
+ 
 -        entityTracker.broadcast(this.getHandle().getAddEntityPacket());
 +        // Paper start, resend possibly desynced entity instead of add entity packet
 +        for (ServerPlayerConnection playerConnection : entityTracker.seenBy) {
@@ -137,7 +136,7 @@ index 315d8260e196709ed9084272aa640f11e327c0a8..f7ebddd35ff5a60a81034fd7de035ebb
 +        }
 +        // Paper end
      }
-
+ 
      private static PermissibleBase getPermissibleBase() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java
 index 4dbe8af49fcb4d2c2f517083c013d83f64225b4b..58489a6a34e66cd6fc0d0e28141a3ebc32ac0e05 100644
@@ -146,7 +145,7 @@ index 4dbe8af49fcb4d2c2f517083c013d83f64225b4b..58489a6a34e66cd6fc0d0e28141a3ebc
 @@ -39,9 +39,11 @@ public class CraftItemFrame extends CraftHanging implements ItemFrame {
      protected void update() {
          super.update();
-
+ 
 +        // Paper start, don't mark as dirty as this is handled in super.update()
          // mark dirty, so that the client gets updated with item and rotation
 -        this.getHandle().getEntityData().markDirty(net.minecraft.world.entity.decoration.ItemFrame.DATA_ITEM);
@@ -154,6 +153,6 @@ index 4dbe8af49fcb4d2c2f517083c013d83f64225b4b..58489a6a34e66cd6fc0d0e28141a3ebc
 +        //this.getHandle().getEntityData().markDirty(net.minecraft.world.entity.decoration.ItemFrame.DATA_ITEM);
 +        //this.getHandle().getEntityData().markDirty(net.minecraft.world.entity.decoration.ItemFrame.DATA_ROTATION);
 +        // Paper end
-
+ 
          // update redstone
          if (!this.getHandle().generation) {

--- a/patches/server/0915-Add-Entity-Body-Yaw-API.patch
+++ b/patches/server/0915-Add-Entity-Body-Yaw-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Entity Body Yaw API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 35ce9507933487935da8ae8eff4e94925b1abf76..5cf469a1bba2b09dcd28cf6bc506e8b7a8e2162f 100644
+index d97bc672a8e6fb7c2a0ed668cc15b54bf4254217..314168d162f1242eca67706fd3fa225f1ed30cc4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1446,6 +1446,31 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1450,6 +1450,31 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean isInPowderedSnow() {
          return getHandle().isInPowderSnow || getHandle().wasInPowderSnow; // depending on the location in the entity "tick" either could be needed.
      }

--- a/patches/server/0991-API-for-an-entity-s-scoreboard-name.patch
+++ b/patches/server/0991-API-for-an-entity-s-scoreboard-name.patch
@@ -7,10 +7,10 @@ Was obtainable through different methods, but you had to use different
 methods depending on the implementation of Entity you were working with.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index b1f6915206acf6ba85b719737861babc552b5183..c83d0461ef14ef0df8428387d0d8eac5ad010054 100644
+index d481534da33d98bf44f2b800bc8e6f6d26ab5fc9..9ae86d1eab7d831d6b7d637c40fb6408950f7e71 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1502,4 +1502,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1506,4 +1506,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return !this.getHandle().level().noCollision(this.getHandle(), aabb);
      }
      // Paper End - Collision API

--- a/patches/server/1036-Make-setVelocity-method-of-Fireballs-change-the-trav.patch
+++ b/patches/server/1036-Make-setVelocity-method-of-Fireballs-change-the-trav.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TrollyLoki <trollyloki@gmail.com>
+Date: Tue, 10 Oct 2023 00:45:01 -0400
+Subject: [PATCH] Make setVelocity method of Fireballs change the travel
+ direction to an arbitrary vector
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
+index e04500dcdc5b72cca7ac81b5d12e76822db9c8c5..327d6915eb721368fcbdb5d3b2ba7528a94743bb 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
+@@ -46,6 +46,17 @@ public class CraftFireball extends AbstractProjectile implements Fireball {
+         update(); // SPIGOT-6579
+     }
+ 
++    // Paper start - set direction without normalizing
++    @Override
++    public void setVelocity(Vector velocity) {
++        Preconditions.checkArgument(velocity != null, "Vector velocity cannot be null");
++        this.getHandle().xPower = velocity.getX();
++        this.getHandle().yPower = velocity.getY();
++        this.getHandle().zPower = velocity.getZ();
++        update();
++    }
++    // Paper end
++
+     @Override
+     public AbstractHurtingProjectile getHandle() {
+         return (AbstractHurtingProjectile) entity;

--- a/patches/server/1037-Make-setVelocity-method-of-Fireballs-change-the-trav.patch
+++ b/patches/server/1037-Make-setVelocity-method-of-Fireballs-change-the-trav.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make setVelocity method of Fireballs change the travel
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
-index e04500dcdc5b72cca7ac81b5d12e76822db9c8c5..327d6915eb721368fcbdb5d3b2ba7528a94743bb 100644
+index e04500dcdc5b72cca7ac81b5d12e76822db9c8c5..22d59ca52229dc566b8dfb460b92ecd6318e6db0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftFireball.java
-@@ -46,6 +46,17 @@ public class CraftFireball extends AbstractProjectile implements Fireball {
+@@ -46,6 +46,18 @@ public class CraftFireball extends AbstractProjectile implements Fireball {
          update(); // SPIGOT-6579
      }
  
@@ -17,6 +17,7 @@ index e04500dcdc5b72cca7ac81b5d12e76822db9c8c5..327d6915eb721368fcbdb5d3b2ba7528
 +    @Override
 +    public void setVelocity(Vector velocity) {
 +        Preconditions.checkArgument(velocity != null, "Vector velocity cannot be null");
++        velocity.checkFinite();
 +        this.getHandle().xPower = velocity.getX();
 +        this.getHandle().yPower = velocity.getY();
 +        this.getHandle().zPower = velocity.getZ();


### PR DESCRIPTION
Currently calling the setVelocity() has undefined behavior at best, and in addition there is no way to set a fireballs direction to anything other than a normalized vector. This PR fixes both of these problems at once by overriding the setVelocity method of fireballs to set the travel direction while bypassing the vanilla normalization, allowing for things such as freezing a fireball in-place or changing its speed.