### PR TITLE
Support applicable API during config stage

### DIFF
--- a/patches/server/1052-Support-applicable-API-during-config-stage.patch
+++ b/patches/server/1052-Support-applicable-API-during-config-stage.patch
@@ -1,0 +1,189 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 11 Oct 2023 18:57:45 -0700
+Subject: [PATCH] Support applicable API during config stage
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 6a4637eef14cbd84bbe26ef16f004b8f93367a3d..f7923c317672643e16ec605672658b507da34aaa 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -207,6 +207,7 @@ public class ServerPlayer extends Player {
+     private static final AttributeModifier CREATIVE_BLOCK_INTERACTION_RANGE_MODIFIER = new AttributeModifier(UUID.fromString("736565d2-e1a7-403d-a3f8-1aeb3e302542"), "Creative block interaction range modifier", 0.5D, AttributeModifier.Operation.ADD_VALUE);
+     private static final AttributeModifier CREATIVE_ENTITY_INTERACTION_RANGE_MODIFIER = new AttributeModifier(UUID.fromString("98491ef6-97b1-4584-ae82-71a8cc85cf73"), "Creative entity interaction range modifier", 2.0D, AttributeModifier.Operation.ADD_VALUE);
+     public ServerGamePacketListenerImpl connection;
++    public net.minecraft.server.network.@org.jetbrains.annotations.Nullable ServerConfigurationPacketListenerImpl configConnection; // Paper
+     public final MinecraftServer server;
+     public final ServerPlayerGameMode gameMode;
+     private final PlayerAdvancements advancements;
+diff --git a/src/main/java/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java
+index e4086bea596e5f5d71491e0b7ad650d76939b8f9..758e603f0d1a373dd0370882723ae7e94e206745 100644
+--- a/src/main/java/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java
+@@ -51,6 +51,7 @@ public class ServerConfigurationPacketListenerImpl extends ServerCommonPacketLis
+     public ServerConfigurationPacketListenerImpl(MinecraftServer minecraftserver, Connection networkmanager, CommonListenerCookie commonlistenercookie, ServerPlayer player) {
+         super(minecraftserver, networkmanager, commonlistenercookie, player);
+         // CraftBukkit end
++        player.configConnection = this; // Paper
+         this.gameProfile = commonlistenercookie.gameProfile();
+         this.clientInformation = commonlistenercookie.clientInformation();
+     }
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 4ae88bfcead40cd05f9514a48a922a37767cb3cf..26be1a2ddc540951ca40621b365318348faf52d0 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -307,6 +307,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+         super(server, connection, clientData, player); // CraftBukkit
+         this.chunkSender = new PlayerChunkSender(connection.isMemoryConnection());
+         this.player = player;
++        player.configConnection = null; // Paper
+         player.connection = this;
+         player.getTextFilter().join();
+         UUID uuid = player.getUUID();
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 7e6116963d835d4606ef3d93b69d3e44b61288e1..6c6783f9e3a89e4cb7c67c96b6ca8993fae44d3d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -217,6 +217,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         this.firstPlayed = System.currentTimeMillis();
+     }
+ 
++    // Paper start - send packets during config stage
++    @org.jetbrains.annotations.Contract(pure = true)
++    public net.minecraft.server.network.@org.jetbrains.annotations.Nullable ServerCommonPacketListenerImpl commonListener() {
++        //noinspection ConstantValue,UnreachableCode
++        if (this.getHandle().connection != null) {
++            return this.getHandle().connection;
++        } else if (this.getHandle().configConnection != null) {
++            return this.getHandle().configConnection;
++        } else {
++            return null;
++        }
++    }
++    // Paper end - send packets during config stage
++
+     public GameProfile getProfile() {
+         return this.getHandle().getGameProfile();
+     }
+@@ -648,9 +662,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     @Override
+     public void kickPlayer(String message) {
+         org.spigotmc.AsyncCatcher.catchOp("player kick"); // Spigot
+-        if (this.getHandle().connection == null) return;
++        if (this.commonListener() == null) return; // Paper - configuration stage
+ 
+-        this.getHandle().connection.disconnect(message == null ? "" : message, org.bukkit.event.player.PlayerKickEvent.Cause.PLUGIN); // Paper - kick event cause
++        this.commonListener().disconnect(message == null ? "" : message, org.bukkit.event.player.PlayerKickEvent.Cause.PLUGIN); // Paper - kick event cause // Paper - configuration stage
+     }
+ 
+     // Paper start
+@@ -668,7 +682,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     @Override
+     public void kick(net.kyori.adventure.text.Component message, org.bukkit.event.player.PlayerKickEvent.Cause cause) {
+         org.spigotmc.AsyncCatcher.catchOp("player kick");
+-        final ServerGamePacketListenerImpl connection = this.getHandle().connection;
++        final net.minecraft.server.network.ServerCommonPacketListenerImpl connection = this.commonListener(); // Paper - configuration stage
+         if (connection != null) {
+             connection.disconnect(message == null ? net.kyori.adventure.text.Component.empty() : message, cause);
+         }
+@@ -2494,6 +2508,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     public void setResourcePack(final UUID uuid, final String url, final byte[] hashBytes, final net.kyori.adventure.text.Component prompt, final boolean force) {
+         Preconditions.checkArgument(uuid != null, "Resource pack UUID cannot be null");
+         Preconditions.checkArgument(url != null, "Resource pack URL cannot be null");
++        if (this.commonListener() == null) return;
+         final String hash;
+         if (hashBytes != null) {
+             Preconditions.checkArgument(hashBytes.length == 20, "Resource pack hash should be 20 bytes long but was " + hashBytes.length);
+@@ -2501,18 +2516,28 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         } else {
+             hash = "";
+         }
+-        this.getHandle().connection.send(new ClientboundResourcePackPopPacket(Optional.empty()));
+-        this.getHandle().connection.send(new ClientboundResourcePackPushPacket(uuid, url, hash, force, Optional.ofNullable(prompt).map(io.papermc.paper.adventure.PaperAdventure::asVanilla)));
++        this.commonListener().send(new ClientboundResourcePackPopPacket(Optional.empty())); // Paper - configuration stage
++        this.commonListener().send(new ClientboundResourcePackPushPacket(uuid, url, hash, force, Optional.ofNullable(prompt).map(io.papermc.paper.adventure.PaperAdventure::asVanilla))); // Paper - configuration stage
+     }
+ 
+     @SuppressWarnings({"unchecked", "rawtypes"})
+-    void sendBundle(final List<? extends net.minecraft.network.protocol.Packet<? extends net.minecraft.network.protocol.common.ClientCommonPacketListener>> packet) {
+-        this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundBundlePacket((List) packet));
++    // Paper start - configuration stage
++    void sendBundle(final List<? extends net.minecraft.network.protocol.Packet<? extends net.minecraft.network.protocol.common.ClientCommonPacketListener>> packets) {
++        //noinspection ConstantValue,UnreachableCode
++        if (this.getHandle().connection != null) {
++            // send on game connection
++            this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundBundlePacket((List) packets));
++        } else if (this.getHandle().configConnection != null) {
++            for (final Packet<? extends net.minecraft.network.protocol.common.ClientCommonPacketListener> packet : packets) {
++                this.getHandle().configConnection.send(packet);
++            }
++        }
++        // Paper end - configuration stage
+     }
+ 
+     @Override
+     public void sendResourcePacks(final net.kyori.adventure.resource.ResourcePackRequest request) {
+-        if (this.getHandle().connection == null) return;
++        if (this.commonListener() == null) return; // Paper - configuration stage
+         final List<ClientboundResourcePackPushPacket> packs = new java.util.ArrayList<>(request.packs().size());
+         if (request.replace()) {
+             this.clearResourcePacks();
+@@ -2521,8 +2546,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         for (final java.util.Iterator<net.kyori.adventure.resource.ResourcePackInfo> iter = request.packs().iterator(); iter.hasNext();) {
+             final net.kyori.adventure.resource.ResourcePackInfo pack = iter.next();
+             packs.add(new ClientboundResourcePackPushPacket(pack.id(), pack.uri().toASCIIString(), pack.hash(), request.required(), iter.hasNext() ? Optional.empty() : Optional.ofNullable(prompt)));
+-            if (request.callback() != net.kyori.adventure.resource.ResourcePackCallback.noOp()) {
+-                this.getHandle().connection.packCallbacks.put(pack.id(), request.callback()); // just override if there is a previously existing callback
++            if (request.callback() != net.kyori.adventure.resource.ResourcePackCallback.noOp()) { // Paper - configuration stage
++                this.commonListener().packCallbacks.put(pack.id(), request.callback()); // just override if there is a previously existing callback // Paper - configuration stage
+             }
+         }
+         this.sendBundle(packs);
+@@ -2531,14 +2556,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+ 
+     @Override
+     public void removeResourcePacks(final UUID id, final UUID ... others) {
+-        if (this.getHandle().connection == null) return;
++        if (this.commonListener() == null) return; // Paper - configuration stage
+         this.sendBundle(net.kyori.adventure.util.MonkeyBars.nonEmptyArrayToList(pack -> new ClientboundResourcePackPopPacket(Optional.of(pack)), id, others));
+     }
+ 
+     @Override
+     public void clearResourcePacks() {
+-        if (this.getHandle().connection == null) return;
+-        this.getHandle().connection.send(new ClientboundResourcePackPopPacket(Optional.empty()));
++        if (this.commonListener() == null) return; // Paper - configuration stage
++        this.commonListener().send(new ClientboundResourcePackPopPacket(Optional.empty())); // Paper - configuration stage
+     }
+     // Paper end - adventure
+ 
+@@ -2552,23 +2577,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     @Override
+     public void removeResourcePack(UUID id) {
+         Preconditions.checkArgument(id != null, "Resource pack id cannot be null");
+-        if (this.getHandle().connection == null) return;
+-        this.getHandle().connection.send(new ClientboundResourcePackPopPacket(Optional.of(id)));
++        if (this.commonListener() == null) return; // Paper - configuration stage
++        this.commonListener().send(new ClientboundResourcePackPopPacket(Optional.of(id))); // Paper - configuration stage
+     }
+ 
+     @Override
+     public void removeResourcePacks() {
+-        if (this.getHandle().connection == null) return;
+-        this.getHandle().connection.send(new ClientboundResourcePackPopPacket(Optional.empty()));
++        if (this.commonListener() == null) return; // Paper - configuration stage
++        this.commonListener().send(new ClientboundResourcePackPopPacket(Optional.empty())); // Paper - configuration stage
+     }
+ 
+     private void handlePushResourcePack(ClientboundResourcePackPushPacket resourcePackPushPacket, boolean resetBeforePush) {
+-        if (this.getHandle().connection == null) return;
++        if (this.commonListener() == null) return; // Paper - configuration stage
+ 
+         if (resetBeforePush) {
+             this.removeResourcePacks();
+         }
+-        this.getHandle().connection.send(resourcePackPushPacket);
++        this.commonListener().send(resourcePackPushPacket); // Paper - configuration stage
+     }
+ 
+     public void addChannel(String channel) {


### PR DESCRIPTION
There are at least 2 events I know of that fire during the configuration stage before the `ServerGamePacketListenerImpl` has been created: `PlayerClientOptionsChangeEvent` and `PlayerSpawnLocationEvent`. In addition, there are the listeners for custom payloads that also run. This PR adds support for the functionality that is supported during the configuration phase, namely kicking players, sending custom resource packs, and sending custom payloads.

```[tasklist]
- [x] kick API
- [x] sending resource pack API
- [x] ~~custom channel stuff~~will handle at a later time
```