### PR TITLE
Fix PotionAPI ignores icon flag

### DIFF
--- a/patches/server/0396-Fix-PotionEffect-ignores-icon-flag.patch
+++ b/patches/server/0396-Fix-PotionEffect-ignores-icon-flag.patch
@@ -3,7 +3,7 @@ From: kickash32 <kickash32@gmail.com>
 Date: Fri, 8 May 2020 00:49:18 -0400
 Subject: [PATCH] Fix PotionEffect ignores icon flag
 
-Co-Authored-By: Tamion <70228790+notTamion@users.noreply.github.com>
+Co-authored-by: Tamion <70228790+notTamion@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 index 9ba85d099d0e6893dc3489ce0753119348e937b3..6f62d2ab8a4e3789c9c859ae769bb3e25ad5006d 100644
@@ -36,3 +36,16 @@ index 9ba85d099d0e6893dc3489ce0753119348e937b3..6f62d2ab8a4e3789c9c859ae769bb3e2
          }
          return effects;
      }
+diff --git a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
+index e29679a92da5ec05e122bb972a5ee469059a7a0a..4cdcd3ca7789e078cce7c5e2397bda87a17f1450 100644
+--- a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
++++ b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
+@@ -82,7 +82,7 @@ public class CraftPotionUtil {
+         int duration = effect.getDuration();
+         boolean ambient = effect.isAmbient();
+         boolean particles = effect.isVisible();
+-        return new PotionEffect(type, duration, amp, ambient, particles);
++        return new PotionEffect(type, duration, amp, ambient, particles, effect.showIcon()); // Paper
+     }
+ 
+     public static boolean equals(MobEffect mobEffect, PotionEffectType type) {

--- a/patches/server/0396-Fix-PotionEffect-ignores-icon-flag.patch
+++ b/patches/server/0396-Fix-PotionEffect-ignores-icon-flag.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix PotionEffect ignores icon flag
 Co-authored-by: Tamion <70228790+notTamion@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 9ba85d099d0e6893dc3489ce0753119348e937b3..6f62d2ab8a4e3789c9c859ae769bb3e25ad5006d 100644
+index 9ba85d099d0e6893dc3489ce0753119348e937b3..fd006bc0f14ebd3a2d5373611480a84a2d93bb0b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -443,7 +443,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
@@ -14,7 +14,7 @@ index 9ba85d099d0e6893dc3489ce0753119348e937b3..6f62d2ab8a4e3789c9c859ae769bb3e2
      @Override
      public boolean addPotionEffect(PotionEffect effect, boolean force) {
 -        this.getHandle().addEffect(new MobEffectInstance(CraftPotionEffectType.bukkitToMinecraft(effect.getType()), effect.getDuration(), effect.getAmplifier(), effect.isAmbient(), effect.hasParticles()), EntityPotionEffectEvent.Cause.PLUGIN);
-+        this.getHandle().addEffect(new MobEffectInstance(CraftPotionEffectType.bukkitToMinecraft(effect.getType()), effect.getDuration(), effect.getAmplifier(), effect.isAmbient(), effect.hasParticles(), effect.hasIcon()), EntityPotionEffectEvent.Cause.PLUGIN); // Paper - Don't ignore icon
++        this.getHandle().addEffect(CraftPotionUtil.fromBukkit(effect), EntityPotionEffectEvent.Cause.PLUGIN); // Paper - Don't ignore icon
          return true;
      }
  
@@ -23,7 +23,7 @@ index 9ba85d099d0e6893dc3489ce0753119348e937b3..6f62d2ab8a4e3789c9c859ae769bb3e2
      public PotionEffect getPotionEffect(PotionEffectType type) {
          MobEffectInstance handle = this.getHandle().getEffect(CraftPotionEffectType.bukkitToMinecraft(type));
 -        return (handle == null) ? null : new PotionEffect(CraftPotionEffectType.minecraftToBukkit(handle.getEffect()), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible());
-+        return (handle == null) ? null : new PotionEffect(CraftPotionEffectType.minecraftToBukkit(handle.getEffect()), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible(), handle.showIcon()); // Paper
++        return (handle == null) ? null : CraftPotionUtil.toBukkit(handle); // Paper
      }
  
      @Override
@@ -32,7 +32,7 @@ index 9ba85d099d0e6893dc3489ce0753119348e937b3..6f62d2ab8a4e3789c9c859ae769bb3e2
          List<PotionEffect> effects = new ArrayList<PotionEffect>();
          for (MobEffectInstance handle : this.getHandle().activeEffects.values()) {
 -            effects.add(new PotionEffect(CraftPotionEffectType.minecraftToBukkit(handle.getEffect()), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible()));
-+            effects.add(new PotionEffect(CraftPotionEffectType.minecraftToBukkit(handle.getEffect()), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible(), handle.showIcon())); // Paper
++            effects.add(CraftPotionUtil.toBukkit(handle)); // Paper
          }
          return effects;
      }

--- a/patches/server/0396-Fix-PotionEffect-ignores-icon-flag.patch
+++ b/patches/server/0396-Fix-PotionEffect-ignores-icon-flag.patch
@@ -37,9 +37,18 @@ index 9ba85d099d0e6893dc3489ce0753119348e937b3..6f62d2ab8a4e3789c9c859ae769bb3e2
          return effects;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
-index e29679a92da5ec05e122bb972a5ee469059a7a0a..4cdcd3ca7789e078cce7c5e2397bda87a17f1450 100644
+index e29679a92da5ec05e122bb972a5ee469059a7a0a..844fb8c662a409670f631228f687d85c5436d3dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
 +++ b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
+@@ -73,7 +73,7 @@ public class CraftPotionUtil {
+ 
+     public static MobEffectInstance fromBukkit(PotionEffect effect) {
+         MobEffect type = CraftPotionEffectType.bukkitToMinecraft(effect.getType());
+-        return new MobEffectInstance(type, effect.getDuration(), effect.getAmplifier(), effect.isAmbient(), effect.hasParticles());
++        return new MobEffectInstance(type, effect.getDuration(), effect.getAmplifier(), effect.isAmbient(), effect.hasParticles(), effect.hasIcon()); // Paper
+     }
+ 
+     public static PotionEffect toBukkit(MobEffectInstance effect) {
 @@ -82,7 +82,7 @@ public class CraftPotionUtil {
          int duration = effect.getDuration();
          boolean ambient = effect.isAmbient();

--- a/patches/server/0396-Fix-PotionEffect-ignores-icon-flag.patch
+++ b/patches/server/0396-Fix-PotionEffect-ignores-icon-flag.patch
@@ -3,9 +3,10 @@ From: kickash32 <kickash32@gmail.com>
 Date: Fri, 8 May 2020 00:49:18 -0400
 Subject: [PATCH] Fix PotionEffect ignores icon flag
 
+Co-Authored-By: Tamion <70228790+notTamion@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 9ba85d099d0e6893dc3489ce0753119348e937b3..71a2ac37046adb3826bc2e76b4ac385c7e331f5e 100644
+index 9ba85d099d0e6893dc3489ce0753119348e937b3..6f62d2ab8a4e3789c9c859ae769bb3e25ad5006d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -443,7 +443,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
@@ -17,3 +18,21 @@ index 9ba85d099d0e6893dc3489ce0753119348e937b3..71a2ac37046adb3826bc2e76b4ac385c
          return true;
      }
  
+@@ -464,7 +464,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     @Override
+     public PotionEffect getPotionEffect(PotionEffectType type) {
+         MobEffectInstance handle = this.getHandle().getEffect(CraftPotionEffectType.bukkitToMinecraft(type));
+-        return (handle == null) ? null : new PotionEffect(CraftPotionEffectType.minecraftToBukkit(handle.getEffect()), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible());
++        return (handle == null) ? null : new PotionEffect(CraftPotionEffectType.minecraftToBukkit(handle.getEffect()), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible(), handle.showIcon()); // Paper
+     }
+ 
+     @Override
+@@ -476,7 +476,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     public Collection<PotionEffect> getActivePotionEffects() {
+         List<PotionEffect> effects = new ArrayList<PotionEffect>();
+         for (MobEffectInstance handle : this.getHandle().activeEffects.values()) {
+-            effects.add(new PotionEffect(CraftPotionEffectType.minecraftToBukkit(handle.getEffect()), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible()));
++            effects.add(new PotionEffect(CraftPotionEffectType.minecraftToBukkit(handle.getEffect()), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible(), handle.showIcon())); // Paper
+         }
+         return effects;
+     }

--- a/patches/server/0674-Improve-and-expand-AsyncCatcher.patch
+++ b/patches/server/0674-Improve-and-expand-AsyncCatcher.patch
@@ -17,7 +17,7 @@ Async catch modifications to critical entity state
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ca60102128cd798572a39b3c2eb6c86eba465e90..7119c6377a86cf33e4bddbaf5db1594414b5032c 100644
+index 2f3fddf5427248c3283173afaed220f7a3fd9e31..979515ce93ec0cb6589158ac0b1c54f9283f96b6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1543,6 +1543,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -166,7 +166,7 @@ index 47bab513feec217d875192afef61f3af95b93d24..d3fb277878adb26c7d80cf21f2707038
                  PersistentEntitySectionManager.LOGGER.warn("Entity {} wasn't found in section {} (destroying due to {})", new Object[]{this.entity, SectionPos.of(this.currentSectionKey), reason});
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 59d0002c70e2dae6ab9cb896e0a80e16993e64f3..26054a3b4e2609cb68751d6e37bce22df94c46b8 100644
+index 2ccfd2834db3571cbfed8b12e45a25dfa159e083..ea820fbbbe3f2df060253dd21813a978460cd705 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -464,6 +464,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
@@ -174,7 +174,7 @@ index 59d0002c70e2dae6ab9cb896e0a80e16993e64f3..26054a3b4e2609cb68751d6e37bce22d
      @Override
      public boolean addPotionEffect(PotionEffect effect, boolean force) {
 +        org.spigotmc.AsyncCatcher.catchOp("effect add"); // Paper
-         this.getHandle().addEffect(new MobEffectInstance(CraftPotionEffectType.bukkitToMinecraft(effect.getType()), effect.getDuration(), effect.getAmplifier(), effect.isAmbient(), effect.hasParticles(), effect.hasIcon()), EntityPotionEffectEvent.Cause.PLUGIN); // Paper - Don't ignore icon
+         this.getHandle().addEffect(CraftPotionUtil.fromBukkit(effect), EntityPotionEffectEvent.Cause.PLUGIN); // Paper - Don't ignore icon
          return true;
      }
 diff --git a/src/main/java/org/spigotmc/AsyncCatcher.java b/src/main/java/org/spigotmc/AsyncCatcher.java


### PR DESCRIPTION
Fixes LivingEntity#getPotionEffect and LivingEntity#getActivePotionEffects not passing the icon flag in the PotionEffect ctor