### PR TITLE
Don't fire EntityPotionEffectEvent during worldgen

### DIFF
--- a/patches/server/1054-Don-t-fire-EntityPotionEffectEvent-during-worldgen.patch
+++ b/patches/server/1054-Don-t-fire-EntityPotionEffectEvent-during-worldgen.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 23 Nov 2023 10:33:25 -0800
+Subject: [PATCH] Don't fire EntityPotionEffectEvent during worldgen
+
+Asynchronous chunk generation provides an opportunity for mobs
+being added with generation to have effects added to them. The event
+does not support asynchronous firing.
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index a76eb3d051db0229ed088b71c92ff3f131449007..87134e57a57df0fceda903e35d22f3f2de31adf3 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -1134,6 +1134,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+     }
+ 
+     public boolean addEffect(MobEffectInstance mobeffect, @Nullable Entity entity, EntityPotionEffectEvent.Cause cause) {
++        // Paper start - add boolean param to optionally fire the event
++        return this.addEffect(mobeffect, entity, cause, true);
++    }
++    public boolean addEffect(MobEffectInstance mobeffect, @Nullable Entity entity, EntityPotionEffectEvent.Cause cause, boolean fireEvent) {
++        // Paper end
+         // org.spigotmc.AsyncCatcher.catchOp("effect add"); // Spigot // Paper - move to API
+         if (this.isTickingEffects) {
+             this.effectsToProcess.add(new ProcessableEffect(mobeffect, cause));
+@@ -1153,10 +1158,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
+                 override = new MobEffectInstance(mobeffect1).update(mobeffect);
+             }
+ 
++            if (fireEvent) { // Paper
+             EntityPotionEffectEvent event = CraftEventFactory.callEntityPotionEffectChangeEvent(this, mobeffect1, mobeffect, cause, override);
++            override = event.isOverride(); // Paper
+             if (event.isCancelled()) {
+                 return false;
+             }
++            } // Paper
+             // CraftBukkit end
+ 
+             if (mobeffect1 == null) {
+@@ -1164,7 +1172,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+                 this.onEffectAdded(mobeffect, entity);
+                 flag = true;
+                 // CraftBukkit start
+-            } else if (event.isOverride()) {
++            } else if (override) { // Paper
+                 mobeffect1.update(mobeffect);
+                 this.onEffectUpdated(mobeffect1, true, entity);
+                 // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Spider.java b/src/main/java/net/minecraft/world/entity/monster/Spider.java
+index 71b5a9c97a13f703073c0122742ff9e8a0e49df2..6f12e342adf1a008709fd9a4fbbbe1da8ec31b83 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Spider.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Spider.java
+@@ -182,7 +182,7 @@ public class Spider extends Monster {
+             MobEffect mobeffectlist = entityspider_groupdataspider.effect;
+ 
+             if (mobeffectlist != null) {
+-                this.addEffect(new MobEffectInstance(mobeffectlist, -1), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.SPIDER_SPAWN); // CraftBukkit
++                this.addEffect(new MobEffectInstance(mobeffectlist, -1), null, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.SPIDER_SPAWN, world instanceof net.minecraft.server.level.ServerLevel); // CraftBukkit // Paper - only fire the effect event if this is happening in a ServerLevel
+             }
+         }
+ 


### PR DESCRIPTION
Asynchronous chunk generation provides an opportunity for mobs being added with generation to have effects added to them. The event does not support asynchronous firing.

This functions by checking the type of the ServerLevelAccessor provided in the `finalizeSpawn` method and doesn't fire the event if it's not a ServerLevel.

I don't think this is the final fix for this, some mechanism probably has to be introduced to allow the event to be fired asynchronously without breaking plugins' expectation that all of these events are synchronous. 

Fixes https://github.com/PaperMC/Paper/issues/9234
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-9965.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1073078802.zip)