### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0001-Convert-project-to-Gradle.patch
+++ b/patches/api/0001-Convert-project-to-Gradle.patch
@@ -8,7 +8,7 @@ apply if there are changes made to it from upstream - thus notifying us
 that changes were made.
 
 diff --git a/.gitignore b/.gitignore
-index 11038da2e071699d6561a331565db0c8d7850d0e..317acfec5894101294a55abff61819431e6a5e65 100644
+index 5dd700a956e915c00b25d91dea8d6f285ddab72b..97e78e27ee0eea2c8b24886eeb19164d552323fe 100644
 --- a/.gitignore
 +++ b/.gitignore
 @@ -1,3 +1,5 @@
@@ -17,7 +17,7 @@ index 11038da2e071699d6561a331565db0c8d7850d0e..317acfec5894101294a55abff6181943
  # Eclipse stuff
  /.classpath
  /.project
-@@ -31,3 +33,7 @@
+@@ -32,3 +34,7 @@
  *.ipr
  *.iws
  .idea/

--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -763,7 +763,7 @@ index 0000000000000000000000000000000000000000..6e94562d79206d88b74b53814f9423f1
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 1cd0bc6b58b1fe391f77b95182ed848f2e74a9a5..55b61b5971ac0848174bd4d59952408c437f0e60 100644
+index ea881e5b8fcde8768bd884fde737d38f6ee07a5f..0272b699bd2351511856fe116162a965e928ebc0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -390,7 +390,9 @@ public final class Bukkit {
@@ -1161,7 +1161,7 @@ index ae7b51341fb66c41b8a7c4604fd273d876e311be..4034fcb9abc39b12f0de47c4b679f2ef
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 3a0f7405a481327dd94cfb5fc693ce07c2223954..19d61b2425794b2ca4dbc76bda9e23abe97fc30d 100644
+index 0f38cffd9d858eb3b959d30388e82a77af913ecb..be29b60651f0ab9cae4e0a3ff1df4e8b0422a947 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -62,13 +62,13 @@ import org.jetbrains.annotations.Nullable;
@@ -1508,7 +1508,7 @@ index efb97712cc9dc7c1e12a59f5b94e4f2ad7c6b7d8..3024468af4c073324e536c1cb26beffb
                  return warning == null || warning.value();
              }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 5c9d74a5d8876507ee855dbecc2bfa8755f4062e..1403d28bf9124e3c4cd741dfda06400318e8a0a0 100644
+index cd000a064732ebaa8802f3d7b7ba9bd7ba101f14..30dc2f85b60877930cab68230d3259ce92c08618 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -45,7 +45,7 @@ import org.jetbrains.annotations.Nullable;
@@ -2134,7 +2134,7 @@ index ead9a9aaad3c7469a9393f3c73aa9a5fdb5b7406..121cd27185269339babae1757a604fbb
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481aa7f9f51 100644
+index fc37e0c604e44dd2df54b51cd2f10dd9004f1d98..3f9ed7dfb4633804fe86857dcc9f57aa8cf3ae37 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -51,7 +51,41 @@ import org.jetbrains.annotations.Nullable;
@@ -2325,7 +2325,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      /**
       * Adds this user to the {@link ProfileBanList}. If a previous ban exists, this will
       * update the entry.
-@@ -737,6 +836,106 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -798,6 +897,106 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendEquipmentChange(@NotNull LivingEntity entity, @NotNull Map<EquipmentSlot, ItemStack> items);
  
@@ -2432,7 +2432,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      /**
       * Send a sign change. This fakes a sign change packet for a user at
       * a certain location. This will not actually change the world in any way.
-@@ -754,7 +953,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -815,7 +1014,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param lines the new text on the sign or null to clear it
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -2444,7 +2444,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines) throws IllegalArgumentException;
  
      /**
-@@ -776,7 +979,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -837,7 +1040,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -2456,7 +2456,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException;
  
      /**
-@@ -799,7 +1006,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -860,7 +1067,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -2468,7 +2468,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException;
  
      /**
-@@ -1315,6 +1526,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1376,6 +1587,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *     pack correctly.
       * </ul>
       *
@@ -2476,7 +2476,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
       * @param url The URL from which the client will download the resource
       *     pack. The string must contain only US-ASCII characters and should
       *     be encoded as per RFC 1738.
-@@ -1327,6 +1539,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1388,6 +1600,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
       *     long.
       */
@@ -2484,7 +2484,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      public void setResourcePack(@NotNull String url, @Nullable byte[] hash);
  
      /**
-@@ -1358,6 +1571,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1419,6 +1632,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *     pack correctly.
       * </ul>
       *
@@ -2492,7 +2492,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
       * @param url The URL from which the client will download the resource
       *     pack. The string must contain only US-ASCII characters and should
       *     be encoded as per RFC 1738.
-@@ -1371,8 +1585,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1432,8 +1646,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
       *     long.
       */
@@ -2550,7 +2550,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      /**
       * Request that the player's client download and switch resource packs.
       * <p>
-@@ -1447,6 +1710,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1463,6 +1726,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *     pack correctly.
       * </ul>
       *
@@ -2558,7 +2558,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
       * @param url The URL from which the client will download the resource
       *     pack. The string must contain only US-ASCII characters and should
       *     be encoded as per RFC 1738.
-@@ -1462,8 +1726,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1523,8 +1787,57 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
       *     long.
       */
@@ -2616,7 +2616,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      /**
       * Gets the Scoreboard displayed to this player
       *
-@@ -1598,7 +1911,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1659,7 +1972,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param title Title text
       * @param subtitle Subtitle text
@@ -2625,7 +2625,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
       */
      @Deprecated
      public void sendTitle(@Nullable String title, @Nullable String subtitle);
-@@ -1617,7 +1930,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1678,7 +1991,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param fadeIn time in ticks for titles to fade in. Defaults to 10.
       * @param stay time in ticks for titles to stay. Defaults to 70.
       * @param fadeOut time in ticks for titles to fade out. Defaults to 20.
@@ -2635,7 +2635,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      public void sendTitle(@Nullable String title, @Nullable String subtitle, int fadeIn, int stay, int fadeOut);
  
      /**
-@@ -1844,6 +2159,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1905,6 +2220,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -2650,7 +2650,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1869,8 +2192,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1930,8 +2253,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -2661,7 +2661,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      public String getLocale();
  
      /**
-@@ -1922,6 +2247,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1983,6 +2308,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public boolean isAllowingServerListings();
  
@@ -2676,7 +2676,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1953,11 +2286,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2014,11 +2347,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -2690,7 +2690,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1968,7 +2303,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2029,7 +2364,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -2700,7 +2700,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1978,7 +2315,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2039,7 +2376,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -2710,7 +2710,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1989,7 +2328,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2050,7 +2389,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -2720,7 +2720,7 @@ index 3d84a75a6999129353a9ead48f9db25bc80f685b..e5a54a2f35d83f8c7a5f2b6512b86481
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable java.util.UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -2000,7 +2341,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2061,7 +2402,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send

--- a/patches/api/0011-Timings-v2.patch
+++ b/patches/api/0011-Timings-v2.patch
@@ -2854,7 +2854,7 @@ index 0000000000000000000000000000000000000000..3e61a926620a67daec3af54b72a1b911
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 55b61b5971ac0848174bd4d59952408c437f0e60..dd60025dd956dd360ded51e056163c31908b6d5e 100644
+index 0272b699bd2351511856fe116162a965e928ebc0..7300bba67cfd4d312c59b0f81f597ea0f8a54fcd 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -834,7 +834,6 @@ public final class Bukkit {
@@ -2866,7 +2866,7 @@ index 55b61b5971ac0848174bd4d59952408c437f0e60..dd60025dd956dd360ded51e056163c31
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 19d61b2425794b2ca4dbc76bda9e23abe97fc30d..4cb488d68abc80aae733eb6b17e9cfa015c5a229 100644
+index be29b60651f0ab9cae4e0a3ff1df4e8b0422a947..31227e818b624d641bb7562ac3de8a821815d33a 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1904,6 +1904,26 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -3455,10 +3455,10 @@ index 516d7fc7812aac343782861d0d567f54aa578c2a..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index e5a54a2f35d83f8c7a5f2b6512b86481aa7f9f51..c54d478035f7782074c00f870d41da8283fec538 100644
+index 3f9ed7dfb4633804fe86857dcc9f57aa8cf3ae37..e237c2d34cdbd9968eab4628bb1c0155554586e7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2346,7 +2346,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2407,7 +2407,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          @Deprecated // Paper
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable java.util.UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");

--- a/patches/api/0013-Player-affects-spawning-API.patch
+++ b/patches/api/0013-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c54d478035f7782074c00f870d41da8283fec538..f21183cd5491b09e4543839252aed1ea10ddf849 100644
+index e237c2d34cdbd9968eab4628bb1c0155554586e7..081dbaebc0b209839d48ccbda85ae1a9ed0be439 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2198,6 +2198,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2259,6 +2259,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0018-Add-view-distance-API.patch
+++ b/patches/api/0018-Add-view-distance-API.patch
@@ -8,10 +8,10 @@ Add per player no-tick, tick, and send view distances.
 Also add send/no-tick view distance to World.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 1403d28bf9124e3c4cd741dfda06400318e8a0a0..3559115d09b57acf5c2853b811862e5131f2a625 100644
+index 30dc2f85b60877930cab68230d3259ce92c08618..2867faf0acbbbb2e99c5b503f0c6bc83f3bfe80f 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2663,6 +2663,62 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2745,6 +2745,62 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      int getSimulationDistance();
      // Spigot end
  
@@ -75,10 +75,10 @@ index 1403d28bf9124e3c4cd741dfda06400318e8a0a0..3559115d09b57acf5c2853b811862e51
      public class Spigot {
  
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f21183cd5491b09e4543839252aed1ea10ddf849..f9b9e0269b3a9402c5be1c1c2007956415ff708a 100644
+index 081dbaebc0b209839d48ccbda85ae1a9ed0be439..fa7637dd594821ffd20a53c6c7f5b3d9fa107564 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2212,6 +2212,78 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2273,6 +2273,78 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0022-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0022-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Graduate bungeecord chat API from spigot subclasses
 Change Javadoc to be accurate
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 2a287fc77ef5cc6404dccdab01740e2b8b11ef43..9d1f1b97a16524ba1d523dd9130f113f0cf3e779 100644
+index 4c5671cf75143e741d945834a2a8b56cb52f20dd..3118da2ad367b5bd547769214112ea5299c95866 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -411,6 +411,30 @@ public final class Bukkit {
@@ -41,7 +41,7 @@ index 2a287fc77ef5cc6404dccdab01740e2b8b11ef43..9d1f1b97a16524ba1d523dd9130f113f
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e0ca9516051bc566da2783f0574e791166d5922c..38e3bc502e66229a24833ab1eebba6816155fa19 100644
+index 7ee7fdc8379078456492da00bb213a0738cc6f08..d94483d1481f233897faf378e6b34b6b97f02caf 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -346,6 +346,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -76,10 +76,10 @@ index e0ca9516051bc566da2783f0574e791166d5922c..38e3bc502e66229a24833ab1eebba681
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f9b9e0269b3a9402c5be1c1c2007956415ff708a..284bb156c4430a9a8afce0a7dffa96722b8c29cc 100644
+index fa7637dd594821ffd20a53c6c7f5b3d9fa107564..944153f0d72c6ff5b7250e3d4b4591829deb16c2 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1041,6 +1041,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1102,6 +1102,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  

--- a/patches/api/0026-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/api/0026-Player-Tab-List-and-Title-APIs.patch
@@ -432,10 +432,10 @@ index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb90
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 284bb156c4430a9a8afce0a7dffa96722b8c29cc..d5746291dd0cfc32591482945040e992ad1efb8e 100644
+index 944153f0d72c6ff5b7250e3d4b4591829deb16c2..2025cad529cf317384f6968b7fb65a555b0668c2 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1075,6 +1075,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1136,6 +1136,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }

--- a/patches/api/0028-Complete-resource-pack-API.patch
+++ b/patches/api/0028-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d5746291dd0cfc32591482945040e992ad1efb8e..e12d28143a213abdc0552a15e82cacecc414ca26 100644
+index 2025cad529cf317384f6968b7fb65a555b0668c2..f2311a9842a4d7c45fc88b9f8ca485005a3b3352 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1655,7 +1655,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1716,7 +1716,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the URL is null.
       * @throws IllegalArgumentException Thrown if the URL is too long. The
       *     length restriction is an implementation specific arbitrary value.
@@ -18,7 +18,7 @@ index d5746291dd0cfc32591482945040e992ad1efb8e..e12d28143a213abdc0552a15e82cacec
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -2502,6 +2504,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2563,6 +2565,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0047-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0047-Add-String-based-Action-Bar-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index e12d28143a213abdc0552a15e82cacecc414ca26..3954f40b23536fec495585a8b14e82d092d62e39 100644
+index f2311a9842a4d7c45fc88b9f8ca485005a3b3352..05795d5e86c7427bb962144b66e43f68a9fa3ff3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1042,6 +1042,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1103,6 +1103,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start
@@ -48,7 +48,7 @@ index e12d28143a213abdc0552a15e82cacecc414ca26..3954f40b23536fec495585a8b14e82d0
      /**
       * Sends the component to the player
       *
-@@ -1069,9 +1102,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1130,9 +1163,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Sends an array of components as a single message to the specified screen position of this player
       *

--- a/patches/api/0056-Fix-upstream-javadocs.patch
+++ b/patches/api/0056-Fix-upstream-javadocs.patch
@@ -49,7 +49,7 @@ index a04cde615f8c4bc593f8d9f8f6f1438008aaa707..548f6d28c28d74bed8b58ee828759093
       * @param target the target to remove from this list
       */
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 8f9a19b1795ccddb7be268b72038cc236267821a..365c2cd4f5a3a382d3b52b50377fbf56731a30ae 100644
+index 0ec7937572a28964123322f0cd2c060d4d69e42e..a1c8cb4d89147311539a70901c74eae4020c022f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1464,6 +1464,8 @@ public final class Bukkit {
@@ -75,7 +75,7 @@ index 0cf808356a1a5c6fc4bcf97a694ed9beb80a776a..dc765dea47a9a1c1520fb16ddb24f814
       * @return temperature at given coordinate
       */
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index 02de62c083ceaa466c80cb732e8304b8cc3f07f8..7c2b1eff41dd43fda84d84e76c05bbbf37c186b8 100644
+index 369b95b1598a43bc53fb3ea4f69ebea18dc34308..656c060aee5d9ce778638253603ed9475a2612a1 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
 @@ -158,7 +158,7 @@ public interface RegionAccessor {
@@ -114,7 +114,7 @@ index 02de62c083ceaa466c80cb732e8304b8cc3f07f8..7c2b1eff41dd43fda84d84e76c05bbbf
       * @param statePredicate The predicate which should get used to test if a block should be set or not.
       * @return true if the tree was created successfully, otherwise false
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 86910935fa823f1e23cf1d89604d042c1c87fbc6..36d07fda939a5e1b4acf77d9092bfc42bbd27d78 100644
+index 581955462495d63d07f2f461f45b1353e5b89c5b..95d1e6c57c3331ce3badfb5269531dce490d4079 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -544,13 +544,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -142,10 +142,10 @@ index 86910935fa823f1e23cf1d89604d042c1c87fbc6..36d07fda939a5e1b4acf77d9092bfc42
       * @return an array containing all previous players
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index dbb799aed5bbb80edd2428b63d3fce15cf2e2f05..609e4908ed21f69b9e813500e702bbe784bff00c 100644
+index f5a398aa5f7a7e6280167fd723f78f4d72e2b1dd..faedd3857023513340b6e9fc67b78c79e3989cbe 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2577,7 +2577,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2659,7 +2659,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link StructureType}.
       * Finding unexplored structures can, and will, block if the world is
@@ -154,7 +154,7 @@ index dbb799aed5bbb80edd2428b63d3fce15cf2e2f05..609e4908ed21f69b9e813500e702bbe7
       * temporarily freezing while locating an unexplored structure.
       * <p>
       * The {@code radius} is not a rigid square radius. Each structure may alter
-@@ -2611,7 +2611,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2693,7 +2693,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link StructureType}.
       * Finding unexplored structures can, and will, block if the world is
@@ -163,7 +163,7 @@ index dbb799aed5bbb80edd2428b63d3fce15cf2e2f05..609e4908ed21f69b9e813500e702bbe7
       * temporarily freezing while locating an unexplored structure.
       * <p>
       * The {@code radius} is not a rigid square radius. Each structure may alter
-@@ -2644,7 +2644,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2726,7 +2726,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      /**
       * Find the closest nearby structure of a given {@link Structure}. Finding
       * unexplored structures can, and will, block if the world is looking in
@@ -386,7 +386,7 @@ index ae9eaaa8e38e1d9dfc459926c7fc51ddb89de84a..b2ec535bb1b0ce0c114ddd7638b90218
      @Override
      public int getConversionTime();
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3954f40b23536fec495585a8b14e82d092d62e39..264c6bdeb2f1f0d937e4356d761a3264a1c4d58a 100644
+index 05795d5e86c7427bb962144b66e43f68a9fa3ff3..74823885b0836db404737199b21c09c1ebcbad3c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -431,15 +431,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -409,7 +409,7 @@ index 3954f40b23536fec495585a8b14e82d092d62e39..264c6bdeb2f1f0d937e4356d761a3264
       * <p>
       * Note: This will overwrite the players current inventory, health,
       * motion, etc, with the state from the saved dat file.
-@@ -674,7 +674,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -735,7 +735,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Plays an effect to just this player.
       *
@@ -418,7 +418,7 @@ index 3954f40b23536fec495585a8b14e82d092d62e39..264c6bdeb2f1f0d937e4356d761a3264
       * @param loc the location to play the effect at
       * @param effect the {@link Effect}
       * @param data a data bit needed for some effects
-@@ -1059,7 +1059,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1120,7 +1120,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * Use supplied alternative character to the section symbol to represent legacy color codes.
       *
@@ -427,7 +427,7 @@ index 3954f40b23536fec495585a8b14e82d092d62e39..264c6bdeb2f1f0d937e4356d761a3264
       * @param message The message to send
       * @deprecated use {@link #sendActionBar(net.kyori.adventure.text.Component)}
       */
-@@ -1525,7 +1525,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1586,7 +1586,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
  
      /**
       * Allows this player to see a player that was previously hidden. If
@@ -436,7 +436,7 @@ index 3954f40b23536fec495585a8b14e82d092d62e39..264c6bdeb2f1f0d937e4356d761a3264
       * remain hidden until the other plugin calls this method too.
       *
       * @param plugin Plugin that wants to show the player
-@@ -1554,7 +1554,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1615,7 +1615,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
  
      /**
       * Allows this player to see an entity that was previously hidden. If

--- a/patches/api/0081-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/api/0081-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f9239eae50b86f54f0cd8c604d2ba9468fc5f33b..9dca8fc727b727063d9ca50fdd8f6452173a5cd4 100644
+index 0da374b18e0f602e9836cfaefe07c5219a7d9bd1..e6b4347fc7e14971b8c975f19ff389fdafa16723 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1368,6 +1368,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1429,6 +1429,15 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void resetPlayerWeather();
  
@@ -29,7 +29,7 @@ index f9239eae50b86f54f0cd8c604d2ba9468fc5f33b..9dca8fc727b727063d9ca50fdd8f6452
      /**
       * Gets the player's cooldown between picking up experience orbs.
       *
-@@ -1393,8 +1402,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1454,8 +1463,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Gives the player the amount of experience specified.
       *
       * @param amount Exp amount to give

--- a/patches/api/0092-Player.setPlayerProfile-API.patch
+++ b/patches/api/0092-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 87ce6947a1e974c18e84f56ba622bee9fff3570b..0dfb60e4635cc960b5cb481206b6c02adb36d7f9 100644
+index 8f1f432c9d6c68ac142401626adaf1dc212181f2..8c430623204d419a93ccc67a0214942952f4a33c 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1306,8 +1306,10 @@ public final class Bukkit {
@@ -56,7 +56,7 @@ index bec480aff819e09220b52175cab0cb6d68ae68c6..12349910297a75c00e64f6ccc7981aee
      /**
       * Checks if this player has had their profile banned.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index bc68d8af8b38232392a12ef5f338e85ca80bccd0..ccc1142e496c33c70104646255bae98d43a6b6c2 100644
+index aad8b2fbdbb03fbf32f99b3a533716eca9d42219..405b6a388c3593a83985f766e79b92951006563e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1119,8 +1119,10 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -93,10 +93,10 @@ index bc68d8af8b38232392a12ef5f338e85ca80bccd0..ccc1142e496c33c70104646255bae98d
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9dca8fc727b727063d9ca50fdd8f6452173a5cd4..ccd80734cf5641455fd9d9b63238739987e225da 100644
+index e6b4347fc7e14971b8c975f19ff389fdafa16723..43ba9fbec2060786fe1cb24025adc697a88b8678 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2678,6 +2678,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2739,6 +2739,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0095-Add-openSign-method-to-HumanEntity.patch
+++ b/patches/api/0095-Add-openSign-method-to-HumanEntity.patch
@@ -36,10 +36,10 @@ index abdca9fe5acc90f167219eb769ece66c35682bb1..b3aa3dc6aa5afbc36cc86741b4cba56f
      /**
       * Make the entity drop the item in their hand.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ccd80734cf5641455fd9d9b63238739987e225da..bca4794a67c369b0bb882e56f489ed952488b2c5 100644
+index 43ba9fbec2060786fe1cb24025adc697a88b8678..67d253239b86a120162e7fcc56a345b5ebb88ba9 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2523,10 +2523,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2584,10 +2584,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Open a Sign for editing by the Player.
       *

--- a/patches/api/0096-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0096-Add-Ban-Methods-to-Player-Objects.patch
@@ -74,10 +74,10 @@ index 12349910297a75c00e64f6ccc7981aeeeb43ecd3..8f2f3e0ac5266f571b62a754921422bb
      /**
       * Adds this user to the {@link ProfileBanList}. If a previous ban exists, this will
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index bca4794a67c369b0bb882e56f489ed952488b2c5..a851ec4d350ce442eb01385d21ca75e695cf09d2 100644
+index 67d253239b86a120162e7fcc56a345b5ebb88ba9..e13d09c5d4c62d47f6f4e057a23caea3ed18496a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1042,6 +1042,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1103,6 +1103,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start

--- a/patches/api/0101-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0101-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -523,10 +523,10 @@ index e2adb9901cc92ede9d44ca9939c6a54d4762eb4b..81bd12c8addcee754c71e5e030c729c7
       * Options which can be applied to redstone dust particles - a particle
       * color and size.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 7a6caf93606203198369030a295f1edbffde3c31..3e7385d21380abcd40649045e4666cf4bed32195 100644
+index c7e6e1ef1191ffde924600ed3beb46ffe129c15f..d02b6743e4401004e75501e99b717b58e5acc5ae 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2777,7 +2777,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2859,7 +2859,57 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
       */

--- a/patches/api/0115-Expand-Explosions-API.patch
+++ b/patches/api/0115-Expand-Explosions-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 6693e3d8dc2519facb12db981a6b6325faa095bf..b7ff09ffdd3aecc1843d175bc76fe5fae1f48dde 100644
+index 556e4524c30f8c7faeb591e272546c78090170fc..e8067e91dea3c5f8654c65ea5ec4d3db36d85a6c 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -7,6 +7,7 @@ import java.util.HashMap;
@@ -108,10 +108,10 @@ index 6693e3d8dc2519facb12db981a6b6325faa095bf..b7ff09ffdd3aecc1843d175bc76fe5fa
       * Returns a list of entities within a bounding box centered around a Location.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 3e7385d21380abcd40649045e4666cf4bed32195..266ed71b79d32f9b812be322563c247051ccd9d0 100644
+index d02b6743e4401004e75501e99b717b58e5acc5ae..de896af6006f791625bb388b105983fb64489071 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1392,6 +1392,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1398,6 +1398,88 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public boolean createExplosion(@NotNull Location loc, float power, boolean setFire);
  

--- a/patches/api/0145-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0145-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index a851ec4d350ce442eb01385d21ca75e695cf09d2..9954fc11b2c2fe56c194d7d3ce878a343a9b2429 100644
+index e13d09c5d4c62d47f6f4e057a23caea3ed18496a..d6af835abd8b31cf177ad2912215d80ff7629e64 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2854,6 +2854,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2915,6 +2915,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull com.destroystokyo.paper.profile.PlayerProfile profile);

--- a/patches/api/0157-Add-sun-related-API.patch
+++ b/patches/api/0157-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index fc6b99e4f37179b15254bf0b398b1a800de1b73f..df511007ca4b3b5df04abfa6b7f1c4de636407fc 100644
+index 7aa4103fdfd8a637ad77c2cb6d3521a9c4442459..3727e136dce6eb41c316c3607c946489cf7df7c8 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1782,6 +1782,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1788,6 +1788,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       */
      public void setFullTime(long time);
  

--- a/patches/api/0173-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0173-Fix-Spigot-annotation-mistakes.patch
@@ -40,7 +40,7 @@ index ac420f0059fc50d3e1294f85df7515c9e17ff78f..24daba85ce4129fb0babe67570059ca8
      public static Art getById(int id) {
          return BY_ID.get(id);
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 40b4d6ee5ef1f6b88e0b85131be399526488cd9e..20e8bee8a686f8d37d770d8714c5c55af8491584 100644
+index 5bb11c5ebd02cf4e4c6c9b859cd7987abd2093d6..87d2348f39e2e43c782c1b7bf73ec38c52e67f95 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -838,9 +838,8 @@ public final class Bukkit {
@@ -196,11 +196,11 @@ index 879d637691683ca862045402f74b751a892bf3ff..611b7df0e31de932f15c2f13bd8ed286
      public static Effect getById(int id) {
          return BY_ID.get(id);
 diff --git a/src/main/java/org/bukkit/EntityEffect.java b/src/main/java/org/bukkit/EntityEffect.java
-index 1747b912dd08d82757687aaa7614d32d746fd6a1..7b6d9c2bbe1052371fdd4121f88e5009882a3d41 100644
+index 9db85b2f6ffd56bbc4db1f75f8769f1c15d5950f..5341957b10cccd7bce5a7595699b1d90412a01d0 100644
 --- a/src/main/java/org/bukkit/EntityEffect.java
 +++ b/src/main/java/org/bukkit/EntityEffect.java
-@@ -227,9 +227,9 @@ public enum EntityEffect {
-      * Gets the data value of this EntityEffect
+@@ -345,9 +345,9 @@ public enum EntityEffect {
+      * Gets the data value of this EntityEffect, may not be unique.
       *
       * @return The data value
 -     * @deprecated Magic value
@@ -285,7 +285,7 @@ index 16df0568143a956309e6cab91a0818582fa4ed67..9e80988c71b77bbda1aca27a85953760
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index d56d899ca7737b537ea55c13a384888a873f5da3..55fc700d60051bb17469e0768db3c266ba18f17c 100644
+index 48a42faffc5e117b6d18bc21265caa150117e3ef..2d7cd77002c32e88bfa677f86d645ee6b541062c 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -4459,20 +4459,20 @@ public enum Material implements Keyed, Translatable {
@@ -374,7 +374,7 @@ index f43209cf7b752c26718c303ca8c3e1c7d9912ad3..f0094e6fb05e526736629ad3181c8d2c
  
      /**
 diff --git a/src/main/java/org/bukkit/Note.java b/src/main/java/org/bukkit/Note.java
-index fc3da7ce6f7948aeab0962d9472e8f3a126834cf..bd713f9f7d125998d4bc01aaf11d1605ff64a970 100644
+index 48aecc9421c500137bbef1dfe3bec8de277c3ff9..aff858346776386f1288b648b221404f7f412399 100644
 --- a/src/main/java/org/bukkit/Note.java
 +++ b/src/main/java/org/bukkit/Note.java
 @@ -39,9 +39,9 @@ public class Note {
@@ -425,7 +425,7 @@ index fc3da7ce6f7948aeab0962d9472e8f3a126834cf..bd713f9f7d125998d4bc01aaf11d1605
          @Nullable
          public static Tone getById(byte id) {
              return BY_DATA.get(id);
-@@ -214,9 +214,9 @@ public class Note {
+@@ -222,9 +222,9 @@ public class Note {
       * Returns the internal id of this note.
       *
       * @return the internal id of this note.
@@ -521,7 +521,7 @@ index 6277451c3c6c551078c237cd767b6d70c4f585ea..10f5cfb1885833a1d2c1027c03974da4
      CRACKED(0x0),
      GLYPHED(0x1),
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 7223bf91b369822afd355c600d834c30270197f4..ef71d6036d1df19c730b4d525862f11f3ee5ccb4 100644
+index e1f36d4f35cb53e28f4b64ddd730634b0fa9eb14..3cf66dde58cbe92cf9273c482af378058708b15b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -704,9 +704,8 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -600,7 +600,7 @@ index e455eb21abf121dc6ff10ff8a13dd06f67096a8f..bbc01e7c192ae6689c301670047ff114
          return origin;
      }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index df511007ca4b3b5df04abfa6b7f1c4de636407fc..3f50a3c5af674fdb4c5adc64901d305753a0b5e9 100644
+index 3727e136dce6eb41c316c3607c946489cf7df7c8..f827e55a8dc57e8d29fce4c2c0545de89b54a800 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -416,9 +416,8 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -614,7 +614,7 @@ index df511007ca4b3b5df04abfa6b7f1c4de636407fc..3f50a3c5af674fdb4c5adc64901d3057
      public boolean refreshChunk(int x, int z);
  
      /**
-@@ -3708,6 +3707,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3790,6 +3789,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      // Paper end - view distance api
  
      // Spigot start
@@ -625,7 +625,7 @@ index df511007ca4b3b5df04abfa6b7f1c4de636407fc..3f50a3c5af674fdb4c5adc64901d3057
      public class Spigot {
  
          /**
-@@ -3716,8 +3719,12 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3798,8 +3801,12 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
           * @param loc The location to strike lightning
           * @param isSilent Whether this strike makes no sound
           * @return The lightning entity.
@@ -638,7 +638,7 @@ index df511007ca4b3b5df04abfa6b7f1c4de636407fc..3f50a3c5af674fdb4c5adc64901d3057
          public LightningStrike strikeLightning(@NotNull Location loc, boolean isSilent) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -3728,14 +3735,22 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3810,14 +3817,22 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
           * @param loc The location to strike lightning
           * @param isSilent Whether this strike makes no sound
           * @return The lightning entity.
@@ -661,7 +661,7 @@ index df511007ca4b3b5df04abfa6b7f1c4de636407fc..3f50a3c5af674fdb4c5adc64901d3057
      Spigot spigot();
      // Spigot end
  
-@@ -3866,9 +3881,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3948,9 +3963,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
           * Gets the dimension ID of this environment
           *
           * @return dimension ID
@@ -673,7 +673,7 @@ index df511007ca4b3b5df04abfa6b7f1c4de636407fc..3f50a3c5af674fdb4c5adc64901d3057
          public int getId() {
              return id;
          }
-@@ -3878,9 +3893,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3960,9 +3975,9 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
           *
           * @param id The ID of the environment
           * @return The environment
@@ -895,10 +895,10 @@ index 95c79c5fa0c4e30201f887da6467ce5f81c8a255..7f9c4d4b430a3f0276461346ff2621ba
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9954fc11b2c2fe56c194d7d3ce878a343a9b2429..c3223873d1afe14cdc0a14f97b3aa98d013d6e90 100644
+index d6af835abd8b31cf177ad2912215d80ff7629e64..c463a52aef540e7b69c5ea32bce1239ed6c57a4f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1436,11 +1436,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1497,11 +1497,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
  
      /**
       * Forces an update of the player's entire inventory.

--- a/patches/api/0190-Add-Player-Client-Options-API.patch
+++ b/patches/api/0190-Add-Player-Client-Options-API.patch
@@ -229,10 +229,10 @@ index 0000000000000000000000000000000000000000..cf67dc7d465223710adbf2b798109f52
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c3223873d1afe14cdc0a14f97b3aa98d013d6e90..925bdf4cc2191a89ca8f55ca55121fa5d3a556a2 100644
+index c463a52aef540e7b69c5ea32bce1239ed6c57a4f..46e78e3e7102e3e91f10ac001dca555e13732247 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2871,6 +2871,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2932,6 +2932,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0198-Spawn-Reason-API.patch
+++ b/patches/api/0198-Spawn-Reason-API.patch
@@ -5,49 +5,39 @@ Subject: [PATCH] Spawn Reason API
 
 
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index 7c2b1eff41dd43fda84d84e76c05bbbf37c186b8..bc70f4f5b82ce5b92ab0b2612c8fb8126ed1a8c2 100644
+index 656c060aee5d9ce778638253603ed9475a2612a1..b8575fbc7d30a3f4e6862193e3267ab06e91c32f 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
-@@ -11,6 +11,7 @@ import org.bukkit.block.data.BlockData;
- import org.bukkit.entity.Entity;
- import org.bukkit.entity.EntityType;
- import org.bukkit.entity.LivingEntity;
-+import org.bukkit.event.entity.CreatureSpawnEvent;
- import org.jetbrains.annotations.NotNull;
- import org.jetbrains.annotations.Nullable;
- 
-@@ -309,7 +310,34 @@ public interface RegionAccessor {
+@@ -308,8 +308,31 @@ public interface RegionAccessor {
+      * @throws IllegalArgumentException if either parameter is null or the
       *     {@link Entity} requested cannot be spawned
       */
-     @NotNull
--    <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz, @Nullable Consumer<T> function) throws IllegalArgumentException;
+-    @NotNull
+-    <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz, @Nullable Consumer<? super T> function) throws IllegalArgumentException;
 +    // Paper start
-+    public default <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz, @Nullable Consumer<T> function) throws IllegalArgumentException {
-+        return spawn(location, clazz, CreatureSpawnEvent.SpawnReason.CUSTOM, function);
++    default <T extends Entity> @NotNull T spawn(final @NotNull Location location, final @NotNull Class<T> clazz, final @Nullable Consumer<? super T> function) throws IllegalArgumentException {
++        return this.spawn(location, clazz, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.CUSTOM, function);
 +    }
 +
-+    @NotNull
-+    public default <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz, @NotNull CreatureSpawnEvent.SpawnReason reason) throws IllegalArgumentException {
-+        return spawn(location, clazz, reason, null);
++    default @NotNull <T extends Entity> T spawn(final @NotNull Location location, final @NotNull Class<T> clazz, final org.bukkit.event.entity.CreatureSpawnEvent.@NotNull SpawnReason reason) throws IllegalArgumentException {
++        return this.spawn(location, clazz, reason, null);
 +    }
 +
-+    @NotNull
-+    public default <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz, @NotNull CreatureSpawnEvent.SpawnReason reason, @Nullable Consumer<T> function) throws IllegalArgumentException {
-+        return spawn(location, clazz, function, reason);
++    default @NotNull <T extends Entity> T spawn(final @NotNull Location location, final @NotNull Class<T> clazz, final org.bukkit.event.entity.CreatureSpawnEvent.@NotNull SpawnReason reason, final @Nullable Consumer<? super T> function) throws IllegalArgumentException {
++        return this.spawn(location, clazz, function, reason);
 +    }
 +
-+    @NotNull
-+    public default Entity spawnEntity(@NotNull Location loc, @NotNull org.bukkit.entity.EntityType type, @NotNull CreatureSpawnEvent.SpawnReason reason) {
-+        return spawn(loc, (Class<Entity>) type.getEntityClass(), reason, null);
++    default @NotNull Entity spawnEntity(final @NotNull Location loc, final @NotNull EntityType type, final org.bukkit.event.entity.CreatureSpawnEvent.@NotNull SpawnReason reason) {
++        com.google.common.base.Preconditions.checkArgument(type.getEntityClass() != null, "%s is not a valid EntityType, must have an entity class", type);
++        return this.spawn(loc, type.getEntityClass(), reason, null);
 +    }
 +
-+    @NotNull
-+    public default Entity spawnEntity(@NotNull Location loc, @NotNull org.bukkit.entity.EntityType type, @NotNull CreatureSpawnEvent.SpawnReason reason, @Nullable Consumer<Entity> function) {
-+        return spawn(loc, (Class<Entity>) type.getEntityClass(), reason, function);
++    default @NotNull Entity spawnEntity(final @NotNull Location loc, final @NotNull EntityType type, final org.bukkit.event.entity.CreatureSpawnEvent.@NotNull SpawnReason reason, final @Nullable Consumer<? super Entity> function) {
++        com.google.common.base.Preconditions.checkArgument(type.getEntityClass() != null, "%s is not a valid EntityType, must have an entity class", type);
++        return this.spawn(loc, type.getEntityClass(), reason, function);
 +    }
 +
-+    @NotNull
-+    public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz, @Nullable Consumer<T> function, @NotNull CreatureSpawnEvent.SpawnReason reason) throws IllegalArgumentException;
++    <T extends Entity> @NotNull T spawn(@NotNull Location location, @NotNull Class<T> clazz, @Nullable Consumer<? super T> function, org.bukkit.event.entity.CreatureSpawnEvent.@NotNull SpawnReason reason) throws IllegalArgumentException;
 +    // Paper end
  
      /**

--- a/patches/api/0208-Brand-support.patch
+++ b/patches/api/0208-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 925bdf4cc2191a89ca8f55ca55121fa5d3a556a2..b37f84a11e49f0f09371d2baf6ec3eb1c9262068 100644
+index 46e78e3e7102e3e91f10ac001dca555e13732247..45065768d73075f065ca98064ca9813918e05747 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2985,6 +2985,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3046,6 +3046,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0209-Add-moon-phase-API.patch
+++ b/patches/api/0209-Add-moon-phase-API.patch
@@ -47,10 +47,10 @@ index 0000000000000000000000000000000000000000..df05153397b42930cd53d37b30824c7e
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index bc70f4f5b82ce5b92ab0b2612c8fb8126ed1a8c2..f587a529e4d7b097b3f204a34c636da0bbac6747 100644
+index b8575fbc7d30a3f4e6862193e3267ab06e91c32f..3e5597bac0971f28009a50bfde0cd7f0f10bd876 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
-@@ -421,4 +421,12 @@ public interface RegionAccessor {
+@@ -416,4 +416,12 @@ public interface RegionAccessor {
       * {@link HeightMap}
       */
      public int getHighestBlockYAt(@NotNull Location location, @NotNull HeightMap heightMap);

--- a/patches/api/0218-Player-elytra-boost-API.patch
+++ b/patches/api/0218-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b37f84a11e49f0f09371d2baf6ec3eb1c9262068..7ccc62f77055a8fc7e4407f70b0ebab956e20570 100644
+index 45065768d73075f065ca98064ca9813918e05747..0cb487cd32a5d47eeb56da2acbae6cc1e1409b62 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2877,6 +2877,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2938,6 +2938,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull com.destroystokyo.paper.ClientOption<T> option);

--- a/patches/api/0245-Add-sendOpLevel-API.patch
+++ b/patches/api/0245-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7ccc62f77055a8fc7e4407f70b0ebab956e20570..717b12fceaa918f574d6f15b0f6b2939ce9bd1f9 100644
+index 0cb487cd32a5d47eeb56da2acbae6cc1e1409b62..107edde2e9189f29dde2211cc9e17cbeed3696ae 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2897,6 +2897,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2958,6 +2958,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      }
      // Paper end
  

--- a/patches/api/0265-Expand-world-key-API.patch
+++ b/patches/api/0265-Expand-world-key-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expand world key API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 102f1ac7c2fde48be4c7e582019b8601dcf361e4..def2ea036536d0e15bc3b35bb69e99a9bcba1d60 100644
+index c9f4ec3ff1aaca2f75fe0a7f0c85d63f3dfd97f8..1e6307106391056af17add97080cd1f1908114e7 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -832,6 +832,18 @@ public final class Bukkit {
@@ -28,10 +28,10 @@ index 102f1ac7c2fde48be4c7e582019b8601dcf361e4..def2ea036536d0e15bc3b35bb69e99a9
      /**
       * Create a new virtual {@link WorldBorder}.
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index f587a529e4d7b097b3f204a34c636da0bbac6747..58b81f30f9e29ab481ae96c7eea40ad976a4b192 100644
+index 3e5597bac0971f28009a50bfde0cd7f0f10bd876..60ed2b36e18032270c0689cb2405a63a8a962fad 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
-@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
   * A RegionAccessor gives access to getting, modifying and spawning {@link Biome}, {@link BlockState} and {@link Entity},
   * as well as generating some basic structures.
   */
@@ -40,7 +40,7 @@ index f587a529e4d7b097b3f204a34c636da0bbac6747..58b81f30f9e29ab481ae96c7eea40ad9
  
      /**
       * Gets the {@link Biome} at the given {@link Location}.
-@@ -428,5 +428,14 @@ public interface RegionAccessor {
+@@ -423,5 +423,14 @@ public interface RegionAccessor {
       */
      @NotNull
      io.papermc.paper.world.MoonPhase getMoonPhase();
@@ -56,7 +56,7 @@ index f587a529e4d7b097b3f204a34c636da0bbac6747..58b81f30f9e29ab481ae96c7eea40ad9
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 2864bf08aacedbbfdaa507838d42441b88953786..11be12a66bbc660221760d857daf78cdb18d77f0 100644
+index 578a516d568dcc9fbdd67529bf986817adb480bc..91535f211ba7352c22c8cc30e340ed93b3ace21d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -696,6 +696,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0272-More-World-API.patch
+++ b/patches/api/0272-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 75a3f5528182fed8086bbb7fb9529f7746d005e6..efca79f7fd5a4e3c75d7060efae44c564edeb036 100644
+index 7d2a7aff5b15a66663ef896fb1a7e0c6804e936a..372e3e40bb21f0185c59973d5c8ee48c07ea9725 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3715,6 +3715,122 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3797,6 +3797,122 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      StructureSearchResult locateNearestStructure(@NotNull Location origin, @NotNull Structure structure, int radius, boolean findUnexplored);
  

--- a/patches/api/0297-Add-more-line-of-sight-methods.patch
+++ b/patches/api/0297-Add-more-line-of-sight-methods.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add more line of sight methods
 
 
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index 58b81f30f9e29ab481ae96c7eea40ad976a4b192..63503cf17847a85264c930a9fc23a5aab5955c3c 100644
+index 60ed2b36e18032270c0689cb2405a63a8a962fad..3a0e0af739227d99d854b0d5c9bf342fe9363de4 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
-@@ -437,5 +437,13 @@ public interface RegionAccessor extends Keyed { // Paper
+@@ -432,5 +432,13 @@ public interface RegionAccessor extends Keyed { // Paper
      @NotNull
      @Override
      NamespacedKey getKey();

--- a/patches/api/0341-Multi-Block-Change-API.patch
+++ b/patches/api/0341-Multi-Block-Change-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Multi Block Change API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 549adf75eeb0d014c5baf7c111f4ec1468339bd5..fe1c58a20de699d869a3f86295c8446991cce399 100644
+index 6d8e4f23095716eeaea16206c3a4bb36f794f29f..0e42cd429a75d10f8628acad319ee3dd2cdf02c3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -790,6 +790,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -851,6 +851,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendBlockDamage(@NotNull Location loc, float progress);
  

--- a/patches/api/0355-Add-getComputedBiome-API.patch
+++ b/patches/api/0355-Add-getComputedBiome-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getComputedBiome API
 
 
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index 63503cf17847a85264c930a9fc23a5aab5955c3c..93e20ca14a2b7e5817fab788b6dfa73c6ced6acb 100644
+index 3a0e0af739227d99d854b0d5c9bf342fe9363de4..87489972dff661c7c9ec4d128e25e2f7666b598e 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
-@@ -26,6 +26,7 @@ public interface RegionAccessor extends Keyed { // Paper
+@@ -25,6 +25,7 @@ public interface RegionAccessor extends Keyed { // Paper
       *
       * @param location the location of the biome
       * @return Biome at the given location
@@ -16,7 +16,7 @@ index 63503cf17847a85264c930a9fc23a5aab5955c3c..93e20ca14a2b7e5817fab788b6dfa73c
       */
      @NotNull
      Biome getBiome(@NotNull Location location);
-@@ -37,10 +38,33 @@ public interface RegionAccessor extends Keyed { // Paper
+@@ -36,10 +37,33 @@ public interface RegionAccessor extends Keyed { // Paper
       * @param y Y-coordinate of the block
       * @param z Z-coordinate of the block
       * @return Biome at the given coordinates

--- a/patches/api/0364-Expand-FallingBlock-API.patch
+++ b/patches/api/0364-Expand-FallingBlock-API.patch
@@ -13,7 +13,7 @@ diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/Worl
 index 94e6fe6257b30112066b98ec4fdb1561dbcc93c4..bc6630345bb42eb365ba0057a4c52b1e10c6a05a 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2242,8 +2242,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2248,8 +2248,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     MaterialData} are null or {@link Material} of the {@link MaterialData} is not a block
@@ -24,7 +24,7 @@ index 94e6fe6257b30112066b98ec4fdb1561dbcc93c4..bc6630345bb42eb365ba0057a4c52b1e
      public FallingBlock spawnFallingBlock(@NotNull Location location, @NotNull MaterialData data) throws IllegalArgumentException;
  
      /**
-@@ -2256,8 +2258,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2262,8 +2264,10 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     BlockData} are null
@@ -35,7 +35,7 @@ index 94e6fe6257b30112066b98ec4fdb1561dbcc93c4..bc6630345bb42eb365ba0057a4c52b1e
      public FallingBlock spawnFallingBlock(@NotNull Location location, @NotNull BlockData data) throws IllegalArgumentException;
  
      /**
-@@ -2274,7 +2278,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -2280,7 +2284,7 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The spawned {@link FallingBlock} instance
       * @throws IllegalArgumentException if {@link Location} or {@link
       *     Material} are null or {@link Material} is not a block

--- a/patches/api/0370-More-Teleport-API.patch
+++ b/patches/api/0370-More-Teleport-API.patch
@@ -165,10 +165,10 @@ index 77e29cada05da8946d718fe331e28e7553922033..5607404fa0132febdbdaad051a4e9426
       * Teleports this entity to the given location. If this entity is riding a
       * vehicle, it will be dismounted prior to teleportation.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8dc3c5c963e07e1d3819b78b73b39fc082048387..c0fceea5bc007b3f4c93a8fe8cccf4e3cfa88c4f 100644
+index 0e42cd429a75d10f8628acad319ee3dd2cdf02c3..9794b8f812375ad52b4caceef0bf659d8fbf9d65 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3057,6 +3057,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3118,6 +3118,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      String getClientBrandName();
      // Paper end
  

--- a/patches/api/0372-Custom-Chat-Completion-Suggestions-API.patch
+++ b/patches/api/0372-Custom-Chat-Completion-Suggestions-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom Chat Completion Suggestions API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c0fceea5bc007b3f4c93a8fe8cccf4e3cfa88c4f..cc65c8d4a8e0586d36df630d92a3f904c1169669 100644
+index 9794b8f812375ad52b4caceef0bf659d8fbf9d65..f56bb863affa963615efefc35fe1f8d4b12d1253 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2941,6 +2941,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3002,6 +3002,31 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void sendOpLevel(byte level);
      // Paper end - sendOpLevel API
  

--- a/patches/api/0373-Collision-API.patch
+++ b/patches/api/0373-Collision-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Collision API
 
 
 diff --git a/src/main/java/org/bukkit/RegionAccessor.java b/src/main/java/org/bukkit/RegionAccessor.java
-index 93e20ca14a2b7e5817fab788b6dfa73c6ced6acb..cbb51dde78f792db4ddac43f144d23ff4b12d25f 100644
+index 87489972dff661c7c9ec4d128e25e2f7666b598e..14edb1b4caeda0c8aecf3528bd0005fafa6197ff 100644
 --- a/src/main/java/org/bukkit/RegionAccessor.java
 +++ b/src/main/java/org/bukkit/RegionAccessor.java
-@@ -469,5 +469,15 @@ public interface RegionAccessor extends Keyed { // Paper
+@@ -464,5 +464,15 @@ public interface RegionAccessor extends Keyed { // Paper
       * @return whether a line of sight exists between {@code from} and {@code to}
       */
      public boolean lineOfSightExists(@NotNull Location from, @NotNull Location to);

--- a/patches/api/0382-Elder-Guardian-appearance-API.patch
+++ b/patches/api/0382-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index cc65c8d4a8e0586d36df630d92a3f904c1169669..ae1882f58dcc55c51757fa385effd329d348b896 100644
+index f56bb863affa963615efefc35fe1f8d4b12d1253..11b64a94457c1c64e8557bfe3e1ba6387ca9abe6 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3125,6 +3125,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3186,6 +3186,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
      // Paper end - Teleport API
  

--- a/patches/api/0390-Add-Player-Warden-Warning-API.patch
+++ b/patches/api/0390-Add-Player-Warden-Warning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player Warden Warning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ae1882f58dcc55c51757fa385effd329d348b896..bd35d2da3ef437e7025ea86265ebcc693399ac83 100644
+index 11b64a94457c1c64e8557bfe3e1ba6387ca9abe6..9b820f607142808859262770cb38e8a1afdffd9f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3141,6 +3141,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3202,6 +3202,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param silent whether sound should be silenced
       */
      void showElderGuardian(boolean silent);

--- a/patches/api/0398-fix-Instruments.patch
+++ b/patches/api/0398-fix-Instruments.patch
@@ -7,7 +7,7 @@ Add missing instrument enums
 fix some wrong javadocs
 
 diff --git a/src/main/java/org/bukkit/Instrument.java b/src/main/java/org/bukkit/Instrument.java
-index de976be7132d05506fde7a839cac3954b0dd8da4..642feb8b4578e6dbd2bf78d859283d20f877051f 100644
+index 032d7b812ddc0a85e316882c8f7de0c5a0a4fd30..8df26e0d7bea77bb257cddbc2ab9e969fa160681 100644
 --- a/src/main/java/org/bukkit/Instrument.java
 +++ b/src/main/java/org/bukkit/Instrument.java
 @@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
@@ -17,65 +17,66 @@ index de976be7132d05506fde7a839cac3954b0dd8da4..642feb8b4578e6dbd2bf78d859283d20
 -     * Piano is the standard instrument for a note block.
 +     * Piano (Harp) is the standard instrument for a note block.
       */
-     PIANO(0x0),
+     PIANO(0x0, Sound.BLOCK_NOTE_BLOCK_HARP),
      /**
 @@ -21,7 +21,7 @@ public enum Instrument {
       */
-     SNARE_DRUM(0x2),
+     SNARE_DRUM(0x2, Sound.BLOCK_NOTE_BLOCK_SNARE),
      /**
 -     * Sticks are normally played when a note block is on top of a glass
 +     * Sticks (Hat) are normally played when a note block is on top of a glass
       * block.
       */
-     STICKS(0x3),
-@@ -78,38 +78,36 @@ public enum Instrument {
+     STICKS(0x3, Sound.BLOCK_NOTE_BLOCK_HAT),
+@@ -78,39 +78,37 @@ public enum Instrument {
      /**
       * Zombie is normally played when a Zombie Head is on top of the note block.
       */
--    ZOMBIE,
-+    ZOMBIE(0x10), // Paper
+-    ZOMBIE(Sound.BLOCK_NOTE_BLOCK_IMITATE_ZOMBIE),
++    ZOMBIE(0x10, Sound.BLOCK_NOTE_BLOCK_IMITATE_ZOMBIE), // Paper
      /**
       * Skeleton is normally played when a Skeleton Head is on top of the note block.
       */
--    SKELETON,
-+    SKELETON(0x11), // Paper
+-    SKELETON(Sound.BLOCK_NOTE_BLOCK_IMITATE_SKELETON),
++    SKELETON(0x11, Sound.BLOCK_NOTE_BLOCK_IMITATE_SKELETON), // Paper
      /**
       * Creeper is normally played when a Creeper Head is on top of the note block.
       */
--    CREEPER,
-+    CREEPER(0x12), // Paper
+-    CREEPER(Sound.BLOCK_NOTE_BLOCK_IMITATE_CREEPER),
++    CREEPER(0x12, Sound.BLOCK_NOTE_BLOCK_IMITATE_CREEPER), // Paper
      /**
       * Dragon is normally played when a Dragon Head is on top of the note block.
       */
--    DRAGON,
-+    DRAGON(0x13), // Paper
+-    DRAGON(Sound.BLOCK_NOTE_BLOCK_IMITATE_ENDER_DRAGON),
++    DRAGON(0x13, Sound.BLOCK_NOTE_BLOCK_IMITATE_ENDER_DRAGON), // Paper
      /**
       * Wither Skeleton is normally played when a Wither Skeleton Head is on top of the note block.
       */
--    WITHER_SKELETON,
-+    WITHER_SKELETON(0x14), // Paper
+-    WITHER_SKELETON(Sound.BLOCK_NOTE_BLOCK_IMITATE_WITHER_SKELETON),
++    WITHER_SKELETON(0x14, Sound.BLOCK_NOTE_BLOCK_IMITATE_WITHER_SKELETON), // Paper
      /**
       * Piglin is normally played when a Piglin Head is on top of the note block.
       */
--    PIGLIN,
-+    PIGLIN(0x15), // Paper
+-    PIGLIN(Sound.BLOCK_NOTE_BLOCK_IMITATE_PIGLIN),
++    PIGLIN(0x15, Sound.BLOCK_NOTE_BLOCK_IMITATE_PIGLIN), // Paper
      /**
       * Custom Sound is normally played when a Player Head with the required data is on top of the note block.
       */
--    CUSTOM_HEAD;
-+    CUSTOM_HEAD(0x16); // Paper
+-    CUSTOM_HEAD(null);
++    CUSTOM_HEAD(0x16, null); // Paper
  
      private final byte type;
+     private final Sound sound;
      private static final Map<Byte, Instrument> BY_DATA = Maps.newHashMap();
  
--    private Instrument() {
--        this(-1);
+-    private Instrument(final Sound sound) {
+-        this(-1, sound);
 -    }
 +    // Paper - remove ctor (the server still uses the byte magic value)
  
-     private Instrument(final int type) {
+     private Instrument(final int type, final Sound sound) {
          this.type = (byte) type;
-@@ -117,9 +115,8 @@ public enum Instrument {
+@@ -130,9 +128,8 @@ public enum Instrument {
  
      /**
       * @return The type ID of this instrument.
@@ -86,7 +87,7 @@ index de976be7132d05506fde7a839cac3954b0dd8da4..642feb8b4578e6dbd2bf78d859283d20
      public byte getType() {
          return this.type;
      }
-@@ -129,9 +126,8 @@ public enum Instrument {
+@@ -142,9 +139,8 @@ public enum Instrument {
       *
       * @param type The type ID
       * @return The instrument
@@ -97,21 +98,6 @@ index de976be7132d05506fde7a839cac3954b0dd8da4..642feb8b4578e6dbd2bf78d859283d20
      @Nullable
      public static Instrument getByType(final byte type) {
          return BY_DATA.get(type);
-diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 4d1d81ddc7638e958f9cd1b10fd26227efc1578d..fdb0b8b81e53c85c865c4a3a895719f5afbffd17 100644
---- a/src/main/java/org/bukkit/entity/Player.java
-+++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -511,9 +511,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-     public void playNote(@NotNull Location loc, byte instrument, byte note);
- 
-     /**
--     * Play a note for a player at a location. This requires a note block
--     * at the particular location (as far as the client is concerned). This
--     * will not work without a note block. This will not work with cake.
-+     * Play a note for a player at a location.
-      *
-      * @param loc The location of a note block
-      * @param instrument The instrument
 diff --git a/src/test/java/org/bukkit/InstrumentTest.java b/src/test/java/org/bukkit/InstrumentTest.java
 index 8c1d88885de7d56c1b7c78d2e6e059b0648c982a..b177a47a5bda05bfe3598ec5e6771b92a73f0edf 100644
 --- a/src/test/java/org/bukkit/InstrumentTest.java

--- a/patches/api/0403-Flying-Fall-Damage-API.patch
+++ b/patches/api/0403-Flying-Fall-Damage-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Flying Fall Damage API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 03b4f90ba0cdab27b1ce47eef5489e8639f6d960..7df1dd673cd75cb4dc29bbe2c538d0131eeff03e 100644
+index 1a005fde018a7752209fbdcd92714d67ae5cc633..b9c8ca96b36050b2420c9f168bc15767f751ec23 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1702,6 +1702,23 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1765,6 +1765,23 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void setAllowFlight(boolean flight);
  

--- a/patches/api/0406-Win-Screen-API.patch
+++ b/patches/api/0406-Win-Screen-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Win Screen API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 4db6e9802105eba76d6f59b74873bea9502d2c7e..07d018c4c57d5519554db9063f6e91d017801719 100644
+index b9c8ca96b36050b2420c9f168bc15767f751ec23..5e1a706fb68658061ab5c29cba82d411716e5692 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1072,6 +1072,47 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1135,6 +1135,47 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  

--- a/patches/api/0429-Add-Listing-API-for-Player.patch
+++ b/patches/api/0429-Add-Listing-API-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Listing API for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 0e188288e5ba94b1d17503258c5e1217d08e5549..229bad6cb9433027e06f4247baf7d8c962fdc40b 100644
+index 7d44e8c3c52dcaa732525aa89cbe3d19e3e31b20..f376a6b77aeff0fbe8b0655bd2f1c43e19bbe3ce 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1838,6 +1838,32 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1901,6 +1901,32 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @ApiStatus.Experimental
      public boolean canSee(@NotNull Entity entity);
  

--- a/patches/api/0443-Add-player-idle-duration-API.patch
+++ b/patches/api/0443-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 229bad6cb9433027e06f4247baf7d8c962fdc40b..9240ea09206461d61cc08d4252e8507555bf41cf 100644
+index f376a6b77aeff0fbe8b0655bd2f1c43e19bbe3ce..9130a57cf6ef5d543703a03aeed07aa17b1ab7e8 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3280,6 +3280,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3343,6 +3343,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void increaseWardenWarningLevel();
      // Paper end
  

--- a/patches/api/0445-Add-predicate-for-blocks-when-raytracing.patch
+++ b/patches/api/0445-Add-predicate-for-blocks-when-raytracing.patch
@@ -8,9 +8,9 @@ diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/Worl
 index bc6630345bb42eb365ba0057a4c52b1e10c6a05a..5eb3521f5f91b0684b4beebf4f7ba2c795b41c42 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1714,6 +1714,28 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1720,6 +1720,27 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
-     public RayTraceResult rayTraceEntities(@NotNull Location start, @NotNull Vector direction, double maxDistance, double raySize, @Nullable Predicate<Entity> filter);
+     public RayTraceResult rayTraceEntities(@NotNull Location start, @NotNull Vector direction, double maxDistance, double raySize, @Nullable Predicate<? super Entity> filter);
  
 +    // Paper start
 +    /**
@@ -30,14 +30,13 @@ index bc6630345bb42eb365ba0057a4c52b1e10c6a05a..5eb3521f5f91b0684b4beebf4f7ba2c7
 +     * @return the closest ray trace hit result, or <code>null</code> if there
 +     *     is no hit
 +     */
-+    @Nullable
-+    public RayTraceResult rayTraceEntities(@NotNull io.papermc.paper.math.Position start, @NotNull Vector direction, double maxDistance, double raySize, @Nullable Predicate<Entity> filter);
++    @Nullable RayTraceResult rayTraceEntities(io.papermc.paper.math.@NotNull Position start, @NotNull Vector direction, double maxDistance, double raySize, @Nullable Predicate<? super Entity> filter);
 +    // Paper end
 +
      /**
       * Performs a ray trace that checks for block collisions using the blocks'
       * precise collision shapes.
-@@ -1777,6 +1799,35 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1783,6 +1804,34 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public RayTraceResult rayTraceBlocks(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks);
  
@@ -66,16 +65,15 @@ index bc6630345bb42eb365ba0057a4c52b1e10c6a05a..5eb3521f5f91b0684b4beebf4f7ba2c7
 +     *     with, or <code>null</code> to consider all blocks
 +     * @return the ray trace hit result, or <code>null</code> if there is no hit
 +     */
-+    @Nullable
-+    public RayTraceResult rayTraceBlocks(@NotNull io.papermc.paper.math.Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, @Nullable Predicate<Block> canCollide);
++    @Nullable RayTraceResult rayTraceBlocks(io.papermc.paper.math.@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, @Nullable Predicate<? super Block> canCollide);
 +    // Paper end
 +
      /**
       * Performs a ray trace that checks for both block and entity collisions.
       * <p>
-@@ -1810,6 +1861,43 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -1816,6 +1865,42 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
-     public RayTraceResult rayTrace(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<Entity> filter);
+     public RayTraceResult rayTrace(@NotNull Location start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<? super Entity> filter);
  
 +    // Paper start
 +    /**
@@ -110,8 +108,7 @@ index bc6630345bb42eb365ba0057a4c52b1e10c6a05a..5eb3521f5f91b0684b4beebf4f7ba2c7
 +     * @return the closest ray trace hit result with either a block or an
 +     *     entity, or <code>null</code> if there is no hit
 +     */
-+    @Nullable
-+    public RayTraceResult rayTrace(@NotNull io.papermc.paper.math.Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<Entity> filter, @Nullable Predicate<Block> canCollide);
++    @Nullable RayTraceResult rayTrace(io.papermc.paper.math.@NotNull Position start, @NotNull Vector direction, double maxDistance, @NotNull FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, @Nullable Predicate<? super Entity> filter, @Nullable Predicate<? super Block> canCollide);
 +    // Paper end
 +
      /**

--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -8,7 +8,7 @@ apply if there are changes made to it from upstream - thus notifying us
 that changes were made.
 
 diff --git a/.gitignore b/.gitignore
-index 3df8c60ab5cd1454660980883f80668d535b742b..37c3a00659ce21623be07317f4f6a45bf990d799 100644
+index 37dab9e868dbfb019c271a547d975a48ad1cb571..3811c0d849a3eb028ed1a6b7a2d4747f7f570448 100644
 --- a/.gitignore
 +++ b/.gitignore
 @@ -1,3 +1,6 @@
@@ -18,7 +18,7 @@ index 3df8c60ab5cd1454660980883f80668d535b742b..37c3a00659ce21623be07317f4f6a45b
  # Eclipse stuff
  /.classpath
  /.project
-@@ -38,3 +41,7 @@ dependency-reduced-pom.xml
+@@ -39,3 +42,7 @@ dependency-reduced-pom.xml
  
  /src/main/resources/achievement
  /src/main/resources/lang

--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -6987,7 +6987,7 @@ index dc1f88a562c61781ea9e86ff40041e9fecd308e0..4ff18d9995d5d26bde4dbe2ec31c77c2
          ChunkHolder playerchunk = this.getVisibleChunkIfPresent(pos);
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 0668f61ff7e52d1ea32af9f1fd1879d7280bb7cd..3c00b7519b37c5026e80e76a4b4ced2a3a0166f6 100644
+index 82c9886222d49bd03b642c0d9c07d82d1d27896b..44ae05684a2fe19d3e25617a4fa133c932fd4e51 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -176,6 +176,7 @@ import org.bukkit.event.weather.LightningStrikeEvent;
@@ -7193,7 +7193,7 @@ index 337e0a7b3c14e1b1a28744920e0dc0a69e0c5a87..f5829ae484d93b547a5437b85a962134
      @Override
      public void tell(R runnable) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 33a88623ef7011fd60b2e4dd008bf54635714d81..9a29dea3c02cbca89faaa1cd9b750f1a2694d100 100644
+index a741631a6ead201a79ffa4754fc9d6f3e188a04c..140c6befe7f5cba51904eaae0dc88e936f660a12 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -323,6 +323,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -7860,10 +7860,10 @@ index 25156be63f91a1c41ef41154f675d04eb97459a8..47bab513feec217d875192afef61f3af
              return false;
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 300e79c796dcfcacd4e4828cd239291de54e07f0..9e1c76fe26a07bc211182b819df611b7b8fd2a13 100644
+index 30277808c2206b5519477be46ec8a866dd026012..cc9636326687f9d7cd091c97032ce3e43931625d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -243,8 +243,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -245,8 +245,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {
@@ -7874,7 +7874,7 @@ index 300e79c796dcfcacd4e4828cd239291de54e07f0..9e1c76fe26a07bc211182b819df611b7
      }
  
      @Override
-@@ -319,7 +319,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -321,7 +321,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean refreshChunk(int x, int z) {
@@ -7883,7 +7883,7 @@ index 300e79c796dcfcacd4e4828cd239291de54e07f0..9e1c76fe26a07bc211182b819df611b7
          if (playerChunk == null) return false;
  
          playerChunk.getTickingChunkFuture().thenAccept(either -> {
-@@ -1997,4 +1997,32 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2024,4 +2024,32 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.spigot;
      }
      // Spigot end
@@ -7917,7 +7917,7 @@ index 300e79c796dcfcacd4e4828cd239291de54e07f0..9e1c76fe26a07bc211182b819df611b7
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index c2a1c122f2072759ee69833f3529a89cde3ba535..145542a29cc7df606328a106dd044db956b2c8ff 100644
+index 903ff5a3dbeb4c3cfc1e45765880cc6c03819795..278c2adf102c1ec40328c3f4a966afc33586a7e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1202,4 +1202,37 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -7980,7 +7980,7 @@ index c6881e1d74476c2633e2c2bd3636134c844c5942..8eb170bd71c7158dcd1b90f9c8d46a13
          if (original instanceof CraftItemStack) {
              CraftItemStack stack = (CraftItemStack) original;
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index 591c71352ad2a041ba5dc3d05b7ebc65fcca5e3c..e359668d9f4fceae13bf6c36842db9f2b2817c9b 100644
+index 905adf97c0d1f0d1c774a6835a5dffcfea884e58..2b80ddb42c8e5fd32b37f89e894353167c8a698e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 @@ -44,6 +44,7 @@ import org.bukkit.scheduler.BukkitWorker;

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2868,7 +2868,7 @@ index 23bdb77690ba15bcbbfb0c70af23336d08ac7752..8f144a357174bbe096ac9b38a5e67a61
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3d2c168d29873c4418bc297740e7032d6020ff52..61f124c9c607d077cdaa6a1e9b14b323057af52d 100644
+index b7d5b46fa3af1420a402addb73d6ed95f2456375..269174b1baa6edf91406d563c7873165da2c0b81 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -617,8 +617,10 @@ public final class CraftServer implements Server {
@@ -3053,10 +3053,10 @@ index 3d2c168d29873c4418bc297740e7032d6020ff52..61f124c9c607d077cdaa6a1e9b14b323
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9e1c76fe26a07bc211182b819df611b7b8fd2a13..264cdde172452d0d9df652b0e78b21b6a6561300 100644
+index cc9636326687f9d7cd091c97032ce3e43931625d..1678a5eca31033d31ea76bb8918b8d7323c884a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -153,6 +153,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -155,6 +155,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      private final BlockMetadataStore blockMetadata = new BlockMetadataStore(this);
      private final Object2IntOpenHashMap<SpawnCategory> spawnCategoryLimit = new Object2IntOpenHashMap<>();
      private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftWorld.DATA_TYPE_REGISTRY);
@@ -3064,7 +3064,7 @@ index 9e1c76fe26a07bc211182b819df611b7b8fd2a13..264cdde172452d0d9df652b0e78b21b6
  
      private static final Random rand = new Random();
  
-@@ -1604,6 +1605,39 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1631,6 +1632,39 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              entityTracker.broadcastAndSend(packet);
          }
      }
@@ -3104,7 +3104,7 @@ index 9e1c76fe26a07bc211182b819df611b7b8fd2a13..264cdde172452d0d9df652b0e78b21b6
  
      private static Map<String, GameRules.Key<?>> gamerules;
      public static synchronized Map<String, GameRules.Key<?>> getGameRulesNMS() {
-@@ -2024,5 +2058,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2051,5 +2085,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return ret;
      }
@@ -3644,7 +3644,7 @@ index 61759e8179d0f6342abf0c0294e5a024928db8d9..92e21126a9347f1ee2279ab09bb6abf2
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 54888af764f206690ecc5b3331a13a570972eac3..12a027e243d5336d5e96b88229499bfd2f65758c 100644
+index 2aee9019af40abfae16dcf82aa1fb381c0365110..405142188f1b4089fbec38e54266514a9edc0a73 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -296,14 +296,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -3763,7 +3763,7 @@ index 54888af764f206690ecc5b3331a13a570972eac3..12a027e243d5336d5e96b88229499bfd
      @Override
      public void setCompassTarget(Location loc) {
          Preconditions.checkArgument(loc != null, "Location cannot be null");
-@@ -683,6 +725,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -685,6 +727,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
@@ -3788,7 +3788,7 @@ index 54888af764f206690ecc5b3331a13a570972eac3..12a027e243d5336d5e96b88229499bfd
      @Override
      public void sendSignChange(Location loc, String[] lines) {
          this.sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -706,6 +766,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -708,6 +768,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (this.getHandle().connection == null) return;
  
          Component[] components = CraftSign.sanitizeLines(lines);
@@ -3800,7 +3800,7 @@ index 54888af764f206690ecc5b3331a13a570972eac3..12a027e243d5336d5e96b88229499bfd
          SignBlockEntity sign = new SignBlockEntity(CraftLocation.toBlockPosition(loc), Blocks.OAK_SIGN.defaultBlockState());
          SignText text = sign.getFrontText();
          text = text.setColor(net.minecraft.world.item.DyeColor.byId(dyeColor.getWoolData()));
-@@ -715,7 +780,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -717,7 +782,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          sign.setText(text, true);
  
@@ -3810,7 +3810,7 @@ index 54888af764f206690ecc5b3331a13a570972eac3..12a027e243d5336d5e96b88229499bfd
      }
  
      @Override
-@@ -1684,7 +1750,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1686,7 +1752,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url) {
@@ -3819,7 +3819,7 @@ index 54888af764f206690ecc5b3331a13a570972eac3..12a027e243d5336d5e96b88229499bfd
      }
  
      @Override
-@@ -1699,7 +1765,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1701,7 +1767,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setResourcePack(String url, byte[] hash, boolean force) {
@@ -3828,7 +3828,7 @@ index 54888af764f206690ecc5b3331a13a570972eac3..12a027e243d5336d5e96b88229499bfd
      }
  
      @Override
-@@ -1715,6 +1781,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1717,6 +1783,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -3850,7 +3850,7 @@ index 54888af764f206690ecc5b3331a13a570972eac3..12a027e243d5336d5e96b88229499bfd
      public void addChannel(String channel) {
          Preconditions.checkState(this.channels.size() < 128, "Cannot register channel '%s'. Too many channels registered!", channel);
          channel = StandardMessenger.validateAndCorrectChannel(channel);
-@@ -2110,6 +2191,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2112,6 +2193,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().requestedViewDistance() == 0) ? Bukkit.getViewDistance() : this.getHandle().requestedViewDistance();
      }
  
@@ -3863,7 +3863,7 @@ index 54888af764f206690ecc5b3331a13a570972eac3..12a027e243d5336d5e96b88229499bfd
      @Override
      public int getPing() {
          return this.getHandle().connection.latency();
-@@ -2160,6 +2247,252 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2162,6 +2249,252 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().allowsListing();
      }
  

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -924,7 +924,7 @@ index 188ac9b2879d339a268f6c100c23f1dce90c195a..d10abd28c522612934aada8124e5bb67
                  i = this.context.runTopCommand(customfunction1, source);
              } finally {
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index bf37590324fc900b1ae0cb49a0f8eaf6af81e93f..71e1f83e871f27f3de3afdbbeb432a9135d51f8b 100644
+index 672c9d304f448922c5a50c725ac1f0dd988b1853..4b94b1ca21dbc0d9f993c5c9b86965f03aef75b4 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -58,8 +58,9 @@ import org.apache.logging.log4j.Level;
@@ -1156,7 +1156,7 @@ index 4ff18d9995d5d26bde4dbe2ec31c77c2d1515227..c2db2aad2498f0be2e904d5869a9b0bd
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 3c00b7519b37c5026e80e76a4b4ced2a3a0166f6..e48172c1da6beb7ff5ba3486647b126325b826a7 100644
+index 44ae05684a2fe19d3e25617a4fa133c932fd4e51..2a3f9168d38350eb3f6d97836fea70ae3023204d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1,6 +1,8 @@
@@ -1633,7 +1633,7 @@ index 0eb09ce5c850d85ffd7229d27cf06b3e0edda11b..cc1d7626a82881c4410d65c6a33dadae
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d7cc71f0f7c7977fcab76f32e60c58ec7b1e68d8..3cca5eeaa295d8877fa36258ec73c6c2a8918832 100644
+index e43969ac2881f14082ecb2af30c7e9145e1269bc..e08c7af19ec142c2aa1b918ffd6cb9e1aa7f0c4d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -377,7 +377,7 @@ public final class CraftServer implements Server {
@@ -1847,10 +1847,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 12a027e243d5336d5e96b88229499bfd2f65758c..855ed720cf23b201809a76725db87d71abbac626 100644
+index 405142188f1b4089fbec38e54266514a9edc0a73..9cec05442734dd9e08e749dc73358c045c6d3d24 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2568,6 +2568,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2570,6 +2570,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
              CraftPlayer.this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundSystemChatPacket(components, position == net.md_5.bungee.api.ChatMessageType.ACTION_BAR));
          }
@@ -1866,7 +1866,7 @@ index 12a027e243d5336d5e96b88229499bfd2f65758c..855ed720cf23b201809a76725db87d71
  
      public Player.Spigot spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index e359668d9f4fceae13bf6c36842db9f2b2817c9b..0806f97007f4729dab859855fdae91c088671864 100644
+index 2b80ddb42c8e5fd32b37f89e894353167c8a698e..bd1057681d0c7470c497b873ff18abf03a0a6a66 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 @@ -1,5 +1,6 @@

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -16801,7 +16801,7 @@ index 7abd42e34ce14618f4987933cdd230879b6ac804..27ab6d2749b89cc5d3fd4e22603daee9
  
      public boolean isDebugging() {
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 71e1f83e871f27f3de3afdbbeb432a9135d51f8b..4d81f9789a018463fdec503d795b0ffc7ccb94d6 100644
+index 4b94b1ca21dbc0d9f993c5c9b86965f03aef75b4..64958f6cb9162de791ac90e08b19368a7fc59064 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -399,7 +399,34 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -19532,7 +19532,7 @@ index c2db2aad2498f0be2e904d5869a9b0bd3411618c..b2367f3836689f3aa27b1b4905219e07
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index e48172c1da6beb7ff5ba3486647b126325b826a7..faf0d1e2330b85262cb615cdda360822e246df27 100644
+index 2a3f9168d38350eb3f6d97836fea70ae3023204d..fb183bff8844b6f9db5611b9b55b641f4ec438ff 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -194,7 +194,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -22652,7 +22652,7 @@ index b1aeb021e53a233bfb0439d38f1a889ed6fc301d..7687a81bfa420e8377308fea3d673814
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3cca5eeaa295d8877fa36258ec73c6c2a8918832..819e2238f62b0af747b7e44a72de69a1b79609bf 100644
+index e08c7af19ec142c2aa1b918ffd6cb9e1aa7f0c4d..2df4e56450535d2d3f6e83c06261fac7ee7a12dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1162,7 +1162,7 @@ public final class CraftServer implements Server {
@@ -22683,10 +22683,10 @@ index 3cca5eeaa295d8877fa36258ec73c6c2a8918832..819e2238f62b0af747b7e44a72de69a1
  
      // Paper start - Adventure
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 264cdde172452d0d9df652b0e78b21b6a6561300..e8f3373985ba8d3af6fc93a5f0ba0f0a04f7fc6f 100644
+index 1678a5eca31033d31ea76bb8918b8d7323c884a7..10652bb6eecc9f451181747ba314eadfe6347ad1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -323,10 +323,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -325,10 +325,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          ChunkHolder playerChunk = this.world.getChunkSource().chunkMap.getVisibleChunkIfPresent(ChunkPos.asLong(x, z));
          if (playerChunk == null) return false;
  
@@ -22704,7 +22704,7 @@ index 264cdde172452d0d9df652b0e78b21b6a6561300..e8f3373985ba8d3af6fc93a5f0ba0f0a
  
                  ClientboundLevelChunkWithLightPacket refreshPacket = new ClientboundLevelChunkWithLightPacket(chunk, this.world.getLightEngine(), null, null);
                  for (ServerPlayer player : playersInRange) {
-@@ -334,8 +338,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -336,8 +340,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
                      player.connection.send(refreshPacket);
                  }
@@ -22714,7 +22714,7 @@ index 264cdde172452d0d9df652b0e78b21b6a6561300..e8f3373985ba8d3af6fc93a5f0ba0f0a
  
          return true;
      }
-@@ -412,20 +415,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -414,20 +417,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public Collection<Plugin> getPluginChunkTickets(int x, int z) {
          DistanceManager chunkDistanceManager = this.world.getChunkSource().chunkMap.distanceManager;
@@ -22736,7 +22736,7 @@ index 264cdde172452d0d9df652b0e78b21b6a6561300..e8f3373985ba8d3af6fc93a5f0ba0f0a
      }
  
      @Override
-@@ -433,7 +423,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -435,7 +425,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Map<Plugin, ImmutableList.Builder<Chunk>> ret = new HashMap<>();
          DistanceManager chunkDistanceManager = this.world.getChunkSource().chunkMap.distanceManager;
  
@@ -22745,7 +22745,7 @@ index 264cdde172452d0d9df652b0e78b21b6a6561300..e8f3373985ba8d3af6fc93a5f0ba0f0a
              long chunkKey = chunkTickets.getLongKey();
              SortedArraySet<Ticket<?>> tickets = chunkTickets.getValue();
  
-@@ -1991,14 +1981,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2018,14 +2008,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {
@@ -22802,7 +22802,7 @@ index 264cdde172452d0d9df652b0e78b21b6a6561300..e8f3373985ba8d3af6fc93a5f0ba0f0a
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 855ed720cf23b201809a76725db87d71abbac626..c77bfa14ed74dd522229ec2595fac6f94700024b 100644
+index 9cec05442734dd9e08e749dc73358c045c6d3d24..5e495f89139689ca37982c7b0b79eaf50d444435 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -197,6 +197,48 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0030-Player-affects-spawning-API.patch
+++ b/patches/server/0030-Player-affects-spawning-API.patch
@@ -21,7 +21,7 @@ index 984a13267cc1bb960507bc9231359bb4bb837205..668a7c3f36cdbe48e472cb810b27ae4a
      public static Predicate<Entity> withinDistance(double x, double y, double z, double max) {
          double d4 = max * max;
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index dc9162e8fa4b5649a631d3869be7cd9776f5c7b7..873a96693110982600d3e7979489fb00f3cd7941 100644
+index 6e4980b0e6505f8da90d1d63584ef69f899896ea..2aa3df6ef2da77fa51c11d64124ac55a3769f567 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -848,7 +848,7 @@ public abstract class Mob extends LivingEntity implements Targeting {
@@ -60,7 +60,7 @@ index 96181e8925aef7f3d0a2010305caf1f6d9bcfcc9..6f452605e9dc9ebd9980eae9fdeea344
              return false;
          }
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 9d760f3745efc1248b7817d580e5ceb451fc4096..61ecf5c51fbdf38ec5513453c2de037489fd8c7e 100644
+index 37824f2470c7ddb77216ffbf4da02cc10a95a171..0c9a91990376482bc16f74a8b183ebf049ee1949 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -326,7 +326,7 @@ public class Zombie extends Monster {
@@ -73,7 +73,7 @@ index 9d760f3745efc1248b7817d580e5ceb451fc4096..61ecf5c51fbdf38ec5513453c2de0374
                              entityzombie.finalizeSpawn(worldserver, this.level().getCurrentDifficultyAt(entityzombie.blockPosition()), MobSpawnType.REINFORCEMENT, (SpawnGroupData) null, (CompoundTag) null);
                              worldserver.addFreshEntityWithPassengers(entityzombie, CreatureSpawnEvent.SpawnReason.REINFORCEMENTS); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index d359d4b6f9db4841148428544c4c9d6ca9f8bdda..06522d8d3b7e0d455a42b10ec5004cc82e0d888d 100644
+index 37629bf1193e220bcf872c714c55e0708d9fd7e0..45a5baf2f6e868fd5b41be1204bee46fb2e631b5 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -184,6 +184,9 @@ public abstract class Player extends LivingEntity {
@@ -137,10 +137,10 @@ index 2ec2b1d9d987c7f31c685aec3d3c87f42758c94b..36d793b492d9776ee36f8285b5bab09e
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fb623fed603d235693b86e3a9f3f685187d6fb4e..e1e2895e37a5477e1eee068cc23ec60593bfb5e7 100644
+index 5e495f89139689ca37982c7b0b79eaf50d444435..ed70dc4b4dfd57af877c42ff579296ce5cebadbd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2249,6 +2249,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2251,6 +2251,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().language;
      }
  

--- a/patches/server/0032-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0032-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d2ef107e00995008f3433009d0b22621b4f92f12..b3278a5f44dbbca937c499a2f3ae852052911d7b 100644
+index ed70dc4b4dfd57af877c42ff579296ce5cebadbd..5f72f8ac8271d3a6619a708f52a42dc4b6dc5b80 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1920,12 +1920,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1922,12 +1922,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0045-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0045-Implement-PlayerLocaleChangeEvent.patch
@@ -39,10 +39,10 @@ index 61ec0ed91457e4b04a72010199be520c9d4a9488..b5a8d2505fa41c68abb1400a4269f833
          // CraftBukkit end
          this.language = clientOptions.language();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c06f9da7d33c8d86fdcdd1f293f28e66f63e4de1..850ea32a2ebc192a89c9feec5dbc83f3f7314bfc 100644
+index 5f72f8ac8271d3a6619a708f52a42dc4b6dc5b80..d0448d310fde607a006acf37e86cd3eede93a2ba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2247,7 +2247,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2249,7 +2249,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0048-Use-UserCache-for-player-heads.patch
+++ b/patches/server/0048-Use-UserCache-for-player-heads.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use UserCache for player heads
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 7c6d29da9cb555cf93ef1860d4254ddd0b0be516..028fbc9d7960fec6333301f249178833a24f980d 100644
+index 51e94e6f97a7c75e2281ad751c8e2dbee2e28afd..062594cebbe8cc0a0c94ecf7c8da4ee349a27521 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -213,7 +213,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -211,7 +211,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          if (name == null) {
              this.setProfile(null);
          } else {

--- a/patches/server/0059-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0059-Configurable-inter-world-teleportation-safety.patch
@@ -16,10 +16,10 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 30b1148e057e43db4dcc441dd07d8e527aae6f6f..cea98186e229617e973125fb5bcae965205d3d99 100644
+index ab8b584eb1c98d10caeb7d9581f826b4ae984c7c..c87cba2252f091b026c9169ebf1117cd82d7942b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1162,7 +1162,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1164,7 +1164,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entity.connection.teleport(to);
          } else {
              // The respawn reason should never be used if the passed location is non null.

--- a/patches/server/0065-Complete-resource-pack-API.patch
+++ b/patches/server/0065-Complete-resource-pack-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index b9062fe651de34d5b3f9d5f146ae0b4fe29cbfee..e8b12a8ae009023afa2818ecbf398a1440b9926e 100644
+index 0a0a9f1be333911b6de7502a9541063ab9ea0164..a258a252e749e3b7ebb1a6304b7f143e93a67178 100644
 --- a/src/main/java/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 @@ -156,7 +156,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
@@ -22,7 +22,7 @@ index b9062fe651de34d5b3f9d5f146ae0b4fe29cbfee..e8b12a8ae009023afa2818ecbf398a14
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d1f1df4f437bf9c81503972257af9d0386a457f7..b11c4c6b6fd49fb14096b3b39f15dd7ee37b3d0d 100644
+index c87cba2252f091b026c9169ebf1117cd82d7942b..e542d86dbf44e91058ad026e1bf9105d92fa687c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -191,6 +191,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -36,7 +36,7 @@ index d1f1df4f437bf9c81503972257af9d0386a457f7..b11c4c6b6fd49fb14096b3b39f15dd7e
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -2370,6 +2374,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2372,6 +2376,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0074-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0074-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3fe9b954bf2394986cf8b76f37e6e0780b3d5978..08d7c37c1d9dcee4f1578600ac2cd6b584bf2d71 100644
+index 9b9e02f27f4281d3d39130521b1cc4e6979f8ea5..2cf9d80494c6b70992d8ec74fe1697c6522bd952 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -794,7 +794,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -44,10 +44,10 @@ index 3fe9b954bf2394986cf8b76f37e6e0780b3d5978..08d7c37c1d9dcee4f1578600ac2cd6b5
  
      protected void internalSetAbsorptionAmount(float absorptionAmount) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ec1cbd610250d11536f8fc42e769b749380dc95e..7f9dceaf41426a88d682774c30a959db368fd03b 100644
+index e542d86dbf44e91058ad026e1bf9105d92fa687c..7363c80d35d4ff61d771fb77125a4e520f745bba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2165,6 +2165,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2167,6 +2167,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0125-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0125-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -7,7 +7,7 @@ Provides counts without the ineffeciency of using .getEntities().size()
 which creates copy of the collections.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 7b681914b7f9e7fb6d2ea607e0d63ca7024a7ec3..7cfcbc1e38f5e9145c827dfe26299277a3f14cee 100644
+index 17a15f7f1ad0ce7deed8d72c8a4175634992efc9..407607babfb200152bb0e5c6d56bb66c82217077 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -116,7 +116,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -20,10 +20,10 @@ index 7b681914b7f9e7fb6d2ea607e0d63ca7024a7ec3..7cfcbc1e38f5e9145c827dfe26299277
      private final List<TickingBlockEntity> pendingBlockEntityTickers = Lists.newArrayList();
      private boolean tickingBlockEntities;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index dfd45e5a32e8ff8d7f803addefa8240c0f7424c0..9fc72dd4db44fa65c2d4e8d30cf8c19f0fb556a0 100644
+index 10652bb6eecc9f451181747ba314eadfe6347ad1..78ed93a3bb321bcb30d9ca456a9deb5deeb4397c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -155,6 +155,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -157,6 +157,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftWorld.DATA_TYPE_REGISTRY);
      private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  

--- a/patches/server/0169-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0169-Ability-to-apply-mending-to-XP-API.patch
@@ -14,10 +14,10 @@ public net.minecraft.world.entity.ExperienceOrb durabilityToXp(I)I
 public net.minecraft.world.entity.ExperienceOrb xpToDurability(I)I
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6595ad35eeec3763cb3df277145c6dc7d5f1b1d6..9920a3d81c44972cba742d67764b5066362f79aa 100644
+index 3836c1d2c2565333072fbbae1fc163125663ba3c..e4e36c273af4dc2253030823d51dd25a166c391e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1540,7 +1540,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1542,7 +1542,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override

--- a/patches/server/0171-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/patches/server/0171-Add-setPlayerProfile-API-for-Skulls.patch
@@ -48,10 +48,10 @@ index 6c40bb4e06322bcce31561f5cfb9dc53f266f062..ba063a4e52a841a4365efb1cf78415b0
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 028fbc9d7960fec6333301f249178833a24f980d..b6550a8c52122747668f9f0e93c2c2cbd2e86d94 100644
+index 062594cebbe8cc0a0c94ecf7c8da4ee349a27521..b2bab2d79c969bc81b160312a996fb9cd87d0f95 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -189,6 +189,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -187,6 +187,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          return this.hasOwner() ? this.profile.getName() : null;
      }
  
@@ -71,7 +71,7 @@ index 028fbc9d7960fec6333301f249178833a24f980d..b6550a8c52122747668f9f0e93c2c2cb
      @Override
      public OfflinePlayer getOwningPlayer() {
          if (this.hasOwner()) {
-@@ -239,6 +252,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -237,6 +250,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      }
  
      @Override
@@ -79,7 +79,7 @@ index 028fbc9d7960fec6333301f249178833a24f980d..b6550a8c52122747668f9f0e93c2c2cb
      public PlayerProfile getOwnerProfile() {
          if (!this.hasOwner()) {
              return null;
-@@ -248,11 +262,12 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -246,11 +260,12 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      }
  
      @Override
@@ -93,7 +93,7 @@ index 028fbc9d7960fec6333301f249178833a24f980d..b6550a8c52122747668f9f0e93c2c2cb
          }
      }
  
-@@ -307,7 +322,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -305,7 +320,7 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      Builder<String, Object> serialize(Builder<String, Object> builder) {
          super.serialize(builder);
          if (this.profile != null) {

--- a/patches/server/0182-Player.setPlayerProfile-API.patch
+++ b/patches/server/0182-Player.setPlayerProfile-API.patch
@@ -55,7 +55,7 @@ index 477d3245facb5ae59c786d4f696f64226cb540a6..e8490a58dd4d9bc39a5bb2f9fc109526
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 317f879a1be75ae77a0cc52dece1ef3530cde786..601153fac20f6f15aa09bbc8bc63995e43494611 100644
+index e4e36c273af4dc2253030823d51dd25a166c391e..8b443e6f0bc593004ac91d8b92eb3c54add73291 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -271,11 +271,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -70,7 +70,7 @@ index 317f879a1be75ae77a0cc52dece1ef3530cde786..601153fac20f6f15aa09bbc8bc63995e
      @Override
      public InetSocketAddress getAddress() {
          if (this.getHandle().connection == null) return null;
-@@ -1690,8 +1685,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1692,8 +1687,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      private void untrackAndHideEntity(org.bukkit.entity.Entity entity) {
          // Remove this entity from the hidden player's EntityTrackerEntry
@@ -87,7 +87,7 @@ index 317f879a1be75ae77a0cc52dece1ef3530cde786..601153fac20f6f15aa09bbc8bc63995e
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1704,8 +1706,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1706,8 +1708,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  this.getHandle().connection.send(new ClientboundPlayerInfoRemovePacket(List.of(otherPlayer.getUUID())));
              }
          }
@@ -96,7 +96,7 @@ index 317f879a1be75ae77a0cc52dece1ef3530cde786..601153fac20f6f15aa09bbc8bc63995e
      }
  
      void resetAndHideEntity(org.bukkit.entity.Entity entity) {
-@@ -1770,12 +1770,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1772,12 +1772,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      private void trackAndShowEntity(org.bukkit.entity.Entity entity) {
@@ -122,7 +122,7 @@ index 317f879a1be75ae77a0cc52dece1ef3530cde786..601153fac20f6f15aa09bbc8bc63995e
          }
  
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
-@@ -1785,6 +1798,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1787,6 +1800,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          this.server.getPluginManager().callEvent(new PlayerShowEntityEvent(this, entity));
      }
@@ -162,7 +162,7 @@ index 317f879a1be75ae77a0cc52dece1ef3530cde786..601153fac20f6f15aa09bbc8bc63995e
  
      void resetAndShowEntity(org.bukkit.entity.Entity entity) {
          // SPIGOT-7312: Can't show/hide self
-@@ -1796,6 +1842,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1798,6 +1844,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              this.trackAndShowEntity(entity);
          }
      }

--- a/patches/server/0187-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0187-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c65b82d69fa829f3fdfa0d6c65a2f861c2db9f11..676c29c13ae8ece20cb5acaf1a2cf71fc93424bd 100644
+index 8b443e6f0bc593004ac91d8b92eb3c54add73291..10c9ced5f306b71eeb77ecc9c4e95ef7de3460e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -194,6 +194,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index c65b82d69fa829f3fdfa0d6c65a2f861c2db9f11..676c29c13ae8ece20cb5acaf1a2cf71f
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -2094,7 +2095,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2096,7 +2097,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
  
      public void addChannel(String channel) {

--- a/patches/server/0193-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0193-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,7 +10,7 @@ Adds an option to control the force mode of the particle.
 This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 445b8839d2a7a5ec2debb853d606e499c2a1f20b..365fb14d498a0baecbdc001ce634cc8e81a15b75 100644
+index 39cabe9d047a44452de25be5937cdb2dd66c17ab..92c847fdd2a7e3e20c8607f287c3e1ad27b9e4f7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1719,12 +1719,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -34,10 +34,10 @@ index 445b8839d2a7a5ec2debb853d606e499c2a1f20b..365fb14d498a0baecbdc001ce634cc8e
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1f08be117261f8b567bb4d46f2f21a6515c39aef..6d9de4dbbc0d224ebad03d4279dd45a7d3303848 100644
+index 78ed93a3bb321bcb30d9ca456a9deb5deeb4397c..d8066264008ade869414c505a2b55886bef74fbf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1864,13 +1864,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1891,13 +1891,20 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0211-Expand-Explosions-API.patch
+++ b/patches/server/0211-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c8d960d1fc8b44f64e84abb38f12e3825d2c97bc..2e8e66b6f89334d37a93a8571131a9cf4eb35c6f 100644
+index d8066264008ade869414c505a2b55886bef74fbf..f02cb628d6e2ef303d0f4c574ae5d67a0c92da0d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -717,6 +717,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -719,6 +719,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
          return !this.world.explode(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, breakBlocks ? net.minecraft.world.level.Level.ExplosionInteraction.MOB : net.minecraft.world.level.Level.ExplosionInteraction.NONE).wasCanceled;
      }

--- a/patches/server/0215-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0215-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2e8e66b6f89334d37a93a8571131a9cf4eb35c6f..a0878c2a3164cb0dd6cd5b1b982c5c854b86c322 100644
+index f02cb628d6e2ef303d0f4c574ae5d67a0c92da0d..c6fc48c30475708378bfd4a5d36999093e5382f6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1041,6 +1041,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1043,6 +1043,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return list;
      }
  

--- a/patches/server/0216-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0216-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 391c32093fc5e9084ab480fcdc22207dc4d5dabc..c6ded19cbe33699e4eab20cbc63d4732837dd143 100644
+index 92c847fdd2a7e3e20c8607f287c3e1ad27b9e4f7..2268babbdcd023c1ec7b3746319acf4306845fee 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1451,7 +1451,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -173,10 +173,10 @@ index 602cf19007c622ab9bb12a7018643cf05688f33e..607dc510ac856a0bf3a54bf1004bdf98
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e4ebfccc01edd29521470e7132ac789755b9ba49..845bc8225a5d0694ddd5a26286c1d37e2563f31f 100644
+index 10c9ced5f306b71eeb77ecc9c4e95ef7de3460e8..3ec5ce75a12f7463b73fb11692b545f13ed109dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1191,7 +1191,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1193,7 +1193,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {

--- a/patches/server/0250-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0250-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a0878c2a3164cb0dd6cd5b1b982c5c854b86c322..2948cf1b2ca8e342d366077407231a89bbb36667 100644
+index c6fc48c30475708378bfd4a5d36999093e5382f6..e8229f2004b3a729417e99897b641e5bde0fa781 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -401,7 +401,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -403,7 +403,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0252-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0252-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6765b59b7b57233c0c963782d0b9b88ba49c3637..fc7bca0d0df079e29ea18f1e37194ddf9c0eefd1 100644
+index 3ec5ce75a12f7463b73fb11692b545f13ed109dd..e910029ca34d980a889d33259bd8b68de002e3ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2845,6 +2845,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2847,6 +2847,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0253-Improve-death-events.patch
+++ b/patches/server/0253-Improve-death-events.patch
@@ -392,10 +392,10 @@ index 1047d9a46314e264ab3f72122aedefd161c7851d..91b9ec5831f439426a853ba9ac7a3f22
          this.gameEvent(GameEvent.ENTITY_DIE);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6d34fef4f16bbac6bd66b702fb5c1511edaef3f1..cc5d3e5d1f25a8316b3b09d16183c0e9a79be2a0 100644
+index e910029ca34d980a889d33259bd8b68de002e3ad..938f0cc12e7a6569a8d3585a9f58f6490fd387a0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2343,7 +2343,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2345,7 +2345,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void sendHealthUpdate() {
          FoodData foodData = this.getHandle().getFoodData();

--- a/patches/server/0266-Add-sun-related-API.patch
+++ b/patches/server/0266-Add-sun-related-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add sun related API
 public net.minecraft.world.entity.Mob isSunBurnTick()Z
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ce19d3ba9e86440152f01e9fde22361ccd967ebd..73b476c5c2baa0122cb3cbeb76ec8c42674b6421 100644
+index e8229f2004b3a729417e99897b641e5bde0fa781..c92b931e2a54122e7a7aeafc5f88faee59c5e0fb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -693,6 +693,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -695,6 +695,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
      }
  

--- a/patches/server/0290-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0290-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,7 +16,7 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ca3fe38fa443eb08408eca029a34afb58cd5a118..bc17ba1dc7b744a4325b30703cda73b501da5104 100644
+index 42898f986d317d44d88c39b56e4655366d5a5a1b..32ab4a254b04d8d66c62660c7ad9489ea8ecf7f2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -241,6 +241,7 @@ public class ServerPlayer extends Player {
@@ -28,7 +28,7 @@ index ca3fe38fa443eb08408eca029a34afb58cd5a118..bc17ba1dc7b744a4325b30703cda73b5
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.network.protocol.game.ClientboundSetHealthPacket queuedHealthUpdatePacket;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 98c4a1b8542486f5af1274f974b898a69f2684f1..45bfb32505dfd2a66d8a6ee4627ec293a88da818 100644
+index 3cd1563480d40ff358dce52891ba4bdc8d119888..1619a0573c6996e0f5494bfab6788ba96c08a6d3 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -181,6 +181,7 @@ public abstract class PlayerList {
@@ -40,7 +40,7 @@ index 98c4a1b8542486f5af1274f974b898a69f2684f1..45bfb32505dfd2a66d8a6ee4627ec293
          GameProfileCache usercache = this.server.getProfileCache();
          String s;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
-index c1ef6c8c8e5f030e18b6066a509350ee1e195987..779b6bac307e252fe614cfce958d2eeed94c5f77 100644
+index e8490a58dd4d9bc39a5bb2f9fc109526e031b971..5f590575f95eff8bf0cdcafde7dee0e3c7fc30ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
 @@ -261,6 +261,61 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
@@ -106,7 +106,7 @@ index c1ef6c8c8e5f030e18b6066a509350ee1e195987..779b6bac307e252fe614cfce958d2eee
      public Location getLastDeathLocation() {
          if (this.getData().contains("LastDeathLocation", 10)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 92e64162181b73e5201e1e3e52db9e372c765a75..d939e5385d250095674c1f0c6f4209cdf87ad7cb 100644
+index 938f0cc12e7a6569a8d3585a9f58f6490fd387a0..43fb53bfef71912695266eda459d7fa2d972cd1c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -195,6 +195,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index 92e64162181b73e5201e1e3e52db9e372c765a75..d939e5385d250095674c1f0c6f4209cd
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1952,6 +1953,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1954,6 +1955,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 92e64162181b73e5201e1e3e52db9e372c765a75..d939e5385d250095674c1f0c6f4209cd
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1974,6 +1987,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1976,6 +1989,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index 92e64162181b73e5201e1e3e52db9e372c765a75..d939e5385d250095674c1f0c6f4209cd
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1988,6 +2003,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1990,6 +2005,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0292-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0292-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0a44010d51d8e68640bff5a384f1e79f7f293528..90186b8aef17c7db6663b8cb82fa3b27b4462bd4 100644
+index 43fb53bfef71912695266eda459d7fa2d972cd1c..8341d66dd5cad3cebdd95cfbc995cc3e8d43d934 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2892,6 +2892,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2894,6 +2894,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0308-Add-Heightmap-API.patch
+++ b/patches/server/0308-Add-Heightmap-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 73b476c5c2baa0122cb3cbeb76ec8c42674b6421..8c2f83c8c08b31a6a165ca9aa86a12082ec70ef2 100644
+index c92b931e2a54122e7a7aeafc5f88faee59c5e0fb..e24c43463b3997549e9a7560a464bdeb8823831e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -220,6 +220,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -222,6 +222,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return CraftBlock.at(this.world, new BlockPos(x, y, z));
      }
  

--- a/patches/server/0313-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0313-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -63,7 +63,7 @@ index fb2851e94c178f49ee8046176b196c63254907e7..ef6d98d503fdca4322000278de4cf325
          // this.updateMobSpawningFlags();
          worldserver.setSpawnSettings(this.isSpawningMonsters(), this.isSpawningAnimals());
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 39bfb4660423cd8bdf67a0aca66fe5b0d353aa84..0c27467e481f9226f1092ba82ec566546e74d422 100644
+index 47a1fb476e3825f489fc217ef83fd273b52676a1..dc0a02f08d1c211443f35a10270110791b6fbbcc 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1859,12 +1859,84 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -191,10 +191,10 @@ index 4d2348df25410a0b5364eec066880326d6667dad..286aad3205ef8a9e21a47ef07893844f
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8c2f83c8c08b31a6a165ca9aa86a12082ec70ef2..d4193c9ec7bef6d8e307c94df034f1a24e8685eb 100644
+index e24c43463b3997549e9a7560a464bdeb8823831e..e790c0c348ad8e2448969516d97a036aeee12fa3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1351,15 +1351,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1353,15 +1353,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/patches/server/0316-Fix-World-isChunkGenerated-calls.patch
+++ b/patches/server/0316-Fix-World-isChunkGenerated-calls.patch
@@ -8,7 +8,7 @@ This patch also adds a chunk status cache on region files (note that
 its only purpose is to cache the status on DISK)
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index c69be9cb3f03ec50e4e57d7e1e93a83701e4cd6c..5b7260b5a14cb9d2b90cf3c411d119e6bfa84046 100644
+index 8d3a9f8210bf529484aeaf84ef9a55b54ce8f2af..15e423cdb61547ddffb4497f5c51e101f5dbe8af 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -680,9 +680,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -156,10 +156,10 @@ index 42dc999d820e62c6a222afbd9239cc671fc7de53..b850dba2b0fa5bc762b170ed7083cf89
              } catch (Throwable throwable) {
                  if (dataoutputstream != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fdb3de1dee72a0e90a42a9d39fa021c0b81922ef..6c13c3c55d58d654d28d5eebcc6dd9789f6565dd 100644
+index e790c0c348ad8e2448969516d97a036aeee12fa3..217aac550c3bed7ccb12ed8e8da9294652345d41 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -308,9 +308,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -310,9 +310,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -185,7 +185,7 @@ index fdb3de1dee72a0e90a42a9d39fa021c0b81922ef..6c13c3c55d58d654d28d5eebcc6dd978
              throw new RuntimeException(ex);
          }
      }
-@@ -424,20 +438,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -426,20 +440,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0342-Anti-Xray.patch
+++ b/patches/server/0342-Anti-Xray.patch
@@ -1558,7 +1558,7 @@ index 593cfd68dc0f3679c684b6a1d2036419d4f3bc0c..b4b2f961d1e4f8b5b199052efefd96bc
      private static final byte[] EMPTY_LIGHT = new byte[2048];
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c77e36393a8aaea5954a0ab0fb21f0b6f8d14aee..0e050180f4d35177c7e13dc439813f9fa8ce1d18 100644
+index 53f387da05ed3c9e981cea2141c42fe630b49892..871a1095d28bde74cfb63091d77c860f92a2ea0e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2341,7 +2341,7 @@ public final class CraftServer implements Server {
@@ -1571,10 +1571,10 @@ index c77e36393a8aaea5954a0ab0fb21f0b6f8d14aee..0e050180f4d35177c7e13dc439813f9f
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 27ec5d989be1288ea32fa115ce37e4d98dc54892..d352f6882adbf642b61e0f3f18abebbe5fff1a9b 100644
+index 217aac550c3bed7ccb12ed8e8da9294652345d41..2d9a298e6f364d7ea6fec689833a72b58aba3c17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -419,11 +419,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -421,11 +421,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  List<ServerPlayer> playersInRange = playerChunk.playerProvider.getPlayers(playerChunk.getPos(), false);
                  if (playersInRange.isEmpty()) return true; // Paper - rewrite player chunk loader
  

--- a/patches/server/0407-Fix-CraftScheduler-runTaskTimerAsynchronously-Plugin.patch
+++ b/patches/server/0407-Fix-CraftScheduler-runTaskTimerAsynchronously-Plugin.patch
@@ -7,15 +7,15 @@ Subject: [PATCH] Fix CraftScheduler#runTaskTimerAsynchronously(Plugin,
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index 918e11422854d7301c84b466533770c2a429a682..addf3c442a085281a7ac06245ccd741f08ed7ccb 100644
+index 215310984100722757d9dd38182f7cbc163a4a0f..acb2af336184c0215c409c748b56fddd8d1fb4be 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 @@ -196,7 +196,7 @@ public class CraftScheduler implements BukkitScheduler {
  
      @Override
-     public void runTaskTimerAsynchronously(Plugin plugin, Consumer<BukkitTask> task, long delay, long period) throws IllegalArgumentException {
+     public void runTaskTimerAsynchronously(Plugin plugin, Consumer<? super BukkitTask> task, long delay, long period) throws IllegalArgumentException {
 -        this.runTaskTimerAsynchronously(plugin, (Object) task, delay, CraftTask.NO_REPEATING);
-+        this.runTaskTimerAsynchronously(plugin, (Object) task, delay, period);
++        this.runTaskTimerAsynchronously(plugin, (Object) task, delay, period); // Paper
      }
  
      @Override

--- a/patches/server/0419-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0419-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -63,7 +63,7 @@ index 89be3991ef4fb2deb7276c5409cb571a7fb1f821..9c272f7cf8cbd2bbe147e57f7fabe135
                  return Component.translatable("commands.difficulty.success", difficulty.getDisplayName());
              }, true);
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 474492c3f02f99e801885a983b9c110a8656c7b5..6d7095a62f30b18bc8fb8dbc5a0f3331980b7140 100644
+index 557fc4e380c00bc2ca34381b36eb3d6a38177209..9e631002278e21f1e0a3989573e7d5b2e1a82dd8 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -325,7 +325,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -102,7 +102,7 @@ index 6add371484deca6ed041e434fea5dc54c8db12d9..0080136d9aaead083fd1d94d2f7a0df2
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 509927dc2a8d7f4968470130cde346d039aa50d4..a51cebb2f0f2ade695bb9f8c2b07b066c4872875 100644
+index 8d78720a613c089ad1bd2d78b83da8a42b76fc76..2ac9b9001f60e2b4c2b660cc104387e49141bcf5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -959,8 +959,8 @@ public final class CraftServer implements Server {
@@ -117,10 +117,10 @@ index 509927dc2a8d7f4968470130cde346d039aa50d4..a51cebb2f0f2ade695bb9f8c2b07b066
              for (SpawnCategory spawnCategory : SpawnCategory.values()) {
                  if (CraftSpawnCategory.isValidForLimits(spawnCategory)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d352f6882adbf642b61e0f3f18abebbe5fff1a9b..2a5eea1bce3ed7af358c2dc9456d57e3168b2249 100644
+index 2d9a298e6f364d7ea6fec689833a72b58aba3c17..5fc0c6652f2dff1b41bb447407a1780bd609c6bb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1151,7 +1151,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1153,7 +1153,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setDifficulty(Difficulty difficulty) {

--- a/patches/server/0423-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0423-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a51cebb2f0f2ade695bb9f8c2b07b066c4872875..a0e67773f4af7e35edad2535f95426308868c69b 100644
+index 2ac9b9001f60e2b4c2b660cc104387e49141bcf5..c71a409a457deea6817b863ddbb8bcbf64206544 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -386,7 +386,7 @@ public final class CraftServer implements Server {
@@ -44,10 +44,10 @@ index a51cebb2f0f2ade695bb9f8c2b07b066c4872875..a0e67773f4af7e35edad2535f9542630
          this.printSaveWarning = false;
          this.console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2a5eea1bce3ed7af358c2dc9456d57e3168b2249..6af214882a4208864b1e80231023b9a0644041fb 100644
+index 5fc0c6652f2dff1b41bb447407a1780bd609c6bb..8306f8cce689260111fbf88b31515440a44d3a8c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -280,7 +280,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -282,7 +282,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -62,7 +62,7 @@ index 2a5eea1bce3ed7af358c2dc9456d57e3168b2249..6af214882a4208864b1e80231023b9a0
          return new CraftChunk(chunk);
      }
  
-@@ -294,6 +300,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -296,6 +302,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return new CraftChunk(this.getHandle(), x, z);
      }
  
@@ -75,7 +75,7 @@ index 2a5eea1bce3ed7af358c2dc9456d57e3168b2249..6af214882a4208864b1e80231023b9a0
      @Override
      public Chunk getChunkAt(Block block) {
          Preconditions.checkArgument(block != null, "null block");
-@@ -359,7 +371,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -361,7 +373,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (this.isChunkLoaded(x, z)) {
@@ -84,7 +84,7 @@ index 2a5eea1bce3ed7af358c2dc9456d57e3168b2249..6af214882a4208864b1e80231023b9a0
          }
  
          return true;
-@@ -445,9 +457,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -447,9 +459,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -98,7 +98,7 @@ index 2a5eea1bce3ed7af358c2dc9456d57e3168b2249..6af214882a4208864b1e80231023b9a0
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -455,7 +470,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -457,7 +472,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -107,7 +107,7 @@ index 2a5eea1bce3ed7af358c2dc9456d57e3168b2249..6af214882a4208864b1e80231023b9a0
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -481,7 +496,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -483,7 +498,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -116,7 +116,7 @@ index 2a5eea1bce3ed7af358c2dc9456d57e3168b2249..6af214882a4208864b1e80231023b9a0
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -2236,6 +2251,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2263,6 +2278,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          io.papermc.paper.chunk.system.ChunkSystem.scheduleChunkLoad(this.getHandle(), x, z, gen, ChunkStatus.FULL, true, priority, (c) -> {
              net.minecraft.server.MinecraftServer.getServer().scheduleOnMain(() -> {
                  net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk)c;

--- a/patches/server/0444-Brand-support.patch
+++ b/patches/server/0444-Brand-support.patch
@@ -57,10 +57,10 @@ index d25b6431ce617d90fd1d6489a308d6630b92c175..96ee68e6656a59d959ad7a7e78f5a375
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b92cc9f8d62cc3bfefe42c4c1fb08af4731dd48f..7b1404ac481ea9a059197b9f752327ef0bf72c5c 100644
+index 7c40718a53d2ef480441fd053de7c45971efe416..5e0fc3fd8e55b3dd238b38105fc6da75bfb709fc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3009,6 +3009,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3011,6 +3011,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0447-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0447-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix SpawnChangeEvent not firing for all use-cases
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 0ff614ea19ff5420c506fe402caf230b1e0a3a36..e6694cb87031cb273ba53ac991d4c79b1f5c1ced 100644
+index c1214a8f53428c19ca1fc72942f5040066f45b12..d3f0cb141ce0942e55e395bfd2e7c3e2c2e48952 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1996,9 +1996,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -21,10 +21,10 @@ index 0ff614ea19ff5420c506fe402caf230b1e0a3a36..e6694cb87031cb273ba53ac991d4c79b
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig().spawn.keepSpawnLoadedRange * 16, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6af214882a4208864b1e80231023b9a0644041fb..56710af63bf432ab38c3a39ad3b734371bb429d7 100644
+index 8306f8cce689260111fbf88b31515440a44d3a8c..787f78e663017eae375d7eaee9d1508913598829 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -260,12 +260,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -262,12 +262,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {

--- a/patches/server/0490-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0490-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7b1404ac481ea9a059197b9f752327ef0bf72c5c..1f742a39d1f31ef27cb4e662a6c3935600728d0b 100644
+index 5e0fc3fd8e55b3dd238b38105fc6da75bfb709fc..9ba0165896e819ebb4482cc34113b72ecb466c43 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2524,7 +2524,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2526,7 +2526,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null) {
              Preconditions.checkArgument(particle.getDataType().isInstance(data), "data (%s) should be %s", data.getClass(), particle.getDataType());
          }

--- a/patches/server/0519-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0519-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 6a1001cb708a7f779a801428d2b00fbcde888bc1..2e240ad721928a9a68370114ba61c218
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 56710af63bf432ab38c3a39ad3b734371bb429d7..9b4276290c99cbf9f618746d49746ee9b074744a 100644
+index 787f78e663017eae375d7eaee9d1508913598829..b4e1a0990ca8a9d4a17012ff3bae367e046ae27f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1846,8 +1846,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1873,8 +1873,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index 56710af63bf432ab38c3a39ad3b734371bb429d7..9b4276290c99cbf9f618746d49746ee9
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1883,8 +1888,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1910,8 +1915,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0579-More-World-API.patch
+++ b/patches/server/0579-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9b4276290c99cbf9f618746d49746ee9b074744a..def1c8a46d686f8be5837c76c15b7463dec553ce 100644
+index b4e1a0990ca8a9d4a17012ff3bae367e046ae27f..d2b8fa11c1f78aadab79cb296da192a0e9b493b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2092,6 +2092,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2119,6 +2119,53 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return new CraftStructureSearchResult(CraftStructure.minecraftToBukkit(found.getSecond().value(), this.getHandle().registryAccess()), CraftLocation.toBukkit(found.getFirst(), this));
      }
  

--- a/patches/server/0596-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0596-additions-to-PlayerGameModeChangeEvent.patch
@@ -144,10 +144,10 @@ index 4d641005076c200ffea9f30a5ee447d2b624ae09..71eb195d2f464a434a770e5299836c6f
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 980845e905f702fef698a5272f58e365ae936ac9..674084fa12cf1f7defd00e64a198e278855668d0 100644
+index c7090918ef8ad62742f44eb98756dc9a59d30a45..82616cc51a84425edc3f6c5db36945551d74b55f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1552,7 +1552,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1554,7 +1554,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          Preconditions.checkArgument(mode != null, "GameMode cannot be null");
          if (this.getHandle().connection == null) return;
  

--- a/patches/server/0605-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0605-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add cause to Weather/ThunderChangeEvents
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f6ee996e6d85e1ab886ffc941a4a8cc05857e4e0..61b8ec1ba224551f6898f3e2abbb67992dbb7001 100644
+index bc7bed7f98723a68c1d919020e9e88ad2213d7b8..5b9107557c397b3e1cbfe8378750ea5888f18af0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -666,8 +666,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -95,10 +95,10 @@ index 8f661e3080f8145c1e78ff7bd84d77707eef6d9e..6357ac8640fdf9f47a94ad69e77a67f6
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index def1c8a46d686f8be5837c76c15b7463dec553ce..a50a9f239ef27807d876aca9b18fbbb1dfbb14fa 100644
+index d2b8fa11c1f78aadab79cb296da192a0e9b493b7..8f3847dd4585ef4ae275a77af32ccd6076a38260 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1187,7 +1187,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1189,7 +1189,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index def1c8a46d686f8be5837c76c15b7463dec553ce..a50a9f239ef27807d876aca9b18fbbb1
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1209,7 +1209,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1211,7 +1211,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0620-add-per-world-spawn-limits.patch
+++ b/patches/server/0620-add-per-world-spawn-limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add per world spawn limits
 Taken from #2982. Credit to Chasewhip8
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a50a9f239ef27807d876aca9b18fbbb1dfbb14fa..b69c0e32965b3ed5b3e41d7cdee6f07b572d2b7c 100644
+index 8f3847dd4585ef4ae275a77af32ccd6076a38260..40cf3f53f46537bfa4fb4c2bedc93cc840084606 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -213,6 +213,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -215,6 +215,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          this.biomeProvider = biomeProvider;
  
          this.environment = env;

--- a/patches/server/0643-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0643-Add-PlayerSetSpawnEvent.patch
@@ -187,10 +187,10 @@ index 1a27b7faa22e6b3dc5fce329ed06425de56c4315..b9903c29bdea8d1e3b6fce0e97be6bd9
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 34377bef2b359292d184ec89311f49dd234be53e..4b167b30275a4dd180c4b88f453e5d2ff935a857 100644
+index 31e2c25adba68ba0527f7ad0104318d454826ada..1b677c30a0d4fb03676698b6ea2c775b8474835d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1311,9 +1311,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1313,9 +1313,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0658-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0658-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add methods to find targets for lightning strikes
 public net.minecraft.server.level.ServerLevel findLightningRod(Lnet/minecraft/core/BlockPos;)Ljava/util/Optional;
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index eb4ad9cfd2291b01fd09be2114b56502149fe049..9fd3eca485fc71e5da142f8b6763e44691e3f41c 100644
+index 4cc1cd4924aed4fddd46db9f8c76e45e7bfc661a..dceddff95dd9b152e25f656b95cc71025a123099 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -976,6 +976,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -31,10 +31,10 @@ index eb4ad9cfd2291b01fd09be2114b56502149fe049..9fd3eca485fc71e5da142f8b6763e446
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b69c0e32965b3ed5b3e41d7cdee6f07b572d2b7c..bf92ff17e5f084df565b682c8b026dc20f580912 100644
+index 40cf3f53f46537bfa4fb4c2bedc93cc840084606..874fdf7c0e710e5f685c592ff341025f852bc4b0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -699,6 +699,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -701,6 +701,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0673-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0673-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -278,7 +278,7 @@ index 9df761f5cf043e8d2dffa711c20ab32fe2992331..d08c7b0b52065980f1f13c5533ff6355
          // Paper start - add parameters and int ret type
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c47716b6136c4eaf55864ccc137652e82b620da4..3f83b3e54747c42a1321137bb668c6a457677d05 100644
+index b18bf7b943fe2bb009babf9414559b832a51d505..443ffc28a387c6d29f841288da1bf93e45f30c9b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2247,6 +2247,11 @@ public final class CraftServer implements Server {
@@ -294,10 +294,10 @@ index c47716b6136c4eaf55864ccc137652e82b620da4..3f83b3e54747c42a1321137bb668c6a4
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index bf92ff17e5f084df565b682c8b026dc20f580912..a0b9f22160a2b8277486f79205647125a412d8be 100644
+index 874fdf7c0e710e5f685c592ff341025f852bc4b0..e45d6bcf2d604b7412f8c19469ee6f0f9a5e727a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1705,9 +1705,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1707,9 +1707,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Preconditions.checkArgument(spawnCategory != null, "SpawnCategory cannot be null");
          Preconditions.checkArgument(CraftSpawnCategory.isValidForLimits(spawnCategory), "SpawnCategory.%s are not supported", spawnCategory);
  

--- a/patches/server/0743-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
+++ b/patches/server/0743-Expose-vanilla-BiomeProvider-from-WorldInfo.patch
@@ -18,7 +18,7 @@ index f7c1d07c95f7b67e32bd6679af88612aec74f54f..9d4c9368fcc3a44e452c1b71b5bdb43d
                  biomeProvider = gen.getDefaultBiomeProvider(worldInfo);
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index eccfd44eaeb20db22d77fc85307d2a6caa80a587..1152e408dc13a9b54507707d7a34e9c63655f02c 100644
+index dbddca7d3188c7729d276159f2fb05300fdd97ed..43877a44ff5c0af7ff4819b63d234af6d9c32b11 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1225,7 +1225,7 @@ public final class CraftServer implements Server {
@@ -31,10 +31,10 @@ index eccfd44eaeb20db22d77fc85307d2a6caa80a587..1152e408dc13a9b54507707d7a34e9c6
              biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a0b9f22160a2b8277486f79205647125a412d8be..a0ec7bc7d89a165ad63c524433724caaec7c3c7c 100644
+index e45d6bcf2d604b7412f8c19469ee6f0f9a5e727a..fec640da33879e09a8564e2c579dd0f0302d809d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -203,6 +203,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -205,6 +205,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getPlayerCount() {
          return world.players().size();
      }

--- a/patches/server/0752-Multi-Block-Change-API-Implementation.patch
+++ b/patches/server/0752-Multi-Block-Change-API-Implementation.patch
@@ -24,10 +24,10 @@ index f96d61bdeb556665d6e6e5023f9d77fd82204e89..e3f355c85eb7cc8c1683e3009502c10a
      public void write(FriendlyByteBuf buf) {
          buf.writeLong(this.sectionPos.asLong());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4b167b30275a4dd180c4b88f453e5d2ff935a857..4dcc4ad66e7c6cd9cbf568d8763d707b5e2b3b8b 100644
+index 1b677c30a0d4fb03676698b6ea2c775b8474835d..5dc7ec4275ca7377ba25f508c2ffdb0427ca441f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -879,6 +879,32 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -881,6 +881,32 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  

--- a/patches/server/0760-Implement-regenerateChunk.patch
+++ b/patches/server/0760-Implement-regenerateChunk.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement regenerateChunk
 Co-authored-by: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a0ec7bc7d89a165ad63c524433724caaec7c3c7c..b60765a2176d7a290d2c9b09ba101d61ac572b21 100644
+index fec640da33879e09a8564e2c579dd0f0302d809d..4efa3adc6ccc511501b40b405c691d09c9954553 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -142,6 +142,7 @@ import org.jetbrains.annotations.NotNull;
+@@ -144,6 +144,7 @@ import org.jetbrains.annotations.NotNull;
  public class CraftWorld extends CraftRegionAccessor implements World {
      public static final int CUSTOM_DIMENSION_OFFSET = 10;
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
@@ -17,7 +17,7 @@ index a0ec7bc7d89a165ad63c524433724caaec7c3c7c..b60765a2176d7a290d2c9b09ba101d61
  
      private final ServerLevel world;
      private WorldBorder worldBorder;
-@@ -426,27 +427,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -428,27 +429,61 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean regenerateChunk(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk regenerate"); // Spigot

--- a/patches/server/0773-Fix-falling-block-spawn-methods.patch
+++ b/patches/server/0773-Fix-falling-block-spawn-methods.patch
@@ -11,7 +11,7 @@ Restores the API behavior from previous versions of the server
 public net.minecraft.world.entity.item.FallingBlockEntity <init>(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/level/block/state/BlockState;)V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
-index c0186224fd64d70770a0e16752d17c0870121d8f..30a893f7f63961b752e043b81dda20d946cd63aa 100644
+index e2e5b64812ee403be59b3586bf8b0334574c011f..c21bb08363e35866774871505a32a7c41e12cb45 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftRegionAccessor.java
 @@ -599,7 +599,7 @@ public abstract class CraftRegionAccessor implements RegionAccessor {
@@ -24,10 +24,10 @@ index c0186224fd64d70770a0e16752d17c0870121d8f..30a893f7f63961b752e043b81dda20d9
              if (Snowball.class.isAssignableFrom(clazz)) {
                  entity = new net.minecraft.world.entity.projectile.Snowball(world, x, y, z);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b60765a2176d7a290d2c9b09ba101d61ac572b21..b76d59ae107eec1ea52edfb2d08b1a1da7931593 100644
+index 4efa3adc6ccc511501b40b405c691d09c9954553..3281d65f71387a927d8b1eb8c83b554144a379ef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1397,7 +1397,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1399,7 +1399,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Preconditions.checkArgument(material != null, "Material cannot be null");
          Preconditions.checkArgument(material.isBlock(), "Material.%s must be a block", material);
  
@@ -41,7 +41,7 @@ index b60765a2176d7a290d2c9b09ba101d61ac572b21..b76d59ae107eec1ea52edfb2d08b1a1d
          return (FallingBlock) entity.getBukkitEntity();
      }
  
-@@ -1406,7 +1411,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1408,7 +1413,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Preconditions.checkArgument(location != null, "Location cannot be null");
          Preconditions.checkArgument(data != null, "BlockData cannot be null");
  

--- a/patches/server/0796-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0796-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Pass ServerLevel for gamerule callbacks
 
 
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 5a0a34ea500607b1370df3e5ee4c1ad64f252449..321675996b83fbe34d7e0d690eafe170d7466e17 100644
+index ab7cd594731aaa7b36f80fde00eada52f9e913a5..72c685ed3ece3752e34fc0ae25c7278ec131a505 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -304,7 +304,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -167,10 +167,10 @@ index 2e240ad721928a9a68370114ba61c21884ef1472..1a72fc5368731be617f9cab72e9e756d
              this.onChanged(server);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b76d59ae107eec1ea52edfb2d08b1a1da7931593..6beefb48468779005cb3e93d1c6d8c0465e84d73 100644
+index 3281d65f71387a927d8b1eb8c83b554144a379ef..70be0eb5dd0928ee24ec8dfb92f811c19b27cdd5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1950,7 +1950,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1977,7 +1977,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule));
          handle.deserialize(event.getValue()); // Paper
@@ -179,7 +179,7 @@ index b76d59ae107eec1ea52edfb2d08b1a1da7931593..6beefb48468779005cb3e93d1c6d8c04
          return true;
      }
  
-@@ -1991,7 +1991,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2018,7 +2018,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule.getName()));
          handle.deserialize(event.getValue()); // Paper

--- a/patches/server/0830-More-Teleport-API.patch
+++ b/patches/server/0830-More-Teleport-API.patch
@@ -72,10 +72,10 @@ index 28cda0cc2e179b3f03d4bee3ca6c24c3f831214a..e02c454ba75f440342d85b466426b936
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8c09fbca374bed7707c400adb92e3120815bd508..6005f08cc8423a93c2d209ba080eb0ca68af132e 100644
+index 5dc7ec4275ca7377ba25f508c2ffdb0427ca441f..2b4f34e5889bac44f724935b6e1fc330a75bd9d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1200,13 +1200,101 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1202,13 +1202,101 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setRotation(float yaw, float pitch) {
@@ -178,7 +178,7 @@ index 8c09fbca374bed7707c400adb92e3120815bd508..6005f08cc8423a93c2d209ba080eb0ca
          location.checkFinite();
  
          ServerPlayer entity = this.getHandle();
-@@ -1219,7 +1307,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1221,7 +1309,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
             return false;
          }
  
@@ -187,7 +187,7 @@ index 8c09fbca374bed7707c400adb92e3120815bd508..6005f08cc8423a93c2d209ba080eb0ca
              return false;
          }
  
-@@ -1237,7 +1325,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1239,7 +1327,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          // If this player is riding another entity, we must dismount before teleporting.
@@ -196,7 +196,7 @@ index 8c09fbca374bed7707c400adb92e3120815bd508..6005f08cc8423a93c2d209ba080eb0ca
  
          // SPIGOT-5509: Wakeup, similar to riding
          if (this.isSleeping()) {
-@@ -1253,13 +1341,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1255,13 +1343,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          ServerLevel toWorld = ((CraftWorld) to.getWorld()).getHandle();
  
          // Close any foreign inventory

--- a/patches/server/0834-Warn-on-plugins-accessing-faraway-chunks.patch
+++ b/patches/server/0834-Warn-on-plugins-accessing-faraway-chunks.patch
@@ -18,10 +18,10 @@ index 412f2283a85c39bfb730c73376ec663a79fb9187..a28da797e3ea01eacb378f65da3cfc75
  
      private static boolean isOutsideSpawnableHeight(int y) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6beefb48468779005cb3e93d1c6d8c0465e84d73..c9ab48d99992a39cc6977424c589489a35f36992 100644
+index 70be0eb5dd0928ee24ec8dfb92f811c19b27cdd5..3df9f69e4297ef0f412191f8a0c1cb17311f4de3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -310,9 +310,24 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -312,9 +312,24 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean setSpawnLocation(int x, int y, int z) {
          return this.setSpawnLocation(x, y, z, 0.0F);
      }
@@ -46,7 +46,7 @@ index 6beefb48468779005cb3e93d1c6d8c0465e84d73..c9ab48d99992a39cc6977424c589489a
          // Paper start - add ticket to hold chunk for a little while longer if plugin accesses it
          net.minecraft.world.level.chunk.LevelChunk chunk = this.world.getChunkSource().getChunkAtIfLoadedImmediately(x, z);
          if (chunk == null) {
-@@ -427,6 +442,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -429,6 +444,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean regenerateChunk(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk regenerate"); // Spigot
@@ -54,7 +54,7 @@ index 6beefb48468779005cb3e93d1c6d8c0465e84d73..c9ab48d99992a39cc6977424c589489a
          // Paper start - implement regenerateChunk method
          final ServerLevel serverLevel = this.world;
          final net.minecraft.server.level.ServerChunkCache serverChunkCache = serverLevel.getChunkSource();
-@@ -522,6 +538,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -524,6 +540,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
@@ -62,7 +62,7 @@ index 6beefb48468779005cb3e93d1c6d8c0465e84d73..c9ab48d99992a39cc6977424c589489a
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
          ChunkAccess immediate = world.getChunkSource().getChunkAtIfLoadedImmediately(x, z); // Paper
-@@ -585,6 +602,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -587,6 +604,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean addPluginChunkTicket(int x, int z, Plugin plugin) {
@@ -70,7 +70,7 @@ index 6beefb48468779005cb3e93d1c6d8c0465e84d73..c9ab48d99992a39cc6977424c589489a
          Preconditions.checkArgument(plugin != null, "null plugin");
          Preconditions.checkArgument(plugin.isEnabled(), "plugin is not enabled");
  
-@@ -653,6 +671,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -655,6 +673,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setChunkForceLoaded(int x, int z, boolean forced) {
@@ -78,7 +78,7 @@ index 6beefb48468779005cb3e93d1c6d8c0465e84d73..c9ab48d99992a39cc6977424c589489a
          this.getHandle().setChunkForced(x, z, forced);
      }
  
-@@ -965,6 +984,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -967,6 +986,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public int getHighestBlockYAt(int x, int z, org.bukkit.HeightMap heightMap) {
@@ -86,7 +86,7 @@ index 6beefb48468779005cb3e93d1c6d8c0465e84d73..c9ab48d99992a39cc6977424c589489a
          // Transient load for this tick
          return this.world.getChunk(x >> 4, z >> 4).getHeight(CraftHeightMap.toNMS(heightMap), x, z);
      }
-@@ -2387,6 +2407,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2414,6 +2434,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot end
      // Paper start
      public java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(int x, int z, boolean gen, boolean urgent) {

--- a/patches/server/0862-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0862-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0d8bdc59e8b900fc39234aaeb9b0faa97c71ec33..11a8f6105a3de444dbe3a13ce98f9c91697bdc71 100644
+index 337dbf8e5a2537e1d617d355a9a0f79171a69524..52dc37b5127a3ae3a3948c645968365fd0dc0908 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3162,6 +3162,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3164,6 +3164,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0879-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0879-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 11a8f6105a3de444dbe3a13ce98f9c91697bdc71..6b64a88d7653f2df288764a988d957d94b625ebe 100644
+index 52dc37b5127a3ae3a3948c645968365fd0dc0908..68f12f6352cd19a2a681f7008ec91746323f7af6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3167,6 +3167,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3169,6 +3169,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0893-fix-Instruments.patch
+++ b/patches/server/0893-fix-Instruments.patch
@@ -6,48 +6,51 @@ Subject: [PATCH] fix Instruments
 properly handle Player#playNote
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6b64a88d7653f2df288764a988d957d94b625ebe..28963293732ff801ab0926a4b6affaec52cada54 100644
+index 68f12f6352cd19a2a681f7008ec91746323f7af6..98f8ffe3e69d563fb7dd07f3c42476d52239fff4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -716,29 +716,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -719,7 +719,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         Sound instrumentSound = instrument.getSound();
+         if (instrumentSound == null) return;
  
-         if (this.getHandle().connection == null) return;
- 
--        Sound instrumentSound = switch (instrument.ordinal()) {
--            case 0 -> Sound.BLOCK_NOTE_BLOCK_HARP;
--            case 1 -> Sound.BLOCK_NOTE_BLOCK_BASEDRUM;
--            case 2 -> Sound.BLOCK_NOTE_BLOCK_SNARE;
--            case 3 -> Sound.BLOCK_NOTE_BLOCK_HAT;
--            case 4 -> Sound.BLOCK_NOTE_BLOCK_BASS;
--            case 5 -> Sound.BLOCK_NOTE_BLOCK_FLUTE;
--            case 6 -> Sound.BLOCK_NOTE_BLOCK_BELL;
--            case 7 -> Sound.BLOCK_NOTE_BLOCK_GUITAR;
--            case 8 -> Sound.BLOCK_NOTE_BLOCK_CHIME;
--            case 9 -> Sound.BLOCK_NOTE_BLOCK_XYLOPHONE;
--            case 10 -> Sound.BLOCK_NOTE_BLOCK_IRON_XYLOPHONE;
--            case 11 -> Sound.BLOCK_NOTE_BLOCK_COW_BELL;
--            case 12 -> Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO;
--            case 13 -> Sound.BLOCK_NOTE_BLOCK_BIT;
--            case 14 -> Sound.BLOCK_NOTE_BLOCK_BANJO;
--            case 15 -> Sound.BLOCK_NOTE_BLOCK_PLING;
--            case 16 -> Sound.BLOCK_NOTE_BLOCK_XYLOPHONE;
--            default -> null;
--        };
--
--        float f = (float) Math.pow(2.0D, (note.getId() - 12.0D) / 12.0D);
--        this.getHandle().connection.send(new ClientboundSoundPacket(CraftSound.bukkitToMinecraftHolder(instrumentSound), net.minecraft.sounds.SoundSource.RECORDS, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ(), 3.0f, f, this.getHandle().getRandom().nextLong()));
-+        // Paper start - fix all this (modeled off of NoteBlock)
-+        net.minecraft.world.level.block.state.properties.NoteBlockInstrument noteBlockInstrument = CraftBlockData.toNMS(instrument, net.minecraft.world.level.block.state.properties.NoteBlockInstrument.class);
-+        float pitch;
-+        if (noteBlockInstrument.isTunable()) {
-+            pitch = (float) Math.pow(2.0D, (note.getId() - 12.0D) / 12.0D);
-+        } else {
-+            pitch = 1.0f;
-+        }
-+        if (!noteBlockInstrument.hasCustomSound()) {
-+            this.getHandle().connection.send(new ClientboundSoundPacket(noteBlockInstrument.getSoundEvent(), net.minecraft.sounds.SoundSource.RECORDS, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ(), 3.0f, pitch, this.getHandle().getRandom().nextLong()));
-+        }
+-        float pitch = note.getPitch();
++        // Paper start - use correct pitch (modeled off of NoteBlock)
++        final net.minecraft.world.level.block.state.properties.NoteBlockInstrument noteBlockInstrument = CraftBlockData.toNMS(instrument, net.minecraft.world.level.block.state.properties.NoteBlockInstrument.class);
++        final float pitch = noteBlockInstrument.isTunable() ? note.getPitch() : 1.0f;
 +        // Paper end
+         this.getHandle().connection.send(new ClientboundSoundPacket(CraftSound.bukkitToMinecraftHolder(instrumentSound), net.minecraft.sounds.SoundSource.RECORDS, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ(), 3.0f, pitch, this.getHandle().getRandom().nextLong()));
      }
  
-     @Override
+diff --git a/src/test/java/io/papermc/paper/block/InstrumentSoundTest.java b/src/test/java/io/papermc/paper/block/InstrumentSoundTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..28fc01045675247e75438bdc039fb8a90493419f
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/block/InstrumentSoundTest.java
+@@ -0,0 +1,27 @@
++package io.papermc.paper.block;
++
++import java.util.Arrays;
++import java.util.stream.Stream;
++import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
++import org.bukkit.Instrument;
++import org.bukkit.craftbukkit.CraftSound;
++import org.bukkit.craftbukkit.block.data.CraftBlockData;
++import org.bukkit.support.AbstractTestingBase;
++import org.junit.jupiter.params.ParameterizedTest;
++import org.junit.jupiter.params.provider.MethodSource;
++
++import static org.junit.jupiter.api.Assertions.assertEquals;
++
++class InstrumentSoundTest extends AbstractTestingBase {
++
++    static Stream<Instrument> bukkitInstruments() {
++        return Arrays.stream(Instrument.values()).filter(i -> i.getSound() != null);
++    }
++
++    @ParameterizedTest
++    @MethodSource("bukkitInstruments")
++    void checkInstrumentSound(final Instrument bukkit) {
++        final NoteBlockInstrument nms = CraftBlockData.toNMS(bukkit, NoteBlockInstrument.class);
++        assertEquals(nms.getSoundEvent(), CraftSound.bukkitToMinecraftHolder(bukkit.getSound()));
++    }
++}

--- a/patches/server/0903-Flying-Fall-Damage.patch
+++ b/patches/server/0903-Flying-Fall-Damage.patch
@@ -26,10 +26,10 @@ index f9a308490e1cd7745dc12369c6041f0ae9e0b1e1..481c3e321cfc0f20bb1c4c6942b8bdbd
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 28963293732ff801ab0926a4b6affaec52cada54..a26f4115b3fc1964e259d73bfbca315396394ced 100644
+index 98f8ffe3e69d563fb7dd07f3c42476d52239fff4..b2b50317569364504d51fd02442a30b75069e88a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2382,6 +2382,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2398,6 +2398,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().onUpdateAbilities();
      }
  

--- a/patches/server/0909-Win-Screen-API.patch
+++ b/patches/server/0909-Win-Screen-API.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Win Screen API
 public net.minecraft.server.level.ServerPlayer seenCredits
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a26f4115b3fc1964e259d73bfbca315396394ced..e55898d5237d4413dfa2ea81f7e5f4941901bc08 100644
+index b2b50317569364504d51fd02442a30b75069e88a..e37affe585e207eeb1d69feabbfa99218e08022b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1205,6 +1205,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1221,6 +1221,25 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  

--- a/patches/server/0941-Expand-PlayerItemMendEvent.patch
+++ b/patches/server/0941-Expand-PlayerItemMendEvent.patch
@@ -33,10 +33,10 @@ index 37cd883f4920d5e1e58900ebdcfd4495a0abd2ae..6dac7cd4c9abfbde299f5d279acc2739
              return k > 0 ? this.repairPlayerItems(player, k) : 0;
          } else {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 11f4e48f33d6feacdd961bd1f767dbea11412252..5ab142f17b794bf73dc26ee35b5c59797d13efd3 100644
+index e37affe585e207eeb1d69feabbfa99218e08022b..adc90af7ee07ce5f714bfc92b870c4d78e5c6dc9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1727,11 +1727,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1743,11 +1743,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              orb.setPosRaw(handle.getX(), handle.getY(), handle.getZ());
  
              int i = Math.min(orb.xpToDurability(amount), itemstack.getDamageValue());

--- a/patches/server/0966-Fix-BanList-API.patch
+++ b/patches/server/0966-Fix-BanList-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix BanList API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
-index 9e01ef76bc6d18ab622fbec729f8bde3aa8d3e41..f9b2d773449fa5d332e0c37454ba6ea731982e85 100644
+index a0fcd11e6b0ca2a7055a4d1910124b20bd9c0b94..9daec0782774ab51ea8091cb8ed9d0a106e34cfa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
 @@ -114,17 +114,17 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
@@ -208,10 +208,10 @@ index 172202accf4448a933fcf1ff820316c7910dd7f7..50ee7656580d386db473c054f5c5ec57
              return null;
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 200f2a0a98e32fa722e50bf204d3ee886da58815..48e6b61c0b61507e9aac7557ce3b9c7f115b8539 100644
+index adc90af7ee07ce5f714bfc92b870c4d78e5c6dc9..daf519f6eb367ef2404d33929e69fe44b6f8bb07 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1625,23 +1625,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1641,23 +1641,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override
@@ -240,7 +240,7 @@ index 200f2a0a98e32fa722e50bf204d3ee886da58815..48e6b61c0b61507e9aac7557ce3b9c7f
          if (kickPlayer) {
              this.kickPlayer(reason);
          }
-@@ -1649,12 +1649,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1665,12 +1665,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      @Override

--- a/patches/server/0986-Bandaid-fix-for-Effect.patch
+++ b/patches/server/0986-Bandaid-fix-for-Effect.patch
@@ -45,10 +45,10 @@ index 5a5a8945c786e16ff0df62494ddd1ac85c42b53f..63f9735d356dafd579cee4423d3037eb
          case COMPOSTER_FILL_ATTEMPT:
              datavalue = ((Boolean) data) ? 1 : 0;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c9ab48d99992a39cc6977424c589489a35f36992..5e350fa39f47d54f6048ea89c1317759f122b8ae 100644
+index 3df9f69e4297ef0f412191f8a0c1cb17311f4de3..44d6a7373fe0c7b6afff31e149174367e9873bf9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1374,7 +1374,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1376,7 +1376,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public <T> void playEffect(Location loc, Effect effect, T data, int radius) {
          if (data != null) {
              Preconditions.checkArgument(effect.getData() != null, "Effect.%s does not have a valid Data", effect);
@@ -58,10 +58,10 @@ index c9ab48d99992a39cc6977424c589489a35f36992..5e350fa39f47d54f6048ea89c1317759
              // Special case: the axis is optional for ELECTRIC_SPARK
              Preconditions.checkArgument(effect.getData() == null || effect == Effect.ELECTRIC_SPARK, "Wrong kind of data for the %s effect", effect);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 48e6b61c0b61507e9aac7557ce3b9c7f115b8539..2e0863cf1756c0b76e5637777f15f27e2c94fe6b 100644
+index daf519f6eb367ef2404d33929e69fe44b6f8bb07..17e2a26d5136b23898bdd15ef6a9d5b7ace65c8e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -852,7 +852,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -868,7 +868,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          Preconditions.checkArgument(effect != null, "Effect cannot be null");
          if (data != null) {
              Preconditions.checkArgument(effect.getData() != null, "Effect.%s does not have a valid Data", effect);

--- a/patches/server/0995-Add-Listing-API-for-Player.patch
+++ b/patches/server/0995-Add-Listing-API-for-Player.patch
@@ -113,7 +113,7 @@ index 3a70b7e1319c3ecab9eb720f8a1a34c0efe21a4b..33abcf12b4426572b74ca4c813e4392c
          // Paper end
          player.sentListPacket = true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2e0863cf1756c0b76e5637777f15f27e2c94fe6b..97ef38f744908a09e4d24c445a5cc39db0e6ee7e 100644
+index 17e2a26d5136b23898bdd15ef6a9d5b7ace65c8e..3b6b89954d30908ff5ed23acfacbb3ef9b8a6f03 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -184,6 +184,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -124,7 +124,7 @@ index 2e0863cf1756c0b76e5637777f15f27e2c94fe6b..97ef38f744908a09e4d24c445a5cc39d
      private static final WeakHashMap<Plugin, WeakReference<Plugin>> pluginWeakReferences = new WeakHashMap<>();
      private int hash = 0;
      private double health = 20;
-@@ -1965,7 +1966,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1981,7 +1982,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
                  otherPlayer.setUUID(uuidOverride);
              }
              // Paper end
@@ -133,7 +133,7 @@ index 2e0863cf1756c0b76e5637777f15f27e2c94fe6b..97ef38f744908a09e4d24c445a5cc39d
              if (original != null) otherPlayer.setUUID(original); // Paper - uuid override
          }
  
-@@ -2074,6 +2075,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2090,6 +2091,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (entity != null) ? this.canSee(entity) : false; // If we can't find it, we can't see it
      }
  

--- a/patches/server/1036-Add-player-idle-duration-API.patch
+++ b/patches/server/1036-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f6bc3a4af1bffe6abf5a93e975848de44965cbe3..57b67e42c1e5784ecd752cf1a5165a4d7eccdb15 100644
+index e593e0bc9d207325a9e9d38296b29230a353077e..64c3e4b0ce2cc111eedc2aa1ecf2c6c5d05f1e9d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3270,6 +3270,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3286,6 +3286,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/1039-Allow-null-itemstack-for-Player-sendEquipmentChange.patch
+++ b/patches/server/1039-Allow-null-itemstack-for-Player-sendEquipmentChange.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow null itemstack for Player#sendEquipmentChange
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 57b67e42c1e5784ecd752cf1a5165a4d7eccdb15..00bae5df87bcc1c75d4e2f430241579d3be82c11 100644
+index 64c3e4b0ce2cc111eedc2aa1ecf2c6c5d05f1e9d..3a792ddc31e76038b84e8f87088c4cd94c349138 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1062,7 +1062,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1078,7 +1078,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void sendEquipmentChange(LivingEntity entity, EquipmentSlot slot, ItemStack item) {

--- a/patches/server/1042-Add-predicate-for-blocks-when-raytracing.patch
+++ b/patches/server/1042-Add-predicate-for-blocks-when-raytracing.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add predicate for blocks when raytracing
 
 
 diff --git a/src/main/java/net/minecraft/world/level/BlockGetter.java b/src/main/java/net/minecraft/world/level/BlockGetter.java
-index 799837c172a5f7856c78e6fe2595c575f3058a5e..e2066c52941d20fe01d3381181c3e5bf2d2ccb9a 100644
+index 799837c172a5f7856c78e6fe2595c575f3058a5e..7205865bbe0f83fb35678bddc0977f92980e77b5 100644
 --- a/src/main/java/net/minecraft/world/level/BlockGetter.java
 +++ b/src/main/java/net/minecraft/world/level/BlockGetter.java
 @@ -83,6 +83,12 @@ public interface BlockGetter extends LevelHeightAccessor {
@@ -16,7 +16,7 @@ index 799837c172a5f7856c78e6fe2595c575f3058a5e..e2066c52941d20fe01d3381181c3e5bf
 +        return clip(raytrace1, blockposition, null);
 +    }
 +
-+    default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition, java.util.function.Predicate<org.bukkit.block.Block> canCollide) {
++    default BlockHitResult clip(ClipContext raytrace1, BlockPos blockposition, java.util.function.Predicate<? super org.bukkit.block.Block> canCollide) {
 +            // Paper end
              // Paper start - Prevent raytrace from loading chunks
              BlockState iblockdata = this.getBlockStateIfLoaded(blockposition);
@@ -38,7 +38,7 @@ index 799837c172a5f7856c78e6fe2595c575f3058a5e..e2066c52941d20fe01d3381181c3e5bf
 +        return clip(context, (java.util.function.Predicate<org.bukkit.block.Block>) null);
 +    }
 +
-+    default BlockHitResult clip(ClipContext context, java.util.function.Predicate<org.bukkit.block.Block> canCollide) {
++    default BlockHitResult clip(ClipContext context, java.util.function.Predicate<? super org.bukkit.block.Block> canCollide) {
 +        // Paper end
          return (BlockHitResult) BlockGetter.traverseBlocks(context.getFrom(), context.getTo(), context, (raytrace1, blockposition) -> {
 -            return this.clip(raytrace1, blockposition); // CraftBukkit - moved into separate method
@@ -47,18 +47,18 @@ index 799837c172a5f7856c78e6fe2595c575f3058a5e..e2066c52941d20fe01d3381181c3e5bf
              Vec3 vec3d = raytrace1.getFrom().subtract(raytrace1.getTo());
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5e350fa39f47d54f6048ea89c1317759f122b8ae..746f88db6b78b3c8ec372bfaacb26ec98f3b1163 100644
+index 44d6a7373fe0c7b6afff31e149174367e9873bf9..30528f527de27c1cc21d1d20a6ed7d54bd93cb5a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1118,9 +1118,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1120,9 +1120,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
-     public RayTraceResult rayTraceEntities(Location start, Vector direction, double maxDistance, double raySize, Predicate<Entity> filter) {
+     public RayTraceResult rayTraceEntities(Location start, Vector direction, double maxDistance, double raySize, Predicate<? super Entity> filter) {
 +        // Paper start
 +        return rayTraceEntities((io.papermc.paper.math.Position) start, direction, maxDistance, raySize, filter);
 +    }
 +
-+    public RayTraceResult rayTraceEntities(io.papermc.paper.math.Position start, Vector direction, double maxDistance, double raySize, Predicate<Entity> filter) {
++    public RayTraceResult rayTraceEntities(io.papermc.paper.math.Position start, Vector direction, double maxDistance, double raySize, Predicate<? super Entity> filter) {
          Preconditions.checkArgument(start != null, "Location start cannot be null");
 -        Preconditions.checkArgument(this.equals(start.getWorld()), "Location start cannot be in a different world");
 -        start.checkFinite();
@@ -68,7 +68,7 @@ index 5e350fa39f47d54f6048ea89c1317759f122b8ae..746f88db6b78b3c8ec372bfaacb26ec9
  
          Preconditions.checkArgument(direction != null, "Vector direction cannot be null");
          direction.checkFinite();
-@@ -1170,9 +1176,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1172,9 +1178,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks) {
@@ -77,7 +77,7 @@ index 5e350fa39f47d54f6048ea89c1317759f122b8ae..746f88db6b78b3c8ec372bfaacb26ec9
 +    }
 +
 +    @Override
-+    public RayTraceResult rayTraceBlocks(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, Predicate<Block> canCollide) {
++    public RayTraceResult rayTraceBlocks(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, Predicate<? super Block> canCollide) {
          Preconditions.checkArgument(start != null, "Location start cannot be null");
 -        Preconditions.checkArgument(this.equals(start.getWorld()), "Location start cannot be in a different world");
 -        start.checkFinite();
@@ -87,7 +87,7 @@ index 5e350fa39f47d54f6048ea89c1317759f122b8ae..746f88db6b78b3c8ec372bfaacb26ec9
  
          Preconditions.checkArgument(direction != null, "Vector direction cannot be null");
          direction.checkFinite();
-@@ -1185,16 +1198,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1187,16 +1200,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
  
          Vector dir = direction.clone().normalize().multiply(maxDistance);
@@ -101,14 +101,14 @@ index 5e350fa39f47d54f6048ea89c1317759f122b8ae..746f88db6b78b3c8ec372bfaacb26ec9
      }
  
      @Override
-     public RayTraceResult rayTrace(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<Entity> filter) {
+     public RayTraceResult rayTrace(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<? super Entity> filter) {
 -        RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks);
 +        // Paper start
 +        return this.rayTrace(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, raySize, filter, null);
 +    }
 +
 +    @Override
-+    public RayTraceResult rayTrace(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<Entity> filter, Predicate<Block> canCollide) {
++    public RayTraceResult rayTrace(io.papermc.paper.math.Position start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode, boolean ignorePassableBlocks, double raySize, Predicate<? super Entity> filter, Predicate<? super Block> canCollide) {
 +        RayTraceResult blockHit = this.rayTraceBlocks(start, direction, maxDistance, fluidCollisionMode, ignorePassableBlocks, canCollide);
 +        // Paper end
          Vector startVec = null;

--- a/patches/server/1048-Fix-strikeLightningEffect-powers-lightning-rods-and-.patch
+++ b/patches/server/1048-Fix-strikeLightningEffect-powers-lightning-rods-and-.patch
@@ -46,10 +46,10 @@ index 471275c5362b61ce8b5b9dd5c85b3e93cabd3f76..841ee02f6ad19d737534a2bf9f52d0d0
              BlockState iblockdata = BaseFireBlock.getState(this.level(), blockposition);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 746f88db6b78b3c8ec372bfaacb26ec98f3b1163..c3060d1d4d0caf369c6ab516cb424f45eb851019 100644
+index 30528f527de27c1cc21d1d20a6ed7d54bd93cb5a..f19f2199cac5a7eb275f40cc23472416a40ec0da 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -771,7 +771,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -773,7 +773,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          LightningBolt lightning = EntityType.LIGHTNING_BOLT.create(this.world);
          lightning.moveTo(loc.getX(), loc.getY(), loc.getZ());
@@ -58,7 +58,7 @@ index 746f88db6b78b3c8ec372bfaacb26ec98f3b1163..c3060d1d4d0caf369c6ab516cb424f45
          this.world.strikeLightning(lightning, LightningStrikeEvent.Cause.CUSTOM);
          return (LightningStrike) lightning.getBukkitEntity();
      }
-@@ -2403,7 +2403,6 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2430,7 +2430,6 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          {
              LightningBolt lightning = EntityType.LIGHTNING_BOLT.create( CraftWorld.this.world );
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
@@ -66,7 +66,7 @@ index 746f88db6b78b3c8ec372bfaacb26ec98f3b1163..c3060d1d4d0caf369c6ab516cb424f45
              CraftWorld.this.world.strikeLightning( lightning, LightningStrikeEvent.Cause.CUSTOM );
              return (LightningStrike) lightning.getBukkitEntity();
          }
-@@ -2413,8 +2412,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2440,8 +2439,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          {
              LightningBolt lightning = EntityType.LIGHTNING_BOLT.create( CraftWorld.this.world );
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
96340858 PR-938: Various Sound API improvements
cbfe0ff0 PR-937: Minor improvements to World#rayTrace documentation
e979ee95 PR-935: Change Consumer and Predicates to super
27ae46dc SPIGOT-3641, SPIGOT-7479, PR-931: Add missing values to EntityEffect
0616ec8b Add eclipse .factorypath file to .gitignore

CraftBukkit Changes:
8e162d008 PR-1301: Various Sound API improvements
eeb7dfc2d SPIGOT-7520: Attribute LootTableSeed missing for generated containers with attached LootTable d433f086d PR-1297: Change Consumer and Predicates to super
864f616da SPIGOT-7518: Fix NullPointerException when calling Block#applyBoneMeal()
5a2d905af Add eclipse .factorypath file to .gitignore
7c6bf15d4 Fix SkullMeta configuration serialization / deserialization with note block sound

Spigot Changes:
7de1049b Rebuild patches