### PR TITLE
Fix NPE when no valid world is found on legacy Players

### DIFF
--- a/patches/server/1043-Fix-NPE-when-no-valid-world-is-found-on-legacy-Playe.patch
+++ b/patches/server/1043-Fix-NPE-when-no-valid-world-is-found-on-legacy-Playe.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 28 Oct 2023 23:21:49 -0700
+Subject: [PATCH] Fix NPE when no valid world is found on legacy Players
+
+
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index 03d2dc7f68d6918065f852057321fbaaf22fb413..30dd56871acff2dd730d96406520bab066229d7a 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -221,9 +221,9 @@ public abstract class PlayerList {
+             Logger logger = PlayerList.LOGGER;
+ 
+             Objects.requireNonNull(logger);
+-            resourcekey = (ResourceKey) dataresult.resultOrPartial(logger::error).orElse(player.serverLevel().dimension()); // CraftBukkit - SPIGOT-7507: If no dimension, fall back to existing dimension loaded from "WorldUUID", which in turn defaults to World.OVERWORLD
++            resourcekey = (ResourceKey) dataresult.resultOrPartial(logger::error).orElse(player.serverLevel() != null ? player.serverLevel().dimension() : Level.OVERWORLD); // CraftBukkit - SPIGOT-7507: If no dimension, fall back to existing dimension loaded from "WorldUUID", which in turn defaults to World.OVERWORLD // Paper - account for null level
+         } else {
+-            resourcekey = player.serverLevel().dimension(); // CraftBukkit - SPIGOT-7507: If no dimension, fall back to existing dimension loaded from "WorldUUID", which in turn defaults to World.OVERWORLD
++            resourcekey = player.serverLevel() != null ? player.serverLevel().dimension() : Level.OVERWORLD; // CraftBukkit - SPIGOT-7507: If no dimension, fall back to existing dimension loaded from "WorldUUID", which in turn defaults to World.OVERWORLD // Paper - account for null level
+         }
+ 
+         ResourceKey<Level> resourcekey1 = resourcekey;


### PR DESCRIPTION
Upstream's commit [here](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/75502b6ddcae5aa84b7e97fd02d2e1551afddebc#nms-patches/net/minecraft/server/players/PlayerList.patch) failed to account for the level not being set on the ServerPlayer if it doesn't point to a valid world. This adds a null check on the ServerLevel before getting the level key.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9885.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1014594901.zip)