### PR TITLE
Fix EntityShootBowEvent/ProjectileLaunchEvent consuming arrows when cancelled

### DIFF
--- a/patches/api/0108-EntityShootBowEvent-consumeArrow-and-getArrowItem-AP.patch
+++ b/patches/api/0108-EntityShootBowEvent-consumeArrow-and-getArrowItem-AP.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] EntityShootBowEvent consumeArrow and getArrowItem API
 Adds ability to get what arrow was shot, and control if it should be consumed.
 
 diff --git a/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java b/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
-index 1a8366f6757431baaba4f3d48abea3cf0ec1f1ad..e4efcd757ca51a4edd396f55c812dbe89ffb68c7 100644
+index 1a8366f6757431baaba4f3d48abea3cf0ec1f1ad..1da003ded82f943eff0438126227d1d84599f681 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
 @@ -22,7 +22,32 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
@@ -28,12 +28,12 @@ index 1a8366f6757431baaba4f3d48abea3cf0ec1f1ad..e4efcd757ca51a4edd396f55c812dbe8
 +    public ItemStack getArrowItem() {
 +        return this.getConsumable();
 +    }
-+
+ 
 +    @Deprecated
 +    public EntityShootBowEvent(@NotNull final LivingEntity shooter, @Nullable final ItemStack bow, @NotNull final Entity projectile, final float force) {
 +        this(shooter, bow, new ItemStack(org.bukkit.Material.AIR), projectile, force);
 +    }
- 
++
 +    @Deprecated
 +    public EntityShootBowEvent(@NotNull final LivingEntity shooter, @Nullable final ItemStack bow, @NotNull ItemStack arrowItem, @NotNull final Entity projectile, final float force) {
 +        this(shooter, bow, arrowItem, projectile, EquipmentSlot.HAND, force, true);
@@ -42,3 +42,13 @@ index 1a8366f6757431baaba4f3d48abea3cf0ec1f1ad..e4efcd757ca51a4edd396f55c812dbe8
      public EntityShootBowEvent(@NotNull final LivingEntity shooter, @Nullable final ItemStack bow, @Nullable final ItemStack consumable, @NotNull final Entity projectile, @NotNull final EquipmentSlot hand, final float force, final boolean consumeItem) {
          super(shooter);
          this.bow = bow;
+@@ -112,9 +137,7 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
+      * consumed).
+      *
+      * @param consumeItem whether or not to consume the item
+-     * @deprecated not currently functional
+      */
+-    @Deprecated
+     public void setConsumeItem(boolean consumeItem) {
+         this.consumeItem = consumeItem;
+     }

--- a/patches/server/0200-Improve-EntityShootBowEvent.patch
+++ b/patches/server/0200-Improve-EntityShootBowEvent.patch
@@ -72,7 +72,7 @@ index ac983b6f0bd3d3294481d08831063b6e232e5ef6..6e38d4592dcff69e52fbd0f3bae75da9
                      CriteriaTriggers.SHOT_CROSSBOW.trigger(serverPlayer, stack);
                      serverPlayer.awardStat(Stats.ITEM_USED.get(stack.getItem()));
 diff --git a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-index 56595dd3a0b7df4b5f9819ade797212278c8fd40..193d74236a895b716b86962be405bb3cf44cd4a8 100644
+index 56595dd3a0b7df4b5f9819ade797212278c8fd40..6952acb1e1cbe6eb1a1811a6ce1a3b630347454e 100644
 --- a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
 +++ b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
 @@ -46,7 +46,35 @@ public abstract class ProjectileWeaponItem extends Item {
@@ -129,7 +129,7 @@ index 56595dd3a0b7df4b5f9819ade797212278c8fd40..193d74236a895b716b86962be405bb3c
 +                        continue; // Paper - improve shoot bow - call event for each shot entity
                      }
                  }
-+                if (!event.shouldConsumeItem() && iprojectile instanceof final net.minecraft.world.entity.projectile.AbstractArrow abstractArrow) abstractArrow.pickup = net.minecraft.world.entity.projectile.AbstractArrow.Pickup.CREATIVE_ONLY;
++                if (!event.shouldConsumeItem() && iprojectile instanceof final AbstractArrow abstractArrow) abstractArrow.pickup = AbstractArrow.Pickup.CREATIVE_ONLY; // Paper - improve shoot bow - correctly prevent item consumption
 +                if (event.shouldConsumeItem()) unrealizedDrawResult.consumeProjectilesFromPlayerInventory(i); // Paper - improve shoot bow - correctly prevent item consumption
                  // CraftBukkit end
                  stack.hurtAndBreak(this.getDurabilityUse(itemstack1), shooter, LivingEntity.getSlotForHand(hand));

--- a/patches/server/0200-Improve-EntityShootBowEvent.patch
+++ b/patches/server/0200-Improve-EntityShootBowEvent.patch
@@ -46,7 +46,7 @@ index 93e3454de0b0d62895f165b0772526f3eae1e333..c858556ea457931aa14e338e20672cb5
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/item/BowItem.java b/src/main/java/net/minecraft/world/item/BowItem.java
-index 6eb5c0f23d9dc61e69ad5ad493c89602a9dcd4b5..274b62a44ce1b25160e31193ccc32a14c1c6f9f4 100644
+index 6eb5c0f23d9dc61e69ad5ad493c89602a9dcd4b5..ac5056efcbfc251f12b016c4e51c98ee77418db1 100644
 --- a/src/main/java/net/minecraft/world/item/BowItem.java
 +++ b/src/main/java/net/minecraft/world/item/BowItem.java
 @@ -32,7 +32,7 @@ public class BowItem extends ProjectileWeaponItem {
@@ -54,7 +54,7 @@ index 6eb5c0f23d9dc61e69ad5ad493c89602a9dcd4b5..274b62a44ce1b25160e31193ccc32a14
                      List<ItemStack> list = draw(stack, itemStack, player);
                      if (world instanceof ServerLevel serverLevel && !list.isEmpty()) {
 -                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, f * 3.0F, 1.0F, f == 1.0F, null);
-+                        if(!this.shoot(serverLevel, player, player.getUsedItemHand(), stack, new UnrealizedDrawResult(list, itemStack), f * 3.0F, 1.0F, f == 1.0F, null)) return; // Paper - improve shoot bow - correctly prevent item consumption / return if all events were cancelled
++                        if (!this.shoot(serverLevel, player, player.getUsedItemHand(), stack, new UnrealizedDrawResult(list, itemStack), f * 3.0F, 1.0F, f == 1.0F, null)) return; // Paper - improve shoot bow - correctly prevent item consumption / return if all events were cancelled
                      }
  
                      world.playSound(

--- a/patches/server/0200-Improve-EntityShootBowEvent.patch
+++ b/patches/server/0200-Improve-EntityShootBowEvent.patch
@@ -46,12 +46,15 @@ index 93e3454de0b0d62895f165b0772526f3eae1e333..c858556ea457931aa14e338e20672cb5
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/item/BowItem.java b/src/main/java/net/minecraft/world/item/BowItem.java
-index 6eb5c0f23d9dc61e69ad5ad493c89602a9dcd4b5..ac5056efcbfc251f12b016c4e51c98ee77418db1 100644
+index 6eb5c0f23d9dc61e69ad5ad493c89602a9dcd4b5..795489936265bd5f52afdca3122479ffbf8cfe80 100644
 --- a/src/main/java/net/minecraft/world/item/BowItem.java
 +++ b/src/main/java/net/minecraft/world/item/BowItem.java
-@@ -32,7 +32,7 @@ public class BowItem extends ProjectileWeaponItem {
+@@ -30,9 +30,9 @@ public class BowItem extends ProjectileWeaponItem {
+                 int i = this.getUseDuration(stack, user) - remainingUseTicks;
+                 float f = getPowerForTime(i);
                  if (!((double)f < 0.1)) {
-                     List<ItemStack> list = draw(stack, itemStack, player);
+-                    List<ItemStack> list = draw(stack, itemStack, player);
++                    List<ItemStack> list = draw(stack, itemStack, player, ProjectileDrawingItemConsumption.MAYBE_LATER); // // Paper - improve shoot bow - correctly prevent item consumption
                      if (world instanceof ServerLevel serverLevel && !list.isEmpty()) {
 -                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, f * 3.0F, 1.0F, f == 1.0F, null);
 +                        if (!this.shoot(serverLevel, player, player.getUsedItemHand(), stack, new UnrealizedDrawResult(list, itemStack), f * 3.0F, 1.0F, f == 1.0F, null)) return; // Paper - improve shoot bow - correctly prevent item consumption / return if all events were cancelled
@@ -72,7 +75,7 @@ index ac983b6f0bd3d3294481d08831063b6e232e5ef6..6e38d4592dcff69e52fbd0f3bae75da9
                      CriteriaTriggers.SHOT_CROSSBOW.trigger(serverPlayer, stack);
                      serverPlayer.awardStat(Stats.ITEM_USED.get(stack.getItem()));
 diff --git a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-index 56595dd3a0b7df4b5f9819ade797212278c8fd40..6952acb1e1cbe6eb1a1811a6ce1a3b630347454e 100644
+index 56595dd3a0b7df4b5f9819ade797212278c8fd40..8154773fd74d76e83a65e518e6f6959f1012033c 100644
 --- a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
 +++ b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
 @@ -46,7 +46,35 @@ public abstract class ProjectileWeaponItem extends Item {
@@ -91,8 +94,8 @@ index 56595dd3a0b7df4b5f9819ade797212278c8fd40..6952acb1e1cbe6eb1a1811a6ce1a3b63
 +            final ItemStack nonIntangibleStack = projectileStacks.get(projectStackIndex);
 +
 +            // The stack at index 0 was intangible, this means that net.minecraft.world.item.ProjectileWeaponItem.useAmmo
-+            // determined the player was not consuming items anyway, e.g. via creative mode. Do not remove items in this
-+            // case.
++            // determined the player was not consuming items anyway, e.g. via creative mode or because of other API means.
++            // Do not remove items in this case.
 +            if (nonIntangibleStack.has(DataComponents.INTANGIBLE_PROJECTILE)) return;
 +
 +            originalInPlayerInventory.shrink(nonIntangibleStack.getCount());
@@ -142,12 +145,55 @@ index 56595dd3a0b7df4b5f9819ade797212278c8fd40..6952acb1e1cbe6eb1a1811a6ce1a3b63
      }
  
      protected int getDurabilityUse(ItemStack projectile) {
-@@ -174,7 +206,7 @@ public abstract class ProjectileWeaponItem extends Item {
+@@ -114,6 +146,21 @@ public abstract class ProjectileWeaponItem extends Item {
+     }
+ 
+     protected static List<ItemStack> draw(ItemStack stack, ItemStack projectileStack, LivingEntity shooter) {
++    // Paper start - improve bow shoot event - delayed consumption to allow for consumption cancellation
++        return draw(stack, projectileStack, shooter);
++    }
++    protected enum ProjectileDrawingItemConsumption {
++        // Will immediately consume from the passed projectile stack, like vanilla would
++        IMMEDIATELY,
++
++        // Will create a copyWithCount from the projectileStack, allowing for later reduction.
++        // The stacks yielded will adhere to vanilla's intangibility layout, with the first itemstack
++        // being tangible, allowing for it to be picked up once shot.
++        // Callers that do *not* consume later are responsible for marking the shot projectile as intangible.
++        MAYBE_LATER,
++    }
++    protected static List<ItemStack> draw(ItemStack stack, ItemStack projectileStack, LivingEntity shooter, final ProjectileDrawingItemConsumption consumption) {
++    // Paper end - improve bow shoot event - delayed consumption to allow for consumption cancellation
+         if (projectileStack.isEmpty()) {
+             return List.of();
+         } else {
+@@ -133,7 +180,7 @@ public abstract class ProjectileWeaponItem extends Item {
+             ItemStack itemstack2 = projectileStack.copy();
+ 
+             for (int k = 0; k < j; ++k) {
+-                ItemStack itemstack3 = ProjectileWeaponItem.useAmmo(stack, k == 0 ? projectileStack : itemstack2, shooter, k > 0);
++                ItemStack itemstack3 = ProjectileWeaponItem.useAmmo(stack, k == 0 ? projectileStack : itemstack2, shooter, k > 0, consumption);
+ 
+                 if (!itemstack3.isEmpty()) {
+                     list.add(itemstack3);
+@@ -145,6 +192,11 @@ public abstract class ProjectileWeaponItem extends Item {
+     }
+ 
+     protected static ItemStack useAmmo(ItemStack stack, ItemStack projectileStack, LivingEntity shooter, boolean multishot) {
++    // Paper start - improve bow shoot event - delayed consumption to allow for consumption cancellation
++        return useAmmo(stack, projectileStack, shooter, multishot, ProjectileDrawingItemConsumption.IMMEDIATELY);
++    }
++    protected static ItemStack useAmmo(ItemStack stack, ItemStack projectileStack, LivingEntity shooter, boolean multishot, final ProjectileDrawingItemConsumption consumption) {
++    // Paper end - improve bow shoot event - delayed consumption to allow for consumption cancellation
+         int i;
+         label28:
+         {
+@@ -174,7 +226,7 @@ public abstract class ProjectileWeaponItem extends Item {
                  itemstack2.set(DataComponents.INTANGIBLE_PROJECTILE, Unit.INSTANCE);
                  return itemstack2;
              } else {
 -                itemstack2 = projectileStack.split(j);
-+                itemstack2 = projectileStack.copyWithCount(j); // Paper - improve bow shoot event - do not reduce item in player inventory just yet - create full copy
++                itemstack2 = consumption == ProjectileDrawingItemConsumption.MAYBE_LATER ? projectileStack.copyWithCount(j) : projectileStack.split(j); // Paper - improve bow shoot event - do not reduce item in player inventory just yet - create full copy if configured
                  if (projectileStack.isEmpty() && shooter instanceof Player) {
                      Player entityhuman = (Player) shooter;
  

--- a/patches/server/0200-Improve-EntityShootBowEvent.patch
+++ b/patches/server/0200-Improve-EntityShootBowEvent.patch
@@ -46,7 +46,7 @@ index 93e3454de0b0d62895f165b0772526f3eae1e333..c858556ea457931aa14e338e20672cb5
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/item/BowItem.java b/src/main/java/net/minecraft/world/item/BowItem.java
-index 6eb5c0f23d9dc61e69ad5ad493c89602a9dcd4b5..03f04dc429a5ad034285e16c055258ba25df501c 100644
+index 6eb5c0f23d9dc61e69ad5ad493c89602a9dcd4b5..274b62a44ce1b25160e31193ccc32a14c1c6f9f4 100644
 --- a/src/main/java/net/minecraft/world/item/BowItem.java
 +++ b/src/main/java/net/minecraft/world/item/BowItem.java
 @@ -32,7 +32,7 @@ public class BowItem extends ProjectileWeaponItem {
@@ -54,15 +54,28 @@ index 6eb5c0f23d9dc61e69ad5ad493c89602a9dcd4b5..03f04dc429a5ad034285e16c055258ba
                      List<ItemStack> list = draw(stack, itemStack, player);
                      if (world instanceof ServerLevel serverLevel && !list.isEmpty()) {
 -                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, f * 3.0F, 1.0F, f == 1.0F, null);
-+                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, new UnrealizedDrawResult(list, itemStack), f * 3.0F, 1.0F, f == 1.0F, null); // Paper - improve shoot bow - correctly prevent item consumption
++                        if(!this.shoot(serverLevel, player, player.getUsedItemHand(), stack, new UnrealizedDrawResult(list, itemStack), f * 3.0F, 1.0F, f == 1.0F, null)) return; // Paper - improve shoot bow - correctly prevent item consumption / return if all events were cancelled
                      }
  
                      world.playSound(
+diff --git a/src/main/java/net/minecraft/world/item/CrossbowItem.java b/src/main/java/net/minecraft/world/item/CrossbowItem.java
+index ac983b6f0bd3d3294481d08831063b6e232e5ef6..6e38d4592dcff69e52fbd0f3bae75da9619fd550 100644
+--- a/src/main/java/net/minecraft/world/item/CrossbowItem.java
++++ b/src/main/java/net/minecraft/world/item/CrossbowItem.java
+@@ -186,7 +186,7 @@ public class CrossbowItem extends ProjectileWeaponItem {
+         if (world instanceof ServerLevel serverLevel) {
+             ChargedProjectiles chargedProjectiles = stack.set(DataComponents.CHARGED_PROJECTILES, ChargedProjectiles.EMPTY);
+             if (chargedProjectiles != null && !chargedProjectiles.isEmpty()) {
+-                this.shoot(serverLevel, shooter, hand, stack, chargedProjectiles.getItems(), speed, divergence, shooter instanceof Player, target);
++                if (!this.shoot(serverLevel, shooter, hand, stack, new UnrealizedDrawResult(chargedProjectiles.getItems(), null), speed, divergence, shooter instanceof Player, target)) return; // Paper - improve shoot bow - return if all events were cancelled
+                 if (shooter instanceof ServerPlayer serverPlayer) {
+                     CriteriaTriggers.SHOT_CROSSBOW.trigger(serverPlayer, stack);
+                     serverPlayer.awardStat(Stats.ITEM_USED.get(stack.getItem()));
 diff --git a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-index 56595dd3a0b7df4b5f9819ade797212278c8fd40..0ee3109b3f5b7693bb045f91c239aab1866732f8 100644
+index 56595dd3a0b7df4b5f9819ade797212278c8fd40..193d74236a895b716b86962be405bb3cf44cd4a8 100644
 --- a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
 +++ b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-@@ -46,7 +46,34 @@ public abstract class ProjectileWeaponItem extends Item {
+@@ -46,7 +46,35 @@ public abstract class ProjectileWeaponItem extends Item {
  
      public abstract int getDefaultProjectileRange();
  
@@ -91,14 +104,29 @@ index 56595dd3a0b7df4b5f9819ade797212278c8fd40..0ee3109b3f5b7693bb045f91c239aab1
 +    // Paper start - improve shoot bow - correctly prevent item consumption
 +        shoot(world, shooter, hand, stack, new UnrealizedDrawResult(projectiles, null), speed, divergence, critical, target);
 +    }
-+    protected void shoot(ServerLevel world, LivingEntity shooter, InteractionHand hand, ItemStack stack, UnrealizedDrawResult unrealizedDrawResult, float speed, float divergence, boolean critical, @Nullable LivingEntity target) {
++    protected boolean shoot(ServerLevel world, LivingEntity shooter, InteractionHand hand, ItemStack stack, UnrealizedDrawResult unrealizedDrawResult, float speed, float divergence, boolean critical, @Nullable LivingEntity target) {
 +        final List<ItemStack> projectiles = unrealizedDrawResult.projectileStacks();
++        boolean atLeastOneShootBowEventUncancelled = false;
 +    // Paper end - improve shoot bow - correctly prevent item consumption
          float f2 = EnchantmentHelper.processProjectileSpread(world, stack, shooter, 0.0F);
          float f3 = projectiles.size() == 1 ? 0.0F : 2.0F * f2 / (float) (projectiles.size() - 1);
          float f4 = (float) ((projectiles.size() - 1) % 2) * f3 / 2.0F;
-@@ -77,6 +104,8 @@ public abstract class ProjectileWeaponItem extends Item {
-                         return;
+@@ -66,17 +94,20 @@ public abstract class ProjectileWeaponItem extends Item {
+                 org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(shooter, stack, itemstack1, iprojectile, hand, speed, true);
+                 if (event.isCancelled()) {
+                     event.getProjectile().remove();
+-                    return;
++                    continue; // Paper - improve shoot bow - call event for each shot entity
+                 }
++                atLeastOneShootBowEventUncancelled = true; // Paper - improve shoot bow - track event cancellation to potentially skip sounds/stats
+ 
+                 if (event.getProjectile() == iprojectile.getBukkitEntity()) {
+                     if (!world.addFreshEntity(iprojectile)) {
+                         if (shooter instanceof net.minecraft.server.level.ServerPlayer) {
+                             ((net.minecraft.server.level.ServerPlayer) shooter).getBukkitEntity().updateInventory();
+                         }
+-                        return;
++                        continue; // Paper - improve shoot bow - call event for each shot entity
                      }
                  }
 +                if (!event.shouldConsumeItem() && iprojectile instanceof final net.minecraft.world.entity.projectile.AbstractArrow abstractArrow) abstractArrow.pickup = net.minecraft.world.entity.projectile.AbstractArrow.Pickup.CREATIVE_ONLY;
@@ -106,7 +134,15 @@ index 56595dd3a0b7df4b5f9819ade797212278c8fd40..0ee3109b3f5b7693bb045f91c239aab1
                  // CraftBukkit end
                  stack.hurtAndBreak(this.getDurabilityUse(itemstack1), shooter, LivingEntity.getSlotForHand(hand));
                  if (stack.isEmpty()) {
-@@ -174,7 +203,7 @@ public abstract class ProjectileWeaponItem extends Item {
+@@ -85,6 +116,7 @@ public abstract class ProjectileWeaponItem extends Item {
+             }
+         }
+ 
++        return atLeastOneShootBowEventUncancelled; // Paper - improve shoot bow - track event cancellation to potentially skip sounds/stats
+     }
+ 
+     protected int getDurabilityUse(ItemStack projectile) {
+@@ -174,7 +206,7 @@ public abstract class ProjectileWeaponItem extends Item {
                  itemstack2.set(DataComponents.INTANGIBLE_PROJECTILE, Unit.INSTANCE);
                  return itemstack2;
              } else {

--- a/patches/server/0200-Improve-EntityShootBowEvent.patch
+++ b/patches/server/0200-Improve-EntityShootBowEvent.patch
@@ -45,3 +45,73 @@ index 93e3454de0b0d62895f165b0772526f3eae1e333..c858556ea457931aa14e338e20672cb5
      }
  
      @Override
+diff --git a/src/main/java/net/minecraft/world/item/BowItem.java b/src/main/java/net/minecraft/world/item/BowItem.java
+index 6eb5c0f23d9dc61e69ad5ad493c89602a9dcd4b5..03f04dc429a5ad034285e16c055258ba25df501c 100644
+--- a/src/main/java/net/minecraft/world/item/BowItem.java
++++ b/src/main/java/net/minecraft/world/item/BowItem.java
+@@ -32,7 +32,7 @@ public class BowItem extends ProjectileWeaponItem {
+                 if (!((double)f < 0.1)) {
+                     List<ItemStack> list = draw(stack, itemStack, player);
+                     if (world instanceof ServerLevel serverLevel && !list.isEmpty()) {
+-                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, list, f * 3.0F, 1.0F, f == 1.0F, null);
++                        this.shoot(serverLevel, player, player.getUsedItemHand(), stack, new UnrealizedDrawResult(list, itemStack), f * 3.0F, 1.0F, f == 1.0F, null); // Paper - improve shoot bow - correctly prevent item consumption
+                     }
+ 
+                     world.playSound(
+diff --git a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
+index 56595dd3a0b7df4b5f9819ade797212278c8fd40..0ee3109b3f5b7693bb045f91c239aab1866732f8 100644
+--- a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
++++ b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
+@@ -46,7 +46,34 @@ public abstract class ProjectileWeaponItem extends Item {
+ 
+     public abstract int getDefaultProjectileRange();
+ 
++    // Paper start - improve shoot bow - correctly prevent item consumption
++    protected record UnrealizedDrawResult(
++        List<ItemStack> projectileStacks,
++        @Nullable ItemStack originalInPlayerInventory // Null in case the unrealised draw result is a noop (case of Crossbow)
++    ) {
++        public void consumeProjectilesFromPlayerInventory(int projectStackIndex) {
++            if (projectStackIndex != 0 || originalInPlayerInventory == null) return;
++
++            if (projectileStacks.isEmpty()) return; // Whatever happened hear, nothing
++            final ItemStack nonIntangibleStack = projectileStacks.get(projectStackIndex);
++
++            // The stack at index 0 was intangible, this means that net.minecraft.world.item.ProjectileWeaponItem.useAmmo
++            // determined the player was not consuming items anyway, e.g. via creative mode. Do not remove items in this
++            // case.
++            if (nonIntangibleStack.has(DataComponents.INTANGIBLE_PROJECTILE)) return;
++
++            originalInPlayerInventory.shrink(nonIntangibleStack.getCount());
++        }
++    }
++    // Paper end - improve shoot bow - correctly prevent item consumption
++
+     protected void shoot(ServerLevel world, LivingEntity shooter, InteractionHand hand, ItemStack stack, List<ItemStack> projectiles, float speed, float divergence, boolean critical, @Nullable LivingEntity target) {
++    // Paper start - improve shoot bow - correctly prevent item consumption
++        shoot(world, shooter, hand, stack, new UnrealizedDrawResult(projectiles, null), speed, divergence, critical, target);
++    }
++    protected void shoot(ServerLevel world, LivingEntity shooter, InteractionHand hand, ItemStack stack, UnrealizedDrawResult unrealizedDrawResult, float speed, float divergence, boolean critical, @Nullable LivingEntity target) {
++        final List<ItemStack> projectiles = unrealizedDrawResult.projectileStacks();
++    // Paper end - improve shoot bow - correctly prevent item consumption
+         float f2 = EnchantmentHelper.processProjectileSpread(world, stack, shooter, 0.0F);
+         float f3 = projectiles.size() == 1 ? 0.0F : 2.0F * f2 / (float) (projectiles.size() - 1);
+         float f4 = (float) ((projectiles.size() - 1) % 2) * f3 / 2.0F;
+@@ -77,6 +104,8 @@ public abstract class ProjectileWeaponItem extends Item {
+                         return;
+                     }
+                 }
++                if (!event.shouldConsumeItem() && iprojectile instanceof final net.minecraft.world.entity.projectile.AbstractArrow abstractArrow) abstractArrow.pickup = net.minecraft.world.entity.projectile.AbstractArrow.Pickup.CREATIVE_ONLY;
++                if (event.shouldConsumeItem()) unrealizedDrawResult.consumeProjectilesFromPlayerInventory(i); // Paper - improve shoot bow - correctly prevent item consumption
+                 // CraftBukkit end
+                 stack.hurtAndBreak(this.getDurabilityUse(itemstack1), shooter, LivingEntity.getSlotForHand(hand));
+                 if (stack.isEmpty()) {
+@@ -174,7 +203,7 @@ public abstract class ProjectileWeaponItem extends Item {
+                 itemstack2.set(DataComponents.INTANGIBLE_PROJECTILE, Unit.INSTANCE);
+                 return itemstack2;
+             } else {
+-                itemstack2 = projectileStack.split(j);
++                itemstack2 = projectileStack.copyWithCount(j); // Paper - improve bow shoot event - do not reduce item in player inventory just yet - create full copy
+                 if (projectileStack.isEmpty() && shooter instanceof Player) {
+                     Player entityhuman = (Player) shooter;
+ 

--- a/patches/server/0200-Improve-EntityShootBowEvent.patch
+++ b/patches/server/0200-Improve-EntityShootBowEvent.patch
@@ -75,7 +75,7 @@ index ac983b6f0bd3d3294481d08831063b6e232e5ef6..6e38d4592dcff69e52fbd0f3bae75da9
                      CriteriaTriggers.SHOT_CROSSBOW.trigger(serverPlayer, stack);
                      serverPlayer.awardStat(Stats.ITEM_USED.get(stack.getItem()));
 diff --git a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-index 56595dd3a0b7df4b5f9819ade797212278c8fd40..8154773fd74d76e83a65e518e6f6959f1012033c 100644
+index 56595dd3a0b7df4b5f9819ade797212278c8fd40..91cf693afb95893a2e2d6c7259a3372b0169da7c 100644
 --- a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
 +++ b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
 @@ -46,7 +46,35 @@ public abstract class ProjectileWeaponItem extends Item {
@@ -150,7 +150,7 @@ index 56595dd3a0b7df4b5f9819ade797212278c8fd40..8154773fd74d76e83a65e518e6f6959f
  
      protected static List<ItemStack> draw(ItemStack stack, ItemStack projectileStack, LivingEntity shooter) {
 +    // Paper start - improve bow shoot event - delayed consumption to allow for consumption cancellation
-+        return draw(stack, projectileStack, shooter);
++        return draw(stack, projectileStack, shooter, ProjectileDrawingItemConsumption.IMMEDIATELY);
 +    }
 +    protected enum ProjectileDrawingItemConsumption {
 +        // Will immediately consume from the passed projectile stack, like vanilla would

--- a/patches/server/0459-Add-EntityLoadCrossbowEvent.patch
+++ b/patches/server/0459-Add-EntityLoadCrossbowEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add EntityLoadCrossbowEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/CrossbowItem.java b/src/main/java/net/minecraft/world/item/CrossbowItem.java
-index ac983b6f0bd3d3294481d08831063b6e232e5ef6..1467e6f2df302e0b7992dcb6c136cb626ade3d2b 100644
+index 6e38d4592dcff69e52fbd0f3bae75da9619fd550..68f1e837dfef9954fa47d7d6523c6e482dafb5ea 100644
 --- a/src/main/java/net/minecraft/world/item/CrossbowItem.java
 +++ b/src/main/java/net/minecraft/world/item/CrossbowItem.java
 @@ -89,7 +89,14 @@ public class CrossbowItem extends ProjectileWeaponItem {
@@ -42,10 +42,10 @@ index ac983b6f0bd3d3294481d08831063b6e232e5ef6..1467e6f2df302e0b7992dcb6c136cb62
              crossbow.set(DataComponents.CHARGED_PROJECTILES, ChargedProjectiles.of(list));
              return true;
 diff --git a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-index 0ee3109b3f5b7693bb045f91c239aab1866732f8..5236048914f1aba42ded4accb5456af2b550dce4 100644
+index 193d74236a895b716b86962be405bb3cf44cd4a8..312c8d3da59750440cebc2c574cb2615cbdb0727 100644
 --- a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
 +++ b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-@@ -143,6 +143,11 @@ public abstract class ProjectileWeaponItem extends Item {
+@@ -146,6 +146,11 @@ public abstract class ProjectileWeaponItem extends Item {
      }
  
      protected static List<ItemStack> draw(ItemStack stack, ItemStack projectileStack, LivingEntity shooter) {
@@ -57,7 +57,7 @@ index 0ee3109b3f5b7693bb045f91c239aab1866732f8..5236048914f1aba42ded4accb5456af2
          if (projectileStack.isEmpty()) {
              return List.of();
          } else {
-@@ -162,7 +167,7 @@ public abstract class ProjectileWeaponItem extends Item {
+@@ -165,7 +170,7 @@ public abstract class ProjectileWeaponItem extends Item {
              ItemStack itemstack2 = projectileStack.copy();
  
              for (int k = 0; k < j; ++k) {

--- a/patches/server/0459-Add-EntityLoadCrossbowEvent.patch
+++ b/patches/server/0459-Add-EntityLoadCrossbowEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add EntityLoadCrossbowEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/CrossbowItem.java b/src/main/java/net/minecraft/world/item/CrossbowItem.java
-index 6e38d4592dcff69e52fbd0f3bae75da9619fd550..68f1e837dfef9954fa47d7d6523c6e482dafb5ea 100644
+index 6e38d4592dcff69e52fbd0f3bae75da9619fd550..6ba8b38425291cf2469dad8016dbae5a2bbdb751 100644
 --- a/src/main/java/net/minecraft/world/item/CrossbowItem.java
 +++ b/src/main/java/net/minecraft/world/item/CrossbowItem.java
 @@ -89,7 +89,14 @@ public class CrossbowItem extends ProjectileWeaponItem {
@@ -36,33 +36,31 @@ index 6e38d4592dcff69e52fbd0f3bae75da9619fd550..68f1e837dfef9954fa47d7d6523c6e48
 +        return CrossbowItem.tryLoadProjectiles(shooter, crossbow, true);
 +    }
 +    private static boolean tryLoadProjectiles(LivingEntity shooter, ItemStack crossbow, boolean consume) {
-+        List<ItemStack> list = draw(crossbow, shooter.getProjectile(crossbow), shooter, consume);
++        List<ItemStack> list = draw(crossbow, shooter.getProjectile(crossbow), shooter, consume ? ProjectileDrawingItemConsumption.IMMEDIATELY : ProjectileDrawingItemConsumption.NEVER);
 +        // Paper end - Add EntityLoadCrossbowEvent
          if (!list.isEmpty()) {
              crossbow.set(DataComponents.CHARGED_PROJECTILES, ChargedProjectiles.of(list));
              return true;
 diff --git a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-index 193d74236a895b716b86962be405bb3cf44cd4a8..312c8d3da59750440cebc2c574cb2615cbdb0727 100644
+index 8154773fd74d76e83a65e518e6f6959f1012033c..52555846a873f5006c58f7e1e08f5190854c30ba 100644
 --- a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
 +++ b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-@@ -146,6 +146,11 @@ public abstract class ProjectileWeaponItem extends Item {
+@@ -158,6 +158,9 @@ public abstract class ProjectileWeaponItem extends Item {
+         // being tangible, allowing for it to be picked up once shot.
+         // Callers that do *not* consume later are responsible for marking the shot projectile as intangible.
+         MAYBE_LATER,
++
++        // Will not reduce the passed projectile stack and prepare all returned items to be intangible.
++        NEVER,
      }
+     protected static List<ItemStack> draw(ItemStack stack, ItemStack projectileStack, LivingEntity shooter, final ProjectileDrawingItemConsumption consumption) {
+     // Paper end - improve bow shoot event - delayed consumption to allow for consumption cancellation
+@@ -200,7 +203,7 @@ public abstract class ProjectileWeaponItem extends Item {
+         int i;
+         label28:
+         {
+-            if (!multishot && !shooter.hasInfiniteMaterials()) {
++            if (!multishot && !shooter.hasInfiniteMaterials() && consumption != ProjectileDrawingItemConsumption.NEVER) { // Paper - add EntityLoadCrossbowEvent
+                 Level world = shooter.level();
  
-     protected static List<ItemStack> draw(ItemStack stack, ItemStack projectileStack, LivingEntity shooter) {
-+        // Paper start
-+        return draw(stack, projectileStack, shooter, true);
-+    }
-+    protected static List<ItemStack> draw(ItemStack stack, ItemStack projectileStack, LivingEntity shooter, boolean consume) {
-+        // Paper end
-         if (projectileStack.isEmpty()) {
-             return List.of();
-         } else {
-@@ -165,7 +170,7 @@ public abstract class ProjectileWeaponItem extends Item {
-             ItemStack itemstack2 = projectileStack.copy();
- 
-             for (int k = 0; k < j; ++k) {
--                ItemStack itemstack3 = ProjectileWeaponItem.useAmmo(stack, k == 0 ? projectileStack : itemstack2, shooter, k > 0);
-+                ItemStack itemstack3 = ProjectileWeaponItem.useAmmo(stack, k == 0 ? projectileStack : itemstack2, shooter, k > 0 || !consume); // Paper
- 
-                 if (!itemstack3.isEmpty()) {
-                     list.add(itemstack3);
+                 if (world instanceof ServerLevel) {

--- a/patches/server/0459-Add-EntityLoadCrossbowEvent.patch
+++ b/patches/server/0459-Add-EntityLoadCrossbowEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add EntityLoadCrossbowEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/CrossbowItem.java b/src/main/java/net/minecraft/world/item/CrossbowItem.java
-index f64cdfac1fc1333845ea4ea5efb7922f0ae39619..c39fa953accd6cf35672f452052cca42fe6f29d0 100644
+index ac983b6f0bd3d3294481d08831063b6e232e5ef6..1467e6f2df302e0b7992dcb6c136cb626ade3d2b 100644
 --- a/src/main/java/net/minecraft/world/item/CrossbowItem.java
 +++ b/src/main/java/net/minecraft/world/item/CrossbowItem.java
 @@ -89,7 +89,14 @@ public class CrossbowItem extends ProjectileWeaponItem {
@@ -42,10 +42,10 @@ index f64cdfac1fc1333845ea4ea5efb7922f0ae39619..c39fa953accd6cf35672f452052cca42
              crossbow.set(DataComponents.CHARGED_PROJECTILES, ChargedProjectiles.of(list));
              return true;
 diff --git a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-index 56595dd3a0b7df4b5f9819ade797212278c8fd40..32dd0b13a0819f597d8a93c6bc3a155781067544 100644
+index 0ee3109b3f5b7693bb045f91c239aab1866732f8..5236048914f1aba42ded4accb5456af2b550dce4 100644
 --- a/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
 +++ b/src/main/java/net/minecraft/world/item/ProjectileWeaponItem.java
-@@ -114,6 +114,11 @@ public abstract class ProjectileWeaponItem extends Item {
+@@ -143,6 +143,11 @@ public abstract class ProjectileWeaponItem extends Item {
      }
  
      protected static List<ItemStack> draw(ItemStack stack, ItemStack projectileStack, LivingEntity shooter) {
@@ -57,7 +57,7 @@ index 56595dd3a0b7df4b5f9819ade797212278c8fd40..32dd0b13a0819f597d8a93c6bc3a1557
          if (projectileStack.isEmpty()) {
              return List.of();
          } else {
-@@ -133,7 +138,7 @@ public abstract class ProjectileWeaponItem extends Item {
+@@ -162,7 +167,7 @@ public abstract class ProjectileWeaponItem extends Item {
              ItemStack itemstack2 = projectileStack.copy();
  
              for (int k = 0; k < j; ++k) {


### PR DESCRIPTION
closes #9919 (inventory desync doesn't seem to be an issue anymore since the arrow just gets consumed even when cancelled)
closes #7702 (same here)
closes #11113 
closes #10665
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9949.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/2005820922.zip)