### PR TITLE
Fix crash when version_history.json is empty

### DIFF
--- a/patches/server/0029-Add-version-history-to-version-command.patch
+++ b/patches/server/0029-Add-version-history-to-version-command.patch
@@ -51,10 +51,10 @@ index 22a55be34fde453fedd987173d95b8b347a03588..9d687da5bdf398bb3f6c84cdf1249a72
  }
 diff --git a/src/main/java/com/destroystokyo/paper/VersionHistoryManager.java b/src/main/java/com/destroystokyo/paper/VersionHistoryManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..aac3f66cb23d260729c2a48d8710a9de2346aa22
+index 0000000000000000000000000000000000000000..660b2ec6b63a4ceffee44ab11f54dfa7c0d0996f
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/VersionHistoryManager.java
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,153 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.MoreObjects;
@@ -113,6 +113,14 @@ index 0000000000000000000000000000000000000000..aac3f66cb23d260729c2a48d8710a9de
 +            final String version = Bukkit.getVersion();
 +            if (version == null) {
 +                logger.severe("Failed to retrieve current version");
++                return;
++            }
++
++            if (currentData == null) {
++                // Empty file
++                currentData = new VersionData();
++                currentData.setCurrentVersion(version);
++                writeFile(path);
 +                return;
 +            }
 +


### PR DESCRIPTION
gson returns null when given an empty string/file, this PR adds a null check so that an empty version history file doesn't crash the server