### PR TITLE
Un-experimentalize Entity TP APIs

### DIFF
--- a/patches/api/0370-More-Teleport-API.patch
+++ b/patches/api/0370-More-Teleport-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] More Teleport API
 
 diff --git a/src/main/java/io/papermc/paper/entity/LookAnchor.java b/src/main/java/io/papermc/paper/entity/LookAnchor.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c8312691c27ae436029ec5011ddf073582b12cba
+index 0000000000000000000000000000000000000000..544eec787ea837f7d29df6519255840d6fe087d7
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/entity/LookAnchor.java
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,24 @@
 +package io.papermc.paper.entity;
 +
 +import io.papermc.paper.math.Position;
@@ -22,7 +22,6 @@ index 0000000000000000000000000000000000000000..c8312691c27ae436029ec5011ddf0735
 + * @see org.bukkit.entity.Player#lookAt(Position, LookAnchor)
 + * @see org.bukkit.entity.Player#lookAt(Entity, LookAnchor, LookAnchor)
 + */
-+@org.jetbrains.annotations.ApiStatus.Experimental
 +public enum LookAnchor {
 +    /**
 +     * Represents the entity's feet.
@@ -37,15 +36,14 @@ index 0000000000000000000000000000000000000000..c8312691c27ae436029ec5011ddf0735
 +}
 diff --git a/src/main/java/io/papermc/paper/entity/TeleportFlag.java b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dbacefc919fd6ed6a0f5cdaa0f695a12eda9cc3f
+index 0000000000000000000000000000000000000000..c8b5b570d44da9524bfc59c7e11b2ae59d4b79b9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/entity/TeleportFlag.java
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,79 @@
 +package io.papermc.paper.entity;
 +
 +import org.bukkit.Location;
 +import org.bukkit.event.player.PlayerTeleportEvent;
-+import org.jetbrains.annotations.ApiStatus;
 +
 +/**
 + * Represents a flag that can be set on teleportation that may
@@ -54,7 +52,6 @@ index 0000000000000000000000000000000000000000..dbacefc919fd6ed6a0f5cdaa0f695a12
 + * @see EntityState
 + * @see Relative
 + */
-+@ApiStatus.Experimental
 +public sealed interface TeleportFlag permits TeleportFlag.EntityState, TeleportFlag.Relative {
 +
 +    /**
@@ -68,7 +65,6 @@ index 0000000000000000000000000000000000000000..dbacefc919fd6ed6a0f5cdaa0f695a12
 +     *
 +     * @see org.bukkit.entity.Player#teleport(Location, PlayerTeleportEvent.TeleportCause, TeleportFlag...)
 +     */
-+    @ApiStatus.Experimental
 +    enum Relative implements TeleportFlag {
 +        /**
 +         * Represents the player's X coordinate
@@ -96,7 +92,6 @@ index 0000000000000000000000000000000000000000..dbacefc919fd6ed6a0f5cdaa0f695a12
 +     * Represents flags that effect the entity's state on
 +     * teleportation.
 +     */
-+    @ApiStatus.Experimental
 +    enum EntityState implements TeleportFlag {
 +        /**
 +         * If all passengers should not be required to be removed prior to teleportation.
@@ -125,10 +120,10 @@ index 0000000000000000000000000000000000000000..dbacefc919fd6ed6a0f5cdaa0f695a12
 +
 +}
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 77e29cada05da8946d718fe331e28e7553922033..5607404fa0132febdbdaad051a4e9426fe5f1eb6 100644
+index 77e29cada05da8946d718fe331e28e7553922033..a7e0454344b145242a19eb8020c9c67b18368bdd 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -123,10 +123,34 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -123,10 +123,32 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       *
       * @param yaw the yaw
       * @param pitch the pitch
@@ -144,7 +139,6 @@ index 77e29cada05da8946d718fe331e28e7553922033..5607404fa0132febdbdaad051a4e9426
 +     * @param teleportFlags Flags to be used in this teleportation
 +     * @return <code>true</code> if the teleport was successful
 +     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
 +    default boolean teleport(@NotNull Location location, @NotNull io.papermc.paper.entity.TeleportFlag @NotNull... teleportFlags) {
 +        return this.teleport(location, TeleportCause.PLUGIN, teleportFlags);
 +    }
@@ -157,7 +151,6 @@ index 77e29cada05da8946d718fe331e28e7553922033..5607404fa0132febdbdaad051a4e9426
 +     * @param teleportFlags Flags to be used in this teleportation
 +     * @return <code>true</code> if the teleport was successful
 +     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
 +    boolean teleport(@NotNull Location location, @NotNull TeleportCause cause, @NotNull io.papermc.paper.entity.TeleportFlag @NotNull... teleportFlags);
 +    // Paper end - Teleport API
 +
@@ -168,7 +161,7 @@ diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/buk
 index 0e42cd429a75d10f8628acad319ee3dd2cdf02c3..9794b8f812375ad52b4caceef0bf659d8fbf9d65 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3118,6 +3118,49 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3118,6 +3118,45 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      String getClientBrandName();
      // Paper end
  
@@ -179,7 +172,6 @@ index 0e42cd429a75d10f8628acad319ee3dd2cdf02c3..9794b8f812375ad52b4caceef0bf659d
 +     * @param yaw the yaw
 +     * @param pitch the pitch
 +     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
 +    void setRotation(float yaw, float pitch);
 +
 +    /**
@@ -190,7 +182,6 @@ index 0e42cd429a75d10f8628acad319ee3dd2cdf02c3..9794b8f812375ad52b4caceef0bf659d
 +     * @param z z coordinate
 +     * @param playerAnchor What part of the player should face the given position
 +     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
 +    void lookAt(double x, double y, double z, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor);
 +
 +    /**
@@ -199,7 +190,6 @@ index 0e42cd429a75d10f8628acad319ee3dd2cdf02c3..9794b8f812375ad52b4caceef0bf659d
 +     * @param position Position to look at in the player's current world
 +     * @param playerAnchor What part of the player should face the given position
 +     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
 +    default void lookAt(@NotNull io.papermc.paper.math.Position position, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor) {
 +        this.lookAt(position.x(), position.y(), position.z(), playerAnchor);
 +    }
@@ -211,7 +201,6 @@ index 0e42cd429a75d10f8628acad319ee3dd2cdf02c3..9794b8f812375ad52b4caceef0bf659d
 +     * @param playerAnchor What part of the player should face the entity
 +     * @param entityAnchor What part of the entity the player should face
 +     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
 +    void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
 +    // Paper end - Teleport API
 +
@@ -219,7 +208,7 @@ index 0e42cd429a75d10f8628acad319ee3dd2cdf02c3..9794b8f812375ad52b4caceef0bf659d
      @Override
      Spigot spigot();
 diff --git a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
-index 2deae344c88920ab95eefd2f65df5c858e04750b..32f78f2e32280f5c9ee7394b77ed929845f127d2 100644
+index 2deae344c88920ab95eefd2f65df5c858e04750b..ccfb08af8c57ddac3062c2cec28d7ff428082709 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerTeleportEvent.java
 @@ -13,8 +13,14 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
@@ -242,7 +231,7 @@ index 2deae344c88920ab95eefd2f65df5c858e04750b..32f78f2e32280f5c9ee7394b77ed9298
      }
  
 +    // Paper start - Teleport API
-+    @org.jetbrains.annotations.ApiStatus.Experimental
++    @org.jetbrains.annotations.ApiStatus.Internal
 +    public PlayerTeleportEvent(@NotNull final Player player, @NotNull final Location from, @Nullable final Location to, @NotNull final TeleportCause cause, @NotNull java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull Relative> teleportFlagSet) {
 +        super(player, from, to);
 +        this.teleportFlagSet = teleportFlagSet;
@@ -253,7 +242,7 @@ index 2deae344c88920ab95eefd2f65df5c858e04750b..32f78f2e32280f5c9ee7394b77ed9298
      /**
       * Gets the cause of this teleportation event
       *
-@@ -88,6 +103,31 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
+@@ -88,6 +103,30 @@ public class PlayerTeleportEvent extends PlayerMoveEvent {
          UNKNOWN;
      }
  
@@ -275,7 +264,6 @@ index 2deae344c88920ab95eefd2f65df5c858e04750b..32f78f2e32280f5c9ee7394b77ed9298
 +     *
 +     * @return an immutable set of relative teleportation flags
 +     */
-+    @org.jetbrains.annotations.ApiStatus.Experimental
 +    @NotNull
 +    public java.util.Set<io.papermc.paper.entity.TeleportFlag.@NotNull Relative> getRelativeTeleportationFlags() {
 +        return this.teleportFlagSet;

--- a/patches/api/0373-Collision-API.patch
+++ b/patches/api/0373-Collision-API.patch
@@ -25,10 +25,10 @@ index 87489972dff661c7c9ec4d128e25e2f7666b598e..14edb1b4caeda0c8aecf3528bd0005fa
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 5607404fa0132febdbdaad051a4e9426fe5f1eb6..7f341ba602f0ecbc2953bb19589146b5ae5d0ea9 100644
+index a7e0454344b145242a19eb8020c9c67b18368bdd..368d8da056e41103ad10dde177cc244148c0130e 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -929,4 +929,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -927,4 +927,26 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      boolean isInPowderedSnow();
      // Paper end

--- a/patches/api/0382-Elder-Guardian-appearance-API.patch
+++ b/patches/api/0382-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f56bb863affa963615efefc35fe1f8d4b12d1253..11b64a94457c1c64e8557bfe3e1ba6387ca9abe6 100644
+index 83eaf1b4882c552cf72d222d45ed11fd8f8a57b2..e7eec77471b725f0d13b13c56e5244dfe4145f1e 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3186,6 +3186,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3182,6 +3182,24 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void lookAt(@NotNull org.bukkit.entity.Entity entity, @NotNull io.papermc.paper.entity.LookAnchor playerAnchor, @NotNull io.papermc.paper.entity.LookAnchor entityAnchor);
      // Paper end - Teleport API
  

--- a/patches/api/0390-Add-Player-Warden-Warning-API.patch
+++ b/patches/api/0390-Add-Player-Warden-Warning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Player Warden Warning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 11b64a94457c1c64e8557bfe3e1ba6387ca9abe6..9b820f607142808859262770cb38e8a1afdffd9f 100644
+index e7eec77471b725f0d13b13c56e5244dfe4145f1e..aaa99aca492b14c775180214345095ec02dbc5fc 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3202,6 +3202,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3198,6 +3198,59 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param silent whether sound should be silenced
       */
      void showElderGuardian(boolean silent);

--- a/patches/api/0400-Add-Sneaking-API-for-Entities.patch
+++ b/patches/api/0400-Add-Sneaking-API-for-Entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Sneaking API for Entities
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 7f341ba602f0ecbc2953bb19589146b5ae5d0ea9..9c7eba228dc1c244d49cb5139e1710804b887d6a 100644
+index 368d8da056e41103ad10dde177cc244148c0130e..d601145b41f7e8d0441c0db7ac98a03361866739 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -779,6 +779,25 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -777,6 +777,25 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
      @NotNull
      Pose getPose();
  
@@ -35,7 +35,7 @@ index 7f341ba602f0ecbc2953bb19589146b5ae5d0ea9..9c7eba228dc1c244d49cb5139e171080
       * Get the category of spawn to which this entity belongs.
       *
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index fdb0b8b81e53c85c865c4a3a895719f5afbffd17..2e4b2ad1907a2d5f4462c5fd2d1482f2bb623d3b 100644
+index e356a0927517d2e5a836e9e39514129f2ac5f54d..b6ddd0035c5e85fcae8e6c317503aabf93e78409 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -414,6 +414,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0407-Add-Entity-Body-Yaw-API.patch
+++ b/patches/api/0407-Add-Entity-Body-Yaw-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Entity Body Yaw API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 9c7eba228dc1c244d49cb5139e1710804b887d6a..db4231b6e77a7cf9fe430e5207c1fc9c1702c3f7 100644
+index d601145b41f7e8d0441c0db7ac98a03361866739..07f111b944209dbd395620bae603c42752d1cf25 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -947,6 +947,43 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -945,6 +945,43 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @return true if in powdered snow.
       */
      boolean isInPowderedSnow();

--- a/patches/api/0418-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/api/0418-Folia-scheduler-and-owned-region-API.patch
@@ -769,10 +769,10 @@ index af2bbeff54f0044f51bf0df17727b2f8bec33fe4..3d8a33563cb266fd784e264f6ce38502
 +    // Paper end - Folia region threading API
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index db4231b6e77a7cf9fe430e5207c1fc9c1702c3f7..accf3f265ddd49ab866508d1a71289e185827d5e 100644
+index 07f111b944209dbd395620bae603c42752d1cf25..6602ce33224a337764f8e94422bad3912e3d545b 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -1007,4 +1007,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -1005,4 +1005,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      boolean wouldCollideUsing(@NotNull BoundingBox boundingBox);
      // Paper End - Collision API

--- a/patches/api/0427-API-for-an-entity-s-scoreboard-name.patch
+++ b/patches/api/0427-API-for-an-entity-s-scoreboard-name.patch
@@ -7,10 +7,10 @@ Was obtainable through different methods, but you had to use different
 methods depending on the implementation of Entity you were working with.
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index accf3f265ddd49ab866508d1a71289e185827d5e..2177eb74ab50b30b100aa8f35fc1d99b860ea7fd 100644
+index 6602ce33224a337764f8e94422bad3912e3d545b..c6502a549cf791c769ada483d498673eb969294f 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -1018,4 +1018,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -1016,4 +1016,15 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       */
      @NotNull io.papermc.paper.threadedregions.scheduler.EntityScheduler getScheduler();
      // Paper end - Folia schedulers

--- a/patches/api/0432-Expand-Pose-API.patch
+++ b/patches/api/0432-Expand-Pose-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expand Pose API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 2177eb74ab50b30b100aa8f35fc1d99b860ea7fd..d340ddcf6924cc834455de3acbbac91ab9c66e39 100644
+index c6502a549cf791c769ada483d498673eb969294f..9e3cb75536ae260dc898ab9dafbc1d98398782bc 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -796,6 +796,42 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+@@ -794,6 +794,42 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
       * @param sneak true if the entity should be sneaking
       */
      void setSneaking(boolean sneak);

--- a/patches/api/0443-Add-player-idle-duration-API.patch
+++ b/patches/api/0443-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f376a6b77aeff0fbe8b0655bd2f1c43e19bbe3ce..9130a57cf6ef5d543703a03aeed07aa17b1ab7e8 100644
+index 7b74fe780a8f99068c542f2deb261503ffc3b9e5..47fcfa2a3358766dfda2efc9bbcf5b50e3f2f7c1 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3343,6 +3343,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -3339,6 +3339,29 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void increaseWardenWarningLevel();
      // Paper end
  


### PR DESCRIPTION
The Relative Teleport/Look At APIs has been mature for a while now with no breaking changes needed. I think we can safely remove the `Experimental` annotation from them. I don't want to just end up never removing these annotations.