### PR TITLE
Fix MC-172801

### DIFF
--- a/patches/server/1051-Fixes-MC-172801.patch
+++ b/patches/server/1051-Fixes-MC-172801.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Teak Slack <teakislack@gmail.com>
+Date: Sun, 12 Nov 2023 14:38:52 -0500
+Subject: [PATCH] Fixes MC-172801
+
+This patch intends to fix MC-172801, an issue in which the attribute "generic.flying_speed" would not have any effect. This attribute is intended to change the flying speed of parrots and bees,
+and desite being reported as far back as 1.15.2, this issue has never been fixed officially. This patch modifies the flying speed for entities only with the generic.flying_speed attribute. If they 
+do not have that value, parity with vanilla is perserved by setting the flying speed to 0.02F. The value is multiplied by 0.049999999254942 to perserve the vanilla 0.02 flying speed if flying_speed 
+is at its default value.
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index a76eb3d051db0229ed088b71c92ff3f131449007..090cd219b1b1686753309ad55d0305079efea576 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -2976,7 +2976,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
+     }
+ 
+     protected float getFlyingSpeed() {
+-        return this.getControllingPassenger() instanceof net.minecraft.world.entity.player.Player ? this.getSpeed() * 0.1F : 0.02F;
++        // Paper start - apply generic.flying_speed attribute to flying speed (fixes MC-172801)
++        float flyingSpeed = 0.02F;
++        if(this.getAttributes().hasAttribute(Attributes.FLYING_SPEED))
++            flyingSpeed = (float) (this.getAttribute(Attributes.FLYING_SPEED).getValue() * 0.049999999254942D);
++
++        return this.getControllingPassenger() instanceof net.minecraft.world.entity.player.Player ? this.getSpeed() * 0.1F : flyingSpeed;
++        // Paper end
+     }
+ 
+     public float getSpeed() {


### PR DESCRIPTION
Fixes MC-172801

This patch properly applies the generic.flying_speed attribute to bees and parrots. If entities do not have this attribute, they are unaffected. The flying_speed attribute is multiplied by 0.049999999254942 in order to have bees and parrots with the default value of flying_speed be unaffected, having the vanilla 0.02 value.

Closes #9827 