### PR TITLE
Resend entity using the bundle packet

### DIFF
--- a/patches/server/0893-Properly-resend-entities.patch
+++ b/patches/server/0893-Properly-resend-entities.patch
@@ -16,10 +16,10 @@ See: https://github.com/PaperMC/Paper/pull/1896
 public net.minecraft.server.level.ChunkMap$TrackedEntity serverEntity
 
 diff --git a/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java b/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java
-index d088479d160dbd2fc90b48a30553be141db8eef2..15add3f4dfd718ec09bb1db4f22223466936879c 100644
+index d088479d160dbd2fc90b48a30553be141db8eef2..ccb7d92b6c36b6225a2e640f8cea6c0da37464c8 100644
 --- a/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java
 +++ b/src/main/java/net/minecraft/network/syncher/SynchedEntityData.java
-@@ -253,14 +253,60 @@ public class SynchedEntityData {
+@@ -253,14 +253,63 @@ public class SynchedEntityData {
      // CraftBukkit start
      public void refresh(ServerPlayer to) {
          if (!this.isEmpty()) {
@@ -58,9 +58,12 @@ index d088479d160dbd2fc90b48a30553be141db8eef2..15add3f4dfd718ec09bb1db4f2222346
 +            return;
 +        }
 +
-+        net.minecraft.server.level.ServerEntity serverEntity = this.entity.tracker.serverEntity;
 +        if (player.getBukkitEntity().canSee(entity.getBukkitEntity())) {
-+            serverEntity.sendPairingData(player, player.connection::send);
++            net.minecraft.server.level.ServerEntity serverEntity = this.entity.tracker.serverEntity;
++
++            List<net.minecraft.network.protocol.Packet<net.minecraft.network.protocol.game.ClientGamePacketListener>> list = new ArrayList<>();
++            serverEntity.sendPairingData(player, list::add);
++            player.connection.send(new net.minecraft.network.protocol.game.ClientboundBundlePacket(list));
 +        }
 +    }
 +


### PR DESCRIPTION
The packets used to resend the entity can be moved into a bundle packet to process the packets in the same tick like the first time.