### PR TITLE
Lazily create LootContext for criterions

### DIFF
--- a/patches/server/1053-Lazily-create-LootContext-for-criterions.patch
+++ b/patches/server/1053-Lazily-create-LootContext-for-criterions.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrPowerGamerBR <git@mrpowergamerbr.com>
+Date: Tue, 21 Nov 2023 12:16:39 -0300
+Subject: [PATCH] Lazily create LootContext for criterions
+
+For each player on each tick, enter block triggers are invoked, and these create loot contexts that are promptly thrown away since the trigger doesn't pass the predicate
+
+To avoid this, we now lazily create the LootContext if the criterion passes the predicate AND if any of the listener triggers require a loot context instance
+
+diff --git a/src/main/java/net/minecraft/advancements/critereon/SimpleCriterionTrigger.java b/src/main/java/net/minecraft/advancements/critereon/SimpleCriterionTrigger.java
+index f0367a9cce13ef576fbb7023c0aba6eb48963606..bbdbf62a7696640d92a6bb758052abaaa6f86edd 100644
+--- a/src/main/java/net/minecraft/advancements/critereon/SimpleCriterionTrigger.java
++++ b/src/main/java/net/minecraft/advancements/critereon/SimpleCriterionTrigger.java
+@@ -54,13 +54,18 @@ public abstract class SimpleCriterionTrigger<T extends SimpleCriterionTrigger.Si
+         PlayerAdvancements playerAdvancements = player.getAdvancements();
+         Set<CriterionTrigger.Listener<T>> set = (Set) playerAdvancements.criterionData.get(this); // Paper - fix AdvancementDataPlayer leak
+         if (set != null && !set.isEmpty()) {
+-            LootContext lootContext = EntityPredicate.createContext(player, player);
++            LootContext lootContext = null; // EntityPredicate.createContext(player, player); // Paper - lazily create LootContext for criterions
+             List<CriterionTrigger.Listener<T>> list = null;
+ 
+             for(CriterionTrigger.Listener<T> listener : set) {
+                 T simpleInstance = listener.trigger();
+                 if (predicate.test(simpleInstance)) {
+                     Optional<ContextAwarePredicate> optional = simpleInstance.playerPredicate();
++                    // Paper start - lazily create LootContext for criterions
++                    if (lootContext == null && optional.isPresent()) {
++                        lootContext = EntityPredicate.createContext(player, player);
++                    }
++                    // Paper end
+                     if (optional.isEmpty() || optional.get().matches(lootContext)) {
+                         if (list == null) {
+                             list = Lists.newArrayList();

--- a/patches/server/1053-Lazily-create-LootContext-for-criterions.patch
+++ b/patches/server/1053-Lazily-create-LootContext-for-criterions.patch
@@ -8,10 +8,10 @@ For each player on each tick, enter block triggers are invoked, and these create
 To avoid this, we now lazily create the LootContext if the criterion passes the predicate AND if any of the listener triggers require a loot context instance
 
 diff --git a/src/main/java/net/minecraft/advancements/critereon/SimpleCriterionTrigger.java b/src/main/java/net/minecraft/advancements/critereon/SimpleCriterionTrigger.java
-index f0367a9cce13ef576fbb7023c0aba6eb48963606..bbdbf62a7696640d92a6bb758052abaaa6f86edd 100644
+index f0367a9cce13ef576fbb7023c0aba6eb48963606..997ddf7cd0051ba67e9c4ef7da39481649303791 100644
 --- a/src/main/java/net/minecraft/advancements/critereon/SimpleCriterionTrigger.java
 +++ b/src/main/java/net/minecraft/advancements/critereon/SimpleCriterionTrigger.java
-@@ -54,13 +54,18 @@ public abstract class SimpleCriterionTrigger<T extends SimpleCriterionTrigger.Si
+@@ -54,14 +54,14 @@ public abstract class SimpleCriterionTrigger<T extends SimpleCriterionTrigger.Si
          PlayerAdvancements playerAdvancements = player.getAdvancements();
          Set<CriterionTrigger.Listener<T>> set = (Set) playerAdvancements.criterionData.get(this); // Paper - fix AdvancementDataPlayer leak
          if (set != null && !set.isEmpty()) {
@@ -23,11 +23,8 @@ index f0367a9cce13ef576fbb7023c0aba6eb48963606..bbdbf62a7696640d92a6bb758052abaa
                  T simpleInstance = listener.trigger();
                  if (predicate.test(simpleInstance)) {
                      Optional<ContextAwarePredicate> optional = simpleInstance.playerPredicate();
-+                    // Paper start - lazily create LootContext for criterions
-+                    if (lootContext == null && optional.isPresent()) {
-+                        lootContext = EntityPredicate.createContext(player, player);
-+                    }
-+                    // Paper end
-                     if (optional.isEmpty() || optional.get().matches(lootContext)) {
+-                    if (optional.isEmpty() || optional.get().matches(lootContext)) {
++                    if (optional.isEmpty() || optional.get().matches(lootContext = (lootContext == null ? EntityPredicate.createContext(player, player) : lootContext))) { // Paper - lazily create LootContext for criterions
                          if (list == null) {
                              list = Lists.newArrayList();
+                         }


### PR DESCRIPTION
For each player on each tick, enter block triggers are invoked, and these create loot contexts that are promptly thrown away since a lot of the times the predicate doesn't match. (in vanilla, it should only pass for the end gateway, or when the player is in water to get the boat's recipes, and iirc none of these requires a LootContext)

To avoid this, we now lazily create the LootContext if the criterion passes the predicate AND if any of the listener triggers require a loot context instance.

While the performance increase ain't that big (on a random profile with ~55 players on  my server, the `createContext` call was using 0.10% according to spark), it would be nice to just *avoid* that useless allocation anyway, and theorically if you have a lot of players moving around, the performance impact of this call would be bigger.