### PR TITLE
Configurable memory condition tick rate

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -1338,10 +1338,10 @@ index 0000000000000000000000000000000000000000..351fbbc577556ebbd62222615801a96b
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ed79d30f33b2674863b2d73b1abdb48433c33412
+index 0000000000000000000000000000000000000000..307b48f8089b3854c9f6209d75974f4da9980a8f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,538 @@
+@@ -0,0 +1,542 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1844,6 +1844,10 @@ index 0000000000000000000000000000000000000000..ed79d30f33b2674863b2d73b1abdb484
 +        public int mobSpawner = 1;
 +        public Table<EntityType<?>, String, Integer> sensor = Util.make(HashBasedTable.create(), table -> table.put(EntityType.VILLAGER, "secondarypoisensor", 40));
 +        public Table<EntityType<?>, String, Integer> behavior = Util.make(HashBasedTable.create(), table -> table.put(EntityType.VILLAGER, "validatenearbypoi", -1));
++        public Table<EntityType<?>, String, Integer> memoryCondition = Util.make(HashBasedTable.create(), table -> {
++            table.put(EntityType.VILLAGER, "minecraft:job_site", -1);
++            table.put(EntityType.VILLAGER, "minecraft:potential_job_site", -1);
++        });
 +    }
 +
 +    @Setting(FeatureSeedsGeneration.FEATURE_SEEDS_KEY)

--- a/patches/server/1047-Configurable-memory-condition-tick-rate.patch
+++ b/patches/server/1047-Configurable-memory-condition-tick-rate.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable memory condition tick rate
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/declarative/BehaviorBuilder.java b/src/main/java/net/minecraft/world/entity/ai/behavior/declarative/BehaviorBuilder.java
-index 6f323026b2d6fb5151e8b9dd9466e96eb026ccbd..6aeb432d7e79cbf5c64da934bd6d4d63a7a35e44 100644
+index 6f323026b2d6fb5151e8b9dd9466e96eb026ccbd..4be6a59a7752c35b3a86c62db53735464e57e393 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/declarative/BehaviorBuilder.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/declarative/BehaviorBuilder.java
 @@ -333,8 +333,19 @@ public class BehaviorBuilder<E extends LivingEntity, M> implements App<BehaviorB
@@ -13,7 +13,7 @@ index 6f323026b2d6fb5151e8b9dd9466e96eb026ccbd..6aeb432d7e79cbf5c64da934bd6d4d63
          PureMemory(final MemoryCondition<F, Value> query) {
              super(new BehaviorBuilder.TriggerWithResult<E, MemoryAccessor<F, Value>>() {
 +                // Paper start - memory condition tick rate
-+                private final String configKey = query.memory().toString().toLowerCase(java.util.Locale.ROOT);
++                private final String configKey = net.minecraft.core.registries.BuiltInRegistries.MEMORY_MODULE_TYPE.getKey(query.memory()).toString();
 +                private long endTimestamp;
 +                // Paper end
                  @Override

--- a/patches/server/1047-Configurable-memory-condition-tick-rate.patch
+++ b/patches/server/1047-Configurable-memory-condition-tick-rate.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ruViolence <78062896+ruViolence@users.noreply.github.com>
+Date: Wed, 8 Nov 2023 01:25:45 +0800
+Subject: [PATCH] Configurable memory condition tick rate
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/declarative/BehaviorBuilder.java b/src/main/java/net/minecraft/world/entity/ai/behavior/declarative/BehaviorBuilder.java
+index 6f323026b2d6fb5151e8b9dd9466e96eb026ccbd..6aeb432d7e79cbf5c64da934bd6d4d63a7a35e44 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/behavior/declarative/BehaviorBuilder.java
++++ b/src/main/java/net/minecraft/world/entity/ai/behavior/declarative/BehaviorBuilder.java
+@@ -333,8 +333,19 @@ public class BehaviorBuilder<E extends LivingEntity, M> implements App<BehaviorB
+     static final class PureMemory<E extends LivingEntity, F extends K1, Value> extends BehaviorBuilder<E, MemoryAccessor<F, Value>> {
+         PureMemory(final MemoryCondition<F, Value> query) {
+             super(new BehaviorBuilder.TriggerWithResult<E, MemoryAccessor<F, Value>>() {
++                // Paper start - memory condition tick rate
++                private final String configKey = query.memory().toString().toLowerCase(java.util.Locale.ROOT);
++                private long endTimestamp;
++                // Paper end
+                 @Override
+                 public MemoryAccessor<F, Value> tryTrigger(ServerLevel serverLevel, E livingEntity, long l) {
++                    // Paper start - memory condition tick rate
++                    int tickRate = java.util.Objects.requireNonNullElse(livingEntity.level().paperConfig().tickRates.memoryCondition.get(livingEntity.getType(), this.configKey), -1);
++                    if (tickRate > -1 && l < endTimestamp + tickRate) {
++                        return null;
++                    }
++                    this.endTimestamp = l;
++                    // Paper end
+                     Brain<?> brain = livingEntity.getBrain();
+                     Optional<Value> optional = brain.getMemoryInternal(query.memory());
+                     return optional == null ? null : query.createAccessor(brain, optional);


### PR DESCRIPTION
This setting will help limit the tick rate of OneShot entity tasks because "tick-rate.behaviour" does not limit OneShot tasks.

I did this because players were creating villager farms and the existing settings were not helping me at all:
![img](https://github.com/PaperMC/Paper/assets/78062896/37368824-b6a1-433a-85a5-00c51537ab3a)
