### PR TITLE
Fix plugin bootstrap dependency tree population

### DIFF
--- a/patches/server/1053-Fix-plugin-bootstrap-dependency-tree-population.patch
+++ b/patches/server/1053-Fix-plugin-bootstrap-dependency-tree-population.patch
@@ -1,0 +1,482 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gijs de Jong <berichtaangijs@gmail.com>
+Date: Wed, 22 Nov 2023 23:58:55 +0100
+Subject: [PATCH] Fix plugin bootstrap dependency tree population
+
+This patch fixes a bug where the dependency tree used for classpath joining,
+wasn't built using the bootstrap dependencies, for plugin bootstrappers.
+
+diff --git a/src/main/java/io/papermc/paper/command/subcommands/DumpPluginsCommand.java b/src/main/java/io/papermc/paper/command/subcommands/DumpPluginsCommand.java
+index 8ade7eb97aa899ddd4bb8274b8f588a4d7265868..d4a092243e587e3a555fbc0f00c8f78c00b3d1c6 100644
+--- a/src/main/java/io/papermc/paper/command/subcommands/DumpPluginsCommand.java
++++ b/src/main/java/io/papermc/paper/command/subcommands/DumpPluginsCommand.java
+@@ -16,7 +16,7 @@ import io.papermc.paper.plugin.entrypoint.classloader.group.SimpleListPluginClas
+ import io.papermc.paper.plugin.entrypoint.classloader.group.SpigotPluginClassLoaderGroup;
+ import io.papermc.paper.plugin.entrypoint.classloader.group.StaticPluginClassLoaderGroup;
+ import io.papermc.paper.plugin.entrypoint.dependency.GraphDependencyContext;
+-import io.papermc.paper.plugin.entrypoint.dependency.MetaDependencyTree;
++import io.papermc.paper.plugin.entrypoint.dependency.SimpleMetaDependencyTree;
+ import io.papermc.paper.plugin.provider.entrypoint.DependencyContext;
+ import io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy;
+ import io.papermc.paper.plugin.entrypoint.strategy.ProviderConfiguration;
+@@ -141,7 +141,7 @@ public final class DumpPluginsCommand implements PaperSubcommand {
+                     return false;
+                 }
+             });
+-            modernPluginLoadingStrategy.loadProviders(pluginProviders, new MetaDependencyTree(GraphBuilder.directed().build()));
++            modernPluginLoadingStrategy.loadProviders(pluginProviders, new SimpleMetaDependencyTree(GraphBuilder.directed().build()));
+ 
+             rootProviders.add(entry.getKey().getDebugName(), entrypoint);
+         }
+diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/BootstrapMetaDependencyTree.java b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/BootstrapMetaDependencyTree.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..b6273c99ae2d8a50cb91b3686b8b8b434a87fd7e
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/BootstrapMetaDependencyTree.java
+@@ -0,0 +1,67 @@
++package io.papermc.paper.plugin.entrypoint.dependency;
++
++import com.google.common.graph.GraphBuilder;
++import com.google.common.graph.MutableGraph;
++import io.papermc.paper.plugin.configuration.PluginMeta;
++import io.papermc.paper.plugin.provider.configuration.PaperPluginMeta;
++
++public class BootstrapMetaDependencyTree extends SimpleMetaDependencyTree {
++    public BootstrapMetaDependencyTree() {
++        this(GraphBuilder.directed().build());
++    }
++
++    public BootstrapMetaDependencyTree(MutableGraph<String> graph) {
++        super(graph);
++    }
++
++    @Override
++    public void add(PluginMeta configuration) {
++        if (!(configuration instanceof PaperPluginMeta paperPluginMeta)) {
++            throw new IllegalStateException("Only paper plugins can have a bootstrapper!");
++        }
++
++        String identifier = configuration.getName();
++
++        // Build a validated provider's dependencies into the graph
++        for (String dependency : paperPluginMeta.getBoostrapDependencies().keySet()) {
++            this.graph.putEdge(identifier, dependency);
++        }
++
++        this.graph.addNode(identifier); // Make sure dependencies at least have a node
++
++        // Add the provided plugins to the graph as well
++        for (String provides : configuration.getProvidedPlugins()) {
++            this.graph.putEdge(identifier, provides);
++            this.dependencies.add(provides);
++        }
++        this.dependencies.add(identifier);
++    }
++
++    @Override
++    public void remove(PluginMeta configuration) {
++        String identifier = configuration.getName();
++        // Remove a validated provider's dependencies into the graph
++        if (!(configuration instanceof PaperPluginMeta paperPluginMeta)) {
++            throw new IllegalStateException("PluginMeta must be a PaperPluginMeta");
++        }
++
++        // Build a validated provider's dependencies into the graph
++        for (String dependency : paperPluginMeta.getBoostrapDependencies().keySet()) {
++            this.graph.removeEdge(identifier, dependency);
++        }
++
++        this.graph.removeNode(identifier); // Remove root node
++
++        // Remove the provided plugins to the graph as well
++        for (String provides : configuration.getProvidedPlugins()) {
++            this.graph.removeEdge(identifier, provides);
++            this.dependencies.remove(provides);
++        }
++        this.dependencies.remove(identifier);
++    }
++
++    @Override
++    public String toString() {
++        return "BootstrapDependencyTree{" + "graph=" + this.graph + '}';
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/MetaDependencyTree.java b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/MetaDependencyTree.java
+index e72bec3b0cbc41580f1b4beecae316d1c083d3e3..62da59c30511065379658d1b34e780a33c15ce90 100644
+--- a/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/MetaDependencyTree.java
++++ b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/MetaDependencyTree.java
+@@ -1,117 +1,26 @@
+ package io.papermc.paper.plugin.entrypoint.dependency;
+ 
+-import com.google.common.graph.GraphBuilder;
+-import com.google.common.graph.Graphs;
+ import com.google.common.graph.MutableGraph;
+ import io.papermc.paper.plugin.configuration.PluginMeta;
+ import io.papermc.paper.plugin.provider.PluginProvider;
+ import io.papermc.paper.plugin.provider.entrypoint.DependencyContext;
+-import org.jetbrains.annotations.NotNull;
+ 
+-import java.util.HashSet;
+-import java.util.Set;
++public interface MetaDependencyTree extends DependencyContext {
+ 
+-public class MetaDependencyTree implements DependencyContext {
++    void add(PluginMeta configuration);
+ 
+-    private final MutableGraph<String> graph;
+-
+-    // We need to upkeep a separate collection since when populating
+-    // a graph it adds nodes even if they are not present
+-    private final Set<String> dependencies = new HashSet<>();
+-
+-    public MetaDependencyTree() {
+-        this(GraphBuilder.directed().build());
+-    }
+-
+-    public MetaDependencyTree(MutableGraph<String> graph) {
+-        this.graph = graph;
+-    }
+-
+-    public void add(PluginProvider<?> provider) {
++    default void add(PluginProvider<?> provider) {
+         add(provider.getMeta());
+     }
+ 
+-    public void remove(PluginProvider<?> provider) {
+-        remove(provider.getMeta());
+-    }
+-
+-    public void add(PluginMeta configuration) {
+-        String identifier = configuration.getName();
+-        // Build a validated provider's dependencies into the graph
+-        for (String dependency : configuration.getPluginDependencies()) {
+-            this.graph.putEdge(identifier, dependency);
+-        }
+-        for (String dependency : configuration.getPluginSoftDependencies()) {
+-            this.graph.putEdge(identifier, dependency);
+-        }
+-
+-        this.graph.addNode(identifier); // Make sure dependencies at least have a node
+-
+-        // Add the provided plugins to the graph as well
+-        for (String provides : configuration.getProvidedPlugins()) {
+-            this.graph.putEdge(identifier, provides);
+-            this.dependencies.add(provides);
+-        }
+-        this.dependencies.add(identifier);
+-    }
+-
+-    public void remove(PluginMeta configuration) {
+-        String identifier = configuration.getName();
+-        // Remove a validated provider's dependencies into the graph
+-        for (String dependency : configuration.getPluginDependencies()) {
+-            this.graph.removeEdge(identifier, dependency);
+-        }
+-        for (String dependency : configuration.getPluginSoftDependencies()) {
+-            this.graph.removeEdge(identifier, dependency);
+-        }
+-
+-        this.graph.removeNode(identifier); // Remove root node
+-
+-        // Remove the provided plugins to the graph as well
+-        for (String provides : configuration.getProvidedPlugins()) {
+-            this.graph.removeEdge(identifier, provides);
+-            this.dependencies.remove(provides);
+-        }
+-        this.dependencies.remove(identifier);
+-    }
+-
+-    @Override
+-    public boolean isTransitiveDependency(@NotNull PluginMeta plugin, @NotNull PluginMeta depend) {
+-        String pluginIdentifier = plugin.getName();
+-
+-        if (this.graph.nodes().contains(pluginIdentifier)) {
+-            Set<String> reachableNodes = Graphs.reachableNodes(this.graph, pluginIdentifier);
+-            if (reachableNodes.contains(depend.getName())) {
+-                return true;
+-            }
+-            for (String provided : depend.getProvidedPlugins()) {
+-                if (reachableNodes.contains(provided)) {
+-                    return true;
+-                }
+-            }
+-        }
+-
+-        return false;
+-    }
+-
+-    @Override
+-    public boolean hasDependency(@NotNull String pluginIdentifier) {
+-        return this.dependencies.contains(pluginIdentifier);
+-    }
+-
+     // Used by the legacy loader -- this isn't recommended
+-    public void addDirectDependency(String dependency) {
+-        this.dependencies.add(dependency);
+-    }
++    void addDirectDependency(String dependency);
+ 
+-    @Override
+-    public String toString() {
+-        return "ProviderDependencyTree{" +
+-            "graph=" + this.graph +
+-            '}';
+-    }
++    void remove(PluginMeta configuration);
+ 
+-    public MutableGraph<String> getGraph() {
+-        return graph;
++    default void remove(PluginProvider<?> provider) {
++        remove(provider.getMeta());
+     }
++
++    MutableGraph<String> getGraph();
+ }
+diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/SimpleMetaDependencyTree.java b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/SimpleMetaDependencyTree.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..f02e4fd2d838470dbb0fb25359bdfea1e55552ba
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/plugin/entrypoint/dependency/SimpleMetaDependencyTree.java
+@@ -0,0 +1,107 @@
++package io.papermc.paper.plugin.entrypoint.dependency;
++
++import com.google.common.graph.GraphBuilder;
++import com.google.common.graph.Graphs;
++import com.google.common.graph.MutableGraph;
++import io.papermc.paper.plugin.configuration.PluginMeta;
++import org.jetbrains.annotations.NotNull;
++
++import java.util.HashSet;
++import java.util.Set;
++
++public class SimpleMetaDependencyTree implements MetaDependencyTree {
++    protected final MutableGraph<String> graph;
++
++    // We need to upkeep a separate collection since when populating
++    // a graph it adds nodes even if they are not present
++    protected final Set<String> dependencies = new HashSet<>();
++
++    public SimpleMetaDependencyTree() {
++        this(GraphBuilder.directed().build());
++    }
++
++    public SimpleMetaDependencyTree(MutableGraph<String> graph) {
++        this.graph = graph;
++    }
++
++    public void add(PluginMeta configuration) {
++        String identifier = configuration.getName();
++        // Build a validated provider's dependencies into the graph
++        for (String dependency : configuration.getPluginDependencies()) {
++            this.graph.putEdge(identifier, dependency);
++        }
++        for (String dependency : configuration.getPluginSoftDependencies()) {
++            this.graph.putEdge(identifier, dependency);
++        }
++
++        this.graph.addNode(identifier); // Make sure dependencies at least have a node
++
++        // Add the provided plugins to the graph as well
++        for (String provides : configuration.getProvidedPlugins()) {
++            this.graph.putEdge(identifier, provides);
++            this.dependencies.add(provides);
++        }
++        this.dependencies.add(identifier);
++    }
++
++    public void remove(PluginMeta configuration) {
++        String identifier = configuration.getName();
++        // Remove a validated provider's dependencies into the graph
++        for (String dependency : configuration.getPluginDependencies()) {
++            this.graph.removeEdge(identifier, dependency);
++        }
++        for (String dependency : configuration.getPluginSoftDependencies()) {
++            this.graph.removeEdge(identifier, dependency);
++        }
++
++        this.graph.removeNode(identifier); // Remove root node
++
++        // Remove the provided plugins to the graph as well
++        for (String provides : configuration.getProvidedPlugins()) {
++            this.graph.removeEdge(identifier, provides);
++            this.dependencies.remove(provides);
++        }
++        this.dependencies.remove(identifier);
++    }
++
++    @Override
++    public boolean isTransitiveDependency(@NotNull PluginMeta plugin, @NotNull PluginMeta depend) {
++        String pluginIdentifier = plugin.getName();
++
++        if (this.graph.nodes().contains(pluginIdentifier)) {
++            Set<String> reachableNodes = Graphs.reachableNodes(this.graph, depend.getName());
++            if (reachableNodes.contains(depend.getName())) {
++                return true;
++            }
++            for (String provided : depend.getProvidedPlugins()) {
++                if (reachableNodes.contains(provided)) {
++                    return true;
++                }
++            }
++        }
++
++        return false;
++    }
++
++    @Override
++    public boolean hasDependency(@NotNull String pluginIdentifier) {
++        return this.dependencies.contains(pluginIdentifier);
++    }
++
++    @Override
++    public void addDirectDependency(String dependency) {
++        this.dependencies.add(dependency);
++    }
++
++    @Override
++    public String toString() {
++        return "SimpleDependencyTree{" +
++                "graph=" + this.graph +
++                '}';
++    }
++
++    @Override
++    public MutableGraph<String> getGraph() {
++        return graph;
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java b/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java
+index 9c7552968b8c017c71a7a77557a66a03ed89f125..08b1aab5d37a56dc42542ce15ba1f7ccd1b08400 100644
+--- a/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java
++++ b/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java
+@@ -6,6 +6,7 @@ import com.google.common.graph.MutableGraph;
+ import io.papermc.paper.plugin.configuration.PluginMeta;
+ import io.papermc.paper.plugin.entrypoint.Entrypoint;
+ import io.papermc.paper.plugin.entrypoint.dependency.MetaDependencyTree;
++import io.papermc.paper.plugin.entrypoint.dependency.SimpleMetaDependencyTree;
+ import io.papermc.paper.plugin.entrypoint.strategy.PluginGraphCycleException;
+ import io.papermc.paper.plugin.provider.classloader.ConfiguredPluginClassLoader;
+ import io.papermc.paper.plugin.provider.classloader.PaperClassLoaderStorage;
+@@ -55,7 +56,7 @@ class PaperPluginInstanceManager {
+     private final CommandMap commandMap;
+     private final Server server;
+ 
+-    private final MetaDependencyTree dependencyTree = new MetaDependencyTree(GraphBuilder.directed().build());
++    private final MetaDependencyTree dependencyTree = new SimpleMetaDependencyTree(GraphBuilder.directed().build());
+ 
+     public PaperPluginInstanceManager(PluginManager pluginManager, CommandMap commandMap, Server server) {
+         this.commandMap = commandMap;
+diff --git a/src/main/java/io/papermc/paper/plugin/storage/BootstrapProviderStorage.java b/src/main/java/io/papermc/paper/plugin/storage/BootstrapProviderStorage.java
+index 8ef13e4f00a61db0dab9ef63231d77adcfaba5ab..6db2bacd74a9eec9597bd8e62b1d5c7929655350 100644
+--- a/src/main/java/io/papermc/paper/plugin/storage/BootstrapProviderStorage.java
++++ b/src/main/java/io/papermc/paper/plugin/storage/BootstrapProviderStorage.java
+@@ -5,7 +5,9 @@ import io.papermc.paper.plugin.PluginInitializerManager;
+ import io.papermc.paper.plugin.bootstrap.BootstrapContext;
+ import io.papermc.paper.plugin.bootstrap.PluginBootstrap;
+ import io.papermc.paper.plugin.bootstrap.PluginBootstrapContextImpl;
++import io.papermc.paper.plugin.entrypoint.dependency.BootstrapMetaDependencyTree;
+ import io.papermc.paper.plugin.entrypoint.dependency.DependencyContextHolder;
++import io.papermc.paper.plugin.entrypoint.dependency.MetaDependencyTree;
+ import io.papermc.paper.plugin.entrypoint.strategy.ProviderConfiguration;
+ import io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy;
+ import io.papermc.paper.plugin.provider.PluginProvider;
+@@ -51,6 +53,11 @@ public class BootstrapProviderStorage extends SimpleProviderStorage<PluginBootst
+         }));
+     }
+ 
++    @Override
++    public MetaDependencyTree getDependencyTree() {
++        return new BootstrapMetaDependencyTree();
++    }
++
+     @Override
+     public String toString() {
+         return "BOOTSTRAP:" + super.toString();
+diff --git a/src/main/java/io/papermc/paper/plugin/storage/ProviderStorage.java b/src/main/java/io/papermc/paper/plugin/storage/ProviderStorage.java
+index 374e7d3d69fc8603ecf54999f173123d3a9fbf6e..23269665f5f13bc55a45c2384542f0194235f8b0 100644
+--- a/src/main/java/io/papermc/paper/plugin/storage/ProviderStorage.java
++++ b/src/main/java/io/papermc/paper/plugin/storage/ProviderStorage.java
+@@ -1,5 +1,6 @@
+ package io.papermc.paper.plugin.storage;
+ 
++import io.papermc.paper.plugin.entrypoint.dependency.MetaDependencyTree;
+ import io.papermc.paper.plugin.provider.PluginProvider;
+ 
+ /**
+@@ -11,6 +12,8 @@ public interface ProviderStorage<T> {
+ 
+     void register(PluginProvider<T> provider);
+ 
++    MetaDependencyTree getDependencyTree();
++
+     void enter();
+ 
+     Iterable<PluginProvider<T>> getRegisteredProviders();
+diff --git a/src/main/java/io/papermc/paper/plugin/storage/SimpleProviderStorage.java b/src/main/java/io/papermc/paper/plugin/storage/SimpleProviderStorage.java
+index 861c245290696eef0fca846c3026b407593fdce1..e4296230c773e68c816d7210a70b42f4bb9a0011 100644
+--- a/src/main/java/io/papermc/paper/plugin/storage/SimpleProviderStorage.java
++++ b/src/main/java/io/papermc/paper/plugin/storage/SimpleProviderStorage.java
+@@ -3,8 +3,8 @@ package io.papermc.paper.plugin.storage;
+ import com.google.common.graph.GraphBuilder;
+ import com.google.common.graph.MutableGraph;
+ import com.mojang.logging.LogUtils;
+-import io.papermc.paper.plugin.entrypoint.dependency.GraphDependencyContext;
+ import io.papermc.paper.plugin.entrypoint.dependency.MetaDependencyTree;
++import io.papermc.paper.plugin.entrypoint.dependency.SimpleMetaDependencyTree;
+ import io.papermc.paper.plugin.entrypoint.strategy.PluginGraphCycleException;
+ import io.papermc.paper.plugin.entrypoint.strategy.ProviderLoadingStrategy;
+ import io.papermc.paper.plugin.provider.PluginProvider;
+@@ -44,8 +44,9 @@ public abstract class SimpleProviderStorage<T> implements ProviderStorage<T> {
+         }
+     }
+ 
++    @Override
+     public MetaDependencyTree getDependencyTree() {
+-        return new MetaDependencyTree(GraphBuilder.directed().build());
++        return new SimpleMetaDependencyTree(GraphBuilder.directed().build());
+     }
+ 
+     @Override
+diff --git a/src/test/java/io/papermc/paper/plugin/PluginDependencyValidationTest.java b/src/test/java/io/papermc/paper/plugin/PluginDependencyValidationTest.java
+index ad92ae93acd25af4d223a55a0bcbc2a5740390a9..83b1274ba56f03bec6cb69a35f33dc04f008cc1e 100644
+--- a/src/test/java/io/papermc/paper/plugin/PluginDependencyValidationTest.java
++++ b/src/test/java/io/papermc/paper/plugin/PluginDependencyValidationTest.java
+@@ -1,6 +1,7 @@
+ package io.papermc.paper.plugin;
+ 
+ import io.papermc.paper.plugin.entrypoint.dependency.MetaDependencyTree;
++import io.papermc.paper.plugin.entrypoint.dependency.SimpleMetaDependencyTree;
+ import org.junit.jupiter.api.Test;
+ 
+ import java.util.List;
+@@ -31,7 +32,7 @@ public class PluginDependencyValidationTest {
+ 
+     @Test
+     public void testDependencyTree() {
+-        MetaDependencyTree tree = new MetaDependencyTree();
++        MetaDependencyTree tree = new SimpleMetaDependencyTree();
+         tree.add(MAIN);
+         tree.add(HARD_DEPENDENCY_1);
+         tree.add(SOFT_DEPENDENCY_1);
+diff --git a/src/test/java/io/papermc/paper/plugin/PluginLoadOrderTest.java b/src/test/java/io/papermc/paper/plugin/PluginLoadOrderTest.java
+index a66fd32cf8af310101161c1b820b3468657460f0..c2c3c2f24ea802628bc4a36ef180fc08f4e5d288 100644
+--- a/src/test/java/io/papermc/paper/plugin/PluginLoadOrderTest.java
++++ b/src/test/java/io/papermc/paper/plugin/PluginLoadOrderTest.java
+@@ -1,7 +1,7 @@
+ package io.papermc.paper.plugin;
+ 
+ import com.google.common.graph.GraphBuilder;
+-import io.papermc.paper.plugin.entrypoint.dependency.MetaDependencyTree;
++import io.papermc.paper.plugin.entrypoint.dependency.SimpleMetaDependencyTree;
+ import io.papermc.paper.plugin.provider.entrypoint.DependencyContext;
+ import io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy;
+ import io.papermc.paper.plugin.entrypoint.strategy.ProviderConfiguration;
+@@ -105,7 +105,7 @@ public class PluginLoadOrderTest {
+ 
+         });
+ 
+-        modernPluginLoadingStrategy.loadProviders(REGISTERED_PROVIDERS, new MetaDependencyTree(GraphBuilder.directed().build()));
++        modernPluginLoadingStrategy.loadProviders(REGISTERED_PROVIDERS, new SimpleMetaDependencyTree(GraphBuilder.directed().build()));
+     }
+ 
+     @Test


### PR DESCRIPTION
This patch fixes a bug where the dependency tree used for classpath joining,
wasn't built using the bootstrap dependencies, for plugin bootstrappers.