### PR TITLE
Broadcast take item packets with collector as source

### DIFF
--- a/patches/server/1043-Broadcast-take-item-packets-with-collector-as-source.patch
+++ b/patches/server/1043-Broadcast-take-item-packets-with-collector-as-source.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: booky10 <boooky10@gmail.com>
+Date: Sun, 29 Oct 2023 02:36:10 +0100
+Subject: [PATCH] Broadcast take item packets with collector as source
+
+This fixes players (which can't view the collector) seeing item pickups with themselves as the target.
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 675d695989cef5d8fc2e85673efbb57ec1bb38bd..a76eb3d051db0229ed088b71c92ff3f131449007 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -3701,7 +3701,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+ 
+     public void take(Entity item, int count) {
+         if (!item.isRemoved() && !this.level().isClientSide && (item instanceof ItemEntity || item instanceof AbstractArrow || item instanceof ExperienceOrb)) {
+-            ((ServerLevel) this.level()).getChunkSource().broadcast(item, new ClientboundTakeItemEntityPacket(item.getId(), this.getId(), count));
++            ((ServerLevel) this.level()).getChunkSource().broadcastAndSend(this, new ClientboundTakeItemEntityPacket(item.getId(), this.getId(), count)); // Paper - broadcast with collector as source
+         }
+ 
+     }


### PR DESCRIPTION
This fixes players (which can't view the collector) seeing item pickups with themselves as the target, as the client defaults to themselves if the target entity can't be found.

Issue is reproducible by testing with 2 accounts and hiding one from the other.

Without fix: https://github.com/PaperMC/Paper/assets/53302036/c24e9000-b893-48e9-9288-39f4a5b4fc84
With fix: https://github.com/PaperMC/Paper/assets/53302036/ff6bf87a-e089-4e60-8236-1d45df0190ad
