### PR TITLE
Add entity API for getting the combined gene of a Panda

### DIFF
--- a/patches/api/0299-Missing-Entity-API.patch
+++ b/patches/api/0299-Missing-Entity-API.patch
@@ -619,10 +619,10 @@ index 939a3dbfcf38f38e4e39d28973ef723157ce0a50..738d547d2a6966122cb2f9f6e94263ee
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Panda.java b/src/main/java/org/bukkit/entity/Panda.java
-index 1f027927a1194f4f8e86c1375a2772e6e261c151..57cf24cfd15a541f60aafc8507c189344aead0f7 100644
+index 1f027927a1194f4f8e86c1375a2772e6e261c151..aa5686df134185334a74429576ff0709a604dbfd 100644
 --- a/src/main/java/org/bukkit/entity/Panda.java
 +++ b/src/main/java/org/bukkit/entity/Panda.java
-@@ -107,6 +107,87 @@ public interface Panda extends Animals, Sittable {
+@@ -107,6 +107,98 @@ public interface Panda extends Animals, Sittable {
       */
      int getUnhappyTicks();
  
@@ -705,6 +705,17 @@ index 1f027927a1194f4f8e86c1375a2772e6e261c151..57cf24cfd15a541f60aafc8507c18934
 +     */
 +    @Override
 +    boolean isSitting();
++
++    /**
++     * Gets this Panda's combined gene.
++     * <p>
++     * The combined gene can be modified using
++     * {@link #setMainGene(Gene)} or {@link #setHiddenGene(Gene)}.
++     *
++     * @return combined gene
++     */
++    @NotNull
++    Gene getCombinedGene();
 +    // Paper end - Panda API
 +
      public enum Gene {

--- a/patches/server/0625-Missing-Entity-API.patch
+++ b/patches/server/0625-Missing-Entity-API.patch
@@ -846,13 +846,13 @@ index 77cede9c565a3bc404878c9a4028cadc90f6c010..ade11598bee28fea252e3500aaa1daef
      public String toString() {
          return "CraftMushroomCow";
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
-index 5467e4a74b70ff57b49d9e6bc686c493178f8511..56f9630dbe5d18d5ec33dc85f6531723022d6a3b 100644
+index 5467e4a74b70ff57b49d9e6bc686c493178f8511..01d104d91de9e1319d27e39d3f474318c7809486 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPanda.java
-@@ -40,6 +40,32 @@ public class CraftPanda extends CraftAnimals implements Panda {
-     public void setHiddenGene(Gene gene) {
+@@ -41,6 +41,38 @@ public class CraftPanda extends CraftAnimals implements Panda {
          this.getHandle().setHiddenGene(CraftPanda.toNms(gene));
      }
+ 
 +    // Paper start - Panda API
 +    @Override
 +    public void setSneezeTicks(int ticks) {
@@ -878,10 +878,16 @@ index 5467e4a74b70ff57b49d9e6bc686c493178f8511..56f9630dbe5d18d5ec33dc85f6531723
 +    public void setUnhappyTicks(int ticks) {
 +        this.getHandle().setUnhappyCounter(ticks);
 +    }
++
++    @Override
++    public Gene getCombinedGene() {
++        return CraftPanda.fromNms(this.getHandle().getVariant());
++    }
 +    // Paper end - Panda API
- 
++
      @Override
      public boolean isRolling() {
+         return this.getHandle().isRolling();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPhantom.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPhantom.java
 index 9304e201db1ec96d0916aa8ea781f3e4bc7991e6..8338effd39b1709dbe578e247710a8e58d83e3aa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPhantom.java


### PR DESCRIPTION
While updating #9838 I've noticed that it wasn't possible to get the combined gene of a Panda using the API. This PR adds API to do this. I'm not too sure about the name of the method, vanilla just calls it "variant".