### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0172-Fix-Spigot-annotation-mistakes.patch
@@ -643,6 +643,41 @@ index e1123295b9511a2c610a1baf7195638f7f3e64c4..273ae8e5da0a858d3b82d1b0f5992318
      @Override
      public void setCancelled(boolean cancel) {
          this.cancel = cancel;
+diff --git a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
+index 775e3223aa5054f1883403e50c8f2241d97b1285..5d4817d2a3b709f1a1a1162309a1c923bd09cc1d 100644
+--- a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
++++ b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
+@@ -19,22 +19,27 @@ public class ProjectileHitEvent extends EntityEvent implements Cancellable {
+     private final BlockFace hitFace;
+     private boolean cancel = false;
+ 
++    @Deprecated @io.papermc.paper.annotation.DoNotUse // Paper
+     public ProjectileHitEvent(@NotNull final Projectile projectile) {
+-        this(projectile, null, null);
++        this(projectile, null, null, null); // Paper
+     }
+ 
++    @Deprecated @io.papermc.paper.annotation.DoNotUse // Paper
+     public ProjectileHitEvent(@NotNull final Projectile projectile, @Nullable Entity hitEntity) {
+-        this(projectile, hitEntity, null);
++        this(projectile, hitEntity, null, null); // Paper
+     }
+ 
++    @Deprecated @io.papermc.paper.annotation.DoNotUse // Paper
+     public ProjectileHitEvent(@NotNull final Projectile projectile, @Nullable Block hitBlock) {
+-        this(projectile, null, hitBlock);
++        this(projectile, null, hitBlock, null); // Paper
+     }
+ 
++    @Deprecated @io.papermc.paper.annotation.DoNotUse // Paper
+     public ProjectileHitEvent(@NotNull final Projectile projectile, @Nullable Entity hitEntity, @Nullable Block hitBlock) {
+         this(projectile, hitEntity, hitBlock, null);
+     }
+ 
++    @org.jetbrains.annotations.ApiStatus.Internal // Paper
+     public ProjectileHitEvent(@NotNull final Projectile projectile, @Nullable Entity hitEntity, @Nullable Block hitBlock, @Nullable BlockFace hitFace) {
+         super(projectile);
+         this.hitEntity = hitEntity;
 diff --git a/src/main/java/org/bukkit/event/entity/SpawnerSpawnEvent.java b/src/main/java/org/bukkit/event/entity/SpawnerSpawnEvent.java
 index 9353f0d09272404f42167ab8b7ad83a03620c436..f3ec8f67328b266defb31a44a36d31401d5e9371 100644
 --- a/src/main/java/org/bukkit/event/entity/SpawnerSpawnEvent.java

--- a/patches/api/0297-Add-WaterBottleSplashEvent.patch
+++ b/patches/api/0297-Add-WaterBottleSplashEvent.patch
@@ -136,15 +136,15 @@ index 0000000000000000000000000000000000000000..4c4c645a1597b5afb62f78dc1cfae62c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/event/entity/PotionSplashEvent.java b/src/main/java/org/bukkit/event/entity/PotionSplashEvent.java
-index 80f31a267ef4be88718811484e91a6097106e8d2..97d94aba0a8e86e055abd836dd868b8fe8a486bd 100644
+index bc6ba6c4c07cacfc6ab7a2a72b12dfba110ba911..2e58b716fdb21026d2ee838e81559601344c8a00 100644
 --- a/src/main/java/org/bukkit/event/entity/PotionSplashEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PotionSplashEvent.java
-@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
+@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
  public class PotionSplashEvent extends ProjectileHitEvent implements Cancellable {
      private static final HandlerList handlers = new HandlerList();
      private boolean cancelled;
 -    private final Map<LivingEntity, Double> affectedEntities;
 +    protected final Map<LivingEntity, Double> affectedEntities; // Paper
  
+     @Deprecated
      public PotionSplashEvent(@NotNull final ThrownPotion potion, @NotNull final Map<LivingEntity, Double> affectedEntities) {
-         super(potion);

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -4137,10 +4137,10 @@ index 5725b0281ac53a2354b233223259d6784353bc6e..9ef939b76d06874b856e0c850addb364
      @Override
      public int getLineWidth() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index bd21d57ea4a51ffa14c3650a67b12bed7f6b2f1f..a3cef5eea75fb868dadda191c61c119086cc7638 100644
+index d9547cb0fe2a99b19fe2da63c96315d65aefa244..187011474d15a4a5a5d6cb1638660d9ed2b3a0e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -879,9 +879,9 @@ public class CraftEventFactory {
+@@ -905,9 +905,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -4152,7 +4152,7 @@ index bd21d57ea4a51ffa14c3650a67b12bed7f6b2f1f..a3cef5eea75fb868dadda191c61c1190
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          org.bukkit.World world = entity.getWorld();
-@@ -906,7 +906,7 @@ public class CraftEventFactory {
+@@ -932,7 +932,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(SocketAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/patches/server/0048-Use-UserCache-for-player-heads.patch
+++ b/patches/server/0048-Use-UserCache-for-player-heads.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use UserCache for player heads
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 5daa02d65eb4ca046b2e5dd6b2239ca3692752ee..b202f425cbb880079b9e3ec64d077482d7aa5f99 100644
+index 7c6d29da9cb555cf93ef1860d4254ddd0b0be516..028fbc9d7960fec6333301f249178833a24f980d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -211,7 +211,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -213,7 +213,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          if (name == null) {
              this.setProfile(null);
          } else {

--- a/patches/server/0110-Add-EntityZapEvent.patch
+++ b/patches/server/0110-Add-EntityZapEvent.patch
@@ -28,10 +28,10 @@ index 2f97e4f0078cecbcf044d0b27f375638a6ea047b..b70ee1dff0442de32a9e20ad54b246d5
                  entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
                  entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 73c6bbb854db86a58285466699358eeec4e603a0..cc001f8f1bf4df4fedcc637f5b142d8c059482cc 100644
+index 187011474d15a4a5a5d6cb1638660d9ed2b3a0e5..ff737b309085749aa98b4707c3b72f28a3872278 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1240,6 +1240,14 @@ public class CraftEventFactory {
+@@ -1266,6 +1266,14 @@ public class CraftEventFactory {
          return !event.isCancelled();
      }
  

--- a/patches/server/0114-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0114-Add-source-to-PlayerExpChangeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add source to PlayerExpChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
-index 93c83cfedc7d3a169ad0504aa6e63f600873501b..9dffdfe5bbd0517e9a2c6a6770eea07b43ef9b33 100644
+index 8946d486dab3e639b00716ce7459c817270dad80..f25466e132cb6b0012dc336877fdf17b88a12ddc 100644
 --- a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 +++ b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 @@ -254,7 +254,7 @@ public class ExperienceOrb extends Entity {
@@ -18,10 +18,10 @@ index 93c83cfedc7d3a169ad0504aa6e63f600873501b..9dffdfe5bbd0517e9a2c6a6770eea07b
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cc001f8f1bf4df4fedcc637f5b142d8c059482cc..82a0f2ab2d49cca715b04a5cc661dc81bef3090e 100644
+index ff737b309085749aa98b4707c3b72f28a3872278..d5e4c8a0415f74ba3a7964c7ff491bb37bbff16d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1193,6 +1193,17 @@ public class CraftEventFactory {
+@@ -1219,6 +1219,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0115-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0115-Add-ProjectileCollideEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add ProjectileCollideEvent
 Deprecated now and replaced with ProjectileHitEvent
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 82a0f2ab2d49cca715b04a5cc661dc81bef3090e..5a61bc2979854d891f8f4e384b3c248d882555b3 100644
+index d5e4c8a0415f74ba3a7964c7ff491bb37bbff16d..933cfc466aced42c3c765093c2a987b9f09089a4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1337,6 +1337,17 @@ public class CraftEventFactory {
+@@ -1363,6 +1363,17 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  
@@ -27,7 +27,7 @@ index 82a0f2ab2d49cca715b04a5cc661dc81bef3090e..5a61bc2979854d891f8f4e384b3c248d
      public static ProjectileLaunchEvent callProjectileLaunchEvent(Entity entity) {
          Projectile bukkitEntity = (Projectile) entity.getBukkitEntity();
          ProjectileLaunchEvent event = new ProjectileLaunchEvent(bukkitEntity);
-@@ -1361,8 +1372,15 @@ public class CraftEventFactory {
+@@ -1387,8 +1398,15 @@ public class CraftEventFactory {
          if (position.getType() == HitResult.Type.ENTITY) {
              hitEntity = ((EntityHitResult) position).getEntity().getBukkitEntity();
          }

--- a/patches/server/0171-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/patches/server/0171-Add-setPlayerProfile-API-for-Skulls.patch
@@ -48,10 +48,10 @@ index 6c40bb4e06322bcce31561f5cfb9dc53f266f062..ba063a4e52a841a4365efb1cf78415b0
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index bb9b20ad96b602fd5643f646eaf4d5f8cffa41ee..6398f31a29fdab0f6539139a09336b10d6d11d95 100644
+index 028fbc9d7960fec6333301f249178833a24f980d..b6550a8c52122747668f9f0e93c2c2cbd2e86d94 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -187,6 +187,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -189,6 +189,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          return this.hasOwner() ? this.profile.getName() : null;
      }
  
@@ -71,7 +71,7 @@ index bb9b20ad96b602fd5643f646eaf4d5f8cffa41ee..6398f31a29fdab0f6539139a09336b10
      @Override
      public OfflinePlayer getOwningPlayer() {
          if (this.hasOwner()) {
-@@ -237,6 +250,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -239,6 +252,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      }
  
      @Override
@@ -79,7 +79,7 @@ index bb9b20ad96b602fd5643f646eaf4d5f8cffa41ee..6398f31a29fdab0f6539139a09336b10
      public PlayerProfile getOwnerProfile() {
          if (!this.hasOwner()) {
              return null;
-@@ -246,11 +260,12 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -248,11 +262,12 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      }
  
      @Override
@@ -93,7 +93,7 @@ index bb9b20ad96b602fd5643f646eaf4d5f8cffa41ee..6398f31a29fdab0f6539139a09336b10
          }
      }
  
-@@ -304,7 +319,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -307,7 +322,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      Builder<String, Object> serialize(Builder<String, Object> builder) {
          super.serialize(builder);
          if (this.profile != null) {

--- a/patches/server/0216-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0216-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4c1911140197568685524721e3140739bca039c7..1170b2fb6396fab0aa30a097bc8957e2551f4f1c 100644
+index 391c32093fc5e9084ab480fcdc22207dc4d5dabc..c6ded19cbe33699e4eab20cbc63d4732837dd143 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1451,7 +1451,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -29,7 +29,7 @@ index 4c1911140197568685524721e3140739bca039c7..1170b2fb6396fab0aa30a097bc8957e2
              }
              // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b756cf41f0f201824b055f3936ace7ded3bb6023..63d0b6a241c9ef2e6f7b13e7354e59083a2ffb0a 100644
+index 9b670eb2925caa275cae6f51eb75183a9f5208b0..0f5e616ebb90e187ea38b6489e6f4f5467f1a9c3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -685,7 +685,7 @@ public class ServerPlayer extends Player {
@@ -75,7 +75,7 @@ index b756cf41f0f201824b055f3936ace7ded3bb6023..63d0b6a241c9ef2e6f7b13e7354e5908
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 5b8425b17ea322bb1141b1c94ee3c259d3950ca0..f9c007725420902f55a8730f530daf09ba45340b 100644
+index da4120e6c50605139014b8bf470394253f2b5f73..fdf15bc1a1f5772e50e8a805c2cb8d0720895cf6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -215,6 +215,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -104,7 +104,7 @@ index 5b8425b17ea322bb1141b1c94ee3c259d3950ca0..f9c007725420902f55a8730f530daf09
          this.player.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index e4199b1c4b297db85a99e1e6a1c61ce6d7abc909..49d5410341e949b51c003a0c79d9d77ba5a723f9 100644
+index d767d9259877ecf250d624a489e3f322df318e55..12448b92ffe848c540fffbc58f8e377ee631ff48 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -520,7 +520,7 @@ public abstract class PlayerList {
@@ -117,7 +117,7 @@ index e4199b1c4b297db85a99e1e6a1c61ce6d7abc909..49d5410341e949b51c003a0c79d9d77b
  
          PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : io.papermc.paper.adventure.PaperAdventure.asAdventure(entityplayer.getDisplayName()))); // Paper - Adventure
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index edc73a920f5c0f17e00fda48e64c26c96e71b11d..ddd43b5e9ab77c1baaa7c777dc0b3e89789d7626 100644
+index 78fd8e1ba0e636914108eeef96b78304a63c39c6..c2935b00737418749fc8c20624a1f6792ba7d071 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -270,7 +270,7 @@ public abstract class Player extends LivingEntity {
@@ -144,7 +144,7 @@ index edc73a920f5c0f17e00fda48e64c26c96e71b11d..ddd43b5e9ab77c1baaa7c777dc0b3e89
          this.containerMenu = this.inventoryMenu;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index e5b2686e466a2604ebcdb6e5c3b6fb7ff7bc6eec..aa131c233ee9d7926ca77e1afedd27baf7639423 100644
+index 602cf19007c622ab9bb12a7018643cf05688f33e..607dc510ac856a0bf3a54bf1004bdf98825131e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -376,7 +376,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
@@ -173,7 +173,7 @@ index e5b2686e466a2604ebcdb6e5c3b6fb7ff7bc6eec..aa131c233ee9d7926ca77e1afedd27ba
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 28a51536bcfcb124fecc61095227cabd8844d4e6..1f2c0e3788700a5900664fa61e811a286a347393 100644
+index 676c29c13ae8ece20cb5acaf1a2cf71fc93424bd..a9a2bd81e39ce42138f9931bf0289c82ea9911aa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1191,7 +1191,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -186,10 +186,10 @@ index 28a51536bcfcb124fecc61095227cabd8844d4e6..1f2c0e3788700a5900664fa61e811a28
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5a61bc2979854d891f8f4e384b3c248d882555b3..405c541e790c47c8ccdf05c902cc5f8969a759f9 100644
+index 933cfc466aced42c3c765093c2a987b9f09089a4..ec4022e16d3cdf375520a066afd772f1847e3516 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1306,7 +1306,7 @@ public class CraftEventFactory {
+@@ -1332,7 +1332,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -198,7 +198,7 @@ index 5a61bc2979854d891f8f4e384b3c248d882555b3..405c541e790c47c8ccdf05c902cc5f89
          }
  
          CraftServer server = player.level().getCraftServer();
-@@ -1480,8 +1480,18 @@ public class CraftEventFactory {
+@@ -1520,8 +1520,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0226-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0226-Vanished-players-don-t-have-rights.patch
@@ -89,10 +89,10 @@ index b52a761e84e00f2ccac7b1b9db73e70ffa1c681b..f17cc5da4eb4b4e5bcfae8b234358464
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f531d51d8ffafc65db3885ac6700fbccf47e9965..d9038b215a13c0290b718a41612581dce6e30213 100644
+index ec4022e16d3cdf375520a066afd772f1847e3516..7c8eb12c070bc1203ac94fec1a8f070dd4bda75f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1343,6 +1343,14 @@ public class CraftEventFactory {
+@@ -1369,6 +1369,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0253-Improve-death-events.patch
+++ b/patches/server/0253-Improve-death-events.patch
@@ -412,10 +412,10 @@ index c72dc80c65484d6fac3b37f6be3f8c678df0a432..39bd2e89f218efc8f851b3bbb86677bd
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d9038b215a13c0290b718a41612581dce6e30213..78fed280b403c8934485aeb617e011faabe331a0 100644
+index 7c8eb12c070bc1203ac94fec1a8f070dd4bda75f..d0afefaeb5566afcb8754aa24264423d82f6cd3f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -865,9 +865,16 @@ public class CraftEventFactory {
+@@ -891,9 +891,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -432,7 +432,7 @@ index d9038b215a13c0290b718a41612581dce6e30213..78fed280b403c8934485aeb617e011fa
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -884,8 +891,15 @@ public class CraftEventFactory {
+@@ -910,8 +917,15 @@ public class CraftEventFactory {
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
@@ -448,7 +448,7 @@ index d9038b215a13c0290b718a41612581dce6e30213..78fed280b403c8934485aeb617e011fa
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -902,6 +916,31 @@ public class CraftEventFactory {
+@@ -928,6 +942,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0383-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0383-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -135,10 +135,10 @@ index 91b9ec5831f439426a853ba9ac7a3f225629b099..e4e734e0f4c43c1687c8e3a8bbe15441
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b29d600772b1bf544e211739c24a5b9b4f0c4270..27443e3261e49d6401d599cee56dbcfebaead812 100644
+index 0696f48da86cf1755abedf985e25655bd3a89717..0e40822592f2310d088662ffc923b67d7315ff4b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -868,6 +868,11 @@ public class CraftEventFactory {
+@@ -894,6 +894,11 @@ public class CraftEventFactory {
      }
  
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
@@ -150,7 +150,7 @@ index b29d600772b1bf544e211739c24a5b9b4f0c4270..27443e3261e49d6401d599cee56dbcfe
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
          populateFields(victim, event); // Paper - make cancellable
-@@ -881,11 +886,13 @@ public class CraftEventFactory {
+@@ -907,11 +912,13 @@ public class CraftEventFactory {
          playDeathSound(victim, event);
          // Paper end
          victim.expToDrop = event.getDroppedExp();

--- a/patches/server/0433-Add-PrepareResultEvent.patch
+++ b/patches/server/0433-Add-PrepareResultEvent.patch
@@ -8,7 +8,7 @@ Adds a new event for all crafting stations that generate a result slot item
 Anvil, Grindstone and Smithing now extend this event
 
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index d15f01f5a4f14d25ded9de015c70cbc7977a6a77..e0c3a4ba27e21c3692e601acd0af60873bcbb84c 100644
+index e97953e3dad164862d7e2f86bd86a6eff5b80ae2..f00638e9d7baf8b803dd610f2bf6250da34efab3 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 @@ -338,6 +338,7 @@ public class AnvilMenu extends ItemCombinerMenu {
@@ -32,7 +32,7 @@ index fe1ce65b35e83ee0ada77e44b080729346bb3c2d..819187dbcf468d9278ce33bd97688476
  
      private void setupResultSlot(ItemStack map, ItemStack item, ItemStack oldResult) {
 diff --git a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
-index 2c263447aa8853f18d1c1d476b49a47f6e9ca2ad..03d3edadf39d4871a332808458870ea9479669c4 100644
+index 45242f0ed5a0f98953df5f27fb76874d2d9e3473..811d7415ae843347da374d73b4edfe89642d518a 100644
 --- a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
 @@ -159,6 +159,7 @@ public class GrindstoneMenu extends AbstractContainerMenu {
@@ -70,7 +70,7 @@ index 5c209a3d81db5326f63c506077fa0bfd241b4b12..757ee83a0ec5d381eb328f31f3bef636
              this.resultSlot.set(ItemStack.EMPTY);
              this.selectablePatterns = List.of();
 diff --git a/src/main/java/net/minecraft/world/inventory/SmithingMenu.java b/src/main/java/net/minecraft/world/inventory/SmithingMenu.java
-index f7be3a69909ca0f0aa60619f70e87b5778cf3633..9db5275c43f25ea8ab595017a1b1a8d9db08cb4c 100644
+index 59d9f990a87ab5214fa51e3a6e933bf5ae71b613..857f65be8c4d9ec3a0586017b3f3e8e35cb78b97 100644
 --- a/src/main/java/net/minecraft/world/inventory/SmithingMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/SmithingMenu.java
 @@ -115,6 +115,7 @@ public class SmithingMenu extends ItemCombinerMenu {
@@ -94,10 +94,10 @@ index 9c2fe69ced7a46bbd8b0fbe10fa67d0a39b0f375..70ecc3f673ebd56b65ad901e10f40c28
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index dedc3cec245b120af3266e23cdf7ea8098f45e96..e05b03b356d7a5de9f326a1004326326efd0e301 100644
+index 2aa0026d2df9d09f8770280d8f5a9b43e3f4e948..f4040a1187b49a3aaaca91ff983433b404765043 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1671,26 +1671,53 @@ public class CraftEventFactory {
+@@ -1711,26 +1711,53 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0524-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0524-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 7dd0570b2457c612484ab89a8efcedd094c4772c..b1ba2c1da9d7b59a5316574deb824740
              } else {
                  ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 58ca3b4cbd2626e80f4474753508e8990311771e..bd230fa64b84fa4832e269e72e1ecfc04e6ee617 100644
+index 826bb30bd0075bb7827c13e43c2a1ce7a814f0ce..ecbdddf42495e69bc899a017e1313a9f0c32f0c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1997,4 +1997,12 @@ public class CraftEventFactory {
+@@ -2037,4 +2037,12 @@ public class CraftEventFactory {
          Bukkit.getPluginManager().callEvent(event);
          return event;
      }

--- a/patches/server/0539-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0539-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 5cf5b451fecb1ff04d0c4aca1fb0b702c7f99bdf..9b1e51c1d95da885c80c6d05000d8343
                      tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index bd230fa64b84fa4832e269e72e1ecfc04e6ee617..a422cf5f09d79a06d2e25f59298dc6d732bbd10c 100644
+index ecbdddf42495e69bc899a017e1313a9f0c32f0c4..46ab61bf75bf15bb6156dc9204e4071779e812e6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2004,5 +2004,11 @@ public class CraftEventFactory {
+@@ -2044,5 +2044,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0543-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0543-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index 16784fcc853e23689a854e7dc6c03ed8182a164e..4eb97572a97a8d98af37c4223f42fc63
                              flag1 = true;
                          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a422cf5f09d79a06d2e25f59298dc6d732bbd10c..f9628163c62d39b5ffc7139c110890fc1bccc223 100644
+index 46ab61bf75bf15bb6156dc9204e4071779e812e6..5bc937175a00c836a3a855780e2b8fd9a0005c07 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1594,8 +1594,10 @@ public class CraftEventFactory {
+@@ -1634,8 +1634,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0623-Fix-potions-splash-events.patch
+++ b/patches/server/0623-Fix-potions-splash-events.patch
@@ -8,7 +8,7 @@ Fixes SPIGOT-6221: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-6
 Fix splash events cancellation that still show particles/sound
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-index 50712c4c7f007123a0735acf958fd860d4e76cf8..a3ee89cb4acfa475076e65f06f1047232bcf684f 100644
+index b87077c47a0131c5f4ca085b6b32e657043a9e1a..40307233e5bc67d538f580bc514a033c64d1316a 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 @@ -105,56 +105,77 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
@@ -22,11 +22,11 @@ index 50712c4c7f007123a0735acf958fd860d4e76cf8..a3ee89cb4acfa475076e65f06f104723
 +                showParticles = this.applyWater(); // Paper
              } else if (true || !list.isEmpty()) { // CraftBukkit - Call event even if no effects to apply
                  if (this.isLingering()) {
--                    this.makeAreaOfEffectCloud(itemstack, potionregistry);
-+                    showParticles = this.makeAreaOfEffectCloud(itemstack, potionregistry); // Paper
+-                    this.makeAreaOfEffectCloud(itemstack, potionregistry, hitResult); // CraftBukkit - Pass MovingObjectPosition
++                    showParticles = this.makeAreaOfEffectCloud(itemstack, potionregistry, hitResult); // CraftBukkit - Pass MovingObjectPosition // Paper
                  } else {
--                    this.applySplash(list, hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null);
-+                    showParticles = this.applySplash(list, hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null); // Paper
+-                    this.applySplash(list, hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null, hitResult); // CraftBukkit - Pass MovingObjectPosition
++                    showParticles = this.applySplash(list, hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null, hitResult); // CraftBukkit - Pass MovingObjectPosition // Paper
                  }
              }
  
@@ -99,8 +99,8 @@ index 50712c4c7f007123a0735acf958fd860d4e76cf8..a3ee89cb4acfa475076e65f06f104723
  
      }
  
--    private void applySplash(List<MobEffectInstance> statusEffects, @Nullable Entity entity) {
-+    private boolean applySplash(List<MobEffectInstance> statusEffects, @Nullable Entity entity) { // Paper
+-    private void applySplash(List<MobEffectInstance> list, @Nullable Entity entity, HitResult position) { // CraftBukkit - Pass MovingObjectPosition
++    private boolean applySplash(List<MobEffectInstance> list, @Nullable Entity entity, HitResult position) { // CraftBukkit - Pass MovingObjectPosition // Paper - return boolean
          AABB axisalignedbb = this.getBoundingBox().inflate(4.0D, 2.0D, 4.0D);
          List<net.minecraft.world.entity.LivingEntity> list1 = this.level().getEntitiesOfClass(net.minecraft.world.entity.LivingEntity.class, axisalignedbb);
          Map<LivingEntity, Double> affected = new HashMap<LivingEntity, Double>(); // CraftBukkit
@@ -120,16 +120,16 @@ index 50712c4c7f007123a0735acf958fd860d4e76cf8..a3ee89cb4acfa475076e65f06f104723
  
      }
  
--    private void makeAreaOfEffectCloud(ItemStack stack, Potion potion) {
-+    private boolean makeAreaOfEffectCloud(ItemStack stack, Potion potion) { // Paper
+-    private void makeAreaOfEffectCloud(ItemStack itemstack, Potion potionregistry, HitResult position) { // CraftBukkit - Pass MovingObjectPosition
++    private boolean makeAreaOfEffectCloud(ItemStack itemstack, Potion potionregistry, HitResult position) { // CraftBukkit - Pass MovingObjectPosition // Paper - return boolean
          AreaEffectCloud entityareaeffectcloud = new AreaEffectCloud(this.level(), this.getX(), this.getY(), this.getZ());
          Entity entity = this.getOwner();
  
 @@ -244,10 +267,12 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
-         entityareaeffectcloud.setPotion(potion);
-         Iterator iterator = PotionUtils.getCustomEffects(stack).iterator();
+         entityareaeffectcloud.setPotion(potionregistry);
+         Iterator iterator = PotionUtils.getCustomEffects(itemstack).iterator();
  
-+        boolean noEffects = potion.getEffects().isEmpty(); // Paper
++        boolean noEffects = potionregistry.getEffects().isEmpty(); // Paper
          while (iterator.hasNext()) {
              MobEffectInstance mobeffect = (MobEffectInstance) iterator.next();
  
@@ -137,11 +137,11 @@ index 50712c4c7f007123a0735acf958fd860d4e76cf8..a3ee89cb4acfa475076e65f06f104723
 +            noEffects = false; // Paper
          }
  
-         CompoundTag nbttagcompound = stack.getTag();
+         CompoundTag nbttagcompound = itemstack.getTag();
 @@ -258,12 +283,13 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
  
          // CraftBukkit start
-         org.bukkit.event.entity.LingeringPotionSplashEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callLingeringPotionSplashEvent(this, entityareaeffectcloud);
+         org.bukkit.event.entity.LingeringPotionSplashEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callLingeringPotionSplashEvent(this, position, entityareaeffectcloud);
 -        if (!(event.isCancelled() || entityareaeffectcloud.isRemoved())) {
 +        if (!(event.isCancelled() || entityareaeffectcloud.isRemoved() || (noEffects && entityareaeffectcloud.effects.isEmpty() && entityareaeffectcloud.getPotion().getEffects().isEmpty()))) { // Paper - don't spawn area effect cloud if the effects were empty and not changed during the event handling
              this.level().addFreshEntity(entityareaeffectcloud);

--- a/patches/server/0665-Add-critical-damage-API.patch
+++ b/patches/server/0665-Add-critical-damage-API.patch
@@ -28,7 +28,7 @@ index df8c88bfa749e02f633350446101dcce05db7ac1..1a0f86b5a632469942e33c237c247d2d
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 786ef24e97cfb96ddee2be9e02272e6f572cd64d..39f011a3c5e0eaa24ab95738329ba98aa07a5f36 100644
+index 4bbd46618ec0f00e0aee7f681335bcbdb375c439..8dd7a1405997a7e90aab01ca7c20a616b15ca761 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -1268,7 +1268,7 @@ public abstract class Player extends LivingEntity {
@@ -71,10 +71,10 @@ index 53de7f516aee20cb7b5db0648dea1c38d74e5d96..df7e044a585579534b3cad260abd74c9
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 9d49cdb3f40b4dada89001ba1b63963bc292bf46..bee74b498ebf622ab8d4d810cd07fd1a06c06da2 100644
+index 47ebaf72a087387f9832cfd83f748c8ef3e9c410..98926c017b41226006b7bcd0e106d493c3fec3c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1018,7 +1018,7 @@ public class CraftEventFactory {
+@@ -1044,7 +1044,7 @@ public class CraftEventFactory {
                  } else {
                      damageCause = DamageCause.ENTITY_EXPLOSION;
                  }
@@ -83,7 +83,7 @@ index 9d49cdb3f40b4dada89001ba1b63963bc292bf46..bee74b498ebf622ab8d4d810cd07fd1a
              }
              event.setCancelled(cancelled);
  
-@@ -1050,7 +1050,7 @@ public class CraftEventFactory {
+@@ -1076,7 +1076,7 @@ public class CraftEventFactory {
                  cause = DamageCause.SONIC_BOOM;
              }
  
@@ -92,7 +92,7 @@ index 9d49cdb3f40b4dada89001ba1b63963bc292bf46..bee74b498ebf622ab8d4d810cd07fd1a
          } else if (source.is(DamageTypes.FELL_OUT_OF_WORLD)) {
              EntityDamageEvent event = new EntityDamageByBlockEvent(null, entity.getBukkitEntity(), DamageCause.VOID, modifiers, modifierFunctions);
              event.setCancelled(cancelled);
-@@ -1120,7 +1120,7 @@ public class CraftEventFactory {
+@@ -1146,7 +1146,7 @@ public class CraftEventFactory {
              } else {
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager.getHandle(), source.getMsgId()));
              }
@@ -101,7 +101,7 @@ index 9d49cdb3f40b4dada89001ba1b63963bc292bf46..bee74b498ebf622ab8d4d810cd07fd1a
              event.setCancelled(cancelled);
              CraftEventFactory.callEvent(event);
              if (!event.isCancelled()) {
-@@ -1169,20 +1169,28 @@ public class CraftEventFactory {
+@@ -1195,20 +1195,28 @@ public class CraftEventFactory {
          }
  
          if (cause != null) {

--- a/patches/server/0778-More-Projectile-API.patch
+++ b/patches/server/0778-More-Projectile-API.patch
@@ -20,7 +20,7 @@ public net.minecraft.world.entity.projectile.Projectile canHitEntity(Lnet/minecr
 Co-authored-by: Nassim Jahnke <nassim@njahnke.dev>
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-index a3ee89cb4acfa475076e65f06f1047232bcf684f..3abcb29ff95c29b9b178e0a02d98bf26d60be173 100644
+index 40307233e5bc67d538f580bc514a033c64d1316a..2886f4437d8361cde39922b87e9cc8e5d386e0ad 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 @@ -100,6 +100,11 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
@@ -37,12 +37,30 @@ index a3ee89cb4acfa475076e65f06f1047232bcf684f..3abcb29ff95c29b9b178e0a02d98bf26
              Potion potionregistry = PotionUtils.getPotion(itemstack);
 @@ -113,7 +118,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
                  if (this.isLingering()) {
-                     showParticles = this.makeAreaOfEffectCloud(itemstack, potionregistry); // Paper
+                     showParticles = this.makeAreaOfEffectCloud(itemstack, potionregistry, hitResult); // CraftBukkit - Pass MovingObjectPosition // Paper
                  } else {
--                    showParticles = this.applySplash(list, hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null); // Paper
-+                    showParticles = this.applySplash(list, hitResult != null && hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null); // Paper - nullable hitResult
+-                    showParticles = this.applySplash(list, hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null, hitResult); // CraftBukkit - Pass MovingObjectPosition // Paper
++                    showParticles = this.applySplash(list, hitResult != null && hitResult.getType() == HitResult.Type.ENTITY ? ((EntityHitResult) hitResult).getEntity() : null, hitResult); // CraftBukkit - Pass MovingObjectPosition // Paper - nullable hitResult
                  }
              }
+ 
+@@ -175,7 +180,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
+ 
+     }
+ 
+-    private boolean applySplash(List<MobEffectInstance> list, @Nullable Entity entity, HitResult position) { // CraftBukkit - Pass MovingObjectPosition // Paper - return boolean
++    private boolean applySplash(List<MobEffectInstance> list, @Nullable Entity entity, @Nullable HitResult position) { // CraftBukkit - Pass MovingObjectPosition // Paper - return boolean & nullable hitResult
+         AABB axisalignedbb = this.getBoundingBox().inflate(4.0D, 2.0D, 4.0D);
+         List<net.minecraft.world.entity.LivingEntity> list1 = this.level().getEntitiesOfClass(net.minecraft.world.entity.LivingEntity.class, axisalignedbb);
+         Map<LivingEntity, Double> affected = new HashMap<LivingEntity, Double>(); // CraftBukkit
+@@ -252,7 +257,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
+ 
+     }
+ 
+-    private boolean makeAreaOfEffectCloud(ItemStack itemstack, Potion potionregistry, HitResult position) { // CraftBukkit - Pass MovingObjectPosition // Paper - return boolean
++    private boolean makeAreaOfEffectCloud(ItemStack itemstack, Potion potionregistry, @Nullable HitResult position) { // CraftBukkit - Pass MovingObjectPosition // Paper - return boolean & nullable hitResult
+         AreaEffectCloud entityareaeffectcloud = new AreaEffectCloud(this.level(), this.getX(), this.getY(), this.getZ());
+         Entity entity = this.getOwner();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java b/src/main/java/org/bukkit/craftbukkit/entity/AbstractProjectile.java
 index 91c2d0b40d3fca86938cd454e1415a4eea3df7c7..2c376687349825833e6d9a5ca92ce6afb98c36a3 100644
@@ -490,6 +508,57 @@ index c628594b981f276acae7b9337100d811f919631b..c8b65210d2416b5a293cb4bcc1b71f56
 +    }
      // Paper end
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 98926c017b41226006b7bcd0e106d493c3fec3c1..0d8a13fc70c139291fa26d6e8f9c38dbbc512e7d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -832,19 +832,19 @@ public class CraftEventFactory {
+     /**
+      * PotionSplashEvent
+      */
+-    public static PotionSplashEvent callPotionSplashEvent(net.minecraft.world.entity.projectile.ThrownPotion potion, HitResult position, Map<LivingEntity, Double> affectedEntities) {
++    public static PotionSplashEvent callPotionSplashEvent(net.minecraft.world.entity.projectile.ThrownPotion potion, @Nullable HitResult position, Map<LivingEntity, Double> affectedEntities) { // Paper - nullable hitResult
+         ThrownPotion thrownPotion = (ThrownPotion) potion.getBukkitEntity();
+ 
+         Block hitBlock = null;
+         BlockFace hitFace = null;
+-        if (position.getType() == HitResult.Type.BLOCK) {
++        if (position != null && position.getType() == HitResult.Type.BLOCK) { // Paper - nullable hitResult
+             BlockHitResult positionBlock = (BlockHitResult) position;
+             hitBlock = CraftBlock.at(potion.level(), positionBlock.getBlockPos());
+             hitFace = CraftBlock.notchToBlockFace(positionBlock.getDirection());
+         }
+ 
+         org.bukkit.entity.Entity hitEntity = null;
+-        if (position.getType() == HitResult.Type.ENTITY) {
++        if (position != null && position.getType() == HitResult.Type.ENTITY) { // Paper - nullable hitResult
+             hitEntity = ((EntityHitResult) position).getEntity().getBukkitEntity();
+         }
+ 
+@@ -853,20 +853,20 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
+-    public static LingeringPotionSplashEvent callLingeringPotionSplashEvent(net.minecraft.world.entity.projectile.ThrownPotion potion, HitResult position, net.minecraft.world.entity.AreaEffectCloud cloud) {
++    public static LingeringPotionSplashEvent callLingeringPotionSplashEvent(net.minecraft.world.entity.projectile.ThrownPotion potion, @Nullable HitResult position, net.minecraft.world.entity.AreaEffectCloud cloud) { // Paper - nullable hitResult
+         ThrownPotion thrownPotion = (ThrownPotion) potion.getBukkitEntity();
+         AreaEffectCloud effectCloud = (AreaEffectCloud) cloud.getBukkitEntity();
+ 
+         Block hitBlock = null;
+         BlockFace hitFace = null;
+-        if (position.getType() == HitResult.Type.BLOCK) {
++        if (position != null && position.getType() == HitResult.Type.BLOCK) { // Paper
+             BlockHitResult positionBlock = (BlockHitResult) position;
+             hitBlock = CraftBlock.at(potion.level(), positionBlock.getBlockPos());
+             hitFace = CraftBlock.notchToBlockFace(positionBlock.getDirection());
+         }
+ 
+         org.bukkit.entity.Entity hitEntity = null;
+-        if (position.getType() == HitResult.Type.ENTITY) {
++        if (position != null && position.getType() == HitResult.Type.ENTITY) { // Paper
+             hitEntity = ((EntityHitResult) position).getEntity().getBukkitEntity();
+         }
+ 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 index 221a2ccc4bf840aa301931f26c1198b36ec317fe..5f8f601f5711f4e7aa3f3a6ca047fd75264d0d04 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java

--- a/patches/server/0787-Fix-new-block-data-for-EntityChangeBlockEvent.patch
+++ b/patches/server/0787-Fix-new-block-data-for-EntityChangeBlockEvent.patch
@@ -91,7 +91,7 @@ index 703068eaff84bcce83f61d805afa6cc0fef909b1..1e07febcf7a3dfb281728cc5e3e4f15d
                                      }
                                      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
-index 74a4b1cdfe643007e0afd73f8eb0b1fbe29722cf..b0a97679157a18a3c623ce3b2ae315789772c254 100644
+index decd59f7104ba26145e2150c3b8e5e0404d31885..bd5996eef2d946e9d7765b6b315bc5951158810e 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 @@ -580,7 +580,7 @@ public class EnderMan extends Monster implements NeutralMob {
@@ -131,7 +131,7 @@ index 6f452605e9dc9ebd9980eae9fdeea34417a37a88..2c60a3765d22909e73b660492410ab84
                                  }
                                  // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-index 3abcb29ff95c29b9b178e0a02d98bf26d60be173..06f44946e6cfb7da83a65850e06a9093712e24f9 100644
+index 2886f4437d8361cde39922b87e9cc8e5d386e0ad..2f80d484ad523860322483cebe92cf7cd8cfad22 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 @@ -306,7 +306,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
@@ -196,10 +196,10 @@ index b13d89b1516130507402cd3b4bdb9f3c2a36e807..936644ec4a57e51a1c11a5bf4e8449ab
              }
              // CraftBukkit end
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index bee74b498ebf622ab8d4d810cd07fd1a06c06da2..a017858e05d6068a06feb4bea0e6ef7ea1f0966a 100644
+index 42ebb3e499900aa7bdc694549a267e117ae82915..ee209d885527153c148b99618c9c26b63fb38aac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1385,11 +1385,11 @@ public class CraftEventFactory {
+@@ -1411,11 +1411,11 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0906-Add-exploded-block-state-to-BlockExplodeEvent-and-En.patch
+++ b/patches/server/0906-Add-exploded-block-state-to-BlockExplodeEvent-and-En.patch
@@ -113,7 +113,7 @@ index b9903c29bdea8d1e3b6fce0e97be6bd9493cfdf4..2ed78cf83c0ae66a6ddba1ff307da89a
  
      public static boolean canSetSpawn(Level world) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
-index da4609caecc8183d02c301c7cedbca52ed39323f..716021520c228b5bbced525b751f5d4126d882eb 100644
+index e44cd3b8eef25a3e7eedbe8ae597d74585ecd627..e3b07d623cd64de9645f2372f1e08757edc1a9ed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
 @@ -273,6 +273,12 @@ public final class CraftBlockStates {
@@ -130,10 +130,10 @@ index da4609caecc8183d02c301c7cedbca52ed39323f..716021520c228b5bbced525b751f5d41
      // See BlockStateFactory#createBlockState(World, BlockPosition, IBlockData, TileEntity)
      private static CraftBlockState getBlockState(World world, BlockPos blockPosition, net.minecraft.world.level.block.state.BlockState blockData, BlockEntity tileEntity) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f29ae4e617b2ed37e2c0f14a81e019125b078aee..70a873c4a44dea055c091e1ed57cb9c6e3974f1f 100644
+index f7f325bd2ff46bb02cc8aa31ea99cca5d0cb1ed8..059bde3786ba16e2a95314664d825492111c3787 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1020,7 +1020,7 @@ public class CraftEventFactory {
+@@ -1046,7 +1046,7 @@ public class CraftEventFactory {
              CraftEventFactory.entityDamage = null;
              EntityDamageEvent event;
              if (damager == null) {

--- a/patches/server/0917-Add-EntityFertilizeEggEvent.patch
+++ b/patches/server/0917-Add-EntityFertilizeEggEvent.patch
@@ -69,10 +69,10 @@ index 36b3945832733b5ad66d25aa3a31335234d2acff..47a5125e44cea1ece84657cdb874807f
          this.playSound(SoundEvents.SNIFFER_EGG_PLOP, 1.0F, (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 0.5F);
          } // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 70a873c4a44dea055c091e1ed57cb9c6e3974f1f..c562b5b4048e68a62d114a4a928dff3c956d679a 100644
+index 059bde3786ba16e2a95314664d825492111c3787..a2af7cdc6e538e844f354b2acb30ae3d6e103533 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2049,4 +2049,29 @@ public class CraftEventFactory {
+@@ -2089,4 +2089,29 @@ public class CraftEventFactory {
          return event.callEvent();
      }
      // Paper end

--- a/patches/server/0938-Fix-DamageCause-for-Falling-Blocks.patch
+++ b/patches/server/0938-Fix-DamageCause-for-Falling-Blocks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix DamageCause for Falling Blocks
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c562b5b4048e68a62d114a4a928dff3c956d679a..82a474a09905e9858e0a7b4b00839f5ad5e9adbb 100644
+index a2af7cdc6e538e844f354b2acb30ae3d6e103533..7c0fec2df265bc72cb5e2f8f400c6ad4c128705e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1060,6 +1060,11 @@ public class CraftEventFactory {
+@@ -1086,6 +1086,11 @@ public class CraftEventFactory {
              } else if (source.is(DamageTypes.SONIC_BOOM)) {
                  cause = DamageCause.SONIC_BOOM;
              }

--- a/patches/server/0943-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0943-Expand-PlayerItemMendEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expand PlayerItemMendEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
-index 8d8fe55a05eea237a8af99ed15ab16d6167daa77..eca634792d2a7cc649675e3394e84dbaf1453905 100644
+index 37cd883f4920d5e1e58900ebdcfd4495a0abd2ae..6dac7cd4c9abfbde299f5d279acc2739195fc312 100644
 --- a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 +++ b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 @@ -337,7 +337,7 @@ public class ExperienceOrb extends Entity {
@@ -33,7 +33,7 @@ index 8d8fe55a05eea237a8af99ed15ab16d6167daa77..eca634792d2a7cc649675e3394e84dba
              return k > 0 ? this.repairPlayerItems(player, k) : 0;
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f7be775567a9aba1933bc3cf5d4e887ab589d778..77ea396950ed23ab5bf953b451b12d5b1eb4c5ec 100644
+index 42c6288d26dc866dae19031aa3310d88274a6fbf..2981475368094b7749cfec2e5a99ec0947248eee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1737,11 +1737,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -51,10 +51,10 @@ index f7be775567a9aba1933bc3cf5d4e887ab589d778..77ea396950ed23ab5bf953b451b12d5b
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 82a474a09905e9858e0a7b4b00839f5ad5e9adbb..e4ee6425e6f6c8546e3af8889a67f08d61b1dc94 100644
+index 7c0fec2df265bc72cb5e2f8f400c6ad4c128705e..c562a0a970c83df3bfd4d600bb0ee97878b1649c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1296,10 +1296,10 @@ public class CraftEventFactory {
+@@ -1322,10 +1322,10 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0961-Call-missing-BlockDispenseEvent.patch
+++ b/patches/server/0961-Call-missing-BlockDispenseEvent.patch
@@ -50,10 +50,10 @@ index c0baec6ae9bd90410f47aa04d7c7704233375d1a..e9b748a81ec223a701b56d2dc890c9eb
                              for (int k = 0; k < 5; ++k) {
                                  worldserver.sendParticles(ParticleTypes.SPLASH, (double) blockposition.getX() + worldserver.random.nextDouble(), (double) (blockposition.getY() + 1), (double) blockposition.getZ() + worldserver.random.nextDouble(), 1, 0.0D, 0.0D, 0.0D, 1.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e4ee6425e6f6c8546e3af8889a67f08d61b1dc94..f08abdff3e190391d2b65e32e45eb391aeb4f346 100644
+index c562a0a970c83df3bfd4d600bb0ee97878b1649c..3d93dae82d6fb6bc6abed4f32cf9da32f9159ba6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -2055,6 +2055,32 @@ public class CraftEventFactory {
+@@ -2095,6 +2095,32 @@ public class CraftEventFactory {
      }
      // Paper end
  

--- a/patches/server/1011-Add-titleOverride-to-InventoryOpenEvent.patch
+++ b/patches/server/1011-Add-titleOverride-to-InventoryOpenEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add titleOverride to InventoryOpenEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index cacf251db5d60583fe05f571d0fe7844c44900a1..5d32ce8112562f368e6ebea064181622b22823ed 100644
+index 0a36ec0d3f33d3bfd708cd37c110f40db0f6c42d..d22e75432ff8b0034b8bfffb7a69e3ba8cf5569d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1560,12 +1560,17 @@ public class ServerPlayer extends Player {
@@ -37,7 +37,7 @@ index cacf251db5d60583fe05f571d0fe7844c44900a1..5d32ce8112562f368e6ebea064181622
                  this.initMenu(container);
                  return OptionalInt.of(this.containerCounter);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 5b01ffcdbfff7dbd05143cb08479c90e9b29dfba..017e97c1618b8ee4640b36a0ec1b07026047bfc3 100644
+index 8a6095850cece3203eeae474dbf32090f698a32e..aefb9879b2edadfb4b21d80135d713b9d34c9941 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -357,12 +357,16 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
@@ -79,10 +79,10 @@ index 5b01ffcdbfff7dbd05143cb08479c90e9b29dfba..017e97c1618b8ee4640b36a0ec1b0702
          if (!player.isImmobile()) player.connection.send(new ClientboundOpenScreenPacket(container.containerId, windowType, io.papermc.paper.adventure.PaperAdventure.asVanilla(adventure$title))); // Paper
          player.containerMenu = container;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 3c8160bd5f235f386edd938603ff70d4b73c047e..193ad79f57255b1ea4cf7930071b4f4988dc2b04 100644
+index a0aeb79966d2efdb9603d59ec9e603a5187e4cb9..d4f90e3073646f067b939006b16ceb567a5f5a7a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1415,10 +1415,21 @@ public class CraftEventFactory {
+@@ -1441,10 +1441,21 @@ public class CraftEventFactory {
      }
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container) {
@@ -105,7 +105,7 @@ index 3c8160bd5f235f386edd938603ff70d4b73c047e..193ad79f57255b1ea4cf7930071b4f49
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
              player.connection.handleContainerClose(new ServerboundContainerClosePacket(player.containerMenu.containerId), InventoryCloseEvent.Reason.OPEN_NEW); // Paper
          }
-@@ -1433,10 +1444,10 @@ public class CraftEventFactory {
+@@ -1459,10 +1470,10 @@ public class CraftEventFactory {
  
          if (event.isCancelled()) {
              container.transferTo(player.containerMenu, craftPlayer);


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
19830133 PR-925: Add hit entity/block to events extending ProjectileHitEvent

CraftBukkit Changes:
5a72c3c04 SPIGOT-7510: Try to fix broken reflection usage of plugins
6fa69f235 PR-1281: Add hit entity/block to events extending ProjectileHitEvent
224f733ac Fix NPE introduced in f4d977e

----

Closes https://github.com/PaperMC/Paper/issues/9875
Closes https://github.com/PaperMC/Paper/issues/9873