### PR TITLE
Fix strikeLightningEffect powers lightning rods and clears copper alternative

### DIFF
--- a/patches/server/1039-Fix-strikeLightningEffect-powers-lightning-rods-and-.patch
+++ b/patches/server/1039-Fix-strikeLightningEffect-powers-lightning-rods-and-.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tamion <70228790+notTamion@users.noreply.github.com>
+Date: Mon, 16 Oct 2023 17:32:59 +0200
+Subject: [PATCH] Fix strikeLightningEffect powers lightning rods and clears
+ copper
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 0e670de77a7f9926e295e1dd63d909bed1a959ca..2d7f175783836c5e7c45a0adfb1e19957c562ece 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -771,6 +771,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+         LightningBolt lightning = EntityType.LIGHTNING_BOLT.create(world);
+         lightning.moveTo(loc.getX(), loc.getY(), loc.getZ());
+         lightning.setVisualOnly(isVisual);
++        lightning.isSilent = isVisual; // Paper
+         this.world.strikeLightning(lightning, LightningStrikeEvent.Cause.CUSTOM);
+         return (LightningStrike) lightning.getBukkitEntity();
+     }


### PR DESCRIPTION
resolves #9736 
This is an alternative to #9780 
I personally find the other PR better since it also resolves confusing naming and also doesn't use isSilent of which the current behavior is unintended (and the only api that uses this boolean is deprecated)
But incase paper team thinks this is a better fix i will just open this pr