### PR TITLE
Add more native map methods to PDC

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -63,4 +63,5 @@ Ollie <69084614+olijeffers0n@users.noreply.github.com>
 Oliwier Miodun <naczs@blueflow.pl>
 aerulion <aerulion@gmail.com>
 Lukas Planz <lukas.planz@web.de>
+Xander de Keijzer <xander.dekeijzer@gmail.com>
 ```

--- a/patches/api/0442-Add-more-native-map-methods-to-PDC.patch
+++ b/patches/api/0442-Add-more-native-map-methods-to-PDC.patch
@@ -1,0 +1,350 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Xander <xander.dekeijzer@student.hu.nl>
+Date: Wed, 11 Oct 2023 22:46:36 +0200
+Subject: [PATCH] Add more native map methods to PDC
+
+
+diff --git a/src/main/java/org/bukkit/persistence/PersistentDataContainer.java b/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
+index 57609b7793122e135fa0c3b926500849379637b2..2e84af18c5237a3184aa0af106f21625a6daa1cd 100644
+--- a/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
++++ b/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
+@@ -153,18 +153,335 @@ public interface PersistentDataContainer {
+     PersistentDataAdapterContext getAdapterContext();
+ 
+     // Paper start
++
++    /**
++     * Stores a metadata value on the {@link PersistentDataHolder} instance.
++     * <p>
++     * This API cannot be used to manipulate minecraft data, as the values will
++     * be stored using your namespace. This method will override any existing
++     * value the {@link PersistentDataHolder} may have stored under the provided
++     * key.
++     *
++     * @param key the key this value will be stored under
++     * @param type the type this tag uses
++     * @param value the value stored in the tag
++     * @param <T> the generic java type of the tag value
++     * @param <Z> the generic type of the object to store
++     *
++     * @throws NullPointerException if the key is null
++     * @throws NullPointerException if the type is null
++     * @throws NullPointerException if the value is null. Removing a tag should
++     * be done using {@link #remove(net.kyori.adventure.key.Key)}
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     * the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> void put(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value);
++
++    /**
++     * Returns if the persistent metadata provider has metadata registered
++     * matching the provided parameters.
++     * <p>
++     * This method will only return if the found value has the same primitive
++     * data type as the provided key.
++     * <p>
++     * Storing a value using a custom {@link PersistentDataType} implementation
++     * will not store the complex data type. Therefore storing a UUID (by
++     * storing a byte[]) will match has("key" ,
++     * {@link PersistentDataType#BYTE_ARRAY}). Likewise a stored byte[] will
++     * always match your UUID {@link PersistentDataType} even if it is not 16
++     * bytes long.
++     * <p>
++     * This method is only usable for custom object keys. Overwriting existing
++     * tags, like the the display name, will not work as the values are stored
++     * using your namespace.
++     *
++     * @param key the key the value is stored under
++     * @param type the type which primitive storage type has to match the value
++     * @param <T> the generic type of the stored primitive
++     * @param <Z> the generic type of the eventually created complex object
++     *
++     * @return if a value
++     *
++     * @throws NullPointerException if the key to look up is null
++     * @throws NullPointerException if the type to cast the found object to is
++     * null
++     */
++    <T, Z> boolean has(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type);
++
++    /**
++     * Returns the metadata value that is stored on the
++     * {@link PersistentDataHolder} instance.
++     *
++     * @param key the key to look up in the custom tag map
++     * @param type the type the value must have and will be casted to
++     * @param <T> the generic type of the stored primitive
++     * @param <Z> the generic type of the eventually created complex object
++     *
++     * @return the value or {@code null} if no value was mapped under the given
++     * value
++     *
++     * @throws NullPointerException if the key to look up is null
++     * @throws NullPointerException if the type to cast the found object to is
++     * null
++     * @throws IllegalArgumentException if the value exists under the given key,
++     * but cannot be access using the given type
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     * the {@link
++     * PersistentDataType#getPrimitiveType()}
++     */
++    @Nullable
++    <T, Z> Z get(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type);
++
++    /**
++     * Removes a custom key from the {@link PersistentDataHolder} instance.
++     *
++     * @param key the key
++     *
++     * @throws NullPointerException if the provided key is null
++     */
++    void remove(@NotNull net.kyori.adventure.key.Key key);
++    
++    /**
++     * Stores a metadata value on the {@link PersistentDataHolder} instance.
++     * <p>
++     * This API cannot be used to manipulate minecraft data, as the values will
++     * be stored using your namespace. This method will not override any existing
++     * value the {@link PersistentDataHolder} may have stored under the provided
++     * key.
++     *
++     * @param key   the key this value will be stored under
++     * @param type  the type this tag uses
++     * @param value the value stored in the tag
++     * @param <T>   the generic java type of the tag value
++     * @param <Z>   the generic type of the object to store
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws NullPointerException     if the value is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> void putIfAbsent(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value);
++
++    /**
++     * If the specified key is not already associated with a metadata value (or is mapped
++     * to {@code null}), attempts to compute its value using the given mapping
++     * function and enters it into the {@link PersistentDataContainer}.
++     *
++     * <p>If the mapping function returns {@code null}, no mapping is recorded.
++     * If the mapping function itself throws an (unchecked) exception, the
++     * exception is rethrown, and no mapping is recorded.
++     *
++     * @param key             key with which the specified value is to be associated
++     * @param type            the type this tag uses
++     * @param mappingFunction the mapping function to compute a value
++     * @param <T>             the generic java type of the tag value
++     * @param <Z>             the generic type of the object to store
++     *
++     * @return the current (existing or computed) value associated with
++     * the specified key, or null if the computed value is null
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws NullPointerException     if the mappingFunction is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> @Nullable Z computeIfAbsent(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull java.util.function.Function<? super net.kyori.adventure.key.Key, ? extends Z> mappingFunction);
++
++    /**
++     * If the value for the specified key is present and non-null, attempts to
++     * compute a new mapping given the key and its current mapped value in the {@link PersistentDataContainer}.
++     *
++     * <p>If the remapping function returns {@code null}, the mapping is removed.
++     * If the remapping function itself throws an (unchecked) exception, the
++     * exception is rethrown, and the current mapping is left unchanged.
++     *
++     * @param key               key with which the specified value is to be associated
++     * @param type              the type this tag uses
++     * @param remappingFunction the remapping function to compute a value
++     * @param <T>               the generic java type of the tag value
++     * @param <Z>               the generic type of the object to store
++     *
++     * @return the new value associated with the specified key, or null if none
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws NullPointerException     if the remappingFunction is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> @Nullable Z computeIfPresent(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull java.util.function.BiFunction<? super net.kyori.adventure.key.Key, ? super Z, ? extends Z> remappingFunction);
++
++    /**
++     * Attempts to compute a mapping for the specified key and its current
++     * mapped value (or {@code null} if there is no current mapping).
++     *
++     * <p>If the remapping function returns {@code null}, the mapping is removed
++     * (or remains absent if initially absent). If the remapping function
++     * itself throws an (unchecked) exception, the exception is rethrown, and
++     * the current mapping is left unchanged.
++     *
++     * @param key               key with which the specified value is to be associated
++     * @param type              the type this tag uses
++     * @param remappingFunction the remapping function to compute a value
++     * @param <T>               the generic java type of the tag value
++     * @param <Z>               the generic type of the object to store
++     *
++     * @return the new value associated with the specified key, or null if none
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws NullPointerException     if the remappingFunction is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> @Nullable Z compute(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull java.util.function.BiFunction<? super net.kyori.adventure.key.Key, ? super Z, ? extends Z> remappingFunction);
++
++    /**
++     * Returns the metadata value that is stored on the
++     * {@link PersistentDataHolder} instance. If the value does not exist in the
++     * container, the provided exception is thrown.
++     *
++     * @param key               key with which the specified value is to be associated
++     * @param type              the type this tag uses
++     * @param exceptionSupplier the exception to throw
++     * @param <T>               the generic java type of the tag value
++     * @param <Z>               the generic type of the object to store
++     * @param <X>               the exception type you want to throw
++     *
++     * @return The currently existing metadata within your {@link PersistentDataHolder} instance, if present
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws NullPointerException     if the exceptionSupplier is null
++     * @throws X                        If there was no metadata element bound to your key and type
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z, X extends Throwable> @NotNull Z getOrThrow(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull java.util.function.Supplier<X> exceptionSupplier) throws X;
++
++    /**
++     * Returns the metadata value that is stored on the
++     * {@link PersistentDataHolder} instance. If the value does not exist in the
++     * container, a {@link java.util.NoSuchElementException} is thrown.
++     *
++     * @param key  the key this value will be stored under
++     * @param type the type this tag uses
++     * @param <T>  the generic java type of the tag value
++     * @param <Z>  the generic type of the object to store
++     *
++     * @return the currently existing metadata within your {@link PersistentDataHolder} instance, if present
++     *
++     * @throws NullPointerException             if the key is null
++     * @throws NullPointerException             if the type is null
++     * @throws java.util.NoSuchElementException If there was no metadata element bound to your key and type
++     * @throws IllegalArgumentException         if no suitable adapter will be found for
++     *                                          the {@link PersistentDataType#getPrimitiveType()}
++     */
++    default <T, Z> @NotNull Z getOrThrow(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type) {
++        com.google.common.base.Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
++        com.google.common.base.Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        return getOrThrow(key, type, () -> new java.util.NoSuchElementException("Key " + key.asString() + " was not present in PDC " + this.getClass().getName()));
++    }
++
++    /**
++     * Replaces the metadata value that is stored on the {@link PersistentDataHolder}
++     * instance with newValue only if the value is currently set to oldValue
++     *
++     * @param key      the key this value will be stored under
++     * @param type     the type this tag uses
++     * @param oldValue value expected to be associated with the specified key
++     * @param newValue value to be associated with the specified key
++     * @param <T>      the generic java type of the tag value
++     * @param <Z>      the generic type of the object to store
++     *
++     * @return {@code true} if the value was replaced
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws NullPointerException     if the oldValue is null
++     * @throws NullPointerException     if the newValue is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> boolean replace(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z oldValue, @NotNull Z newValue);
++
++    /**
++     * Stores a metadata value on the {@link PersistentDataHolder} instance.
++     * <p>
++     * This API cannot be used to manipulate minecraft data, as the values will
++     * be stored using your namespace. This method will override any existing
++     * value the {@link PersistentDataHolder} may have stored under the provided
++     * key and returns the metadata currently stored under that key.
++     *
++     * @param key   the key this value will be stored under
++     * @param type  the type this tag uses
++     * @param value the value stored in the tag
++     * @param <T>   the generic java type of the tag value
++     * @param <Z>   the generic type of the object to store
++     *
++     * @return the previous existing metadata within your {@link PersistentDataHolder} instance, or {@code null} if there was no mapping for the key.
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws NullPointerException     if the value is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> @Nullable Z replace(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value);
++
++    /**
++     * Attempts to merge a mapping for the specified key if it is already associated
++     * with a value, otherwise maps the given non-null value paramater.
++     *
++     * <p>If the remapping function returns {@code null}, the mapping is removed
++     * (or remains absent if initially absent). If the remapping function
++     * itself throws an (unchecked) exception, the exception is rethrown, and
++     * the current mapping is left unchanged.
++     *
++     * @param key               key with which the specified value is to be associated
++     * @param type              the type this tag uses
++     * @param value             the value to use to merge with
++     * @param remappingFunction the remapping function to compute a value
++     * @param <T>               the generic java type of the tag value
++     * @param <Z>               the generic type of the object to store
++     *
++     * @return the new value associated with the specified key, or null if none
++     *
++     * @throws NullPointerException     if the key is null
++     * @throws NullPointerException     if the type is null
++     * @throws NullPointerException     if the value is null
++     * @throws NullPointerException     if the remappingFunction is null
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     *                                  the {@link PersistentDataType#getPrimitiveType()}
++     */
++    <T, Z> @Nullable Z merge(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value, @NotNull java.util.function.BiFunction<? super Z, ? super Z, ? extends Z> remappingFunction);
++
+     /**
+      * Returns if the persistent metadata provider has metadata registered
+-     * matching the provided key.
+-     * 
++     * matching the provided {@link NamespacedKey}.
++     *
+      * @param key the key for which existence should be checked.
+-     * 
++     *
+      * @return whether the key exists
+-     * 
++     *
+      * @throws NullPointerException if the key to look up is null
+      */
+     boolean has(@NotNull NamespacedKey key);
+ 
++    /**
++     * Returns if the persistent metadata provider has metadata registered
++     * matching the provided {@link net.kyori.adventure.key.Key}.
++     *
++     * @param key the key for which existence should be checked.
++     *
++     * @return whether the key exists
++     *
++     * @throws NullPointerException if the key to look up is null
++     */
++    boolean has(@NotNull net.kyori.adventure.key.Key key);
++
+     /**
+      * Serialize this {@link PersistentDataContainer} instance to a
+      * byte array.

--- a/patches/api/0442-Add-more-native-map-methods-to-PDC.patch
+++ b/patches/api/0442-Add-more-native-map-methods-to-PDC.patch
@@ -1,5 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Xander <xander.dekeijzer@student.hu.nl>
+Co-authored-by: TheRealRyGuy <ryan@ryguy.me>
 Date: Wed, 11 Oct 2023 22:46:36 +0200
 Subject: [PATCH] Add more native map methods to PDC
 

--- a/patches/api/0442-Add-more-native-map-methods-to-PDC.patch
+++ b/patches/api/0442-Add-more-native-map-methods-to-PDC.patch
@@ -1,15 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Xander <xander.dekeijzer@student.hu.nl>
 Co-authored-by: TheRealRyGuy <ryan@ryguy.me>
-Date: Wed, 11 Oct 2023 22:46:36 +0200
+Date: Sun, 15 Oct 2023 17:44:57 +0200
 Subject: [PATCH] Add more native map methods to PDC
 
 
 diff --git a/src/main/java/org/bukkit/persistence/PersistentDataContainer.java b/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
-index 57609b7793122e135fa0c3b926500849379637b2..2e84af18c5237a3184aa0af106f21625a6daa1cd 100644
+index 57609b7793122e135fa0c3b926500849379637b2..9d05980205aebb0f042dbaa389acee2ee38e4fdc 100644
 --- a/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
 +++ b/src/main/java/org/bukkit/persistence/PersistentDataContainer.java
-@@ -153,18 +153,335 @@ public interface PersistentDataContainer {
+@@ -153,18 +153,361 @@ public interface PersistentDataContainer {
      PersistentDataAdapterContext getAdapterContext();
  
      // Paper start
@@ -91,6 +91,32 @@ index 57609b7793122e135fa0c3b926500849379637b2..2e84af18c5237a3184aa0af106f21625
 +     */
 +    @Nullable
 +    <T, Z> Z get(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type);
++    
++    /**
++     * Returns the metadata value that is stored on the
++     * {@link PersistentDataHolder} instance. If the value does not exist in the
++     * container, the default value provided is returned.
++     *
++     * @param key the key to look up in the custom tag map
++     * @param type the type the value must have and will be casted to
++     * @param defaultValue the default value to return if no value was found for
++     * the provided key
++     * @param <T> the generic type of the stored primitive
++     * @param <Z> the generic type of the eventually created complex object
++     *
++     * @return the value or the default value if no value was mapped under the
++     * given value
++     *
++     * @throws NullPointerException if the key to look up is null
++     * @throws NullPointerException if the type to cast the found object to is
++     * null
++     * @throws IllegalArgumentException if the value exists under the given key,
++     * but cannot be access using the given type
++     * @throws IllegalArgumentException if no suitable adapter will be found for
++     * the {@link PersistentDataType#getPrimitiveType()}
++     */
++    @NotNull
++    <T, Z> Z getOrDefault(@NotNull net.kyori.adventure.key.Key key, @NotNull PersistentDataType<T, Z> type, @NotNull Z defaultValue);
 +
 +    /**
 +     * Removes a custom key from the {@link PersistentDataHolder} instance.

--- a/patches/server/1039-Add-more-native-map-methods-to-PDC.patch
+++ b/patches/server/1039-Add-more-native-map-methods-to-PDC.patch
@@ -1,0 +1,214 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Xander <xander.dekeijzer@student.hu.nl>
+Co-authored-by: TheRealRyGuy <ryan@ryguy.me>
+Date: Wed, 11 Oct 2023 21:21:05 +0200
+Subject: [PATCH] Add more native map methods to PDC
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
+index 91cb4a28afa5d83e6de10dab834ed63e2eb3b76f..c2eab2278ff9cc0b7fbc17281ccb2a41c257c81c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
++++ b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
+@@ -34,6 +34,13 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+ 
+     @Override
+     public <T, Z> void set(NamespacedKey key, PersistentDataType<T, Z> type, Z value) {
++        // Paper start
++        put(key, type, value);
++    }
++    
++    @Override
++    public <T, Z> void put(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type, Z value) {
++        // Paper end
+         Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+         Preconditions.checkArgument(type != null, "The provided type cannot be null");
+         Preconditions.checkArgument(value != null, "The provided value cannot be null");
+@@ -43,6 +50,13 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+ 
+     @Override
+     public <T, Z> boolean has(NamespacedKey key, PersistentDataType<T, Z> type) {
++        // Paper start
++        return has((net.kyori.adventure.key.Key) key, type);
++    }
++
++    @Override
++    public <T, Z> boolean has(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type) {
++        // Paper end
+         Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+         Preconditions.checkArgument(type != null, "The provided type cannot be null");
+ 
+@@ -56,6 +70,13 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+ 
+     @Override
+     public <T, Z> Z get(NamespacedKey key, PersistentDataType<T, Z> type) {
++        // Paper start
++        return get((net.kyori.adventure.key.Key) key, type);
++    }
++
++    @Override
++    public <T, Z> Z get(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type) {
++        // Paper end
+         Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+         Preconditions.checkArgument(type != null, "The provided type cannot be null");
+ 
+@@ -89,6 +110,13 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+ 
+     @Override
+     public void remove(NamespacedKey key) {
++        // Paper start
++        remove((net.kyori.adventure.key.Key) key);
++    }
++
++    @Override
++    public void remove(net.kyori.adventure.key.Key key) {
++        // Paper end
+         Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
+ 
+         this.customDataTags.remove(key.toString());
+@@ -161,9 +189,146 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+     public void clear() {
+         this.customDataTags.clear();
+     }
++    
++    @Override
++    public <T, Z> void putIfAbsent(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type, Z value) {
++        Preconditions.checkArgument(key != null, "The key cannot be null");
++        Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        Preconditions.checkArgument(value != null, "The provided value cannot be null");
++        
++        Z z = get(key, type);
++        if (z == null) {
++            put(key, type, value);
++        }
++    }
++    
++    @Override
++    public <T, Z> Z computeIfAbsent(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type, java.util.function.Function<? super net.kyori.adventure.key.Key, ? extends Z> mappingFunction) {
++        Preconditions.checkArgument(key != null, "The key cannot be null");
++        Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        Preconditions.checkArgument(mappingFunction != null, "The provided mappingFunction cannot be null");
++        
++        Z z;
++        if ((z = get(key, type)) == null) {
++            Z newValue;
++            if ((newValue = mappingFunction.apply(key)) != null) {
++                put(key, type, newValue);
++                return newValue;
++            }
++        }
++
++        return z;
++    }
++
++    @Override
++    public <T, Z> Z computeIfPresent(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type, java.util.function.BiFunction<? super net.kyori.adventure.key.Key, ? super Z, ? extends Z> remappingFunction) {
++        Preconditions.checkArgument(key != null, "The key cannot be null");
++        Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        Preconditions.checkArgument(remappingFunction != null, "The provided remappingFunction cannot be null");
++        
++        Z oldValue;
++        if ((oldValue = get(key, type)) != null) {
++            Z newValue = remappingFunction.apply(key, oldValue);
++            if (newValue != null) {
++                put(key, type, newValue);
++                return newValue;
++            } else {
++                remove(key);
++                return null;
++            }
++        } else {
++            return null;
++        }
++    }
++
++    @Override
++    public <T, Z> Z compute(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type, java.util.function.BiFunction<? super net.kyori.adventure.key.Key, ? super Z, ? extends Z> remappingFunction) {
++        Preconditions.checkArgument(key != null, "The key cannot be null");
++        Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        Preconditions.checkArgument(remappingFunction != null, "The provided remappingFunction cannot be null");
++        
++        Z oldValue = get(key, type);
++
++        Z newValue = remappingFunction.apply(key, oldValue);
++        if (newValue == null) {
++            if (oldValue != null || has(key, type)) {
++                remove(key);
++                return null;
++            } else {
++                return null;
++            }
++        } else {
++            put(key, type, newValue);
++            return newValue;
++        }
++    }
++
++    @Override
++    public <T, Z, X extends Throwable> Z getOrThrow(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type, java.util.function.Supplier<X> exceptionSupplier) throws X {
++        Preconditions.checkArgument(key != null, "The key cannot be null");
++        Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        Preconditions.checkArgument(exceptionSupplier != null, "The provided exceptionSupplier cannot be null");
++        
++        Z value = get(key, type);
++        if (value == null) {
++            throw exceptionSupplier.get();
++        } else {
++            return value;
++        }
++    }
++
++    @Override
++    public <T, Z> boolean replace(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type, Z oldValue, Z newValue) {
++        Preconditions.checkArgument(key != null, "The key cannot be null");
++        Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        Preconditions.checkArgument(oldValue != null, "The provided oldValue cannot be null");
++        Preconditions.checkArgument(newValue != null, "The provided newValue cannot be null");
++        
++        Z curValue = get(key, type);
++        if (!Objects.equals(curValue, oldValue) || (curValue == null && !has(key))) {
++            return false;
++        }
++        put(key, type, newValue);
++        return true;
++    }
++
++    @Override
++    public <T, Z> Z replace(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type, Z value) {
++        Preconditions.checkArgument(key != null, "The key cannot be null");
++        Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        Preconditions.checkArgument(value != null, "The provided value cannot be null");
++        
++        Z curvalue;
++        if (((curvalue = get(key, type)) != null) || has(key)) {
++            put(key, type, value);
++        }
++        return curvalue;
++    }
++
++    @Override
++    public <T, Z> Z merge(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type, Z value, java.util.function.BiFunction<? super Z, ? super Z, ? extends Z> remappingFunction) {
++        Preconditions.checkArgument(key != null, "The key cannot be null");
++        Preconditions.checkArgument(type != null, "The provided type cannot be null");
++        Preconditions.checkArgument(value != null, "The provided value cannot be null");
++        Preconditions.checkArgument(remappingFunction != null, "The provided remappingFunction cannot be null");
++        
++        Z oldValue = get(key, type);
++        Z newValue = (oldValue == null) ? value : remappingFunction.apply(oldValue, value);
++        if (newValue == null) {
++            remove(key);
++        } else {
++            put(key, type, newValue);
++        }
++        return newValue;
++    }
+ 
+     @Override
+     public boolean has(NamespacedKey key) {
++        return has((net.kyori.adventure.key.Key) key);
++    }
++    
++    @Override
++    public boolean has(net.kyori.adventure.key.Key key) {
+         Preconditions.checkArgument(key != null, "The provided key for the custom value was null");
+ 
+         return this.customDataTags.containsKey(key.toString());

--- a/patches/server/1039-Add-more-native-map-methods-to-PDC.patch
+++ b/patches/server/1039-Add-more-native-map-methods-to-PDC.patch
@@ -1,11 +1,12 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Xander <xander.dekeijzer@student.hu.nl>
-Date: Wed, 11 Oct 2023 23:11:53 +0200
+Co-authored-by: TheRealRyGuy <ryan@ryguy.me>
+Date: Sun, 15 Oct 2023 17:44:38 +0200
 Subject: [PATCH] Add more native map methods to PDC
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
-index 91cb4a28afa5d83e6de10dab834ed63e2eb3b76f..c2eab2278ff9cc0b7fbc17281ccb2a41c257c81c 100644
+index 91cb4a28afa5d83e6de10dab834ed63e2eb3b76f..7347115d3c03f5bcd7570f034c60190752806abc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataContainer.java
 @@ -34,6 +34,13 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
@@ -50,7 +51,20 @@ index 91cb4a28afa5d83e6de10dab834ed63e2eb3b76f..c2eab2278ff9cc0b7fbc17281ccb2a41
          Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
          Preconditions.checkArgument(type != null, "The provided type cannot be null");
  
-@@ -89,6 +110,13 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+@@ -69,6 +90,12 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+ 
+     @Override
+     public <T, Z> Z getOrDefault(NamespacedKey key, PersistentDataType<T, Z> type, Z defaultValue) {
++        // Paper start
++        return getOrDefault((net.kyori.adventure.key.Key) key, type, defaultValue);
++    }
++    
++    @Override
++    public <T, Z> Z getOrDefault(net.kyori.adventure.key.Key key, PersistentDataType<T, Z> type, Z defaultValue) {
+         Z z = this.get(key, type);
+         return z != null ? z : defaultValue;
+     }
+@@ -89,6 +116,13 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
  
      @Override
      public void remove(NamespacedKey key) {
@@ -64,7 +78,7 @@ index 91cb4a28afa5d83e6de10dab834ed63e2eb3b76f..c2eab2278ff9cc0b7fbc17281ccb2a41
          Preconditions.checkArgument(key != null, "The NamespacedKey key cannot be null");
  
          this.customDataTags.remove(key.toString());
-@@ -161,9 +189,146 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
+@@ -161,9 +195,146 @@ public class CraftPersistentDataContainer implements PersistentDataContainer {
      public void clear() {
          this.customDataTags.clear();
      }

--- a/patches/server/1039-Add-more-native-map-methods-to-PDC.patch
+++ b/patches/server/1039-Add-more-native-map-methods-to-PDC.patch
@@ -1,7 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Xander <xander.dekeijzer@student.hu.nl>
-Co-authored-by: TheRealRyGuy <ryan@ryguy.me>
-Date: Wed, 11 Oct 2023 21:21:05 +0200
+Date: Wed, 11 Oct 2023 23:11:53 +0200
 Subject: [PATCH] Add more native map methods to PDC
 
 
@@ -212,3 +211,165 @@ index 91cb4a28afa5d83e6de10dab834ed63e2eb3b76f..c2eab2278ff9cc0b7fbc17281ccb2a41
          Preconditions.checkArgument(key != null, "The provided key for the custom value was null");
  
          return this.customDataTags.containsKey(key.toString());
+diff --git a/src/test/java/io/papermc/paper/persistence/PersistentDataContainerTest.java b/src/test/java/io/papermc/paper/persistence/PersistentDataContainerTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..e5a5dda6fb46aa58cd0e0b1235a0b121f7d0c66e
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/persistence/PersistentDataContainerTest.java
+@@ -0,0 +1,156 @@
++package io.papermc.paper.persistence;
++
++import net.kyori.adventure.key.Key;
++import org.bukkit.NamespacedKey;
++import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer;
++import org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry;
++import org.bukkit.persistence.PersistentDataType;
++import org.junit.jupiter.api.Test;
++
++import java.util.NoSuchElementException;
++import java.util.function.Supplier;
++
++import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
++import static org.junit.jupiter.api.Assertions.assertEquals;
++import static org.junit.jupiter.api.Assertions.assertNotEquals;
++import static org.junit.jupiter.api.Assertions.assertNull;
++import static org.junit.jupiter.api.Assertions.assertThrows;
++import static org.junit.jupiter.api.Assertions.assertTrue;
++import static org.junit.jupiter.api.Assertions.assertFalse;
++
++public class PersistentDataContainerTest {
++    
++    static private CraftPersistentDataContainer createContainer() {
++        CraftPersistentDataTypeRegistry registry = new CraftPersistentDataTypeRegistry();
++        CraftPersistentDataContainer container = new CraftPersistentDataContainer(registry);
++        return container;
++    }
++    
++    @Test
++    public void basicTest() {
++        CraftPersistentDataContainer container = createContainer();
++        Key key = new NamespacedKey("test", "key");
++        
++        container.put(key, PersistentDataType.STRING, "value");
++        assertTrue(container.has(key));
++        
++        String value = container.get(key, PersistentDataType.STRING);
++        assertEquals(value, "value");
++        
++        container.remove(key);
++        assertFalse(container.has(key));
++    }
++    
++    @Test
++    public void putIfAbsentTest() {
++        CraftPersistentDataContainer container = createContainer();
++        Key key = new NamespacedKey("test", "key");
++        
++        container.putIfAbsent(key, PersistentDataType.STRING, "value");
++        String value = container.get(key, PersistentDataType.STRING);
++        assertEquals(value, "value");
++        
++        container.putIfAbsent(key, PersistentDataType.STRING, "value2");
++        String value2 = container.get(key, PersistentDataType.STRING);
++        assertNotEquals(value2, "value2");
++        assertEquals(value2, "value");
++    }
++    
++    @Test
++    public void computeIfAbsentTest() {
++        CraftPersistentDataContainer container = createContainer();
++        Key key = new NamespacedKey("test", "key");
++        
++        assertNull(container.computeIfAbsent(key, PersistentDataType.STRING, (Key _key) -> null));
++        assertFalse(container.has(key));
++
++        assertEquals(container.computeIfAbsent(key, PersistentDataType.STRING, (Key _key) -> "value"), "value");
++        assertEquals(container.get(key, PersistentDataType.STRING), "value");
++
++        assertEquals(container.computeIfAbsent(key, PersistentDataType.STRING, (Key _key) -> "value2"), "value");
++        assertEquals(container.get(key, PersistentDataType.STRING), "value");
++    }
++    
++    @Test
++    public void computeIfPresentTest() {
++        CraftPersistentDataContainer container = createContainer();
++        Key key = new NamespacedKey("test", "key");
++        
++        container.computeIfPresent(key, PersistentDataType.STRING, (Key _key, String _value) -> "value2");
++        assertFalse(container.has(key));
++        
++        container.put(key, PersistentDataType.STRING, "value");
++        container.computeIfPresent(key, PersistentDataType.STRING, (Key _key, String _value) -> "value2");
++        assertEquals(container.get(key, PersistentDataType.STRING), "value2");
++        
++        container.computeIfPresent(key, PersistentDataType.STRING, (Key _key, String _value) -> null);
++        assertFalse(container.has(key));
++    }
++    
++    @Test
++    public void computeTest() {
++        CraftPersistentDataContainer container = createContainer();
++        Key key = new NamespacedKey("test", "key");
++        
++        assertEquals(container.compute(key, PersistentDataType.STRING, (Key _key, String _value) -> "value"), "value");
++        assertEquals(container.get(key, PersistentDataType.STRING), "value");
++
++        assertEquals(container.compute(key, PersistentDataType.STRING, (Key _key, String _value) -> "value2"), "value2");
++        assertEquals(container.get(key, PersistentDataType.STRING), "value2");
++
++        assertNull(container.compute(key, PersistentDataType.STRING, (Key _key, String _value) -> null));
++        assertFalse(container.has(key));
++    }
++    
++    @Test
++    public void getOrThrowTest() {
++        CraftPersistentDataContainer container = createContainer();
++        Key key = new NamespacedKey("test", "key");
++        
++        assertThrows(NoSuchElementException.class, () -> container.getOrThrow(key, PersistentDataType.STRING));
++        assertThrows(NoSuchElementException.class, () -> container.getOrThrow(key, PersistentDataType.STRING, NoSuchElementException::new));
++        
++        container.put(key, PersistentDataType.STRING, "value");
++        
++        assertDoesNotThrow(() -> container.getOrThrow(key, PersistentDataType.STRING));
++        assertDoesNotThrow(() -> container.getOrThrow(key, PersistentDataType.STRING, NoSuchElementException::new));
++    }
++    
++    @Test
++    public void replaceTest() {
++        CraftPersistentDataContainer container = createContainer();
++        Key key = new NamespacedKey("test", "key");
++        
++        assertFalse(container.replace(key, PersistentDataType.STRING, "value", "value2"));
++        assertFalse(container.has(key));
++        
++        assertNull(container.replace(key, PersistentDataType.STRING, "value2"));
++        assertFalse(container.has(key));
++        
++        container.put(key, PersistentDataType.STRING, "value");
++        
++        assertFalse(container.replace(key, PersistentDataType.STRING, "value2", "value"));
++        assertEquals(container.get(key, PersistentDataType.STRING), "value");
++        
++        assertTrue(container.replace(key, PersistentDataType.STRING, "value", "value2"));
++        assertEquals(container.get(key, PersistentDataType.STRING), "value2");
++        
++        assertEquals(container.replace(key, PersistentDataType.STRING, "value"), "value2");
++    }
++    
++    @Test
++    public void mergeTest() {
++        CraftPersistentDataContainer container = createContainer();
++        Key key = new NamespacedKey("test", "key");
++        
++        assertEquals(container.merge(key, PersistentDataType.STRING, "value", (String cur, String val) -> "value2"), "value");
++        assertEquals(container.get(key, PersistentDataType.STRING), "value");
++        
++        assertEquals(container.merge(key, PersistentDataType.STRING, "value", (String cur, String val) -> "value2"), "value2");
++        assertEquals(container.get(key, PersistentDataType.STRING), "value2");
++        
++        assertNull(container.merge(key, PersistentDataType.STRING, "value", (String cur, String val) -> null));
++        assertFalse(container.has(key));
++    }
++    
++}


### PR DESCRIPTION
Closes issue #8925 
Accidentally closed the previous PR #9787 

PDC now implements these methods

    #put(Key, PersistentDataType, Object)
    #has(Key, PersistentDataType)
    #get(Key, PersistentDataType)
    #getOrDefault(Key, PersistentDataType, Object)
    #remove(Key)
    #has(Key)
    #putIfAbsent(Key, PersistentDataType, Object)
    #computeIfAbsent(Key, PersistentDataType, Function)
    #computeIfPresent(Key, PersistentDataType, BiFunction)
    #compute(Key, PersistentDataType, BiFunction)
    #getOrThrow(Key, PersistentDataType, Supplier)
    #getOrThrow(Key, PersistentDataType)
    #replace(Key, PersistentDataType, Object, Object)
    #replace(Key, PersistentDataType, Object)
    #merge(Key, PersistentDataType, Object, BiFunction)
