### PR TITLE
Call LivingEntity#onItemPickup before mutation

### DIFF
--- a/patches/server/0859-EntityPickupItemEvent-fixes.patch
+++ b/patches/server/0859-EntityPickupItemEvent-fixes.patch
@@ -25,10 +25,10 @@ index 1c42425b9211bea7cb189e967e566ad80fd278c2..6407ddef8442fce4f310ac4babf3e3de
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java b/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
-index f0059bd69705ecc7964867b103c93e1df9985803..5c13e376dd079134da465044f1057bcce66973a3 100644
+index f0059bd69705ecc7964867b103c93e1df9985803..372d084609216d5437b92ee60810a9efbb0b6f31 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/piglin/PiglinAi.java
-@@ -241,7 +241,10 @@ public class PiglinAi {
+@@ -241,11 +241,16 @@ public class PiglinAi {
          ItemStack itemstack;
  
          // CraftBukkit start
@@ -36,18 +36,16 @@ index f0059bd69705ecc7964867b103c93e1df9985803..5c13e376dd079134da465044f1057bcc
 +        // Paper start - fix event firing twice
 +        if (drop.getItem().is(Items.GOLD_NUGGET) /* && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityPickupItemEvent(piglin, drop, 0, false).isCancelled() */) {
 +            if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityPickupItemEvent(piglin, drop, 0, false).isCancelled()) return;
++            piglin.onItemPickup(drop); // Paper - moved from Piglin#pickUpItem - call prior to item entity modification
 +            // Paper end
              piglin.take(drop, drop.getItem().getCount());
              itemstack = drop.getItem();
              drop.discard();
-@@ -251,6 +254,7 @@ public class PiglinAi {
+         } else if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityPickupItemEvent(piglin, drop, drop.getItem().getCount() - 1, false).isCancelled()) {
++            piglin.onItemPickup(drop); // Paper - moved from Piglin#pickUpItem - call prior to item entity modification
+             piglin.take(drop, 1);
+             itemstack = PiglinAi.removeOneItemFromItemEntity(drop);
          } else {
-             return;
-         }
-+        piglin.onItemPickup(drop); // Paper - moved from Piglin#pickUpItem
-         // CraftBukkit end
- 
-         if (PiglinAi.isLovedItem(itemstack, piglin)) { // CraftBukkit - Changes to allow for custom payment in bartering
 diff --git a/src/main/java/net/minecraft/world/entity/raid/Raider.java b/src/main/java/net/minecraft/world/entity/raid/Raider.java
 index 5538f7a9024d8708b70de836aa78a4015656a828..cdbc925ef61b8b439415f0a89368227890bcecb2 100644
 --- a/src/main/java/net/minecraft/world/entity/raid/Raider.java


### PR DESCRIPTION
The existing EntityPickupItemEvent fixes patch moves the call to LivingEntity#onItemPickup for piglins after the respective EntityPickupItemEvent calls, which is correct.
However the patch moved the call so far down the line that the existing logic already mutated the picked up item entity, leading to faulty state being passed to the onItemPickup method.

To prevent logic in LivingEntity#onItemPickup to read from an ItemEntity that was already mutated, this commit moves the calls prior to the two respective mutations (either gold_nugget or rest).

This was chosen above taking a copy of the original item and restoring state later on to avoid a full item stack clone.

Resolves: #9947