### PR TITLE
Remove duplicate water-sensitivity damage for unaware mobs

### DIFF
--- a/patches/server/0023-Allow-nerfed-mobs-to-jump.patch
+++ b/patches/server/0023-Allow-nerfed-mobs-to-jump.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 1 Mar 2016 13:24:16 -0600
-Subject: [PATCH] Allow nerfed mobs to jump and take water damage
+Subject: [PATCH] Allow nerfed mobs to jump
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index ec841a4d9a11f0d9047c202a31f944b340da33c8..ffd8b35b606452ce5d189f2761aa76eb9b56ccd6 100644
+index ec841a4d9a11f0d9047c202a31f944b340da33c8..6cc544b39b62cf5be582e697a0df13f82fb73a4b 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -111,6 +111,7 @@ public abstract class Mob extends LivingEntity implements Targeting {
@@ -16,18 +16,16 @@ index ec841a4d9a11f0d9047c202a31f944b340da33c8..ffd8b35b606452ce5d189f2761aa76eb
      public GoalSelector targetSelector;
      @Nullable
      private LivingEntity target;
-@@ -876,7 +877,17 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -876,7 +877,15 @@ public abstract class Mob extends LivingEntity implements Targeting {
      @Override
      protected final void serverAiStep() {
          ++this.noActionTime;
 -        if (!this.aware) return; // CraftBukkit
-+        if (!this.aware) { // Paper start - Allow nerfed mobs to jump, float and take water damage
++        // Paper start - Allow nerfed mobs to jump and float
++        if (!this.aware) {
 +            if (goalFloat != null) {
 +                if (goalFloat.canUse()) goalFloat.tick();
 +                this.getJumpControl().tick();
-+            }
-+            if (this.isSensitiveToWater() && isInWaterRainOrBubble()) {
-+                hurt(this.damageSources().drown(), 1.0F);
 +            }
 +            return;
 +        }

--- a/patches/server/0210-Implement-EntityKnockbackByEntityEvent-and-EntityPus.patch
+++ b/patches/server/0210-Implement-EntityKnockbackByEntityEvent-and-EntityPus.patch
@@ -9,7 +9,7 @@ Co-authored-by: aerulion <aerulion@gmail.com>
 This event is called when an entity receives knockback by another entity.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1d21c5d5ea84f76d4cafe9d2d22226cf50232ee1..ca773bca9df5a313d979e97e3a5245e701353793 100644
+index 407195f54ec5e5a86a228d301222022cc48cdeb6..c039409ebb50496f79d535fcebcc4e7082d0f81c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1902,8 +1902,17 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -33,7 +33,7 @@ index 1d21c5d5ea84f76d4cafe9d2d22226cf50232ee1..ca773bca9df5a313d979e97e3a5245e7
  
      protected void markHurt() {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 91de8c2ca2bd681c8289ce0c59f3ddb1d56be83e..d9ed53c65b8b59da452016d415e925e9e579fe94 100644
+index 8892714b9e7776183da9d9253db2c56da43319c6..06318ffaa20b2682c99c767b1ff4b66f377796e1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1514,7 +1514,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -83,10 +83,10 @@ index 91de8c2ca2bd681c8289ce0c59f3ddb1d56be83e..d9ed53c65b8b59da452016d415e925e9
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 645ee527b9e7e7edbf3320eae6e441bea84f58f9..2b5f5aed31bd235a213f57b9d65b0ea1fae8de08 100644
+index 2d0a188cca46a4d580fb76baa19e85a653e87687..1b4ff79a514dd67660f6f816b4552c5a33d73563 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1647,7 +1647,7 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1645,7 +1645,7 @@ public abstract class Mob extends LivingEntity implements Targeting {
  
          if (flag) {
              if (f1 > 0.0F && target instanceof LivingEntity) {
@@ -122,7 +122,7 @@ index 29cfd065f246bbd3d3c2a5bbd32c3f4813a02951..03ec02f9a2fb5abb5387cd0d83c9481d
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 8bfb2f94226e6b623def141a7af79d0f46d7d445..fc0750f9b2257a3dbf0fab2f0cd4bb020e044752 100644
+index f68aef2298c3b2994c46d34b0888f988af9190dc..12906de1ee386af4c63d53742042dead280eaaf0 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 @@ -458,7 +458,7 @@ public class EnderDragon extends Mob implements Enemy {
@@ -161,7 +161,7 @@ index 81003ce3f05c6be6f52a92b86a4721235f4ce12a..004382377ee364143a34287e7b6546ae
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 799ebcf4c148d402039efc369fd4cda5354c5473..edc73a920f5c0f17e00fda48e64c26c96e71b11d 100644
+index 587e3529b5b658ab943b4e7ffaa235de34542e9c..78fd8e1ba0e636914108eeef96b78304a63c39c6 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -1290,9 +1290,9 @@ public abstract class Player extends LivingEntity {
@@ -186,7 +186,7 @@ index 799ebcf4c148d402039efc369fd4cda5354c5473..edc73a920f5c0f17e00fda48e64c26c9
                                      // CraftBukkit end
                                  }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-index 61a23f67c71116881bab9febf8db219a6c0b98a1..c5512adfb2d38616bb741d03038158c379020ecf 100644
+index 8d9e78efcd07e0fea627c2a5a128c7f15cf3413c..a8caa11bd0ef045b29cc3cb452dec9fd41948045 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 @@ -401,7 +401,7 @@ public abstract class AbstractArrow extends Projectile {

--- a/patches/server/0253-Improve-death-events.patch
+++ b/patches/server/0253-Improve-death-events.patch
@@ -70,7 +70,7 @@ index 0f5e616ebb90e187ea38b6489e6f4f5467f1a9c3..de062ef7553a7edff3d0fa6f50a9987b
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 16fb709582d5311c4b59d72974467eaa1c61a2ab..73b30df698142abf569c232630ec1d953b79ab96 100644
+index 0cc9a6ae1adcae0a6e94fc2d8c448c2b5610e90a..3c7dd373c557f3ceef0173e415d3d6c310fa9e95 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -260,6 +260,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -225,10 +225,10 @@ index 16fb709582d5311c4b59d72974467eaa1c61a2ab..73b30df698142abf569c232630ec1d95
      // CraftBukkit start
      public int getExpReward() {
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 2b5f5aed31bd235a213f57b9d65b0ea1fae8de08..df0cc02f9bbea857226765c6066a2b945036a0d9 100644
+index 1b4ff79a514dd67660f6f816b4552c5a33d73563..3d754bcfc7ab44fe833b6a68794cbcf8da5f4792 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1076,7 +1076,13 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1074,7 +1074,13 @@ public abstract class Mob extends LivingEntity implements Targeting {
                  }
  
                  this.spawnAtLocation(itemstack);

--- a/patches/server/0544-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0544-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add dropLeash variable to EntityUnleashEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 7bbb68bf06e04b58b6c4fa546fe919e387e00b27..c17ea8bdbbd5581b4a2728564fad72f6bb518f66 100644
+index 20007742739eb57fd36865526aa79ccebfca0b99..2e8b1d7b81e212a7b06f4844d0633241dc4b77bf 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1306,12 +1306,15 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1304,12 +1304,15 @@ public abstract class Mob extends LivingEntity implements Targeting {
              return InteractionResult.PASS;
          } else if (this.getLeashHolder() == player) {
              // CraftBukkit start - fire PlayerUnleashEntityEvent
@@ -26,7 +26,7 @@ index 7bbb68bf06e04b58b6c4fa546fe919e387e00b27..c17ea8bdbbd5581b4a2728564fad72f6
              this.gameEvent(GameEvent.ENTITY_INTERACT, player);
              return InteractionResult.sidedSuccess(this.level().isClientSide);
          } else {
-@@ -1479,8 +1482,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1477,8 +1480,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
  
          if (this.leashHolder != null) {
              if (!this.isAlive() || !this.leashHolder.isAlive()) {
@@ -40,7 +40,7 @@ index 7bbb68bf06e04b58b6c4fa546fe919e387e00b27..c17ea8bdbbd5581b4a2728564fad72f6
              }
  
          }
-@@ -1543,8 +1549,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1541,8 +1547,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
          boolean flag1 = super.startRiding(entity, force);
  
          if (flag1 && this.isLeashed()) {
@@ -54,7 +54,7 @@ index 7bbb68bf06e04b58b6c4fa546fe919e387e00b27..c17ea8bdbbd5581b4a2728564fad72f6
          }
  
          return flag1;
-@@ -1733,8 +1742,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1731,8 +1740,11 @@ public abstract class Mob extends LivingEntity implements Targeting {
      @Override
      protected void removeAfterChangingDimensions() {
          super.removeAfterChangingDimensions();

--- a/patches/server/0653-Make-EntityUnleashEvent-cancellable.patch
+++ b/patches/server/0653-Make-EntityUnleashEvent-cancellable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make EntityUnleashEvent cancellable
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index c17ea8bdbbd5581b4a2728564fad72f6bb518f66..bb29725ea06128fb2386c50d088316fea01c312c 100644
+index 2e8b1d7b81e212a7b06f4844d0633241dc4b77bf..1e997c1758ed86dc563983317ceb17e626b8dba7 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1551,7 +1551,7 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1549,7 +1549,7 @@ public abstract class Mob extends LivingEntity implements Targeting {
          if (flag1 && this.isLeashed()) {
              // Paper start - drop leash variable
              EntityUnleashEvent event = new EntityUnleashEvent(this.getBukkitEntity(), EntityUnleashEvent.UnleashReason.UNKNOWN, true);

--- a/patches/server/1019-Fix-silent-equipment-change-for-mobs.patch
+++ b/patches/server/1019-Fix-silent-equipment-change-for-mobs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix silent equipment change for mobs
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index bb29725ea06128fb2386c50d088316fea01c312c..d28c477171c1b6888a45175075017d960464b5cd 100644
+index 1e997c1758ed86dc563983317ceb17e626b8dba7..956d05e2ae59978ea9623ca0e167c0afe0b87306 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1060,13 +1060,20 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -1058,13 +1058,20 @@ public abstract class Mob extends LivingEntity implements Targeting {
  
      @Override
      public void setItemSlot(EquipmentSlot slot, ItemStack stack) {
@@ -47,7 +47,7 @@ index 8e9469fec42f7b6a132cf173f6f5a95777a29b3b..b319021b22c5dceba6199ed27814b2dc
              this.reassessWeaponGoal();
          }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 87cae8ed22a2428a1dda8f2a4510e45fbc31eab5..ea8a0961190e9aafda4fed6fecd85097c141040a 100644
+index f2f93761985a78b563dd1eda57f9a08b1cc8893a..2354a0e5d15e9be633d9fe3a1a9feefe7b9b7782 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -1870,7 +1870,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {


### PR DESCRIPTION
The drown damage is already dealt in another method even for unaware mobs, i guess previously it was dealt in that same method causing the return to break that.