### PR TITLE
[ci skip] Correct Windows requiring path to gradlew

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Assuming you have already forked the repository:
 
 1. Clone your fork to your local machine;
 2. Type `./gradlew applyPatches` in a terminal to apply the changes from upstream.
-In the Windows Command Prompt, leave out the `./` at the beginning for all `gradlew` commands;
+On Windows, replace the `./` with `.\` at the beginning for all `gradlew` commands;
 3. cd into `Paper-Server` for server changes, and `Paper-API` for API changes.  
 <!--You can also run `./paper server` or `./paper api` for these same directories
 respectively.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Assuming you have already forked the repository:
 
 1. Clone your fork to your local machine;
 2. Type `./gradlew applyPatches` in a terminal to apply the changes from upstream.
-On Windows, leave out the `./` at the beginning for all `gradlew` commands;
+In the Windows Command Prompt, leave out the `./` at the beginning for all `gradlew` commands;
 3. cd into `Paper-Server` for server changes, and `Paper-API` for API changes.  
 <!--You can also run `./paper server` or `./paper api` for these same directories
 respectively.


### PR DESCRIPTION
with powershell being the "new" default terminal for windows (which does not load commands from the current directory by default) i think this should be mentioned