### PR TITLE
Fix entity camera not being reset when cancelling spectating start/stop events

### DIFF
--- a/patches/server/0269-Call-player-spectator-target-events-and-improve-impl.patch
+++ b/patches/server/0269-Call-player-spectator-target-events-and-improve-impl.patch
@@ -19,10 +19,10 @@ spectate the target entity.
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ba938eb9844157cccedb5f673a44720538912bc5..be56cbfc2a7d966a8c5fc9c89f99f73c94e23ab6 100644
+index de062ef7553a7edff3d0fa6f50a9987bb62b9e09..ac4bb5d84689a6e4f8f9b425cee5188436d0efce 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1983,6 +1983,19 @@ public class ServerPlayer extends Player {
+@@ -1983,6 +1983,21 @@ public class ServerPlayer extends Player {
  
          this.camera = (Entity) (entity == null ? this : entity);
          if (entity1 != this.camera) {
@@ -30,11 +30,13 @@ index ba938eb9844157cccedb5f673a44720538912bc5..be56cbfc2a7d966a8c5fc9c89f99f73c
 +            if (this.camera == this) {
 +                com.destroystokyo.paper.event.player.PlayerStopSpectatingEntityEvent playerStopSpectatingEntityEvent = new com.destroystokyo.paper.event.player.PlayerStopSpectatingEntityEvent(this.getBukkitEntity(), entity1.getBukkitEntity());
 +                if (!playerStopSpectatingEntityEvent.callEvent()) {
++                    this.camera = entity1; // rollback camera entity again
 +                    return;
 +                }
 +            } else {
 +                com.destroystokyo.paper.event.player.PlayerStartSpectatingEntityEvent playerStartSpectatingEntityEvent = new com.destroystokyo.paper.event.player.PlayerStartSpectatingEntityEvent(this.getBukkitEntity(), entity1.getBukkitEntity(), entity.getBukkitEntity());
 +                if (!playerStartSpectatingEntityEvent.callEvent()) {
++                    this.camera = entity1; // rollback camera entity again
 +                    return;
 +                }
 +            }
@@ -42,11 +44,3 @@ index ba938eb9844157cccedb5f673a44720538912bc5..be56cbfc2a7d966a8c5fc9c89f99f73c
              Level world = this.camera.level();
  
              if (world instanceof ServerLevel) {
-@@ -1998,7 +2011,6 @@ public class ServerPlayer extends Player {
-             this.connection.send(new ClientboundSetCameraPacket(this.camera));
-             this.connection.resetPosition();
-         }
--
-     }
- 
-     @Override

--- a/patches/server/0274-Reset-players-airTicks-on-respawn.patch
+++ b/patches/server/0274-Reset-players-airTicks-on-respawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset players airTicks on respawn
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index be56cbfc2a7d966a8c5fc9c89f99f73c94e23ab6..ca3fe38fa443eb08408eca029a34afb58cd5a118 100644
+index ac4bb5d84689a6e4f8f9b425cee5188436d0efce..42898f986d317d44d88c39b56e4655366d5a5a1b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2455,6 +2455,7 @@ public class ServerPlayer extends Player {
+@@ -2458,6 +2458,7 @@ public class ServerPlayer extends Player {
  
          this.setHealth(this.getMaxHealth());
          this.stopUsingItem(); // CraftBukkit - SPIGOT-6682: Clear active item on reset

--- a/patches/server/0598-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0598-additions-to-PlayerGameModeChangeEvent.patch
@@ -45,7 +45,7 @@ index aee8618e27b893b72931e925724dd683d2e6d2aa..5cb15e2209d7b315904a1fc6d650ce1e
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 1d7fe0e7d382d2f2aa5a38732cc6212d6c7a11e3..e12e512b607882f68b6f32b6201aeb2b3e39a699 100644
+index 86b870e8316d2c27861c85ee5a8f7ddd857e8297..176a966ed1cc1c2e436e1d1fd849bfa0cbf9f799 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1887,8 +1887,16 @@ public class ServerPlayer extends Player {
@@ -76,7 +76,7 @@ index 1d7fe0e7d382d2f2aa5a38732cc6212d6c7a11e3..e12e512b607882f68b6f32b6201aeb2b
          }
      }
  
-@@ -2309,6 +2317,16 @@ public class ServerPlayer extends Player {
+@@ -2312,6 +2320,16 @@ public class ServerPlayer extends Player {
      }
  
      public void loadGameTypes(@Nullable CompoundTag nbt) {
@@ -94,7 +94,7 @@ index 1d7fe0e7d382d2f2aa5a38732cc6212d6c7a11e3..e12e512b607882f68b6f32b6201aeb2b
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index c256423e9dc9d1837b847da44fb2920c58842c8b..0cb9803e30702de1cc530c1205fe9bbb4dcb2c08 100644
+index 40ac674da09a5d28c3b691d8979b228b9c6a8a84..8a8b766d91d9e2328486e3156bd6a408808dc1e3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -73,21 +73,28 @@ public class ServerPlayerGameMode {
@@ -131,7 +131,7 @@ index c256423e9dc9d1837b847da44fb2920c58842c8b..0cb9803e30702de1cc530c1205fe9bbb
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 73ea4907e81d7fd7830b3a9a368c88ac903428bb..4ba775edd90e716435c9ff5dc5579d96d49507c1 100644
+index 1c795202f3b5be8f7ee41724258b509aa5b1947d..bca39612af8c9bed1e97697c42825fb7f128197c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2637,7 +2637,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -144,7 +144,7 @@ index 73ea4907e81d7fd7830b3a9a368c88ac903428bb..4ba775edd90e716435c9ff5dc5579d96
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 467ab8fbb335617ef419b35c7881ca5606b3e541..6216a1b2c5fbfeafcce4fee81d7b12a14a8f594b 100644
+index 47f3bd3be8da2c79d3655823ac0f2f4a8f9d7efe..a4869668643bcfe11c4a0f33d02e4b800da29a48 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1564,7 +1564,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0625-Fix-PlayerDropItemEvent-using-wrong-item.patch
+++ b/patches/server/0625-Fix-PlayerDropItemEvent-using-wrong-item.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix PlayerDropItemEvent using wrong item
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e12e512b607882f68b6f32b6201aeb2b3e39a699..963af930dc40b30d84c1e5d46be752ef74908a8a 100644
+index 176a966ed1cc1c2e436e1d1fd849bfa0cbf9f799..aa2185e46bd47748a0a2b092ab2caf134fa4fa69 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2286,7 +2286,7 @@ public class ServerPlayer extends Player {
+@@ -2289,7 +2289,7 @@ public class ServerPlayer extends Player {
  
              if (retainOwnership) {
                  if (!itemstack1.isEmpty()) {
@@ -18,7 +18,7 @@ index e12e512b607882f68b6f32b6201aeb2b3e39a699..963af930dc40b30d84c1e5d46be752ef
  
                  this.awardStat(Stats.DROP);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index dee00042a780b053cd094081874aad221abf1b2b..786ef24e97cfb96ddee2be9e02272e6f572cd64d 100644
+index 0d65e04efacef0bef245e6b5b21e430d90696c5d..4bbd46618ec0f00e0aee7f681335bcbdb375c439 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -730,6 +730,11 @@ public abstract class Player extends LivingEntity {

--- a/patches/server/0645-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0645-Add-PlayerSetSpawnEvent.patch
@@ -49,7 +49,7 @@ index a2d0699e8427b2262a2396495111125eccafbb66..d797637f61bdf8a424f56fbb48e28b7c
      }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 47e7bc46d349e0f0000676948a5c251f555abeb1..6b92189b6dddee7e632c142430eaa784d22adbca 100644
+index 00adb106eea35b745e98e28e6b9e0affe2d00651..c358a078bdbb672b41f606cf83353fc35bcb4b15 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1351,7 +1351,7 @@ public class ServerPlayer extends Player {
@@ -61,7 +61,7 @@ index 47e7bc46d349e0f0000676948a5c251f555abeb1..6b92189b6dddee7e632c142430eaa784
                  if (this.level().isDay()) {
                      return Either.left(Player.BedSleepingProblem.NOT_POSSIBLE_NOW);
                  } else {
-@@ -2206,44 +2206,50 @@ public class ServerPlayer extends Player {
+@@ -2209,44 +2209,50 @@ public class ServerPlayer extends Player {
          return this.respawnForced;
      }
  
@@ -145,7 +145,7 @@ index 47e7bc46d349e0f0000676948a5c251f555abeb1..6b92189b6dddee7e632c142430eaa784
          } else {
              this.respawnPosition = null;
              this.respawnDimension = Level.OVERWORLD;
-@@ -2251,6 +2257,7 @@ public class ServerPlayer extends Player {
+@@ -2254,6 +2260,7 @@ public class ServerPlayer extends Player {
              this.respawnForced = false;
          }
  
@@ -154,7 +154,7 @@ index 47e7bc46d349e0f0000676948a5c251f555abeb1..6b92189b6dddee7e632c142430eaa784
  
      public SectionPos getLastSectionPos() {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 14f3873d4bf43d5576a4c93b80d8a97841b23355..965dd34bd9a23a2fb17e5800af3b294b75b1146a 100644
+index e9b012889987d3c0fca2c90a4edee36b2c86cb88..87fc2c057667eaf7303f3be474e436e0d4cf109a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -855,7 +855,7 @@ public abstract class PlayerList {
@@ -187,7 +187,7 @@ index 1a27b7faa22e6b3dc5fce329ed06425de56c4315..b9903c29bdea8d1e3b6fce0e97be6bd9
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a068e2ae2e419b8b6a8cc560754613a55717c399..0cc3a2949b72cfd3eaced42947c365539087e576 100644
+index dad0a07790579bc3d8b018e1c5e281d4fe9633ba..529792ac8f17ffd4960e67638e87974474cd776c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1323,9 +1323,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {


### PR DESCRIPTION
Issue can be reproduced by cancelling all `PlayerStartSpectatingEntity` events and sneaking after trying to start spectating an entity.

(btw 415d7081d2cdddba83b91a68cf2397ce95ac115b broke patching, I think the submodule-update wasn't intentional)