### PR TITLE
Downstream Remove-unused-skyLightSources from Folia

### DIFF
--- a/patches/server/1039-Remove-unused-skyLightSources.patch
+++ b/patches/server/1039-Remove-unused-skyLightSources.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Sat, 10 Jun 2023 14:05:26 -0700
+Subject: [PATCH] Remove unused skyLightSources
+
+Starlight does not use the sky light sources.
+We can just delete it entirely.
+
+diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java b/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
+index 8b96d1b7548d354fbcabe6d1b5e9d6c3e2a5cb9d..695995333a31d766419cad0b0e78d88658cd9c42 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
++++ b/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
+@@ -74,7 +74,7 @@ public abstract class ChunkAccess implements BlockGetter, BiomeManager.NoiseBiom
+     @Nullable
+     protected BlendingData blendingData;
+     public final Map<Heightmap.Types, Heightmap> heightmaps = Maps.newEnumMap(Heightmap.Types.class);
+-    protected ChunkSkyLightSources skyLightSources;
++    // protected ChunkSkyLightSources skyLightSources; // Paper - remove unused skyLightSources
+     private final Map<Structure, StructureStart> structureStarts = Maps.newHashMap();
+     private final Map<Structure, LongSet> structuresRefences = Maps.newHashMap();
+     protected final Map<BlockPos, CompoundTag> pendingBlockEntities = Maps.newHashMap();
+@@ -137,7 +137,7 @@ public abstract class ChunkAccess implements BlockGetter, BiomeManager.NoiseBiom
+         this.inhabitedTime = inhabitedTime;
+         this.postProcessing = new ShortList[heightLimitView.getSectionsCount()];
+         this.blendingData = blendingData;
+-        this.skyLightSources = new ChunkSkyLightSources(heightLimitView);
++        // this.skyLightSources = new ChunkSkyLightSources(heightLimitView); // Paper - remove unused skyLightSources
+         if (sectionArray != null) {
+             if (this.sections.length == sectionArray.length) {
+                 System.arraycopy(sectionArray, 0, this.sections, 0, this.sections.length);
+@@ -549,12 +549,12 @@ public abstract class ChunkAccess implements BlockGetter, BiomeManager.NoiseBiom
+     }
+ 
+     public void initializeLightSources() {
+-        this.skyLightSources.fillFrom(this);
++        // this.skyLightSources.fillFrom(this); // Paper - remove unused skyLightSources
+     }
+ 
+     @Override
+     public ChunkSkyLightSources getSkyLightSources() {
+-        return this.skyLightSources;
++        return null; // Paper - remove unused skyLightSources
+     }
+ 
+     public static record TicksToSave(SerializableTickContainer<Block> blocks, SerializableTickContainer<Fluid> fluids) {
+diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
+index 4abec88caab4116cfa318f7b66c6b1a8346a7401..2f0d1dc5d8059753320d98c41232e3b9be2da285 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
++++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
+@@ -257,7 +257,7 @@ public class LevelChunk extends ChunkAccess {
+             }
+         }
+ 
+-        this.skyLightSources = protoChunk.skyLightSources;
++        // this.skyLightSources = protoChunk.skyLightSources; // Paper - remove unused skyLightSources
+         this.setLightCorrect(protoChunk.isLightCorrect());
+         this.unsaved = true;
+         this.needsDecoration = true; // CraftBukkit
+@@ -448,7 +448,7 @@ public class LevelChunk extends ChunkAccess {
+                     ProfilerFiller gameprofilerfiller = this.level.getProfiler();
+ 
+                     gameprofilerfiller.push("updateSkyLightSources");
+-                    this.skyLightSources.update(this, j, i, l);
++                    // this.skyLightSources.update(this, j, i, l); // Paper - remove unused skyLightSources
+                     gameprofilerfiller.popPush("queueCheckLight");
+                     this.level.getChunkSource().getLightEngine().checkBlock(blockposition);
+                     gameprofilerfiller.pop();
+diff --git a/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java b/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
+index 6c72eb36020bc05104b21e52cea89de09b85f2d7..7429f5ab7610a65ed05319f8d1fe79ee857ad1c3 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
++++ b/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
+@@ -140,7 +140,7 @@ public class ProtoChunk extends ChunkAccess {
+                     }
+ 
+                     if (LightEngine.hasDifferentLightProperties(this, pos, blockState, state)) {
+-                        this.skyLightSources.update(this, m, j, o);
++                        // this.skyLightSources.update(this, m, j, o); // Paper - remove unused skyLightSources
+                         this.lightEngine.checkBlock(pos);
+                     }
+                 }


### PR DESCRIPTION
Modified slightly from https://github.com/PaperMC/Folia/blob/edafbcef6884cffe493e62cd71f4957708fba7ff/patches/server/0019-Remove-unused-skyLightSources.patch