### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -1091,10 +1091,10 @@ index b79daa857fc686f00ac06b8851e0ab68d83ae949..45d996878ba8d314a47078589b6da59d
      public void setCustomName(@Nullable String name);
  }
 diff --git a/src/main/java/org/bukkit/NamespacedKey.java b/src/main/java/org/bukkit/NamespacedKey.java
-index c559f38fdb92cfee9f2e0ffb7088d1cf74a7f73d..a42f1d53340e4073038d46b7fabf5d44248d5b32 100644
+index ae7b51341fb66c41b8a7c4604fd273d876e311be..4034fcb9abc39b12f0de47c4b679f2ef82353c89 100644
 --- a/src/main/java/org/bukkit/NamespacedKey.java
 +++ b/src/main/java/org/bukkit/NamespacedKey.java
-@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
   * underscores, hyphens, and forward slashes.
   *
   */
@@ -1103,7 +1103,7 @@ index c559f38fdb92cfee9f2e0ffb7088d1cf74a7f73d..a42f1d53340e4073038d46b7fabf5d44
  
      /**
       * The namespace representing all inbuilt keys.
-@@ -129,10 +129,11 @@ public final class NamespacedKey {
+@@ -130,10 +130,11 @@ public final class NamespacedKey {
  
      @Override
      public int hashCode() {
@@ -1119,7 +1119,7 @@ index c559f38fdb92cfee9f2e0ffb7088d1cf74a7f73d..a42f1d53340e4073038d46b7fabf5d44
      }
  
      @Override
-@@ -140,11 +141,10 @@ public final class NamespacedKey {
+@@ -141,11 +142,10 @@ public final class NamespacedKey {
          if (obj == null) {
              return false;
          }
@@ -1135,7 +1135,7 @@ index c559f38fdb92cfee9f2e0ffb7088d1cf74a7f73d..a42f1d53340e4073038d46b7fabf5d44
      }
  
      @Override
-@@ -246,4 +246,24 @@ public final class NamespacedKey {
+@@ -247,4 +247,24 @@ public final class NamespacedKey {
      public static NamespacedKey fromString(@NotNull String key) {
          return fromString(key, null);
      }
@@ -4007,10 +4007,10 @@ index e12996492c1558fed9fab30de9f8018e0ed7fac3..002acfbdce1db10f7ba1b6a013e678f5
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index a66bec33fffd4e11d859efd8d17d274a5fa75f69..9578d6b0fa54feac75fa9a0727d878bd13b9e19e 100644
+index 502a1fd398fb0dcfbaf82081a655e2efc3bf71dc..30770d03044da684aa8c79ca74796050c319f6be 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -171,4 +171,24 @@ public interface ItemFactory {
+@@ -172,4 +172,24 @@ public interface ItemFactory {
       */
      @Nullable
      Material getSpawnEgg(@NotNull EntityType type);
@@ -4317,10 +4317,10 @@ index 94852d50e88d0594b84b581cd627174043629995..be7c2cfc757e4dd15927be850739d401
              throw new UnsupportedOperationException("Not supported yet.");
          }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 2fbb0b7640dd9b9b0e70d4bc60fbb0310d5ec250..049c70c935fd7a781280d223f74bbbf87223f505 100644
+index 8ca9605fc1193de9277407f02f755d81190472a4..d7fab2b856f6dfec4f9225c1bdb4254b238d98a4 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -31,6 +31,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -32,6 +32,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       */
      boolean hasDisplayName();
  
@@ -4345,7 +4345,7 @@ index 2fbb0b7640dd9b9b0e70d4bc60fbb0310d5ec250..049c70c935fd7a781280d223f74bbbf8
      /**
       * Gets the display name that is set.
       * <p>
-@@ -38,7 +56,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -39,7 +57,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * before calling this method.
       *
       * @return the display name that is set
@@ -4355,7 +4355,7 @@ index 2fbb0b7640dd9b9b0e70d4bc60fbb0310d5ec250..049c70c935fd7a781280d223f74bbbf8
      @NotNull
      String getDisplayName();
  
-@@ -46,7 +66,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -47,7 +67,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Sets the display name.
       *
       * @param name the name to set
@@ -4365,7 +4365,7 @@ index 2fbb0b7640dd9b9b0e70d4bc60fbb0310d5ec250..049c70c935fd7a781280d223f74bbbf8
      void setDisplayName(@Nullable String name);
  
      /**
-@@ -81,6 +103,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -82,6 +104,24 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       */
      boolean hasLore();
  
@@ -4390,7 +4390,7 @@ index 2fbb0b7640dd9b9b0e70d4bc60fbb0310d5ec250..049c70c935fd7a781280d223f74bbbf8
      /**
       * Gets the lore that is set.
       * <p>
-@@ -88,7 +128,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -89,7 +129,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * calling this method.
       *
       * @return a list of lore that is set
@@ -4400,7 +4400,7 @@ index 2fbb0b7640dd9b9b0e70d4bc60fbb0310d5ec250..049c70c935fd7a781280d223f74bbbf8
      @Nullable
      List<String> getLore();
  
-@@ -97,7 +139,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -98,7 +140,9 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Removes lore when given null.
       *
       * @param lore the lore that will be set

--- a/patches/api/0008-Paper-Plugins.patch
+++ b/patches/api/0008-Paper-Plugins.patch
@@ -1449,10 +1449,10 @@ index 94f8ceb965cecb5669a84a0ec61c0f706c2a2673..e773db6da357ad210eb24d4c389af2dc
      }
  }
 diff --git a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
-index 539df5665a7cc1406a358fc435e36365b9c14068..32986df9a9854e561a77eefab99c934efbcb5aac 100644
+index f48bdeb628a82416d93f84a0a10141447482bf83..c0691a849831f99268fdcb7b0f471f80a1a2a70e 100644
 --- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
 +++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
-@@ -197,7 +197,7 @@ import org.yaml.snakeyaml.representer.Representer;
+@@ -198,7 +198,7 @@ import org.yaml.snakeyaml.representer.Representer;
   *      inferno.burningdeaths: true
   *</pre></blockquote>
   */
@@ -1461,7 +1461,7 @@ index 539df5665a7cc1406a358fc435e36365b9c14068..32986df9a9854e561a77eefab99c934e
      private static final Pattern VALID_NAME = Pattern.compile("^[A-Za-z0-9 _.-]+$");
      private static final ThreadLocal<Yaml> YAML = new ThreadLocal<Yaml>() {
          @Override
-@@ -258,6 +258,70 @@ public final class PluginDescriptionFile {
+@@ -259,6 +259,70 @@ public final class PluginDescriptionFile {
      private Set<PluginAwareness> awareness = ImmutableSet.of();
      private String apiVersion = null;
      private List<String> libraries = ImmutableList.of();
@@ -2088,10 +2088,10 @@ index 6d634b0ea813ccb19f1562a7d0e5a59cea4eab21..e4b6f278a811acbb0070e311c5c3bdaf
          }
  
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fdadf45bdc 100644
+index 64a294aeb6fb548794708b38c3707f9dd882b2ff..74b6581a97a092c44a0876e7981ff8a8e6153100 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -29,7 +29,8 @@ import org.jetbrains.annotations.Nullable;
+@@ -31,7 +31,8 @@ import org.jetbrains.annotations.Nullable;
  /**
   * A ClassLoader for plugins, to allow shared classes across multiple plugins
   */
@@ -2101,7 +2101,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
      private final JavaPluginLoader loader;
      private final Map<String, Class<?>> classes = new ConcurrentHashMap<String, Class<?>>();
      private final PluginDescriptionFile description;
-@@ -43,24 +44,32 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -45,24 +46,32 @@ final class PluginClassLoader extends URLClassLoader {
      private JavaPlugin pluginInit;
      private IllegalStateException pluginState;
      private final Set<String> seenIllegalAccess = Collections.newSetFromMap(new ConcurrentHashMap<>());
@@ -2130,15 +2130,15 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
          this.url = file.toURI().toURL();
          this.libraryLoader = libraryLoader;
  
-+
 +        // Paper start
 +        this.dependencyContext = dependencyContext;
 +        this.classLoaderGroup = io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage.instance().registerSpigotGroup(this);
 +        // Paper end
++
+         Class<?> jarClass;
          try {
-             Class<?> jarClass;
-             try {
-@@ -94,6 +103,27 @@ final class PluginClassLoader extends URLClassLoader {
+             jarClass = Class.forName(description.getMain(), true, this);
+@@ -107,6 +116,27 @@ final class PluginClassLoader extends URLClassLoader {
          return findResources(name);
      }
  
@@ -2166,7 +2166,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
      @Override
      protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
          return loadClass0(name, resolve, true, true);
-@@ -119,26 +149,11 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -132,26 +162,11 @@ final class PluginClassLoader extends URLClassLoader {
  
          if (checkGlobal) {
              // This ignores the libraries of other plugins, unless they are transitive dependencies.
@@ -2195,7 +2195,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
  
                  return result;
              }
-@@ -167,7 +182,7 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -180,7 +195,7 @@ final class PluginClassLoader extends URLClassLoader {
                      throw new ClassNotFoundException(name, ex);
                  }
  
@@ -2204,7 +2204,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
  
                  int dot = name.lastIndexOf('.');
                  if (dot != -1) {
-@@ -197,8 +212,8 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -210,8 +225,8 @@ final class PluginClassLoader extends URLClassLoader {
                  result = super.findClass(name);
              }
  
@@ -2214,7 +2214,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
          }
  
          return result;
-@@ -207,6 +222,12 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -220,6 +235,12 @@ final class PluginClassLoader extends URLClassLoader {
      @Override
      public void close() throws IOException {
          try {
@@ -2227,7 +2227,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
              super.close();
          } finally {
              jar.close();
-@@ -218,7 +239,7 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -231,7 +252,7 @@ final class PluginClassLoader extends URLClassLoader {
          return classes.values();
      }
  
@@ -2236,7 +2236,7 @@ index 2f74ec96ece706de23156ebabfe493211bc05391..302319acbc257a075adfb78d9f5c49fd
          Preconditions.checkArgument(javaPlugin != null, "Initializing plugin cannot be null");
          Preconditions.checkArgument(javaPlugin.getClass().getClassLoader() == this, "Cannot initialize plugin outside of this class loader");
          if (this.plugin != null || this.pluginInit != null) {
-@@ -228,6 +249,38 @@ final class PluginClassLoader extends URLClassLoader {
+@@ -241,6 +262,38 @@ final class PluginClassLoader extends URLClassLoader {
          pluginState = new IllegalStateException("Initial initialization");
          this.pluginInit = javaPlugin;
  

--- a/patches/api/0055-Fix-upstream-javadocs.patch
+++ b/patches/api/0055-Fix-upstream-javadocs.patch
@@ -74,25 +74,6 @@ index 0cf808356a1a5c6fc4bcf97a694ed9beb80a776a..dc765dea47a9a1c1520fb16ddb24f814
       * @param z Z-coordinate (0-15)
       * @return temperature at given coordinate
       */
-diff --git a/src/main/java/org/bukkit/Particle.java b/src/main/java/org/bukkit/Particle.java
-index 73b782c3975ad13159b6236976783fcfabd20493..e9cbbdf310e48011ee538c5592baee2535965fee 100644
---- a/src/main/java/org/bukkit/Particle.java
-+++ b/src/main/java/org/bukkit/Particle.java
-@@ -120,8 +120,14 @@ public enum Particle {
-     SCRAPE,
-     SONIC_BOOM,
-     SCULK_SOUL,
-+    /**
-+     * Uses {@link Float} as DataType, representing the angle the particle displays at in radians
-+     */
-     SCULK_CHARGE(Float.class),
-     SCULK_CHARGE_POP,
-+    /**
-+     * Uses {@link Integer} as DataType, representing the delay in ticks until the particle shows up
-+     */
-     SHRIEK(Integer.class),
-     CHERRY_LEAVES,
-     EGG_CRACK,
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
 index 02de62c083ceaa466c80cb732e8304b8cc3f07f8..7c2b1eff41dd43fda84d84e76c05bbbf37c186b8 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
@@ -1222,10 +1203,10 @@ index 07c3dff4d6190ef388d9c1e1c36f67f00a3e8e66..597a18a767b68b47e81454b7d44613c7
       * @param input The input choice.
       * @return The changed recipe, so you can chain calls.
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 049c70c935fd7a781280d223f74bbbf87223f505..f78714c2a6d9da162c9802552984cbfad76ff728 100644
+index d7fab2b856f6dfec4f9225c1bdb4254b238d98a4..9d40e6a5ce7adc377934cfc5ce663b5d9cb2e4dc 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -305,7 +305,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -306,7 +306,7 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Return an immutable copy of all {@link Attribute}s and their
       * {@link AttributeModifier}s for a given {@link EquipmentSlot}.<br>

--- a/patches/api/0065-Add-getI18NDisplayName-API.patch
+++ b/patches/api/0065-Add-getI18NDisplayName-API.patch
@@ -8,10 +8,10 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 9578d6b0fa54feac75fa9a0727d878bd13b9e19e..a6795b102c9678b122dfd3b36d02783b9e108b48 100644
+index 30770d03044da684aa8c79ca74796050c319f6be..f0025ba978f4bdf1e6bab7d30466fc950bb2a13b 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -191,4 +191,20 @@ public interface ItemFactory {
+@@ -192,4 +192,20 @@ public interface ItemFactory {
      @NotNull
      net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack);
      // Paper end - Adventure

--- a/patches/api/0066-ensureServerConversions-API.patch
+++ b/patches/api/0066-ensureServerConversions-API.patch
@@ -7,10 +7,10 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index a6795b102c9678b122dfd3b36d02783b9e108b48..74cd662d0594f2fbc5aa30ba64d9e4928145dbb9 100644
+index f0025ba978f4bdf1e6bab7d30466fc950bb2a13b..d641a8293f3acd465d5fdde8507046647cb6c568 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -207,4 +207,18 @@ public interface ItemFactory {
+@@ -208,4 +208,18 @@ public interface ItemFactory {
      @Deprecated
      String getI18NDisplayName(@Nullable ItemStack item);
      // Paper end - add getI18NDisplayName

--- a/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
+++ b/patches/api/0072-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
@@ -93,19 +93,18 @@ index 7cd9f98c042dc2bb80876af35c755f81bef34651..5cd236965de12392d8c7aa81307c0ff1
  
      /**
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 302319acbc257a075adfb78d9f5c49fdadf45bdc..a8ac1fb22a6fba50d69bf726b49c49ba190ab79a 100644
+index 74b6581a97a092c44a0876e7981ff8a8e6153100..d6d3e1332e51adc5611543b2a6689efa5921a9f2 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -65,7 +65,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -67,6 +67,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
          this.url = file.toURI().toURL();
          this.libraryLoader = libraryLoader;
  
--
 +        this.logger = com.destroystokyo.paper.utils.PaperPluginLogger.getLogger(description); // Paper - Register logger early
          // Paper start
          this.dependencyContext = dependencyContext;
          this.classLoaderGroup = io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage.instance().registerSpigotGroup(this);
-@@ -249,7 +249,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -262,7 +263,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
          pluginState = new IllegalStateException("Initial initialization");
          this.pluginInit = javaPlugin;
  

--- a/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0100-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -500,11 +500,11 @@ index 0000000000000000000000000000000000000000..f45b8cfd1611345e8d81ecb8297a586f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Particle.java b/src/main/java/org/bukkit/Particle.java
-index e9cbbdf310e48011ee538c5592baee2535965fee..dbedaf6a92681bc32d74f067cd4686c8b609d568 100644
+index e2adb9901cc92ede9d44ca9939c6a54d4762eb4b..81bd12c8addcee754c71e5e030c729c7e096fb4c 100644
 --- a/src/main/java/org/bukkit/Particle.java
 +++ b/src/main/java/org/bukkit/Particle.java
-@@ -168,6 +168,17 @@ public enum Particle {
-         return dataType;
+@@ -194,6 +194,18 @@ public enum Particle implements Keyed {
+         return key;
      }
  
 +    // Paper start - Particle API expansion
@@ -518,6 +518,7 @@ index e9cbbdf310e48011ee538c5592baee2535965fee..dbedaf6a92681bc32d74f067cd4686c8
 +        return new com.destroystokyo.paper.ParticleBuilder(this);
 +    }
 +    // Paper end
++
      /**
       * Options which can be applied to redstone dust particles - a particle
       * color and size.

--- a/patches/api/0148-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-values.patch
+++ b/patches/api/0148-Add-an-API-for-CanPlaceOn-and-CanDestroy-NBT-values.patch
@@ -199,10 +199,10 @@ index 0000000000000000000000000000000000000000..28f3fda950999a9c964a3608042ca605
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/NamespacedKey.java b/src/main/java/org/bukkit/NamespacedKey.java
-index a42f1d53340e4073038d46b7fabf5d44248d5b32..dbc22807a33606f8fe326cc2f5f755fee5edc7aa 100644
+index 4034fcb9abc39b12f0de47c4b679f2ef82353c89..6fa219aef009f8dfb8a2b1e5ee0603b18cf3d0f5 100644
 --- a/src/main/java/org/bukkit/NamespacedKey.java
 +++ b/src/main/java/org/bukkit/NamespacedKey.java
-@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
   * underscores, hyphens, and forward slashes.
   *
   */
@@ -211,7 +211,7 @@ index a42f1d53340e4073038d46b7fabf5d44248d5b32..dbc22807a33606f8fe326cc2f5f755fe
  
      /**
       * The namespace representing all inbuilt keys.
-@@ -118,11 +118,13 @@ public final class NamespacedKey implements net.kyori.adventure.key.Key { // Pap
+@@ -119,11 +119,13 @@ public final class NamespacedKey implements net.kyori.adventure.key.Key { // Pap
      }
  
      @NotNull
@@ -226,10 +226,10 @@ index a42f1d53340e4073038d46b7fabf5d44248d5b32..dbc22807a33606f8fe326cc2f5f755fe
          return key;
      }
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index f78714c2a6d9da162c9802552984cbfad76ff728..55e9dc5d1d87fbc9d0dabbb7bd59584fe2c5f379 100644
+index 9d40e6a5ce7adc377934cfc5ce663b5d9cb2e4dc..46ac120ed51274a2084719387e35e517981bbf4b 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -444,4 +444,87 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -445,4 +445,87 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @SuppressWarnings("javadoc")
      @NotNull
      ItemMeta clone();

--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -119,10 +119,10 @@ index d56d899ca7737b537ea55c13a384888a873f5da3..cbec3b145a44ceee20823ae0e9c8162b
          Preconditions.checkArgument(legacy, "Cannot get data class of Modern Material");
          return ctor.getDeclaringClass();
 diff --git a/src/main/java/org/bukkit/NamespacedKey.java b/src/main/java/org/bukkit/NamespacedKey.java
-index dbc22807a33606f8fe326cc2f5f755fee5edc7aa..1416918d1924b362a688635823484f16e6adf125 100644
+index 6fa219aef009f8dfb8a2b1e5ee0603b18cf3d0f5..8ac72cb0b05e2c493d98310f2e87c3714d15c5e3 100644
 --- a/src/main/java/org/bukkit/NamespacedKey.java
 +++ b/src/main/java/org/bukkit/NamespacedKey.java
-@@ -73,12 +73,14 @@ public final class NamespacedKey implements net.kyori.adventure.key.Key, com.des
+@@ -74,12 +74,14 @@ public final class NamespacedKey implements net.kyori.adventure.key.Key, com.des
  
      /**
       * Create a key in a specific namespace.
@@ -132,10 +132,10 @@ index dbc22807a33606f8fe326cc2f5f755fee5edc7aa..1416918d1924b362a688635823484f16
       *
       * @param namespace namespace
       * @param key key
--     * @deprecated should never be used by plugins, for internal use only!!
+-     * @apiNote should never be used by plugins, for internal use only!!
 +     * @see #NamespacedKey(Plugin, String)
       */
--    @Deprecated
+-    @ApiStatus.Internal
      public NamespacedKey(@NotNull String namespace, @NotNull String key) {
          Preconditions.checkArgument(namespace != null && isValidNamespace(namespace), "Invalid namespace. Must be [a-z0-9._-]: %s", namespace);
          Preconditions.checkArgument(key != null && isValidKey(key), "Invalid key. Must be [a-z0-9/._-]: %s", key);
@@ -155,11 +155,47 @@ index f43209cf7b752c26718c303ca8c3e1c7d9912ad3..f0094e6fb05e526736629ad3181c8d2c
  public enum NetherWartsState {
  
      /**
+diff --git a/src/main/java/org/bukkit/Particle.java b/src/main/java/org/bukkit/Particle.java
+index 81bd12c8addcee754c71e5e030c729c7e096fb4c..6992600d6cff9ed0a30d37ac4dc5dc0e56ecb2c7 100644
+--- a/src/main/java/org/bukkit/Particle.java
++++ b/src/main/java/org/bukkit/Particle.java
+@@ -54,7 +54,9 @@ public enum Particle implements Keyed {
+     BLOCK_CRACK("block", BlockData.class),
+     /**
+      * Uses {@link BlockData} as DataType
++     * @deprecated use {@link #BLOCK_CRACK}
+      */
++    @Deprecated // Paper
+     BLOCK_DUST("block", BlockData.class, false),
+     WATER_DROP("rain"),
+     MOB_APPEARANCE("elder_guardian"),
+@@ -138,15 +140,21 @@ public enum Particle implements Keyed {
+     // ----- Legacy Separator -----
+     /**
+      * Uses {@link MaterialData} as DataType
++     * @deprecated {@link MaterialData} is deprecated API
+      */
++    @Deprecated // Paper
+     LEGACY_BLOCK_CRACK(null, MaterialData.class, false),
+     /**
+      * Uses {@link MaterialData} as DataType
++     * @deprecated {@link MaterialData} is deprecated API
+      */
++    @Deprecated // Paper
+     LEGACY_BLOCK_DUST(null, MaterialData.class, false),
+     /**
+      * Uses {@link MaterialData} as DataType
++     * @deprecated {@link MaterialData} is deprecated API
+      */
++    @Deprecated // Paper
+     LEGACY_FALLING_DUST(null, MaterialData.class, false);
+ 
+     private final NamespacedKey key;
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index f79f4f20ee9f1f2ca3d12984064fc7fe57a932ba..82a206bd3000bc8d601c6e7c0bd078b4bb7e962f 100644
+index c373614a865d6df8a2fe265497cf0b5f074490b0..8e0f985e8a6af728376a85eef998f7881e50786c 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -191,14 +191,14 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -197,14 +197,14 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @see TrimMaterial
       */
@@ -176,7 +212,7 @@ index f79f4f20ee9f1f2ca3d12984064fc7fe57a932ba..82a206bd3000bc8d601c6e7c0bd078b4
      Registry<TrimPattern> TRIM_PATTERN = Bukkit.getRegistry(TrimPattern.class);
      /**
       * Villager profession.
-@@ -280,8 +280,11 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -286,8 +286,11 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       *
       * @param input non-null input
       * @return registered object or null if does not exist
@@ -937,10 +973,10 @@ index 002acfbdce1db10f7ba1b6a013e678f504ac6e69..aac9180fa3bcbdb0c17dcf96c86647b5
          return getPlayer().getItemOnCursor();
      }
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 74cd662d0594f2fbc5aa30ba64d9e4928145dbb9..856751439b6599943d85203a59efd691ddbd89e9 100644
+index d641a8293f3acd465d5fdde8507046647cb6c568..74aa058e0dee7ae858a2a1d0a48e3bb9093a53ea 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -27,7 +27,7 @@ public interface ItemFactory {
+@@ -28,7 +28,7 @@ public interface ItemFactory {
       * @return a new ItemMeta that could be applied to an item stack of the
       *     specified material
       */
@@ -1146,10 +1182,10 @@ index 5ccae862dbac393805a47fe26c18a2f33f1e140d..72281899817c5c140cdca2afff75fbce
  
      @Override
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 55e9dc5d1d87fbc9d0dabbb7bd59584fe2c5f379..5c1ca0e47f0ac1525c3d37b55f52874878f44c28 100644
+index 46ac120ed51274a2084719387e35e517981bbf4b..420a91a834016d3af95efd79ca92ae45c4f081c4 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-@@ -74,8 +74,10 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -75,8 +75,10 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      /**
       * Checks for existence of a localized name.
       *
@@ -1160,7 +1196,7 @@ index 55e9dc5d1d87fbc9d0dabbb7bd59584fe2c5f379..5c1ca0e47f0ac1525c3d37b55f528748
      boolean hasLocalizedName();
  
      /**
-@@ -84,16 +86,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -85,16 +87,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
       * Plugins should check that hasLocalizedName() returns <code>true</code>
       * before calling this method.
       *

--- a/patches/api/0202-Support-components-in-ItemMeta.patch
+++ b/patches/api/0202-Support-components-in-ItemMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 5c1ca0e47f0ac1525c3d37b55f52874878f44c28..e33ec3eaa1cd520db8224250e886e6240fefe76f 100644
+index 420a91a834016d3af95efd79ca92ae45c4f081c4..ea64d5b1ebaa652785ddbc7b515808174f636a62 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -5,6 +5,7 @@ import java.util.Collection;
@@ -16,7 +16,7 @@ index 5c1ca0e47f0ac1525c3d37b55f52874878f44c28..e33ec3eaa1cd520db8224250e886e624
  import org.bukkit.attribute.Attribute;
  import org.bukkit.attribute.AttributeModifier;
  import org.bukkit.configuration.serialization.ConfigurationSerializable;
-@@ -62,6 +63,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -63,6 +64,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @NotNull
      String getDisplayName();
  
@@ -37,7 +37,7 @@ index 5c1ca0e47f0ac1525c3d37b55f52874878f44c28..e33ec3eaa1cd520db8224250e886e624
      /**
       * Sets the display name.
       *
-@@ -71,6 +86,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -72,6 +87,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Deprecated // Paper
      void setDisplayName(@Nullable String name);
  
@@ -54,7 +54,7 @@ index 5c1ca0e47f0ac1525c3d37b55f52874878f44c28..e33ec3eaa1cd520db8224250e886e624
      /**
       * Checks for existence of a localized name.
       *
-@@ -140,6 +165,19 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -141,6 +166,19 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Nullable
      List<String> getLore();
  
@@ -74,7 +74,7 @@ index 5c1ca0e47f0ac1525c3d37b55f52874878f44c28..e33ec3eaa1cd520db8224250e886e624
      /**
       * Sets the lore for this item.
       * Removes lore when given null.
-@@ -150,6 +188,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -151,6 +189,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Deprecated // Paper
      void setLore(@Nullable List<String> lore);
  

--- a/patches/api/0212-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/patches/api/0212-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 856751439b6599943d85203a59efd691ddbd89e9..77ca38e5edda55daf67ab8af9afd633efb4000b1 100644
+index 74aa058e0dee7ae858a2a1d0a48e3bb9093a53ea..9045746aa3077c536173d4ac826e0bf49e732b32 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -221,4 +221,65 @@ public interface ItemFactory {
+@@ -222,4 +222,65 @@ public interface ItemFactory {
      @NotNull
      ItemStack ensureServerConversions(@NotNull ItemStack item);
      // Paper end - ensure server conversions API

--- a/patches/api/0246-Add-StructuresLocateEvent.patch
+++ b/patches/api/0246-Add-StructuresLocateEvent.patch
@@ -505,10 +505,10 @@ index 0000000000000000000000000000000000000000..1e7b53f9bc13dcd5a0a4a40004591e4f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 82a206bd3000bc8d601c6e7c0bd078b4bb7e962f..3818f940b98488bd1068d941cfbbac3721677c7a 100644
+index 8e0f985e8a6af728376a85eef998f7881e50786c..469ef0a9241fddbd869ac2c0662c98b3022cc8aa 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -255,6 +255,17 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -261,6 +261,17 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       * @see GameEvent
       */
      Registry<GameEvent> GAME_EVENT = Objects.requireNonNull(Bukkit.getRegistry(GameEvent.class), "No registry present for GameEvent. This is a bug.");

--- a/patches/api/0264-Expand-world-key-API.patch
+++ b/patches/api/0264-Expand-world-key-API.patch
@@ -93,10 +93,10 @@ index 96b66f4f6fb8637ab3ad275ddd980d5b71711a6c..27d5f37a9b2da92307e5b505e3b31cca
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/WorldCreator.java b/src/main/java/org/bukkit/WorldCreator.java
-index f9fa287d25a0243de8d8d7b0d13144ce919750b0..29f0bb4d5bb1d5ef1b6bd64726ca84c25091f9e4 100644
+index 27537aeabd3bd1b5383e6ecf775aa89e033aa2bc..afc0ce2eaa7cf48d1255fec7377103b1f7a99734 100644
 --- a/src/main/java/org/bukkit/WorldCreator.java
 +++ b/src/main/java/org/bukkit/WorldCreator.java
-@@ -12,6 +12,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
   * Represents various types of options that may be used to create a world.
   */
  public class WorldCreator {
@@ -104,12 +104,11 @@ index f9fa287d25a0243de8d8d7b0d13144ce919750b0..29f0bb4d5bb1d5ef1b6bd64726ca84c2
      private final String name;
      private long seed;
      private World.Environment environment = World.Environment.NORMAL;
-@@ -28,13 +29,80 @@ public class WorldCreator {
+@@ -30,11 +31,80 @@ public class WorldCreator {
       * @param name Name of the world that will be created
       */
      public WorldCreator(@NotNull String name) {
--        if (name == null) {
--            throw new IllegalArgumentException("World name cannot be null");
+-        Preconditions.checkArgument(name != null, "World name cannot be null");
 +        // Paper start
 +        this(name, getWorldKey(name));
 +    }
@@ -124,7 +123,7 @@ index f9fa287d25a0243de8d8d7b0d13144ce919750b0..29f0bb4d5bb1d5ef1b6bd64726ca84c2
 +            return NamespacedKey.minecraft("the_end");
 +        } else {
 +            return NamespacedKey.minecraft(name.toLowerCase(java.util.Locale.ENGLISH).replace(" ", "_"));
-         }
++        }
 +    }
  
 -        this.name = name;

--- a/patches/api/0304-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
+++ b/patches/api/0304-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Rewrite LogEvents to contain the source jars in stack traces
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index a8ac1fb22a6fba50d69bf726b49c49ba190ab79a..b4732c8dd12134a094ef9afc1870077412ce0435 100644
+index d6d3e1332e51adc5611543b2a6689efa5921a9f2..877bfe10b858145278133acbc7049f700d2b4f8a 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -54,7 +54,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -56,7 +56,7 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
  
      @org.jetbrains.annotations.ApiStatus.Internal // Paper
      public PluginClassLoader(@Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader, JarFile jarFile, io.papermc.paper.plugin.provider.entrypoint.DependencyContext dependencyContext) throws IOException, InvalidPluginException, MalformedURLException { // Paper // Paper - use JarFile provided by SpigotPluginProvider

--- a/patches/api/0344-More-PotionEffectType-API.patch
+++ b/patches/api/0344-More-PotionEffectType-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More PotionEffectType API
 
 
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 3818f940b98488bd1068d941cfbbac3721677c7a..c936a6e193163f2af147484daf6accf24c2f3644 100644
+index 469ef0a9241fddbd869ac2c0662c98b3022cc8aa..ba934feab58da978311c642408227a1fa686dfbb 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -264,6 +264,31 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -270,6 +270,31 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
       */
      @Deprecated(forRemoval = true)
      Registry<io.papermc.paper.world.structure.ConfiguredStructure> CONFIGURED_STRUCTURE = Bukkit.getRegistry(io.papermc.paper.world.structure.ConfiguredStructure.class);

--- a/patches/api/0355-Add-enchantWithLevels-API.patch
+++ b/patches/api/0355-Add-enchantWithLevels-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add enchantWithLevels API
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 77ca38e5edda55daf67ab8af9afd633efb4000b1..ab73893656932f54009340df59293df2a732be51 100644
+index 9045746aa3077c536173d4ac826e0bf49e732b32..1c4e0c7356047163a38f5ac4dd544129d0b36271 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -173,6 +173,22 @@ public interface ItemFactory {
+@@ -174,6 +174,22 @@ public interface ItemFactory {
      Material getSpawnEgg(@NotNull EntityType type);
  
      // Paper start - Adventure

--- a/patches/api/0360-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/api/0360-WorldCreator-keepSpawnLoaded.patch
@@ -5,24 +5,70 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/WorldCreator.java b/src/main/java/org/bukkit/WorldCreator.java
-index 29f0bb4d5bb1d5ef1b6bd64726ca84c25091f9e4..649256cb267bcf05ef4c15699cbf4e7e7e99b612 100644
+index afc0ce2eaa7cf48d1255fec7377103b1f7a99734..58e3e3e0e772640b3944b4acb5a92d96431728a7 100644
 --- a/src/main/java/org/bukkit/WorldCreator.java
 +++ b/src/main/java/org/bukkit/WorldCreator.java
-@@ -22,6 +22,7 @@ public class WorldCreator {
+@@ -23,7 +23,7 @@ public class WorldCreator {
      private boolean generateStructures = true;
      private String generatorSettings = "";
      private boolean hardcore = false;
+-    private boolean keepSpawnInMemory = true;
 +    private net.kyori.adventure.util.TriState keepSpawnLoaded = net.kyori.adventure.util.TriState.NOT_SET; // Paper
  
      /**
       * Creates an empty WorldCreationOptions for the given world name
-@@ -573,4 +574,32 @@ public class WorldCreator {
+@@ -123,7 +123,7 @@ public class WorldCreator {
+         type = world.getWorldType();
+         generateStructures = world.canGenerateStructures();
+         hardcore = world.isHardcore();
+-        keepSpawnInMemory = world.getKeepSpawnInMemory();
++        this.keepSpawnLoaded = net.kyori.adventure.util.TriState.byBoolean(world.getKeepSpawnInMemory()); // Paper
+ 
+         return this;
+     }
+@@ -146,7 +146,7 @@ public class WorldCreator {
+         generateStructures = creator.generateStructures();
+         generatorSettings = creator.generatorSettings();
+         hardcore = creator.hardcore();
+-        keepSpawnInMemory = creator.keepSpawnInMemory();
++        keepSpawnLoaded = creator.keepSpawnLoaded(); // Paper
+ 
+         return this;
+     }
+@@ -470,21 +470,23 @@ public class WorldCreator {
+      *
+      * @param keepSpawnInMemory Whether the spawn chunks will be kept loaded
+      * @return This object, for chaining
++     * @deprecated use {@link #keepSpawnLoaded(net.kyori.adventure.util.TriState)}
+      */
+     @NotNull
++    @Deprecated(forRemoval = true) // Paper
+     public WorldCreator keepSpawnInMemory(boolean keepSpawnInMemory) {
+-        this.keepSpawnInMemory = keepSpawnInMemory;
+-
+-        return this;
++        return this.keepSpawnLoaded(net.kyori.adventure.util.TriState.byBoolean(keepSpawnInMemory)); // Paper
+     }
+ 
+     /**
+      * Gets whether or not the spawn chunks will be kept loaded.
+      *
+      * @return True if the spawn chunks will be kept loaded
++     * @deprecated use {@link #keepSpawnLoaded()}
+      */
++    @Deprecated(forRemoval = true) // Paper
+     public boolean keepSpawnInMemory() {
+-        return keepSpawnInMemory;
++        return this.keepSpawnLoaded() == net.kyori.adventure.util.TriState.TRUE; // Paper
+     }
+ 
+     /**
+@@ -594,4 +596,31 @@ public class WorldCreator {
  
          return result;
      }
 +
-+    // Paper start
-+
++    // Paper start - keep spawn loaded tristate
 +    /**
 +     * Returns the current intent to keep the world loaded, @see {@link WorldCreator#keepSpawnLoaded(net.kyori.adventure.util.TriState)}
 +     *
@@ -42,10 +88,10 @@ index 29f0bb4d5bb1d5ef1b6bd64726ca84c25091f9e4..649256cb267bcf05ef4c15699cbf4e7e
 +     */
 +    @NotNull
 +    public WorldCreator keepSpawnLoaded(@NotNull net.kyori.adventure.util.TriState keepSpawnLoaded) {
-+        java.util.Objects.requireNonNull(keepSpawnLoaded, "keepSpawnLoaded");
++        Preconditions.checkArgument(keepSpawnLoaded != null, "keepSpawnLoaded");
 +        this.keepSpawnLoaded = keepSpawnLoaded;
 +        return this;
 +    }
 +
-+    // Paper end
++    // Paper end - keep spawn loaded tristate
  }

--- a/patches/api/0375-Also-load-resources-from-LibraryLoader.patch
+++ b/patches/api/0375-Also-load-resources-from-LibraryLoader.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Also load resources from LibraryLoader
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index b4732c8dd12134a094ef9afc1870077412ce0435..13da387d3b59bc67c0d73e3fbd3a4034b1281527 100644
+index 877bfe10b858145278133acbc7049f700d2b4f8a..f9b57b872780aa6b9b959494874b57c7a8ff0c53 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -95,14 +95,35 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
+@@ -109,14 +109,35 @@ public final class PluginClassLoader extends URLClassLoader implements io.paperm
  
      @Override
      public URL getResource(String name) {

--- a/patches/server/0002-Remap-fixes.patch
+++ b/patches/server/0002-Remap-fixes.patch
@@ -88,6 +88,36 @@ index 95a5ce711150c4c999a9d17f28a497f034638610..214215d203892b8009595539f25ce26e
          private LootContextParamSet paramSet;
          private Optional<ResourceLocation> randomSequence;
  
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftParticle.java b/src/main/java/org/bukkit/craftbukkit/CraftParticle.java
+index 8a7d1c7b214a29f1364f42c1eb0aa89d0e3e4b41..af88ca7eaf94dc52d4b9dd96ffc8f8c956230812 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftParticle.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftParticle.java
+@@ -113,7 +113,7 @@ public abstract class CraftParticle<D> implements Keyed {
+         private static final BiFunction<NamespacedKey, net.minecraft.core.particles.ParticleType<?>, CraftParticle<?>> VOID_FUNCTION = (name, particle) -> new CraftParticle<>(name, particle, Void.class) {
+             @Override
+             public ParticleOptions createParticleParam(Void data) {
+-                return (SimpleParticleType) CraftParticle.this.getHandle();
++                return (SimpleParticleType) this.getHandle(); // Paper - fix?
+             }
+         };
+ 
+@@ -129,14 +129,14 @@ public abstract class CraftParticle<D> implements Keyed {
+             BiFunction<NamespacedKey, net.minecraft.core.particles.ParticleType<?>, CraftParticle<?>> itemStackFunction = (name, particle) -> new CraftParticle<>(name, particle, ItemStack.class) {
+                 @Override
+                 public ParticleOptions createParticleParam(ItemStack data) {
+-                    return new ItemParticleOption((net.minecraft.core.particles.ParticleType<ItemParticleOption>) CraftParticle.this.getHandle(), CraftItemStack.asNMSCopy(data));
++                    return new ItemParticleOption((net.minecraft.core.particles.ParticleType<ItemParticleOption>) this.getHandle(), CraftItemStack.asNMSCopy(data)); // Paper - fix?
+                 }
+             };
+ 
+             BiFunction<NamespacedKey, net.minecraft.core.particles.ParticleType<?>, CraftParticle<?>> blockDataFunction = (name, particle) -> new CraftParticle<>(name, particle, BlockData.class) {
+                 @Override
+                 public ParticleOptions createParticleParam(BlockData data) {
+-                    return new BlockParticleOption((net.minecraft.core.particles.ParticleType<BlockParticleOption>) CraftParticle.this.getHandle(), ((CraftBlockData) data).getState());
++                    return new BlockParticleOption((net.minecraft.core.particles.ParticleType<BlockParticleOption>) this.getHandle(), ((CraftBlockData) data).getState()); // Paper - fix?
+                 }
+             };
+ 
 diff --git a/src/test/java/org/bukkit/DyeColorsTest.java b/src/test/java/org/bukkit/DyeColorsTest.java
 index b70450722da13bc4d358a70d3d1d2f30a2cca2b9..86d86c292bdeeb7f42685691287c3b4bd476ea14 100644
 --- a/src/test/java/org/bukkit/DyeColorsTest.java
@@ -118,6 +148,19 @@ index b70450722da13bc4d358a70d3d1d2f30a2cca2b9..86d86c292bdeeb7f42685691287c3b4b
          assertThat(color, is(Color.fromRGB(nmsColor)));
      }
  }
+diff --git a/src/test/java/org/bukkit/ParticleTest.java b/src/test/java/org/bukkit/ParticleTest.java
+index 1edc58410316eaf45858db56897179587e8b22ee..cf6f34e506570e7bb9624c5899fbcdd762d8e0c4 100644
+--- a/src/test/java/org/bukkit/ParticleTest.java
++++ b/src/test/java/org/bukkit/ParticleTest.java
+@@ -231,7 +231,7 @@ public class ParticleTest extends AbstractTestingBase {
+                 Check in CraftParticle if the conversion is still correct.
+                 """, bukkit.getKey()));
+ 
+-        DataResult<Tag> encoded = assertDoesNotThrow(() -> minecraft.codec().encodeStart(DynamicOpsNBT.INSTANCE, particleParam),
++        DataResult<Tag> encoded = assertDoesNotThrow(() -> minecraft.codec().encodeStart(NbtOps.INSTANCE, particleParam), // Paper - remap fix
+                 String.format("""
+                         Could not encoded particle param for particle %s.
+                         This can indicated, that the wrong particle param is created in CraftParticle.
 diff --git a/src/test/java/org/bukkit/RegistryConstantsTest.java b/src/test/java/org/bukkit/RegistryConstantsTest.java
 index 6be404dafe1f0ae5ab39a0782e4c3ca7c0923752..545a329a52be0dc1f3cf8ca1315152d8b4a465dd 100644
 --- a/src/test/java/org/bukkit/RegistryConstantsTest.java

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -137,7 +137,7 @@ index 7db49f077704f03d1815f8382523199bd6c9a0dc..4ed8f38ba9c7b075b99a0da0e213a1e9
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index effbf096caa179929a6809452c1c08d24163c536..85b8e4ca89e9745d0fa27501712113937770de1f 100644
+index e325cb56f2bafce21ce06bb5c674837abbb676e7..8a30ebbac91a0750c00ebbcb5372e6d2a45c064a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -209,7 +209,7 @@ public class Main {
@@ -148,7 +148,7 @@ index effbf096caa179929a6809452c1c08d24163c536..85b8e4ca89e9745d0fa2750171211393
 +                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -7);
+                     deadline.add(Calendar.DAY_OF_YEAR, -21);
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 index 93046379d0cefd5d3236fc59e698809acdc18f80..774556a62eb240da42e84db4502e2ed43495be17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java

--- a/patches/server/0008-CB-fixes.patch
+++ b/patches/server/0008-CB-fixes.patch
@@ -84,10 +84,10 @@ index 6ab2fd523b7f4e5cacef4ebb95f6812f391985d1..85133c388eff009ea1ffa391824b6556
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2d5627f5dc48c0d51464452907b50bbeb069e67c..f890e0e8ae52965f671fe82911b006a61a33a86b 100644
+index dbc424ae95f522e8e539922c8a70e43381ffcbe6..a694a208f7c84f4c2ffa654cdf96942e483eedba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2359,7 +2359,13 @@ public final class CraftServer implements Server {
+@@ -2360,7 +2360,13 @@ public final class CraftServer implements Server {
          Preconditions.checkArgument(key != null, "NamespacedKey key cannot be null");
  
          LootDataManager registry = this.getServer().getLootData();

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -7159,7 +7159,7 @@ index a63d5ba706a5b8e430aedc045bdeb3a410bd0eef..e96a0ca47e4701ba187555bd92c96834
      public BlockState getBlockState(BlockPos pos) {
          return this.getChunk(SectionPos.blockToSectionCoord(pos.getX()), SectionPos.blockToSectionCoord(pos.getZ())).getBlockState(pos);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0fcac9b089e030b387d1b4c79c26e69ed9dcf4ed..10b263b2693a6b507c858b6550b5b98a53cea575 100644
+index 7f2ef8946be167e899656141d61921a2ff6356b0..fc56906135347e0d5e4b18c39adef6932496d924 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -178,6 +178,7 @@ public abstract class PlayerList {
@@ -7856,7 +7856,7 @@ index 25156be63f91a1c41ef41154f675d04eb97459a8..47bab513feec217d875192afef61f3af
              return false;
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 72120be90f1aa3a5408b9dc96f00b5f645809fe6..437f546cb22e0ed7d400540d890e5130889fac0c 100644
+index 146cf1168c82430b4faf35d7544abbec8e5f1c08..ea49dea83b9e8fa168e2a83451eed1b5977a336e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -243,8 +243,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -7879,7 +7879,7 @@ index 72120be90f1aa3a5408b9dc96f00b5f645809fe6..437f546cb22e0ed7d400540d890e5130
          if (playerChunk == null) return false;
  
          playerChunk.getTickingChunkFuture().thenAccept(either -> {
-@@ -1995,4 +1995,32 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1997,4 +1997,32 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2561,7 +2561,7 @@ index 1cb95db25a20d38faacd99a5805630c1598e9db3..d99b2235038eb1aba8cda474c4aa51e2
  
                  @Override
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 10b263b2693a6b507c858b6550b5b98a53cea575..3b646b86f2b01306618fd2a319307cad4dde9588 100644
+index fc56906135347e0d5e4b18c39adef6932496d924..b278ecc71399b3c6f30040402a38e6673ff823e8 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -270,7 +270,7 @@ public abstract class PlayerList {
@@ -2866,7 +2866,7 @@ index 23bdb77690ba15bcbbfb0c70af23336d08ac7752..8f144a357174bbe096ac9b38a5e67a61
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f890e0e8ae52965f671fe82911b006a61a33a86b..e04b981e990efc6402978a329dee8024440b48fa 100644
+index a694a208f7c84f4c2ffa654cdf96942e483eedba..39a3ab010a2960ea99a6cc246edd343994bb523f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -616,8 +616,10 @@ public final class CraftServer implements Server {
@@ -2880,7 +2880,7 @@ index f890e0e8ae52965f671fe82911b006a61a33a86b..e04b981e990efc6402978a329dee8024
      }
  
      @Override
-@@ -1473,7 +1475,15 @@ public final class CraftServer implements Server {
+@@ -1474,7 +1476,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -2896,7 +2896,7 @@ index f890e0e8ae52965f671fe82911b006a61a33a86b..e04b981e990efc6402978a329dee8024
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1641,7 +1651,20 @@ public final class CraftServer implements Server {
+@@ -1642,7 +1652,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -2917,7 +2917,7 @@ index f890e0e8ae52965f671fe82911b006a61a33a86b..e04b981e990efc6402978a329dee8024
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1649,14 +1672,14 @@ public final class CraftServer implements Server {
+@@ -1650,14 +1673,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -2934,7 +2934,7 @@ index f890e0e8ae52965f671fe82911b006a61a33a86b..e04b981e990efc6402978a329dee8024
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1919,6 +1942,14 @@ public final class CraftServer implements Server {
+@@ -1920,6 +1943,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -2949,7 +2949,7 @@ index f890e0e8ae52965f671fe82911b006a61a33a86b..e04b981e990efc6402978a329dee8024
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Preconditions.checkArgument(type != null, "InventoryType cannot be null");
-@@ -1933,13 +1964,28 @@ public final class CraftServer implements Server {
+@@ -1934,13 +1965,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -2978,7 +2978,7 @@ index f890e0e8ae52965f671fe82911b006a61a33a86b..e04b981e990efc6402978a329dee8024
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -2004,6 +2050,17 @@ public final class CraftServer implements Server {
+@@ -2005,6 +2051,17 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -2996,7 +2996,7 @@ index f890e0e8ae52965f671fe82911b006a61a33a86b..e04b981e990efc6402978a329dee8024
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2438,4 +2495,53 @@ public final class CraftServer implements Server {
+@@ -2439,4 +2496,53 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
@@ -3051,7 +3051,7 @@ index f890e0e8ae52965f671fe82911b006a61a33a86b..e04b981e990efc6402978a329dee8024
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 437f546cb22e0ed7d400540d890e5130889fac0c..91334fc68e9e66facbf1ba9b445d87fcf4b26ddf 100644
+index ea49dea83b9e8fa168e2a83451eed1b5977a336e..7efdca87cc2dda12e545d053e9fea271e9f857d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -153,6 +153,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -3102,7 +3102,7 @@ index 437f546cb22e0ed7d400540d890e5130889fac0c..91334fc68e9e66facbf1ba9b445d87fc
  
      private static Map<String, GameRules.Key<?>> gamerules;
      public static synchronized Map<String, GameRules.Key<?>> getGameRulesNMS() {
-@@ -2022,5 +2056,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2024,5 +2058,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return ret;
      }
@@ -3122,7 +3122,7 @@ index 437f546cb22e0ed7d400540d890e5130889fac0c..91334fc68e9e66facbf1ba9b445d87fc
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 6b93a90f2871781e7721499b8d322d5108254092..eb8120877490944ea8f5cbae2986f190c78b144b 100644
+index 67d408b79422cf0c4aed6636cfd4ebb9e13e19f9..442beb8675d6d53a92fb6a5b7c2abdda2822e6fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -20,6 +20,12 @@ public class Main {
@@ -3642,7 +3642,7 @@ index 10fa80df3ae2406f34af669f89d087b15ad1d71b..66fb6aeb49b7e93d2a4d9b5ce7f1a7d6
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2423c838777d99ff34bbde2e791105b3a00c7810..c6e13e9c688eb48518e7b5255521310c17ea452c 100644
+index 6c75e58ccb778d5f292c23743944b04bf3d2967e..d78b466e0e97557da78424c09ba1b61947c64dcd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -296,14 +296,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -3848,7 +3848,7 @@ index 2423c838777d99ff34bbde2e791105b3a00c7810..c6e13e9c688eb48518e7b5255521310c
      public void addChannel(String channel) {
          Preconditions.checkState(this.channels.size() < 128, "Cannot register channel '%s'. Too many channels registered!", channel);
          channel = StandardMessenger.validateAndCorrectChannel(channel);
-@@ -2108,6 +2189,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2110,6 +2191,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().requestedViewDistance() == 0) ? Bukkit.getViewDistance() : this.getHandle().requestedViewDistance();
      }
  
@@ -3861,7 +3861,7 @@ index 2423c838777d99ff34bbde2e791105b3a00c7810..c6e13e9c688eb48518e7b5255521310c
      @Override
      public int getPing() {
          return this.getHandle().connection.latency();
-@@ -2158,6 +2245,252 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2160,6 +2247,252 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  

--- a/patches/server/0011-Paper-command.patch
+++ b/patches/server/0011-Paper-command.patch
@@ -617,7 +617,7 @@ index a9ec28c3cf3ed50d929c80ac21959d82603ff0aa..95a4bcd09f3a9d462ff4c92431c07e3d
  
          this.setPvpAllowed(dedicatedserverproperties.pvp);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e04b981e990efc6402978a329dee8024440b48fa..f75e17f3b475fcdaa2aa83829df647a09b863071 100644
+index 39a3ab010a2960ea99a6cc246edd343994bb523f..411d744bbdbc333b1f3854e474964c10a955ed66 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -942,6 +942,7 @@ public final class CraftServer implements Server {
@@ -628,7 +628,7 @@ index e04b981e990efc6402978a329dee8024440b48fa..f75e17f3b475fcdaa2aa83829df647a0
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2535,6 +2536,34 @@ public final class CraftServer implements Server {
+@@ -2536,6 +2537,34 @@ public final class CraftServer implements Server {
      // Paper end
  
      // Paper start

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -1322,7 +1322,7 @@ index 1c0a14dc1ddfe7806d06af83f9b5de6e42b4b0cc..688f974d9e4f9728dfb1a41e083cf324
      }
      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3b646b86f2b01306618fd2a319307cad4dde9588..b30128b77d2fe8a8c1db9b5746aab537a9a25430 100644
+index b278ecc71399b3c6f30040402a38e6673ff823e8..5583b4db7813aeb88359243233d213474c48f402 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1,5 +1,6 @@
@@ -1636,7 +1636,7 @@ index 0eb09ce5c850d85ffd7229d27cf06b3e0edda11b..cc1d7626a82881c4410d65c6a33dadae
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bf4a82c183ad0aa148c6c14615d2d2606a8befb3..319be97869dcc8fb1baed483633612bae17a491a 100644
+index 15fa1f1bd2bdd007667e574775b14f0c73f1bb52..200c4f394002b7a7592f7fe6fdf885f396cf23eb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -376,7 +376,7 @@ public final class CraftServer implements Server {
@@ -1648,7 +1648,7 @@ index bf4a82c183ad0aa148c6c14615d2d2606a8befb3..319be97869dcc8fb1baed483633612ba
          this.overrideSpawnLimits();
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
-@@ -2452,12 +2452,31 @@ public final class CraftServer implements Server {
+@@ -2453,12 +2453,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  
@@ -1850,10 +1850,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c6e13e9c688eb48518e7b5255521310c17ea452c..ed17c517db079920e3bd11753ebdcb40b7054b43 100644
+index d78b466e0e97557da78424c09ba1b61947c64dcd..55bd1f3958ac058709077a34016187466824e98e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2566,6 +2566,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2568,6 +2568,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
              CraftPlayer.this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(components, position == net.md_5.bungee.api.ChatMessageType.ACTION_BAR));
          }

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -20492,7 +20492,7 @@ index 688f974d9e4f9728dfb1a41e083cf3247743cd22..ea53b30fb9b9e0b2b9751b7a2675259f
          StringReader stringreader = new StringReader(packet.getCommand());
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b30128b77d2fe8a8c1db9b5746aab537a9a25430..5ae47b3449df7a83a5c22a266f7b9e4ea681a492 100644
+index 5583b4db7813aeb88359243233d213474c48f402..71e097d0944bbfdf9dbde2f867870ff483a8d2d4 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -251,7 +251,7 @@ public abstract class PlayerList {
@@ -22586,10 +22586,10 @@ index 9f6c2e5b5d9e8d714a47c770e255d06c0ef7c190..ac807277a6b26d140ea9873d17c7aa4f
  
              for(SavedTick<T> savedTick : this.pendingTicks) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 86f4d05a70d4c02a8eecfb685a23e257b55f58fd..03431a9d2ba736285836f5df1fe46b4e0d7ff50e 100644
+index c8c3c8b82a013f4903d3fff4613753d84c4eb770..54448802a7db5734159c381226a50e7be4ec8368 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -112,7 +112,7 @@ public class CraftChunk implements Chunk {
+@@ -113,7 +113,7 @@ public class CraftChunk implements Chunk {
  
      @Override
      public boolean isEntitiesLoaded() {
@@ -22598,7 +22598,7 @@ index 86f4d05a70d4c02a8eecfb685a23e257b55f58fd..03431a9d2ba736285836f5df1fe46b4e
      }
  
      @Override
-@@ -121,51 +121,7 @@ public class CraftChunk implements Chunk {
+@@ -122,51 +122,7 @@ public class CraftChunk implements Chunk {
              this.getWorld().getChunkAt(x, z); // Transient load for this tick
          }
  
@@ -22652,10 +22652,10 @@ index 86f4d05a70d4c02a8eecfb685a23e257b55f58fd..03431a9d2ba736285836f5df1fe46b4e
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 319be97869dcc8fb1baed483633612bae17a491a..8377270a5daa3257cd9799e242fe8894a6d22c5c 100644
+index 200c4f394002b7a7592f7fe6fdf885f396cf23eb..e4bc9b3b7097c1fc3cc15698744a995b15a2b98e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1160,7 +1160,7 @@ public final class CraftServer implements Server {
+@@ -1161,7 +1161,7 @@ public final class CraftServer implements Server {
          this.console.addLevel(internal);
  
          this.getServer().prepareLevels(internal.getChunkSource().chunkMap.progressListener, internal);
@@ -22664,7 +22664,7 @@ index 319be97869dcc8fb1baed483633612bae17a491a..8377270a5daa3257cd9799e242fe8894
  
          this.pluginManager.callEvent(new WorldLoadEvent(internal.getWorld()));
          return internal.getWorld();
-@@ -1204,7 +1204,7 @@ public final class CraftServer implements Server {
+@@ -1205,7 +1205,7 @@ public final class CraftServer implements Server {
              }
  
              handle.getChunkSource().close(save);
@@ -22673,7 +22673,7 @@ index 319be97869dcc8fb1baed483633612bae17a491a..8377270a5daa3257cd9799e242fe8894
              handle.convertable.close();
          } catch (Exception ex) {
              this.getLogger().log(Level.SEVERE, null, ex);
-@@ -2035,7 +2035,7 @@ public final class CraftServer implements Server {
+@@ -2036,7 +2036,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {
@@ -22683,7 +22683,7 @@ index 319be97869dcc8fb1baed483633612bae17a491a..8377270a5daa3257cd9799e242fe8894
  
      // Paper start - Adventure
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 91334fc68e9e66facbf1ba9b445d87fcf4b26ddf..dfd45e5a32e8ff8d7f803addefa8240c0f7424c0 100644
+index 7efdca87cc2dda12e545d053e9fea271e9f857d1..c0eef4c85729de69fa9bea2e1851e17fb9fdb882 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -323,10 +323,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -22745,7 +22745,7 @@ index 91334fc68e9e66facbf1ba9b445d87fcf4b26ddf..dfd45e5a32e8ff8d7f803addefa8240c
              long chunkKey = chunkTickets.getLongKey();
              SortedArraySet<Ticket<?>> tickets = chunkTickets.getValue();
  
-@@ -1989,14 +1979,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1991,14 +1981,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {
@@ -22802,7 +22802,7 @@ index 91334fc68e9e66facbf1ba9b445d87fcf4b26ddf..dfd45e5a32e8ff8d7f803addefa8240c
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ed17c517db079920e3bd11753ebdcb40b7054b43..efd64bfd21a277eb775877382f3f50f86699d8bc 100644
+index 55bd1f3958ac058709077a34016187466824e98e..fb623fed603d235693b86e3a9f3f685187d6fb4e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -197,6 +197,48 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0027-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0027-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -19,7 +19,7 @@ index 151259cc254d4e796e6af810e37eaa30b832daa3..ce626187e7ffda51a54225fa6e43b817
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d1b6c5689e036285515f74263d6b6bc7c32af108..4327b8da53f2417ef3dabd221e0caf792c55dd6e 100644
+index 4c9de9ec9eada494c3a470753dc107792bf9732b..53168d866c59d38c83e9c532109bb2b4371459d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -265,7 +265,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -32,11 +32,11 @@ index d1b6c5689e036285515f74263d6b6bc7c32af108..4327b8da53f2417ef3dabd221e0caf79
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 3c5bbc60a1a2da6ff4dd25f9a6c1929b1a5be6f5..f85240cb888688ac0a2b6bedd83fb1c1e1dd5722 100644
+index 6aeb5c145ea26243abda693e81014f73c6abfb56..e45fabbf0a7fe125c1b4f82894a177d061950833 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -240,12 +240,25 @@ public class Main {
-                     deadline.add(Calendar.DAY_OF_YEAR, -7);
+                     deadline.add(Calendar.DAY_OF_YEAR, -21);
                      if (buildDate.before(deadline.getTime())) {
                          System.err.println("*** Error, this build is outdated ***");
 -                        System.err.println("*** Please download a new build as per instructions from https://www.spigotmc.org/go/outdated-spigot ***");

--- a/patches/server/0030-Player-affects-spawning-API.patch
+++ b/patches/server/0030-Player-affects-spawning-API.patch
@@ -137,10 +137,10 @@ index 2ec2b1d9d987c7f31c685aec3d3c87f42758c94b..36d793b492d9776ee36f8285b5bab09e
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index efd64bfd21a277eb775877382f3f50f86699d8bc..d2ef107e00995008f3433009d0b22621b4f92f12 100644
+index fb623fed603d235693b86e3a9f3f685187d6fb4e..e1e2895e37a5477e1eee068cc23ec60593bfb5e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2247,6 +2247,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2249,6 +2249,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().language;
      }
  

--- a/patches/server/0031-Further-improve-server-tick-loop.patch
+++ b/patches/server/0031-Further-improve-server-tick-loop.patch
@@ -145,10 +145,10 @@ index ce626187e7ffda51a54225fa6e43b817c6c19db8..086be61bfc8a43076b502bbf00e9f2d2
                  this.startMetricsRecordingTick();
                  this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4327b8da53f2417ef3dabd221e0caf792c55dd6e..97801c6b11df3b80ad80d7e6fd03d769c400b417 100644
+index 53168d866c59d38c83e9c532109bb2b4371459d2..733b2dec7eb1bf7d1fa392750b2872076b23f3ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2477,6 +2477,17 @@ public final class CraftServer implements Server {
+@@ -2478,6 +2478,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0045-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0045-Implement-PlayerLocaleChangeEvent.patch
@@ -39,10 +39,10 @@ index 10a99aff9632db578d19683675ba12242ae6970b..77668e9534f6d68755020cbae09aae5d
          // CraftBukkit end
          this.language = clientOptions.language();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b3278a5f44dbbca937c499a2f3ae852052911d7b..ca8c713342c7e217c8bbcd2c92309ad188f7dd27 100644
+index f31df6901597891e269fa4e64ac7714561a2e8a7..944f6b53d1ed9e55900dd2d09c6e4b386ccbd3f2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2245,7 +2245,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2247,7 +2247,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0053-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/patches/server/0053-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -18,10 +18,10 @@ index 2e343d108714bd136ab8e7b20acbf241166177de..382cdfd7d7dceeeffed1cdc34b9e475a
              if (random.nextInt(10) == 0 && flag && pos.getY() < 40) {
                  return checkMobSpawnRules(type, world, spawnReason, pos, random);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 4efdde5f48f50db57fdd70f84bf36a768e2601ea..5473e6ffe55c6e0a0947356e89831d71a86cf6a5 100644
+index 54448802a7db5734159c381226a50e7be4ec8368..9363bcb40963bcbc39a26313260a41eef34981c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -170,7 +170,7 @@ public class CraftChunk implements Chunk {
+@@ -171,7 +171,7 @@ public class CraftChunk implements Chunk {
      @Override
      public boolean isSlimeChunk() {
          // 987234911L is deterimined in EntitySlime when seeing if a slime can spawn in a chunk

--- a/patches/server/0054-Expose-server-CommandMap.patch
+++ b/patches/server/0054-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0afb5b57fdd027b0a5aa05c4710b4ebb9c3d12ac..afb8f7c86558f9f72858d0e490c174d24bfcc670 100644
+index 0e51fffcd58f34d9ed9409a02dcbeaeac8ccec78..e5a65f77c35c9cb61e418a0e9b49aa3da7cb40de 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2017,6 +2017,7 @@ public final class CraftServer implements Server {
+@@ -2018,6 +2018,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0065-Complete-resource-pack-API.patch
+++ b/patches/server/0065-Complete-resource-pack-API.patch
@@ -22,7 +22,7 @@ index b9062fe651de34d5b3f9d5f146ae0b4fe29cbfee..e8b12a8ae009023afa2818ecbf398a14
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 648c5fd5fe3b2f07b6b5ada7e0d48999db9a6392..ec1cbd610250d11536f8fc42e769b749380dc95e 100644
+index d1f1df4f437bf9c81503972257af9d0386a457f7..b11c4c6b6fd49fb14096b3b39f15dd7ee37b3d0d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -191,6 +191,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -36,7 +36,7 @@ index 648c5fd5fe3b2f07b6b5ada7e0d48999db9a6392..ec1cbd610250d11536f8fc42e769b749
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -2368,6 +2372,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2370,6 +2374,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0067-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0067-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 99521b04cb5d3fd6ab5fbf5b663a30c20b0341aa..135fe9abe46d31cdf3a5fb3fb3dfd296e658e2cf 100644
+index 1ba7e571a1286415d8b6ff2807050f8a43811500..c99e7d7dbcd83454ca3f08b08f367f8c6336889f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2621,5 +2621,23 @@ public final class CraftServer implements Server {
+@@ -2622,5 +2622,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0106-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0106-Add-setting-for-proxy-online-mode-status.patch
@@ -43,10 +43,10 @@ index 0214830d9bc98b8d435ff11f40df65596980cf77..5db27d7bcaaa2eeaeeb08401513d8d23
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 69934e156db7fdec00b6b77b20835894a1e3dcb3..085c11983884911a61bc96a6df07ad8a96657e6c 100644
+index ba7f67600d259cfb307e610d55d657a8ac75d4ec..968e4bcdae14d580561b2a310359026080dbab0a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1726,7 +1726,7 @@ public final class CraftServer implements Server {
+@@ -1727,7 +1727,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0113-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 085c11983884911a61bc96a6df07ad8a96657e6c..c3d60b4fe6e19e7c67926529b650bd61eaf869d2 100644
+index 968e4bcdae14d580561b2a310359026080dbab0a..237941f8ba3ef712b5bea9aa7fee0a392357f7b3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2647,5 +2647,24 @@ public final class CraftServer implements Server {
+@@ -2648,5 +2648,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0133-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0133-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c3d60b4fe6e19e7c67926529b650bd61eaf869d2..7631ccc163b9370eb4f0c181bf1f7ef657dfc828 100644
+index 237941f8ba3ef712b5bea9aa7fee0a392357f7b3..584d12cfd6875034dfe9ca0bdcd821e36c2a397b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2666,5 +2666,10 @@ public final class CraftServer implements Server {
+@@ -2667,5 +2667,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0134-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0134-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -25,7 +25,7 @@ Other changes:
 Co-Authored-By: Emilia Kond <emilia@rymiel.space>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index f86524b7ec33041f4394e12099afe8df8efb4457..c5ebde259622ef3acde1ed42ce5b9797807ca5b1 100644
+index 3aca132fcbd7dce2b26ac17f8e365d5f22d61e8d..526f9e79502a6b0055807a6b831602271b704b23 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -6,9 +6,30 @@ plugins {
@@ -375,7 +375,7 @@ index 75083eeb9b413e6dd5375007360dce6857a08fff..d292fdb165436f0b9b46b32110f5e09a
          if (!SwingUtilities.isEventDispatchThread()) {
              SwingUtilities.invokeLater(() -> {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 845a90426545b554aaf5c278723c107ba9791270..a3c150e9552fbc9b9244c70508c27f03a3834fa2 100644
+index aba09b0606602b4081ceb235cc168554c3ab638b..7a3f339528808c84a5833a127786c9d88423fe18 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -162,8 +162,7 @@ public abstract class PlayerList {
@@ -389,7 +389,7 @@ index 845a90426545b554aaf5c278723c107ba9791270..a3c150e9552fbc9b9244c70508c27f03
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7631ccc163b9370eb4f0c181bf1f7ef657dfc828..66de956051f6c5b66f806063869e25430144c6ce 100644
+index 584d12cfd6875034dfe9ca0bdcd821e36c2a397b..4a699d50d1174923991cbd0e4b7d37d1e4e76a90 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -44,7 +44,6 @@ import java.util.logging.Level;
@@ -400,7 +400,7 @@ index 7631ccc163b9370eb4f0c181bf1f7ef657dfc828..66de956051f6c5b66f806063869e2543
  import net.minecraft.advancements.Advancement;
  import net.minecraft.advancements.AdvancementHolder;
  import net.minecraft.commands.CommandSourceStack;
-@@ -1294,9 +1293,13 @@ public final class CraftServer implements Server {
+@@ -1295,9 +1294,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  
@@ -415,7 +415,7 @@ index 7631ccc163b9370eb4f0c181bf1f7ef657dfc828..66de956051f6c5b66f806063869e2543
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 175ab86055f249dc68db64406622ab161dcf5a66..77008ef0458f318125891fa22a5f6411ef69d49a 100644
+index 6f2135690892f23e80648d4f9237cea34ec19740..960885c891c98859e8ef375d0796c8b53fcf562c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -13,7 +13,6 @@ import java.util.logging.Logger;

--- a/patches/server/0141-Basic-PlayerProfile-API.patch
+++ b/patches/server/0141-Basic-PlayerProfile-API.patch
@@ -622,7 +622,7 @@ index c70cd016e1978931d115cfca94664897f0158196..eac9658fa4cab7a651e10e4e18c679e0
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0ef8750c7c862a44dfb0e15602ef819790c9f1a4..a230e2ac2de48d4d5d963e1de2bd87999b4ad2fc 100644
+index a8a605251bc5a3c700ead923f94c32d2fb46b62e..7e629afd43e1ac486d259e70c494d0ed89edb1d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -263,6 +263,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -643,7 +643,7 @@ index 0ef8750c7c862a44dfb0e15602ef819790c9f1a4..a230e2ac2de48d4d5d963e1de2bd8799
          CraftItemFactory.instance();
      }
  
-@@ -2681,5 +2685,42 @@ public final class CraftServer implements Server {
+@@ -2682,5 +2686,42 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }

--- a/patches/server/0150-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0150-Fix-this-stupid-bullshit.patch
@@ -31,12 +31,12 @@ index 8ff786c366332588a2df053438f23cc9fb7e2b84..c887d34171f89c731d76c4ca92c70be2
              Bootstrap.isBootstrapped = true;
              Instant instant = Instant.now();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 77008ef0458f318125891fa22a5f6411ef69d49a..a271ac2e6b17524bf61ef0bc5df7f865dacbe6b0 100644
+index 960885c891c98859e8ef375d0796c8b53fcf562c..863a983165aa845abbf7b8f2a3cd0c5057bb47d8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -257,10 +257,12 @@ public class Main {
                      Calendar deadline = Calendar.getInstance();
-                     deadline.add(Calendar.DAY_OF_YEAR, -7);
+                     deadline.add(Calendar.DAY_OF_YEAR, -21);
                      if (buildDate.before(deadline.getTime())) {
 -                        System.err.println("*** Error, this build is outdated ***");
 +                        // Paper start - This is some stupid bullshit

--- a/patches/server/0167-AsyncTabCompleteEvent.patch
+++ b/patches/server/0167-AsyncTabCompleteEvent.patch
@@ -91,10 +91,10 @@ index 1b856ecd7926e90a62045176f75d7ae6f0ac69d5..4ba7ed0a4ff52caa21632f69ab087564
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a230e2ac2de48d4d5d963e1de2bd87999b4ad2fc..eb56b65b5f10fe00c3d44153e7c3bd6e6eef1071 100644
+index 7e629afd43e1ac486d259e70c494d0ed89edb1d4..b1c965e4a9c8b68a764781266dee078880ee5566 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2131,7 +2131,7 @@ public final class CraftServer implements Server {
+@@ -2132,7 +2132,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0183-getPlayerUniqueId-API.patch
+++ b/patches/server/0183-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index eb56b65b5f10fe00c3d44153e7c3bd6e6eef1071..14a56b1153e87630065a58a6477573bef1597d12 100644
+index b1c965e4a9c8b68a764781266dee078880ee5566..895a12e5859b5e2b21c2f9d7a82932e603a1f791 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1729,6 +1729,25 @@ public final class CraftServer implements Server {
+@@ -1730,6 +1730,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0193-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0193-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,7 +10,7 @@ Adds an option to control the force mode of the particle.
 This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 445b8839d2a7a5ec2debb853d606e499c2a1f20b..4c1911140197568685524721e3140739bca039c7 100644
+index 445b8839d2a7a5ec2debb853d606e499c2a1f20b..365fb14d498a0baecbdc001ce634cc8e81a15b75 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1719,12 +1719,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -20,7 +20,7 @@ index 445b8839d2a7a5ec2debb853d606e499c2a1f20b..4c1911140197568685524721e3140739
 +        // Paper start - Particle API Expansion
 +        return sendParticles(players, sender, t0, d0, d1, d2, i, d3, d4, d5, d6, force);
 +    }
-+    public <T extends ParticleOptions> int sendParticles(List<ServerPlayer> receivers, ServerPlayer sender, T t0, double d0, double d1, double d2, int i, double d3, double d4, double d5, double d6, boolean force) {
++    public <T extends ParticleOptions> int sendParticles(List<ServerPlayer> receivers, @Nullable ServerPlayer sender, T t0, double d0, double d1, double d2, int i, double d3, double d4, double d5, double d6, boolean force) {
 +        // Paper end
          ClientboundLevelParticlesPacket packetplayoutworldparticles = new ClientboundLevelParticlesPacket(t0, force, d0, d1, d2, (float) d3, (float) d4, (float) d5, (float) d6, i);
          // CraftBukkit end
@@ -34,26 +34,28 @@ index 445b8839d2a7a5ec2debb853d606e499c2a1f20b..4c1911140197568685524721e3140739
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9fc72dd4db44fa65c2d4e8d30cf8c19f0fb556a0..c8d960d1fc8b44f64e84abb38f12e3825d2c97bc 100644
+index 1f08be117261f8b567bb4d46f2f21a6515c39aef..6d9de4dbbc0d224ebad03d4279dd45a7d3303848 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1864,11 +1864,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1864,13 +1864,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {
--        if (data != null) {
 +        // Paper start - Particle API Expansion
 +        spawnParticle(particle, null, null, x, y, z, count, offsetX, offsetY, offsetZ, extra, data, force);
 +    }
++    @Override
 +    public <T> void spawnParticle(Particle particle, List<Player> receivers, Player sender, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {
 +        // Paper end
-+        if (data != null && !particle.getDataType().isInstance(data)) {
+         particle = CraftParticle.convertLegacy(particle);
+         data = CraftParticle.convertLegacy(data);
+         if (data != null) {
              Preconditions.checkArgument(particle.getDataType().isInstance(data), "data (%s) should be %s", data.getClass(), particle.getDataType());
          }
          this.getHandle().sendParticles(
 -                null, // Sender
 +                receivers == null ? getHandle().players() : receivers.stream().map(player -> ((CraftPlayer) player).getHandle()).collect(java.util.stream.Collectors.toList()), // Paper -  Particle API Expansion
 +                sender != null ? ((CraftPlayer) sender).getHandle() : null, // Sender // Paper - Particle API Expansion
-                 CraftParticle.toNMS(particle, data), // Particle
+                 CraftParticle.createParticleParam(particle, data), // Particle
                  x, y, z, // Position
                  count,  // Count

--- a/patches/server/0240-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/patches/server/0240-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 5473e6ffe55c6e0a0947356e89831d71a86cf6a5..d10dcf5b9c987bbd4761470c16c9d4693ccf896d 100644
+index 9363bcb40963bcbc39a26313260a41eef34981c1..6daa3591ba17155718c7ff3260de5180b84bb105 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -126,6 +126,13 @@ public class CraftChunk implements Chunk {
+@@ -127,6 +127,13 @@ public class CraftChunk implements Chunk {
  
      @Override
      public BlockState[] getTileEntities() {
@@ -22,7 +22,7 @@ index 5473e6ffe55c6e0a0947356e89831d71a86cf6a5..d10dcf5b9c987bbd4761470c16c9d469
          if (!this.isLoaded()) {
              this.getWorld().getChunkAt(x, z); // Transient load for this tick
          }
-@@ -135,7 +142,29 @@ public class CraftChunk implements Chunk {
+@@ -136,7 +143,29 @@ public class CraftChunk implements Chunk {
          BlockState[] entities = new BlockState[chunk.blockEntities.size()];
  
          for (BlockPos position : chunk.blockEntities.keySet()) {

--- a/patches/server/0252-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0252-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1f2c0e3788700a5900664fa61e811a286a347393..9c988b83338c5cf2cbe12aabc729b9184bb3e97d 100644
+index 6765b59b7b57233c0c963782d0b9b88ba49c3637..fc7bca0d0df079e29ea18f1e37194ddf9c0eefd1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2843,6 +2843,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2845,6 +2845,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0282-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0282-Make-the-default-permission-message-configurable.patch
@@ -18,10 +18,10 @@ index 0dd48e4098191c8b6e29945d62bc473e9f3a1e77..ae51993e0de706cb62c96795ca9de766
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 37ce30dea4c46eeb301b986de5920c16d46990a1..4758931f21a477b328ee463369338e22b22d4e1b 100644
+index cbdf413e16b819432b291d8fb2a87d6c3dba2ed2..4ca91d6e23862c9c7cb0bd3272cd6774d37960a5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2707,6 +2707,16 @@ public final class CraftServer implements Server {
+@@ -2708,6 +2708,16 @@ public final class CraftServer implements Server {
          return io.papermc.paper.configuration.GlobalConfiguration.get().commands.suggestPlayerNamesWhenNullTabCompletions;
      }
  

--- a/patches/server/0292-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0292-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d939e5385d250095674c1f0c6f4209cdf87ad7cb..94cb3513aeef549da3626ff18c1ea0662252ecb9 100644
+index 0a44010d51d8e68640bff5a384f1e79f7f293528..90186b8aef17c7db6663b8cb82fa3b27b4462bd4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2890,6 +2890,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2892,6 +2892,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0315-Expose-the-internal-current-tick.patch
+++ b/patches/server/0315-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4758931f21a477b328ee463369338e22b22d4e1b..dd4d1b6f59992c8bf0336b146cc163c6a612999d 100644
+index 4ca91d6e23862c9c7cb0bd3272cd6774d37960a5..e331fc0866ae91b1463879661b04dad16f6117ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2753,5 +2753,10 @@ public final class CraftServer implements Server {
+@@ -2754,5 +2754,10 @@ public final class CraftServer implements Server {
          profile.getProperties().putAll(((CraftPlayer) player).getHandle().getGameProfile().getProperties());
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }

--- a/patches/server/0342-Anti-Xray.patch
+++ b/patches/server/0342-Anti-Xray.patch
@@ -1100,7 +1100,7 @@ index be89e5b8c1ea7f85aef267a15986affa5fa1fd4b..43472855136f26b282d94fd241853d86
  
      public ClientboundLevelChunkWithLightPacket(FriendlyByteBuf buf) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 35e2688f9252fbc12b69519e5e5fbaec5ff82e42..041a6b20fa88852cd5b37438f2ddf30517b95820 100644
+index 27386e814ae956dbb9f2025bcb682456d7cd0eaf..1c30b2f5aa49b2e377bea4278215929a0baa172c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -566,7 +566,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -1541,7 +1541,7 @@ index 982fb3ef071d6a66f16744717e8e146bef6d9e8c..02beedb84a8bec001270116c6ce496db
      // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 35f8fbd29e18cf3aba120a6658552eb5dbe535d4..593c73bf497ff571ea4c19867aa9be4b8272f39b 100644
+index 6daa3591ba17155718c7ff3260de5180b84bb105..40f0fbd5492ccd9cbb622359c17a23041ede7fb6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 @@ -53,7 +53,7 @@ public class CraftChunk implements Chunk {
@@ -1550,14 +1550,14 @@ index 35f8fbd29e18cf3aba120a6658552eb5dbe535d4..593c73bf497ff571ea4c19867aa9be4b
      private final int z;
 -    private static final PalettedContainer<net.minecraft.world.level.block.state.BlockState> emptyBlockIDs = new PalettedContainer<>(net.minecraft.world.level.block.Block.BLOCK_STATE_REGISTRY, Blocks.AIR.defaultBlockState(), PalettedContainer.Strategy.SECTION_STATES);
 +    private static final PalettedContainer<net.minecraft.world.level.block.state.BlockState> emptyBlockIDs = new PalettedContainer<>(net.minecraft.world.level.block.Block.BLOCK_STATE_REGISTRY, Blocks.AIR.defaultBlockState(), PalettedContainer.Strategy.SECTION_STATES, null); // Paper - Anti-Xray - Add preset block states
-     private static final byte[] emptyLight = new byte[2048];
+     private static final byte[] FULL_LIGHT = new byte[2048];
+     private static final byte[] EMPTY_LIGHT = new byte[2048];
  
-     public CraftChunk(net.minecraft.world.level.chunk.LevelChunk chunk) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dd4d1b6f59992c8bf0336b146cc163c6a612999d..be805e78fb4cb9fba25afd53af8d72ff4a1e1526 100644
+index e331fc0866ae91b1463879661b04dad16f6117ca..30adaccd8c5a9d9696bede7967f4b9406ffd066e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2277,7 +2277,7 @@ public final class CraftServer implements Server {
+@@ -2278,7 +2278,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Preconditions.checkArgument(world != null, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();
@@ -1567,7 +1567,7 @@ index dd4d1b6f59992c8bf0336b146cc163c6a612999d..be805e78fb4cb9fba25afd53af8d72ff
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6c13c3c55d58d654d28d5eebcc6dd9789f6565dd..0f2166ce8facfdc8d51a580ca0c5107b7fbe67c2 100644
+index ed05b94c3ae1f9a45c604d6e5f371edb8d2d9746..098174ddfec746d4212a5ab8e9d353840d3c49c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -419,11 +419,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0358-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0358-Add-tick-times-API-and-mspt-command.patch
@@ -184,10 +184,10 @@ index 4d3cd4a5dbf7adb482e60dc88ededdaccf558061..951e283d38cb7601049ac6f24385acde
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index be805e78fb4cb9fba25afd53af8d72ff4a1e1526..89d7ae645a0a34a260aa84464661b2ba47b9bc51 100644
+index 30adaccd8c5a9d9696bede7967f4b9406ffd066e..42d92cd77bea7fa412a60cc6ec67120eedb90ae4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2532,6 +2532,16 @@ public final class CraftServer implements Server {
+@@ -2533,6 +2533,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0359-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0359-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 89d7ae645a0a34a260aa84464661b2ba47b9bc51..ba381026071767428273b35cc57b4181c57c43f1 100644
+index 42d92cd77bea7fa412a60cc6ec67120eedb90ae4..cb49056d4745ecdca38d30d41e1b5f579c7d2c0c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2768,5 +2768,10 @@ public final class CraftServer implements Server {
+@@ -2769,5 +2769,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0392-Implement-Mob-Goal-API.patch
+++ b/patches/server/0392-Implement-Mob-Goal-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index c210a1d4d779cc64ff7f5ae2d2c63b249ceb6205..0fb730260d1a31cf74db808d3655a566a61fd754 100644
+index dd300f1048b806c1292ac09dd232fd3eb24a7bf0..61d2f46ed71a8abff05e8295ac764b4af78095de 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -45,6 +45,7 @@ dependencies {
@@ -792,10 +792,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 98fec62469f19680cb849cffb6c00b603c34fb65..70dfd93212fb0cb2c1e5e70e0d46e913be6a85e4 100644
+index 3b94e516bdfe927c6741d6bc47ccc86876860f69..e98c1c975ee09e123935a84f0b7f2b8b46d5f237 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2781,5 +2781,11 @@ public final class CraftServer implements Server {
+@@ -2782,5 +2782,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0422-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0422-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7494c8762f7ea9828a7dfc71dc2965838bbd8a0f..e58a2a3532d6ba62e99708b0f4f2cc8f3b6b97bc 100644
+index 90d713ec27c260b9845473b886abd22644abd125..b1761300567e0e36ed17caed76f2aaa0ddb949d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -384,7 +384,7 @@ public final class CraftServer implements Server {
@@ -44,7 +44,7 @@ index 7494c8762f7ea9828a7dfc71dc2965838bbd8a0f..e58a2a3532d6ba62e99708b0f4f2cc8f
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 689a0ca651e51b0207afc7346c891f363d1ec1aa..38d8a8306acb43e9a8bc69bd3990be8e53536e0d 100644
+index bae5f6cf00c8cccfb6284b5e3dbfc8b26a724a71..a42d9425576e00318d3eb6431b56005397a90baa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -280,7 +280,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -116,7 +116,7 @@ index 689a0ca651e51b0207afc7346c891f363d1ec1aa..38d8a8306acb43e9a8bc69bd3990be8e
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -2233,6 +2248,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2236,6 +2251,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          io.papermc.paper.chunk.system.ChunkSystem.scheduleChunkLoad(this.getHandle(), x, z, gen, ChunkStatus.FULL, true, priority, (c) -> {
              net.minecraft.server.MinecraftServer.getServer().scheduleOnMain(() -> {
                  net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk)c;

--- a/patches/server/0444-Brand-support.patch
+++ b/patches/server/0444-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 4a4002b666c70c7065cad0743377cd13e443aa37..54d0b44eba475f17a908e09d9b56a94a7f050672 100644
+index 4f98f80f6d8bebba33bad37fe6a722f778f93ed8..48985c0577fe1a09838137286e32128b29a60552 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -271,6 +271,7 @@ public class ServerPlayer extends Player {
@@ -57,10 +57,10 @@ index d1808bf9dc19fad84da5eb3b4c3d549bc624b00a..e8133a1ec975b7f63926acc7d6ab9291
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f4a15de92c3af88624f337c36fadbea67d339064..0656ea43e1d508d8f6af308475942c28d77655a4 100644
+index a516aa3ff7949d933c15220160f83a5b5dd5fd6c..82c3cac22e7384966bcd4d55a3434b781b5a6795 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3007,6 +3007,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3009,6 +3009,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0480-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0480-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e58a2a3532d6ba62e99708b0f4f2cc8f3b6b97bc..877ce4baa6a0e755d81bdc3df57fcc9a0a90f1a5 100644
+index b1761300567e0e36ed17caed76f2aaa0ddb949d3..dac43bcd9dc796ffec983013291530f3bc541a26 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1813,6 +1813,28 @@ public final class CraftServer implements Server {
+@@ -1814,6 +1814,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0491-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0491-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,15 +5,15 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a0ee2811d691f0088d94a308705dab5529d52810..47fdb3c21e10f86c34c1634708dac784577cd5f0 100644
+index 45fa80f600f83f2235e39f5aa4ddb1eaa273d7cd..7392a6d58ec2c767b2982b928e7186eb8dda4cd4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2536,7 +2536,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2538,7 +2538,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null) {
              Preconditions.checkArgument(particle.getDataType().isInstance(data), "data (%s) should be %s", data.getClass(), particle.getDataType());
          }
--        ClientboundLevelParticlesPacket packetplayoutworldparticles = new ClientboundLevelParticlesPacket(CraftParticle.toNMS(particle, data), true, (float) x, (float) y, (float) z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count);
-+        ClientboundLevelParticlesPacket packetplayoutworldparticles = new ClientboundLevelParticlesPacket(CraftParticle.toNMS(particle, data), true, x, y, z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count); // Paper - Fix x/y/z coordinate precision loss
+-        ClientboundLevelParticlesPacket packetplayoutworldparticles = new ClientboundLevelParticlesPacket(CraftParticle.createParticleParam(particle, data), true, (float) x, (float) y, (float) z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count);
++        ClientboundLevelParticlesPacket packetplayoutworldparticles = new ClientboundLevelParticlesPacket(CraftParticle.createParticleParam(particle, data), true, x, y, z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count); // Paper - Fix x/y/z coordinate precision loss
          this.getHandle().connection.send(packetplayoutworldparticles);
  
      }

--- a/patches/server/0564-Expand-world-key-API.patch
+++ b/patches/server/0564-Expand-world-key-API.patch
@@ -20,7 +20,7 @@ index 93f44ca0c8388935baaa41f9b0ebb6de2f6906bb..53b62be779bbb31723c4953221d8b5f2
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 877ce4baa6a0e755d81bdc3df57fcc9a0a90f1a5..48ba01082041281d247b898cfa84bccf21ce9b15 100644
+index dac43bcd9dc796ffec983013291530f3bc541a26..e57af8c8f4a1ddfcf9689c8d721b2e2dc887f0be 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1139,9 +1139,15 @@ public final class CraftServer implements Server {
@@ -50,7 +50,7 @@ index 877ce4baa6a0e755d81bdc3df57fcc9a0a90f1a5..48ba01082041281d247b898cfa84bccf
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, worlddimension, this.getServer().progressListenerFactory.create(11),
-@@ -1320,6 +1326,15 @@ public final class CraftServer implements Server {
+@@ -1321,6 +1327,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0581-More-World-API.patch
+++ b/patches/server/0581-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 31fda85d5da2cbf4af199fd2431b258592f14af4..4d5e34a9ad59c3ed3b39630f0fd4e119ea3326e0 100644
+index 1d97b5322182eecf42ca7f15e327d1ab1a49b7cc..55ddaa34eb9ec94b5e2e41b3c5f45003dedd7e6a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2089,6 +2089,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2092,6 +2092,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return new CraftStructureSearchResult(CraftStructure.minecraftToBukkit(found.getSecond().value(), this.getHandle().registryAccess()), CraftLocation.toBukkit(found.getFirst(), this));
      }
  

--- a/patches/server/0596-Add-basic-Datapack-API.patch
+++ b/patches/server/0596-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 48ba01082041281d247b898cfa84bccf21ce9b15..87374f4f81affc7ae72d7178f4c414026518a5f6 100644
+index e57af8c8f4a1ddfcf9689c8d721b2e2dc887f0be..23a433f28a7185c86c129deec32b606079c13f9c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -303,6 +303,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index 48ba01082041281d247b898cfa84bccf21ce9b15..87374f4f81affc7ae72d7178f4c41402
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2849,5 +2851,11 @@ public final class CraftServer implements Server {
+@@ -2850,5 +2852,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0626-Missing-Entity-API.patch
+++ b/patches/server/0626-Missing-Entity-API.patch
@@ -108,7 +108,7 @@ index 0000000000000000000000000000000000000000..41bf71d116ffc5431586ce54abba7f8d
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/animal/AbstractSchoolingFish.java b/src/main/java/net/minecraft/world/entity/animal/AbstractSchoolingFish.java
-index afac0fd1d5c7f732ec0614bd64a224e2a890e45c..235e86549b691c0698f13c8438b35e76d528f0b5 100644
+index 39ed3ca76d6b64ef3917280ec822721cc02afada..86b437836cb4b1f6e8ca9acd5f1f93b925cf9e51 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/AbstractSchoolingFish.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/AbstractSchoolingFish.java
 @@ -52,6 +52,7 @@ public abstract class AbstractSchoolingFish extends AbstractFish {
@@ -428,10 +428,10 @@ index 3f1f4d65525562b3117fdc21c8a7f535b12c3c46..90a989c7c9de6f9ba55ab640761915e9
 +    // Paper end - Horse API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
-index d9895ac178a11a349572aa3d342a0ffd0df4139e..e7b0f4583f80e5df204269becb0feba20c6ab69d 100644
+index 35580198ee9ea566dd2643a707653512c6cd938f..a46b2dfb2f1c0c7c3b55d81fc881e481348f98b8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftAreaEffectCloud.java
-@@ -239,4 +239,17 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
+@@ -244,4 +244,17 @@ public class CraftAreaEffectCloud extends CraftEntity implements AreaEffectCloud
              this.getHandle().setOwner(null);
          }
      }

--- a/patches/server/0675-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0675-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -278,10 +278,10 @@ index 9df761f5cf043e8d2dffa711c20ab32fe2992331..d08c7b0b52065980f1f13c5533ff6355
          // Paper start - add parameters and int ret type
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2a5daa15b1095b20716e997c18fe68ac7d550da6..58e9e04d05d23471690e0d9e42aeb98a64d8dabf 100644
+index d2c6ce68b1ec10e83b21fa57ead41b9fcb06367f..38738fa0b19c665d5458286431db46dbe30dbb41 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2183,6 +2183,11 @@ public final class CraftServer implements Server {
+@@ -2184,6 +2184,11 @@ public final class CraftServer implements Server {
  
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
@@ -294,7 +294,7 @@ index 2a5daa15b1095b20716e997c18fe68ac7d550da6..58e9e04d05d23471690e0d9e42aeb98a
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b137d0946b45b1f1a0170177b47fcece406a70dc..4de85b0f3b77d838c91e79b1126e39d41c1f6132 100644
+index 45147b34c60261fa3a7218529c18d327ea27c110..3dd98ee8c2876c28f45a7c4521e13858ef24d350 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1705,9 +1705,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0725-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0725-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 58e9e04d05d23471690e0d9e42aeb98a64d8dabf..c103ac154104a1e50ed687a2154a1e0e579b786a 100644
+index 38738fa0b19c665d5458286431db46dbe30dbb41..f436c42325a0dd90bd62f7358a3a9132ce02c192 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2363,6 +2363,88 @@ public final class CraftServer implements Server {
+@@ -2364,6 +2364,88 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registries.BIOME), world); // Paper - Anti-Xray - Add parameters
      }
  

--- a/patches/server/0728-Fix-ChunkSnapshot-isSectionEmpty-int-and-optimize-Pa.patch
+++ b/patches/server/0728-Fix-ChunkSnapshot-isSectionEmpty-int-and-optimize-Pa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix ChunkSnapshot#isSectionEmpty(int) and optimize
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 593c73bf497ff571ea4c19867aa9be4b8272f39b..e03345e5b29040b851eec285b994df831aabef81 100644
+index 40f0fbd5492ccd9cbb622359c17a23041ede7fb6..2d36a132bdf67413b40d3b2dd97f52a741538a6f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -290,13 +290,17 @@ public class CraftChunk implements Chunk {
+@@ -291,13 +291,17 @@ public class CraftChunk implements Chunk {
          PalettedContainerRO<Holder<net.minecraft.world.level.biome.Biome>>[] biome = (includeBiome || includeBiomeTempRain) ? new PalettedContainer[cs.length] : null;
  
          Registry<net.minecraft.world.level.biome.Biome> iregistry = this.worldServer.registryAccess().registryOrThrow(Registries.BIOME);
@@ -31,7 +31,7 @@ index 593c73bf497ff571ea4c19867aa9be4b8272f39b..e03345e5b29040b851eec285b994df83
  
              LevelLightEngine lightengine = this.worldServer.getLightEngine();
              DataLayer skyLightArray = lightengine.getLayerListener(LightLayer.SKY).getDataLayerData(SectionPos.of(x, chunk.getSectionYFromSectionIndex(i), z)); // SPIGOT-7498: Convert section index
-@@ -315,8 +319,7 @@ public class CraftChunk implements Chunk {
+@@ -316,8 +320,7 @@ public class CraftChunk implements Chunk {
              }
  
              if (biome != null) {

--- a/patches/server/0760-API-for-creating-command-sender-which-forwards-feedb.patch
+++ b/patches/server/0760-API-for-creating-command-sender-which-forwards-feedb.patch
@@ -122,10 +122,10 @@ index 0000000000000000000000000000000000000000..e3a5f1ec376319bdfda87fa27ae217bf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 73738d920a7a5776165eb3586ddf0676ffa64886..801479941333e421427b22edd2c129b8ab095b38 100644
+index 46944a7f368b8c1da29400a171876b903844377c..6254c962346c243a596ba3ace41a2d5218c86776 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2014,6 +2014,13 @@ public final class CraftServer implements Server {
+@@ -2015,6 +2015,13 @@ public final class CraftServer implements Server {
          return console.console;
      }
  

--- a/patches/server/0764-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
+++ b/patches/server/0764-Add-missing-Validate-calls-to-CraftServer-getSpawnLi.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing Validate calls to CraftServer#getSpawnLimit
 Copies appropriate checks from CraftWorld#getSpawnLimit
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 801479941333e421427b22edd2c129b8ab095b38..6fa952f517759e11728450d73b169b2d06b2c35e 100644
+index 6254c962346c243a596ba3ace41a2d5218c86776..28c4be4c1876daa1919ac0c2e506747460918631 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2191,6 +2191,8 @@ public final class CraftServer implements Server {
+@@ -2192,6 +2192,8 @@ public final class CraftServer implements Server {
      @Override
      public int getSpawnLimit(SpawnCategory spawnCategory) {
          // Paper start

--- a/patches/server/0765-Add-GameEvent-tags.patch
+++ b/patches/server/0765-Add-GameEvent-tags.patch
@@ -46,10 +46,10 @@ index 0000000000000000000000000000000000000000..e7d9fd2702a1ce96596580fff8f5ee4f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6fa952f517759e11728450d73b169b2d06b2c35e..3ca63ce5bb1d16db02c8f924431a7911f8682937 100644
+index 28c4be4c1876daa1919ac0c2e506747460918631..b29ae6ae2a869cba148f5e3be76962182934a577 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2612,6 +2612,15 @@ public final class CraftServer implements Server {
+@@ -2613,6 +2613,15 @@ public final class CraftServer implements Server {
                      return (org.bukkit.Tag<T>) new CraftEntityTag(BuiltInRegistries.ENTITY_TYPE, entityTagKey);
                  }
              }
@@ -65,7 +65,7 @@ index 6fa952f517759e11728450d73b169b2d06b2c35e..3ca63ce5bb1d16db02c8f924431a7911
              default -> throw new IllegalArgumentException();
          }
  
-@@ -2644,6 +2653,13 @@ public final class CraftServer implements Server {
+@@ -2645,6 +2654,13 @@ public final class CraftServer implements Server {
                  net.minecraft.core.Registry<EntityType<?>> entityTags = BuiltInRegistries.ENTITY_TYPE;
                  return entityTags.getTags().map(pair -> (org.bukkit.Tag<T>) new CraftEntityTag(entityTags, pair.getFirst())).collect(ImmutableList.toImmutableList());
              }

--- a/patches/server/0771-Put-world-into-worldlist-before-initing-the-world.patch
+++ b/patches/server/0771-Put-world-into-worldlist-before-initing-the-world.patch
@@ -23,10 +23,10 @@ index 7d944606f7e136aa60a0ea376ef325887bd4e6a8..e7bd891260ad4c95c6161542e6d1412c
  
              if (worlddata.getCustomBossEvents() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3ca63ce5bb1d16db02c8f924431a7911f8682937..ea08e06eb17ae67cc0eb65b4e3900705cb7e4300 100644
+index b29ae6ae2a869cba148f5e3be76962182934a577..91bdf2bc934d98513fd6b9b83f8e422763551e91 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1252,10 +1252,11 @@ public final class CraftServer implements Server {
+@@ -1253,10 +1253,11 @@ public final class CraftServer implements Server {
              return null;
          }
  

--- a/patches/server/0773-Custom-Potion-Mixes.patch
+++ b/patches/server/0773-Custom-Potion-Mixes.patch
@@ -172,7 +172,7 @@ index 424406d2692856cfd82b6f3b7b6228fa3bd20c2f..c57efcb9a79337ec791e4e8f6671612f
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ea08e06eb17ae67cc0eb65b4e3900705cb7e4300..1a958746f7a9992b1fe6c7ea07d044ad98dcb26d 100644
+index 91bdf2bc934d98513fd6b9b83f8e422763551e91..f8dbfec818059921e3bed2f79929385e5ee9dd7d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -306,6 +306,7 @@ public final class CraftServer implements Server {
@@ -192,7 +192,7 @@ index ea08e06eb17ae67cc0eb65b4e3900705cb7e4300..1a958746f7a9992b1fe6c7ea07d044ad
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2976,5 +2977,10 @@ public final class CraftServer implements Server {
+@@ -2977,5 +2978,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  

--- a/patches/server/0784-Fix-saving-in-unloadWorld.patch
+++ b/patches/server/0784-Fix-saving-in-unloadWorld.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix saving in unloadWorld
 Change savingDisabled to false to ensure ServerLevel's saving logic gets called when unloadWorld is called with save = true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1a958746f7a9992b1fe6c7ea07d044ad98dcb26d..0efe5a68095b1ae1cdc3c566179c6f885217e79a 100644
+index f8dbfec818059921e3bed2f79929385e5ee9dd7d..34934e9b1022facc9ca8a2770a4d8632c08f97a0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1300,7 +1300,7 @@ public final class CraftServer implements Server {
+@@ -1301,7 +1301,7 @@ public final class CraftServer implements Server {
  
          try {
              if (save) {

--- a/patches/server/0800-WorldCreator-keepSpawnLoaded.patch
+++ b/patches/server/0800-WorldCreator-keepSpawnLoaded.patch
@@ -5,10 +5,19 @@ Subject: [PATCH] WorldCreator#keepSpawnLoaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0efe5a68095b1ae1cdc3c566179c6f885217e79a..a62bacbda6e3698403d41365db22f6a7140f1c0c 100644
+index 34934e9b1022facc9ca8a2770a4d8632c08f97a0..d77f5be56ffa1bee3d2b33ffcc5e492ce6b944fa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1259,6 +1259,7 @@ public final class CraftServer implements Server {
+@@ -1248,7 +1248,7 @@ public final class CraftServer implements Server {
+ 
+         ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, worlddimension, this.getServer().progressListenerFactory.create(11),
+                 worlddata.isDebugWorld(), j, creator.environment() == Environment.NORMAL ? list : ImmutableList.of(), true, this.console.overworld().getRandomSequences(), creator.environment(), generator, biomeProvider);
+-        internal.keepSpawnInMemory = creator.keepSpawnInMemory();
++        // internal.keepSpawnInMemory = creator.keepSpawnInMemory(); // Paper - replace
+ 
+         if (!(this.worlds.containsKey(name.toLowerCase(java.util.Locale.ENGLISH)))) {
+             return null;
+@@ -1260,6 +1260,7 @@ public final class CraftServer implements Server {
          internal.setSpawnSettings(true, true);
          // Paper - move up
  

--- a/patches/server/0816-Throw-exception-on-world-create-while-being-ticked.patch
+++ b/patches/server/0816-Throw-exception-on-world-create-while-being-ticked.patch
@@ -45,7 +45,7 @@ index a197fa2864382363860b4a3db8160ed64f928df7..dd05048c5c9c37002708f0eee4e4fa0f
          this.profiler.popPush("connection");
          MinecraftTimings.connectionTimer.startTiming(); // Spigot
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a62bacbda6e3698403d41365db22f6a7140f1c0c..3ccd26eb31aab876dc3a2da2f3c3baa95afd7200 100644
+index 28be626682884f0a19692d3fbed1c71d051106e4..78970e3183877c329eb6fea4575289cfda120df4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -876,6 +876,11 @@ public final class CraftServer implements Server {
@@ -68,7 +68,7 @@ index a62bacbda6e3698403d41365db22f6a7140f1c0c..3ccd26eb31aab876dc3a2da2f3c3baa9
          Preconditions.checkArgument(creator != null, "WorldCreator cannot be null");
  
          String name = creator.name();
-@@ -1274,6 +1280,7 @@ public final class CraftServer implements Server {
+@@ -1275,6 +1281,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {

--- a/patches/server/0823-Don-t-broadcast-messages-to-command-blocks.patch
+++ b/patches/server/0823-Don-t-broadcast-messages-to-command-blocks.patch
@@ -20,10 +20,10 @@ index e05eb08a9c229b371887676da510df948b896a85..ceeedbd88c56c08ec8b047c9ca2f14cc
              Date date = new Date();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3ccd26eb31aab876dc3a2da2f3c3baa95afd7200..7441b15d074de921d3dc0f594e491d036b1f6064 100644
+index 78970e3183877c329eb6fea4575289cfda120df4..ab0e24d948f3192e6225966433c7f6e87b6718c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1776,7 +1776,7 @@ public final class CraftServer implements Server {
+@@ -1777,7 +1777,7 @@ public final class CraftServer implements Server {
          // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {

--- a/patches/server/0836-Warn-on-plugins-accessing-faraway-chunks.patch
+++ b/patches/server/0836-Warn-on-plugins-accessing-faraway-chunks.patch
@@ -18,7 +18,7 @@ index ba5ad3372b3f3f2110841100729ea3b4c06ecc75..07a5bbdcada2d2cdb1c3d245379217fe
  
      private static boolean isOutsideSpawnableHeight(int y) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c5b6957aca67739a2d265ca985a0cc5b35c9c1e6..a54b8615b9652760eaa72b30dfa5460e77d4440a 100644
+index 32116487ea913080bc01a2e74b66d6034813b86e..2235b327afc8f1e4d54fcf3dc9e99c6fcd8cf901 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -310,9 +310,24 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -86,7 +86,7 @@ index c5b6957aca67739a2d265ca985a0cc5b35c9c1e6..a54b8615b9652760eaa72b30dfa5460e
          // Transient load for this tick
          return this.world.getChunk(x >> 4, z >> 4).getHeight(CraftHeightMap.toNMS(heightMap), x, z);
      }
-@@ -2384,6 +2404,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2387,6 +2407,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot end
      // Paper start
      public java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent) {

--- a/patches/server/0864-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0864-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 55d95fe1bb0fe5064bf5855a4e7aaee8a0b4abd7..ecd5a7578a8419a2eed0036cb1a52d6266cf11f1 100644
+index 7f46ada61d9f64e7fd6e462be234146cb329d152..eb2ef913705a8350493ef215c1ad123082b69c98 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3170,6 +3170,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3172,6 +3172,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0881-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0881-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ecd5a7578a8419a2eed0036cb1a52d6266cf11f1..4096145769065693c6d67f092ccedccb78ef4578 100644
+index eb2ef913705a8350493ef215c1ad123082b69c98..8b94aefb8386b7569028fc999c77e64d1b5c9399 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3175,6 +3175,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3177,6 +3177,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0967-Suppress-Item-Meta-Validation-Checks.patch
+++ b/patches/server/0967-Suppress-Item-Meta-Validation-Checks.patch
@@ -67,10 +67,10 @@ index f79ea76c0127b7b57ab0511afbed626a3b42fd05..3cea851c3f5389a5dd92601dfbef2975
                  continue;
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 9b9e20014042da4324c9f4babb05d8ba9513f81d..ee37b43060e0b102ab23cf318fd22041f5abaeb0 100644
+index 954768f5f04a583e343b826e832e76cba189af95..c6340b7259242f44a9a681bff2ec46cc633eada3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -72,11 +72,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -71,11 +71,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      CraftMetaSkull(CompoundTag tag) {
          super(tag);
  

--- a/patches/server/0979-API-for-updating-recipes-on-clients.patch
+++ b/patches/server/0979-API-for-updating-recipes-on-clients.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] API for updating recipes on clients
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 2fcca41018e6432211606276ea33170ff4f86529..c2d50d5b070e2e916cd9cb370d2d8ce074049e56 100644
+index 4b3a121e8443aa0e0e7cd26806e7d5b00ddf59af..468231acdf3bb3d8e92be5636b5a32a103709cd1 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1518,6 +1518,13 @@ public abstract class PlayerList {
@@ -39,7 +39,7 @@ index 2fcca41018e6432211606276ea33170ff4f86529..c2d50d5b070e2e916cd9cb370d2d8ce0
          Iterator iterator1 = this.players.iterator();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index edbdfb66c629a5dc01db01d1164c22b4c6df6d00..243050b941b5e71796f6cf72ec831b4b6105c505 100644
+index 4794cea2353c47bd57c86e37beb1164629791211..a97136b944991bc93d7e33a375cfae717ea86220 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1131,6 +1131,18 @@ public final class CraftServer implements Server {
@@ -61,7 +61,7 @@ index edbdfb66c629a5dc01db01d1164c22b4c6df6d00..243050b941b5e71796f6cf72ec831b4b
      private void loadIcon() {
          this.icon = new CraftIconCache(null);
          try {
-@@ -1473,6 +1485,13 @@ public final class CraftServer implements Server {
+@@ -1474,6 +1486,13 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean addRecipe(Recipe recipe) {
@@ -75,7 +75,7 @@ index edbdfb66c629a5dc01db01d1164c22b4c6df6d00..243050b941b5e71796f6cf72ec831b4b
          CraftRecipe toAdd;
          if (recipe instanceof CraftRecipe) {
              toAdd = (CraftRecipe) recipe;
-@@ -1502,6 +1521,11 @@ public final class CraftServer implements Server {
+@@ -1503,6 +1522,11 @@ public final class CraftServer implements Server {
              }
          }
          toAdd.addToCraftingManager();
@@ -87,7 +87,7 @@ index edbdfb66c629a5dc01db01d1164c22b4c6df6d00..243050b941b5e71796f6cf72ec831b4b
          return true;
      }
  
-@@ -1621,10 +1645,23 @@ public final class CraftServer implements Server {
+@@ -1622,10 +1646,23 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean removeRecipe(NamespacedKey recipeKey) {

--- a/patches/server/0992-Deprecate-and-replace-methods-with-old-StructureType.patch
+++ b/patches/server/0992-Deprecate-and-replace-methods-with-old-StructureType.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Deprecate and replace methods with old StructureType
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c40fbae05a174efc98ed721c7049e1d41d1bd3b8..b7e7e6ed60f55d2ab5e4fcefb3638ad1768c3b7f 100644
+index 8aa576877ceb0e6917e02db99ddd4fa851dca811..bc761127b14dc5e91b51966f932c92a3c875f759 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1854,6 +1854,11 @@ public final class CraftServer implements Server {
+@@ -1855,6 +1855,11 @@ public final class CraftServer implements Server {
  
          ServerLevel worldServer = ((CraftWorld) world).getHandle();
          Location structureLocation = world.locateNearestStructure(location, structureType, radius, findUnexplored);
@@ -20,7 +20,7 @@ index c40fbae05a174efc98ed721c7049e1d41d1bd3b8..b7e7e6ed60f55d2ab5e4fcefb3638ad1
          BlockPos structurePosition = CraftLocation.toBlockPosition(structureLocation);
  
          // Create map with trackPlayer = true, unlimitedTracking = true
-@@ -1864,6 +1869,31 @@ public final class CraftServer implements Server {
+@@ -1865,6 +1870,31 @@ public final class CraftServer implements Server {
  
          return CraftItemStack.asBukkitCopy(stack);
      }

--- a/patches/server/1039-Fix-NPE-in-SculkBloomEvent-world-access.patch
+++ b/patches/server/1039-Fix-NPE-in-SculkBloomEvent-world-access.patch
@@ -4,21 +4,8 @@ Date: Fri, 20 Oct 2023 19:50:22 +0200
 Subject: [PATCH] Fix NPE in SculkBloomEvent world access
 
 
-diff --git a/src/main/java/net/minecraft/world/level/block/SculkSpreader.java b/src/main/java/net/minecraft/world/level/block/SculkSpreader.java
-index de90a216321f7d82310a0d1c915fefe64360534c..6010c6cc727cee90f61e15848bd111385c6d52fb 100644
---- a/src/main/java/net/minecraft/world/level/block/SculkSpreader.java
-+++ b/src/main/java/net/minecraft/world/level/block/SculkSpreader.java
-@@ -62,7 +62,7 @@ public class SculkSpreader {
-     private final int additionalDecayRate;
-     private List<SculkSpreader.ChargeCursor> cursors = new ArrayList();
-     private static final Logger LOGGER = LogUtils.getLogger();
--    Level level; // CraftBukkit
-+    public Level level; // CraftBukkit // Paper - package-private -> public
- 
-     public SculkSpreader(boolean worldGen, TagKey<Block> replaceableTag, int extraBlockChance, int maxDistance, int spreadChance, int decayChance) {
-         this.isWorldGeneration = worldGen;
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/SculkCatalystBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/SculkCatalystBlockEntity.java
-index 6c378e3485fef4e8b8906c33a45a23e6f77e9cdd..8c4987075d8bcae85a7048c38ca97b455fb387eb 100644
+index 9ca735d77db051dade99f27bfa2d86a6043c76d5..65112ec3a6ea1c27f032477720ae74395523012b 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/SculkCatalystBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/SculkCatalystBlockEntity.java
 @@ -32,9 +32,16 @@ public class SculkCatalystBlockEntity extends BlockEntity implements GameEventLi
@@ -39,7 +26,7 @@ index 6c378e3485fef4e8b8906c33a45a23e6f77e9cdd..8c4987075d8bcae85a7048c38ca97b45
      public static void serverTick(Level world, BlockPos pos, BlockState state, SculkCatalystBlockEntity blockEntity) {
          org.bukkit.craftbukkit.event.CraftEventFactory.sourceBlockOverride = blockEntity.getBlockPos(); // CraftBukkit - SPIGOT-7068: Add source block override, not the most elegant way but better than passing down a BlockPosition up to five methods deep.
          blockEntity.catalystListener.getSculkSpreader().updateCursors(world, pos, world.getRandom(), true);
-@@ -64,7 +71,6 @@ public class SculkCatalystBlockEntity extends BlockEntity implements GameEventLi
+@@ -64,13 +71,12 @@ public class SculkCatalystBlockEntity extends BlockEntity implements GameEventLi
          final SculkSpreader sculkSpreader;
          private final BlockState blockState;
          private final PositionSource positionSource;
@@ -47,3 +34,10 @@ index 6c378e3485fef4e8b8906c33a45a23e6f77e9cdd..8c4987075d8bcae85a7048c38ca97b45
  
          public CatalystListener(BlockState state, PositionSource positionSource) {
              this.blockState = state;
+             this.positionSource = positionSource;
+             this.sculkSpreader = SculkSpreader.createLevelSpreader();
+-            this.sculkSpreader.level = this.level; // CraftBukkit
++            // this.sculkSpreader.level = this.level; // CraftBukkit // Paper - bad fix
+         }
+ 
+         @Override


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
5010ed00 PR-923: Back Particle by a minecraft registry
d47dd212 Increase clarity of errors when loading malformed plugin main classes
2c3c3337 PR-914: Make use of ApiStatus.Internal reather than deprecation
2b4c3b46 PR-922: Add keepSpawnInMemory setting to WorldCreator

CraftBukkit Changes:
75502b6dd SPIGOT-7507: Fall back to world UUIDs if Dimension tag missing or invalid
67a52a648 PR-1279: Back Particle by a minecraft registry
f4d977e79 Simplify texture updating in CraftMetaSkull
e42510b06 Increase outdated build delay
f3ad63aad SPIGOT-7506: SculkBloomEvent.getBlock() world is null
b59004114 PR-1278: Return correct default light in chunk snapshot
2a381856b SPIGOT-7503: Remove special handling for minecraft:brand custom channel
2fa7644d0 PR-1277: Add keepSpawnInMemory setting to WorldCreator

Spigot Changes:
dba3cdc3 Rebuild patches