### PR TITLE
[ci skip] Improve PlayerChatEvent Deprecation Message

### DIFF
--- a/patches/api/0005-Adventure.patch
+++ b/patches/api/0005-Adventure.patch
@@ -3210,14 +3210,20 @@ index 9866c07c999f46cb585709804aaad710c3031d5a..c7c45e2de8cca1bf8b8e12752e08db62
  
      /**
 diff --git a/src/main/java/org/bukkit/event/player/PlayerChatEvent.java b/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
-index a1f4261eaa1497554f1e51d1d5a072c2eb9226df..3a1da86e3dbf18c6e1040086c1df4b8976bc2b9d 100644
+index a1f4261eaa1497554f1e51d1d5a072c2eb9226df..2c021bc2ff18f0b3af5feb9dafc8ccebd604f8b5 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerChatEvent.java
-@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
-  *     Listening to this event forces chat to wait for the main thread which
-  *     causes delays for chat. {@link AsyncPlayerChatEvent} is the encouraged
-  *     alternative for thread safe implementations.
-+ * @deprecated use {@link io.papermc.paper.event.player.ChatEvent} instead
+@@ -12,12 +12,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Holds information for player chat and commands
+  *
+- * @deprecated This event will fire from the main thread and allows the use of
+- *     all of the Bukkit API, unlike the {@link AsyncPlayerChatEvent}.
+- *     <p>
+- *     Listening to this event forces chat to wait for the main thread which
+- *     causes delays for chat. {@link AsyncPlayerChatEvent} is the encouraged
+- *     alternative for thread safe implementations.
++ * @deprecated Listening to this event forces chat to wait for the main thread, delaying chat messages. It is recommended to use {@link io.papermc.paper.event.player.AsyncChatEvent} instead, wherever possible.
   */
  @Deprecated
  @Warning(reason = "Listening to this event forces chat to wait for the main thread, delaying chat messages.")


### PR DESCRIPTION
The PlayerChatEvent previously linked to the now deprecated AsyncPlayerChatEvent and there were double deprecated annotations. I just took the deprecation message from ChatEvent since that one seems nice and compact  