### PR TITLE
Cleanup disable explosion knockback patch

### DIFF
--- a/patches/server/0041-Disable-explosion-knockback.patch
+++ b/patches/server/0041-Disable-explosion-knockback.patch
@@ -4,31 +4,6 @@ Date: Wed, 2 Mar 2016 14:48:03 -0600
 Subject: [PATCH] Disable explosion knockback
 
 
-diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index de73a18438462b478af813a7a709964506b41174..7fd5e2cb9139f53c0c08cf14760db311347f843d 100644
---- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
-+++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1476,10 +1476,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
-                 }
-             }
- 
-+            boolean knockbackCancelled = this.level().paperConfig().environment.disableExplosionKnockback && source.is(DamageTypeTags.IS_EXPLOSION) && this instanceof net.minecraft.world.entity.player.Player; // Paper - Disable explosion knockback
-             if (flag1) {
-                 if (flag) {
-                     this.level().broadcastEntityEvent(this, (byte) 29);
-                 } else {
-+                    if (!knockbackCancelled) // Paper - Disable explosion knockback
-                     this.level().broadcastDamageEvent(this, source);
-                 }
- 
-@@ -1503,6 +1505,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
-                 }
-             }
- 
-+            if (knockbackCancelled) this.level().broadcastEntityEvent(this, (byte) 2); // Paper - Disable explosion knockback
-             if (this.isDeadOrDying()) {
-                 if (!this.checkTotemDeathProtection(source)) {
-                     SoundEvent soundeffect = this.getDeathSound();
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
 index 03151b8042912882ebb969dda16cc378562a0005..aea135503da20b7c4e2c6cd2dba81998f101b0c4 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java

--- a/patches/server/0072-Custom-replacement-for-eaten-items.patch
+++ b/patches/server/0072-Custom-replacement-for-eaten-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom replacement for eaten items
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f22055ef2b5ff7a98c9388b0324b8e3e4b5e1172..a2cc42373e4fe078197d90e2f16245fb75cd18bb 100644
+index 0c049587bd99b66b5307cd37da72b1b01f201a86..b819c60cb7640c10594953597e3dde3007ff3be5 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3699,10 +3699,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3696,10 +3696,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
@@ -21,7 +21,7 @@ index f22055ef2b5ff7a98c9388b0324b8e3e4b5e1172..a2cc42373e4fe078197d90e2f16245fb
                          this.level().getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {
-@@ -3716,6 +3717,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3713,6 +3714,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      } else {
                          itemstack = this.useItem.finishUsingItem(this.level(), this);
                      }
@@ -34,7 +34,7 @@ index f22055ef2b5ff7a98c9388b0324b8e3e4b5e1172..a2cc42373e4fe078197d90e2f16245fb
                      // CraftBukkit end
  
                      if (itemstack != this.useItem) {
-@@ -3723,6 +3730,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3720,6 +3727,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0073-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
+++ b/patches/server/0073-Strip-raytracing-for-EntityLiving-hasLineOfSight.patch
@@ -26,10 +26,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a2cc42373e4fe078197d90e2f16245fb75cd18bb..dc5ff4fc1fb2472ff1e9b1f142b5d964e9d740ee 100644
+index b819c60cb7640c10594953597e3dde3007ff3be5..3fe9b954bf2394986cf8b76f37e6e0780b3d5978 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3467,7 +3467,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3464,7 +3464,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  

--- a/patches/server/0074-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0074-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index dc5ff4fc1fb2472ff1e9b1f142b5d964e9d740ee..82eee07363edd313c6f1f6243867d91185076382 100644
+index 3fe9b954bf2394986cf8b76f37e6e0780b3d5978..08d7c37c1d9dcee4f1578600ac2cd6b584bf2d71 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -794,7 +794,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -34,7 +34,7 @@ index dc5ff4fc1fb2472ff1e9b1f142b5d964e9d740ee..82eee07363edd313c6f1f6243867d911
          // CraftBukkit start - Handle scaled health
          if (this instanceof ServerPlayer) {
              org.bukkit.craftbukkit.entity.CraftPlayer player = ((ServerPlayer) this).getBukkitEntity();
-@@ -3532,7 +3542,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3529,7 +3539,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public final void setAbsorptionAmount(float absorptionAmount) {

--- a/patches/server/0127-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0127-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -136,7 +136,7 @@ diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/ma
 index c178a564156562d1dd2c0a30eec3040cb8b4c2d1..3d99e7ea6109261dc5d8de610791ec08dde180b4 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1792,7 +1792,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1789,7 +1789,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
      protected void dropExperience() {
          // CraftBukkit start - Update getExpReward() above if the removed if() changes!
          if (true && !(this instanceof net.minecraft.world.entity.boss.enderdragon.EnderDragon)) { // CraftBukkit - SPIGOT-2420: Special case ender dragon will drop the xp over time

--- a/patches/server/0128-Cap-Entity-Collisions.patch
+++ b/patches/server/0128-Cap-Entity-Collisions.patch
@@ -24,10 +24,10 @@ index f3db63ddb175f82b6eafee48686065050437fc92..4e71fb3fcbd89c21e5132cfb76dcbf8c
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 402fa40908a82a55686c6dc02266093384e7a4e4..42a90da13826d0cdae3f1d4cb609c11fa23ceaae 100644
+index e9948f593c5d0df365104f50444e520b1be3d974..382e3546fb8d1482956484920ea6ece691a828e1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3349,10 +3349,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3346,10 +3346,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  }
  
                  Iterator iterator1 = list.iterator();

--- a/patches/server/0162-Add-PlayerArmorChangeEvent.patch
+++ b/patches/server/0162-Add-PlayerArmorChangeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 42a90da13826d0cdae3f1d4cb609c11fa23ceaae..29d6fcdd74445a8e9088db6078ce1d8bd176029e 100644
+index 382e3546fb8d1482956484920ea6ece691a828e1..1371e57840727fee82186c44618064e8e147d260 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1,5 +1,6 @@
@@ -15,7 +15,7 @@ index 42a90da13826d0cdae3f1d4cb609c11fa23ceaae..29d6fcdd74445a8e9088db6078ce1d8b
  import com.google.common.base.Objects;
  import com.google.common.collect.ImmutableList;
  import com.google.common.collect.ImmutableMap;
-@@ -3053,6 +3054,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3050,6 +3051,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
              ItemStack itemstack1 = this.getItemBySlot(enumitemslot);
  
              if (this.equipmentHasChanged(itemstack, itemstack1)) {

--- a/patches/server/0207-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0207-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 29d6fcdd74445a8e9088db6078ce1d8bd176029e..4fabac2c6e5edc64ff71f92b527d8ceead36e498 100644
+index 1371e57840727fee82186c44618064e8e147d260..91de8c2ca2bd681c8289ce0c59f3ddb1d56be83e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3809,12 +3809,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3806,12 +3806,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (this.isUsingItem() && !this.useItem.isEmpty()) {
              Item item = this.useItem.getItem();
  

--- a/patches/server/0210-Implement-EntityKnockbackByEntityEvent-and-EntityPus.patch
+++ b/patches/server/0210-Implement-EntityKnockbackByEntityEvent-and-EntityPus.patch
@@ -33,10 +33,10 @@ index 1d21c5d5ea84f76d4cafe9d2d22226cf50232ee1..ca773bca9df5a313d979e97e3a5245e7
  
      protected void markHurt() {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4fabac2c6e5edc64ff71f92b527d8ceead36e498..b3690175df91a21517d2d192a824984d75473d1e 100644
+index 91de8c2ca2bd681c8289ce0c59f3ddb1d56be83e..d9ed53c65b8b59da452016d415e925e9e579fe94 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1516,7 +1516,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1514,7 +1514,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                          d0 = (Math.random() - Math.random()) * 0.01D;
                      }
  
@@ -45,7 +45,7 @@ index 4fabac2c6e5edc64ff71f92b527d8ceead36e498..b3690175df91a21517d2d192a824984d
                      if (!flag) {
                          this.indicateDamage(d0, d1);
                      }
-@@ -1565,7 +1565,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1562,7 +1562,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      protected void blockedByShield(LivingEntity target) {
@@ -54,7 +54,7 @@ index 4fabac2c6e5edc64ff71f92b527d8ceead36e498..b3690175df91a21517d2d192a824984d
      }
  
      private boolean checkTotemDeathProtection(DamageSource source) {
-@@ -1826,6 +1826,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1823,6 +1823,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public void knockback(double strength, double x, double z) {
@@ -66,7 +66,7 @@ index 4fabac2c6e5edc64ff71f92b527d8ceead36e498..b3690175df91a21517d2d192a824984d
          strength *= 1.0D - this.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE);
          if (strength > 0.0D) {
              this.hasImpulse = true;
-@@ -1833,6 +1838,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1830,6 +1835,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Vec3 vec3d1 = (new Vec3(x, 0.0D, z)).normalize().scale(strength);
  
              this.setDeltaMovement(vec3d.x / 2.0D - vec3d1.x, this.onGround() ? Math.min(0.4D, vec3d.y / 2.0D + strength) : vec3d.y, vec3d.z / 2.0D - vec3d1.z);

--- a/patches/server/0251-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/server/0251-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ray tracing methods to LivingEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index b3690175df91a21517d2d192a824984d75473d1e..05595ff2336b25712b59b8ad6b11163dd333e6c0 100644
+index d9ed53c65b8b59da452016d415e925e9e579fe94..036299bd181f36776cac3843d2909a65ec2a875e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3830,6 +3830,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3827,6 +3827,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      // Paper start

--- a/patches/server/0253-Improve-death-events.patch
+++ b/patches/server/0253-Improve-death-events.patch
@@ -81,8 +81,8 @@ index 16fb709582d5311c4b59d72974467eaa1c61a2ab..73b30df698142abf569c232630ec1d95
  
      @Override
      public float getBukkitYaw() {
-@@ -1526,13 +1527,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
-             if (knockbackCancelled) this.level().broadcastEntityEvent(this, (byte) 2); // Paper - Disable explosion knockback
+@@ -1523,13 +1524,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+ 
              if (this.isDeadOrDying()) {
                  if (!this.checkTotemDeathProtection(source)) {
 -                    SoundEvent soundeffect = this.getDeathSound();
@@ -99,7 +99,7 @@ index 16fb709582d5311c4b59d72974467eaa1c61a2ab..73b30df698142abf569c232630ec1d95
                  }
              } else if (flag1) {
                  this.playHurtSound(source);
-@@ -1685,7 +1685,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1682,7 +1682,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (!this.isRemoved() && !this.dead) {
              Entity entity = damageSource.getEntity();
              LivingEntity entityliving = this.getKillCredit();
@@ -108,7 +108,7 @@ index 16fb709582d5311c4b59d72974467eaa1c61a2ab..73b30df698142abf569c232630ec1d95
              if (this.deathScore >= 0 && entityliving != null) {
                  entityliving.awardKillScore(this, this.deathScore, damageSource);
              }
-@@ -1697,24 +1697,59 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1694,24 +1694,59 @@ public abstract class LivingEntity extends Entity implements Attackable {
              if (!this.level().isClientSide && this.hasCustomName()) {
                  if (org.spigotmc.SpigotConfig.logNamedDeaths) LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString()); // Spigot
              }
@@ -173,7 +173,7 @@ index 16fb709582d5311c4b59d72974467eaa1c61a2ab..73b30df698142abf569c232630ec1d95
          }
      }
  
-@@ -1722,7 +1757,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1719,7 +1754,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (!this.level().isClientSide) {
              boolean flag = false;
  
@@ -182,7 +182,7 @@ index 16fb709582d5311c4b59d72974467eaa1c61a2ab..73b30df698142abf569c232630ec1d95
                  if (this.level().getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
                      BlockPos blockposition = this.blockPosition();
                      BlockState iblockdata = Blocks.WITHER_ROSE.defaultBlockState();
-@@ -1751,7 +1786,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1748,7 +1783,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
      }
  
@@ -195,7 +195,7 @@ index 16fb709582d5311c4b59d72974467eaa1c61a2ab..73b30df698142abf569c232630ec1d95
          Entity entity = source.getEntity();
          int i;
  
-@@ -1766,18 +1805,27 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1763,18 +1802,27 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.dropEquipment(); // CraftBukkit - from below
          if (this.shouldDropLoot() && this.level().getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
              this.dropFromLootTable(source, flag);

--- a/patches/server/0265-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0265-Add-LivingEntity-getTargetEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 96e9616f4ceedf95ec94854a0b1d8526a80057f5..4778851ce1592d5f7fafb03310a7c965b6cde492 100644
+index a16e60f7dde5ad3b908d76d1889ea8ddb3d5e102..d8c413e60abbdbd337afef31f0b88a1b8ac6a59f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -116,6 +116,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
@@ -16,7 +16,7 @@ index 96e9616f4ceedf95ec94854a0b1d8526a80057f5..4778851ce1592d5f7fafb03310a7c965
  import net.minecraft.world.phys.HitResult;
  import net.minecraft.world.phys.Vec3;
  import net.minecraft.world.scores.PlayerTeam;
-@@ -3892,6 +3893,38 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3889,6 +3890,38 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return this.level().clip(raytrace);
      }
  

--- a/patches/server/0285-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0285-force-entity-dismount-during-teleportation.patch
@@ -72,10 +72,10 @@ index 63f9f874ef9da0d5f0c6d6df2901be27df5e30a0..72c33eaa232503c373bf8cf9a1c1c760
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4778851ce1592d5f7fafb03310a7c965b6cde492..491ba787cbcc89ec2fee4885d29940e58d0d09b0 100644
+index d8c413e60abbdbd337afef31f0b88a1b8ac6a59f..8606dabdc5759e7b09e3e47d5a1ef7045a0de78b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3472,9 +3472,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3469,9 +3469,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      @Override
      public void stopRiding() {

--- a/patches/server/0322-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0322-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 491ba787cbcc89ec2fee4885d29940e58d0d09b0..30defcdf671696125314a6baf81aa3e36010340b 100644
+index 8606dabdc5759e7b09e3e47d5a1ef7045a0de78b..80b60e33e9e39bc62f65bfddf121254d333aecae 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3710,9 +3710,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3707,9 +3707,14 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public void startUsingItem(InteractionHand hand) {
@@ -24,7 +24,7 @@ index 491ba787cbcc89ec2fee4885d29940e58d0d09b0..30defcdf671696125314a6baf81aa3e3
              this.useItem = itemstack;
              this.useItemRemaining = itemstack.getUseDuration();
              if (!this.level().isClientSide) {
-@@ -3792,6 +3797,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3789,6 +3794,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -32,7 +32,7 @@ index 491ba787cbcc89ec2fee4885d29940e58d0d09b0..30defcdf671696125314a6baf81aa3e3
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
-@@ -3826,8 +3832,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3823,8 +3829,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0349-Entity-Jump-API.patch
+++ b/patches/server/0349-Entity-Jump-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 30defcdf671696125314a6baf81aa3e36010340b..1a6581a1524ab6599b13e6ae3fd419d59a1c915d 100644
+index 80b60e33e9e39bc62f65bfddf121254d333aecae..1b8f69d2bc595b655de4a2cdffe77c81433648e3 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3284,8 +3284,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3281,8 +3281,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
              } else if (this.isInLava() && (!this.onGround() || d3 > d4)) {
                  this.jumpInLiquid(FluidTags.LAVA);
              } else if ((this.onGround() || flag && d3 <= d4) && this.noJumpDelay == 0) {

--- a/patches/server/0375-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0375-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -12,10 +12,10 @@ The entity's current team collision rule causes them to NEVER collide.
 Co-authored-by: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1a6581a1524ab6599b13e6ae3fd419d59a1c915d..4c4a0f8d9c48f15095d9ce5c1773bf58b35137af 100644
+index 1b8f69d2bc595b655de4a2cdffe77c81433648e3..53adda63cf8a212af28ef14a7c26c0254c9bae55 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3399,10 +3399,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3396,10 +3396,24 @@ public abstract class LivingEntity extends Entity implements Attackable {
          if (this.level().isClientSide()) {
              this.level().getEntities(EntityTypeTest.forClass(net.minecraft.world.entity.player.Player.class), this.getBoundingBox(), EntitySelector.pushableBy(this)).forEach(this::doPush);
          } else {

--- a/patches/server/0380-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/server/0380-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4c4a0f8d9c48f15095d9ce5c1773bf58b35137af..4edf7a989f12cae065977d1f529e856a7d3a932b 100644
+index 53adda63cf8a212af28ef14a7c26c0254c9bae55..00a3b2d0b28e6f76ad94105f091c78366c91b2d7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2196,7 +2196,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2193,7 +2193,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
              EntityDamageEvent event = CraftEventFactory.handleLivingEntityDamageEvent(this, damagesource, originalDamage, hardHatModifier, blockingModifier, armorModifier, resistanceModifier, magicModifier, absorptionModifier, hardHat, blocking, armor, resistance, magic, absorption);
              if (damagesource.getEntity() instanceof net.minecraft.world.entity.player.Player) {

--- a/patches/server/0383-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0383-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -83,7 +83,7 @@ diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/ma
 index 61b9c3ebc97b0a778c3a75a926c0d689f43df823..50c68e48992add57accf7f5479952d17beca577a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1711,9 +1711,9 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1708,9 +1708,9 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  // Paper start
                  org.bukkit.event.entity.EntityDeathEvent deathEvent = this.dropAllDeathLoot(damageSource);
                  if (deathEvent == null || !deathEvent.isCancelled()) {
@@ -96,7 +96,7 @@ index 61b9c3ebc97b0a778c3a75a926c0d689f43df823..50c68e48992add57accf7f5479952d17
                      // Paper start - clear equipment if event is not cancelled
                      if (this instanceof Mob) {
                          for (EquipmentSlot slot : this.clearedEquipmentSlots) {
-@@ -1814,8 +1814,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1811,8 +1811,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.dropCustomDeathLoot(source, i, flag);
              this.clearEquipmentSlots = prev; // Paper
          }

--- a/patches/server/0434-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0434-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f01a5ba97d391292192100b6cd7fa018cdeb7e05..e09eb0437ec274ecaae7ec6f1efd1ac058fbb57f 100644
+index c87b149c7de77275252a5d6e182f96059760890b..b2383510e00dcd68dee1a1f48aab873ae09f4d97 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3511,7 +3511,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3508,7 +3508,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - suppress

--- a/patches/server/0496-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0496-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -45,10 +45,10 @@ index d15e62da0307728a7c2be191a27f87da1bb29f49..de06ae3e8757c923a6f3f475a34885d2
              } else if (entity.level().isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e09eb0437ec274ecaae7ec6f1efd1ac058fbb57f..583a86ac39c7e8526f51f12ab9a39f6340949610 100644
+index b2383510e00dcd68dee1a1f48aab873ae09f4d97..f767d1d98574fc847c495baee1bf369444443aad 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3427,7 +3427,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3424,7 +3424,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  return;
              }
              // Paper end - don't run getEntities if we're not going to use its result
@@ -57,7 +57,7 @@ index e09eb0437ec274ecaae7ec6f1efd1ac058fbb57f..583a86ac39c7e8526f51f12ab9a39f63
  
              if (!list.isEmpty()) {
                  // Paper - moved up
-@@ -3617,9 +3617,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3614,9 +3614,16 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0546-EntityMoveEvent.patch
+++ b/patches/server/0546-EntityMoveEvent.patch
@@ -29,10 +29,10 @@ index 18a69ab85de7f23f5ff468307bf2669544eba8af..e0a94d75ddf5cc0988876e7438fbcc44
          final Throwable thr = new Throwable(entity + " Added to world at " + new java.util.Date());
          io.papermc.paper.util.StacktraceDeobfuscator.INSTANCE.deobfuscateThrowable(thr);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 583a86ac39c7e8526f51f12ab9a39f6340949610..e0aa747992218e59440fbd9d7d87b72f9126b13b 100644
+index f767d1d98574fc847c495baee1bf369444443aad..d56c968a5af7358ec07ba44fa4c7e0dc0861c86a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3362,6 +3362,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3359,6 +3359,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          this.pushEntities();
          this.level().getProfiler().pop();

--- a/patches/server/0572-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0572-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e0aa747992218e59440fbd9d7d87b72f9126b13b..f2aa9f94f47bd2190e21287d06cb13c58df98e04 100644
+index d56c968a5af7358ec07ba44fa4c7e0dc0861c86a..b2a5b9c7502af235e7f31ffa45c0f4d501a5f459 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3860,6 +3860,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3857,6 +3857,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                          this.level().getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {

--- a/patches/server/0621-Line-Of-Sight-Changes.patch
+++ b/patches/server/0621-Line-Of-Sight-Changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f2aa9f94f47bd2190e21287d06cb13c58df98e04..c46e543cfe8fa5cef2e09c72b0cf82f66359482a 100644
+index b2a5b9c7502af235e7f31ffa45c0f4d501a5f459..fd910b23f4f761a8a1ca3da12a114d9138753f20 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3607,7 +3607,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3604,7 +3604,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  

--- a/patches/server/0642-Improve-boat-collision-performance.patch
+++ b/patches/server/0642-Improve-boat-collision-performance.patch
@@ -17,7 +17,7 @@ index 5e9401f0c2de0743aca9237ee8c4dfba586cfdb9..25b2d7016b60ee9bad0a2fb4a2c7c8ee
      };
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3ece54f48b1cda01a04d6b943e2b10a9ad8c2af5..14d5d124c34a2092f7a0fc9e1e1305ac9b17ce81 100644
+index 8ce2eae72048701f02026fc5309b406005900694..705a76c73233a29105f5cb2e50d4d200376a4c60 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1414,7 +1414,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -29,7 +29,7 @@ index 3ece54f48b1cda01a04d6b943e2b10a9ad8c2af5..14d5d124c34a2092f7a0fc9e1e1305ac
                          LivingEntity entityliving = (LivingEntity) entity;
  
                          this.blockUsingShield(entityliving);
-@@ -1510,11 +1510,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1508,11 +1508,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  }
  
                  if (entity1 != null && !source.is(DamageTypeTags.NO_KNOCKBACK)) {
@@ -44,7 +44,7 @@ index 3ece54f48b1cda01a04d6b943e2b10a9ad8c2af5..14d5d124c34a2092f7a0fc9e1e1305ac
                          d0 = (Math.random() - Math.random()) * 0.01D;
                      }
  
-@@ -2247,7 +2248,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2244,7 +2245,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/0716-Prevent-excessive-velocity-through-repeated-crits.patch
+++ b/patches/server/0716-Prevent-excessive-velocity-through-repeated-crits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent excessive velocity through repeated crits
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a92345f1f7c4a4153fa55e2b23f4097faf90161d..743ad0879e240bb88b2a6735b565911c44cfad8b 100644
+index d9f9eb379c6d00aa7be40d4889d8ee4fbffab357..ac66d2ee0608b079ac0f1809d9116242daf557c1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2683,13 +2683,26 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2680,13 +2680,26 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return this.hasEffect(MobEffects.JUMP) ? 0.1F * ((float) this.getEffect(MobEffects.JUMP).getAmplifier() + 1.0F) : 0.0F;
      }
  

--- a/patches/server/0719-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0719-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -34,10 +34,10 @@ index e0802f1cb73a80b08482832c2b269ac8485d5c1a..8d2870c780c4c253f6570c7ef73f6e7c
              }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 743ad0879e240bb88b2a6735b565911c44cfad8b..f8738a28fb30c8fdb52ed3e6f8000144129c1f00 100644
+index ac66d2ee0608b079ac0f1809d9116242daf557c1..f6b8518df044cd57eeafa84890920bba5c36c012 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3194,7 +3194,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3191,7 +3191,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
          equipmentChanges.forEach((enumitemslot, itemstack) -> {
              ItemStack itemstack1 = itemstack.copy();
  
@@ -49,7 +49,7 @@ index 743ad0879e240bb88b2a6735b565911c44cfad8b..f8738a28fb30c8fdb52ed3e6f8000144
              switch (enumitemslot.getType()) {
                  case HAND:
                      this.setLastHandItem(enumitemslot, itemstack1);
-@@ -3207,6 +3210,34 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3204,6 +3207,34 @@ public abstract class LivingEntity extends Entity implements Attackable {
          ((ServerLevel) this.level()).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  

--- a/patches/server/0720-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0720-Hide-unnecessary-itemmeta-from-clients.patch
@@ -36,7 +36,7 @@ diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/ma
 index 8959e7d6142025937f9fea3fb8dc25410564cec7..9e1a5eb4cc834305e8959bb1552202c3b64fc869 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3196,7 +3196,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3193,7 +3193,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
              // Paper start - prevent oversized data
              ItemStack toSend = sanitizeItemStack(itemstack1, true);
@@ -45,7 +45,7 @@ index 8959e7d6142025937f9fea3fb8dc25410564cec7..9e1a5eb4cc834305e8959bb1552202c3
              // Paper end
              switch (enumitemslot.getType()) {
                  case HAND:
-@@ -3210,6 +3210,77 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3207,6 +3207,77 @@ public abstract class LivingEntity extends Entity implements Attackable {
          ((ServerLevel) this.level()).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  

--- a/patches/server/0756-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0756-Freeze-Tick-Lock-API.patch
@@ -46,10 +46,10 @@ index da8bd9746a3ddef673230c12370a34c8228aa0c7..a1e795810e7e49acf4959b9c88bed1f9
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4dc9647b9c7206b1e98554d2db0f193b0dce0a94..69fc62b95f068f498a0eb77cf951042ae159204f 100644
+index 4e4cd3978499a363b16a2c2a0a81abef6bb6c815..7a530681bf043f4b335c16277cf07a7934afa8d9 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3453,7 +3453,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3450,7 +3450,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          this.level().getProfiler().pop();
          this.level().getProfiler().push("freezing");

--- a/patches/server/0806-Add-PlayerStopUsingItemEvent.patch
+++ b/patches/server/0806-Add-PlayerStopUsingItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerStopUsingItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 69fc62b95f068f498a0eb77cf951042ae159204f..a483a9558b3f31c3712ea7d8519b8539b0cb0746 100644
+index 7a530681bf043f4b335c16277cf07a7934afa8d9..67fdb5ea2b11588d17cd6f30766d1aa3d7796b1c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -4026,6 +4026,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4023,6 +4023,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
      public void releaseUsingItem() {
          if (!this.useItem.isEmpty()) {

--- a/patches/server/0846-Stop-large-look-changes-from-crashing-the-server.patch
+++ b/patches/server/0846-Stop-large-look-changes-from-crashing-the-server.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Stop large look changes from crashing the server
 Co-authored-by: Jaren Knodel <Jaren@Knodel.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4d7c0063000eb6c0469b837122c881a4a728629a..e25b6a9f50eea2e012315f5a395f369761117de5 100644
+index 67fdb5ea2b11588d17cd6f30766d1aa3d7796b1c..3ac6e5c091077add9bb21675f4b082cd90e946a2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3062,37 +3062,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3059,37 +3059,15 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.level().getProfiler().pop();
          this.level().getProfiler().push("rangeChecks");
  

--- a/patches/server/0884-check-global-player-list-where-appropriate.patch
+++ b/patches/server/0884-check-global-player-list-where-appropriate.patch
@@ -24,10 +24,10 @@ index 5803f7b286cd262a8f79d0adb159d897361275a2..42f0ea87dd0bb3be3fbe9e0f7d87582c
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9a82adb03cdb046f950ca63a029f9f3b6e04538c..4ed23c6143a96e75b0e2e060861dd7c702ce6a95 100644
+index 3ac6e5c091077add9bb21675f4b082cd90e946a2..17cb02b76fd7e5944e0299a78230baf970bc2f25 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3679,7 +3679,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3676,7 +3676,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
      }
  
      public void onItemPickup(ItemEntity item) {

--- a/patches/server/0910-Correctly-shrink-items-during-EntityResurrectEvent.patch
+++ b/patches/server/0910-Correctly-shrink-items-during-EntityResurrectEvent.patch
@@ -22,10 +22,10 @@ This patch corrects this behaviour by only shrinking the item if a totem
 of undying was found and the event was called uncancelled.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a28a7de154da42d24f9a96ba2f0a52aefd9febf5..882ad70e2b6f8dcacef93022f99d9c42356a929e 100644
+index fbdbf706c589b38b97b6a540b3b4e60157e3b7c8..ee8e341d138418b6512cae55a74cd65fd081c715 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1614,7 +1614,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -1611,7 +1611,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.level().getCraftServer().getPluginManager().callEvent(event);
  
              if (!event.isCancelled()) {

--- a/patches/server/0921-Fix-advancement-triggers-for-entity-damage.patch
+++ b/patches/server/0921-Fix-advancement-triggers-for-entity-damage.patch
@@ -23,10 +23,10 @@ index f054d67a637b204de604fadc0d321f5c9816d808..fc5f1e1b445f0a55a35a31d58a90920a
  
              return !this.getResponse();
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 882ad70e2b6f8dcacef93022f99d9c42356a929e..086626fc52fe22b1a7bdec5186f6801faf456eef 100644
+index ee8e341d138418b6512cae55a74cd65fd081c715..0af0a1ee44375e17942f641df49c53c7804c50fc 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2307,7 +2307,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2304,7 +2304,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  // Duplicate triggers if blocking
                  if (event.getDamage(DamageModifier.BLOCKING) < 0) {
                      if (this instanceof ServerPlayer) {
@@ -35,7 +35,7 @@ index 882ad70e2b6f8dcacef93022f99d9c42356a929e..086626fc52fe22b1a7bdec5186f6801f
                          f2 = (float) -event.getDamage(DamageModifier.BLOCKING);
                          if (f2 > 0.0F && f2 < 3.4028235E37F) {
                              ((ServerPlayer) this).awardStat(Stats.DAMAGE_BLOCKED_BY_SHIELD, Math.round(originalDamage * 10.0F));
-@@ -2315,7 +2315,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -2312,7 +2312,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
                      }
  
                      if (damagesource.getEntity() instanceof ServerPlayer) {

--- a/patches/server/0956-Properly-Cancel-Usable-Items.patch
+++ b/patches/server/0956-Properly-Cancel-Usable-Items.patch
@@ -34,7 +34,7 @@ index 34ecfb89372f459117db99d57a7edd6f681bbe8a..baf3e79489e310f443788bc917c553ae
          return enuminteractionresult;
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index afbc246a2dc55f0f1576c0468118ef80671a034e..1c86eaf44e6c797a51e69f14e08bb9a3f91b4c20 100644
+index 93d84ca1d132222c8daed9d2683bf72f95dbb078..2af12e7dddf872f3b80d6288c0b1bd47fcd2b2f7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1923,6 +1923,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -46,10 +46,10 @@ index afbc246a2dc55f0f1576c0468118ef80671a034e..1c86eaf44e6c797a51e69f14e08bb9a3
                  return;
              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8b0d715d3adf4694cd93bbf1152dd2e20d3d44de..485b7c3e3a13ad8fdbf0b17fef31e05803f1615e 100644
+index 0af0a1ee44375e17942f641df49c53c7804c50fc..9cc236acc47b54f84f0ad9137bfa4b7c38412a5c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3814,6 +3814,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3811,6 +3811,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  

--- a/patches/server/1027-Lag-compensation-ticks.patch
+++ b/patches/server/1027-Lag-compensation-ticks.patch
@@ -65,10 +65,10 @@ index 618ab9a2903f6d4139acd4aaa2e6db0a26e88ba9..b2c2bd5ec0afd479973f7237a5c610f2
  
          if (this.hasDelayedDestroy) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 485b7c3e3a13ad8fdbf0b17fef31e05803f1615e..b95f88d5e5b4785ee063695fd81935636a0588d1 100644
+index 9cc236acc47b54f84f0ad9137bfa4b7c38412a5c..24a9cdcd7edd2d9e9b002fd2449a7d80057c5ad7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3819,6 +3819,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3816,6 +3816,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
          this.getEntityData().resendPossiblyDesyncedDataValues(java.util.List.of(DATA_LIVING_ENTITY_FLAGS), serverPlayer);
      }
      // Paper end
@@ -79,7 +79,7 @@ index 485b7c3e3a13ad8fdbf0b17fef31e05803f1615e..b95f88d5e5b4785ee063695fd8193563
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameItem(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -3837,7 +3841,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3834,7 +3838,12 @@ public abstract class LivingEntity extends Entity implements Attackable {
              this.triggerItemUseEffects(stack, 5);
          }
  
@@ -93,7 +93,7 @@ index 485b7c3e3a13ad8fdbf0b17fef31e05803f1615e..b95f88d5e5b4785ee063695fd8193563
              this.completeUsingItem();
          }
  
-@@ -3885,7 +3894,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3882,7 +3891,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
  
          if (!itemstack.isEmpty() && !this.isUsingItem() || forceUpdate) { // Paper use override flag
              this.useItem = itemstack;
@@ -105,7 +105,7 @@ index 485b7c3e3a13ad8fdbf0b17fef31e05803f1615e..b95f88d5e5b4785ee063695fd8193563
              if (!this.level().isClientSide) {
                  this.setLivingEntityFlag(1, true);
                  this.setLivingEntityFlag(2, hand == InteractionHand.OFF_HAND);
-@@ -3910,7 +3922,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -3907,7 +3919,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
                  }
              } else if (!this.isUsingItem() && !this.useItem.isEmpty()) {
                  this.useItem = ItemStack.EMPTY;
@@ -117,7 +117,7 @@ index 485b7c3e3a13ad8fdbf0b17fef31e05803f1615e..b95f88d5e5b4785ee063695fd8193563
              }
          }
  
-@@ -4045,7 +4060,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -4042,7 +4057,10 @@ public abstract class LivingEntity extends Entity implements Attackable {
          }
  
          this.useItem = ItemStack.EMPTY;


### PR DESCRIPTION
EntityEvent 2 was previously used to show damage effects. This is no longer used in modern clients.
+Fixes the issue of damage sounds not playing when the option is enabled.