### PR TITLE
Log correct recipes and advancement count on server start

### DIFF
--- a/patches/server/0898-Improve-logging-and-errors.patch
+++ b/patches/server/0898-Improve-logging-and-errors.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Improve logging and errors
 Co-authored-by: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/advancements/AdvancementTree.java b/src/main/java/net/minecraft/advancements/AdvancementTree.java
-index 938fe76677139e7e99698b61691bfcadf70dbd87..8aa7439d9f3c071f88c84c6c75b7a65e5e5cfa82 100644
+index 938fe76677139e7e99698b61691bfcadf70dbd87..5cf3732d2197b381ae9256d8bed03a755d8539f4 100644
 --- a/src/main/java/net/minecraft/advancements/AdvancementTree.java
 +++ b/src/main/java/net/minecraft/advancements/AdvancementTree.java
 @@ -35,7 +35,7 @@ public class AdvancementTree {
@@ -18,6 +18,27 @@ index 938fe76677139e7e99698b61691bfcadf70dbd87..8aa7439d9f3c071f88c84c6c75b7a65e
          this.nodes.remove(advancement.holder().id());
          if (advancement.parent() == null) {
              this.roots.remove(advancement);
+@@ -77,7 +77,7 @@ public class AdvancementTree {
+             }
+         }
+ 
+-        // AdvancementTree.LOGGER.info("Loaded {} advancements", this.nodes.size()); // CraftBukkit - moved to AdvancementDataWorld#reload
++        // AdvancementTree.LOGGER.info("Loaded {} advancements", this.nodes.size()); // CraftBukkit - moved to AdvancementDataWorld#reload // Paper - you say it was moved... but it wasn't :) it should be moved however, since this is called when the API creates an advancement
+     }
+ 
+     private boolean tryInsert(AdvancementHolder advancement) {
+diff --git a/src/main/java/net/minecraft/server/ServerAdvancementManager.java b/src/main/java/net/minecraft/server/ServerAdvancementManager.java
+index ebcd2bbcf8f25c52de3deaff32a8522dbf662141..8189c549edd14a351fc5e75be23da7378bbd3532 100644
+--- a/src/main/java/net/minecraft/server/ServerAdvancementManager.java
++++ b/src/main/java/net/minecraft/server/ServerAdvancementManager.java
+@@ -63,6 +63,7 @@ public class ServerAdvancementManager extends SimpleJsonResourceReloadListener {
+         AdvancementTree advancementtree = new AdvancementTree();
+ 
+         advancementtree.addAll(this.advancements.values());
++        LOGGER.info("Loaded {} advancements", advancementtree.nodes().size()); // Paper - moved from AdvancementTree#addAll
+         Iterator iterator = advancementtree.roots().iterator();
+ 
+         while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 index d63451592c34429c1c827ff8e16989347e2efdaa..e87e99569fe5d6d916faa385b1793db858ab39b7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
@@ -48,6 +69,19 @@ index 89aa86a49eda563c82ccedc99641e699f8e578b0..4822f94ce183a99ad9e0d1bdc6c5708d
                  if (ResourceLocation.isValidNamespace(string)) {
                      set.add(string);
                  } else {
+diff --git a/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java b/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
+index bf16c44e2d61dccb662eceeef89a143a25ba40b0..43aacadcf8be10432a61c83f69ee86580c86d0a3 100644
+--- a/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
++++ b/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
+@@ -84,7 +84,7 @@ public class RecipeManager extends SimpleJsonResourceReloadListener {
+             return entry1.getValue(); // CraftBukkit // Paper - decompile fix - *shrugs internally* // todo: is this needed anymore?
+         }));
+         this.byName = Maps.newHashMap(builder.build()); // CraftBukkit
+-        RecipeManager.LOGGER.info("Loaded {} recipes", map1.size());
++        RecipeManager.LOGGER.info("Loaded {} recipes", this.byName.size()); // Paper - log correct number of recipes
+     }
+ 
+     // CraftBukkit start
 diff --git a/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java b/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java
 index 080cca90f15d90249b7a38f33286ae2f735ba7d9..2677e21d8239bf0361a3bc5c9a50c328e54d70f6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/legacy/CraftLegacy.java


### PR DESCRIPTION
Previously, the recipe count log always logged `Loaded 7 recipes`. It was logging the number of recipe types, not the number of recipes loaded.

Also, upstream claimed to have moved the log message logging the number of advancements loaded to somewhere else, but I can't find it and it doesn't show up, so I added it back.