### PR TITLE
Add player idle duration API

### DIFF
--- a/patches/api/0442-Add-player-idle-duration-API.patch
+++ b/patches/api/0442-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting, setting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 20fa1024f9ad8f478a347be5c554b5e45b398a1c..2fc042b8ffe610a7ec431aad3c1d3ba407f05d40 100644
+index 20fa1024f9ad8f478a347be5c554b5e45b398a1c..2996db88343060624d6aab7889290ae74a973fe8 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3274,6 +3274,37 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3274,6 +3274,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void increaseWardenWarningLevel();
      // Paper end
  
@@ -24,14 +24,6 @@ index 20fa1024f9ad8f478a347be5c554b5e45b398a1c..2fc042b8ffe610a7ec431aad3c1d3ba4
 +     * @return the current idle duration of this player
 +     */
 +    @NotNull Duration getIdleDuration();
-+
-+    /**
-+     * After the idle duration exceeds {@link org.bukkit.Bukkit#getIdleTimeout()}, the
-+     * player will be kicked for {@link org.bukkit.event.player.PlayerKickEvent.Cause#IDLING}.
-+     *
-+     * @param duration the new idle duration of this player
-+     */
-+    void setIdleDuration(@NotNull Duration duration);
 +
 +    /**
 +     * Resets this player's idle duration.

--- a/patches/api/0442-Add-player-idle-duration-API.patch
+++ b/patches/api/0442-Add-player-idle-duration-API.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: booky10 <boooky10@gmail.com>
+Date: Sat, 14 Oct 2023 03:11:11 +0200
+Subject: [PATCH] Add player idle duration API
+
+Implements API for getting, setting and resetting a player's idle duration.
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 20fa1024f9ad8f478a347be5c554b5e45b398a1c..2fc042b8ffe610a7ec431aad3c1d3ba407f05d40 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -3274,6 +3274,37 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     void increaseWardenWarningLevel();
+     // Paper end
+ 
++    // Paper start
++    /**
++     * The idle duration is reset when the player
++     * sends specific action packets.
++     * <p>
++     * After the idle duration exceeds {@link org.bukkit.Bukkit#getIdleTimeout()}, the
++     * player will be kicked for {@link org.bukkit.event.player.PlayerKickEvent.Cause#IDLING}.
++     *
++     * @return the current idle duration of this player
++     */
++    @NotNull Duration getIdleDuration();
++
++    /**
++     * After the idle duration exceeds {@link org.bukkit.Bukkit#getIdleTimeout()}, the
++     * player will be kicked for {@link org.bukkit.event.player.PlayerKickEvent.Cause#IDLING}.
++     *
++     * @param duration the new idle duration of this player
++     */
++    void setIdleDuration(@NotNull Duration duration);
++
++    /**
++     * Resets this player's idle duration.
++     * <p>
++     * After the idle duration exceeds {@link org.bukkit.Bukkit#getIdleTimeout()}, the
++     * player will be kicked for {@link org.bukkit.event.player.PlayerKickEvent.Cause#IDLING}.
++     *
++     * @see #getIdleDuration()
++     */
++    void resetIdleDuration();
++    // Paper end
++
+     @NotNull
+     @Override
+     Spigot spigot();

--- a/patches/api/0442-Add-player-idle-duration-API.patch
+++ b/patches/api/0442-Add-player-idle-duration-API.patch
@@ -3,7 +3,7 @@ From: booky10 <boooky10@gmail.com>
 Date: Sat, 14 Oct 2023 03:11:11 +0200
 Subject: [PATCH] Add player idle duration API
 
-Implements API for getting, setting and resetting a player's idle duration.
+Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
 index 20fa1024f9ad8f478a347be5c554b5e45b398a1c..2996db88343060624d6aab7889290ae74a973fe8 100644

--- a/patches/server/1039-Add-player-idle-duration-API.patch
+++ b/patches/server/1039-Add-player-idle-duration-API.patch
@@ -3,7 +3,7 @@ From: booky10 <boooky10@gmail.com>
 Date: Sat, 14 Oct 2023 03:11:11 +0200
 Subject: [PATCH] Add player idle duration API
 
-Implements API for getting, setting and resetting a player's idle duration.
+Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 index 604ed1f6742a6b028b9db2809f7bd4b9a3b38f4d..bd2cb9080a5a215c97d4dc038ab8e8d1f7c20f8f 100644

--- a/patches/server/1039-Add-player-idle-duration-API.patch
+++ b/patches/server/1039-Add-player-idle-duration-API.patch
@@ -5,26 +5,18 @@ Subject: [PATCH] Add player idle duration API
 
 Implements API for getting, setting and resetting a player's idle duration.
 
-== AT ==
-public net.minecraft.server.level.ServerPlayer lastActionTime
-
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 604ed1f6742a6b028b9db2809f7bd4b9a3b38f4d..03020b3e2e1e76dc8b202053088a5f13dd175b6f 100644
+index 604ed1f6742a6b028b9db2809f7bd4b9a3b38f4d..bd2cb9080a5a215c97d4dc038ab8e8d1f7c20f8f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3278,6 +3278,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3278,6 +3278,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  
 +    // Paper start
 +    @Override
 +    public Duration getIdleDuration() {
-+        return Duration.ofMillis(net.minecraft.Util.getMillis() - this.getHandle().lastActionTime);
-+    }
-+
-+    @Override
-+    public void setIdleDuration(Duration duration) {
-+        this.getHandle().lastActionTime = net.minecraft.Util.getMillis() - duration.toMillis();
++        return Duration.ofMillis(net.minecraft.Util.getMillis() - this.getHandle().getLastActionTime());
 +    }
 +
 +    @Override

--- a/patches/server/1039-Add-player-idle-duration-API.patch
+++ b/patches/server/1039-Add-player-idle-duration-API.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: booky10 <boooky10@gmail.com>
+Date: Sat, 14 Oct 2023 03:11:11 +0200
+Subject: [PATCH] Add player idle duration API
+
+Implements API for getting, setting and resetting a player's idle duration.
+
+== AT ==
+public net.minecraft.server.level.ServerPlayer lastActionTime
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 604ed1f6742a6b028b9db2809f7bd4b9a3b38f4d..03020b3e2e1e76dc8b202053088a5f13dd175b6f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -3278,6 +3278,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+     // Paper end
+ 
++    // Paper start
++    @Override
++    public Duration getIdleDuration() {
++        return Duration.ofMillis(net.minecraft.Util.getMillis() - this.getHandle().lastActionTime);
++    }
++
++    @Override
++    public void setIdleDuration(Duration duration) {
++        this.getHandle().lastActionTime = net.minecraft.Util.getMillis() - duration.toMillis();
++    }
++
++    @Override
++    public void resetIdleDuration() {
++        this.getHandle().resetLastActionTime();
++    }
++    // Paper end
++
+     public Player.Spigot spigot()
+     {
+         return this.spigot;


### PR DESCRIPTION
Implements API for getting, setting and resetting a player's idle duration.

---

Related to #6299, which exposed a getter for the idle time, but got closed because it went stale.