### PR TITLE
Fix duplicate egg throw sound

### DIFF
--- a/patches/server/0215-PlayerElytraBoostEvent.patch
+++ b/patches/server/0215-PlayerElytraBoostEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerElytraBoostEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/FireworkRocketItem.java b/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
-index 7c627d27300247db9122ab2081049345ef306073..6e6c9477b70b0e1ab36bca9fa91806a283ebedd1 100644
+index 7c627d27300247db9122ab2081049345ef306073..badd3ff4b8e716c0ac255397c8592b72d8a6e4db 100644
 --- a/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
 +++ b/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
-@@ -61,12 +61,19 @@ public class FireworkRocketItem extends Item {
+@@ -61,8 +61,17 @@ public class FireworkRocketItem extends Item {
              if (!world.isClientSide) {
                  FireworkRocketEntity fireworkRocketEntity = new FireworkRocketEntity(world, itemStack, user);
                  fireworkRocketEntity.spawningEntity = user.getUUID(); // Paper
@@ -16,18 +16,15 @@ index 7c627d27300247db9122ab2081049345ef306073..6e6c9477b70b0e1ab36bca9fa91806a2
 -                if (!user.getAbilities().instabuild) {
 +                // Paper start - PlayerElytraBoostEvent
 +                com.destroystokyo.paper.event.player.PlayerElytraBoostEvent event = new com.destroystokyo.paper.event.player.PlayerElytraBoostEvent((org.bukkit.entity.Player) user.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), (org.bukkit.entity.Firework) fireworkRocketEntity.getBukkitEntity());
-+                if (event.callEvent() && world.addFreshEntity(fireworkRocketEntity)) {
-+                    user.awardStat(Stats.ITEM_USED.get(this));
-+                    if (event.shouldConsume() && !user.getAbilities().instabuild) {
-                     itemStack.shrink(1);
-+                    } else ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
-+                } else if (user instanceof net.minecraft.server.level.ServerPlayer) {
-+                    ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
++                if (!event.callEvent() || !world.addFreshEntity(fireworkRocketEntity)) {
++                    user.containerMenu.sendAllDataToRemote();
++                    return InteractionResultHolder.fail(itemStack);
++                }
++
++                if (!event.shouldConsume() && !user.getAbilities().instabuild) {
++                    user.containerMenu.sendAllDataToRemote();
++                } else {
 +                    // Paper end - PlayerElytraBoostEvent
+                     itemStack.shrink(1);
                  }
  
--                user.awardStat(Stats.ITEM_USED.get(this));
-+                // user.awardStat(Stats.ITEM_USED.get(this)); // Paper - PlayerElytraBoostEvent; move up
-             }
- 
-             return InteractionResultHolder.sidedSuccess(user.getItemInHand(hand), world.isClientSide());

--- a/patches/server/0216-PlayerLaunchProjectileEvent.patch
+++ b/patches/server/0216-PlayerLaunchProjectileEvent.patch
@@ -5,98 +5,102 @@ Subject: [PATCH] PlayerLaunchProjectileEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/EggItem.java b/src/main/java/net/minecraft/world/item/EggItem.java
-index 32b63407b943fb00d765dbf4e0eefb4b06f801b6..a3bd507793994e9cc87a956871a8afbb8ca9460d 100644
+index 32b63407b943fb00d765dbf4e0eefb4b06f801b6..a976bdfc33a409ef3f1439488da310fbb4c45dca 100644
 --- a/src/main/java/net/minecraft/world/item/EggItem.java
 +++ b/src/main/java/net/minecraft/world/item/EggItem.java
-@@ -25,21 +25,33 @@ public class EggItem extends Item {
+@@ -20,24 +20,35 @@ public class EggItem extends Item {
+         ItemStack itemstack = user.getItemInHand(hand);
+ 
+         // world.playSound((EntityHuman) null, entityhuman.getX(), entityhuman.getY(), entityhuman.getZ(), SoundEffects.EGG_THROW, SoundCategory.PLAYERS, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F)); // CraftBukkit - moved down
++        boolean shouldConsume = true; // Paper - PlayerLaunchProjectileEvent
+         if (!world.isClientSide) {
+             ThrownEgg entityegg = new ThrownEgg(world, user);
  
              entityegg.setItem(itemstack);
              entityegg.shootFromRotation(user, user.getXRot(), user.getYRot(), 0.0F, 1.5F, 1.0F);
--            // CraftBukkit start
+             // CraftBukkit start
 -            if (!world.addFreshEntity(entityegg)) {
 +            // Paper start - PlayerLaunchProjectileEvent
 +            com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent event = new com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent((org.bukkit.entity.Player) user.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemstack), (org.bukkit.entity.Projectile) entityegg.getBukkitEntity());
-+            if (event.callEvent() && world.addFreshEntity(entityegg)) {
-+                if (event.shouldConsume() && !user.getAbilities().instabuild) {
-+                    itemstack.shrink(1);
-+                } else if (user instanceof net.minecraft.server.level.ServerPlayer) {
-+                    ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
-+                }
-+
-+                world.playSound((Player) null, user.getX(), user.getY(), user.getZ(), net.minecraft.sounds.SoundEvents.EGG_THROW, net.minecraft.sounds.SoundSource.PLAYERS, 0.5F, 0.4F / (net.minecraft.world.entity.Entity.SHARED_RANDOM.nextFloat() * 0.4F + 0.8F));
-+                user.awardStat(Stats.ITEM_USED.get(this));
-+            } else {
++            if (!event.callEvent() || !world.addFreshEntity(entityegg)) {
++                // Paper end - PlayerLaunchProjectileEvent
                  if (user instanceof net.minecraft.server.level.ServerPlayer) {
                      ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
                  }
                  return InteractionResultHolder.fail(itemstack);
              }
--            // CraftBukkit end
+             // CraftBukkit end
++
++            // Paper start - PlayerLaunchProjectileEvent
++            shouldConsume = event.shouldConsume();
++            if (!shouldConsume && !user.getAbilities().instabuild) {
++                user.containerMenu.sendAllDataToRemote();
++            }
 +            // Paper end - PlayerLaunchProjectileEvent
          }
          world.playSound((Player) null, user.getX(), user.getY(), user.getZ(), SoundEvents.EGG_THROW, SoundSource.PLAYERS, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F));
  
-+        /* // Paper start - PlayerLaunchProjectileEvent; moved up
          user.awardStat(Stats.ITEM_USED.get(this));
-         if (!user.getAbilities().instabuild) {
+-        if (!user.getAbilities().instabuild) {
++        if (shouldConsume && !user.getAbilities().instabuild) { // Paper - PlayerLaunchProjectileEvent
              itemstack.shrink(1);
          }
-+        */ // Paper end - PlayerLaunchProjectileEvent
  
-         return InteractionResultHolder.sidedSuccess(itemstack, world.isClientSide());
-     }
 diff --git a/src/main/java/net/minecraft/world/item/EnderpearlItem.java b/src/main/java/net/minecraft/world/item/EnderpearlItem.java
-index c7d4745aed77b23562cde7c68b8870fa239428d4..8c8cf8705107c95d9a4eab28b5845ae13c4ffb3c 100644
+index c7d4745aed77b23562cde7c68b8870fa239428d4..aaac334475563508e0af0d3711826ae2a94b7818 100644
 --- a/src/main/java/net/minecraft/world/item/EnderpearlItem.java
 +++ b/src/main/java/net/minecraft/world/item/EnderpearlItem.java
-@@ -25,7 +25,20 @@ public class EnderpearlItem extends Item {
+@@ -20,17 +20,29 @@ public class EnderpearlItem extends Item {
+         ItemStack itemstack = user.getItemInHand(hand);
+ 
+         // CraftBukkit start - change order
++        boolean shouldConsume = true; // Paper - PlayerLaunchProjectileEvent
+         if (!world.isClientSide) {
+             ThrownEnderpearl entityenderpearl = new ThrownEnderpearl(world, user);
  
              entityenderpearl.setItem(itemstack);
              entityenderpearl.shootFromRotation(user, user.getXRot(), user.getYRot(), 0.0F, 1.5F, 1.0F);
 -            if (!world.addFreshEntity(entityenderpearl)) {
 +            // Paper start - PlayerLaunchProjectileEvent
 +            com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent event = new com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent((org.bukkit.entity.Player) user.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemstack), (org.bukkit.entity.Projectile) entityenderpearl.getBukkitEntity());
-+            if (event.callEvent() && world.addFreshEntity(entityenderpearl)) {
-+                if (event.shouldConsume() && !user.getAbilities().instabuild) {
-+                    itemstack.shrink(1);
-+                } else if (user instanceof net.minecraft.server.level.ServerPlayer) {
-+                    ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
-+                }
-+
-+                world.playSound((Player) null, user.getX(), user.getY(), user.getZ(), SoundEvents.ENDER_PEARL_THROW, SoundSource.NEUTRAL, 0.5F, 0.4F / (net.minecraft.world.entity.Entity.SHARED_RANDOM.nextFloat() * 0.4F + 0.8F));
-+                user.awardStat(Stats.ITEM_USED.get(this));
-+                user.getCooldowns().addCooldown(this, 20);
-+            } else {
++            if (!event.callEvent() || !world.addFreshEntity(entityenderpearl)) {
 +                // Paper end - PlayerLaunchProjectileEvent
                  if (user instanceof net.minecraft.server.level.ServerPlayer) {
++                    ((net.minecraft.server.level.ServerPlayer) user).connection.send(new net.minecraft.network.protocol.game.ClientboundCooldownPacket(this, 0)); // Paper - PlayerLaunchProjectileEvent; reset cooldown visually
                      ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
                  }
-@@ -33,6 +46,7 @@ public class EnderpearlItem extends Item {
+                 return InteractionResultHolder.fail(itemstack);
              }
++
++            // Paper start - PlayerLaunchProjectileEvent
++            shouldConsume = event.shouldConsume();
++            if (!shouldConsume && !user.getAbilities().instabuild) {
++                user.containerMenu.sendAllDataToRemote();
++            }
++            // Paper end - PlayerLaunchProjectileEvent
          }
  
-+        /* // Paper start - PlayerLaunchProjectileEvent; moved up
          world.playSound((Player) null, user.getX(), user.getY(), user.getZ(), SoundEvents.ENDER_PEARL_THROW, SoundSource.NEUTRAL, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F));
-         user.getCooldowns().addCooldown(this, 20);
+@@ -38,7 +50,7 @@ public class EnderpearlItem extends Item {
          // CraftBukkit end
-@@ -41,6 +55,7 @@ public class EnderpearlItem extends Item {
-         if (!user.getAbilities().instabuild) {
+ 
+         user.awardStat(Stats.ITEM_USED.get(this));
+-        if (!user.getAbilities().instabuild) {
++        if (shouldConsume && !user.getAbilities().instabuild) { // Paper - PlayerLaunchProjectileEvent
              itemstack.shrink(1);
          }
-+        */ // Paper end - PlayerLaunchProjectileEvent; moved up
  
-         return InteractionResultHolder.sidedSuccess(itemstack, world.isClientSide());
-     }
 diff --git a/src/main/java/net/minecraft/world/item/ExperienceBottleItem.java b/src/main/java/net/minecraft/world/item/ExperienceBottleItem.java
-index 72dfb7b652f515bf9df201d524a851ab56706544..39fe6734c8dcd34c563e33e717937bbd91882e1e 100644
+index 72dfb7b652f515bf9df201d524a851ab56706544..05561a138b6b2aeaf6b6cd6b52dbd0c6c1684808 100644
 --- a/src/main/java/net/minecraft/world/item/ExperienceBottleItem.java
 +++ b/src/main/java/net/minecraft/world/item/ExperienceBottleItem.java
-@@ -22,18 +22,37 @@ public class ExperienceBottleItem extends Item {
+@@ -22,16 +22,30 @@ public class ExperienceBottleItem extends Item {
      @Override
      public InteractionResultHolder<ItemStack> use(Level world, Player user, InteractionHand hand) {
          ItemStack itemStack = user.getItemInHand(hand);
 -        world.playSound((Player)null, user.getX(), user.getY(), user.getZ(), SoundEvents.EXPERIENCE_BOTTLE_THROW, SoundSource.NEUTRAL, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F));
 +        // world.playSound((Player)null, user.getX(), user.getY(), user.getZ(), SoundEvents.EXPERIENCE_BOTTLE_THROW, SoundSource.NEUTRAL, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F)); // Paper - PlayerLaunchProjectileEvent; moved down
++        boolean shouldConsume = true; // Paper - PlayerLaunchProjectileEvent
          if (!world.isClientSide) {
              ThrownExperienceBottle thrownExperienceBottle = new ThrownExperienceBottle(world, user);
              thrownExperienceBottle.setItem(itemStack);
@@ -104,168 +108,162 @@ index 72dfb7b652f515bf9df201d524a851ab56706544..39fe6734c8dcd34c563e33e717937bbd
 -            world.addFreshEntity(thrownExperienceBottle);
 +            // Paper start - PlayerLaunchProjectileEvent
 +            com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent event = new com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent((org.bukkit.entity.Player) user.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), (org.bukkit.entity.Projectile) thrownExperienceBottle.getBukkitEntity());
-+            if (event.callEvent() && world.addFreshEntity(thrownExperienceBottle)) {
-+                if (event.shouldConsume() && !user.getAbilities().instabuild) {
-+                    itemStack.shrink(1);
-+                } else if (user instanceof net.minecraft.server.level.ServerPlayer) {
-+                    ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
-+                }
-+
-+                world.playSound((Player) null, user.getX(), user.getY(), user.getZ(), SoundEvents.EXPERIENCE_BOTTLE_THROW, SoundSource.NEUTRAL, 0.5F, 0.4F / (net.minecraft.world.entity.Entity.SHARED_RANDOM.nextFloat() * 0.4F + 0.8F));
-+                user.awardStat(Stats.ITEM_USED.get(this));
-+            } else {
-+                if (user instanceof net.minecraft.server.level.ServerPlayer) {
-+                    ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
-+                }
++            if (!event.callEvent() || !world.addFreshEntity(thrownExperienceBottle)) {
++                user.containerMenu.sendAllDataToRemote();
 +                return InteractionResultHolder.fail(itemStack);
 +            }
++
++            shouldConsume = event.shouldConsume();
++            if (!shouldConsume && !user.getAbilities().instabuild) {
++                user.containerMenu.sendAllDataToRemote();
++            }
++
++            world.playSound((Player)null, user.getX(), user.getY(), user.getZ(), SoundEvents.EXPERIENCE_BOTTLE_THROW, SoundSource.NEUTRAL, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F)); // moved from above
 +            // Paper end - PlayerLaunchProjectileEvent
          }
  
-+        /* // Paper start - PlayerLaunchProjectileEvent; moved up
          user.awardStat(Stats.ITEM_USED.get(this));
-         if (!user.getAbilities().instabuild) {
+-        if (!user.getAbilities().instabuild) {
++        if (shouldConsume && !user.getAbilities().instabuild) { // Paper - PlayerLaunchProjectileEvent
              itemStack.shrink(1);
          }
-+        */ // Paper end - PlayerLaunchProjectileEvent
  
-         return InteractionResultHolder.sidedSuccess(itemStack, world.isClientSide());
-     }
 diff --git a/src/main/java/net/minecraft/world/item/FireworkRocketItem.java b/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
-index 6e6c9477b70b0e1ab36bca9fa91806a283ebedd1..0821c06a4c66edc8fcee09fc192335a588d2944b 100644
+index 6249ff490d1f6c26d05a054e6376d94f64858d14..2cf9c4d34910e4844c8fe6d0477dafa2946ed5e5 100644
 --- a/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
 +++ b/src/main/java/net/minecraft/world/item/FireworkRocketItem.java
-@@ -47,8 +47,12 @@ public class FireworkRocketItem extends Item {
+@@ -47,8 +47,25 @@ public class FireworkRocketItem extends Item {
              Direction direction = context.getClickedFace();
              FireworkRocketEntity fireworkRocketEntity = new FireworkRocketEntity(level, context.getPlayer(), vec3.x + (double)direction.getStepX() * 0.15D, vec3.y + (double)direction.getStepY() * 0.15D, vec3.z + (double)direction.getStepZ() * 0.15D, itemStack);
              fireworkRocketEntity.spawningEntity = context.getPlayer() == null ? null : context.getPlayer().getUUID(); // Paper
 -            level.addFreshEntity(fireworkRocketEntity);
--            itemStack.shrink(1);
 +            // Paper start - PlayerLaunchProjectileEvent
-+            com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent event = new com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent((org.bukkit.entity.Player) context.getPlayer().getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), (org.bukkit.entity.Firework) fireworkRocketEntity.getBukkitEntity());
-+            if (!event.callEvent() || !level.addFreshEntity(fireworkRocketEntity)) return InteractionResult.PASS;
-+            if (event.shouldConsume() && !context.getPlayer().getAbilities().instabuild) itemStack.shrink(1);
-+            else if (context.getPlayer() instanceof net.minecraft.server.level.ServerPlayer) ((net.minecraft.server.level.ServerPlayer) context.getPlayer()).getBukkitEntity().updateInventory();
++            Player player = context.getPlayer();
++            boolean shouldConsume = true;
++            if (player != null) {
++                com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent event = new com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent((org.bukkit.entity.Player) player.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), (org.bukkit.entity.Firework) fireworkRocketEntity.getBukkitEntity());
++                if (!event.callEvent() || !level.addFreshEntity(fireworkRocketEntity)) {
++                    return InteractionResult.PASS;
++                }
++
++                shouldConsume = event.shouldConsume();
++                if (!shouldConsume && !player.getAbilities().instabuild) {
++                    player.containerMenu.sendAllDataToRemote();
++                }
++            }
++
++            if (shouldConsume) {
+             itemStack.shrink(1);
++            }
 +            // Paper end - PlayerLaunchProjectileEvent
          }
  
          return InteractionResult.sidedSuccess(level.isClientSide);
 diff --git a/src/main/java/net/minecraft/world/item/LingeringPotionItem.java b/src/main/java/net/minecraft/world/item/LingeringPotionItem.java
-index 04370590e6c8051ad17f937576b4cd88f6afb5d9..8526251e45899499bc4d9b6254fa1b190a3843d8 100644
+index 04370590e6c8051ad17f937576b4cd88f6afb5d9..7b03ebe1231dccf9e108e93b3af7a49807d1d563 100644
 --- a/src/main/java/net/minecraft/world/item/LingeringPotionItem.java
 +++ b/src/main/java/net/minecraft/world/item/LingeringPotionItem.java
-@@ -23,7 +23,12 @@ public class LingeringPotionItem extends ThrowablePotionItem {
+@@ -23,7 +23,14 @@ public class LingeringPotionItem extends ThrowablePotionItem {
  
      @Override
      public InteractionResultHolder<ItemStack> use(Level world, Player user, InteractionHand hand) {
 +        // Paper start - PlayerLaunchProjectileEvent
 +        InteractionResultHolder<ItemStack> wrapper = super.use(world, user, hand);
-+        if (wrapper.getResult() != net.minecraft.world.InteractionResult.FAIL) {
++        if (wrapper.getResult() == net.minecraft.world.InteractionResult.FAIL) {
++            return wrapper;
++        }
++        // Paper end - PlayerLaunchProjectileEvent
++
          world.playSound((Player)null, user.getX(), user.getY(), user.getZ(), SoundEvents.LINGERING_POTION_THROW, SoundSource.NEUTRAL, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F));
 -        return super.use(world, user, hand);
-+        }
-+        return wrapper;
-+        // Paper end - PlayerLaunchProjectileEvent
++        return wrapper; // Paper - PlayerLaunchProjectileEvent
      }
  }
 diff --git a/src/main/java/net/minecraft/world/item/SnowballItem.java b/src/main/java/net/minecraft/world/item/SnowballItem.java
-index d60e57e84f7d66e1858ab50ac33777feedf1c54d..bc8186a5bc3a98b35fad570729dd4ba52efab238 100644
+index d60e57e84f7d66e1858ab50ac33777feedf1c54d..d5bf6adacff19da67022a4b9e8644e3e74e1adb5 100644
 --- a/src/main/java/net/minecraft/world/item/SnowballItem.java
 +++ b/src/main/java/net/minecraft/world/item/SnowballItem.java
-@@ -26,18 +26,26 @@ public class SnowballItem extends Item {
+@@ -26,14 +26,22 @@ public class SnowballItem extends Item {
  
              entitysnowball.setItem(itemstack);
              entitysnowball.shootFromRotation(user, user.getXRot(), user.getYRot(), 0.0F, 1.5F, 1.0F);
 -            if (world.addFreshEntity(entitysnowball)) {
 -                if (!user.getAbilities().instabuild) {
 +            // Paper start - PlayerLaunchProjectileEvent
-+            com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent event = new com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent((org.bukkit.entity.Player) user.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemstack), (org.bukkit.entity.Projectile) entitysnowball.getBukkitEntity());
-+            if (event.callEvent() && world.addFreshEntity(entitysnowball)) {
-+                user.awardStat(Stats.ITEM_USED.get(this));
-+                if (event.shouldConsume() && !user.getAbilities().instabuild) {
++            {
++                com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent event = new com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent((org.bukkit.entity.Player) user.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemstack), (org.bukkit.entity.Projectile) entitysnowball.getBukkitEntity());
++                if (!event.callEvent() || !world.addFreshEntity(entitysnowball)) {
++                    user.containerMenu.sendAllDataToRemote();
++                    return InteractionResultHolder.fail(itemstack);
++                }
++
++                if (!event.shouldConsume() && !user.getAbilities().instabuild) {
++                    user.containerMenu.sendAllDataToRemote();
++                } else {
 +                    // Paper end - PlayerLaunchProjectileEvent
                      itemstack.shrink(1);
-+                } else if (user instanceof net.minecraft.server.level.ServerPlayer) {  // Paper - PlayerLaunchProjectileEvent
-+                    ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();  // Paper - PlayerLaunchProjectileEvent
                  }
  
                  world.playSound((Player) null, user.getX(), user.getY(), user.getZ(), SoundEvents.SNOWBALL_THROW, SoundSource.NEUTRAL, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F));
 -            } else if (user instanceof net.minecraft.server.level.ServerPlayer) {
 -                ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
-+            } else { // Paper - PlayerLaunchProjectileEvent
-+                if (user instanceof net.minecraft.server.level.ServerPlayer) ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory(); // Paper - PlayerLaunchProjectileEvent
-+                return InteractionResultHolder.fail(itemstack); // Paper - PlayerLaunchProjectileEvent
              }
          }
          // CraftBukkit end
- 
-+        /* // Paper start - PlayerLaunchProjectileEvent; moved up
-         user.awardStat(Stats.ITEM_USED.get(this));
-         // CraftBukkit start - moved up
-         /*
-@@ -45,6 +53,7 @@ public class SnowballItem extends Item {
-             itemstack.shrink(1);
-         }
-         */
-+        // Paper end - PlayerLaunchProjectileEvent
- 
-         return InteractionResultHolder.sidedSuccess(itemstack, world.isClientSide());
-     }
 diff --git a/src/main/java/net/minecraft/world/item/SplashPotionItem.java b/src/main/java/net/minecraft/world/item/SplashPotionItem.java
-index 317e20052bcac9118e1adeb619bedaacc6fcd690..3bd127780091c6bb9ec17c88f0cf57b0b8f37e11 100644
+index 317e20052bcac9118e1adeb619bedaacc6fcd690..edaab2b8a6cbae6a2f2d8c0416c46e1f855768b6 100644
 --- a/src/main/java/net/minecraft/world/item/SplashPotionItem.java
 +++ b/src/main/java/net/minecraft/world/item/SplashPotionItem.java
-@@ -14,7 +14,12 @@ public class SplashPotionItem extends ThrowablePotionItem {
+@@ -14,7 +14,14 @@ public class SplashPotionItem extends ThrowablePotionItem {
  
      @Override
      public InteractionResultHolder<ItemStack> use(Level world, Player user, InteractionHand hand) {
 +        // Paper start - PlayerLaunchProjectileEvent
 +        InteractionResultHolder<ItemStack> wrapper = super.use(world, user, hand);
-+        if (wrapper.getResult() != net.minecraft.world.InteractionResult.FAIL) {
++        if (wrapper.getResult() == net.minecraft.world.InteractionResult.FAIL) {
++            return wrapper;
++        }
++        // Paper end - PlayerLaunchProjectileEvent
++
          world.playSound((Player)null, user.getX(), user.getY(), user.getZ(), SoundEvents.SPLASH_POTION_THROW, SoundSource.PLAYERS, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F));
 -        return super.use(world, user, hand);
-+        }
-+        return wrapper;
-+        // Paper end - PlayerLaunchProjectileEvent
++        return wrapper; // Paper - PlayerLaunchProjectileEvent
      }
  }
 diff --git a/src/main/java/net/minecraft/world/item/ThrowablePotionItem.java b/src/main/java/net/minecraft/world/item/ThrowablePotionItem.java
-index 0673f62f25532955f3552b64f122e644d42027e4..f47f793c62a919fb65c081ddb82d597a978d3b20 100644
+index 0673f62f25532955f3552b64f122e644d42027e4..761b44a05e888adceb808452bffa159f18946dc8 100644
 --- a/src/main/java/net/minecraft/world/item/ThrowablePotionItem.java
 +++ b/src/main/java/net/minecraft/world/item/ThrowablePotionItem.java
-@@ -19,13 +19,31 @@ public class ThrowablePotionItem extends PotionItem {
+@@ -15,15 +15,27 @@ public class ThrowablePotionItem extends PotionItem {
+     @Override
+     public InteractionResultHolder<ItemStack> use(Level world, Player user, InteractionHand hand) {
+         ItemStack itemStack = user.getItemInHand(hand);
++        boolean shouldConsume = true; // Paper - PlayerLaunchProjectileEvent
+         if (!world.isClientSide) {
              ThrownPotion thrownPotion = new ThrownPotion(world, user);
              thrownPotion.setItem(itemStack);
              thrownPotion.shootFromRotation(user, user.getXRot(), user.getYRot(), -20.0F, 0.5F, 1.0F);
 -            world.addFreshEntity(thrownPotion);
 +            // Paper start - PlayerLaunchProjectileEvent
 +            com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent event = new com.destroystokyo.paper.event.player.PlayerLaunchProjectileEvent((org.bukkit.entity.Player) user.getBukkitEntity(), org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), (org.bukkit.entity.Projectile) thrownPotion.getBukkitEntity());
-+            if (event.callEvent() && world.addFreshEntity(thrownPotion)) {
-+                if (event.shouldConsume() && !user.getAbilities().instabuild) {
-+                    itemStack.shrink(1);
-+                } else if (user instanceof net.minecraft.server.level.ServerPlayer) {
-+                    ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
-+                }
-+
-+                user.awardStat(Stats.ITEM_USED.get(this));
-+            } else {
-+                if (user instanceof net.minecraft.server.level.ServerPlayer) {
-+                    ((net.minecraft.server.level.ServerPlayer) user).getBukkitEntity().updateInventory();
-+                }
++            if (!event.callEvent() || !world.addFreshEntity(thrownPotion)) {
++                user.containerMenu.sendAllDataToRemote();
 +                return InteractionResultHolder.fail(itemStack);
++            }
++
++            shouldConsume = event.shouldConsume();
++            if (!shouldConsume && !user.getAbilities().instabuild) {
++                user.containerMenu.sendAllDataToRemote();
 +            }
 +            // Paper end - PlayerLaunchProjectileEvent
          }
  
-+        /* // Paper start - PlayerLaunchProjectileEvent; moved up
          user.awardStat(Stats.ITEM_USED.get(this));
-         if (!user.getAbilities().instabuild) {
+-        if (!user.getAbilities().instabuild) {
++        if (shouldConsume && !user.getAbilities().instabuild) { // Paper - PlayerLaunchProjectileEvent
              itemStack.shrink(1);
          }
-+        */ // Paper end
  
-         return InteractionResultHolder.sidedSuccess(itemStack, world.isClientSide());
-     }
 diff --git a/src/main/java/net/minecraft/world/item/TridentItem.java b/src/main/java/net/minecraft/world/item/TridentItem.java
 index 2ccbba4775d7550c5c7277aee9cab9ff7d665693..fa876ddf54780728e7f3ecfe02aa8a16b8ef6f8d 100644
 --- a/src/main/java/net/minecraft/world/item/TridentItem.java


### PR DESCRIPTION
This fix an issue with the egg throw sound being played twice (slightly noticeable with the volume of the sound compared to other projectile) and the enderpearl that didn't reset its cooldown clientside when the PlayerLaunchProjectileEvent is cancelled.