### PR TITLE
Fix vanilla components not being translated

### DIFF
--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -1221,7 +1221,7 @@ index 0000000000000000000000000000000000000000..2fd6c3e65354071af71c7d8ebb97b559
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1fb9b0ea9f2dbff12d8d2fbc2ad2f4d88ca9f7ad
+index 0000000000000000000000000000000000000000..f5ba56f9c8406aef2fe91d6b4174762cfed11fce
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 @@ -0,0 +1,394 @@
@@ -1430,7 +1430,7 @@ index 0000000000000000000000000000000000000000..1fb9b0ea9f2dbff12d8d2fbc2ad2f4d8
 +        return PlainTextComponentSerializer.plainText().serialize(translated(component, locale));
 +    }
 +
-+    private static Component translated(final Component component, final Locale locale) {
++    public static Component translated(final Component component, final Locale locale) {
 +        return GlobalTranslator.render(
 +            component,
 +            // play it safe
@@ -2120,7 +2120,7 @@ index d120fff432d9c4fc7a35ddffdc4186459e45e950..73c15a0c56a103ba4e62f0a51af8d425
          }
      }
 diff --git a/src/main/java/net/minecraft/network/FriendlyByteBuf.java b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-index 9373502ede6c8a881af67db005cf12fd9313f37f..50c7e0a449ea9d71e21e86b4f03dac0298f96130 100644
+index 9373502ede6c8a881af67db005cf12fd9313f37f..d9be3fada2e603684275a2094954e29039fb07c7 100644
 --- a/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 +++ b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 @@ -87,6 +87,7 @@ public class FriendlyByteBuf extends ByteBuf {
@@ -2131,7 +2131,7 @@ index 9373502ede6c8a881af67db005cf12fd9313f37f..50c7e0a449ea9d71e21e86b4f03dac02
      public static final short MAX_STRING_LENGTH = 32767;
      public static final int MAX_COMPONENT_STRING_LENGTH = 262144;
      private static final int PUBLIC_KEY_SIZE = 256;
-@@ -526,8 +527,19 @@ public class FriendlyByteBuf extends ByteBuf {
+@@ -526,8 +527,18 @@ public class FriendlyByteBuf extends ByteBuf {
          return (Component) this.readWithCodecTrusted(NbtOps.INSTANCE, ComponentSerialization.CODEC);
      }
  
@@ -2141,12 +2141,12 @@ index 9373502ede6c8a881af67db005cf12fd9313f37f..50c7e0a449ea9d71e21e86b4f03dac02
 +    }
 +
      public FriendlyByteBuf writeComponent(Component text) {
+-        return this.writeWithCodec(NbtOps.INSTANCE, ComponentSerialization.CODEC, text);
 +        if (text instanceof io.papermc.paper.adventure.AdventureComponent adv) {
 +            return this.writeComponent(adv.adventure$component());
 +        }
 +
-+        // TODO this.adventure$locale
-         return this.writeWithCodec(NbtOps.INSTANCE, ComponentSerialization.CODEC, text);
++        return this.writeWithCodec(NbtOps.INSTANCE, ComponentSerialization.localizedCodec(this.adventure$locale), text);
 +        // Paper end - adventure
      }
  
@@ -2270,14 +2270,35 @@ index d3a80d0a23be762c05931ae8001d98e43cab2b4a..e0037b99838519eee5fb6f7e95ffaad2
          }
      }
 diff --git a/src/main/java/net/minecraft/network/chat/ComponentSerialization.java b/src/main/java/net/minecraft/network/chat/ComponentSerialization.java
-index 49138ccda0f378b13c7f425be765876eb4026b06..ddc91d376fd59da982e594188fcef7202a2a5972 100644
+index 49138ccda0f378b13c7f425be765876eb4026b06..d6008d7d800ecfa7c97b9c89a6058a17342d8552 100644
 --- a/src/main/java/net/minecraft/network/chat/ComponentSerialization.java
 +++ b/src/main/java/net/minecraft/network/chat/ComponentSerialization.java
-@@ -61,6 +61,33 @@ public class ComponentSerialization {
+@@ -55,12 +55,61 @@ public class ComponentSerialization {
+         return ExtraCodecs.orCompressed(mapCodec3, mapCodec2);
+     }
+ 
++    // Paper start - adventure
++    private static final java.util.Map<java.util.Locale, Codec<Component>> LOCALIZED_CODECS = new java.util.concurrent.ConcurrentHashMap<>();
++
++    public static Codec<Component> localizedCodec(java.util.Locale locale) {
++        return LOCALIZED_CODECS.computeIfAbsent(locale,
++            loc -> ExtraCodecs.recursive("Component", selfCodec -> createCodec(selfCodec, loc)));
++    }
++    // Paper end
++
+     private static Codec<Component> createCodec(Codec<Component> selfCodec) {
++        // Paper start - adventure
++        return createCodec(selfCodec, null);
++    }
++
++    private static Codec<Component> createCodec(Codec<Component> selfCodec, @javax.annotation.Nullable java.util.Locale locale) {
++        // Paper end
+         ComponentContents.Type<?>[] types = new ComponentContents.Type[]{PlainTextContents.TYPE, TranslatableContents.TYPE, KeybindContents.TYPE, ScoreContents.TYPE, SelectorContents.TYPE, NbtContents.TYPE};
+         MapCodec<ComponentContents> mapCodec = createLegacyComponentMatcher(types, ComponentContents.Type::codec, ComponentContents::type, "type");
          Codec<Component> codec = RecordCodecBuilder.create((instance) -> {
              return instance.group(mapCodec.forGetter(Component::getContents), ExtraCodecs.strictOptionalField(ExtraCodecs.nonEmptyList(selfCodec.listOf()), "extra", List.of()).forGetter(Component::getSiblings), Style.Serializer.MAP_CODEC.forGetter(Component::getStyle)).apply(instance, MutableComponent::new);
          });
-+        // Paper start
++        // Paper start - adventure
 +        final Codec<Component> origCodec = codec;
 +        codec = new Codec<>() {
 +            @Override
@@ -2288,11 +2309,18 @@ index 49138ccda0f378b13c7f425be765876eb4026b06..ddc91d376fd59da982e594188fcef720
 +            @Override
 +            public <T> DataResult<T> encode(final Component input, final DynamicOps<T> ops, final T prefix) {
 +                if (input instanceof io.papermc.paper.adventure.AdventureComponent adv) {
-+                    if (adv.deepConvertedIfPresent() != null) {
-+                        return origCodec.encode(java.util.Objects.requireNonNull(adv.deepConvertedIfPresent()), ops, prefix);
-+                    } else {
-+                        // return io.papermc.paper.adventure.PaperAdventure.localizedCodec(locale).encode(adv.adventure$component(), ops, prefix); // TODO
-+                        return io.papermc.paper.adventure.AdventureCodecs.COMPONENT_CODEC.encode(adv.adventure$component(), ops, prefix);
++                    return io.papermc.paper.adventure.PaperAdventure.localizedCodec(locale)
++                        .encode(adv.adventure$component(), ops, prefix);
++                }
++                if (locale != null && input.getContents() instanceof TranslatableContents) {
++                    final net.kyori.adventure.text.Component adventureComponent
++                        = io.papermc.paper.adventure.PaperAdventure.asAdventure(input);
++                    final net.kyori.adventure.text.Component translatedComponent
++                        = io.papermc.paper.adventure.PaperAdventure.translated(adventureComponent, locale);
++                    if (!adventureComponent.equals(translatedComponent)) {
++                        final Component miencraftComponent
++                            = io.papermc.paper.adventure.PaperAdventure.asVanilla(translatedComponent);
++                        return origCodec.encode(miencraftComponent, ops, prefix);
 +                    }
 +                }
 +                return origCodec.encode(input, ops, prefix);

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -1221,10 +1221,10 @@ index 0000000000000000000000000000000000000000..2fd6c3e65354071af71c7d8ebb97b559
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f5ba56f9c8406aef2fe91d6b4174762cfed11fce
+index 0000000000000000000000000000000000000000..c10c0ffa29332d73328f088935a0b914260d4c50
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
-@@ -0,0 +1,394 @@
+@@ -0,0 +1,397 @@
 +package io.papermc.paper.adventure;
 +
 +import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -1419,7 +1419,10 @@ index 0000000000000000000000000000000000000000..f5ba56f9c8406aef2fe91d6b4174762c
 +
 +    private static final Map<Locale, com.mojang.serialization.Codec<Component>> LOCALIZED_CODECS = new ConcurrentHashMap<>();
 +
-+    public static com.mojang.serialization.Codec<Component> localizedCodec(final Locale l) {
++    public static com.mojang.serialization.Codec<Component> localizedCodec(final @Nullable Locale l) {
++        if (l == null) {
++            return AdventureCodecs.COMPONENT_CODEC;
++        }
 +        return LOCALIZED_CODECS.computeIfAbsent(l, locale -> AdventureCodecs.COMPONENT_CODEC.xmap(
 +            component -> component, // decode
 +            component -> translated(component, locale) // encode
@@ -1430,7 +1433,7 @@ index 0000000000000000000000000000000000000000..f5ba56f9c8406aef2fe91d6b4174762c
 +        return PlainTextComponentSerializer.plainText().serialize(translated(component, locale));
 +    }
 +
-+    public static Component translated(final Component component, final Locale locale) {
++    private static Component translated(final Component component, final Locale locale) {
 +        return GlobalTranslator.render(
 +            component,
 +            // play it safe
@@ -2270,17 +2273,20 @@ index d3a80d0a23be762c05931ae8001d98e43cab2b4a..e0037b99838519eee5fb6f7e95ffaad2
          }
      }
 diff --git a/src/main/java/net/minecraft/network/chat/ComponentSerialization.java b/src/main/java/net/minecraft/network/chat/ComponentSerialization.java
-index 49138ccda0f378b13c7f425be765876eb4026b06..d6008d7d800ecfa7c97b9c89a6058a17342d8552 100644
+index 49138ccda0f378b13c7f425be765876eb4026b06..ca662b668177532a73e7e309bb8b0fb3c4e310f1 100644
 --- a/src/main/java/net/minecraft/network/chat/ComponentSerialization.java
 +++ b/src/main/java/net/minecraft/network/chat/ComponentSerialization.java
-@@ -55,12 +55,61 @@ public class ComponentSerialization {
+@@ -55,12 +55,58 @@ public class ComponentSerialization {
          return ExtraCodecs.orCompressed(mapCodec3, mapCodec2);
      }
  
 +    // Paper start - adventure
 +    private static final java.util.Map<java.util.Locale, Codec<Component>> LOCALIZED_CODECS = new java.util.concurrent.ConcurrentHashMap<>();
 +
-+    public static Codec<Component> localizedCodec(java.util.Locale locale) {
++    public static Codec<Component> localizedCodec(final java.util.@org.checkerframework.checker.nullness.qual.Nullable Locale locale) {
++        if (locale == null) {
++            return CODEC;
++        }
 +        return LOCALIZED_CODECS.computeIfAbsent(locale,
 +            loc -> ExtraCodecs.recursive("Component", selfCodec -> createCodec(selfCodec, loc)));
 +    }
@@ -2308,22 +2314,16 @@ index 49138ccda0f378b13c7f425be765876eb4026b06..d6008d7d800ecfa7c97b9c89a6058a17
 +
 +            @Override
 +            public <T> DataResult<T> encode(final Component input, final DynamicOps<T> ops, final T prefix) {
++                final net.kyori.adventure.text.Component adventureComponent;
 +                if (input instanceof io.papermc.paper.adventure.AdventureComponent adv) {
-+                    return io.papermc.paper.adventure.PaperAdventure.localizedCodec(locale)
-+                        .encode(adv.adventure$component(), ops, prefix);
++                    adventureComponent = adv.adventure$component();
++                } else if (locale != null && input.getContents() instanceof TranslatableContents) {
++                    adventureComponent = io.papermc.paper.adventure.PaperAdventure.asAdventure(input);
++                } else {
++                    return origCodec.encode(input, ops, prefix);
 +                }
-+                if (locale != null && input.getContents() instanceof TranslatableContents) {
-+                    final net.kyori.adventure.text.Component adventureComponent
-+                        = io.papermc.paper.adventure.PaperAdventure.asAdventure(input);
-+                    final net.kyori.adventure.text.Component translatedComponent
-+                        = io.papermc.paper.adventure.PaperAdventure.translated(adventureComponent, locale);
-+                    if (!adventureComponent.equals(translatedComponent)) {
-+                        final Component miencraftComponent
-+                            = io.papermc.paper.adventure.PaperAdventure.asVanilla(translatedComponent);
-+                        return origCodec.encode(miencraftComponent, ops, prefix);
-+                    }
-+                }
-+                return origCodec.encode(input, ops, prefix);
++                return io.papermc.paper.adventure.PaperAdventure.localizedCodec(locale)
++                    .encode(adventureComponent, ops, prefix);
 +            }
 +
 +            @Override

--- a/patches/server/0056-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/server/0056-Player-Tab-List-and-Title-APIs.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Player Tab List and Title APIs
 
 
 diff --git a/src/main/java/net/minecraft/network/FriendlyByteBuf.java b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-index 50c7e0a449ea9d71e21e86b4f03dac0298f96130..dd542b8b235115c4ce54578120d9bc184e852676 100644
+index d9be3fada2e603684275a2094954e29039fb07c7..95bd5958f55fc80d05ccb9cab4d37ff2ef6355e6 100644
 --- a/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 +++ b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-@@ -541,6 +541,12 @@ public class FriendlyByteBuf extends ByteBuf {
-         return this.writeWithCodec(NbtOps.INSTANCE, ComponentSerialization.CODEC, text);
+@@ -540,6 +540,12 @@ public class FriendlyByteBuf extends ByteBuf {
+         return this.writeWithCodec(NbtOps.INSTANCE, ComponentSerialization.localizedCodec(this.adventure$locale), text);
          // Paper end - adventure
      }
 +    // Paper start - deprecated Tab List & Title APIs

--- a/patches/server/0233-Remove-unnecessary-itemmeta-handling.patch
+++ b/patches/server/0233-Remove-unnecessary-itemmeta-handling.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove unnecessary itemmeta handling
 
 
 diff --git a/src/main/java/net/minecraft/network/FriendlyByteBuf.java b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-index dd542b8b235115c4ce54578120d9bc184e852676..6b566413cd53f84820f0920249037fc9c2c1c4ca 100644
+index 95bd5958f55fc80d05ccb9cab4d37ff2ef6355e6..b13bc90b28b02f5e80d935bfcba727f92c5e4c4f 100644
 --- a/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 +++ b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-@@ -645,7 +645,7 @@ public class FriendlyByteBuf extends ByteBuf {
+@@ -644,7 +644,7 @@ public class FriendlyByteBuf extends ByteBuf {
              if (item.canBeDepleted() || item.shouldOverrideMultiplayerNbt()) {
                  // Spigot start - filter
                  stack = stack.copy();
@@ -17,7 +17,7 @@ index dd542b8b235115c4ce54578120d9bc184e852676..6b566413cd53f84820f0920249037fc9
                  // Spigot end
                  nbttagcompound = stack.getTag();
              }
-@@ -666,7 +666,7 @@ public class FriendlyByteBuf extends ByteBuf {
+@@ -665,7 +665,7 @@ public class FriendlyByteBuf extends ByteBuf {
  
              itemstack.setTag(this.readNbt());
              // CraftBukkit start


### PR DESCRIPTION
Vanilla components were just converted to normal json strings without being translated by the `GlobalTranslator`. This caused custom name's of entities to no longer be translated properly after a server restart or an entity unload.

This does have a small performance cost, as all vanilla components (not backed by an adventure component) are now converted to an adventure component by serializing to json and deserializing from json again.

<details>
<summary>Test plugin diff</summary>

```diff
Index: test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java b/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
--- a/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java	(revision c71e79c2d56d2cd374995cbd5a5ac7c3d1fcf5b2)
+++ b/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java	(date 1698715701243)
@@ -1,5 +1,16 @@
 package io.papermc.testplugin;
 
+import io.papermc.paper.event.player.AsyncChatEvent;
+import java.text.MessageFormat;
+import java.util.Locale;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.translation.GlobalTranslator;
+import net.kyori.adventure.translation.TranslationRegistry;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -8,5 +19,20 @@
     @Override
     public void onEnable() {
         this.getServer().getPluginManager().registerEvents(this, this);
+
+        TranslationRegistry registry = TranslationRegistry.create(new NamespacedKey(this, "i18n"));
+        registry.register("testplugin.armorstand", Locale.ENGLISH, new MessageFormat("Success!"));
+        GlobalTranslator.translator().addSource(registry);
+    }
+
+    @EventHandler
+    public void onChat(AsyncChatEvent event) {
+        Bukkit.getScheduler().runTask(this, () -> {
+            Location spawnLoc = event.getPlayer().getLocation();
+            spawnLoc.getWorld().spawn(spawnLoc, ArmorStand.class, armorStand -> {
+                armorStand.setCustomNameVisible(true);
+                armorStand.customName(Component.translatable("testplugin.armorstand"));
+            });
+        });
     }
 }

```
</details>