### PR TITLE
Remove unnecessary durability check in ItemStack#isSimilar

### DIFF
--- a/patches/api/0449-Optimize-ItemStack-isSimilar-.-by-removing-the-unnec.patch
+++ b/patches/api/0449-Optimize-ItemStack-isSimilar-.-by-removing-the-unnec.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrPowerGamerBR <git@mrpowergamerbr.com>
+Date: Sun, 26 Nov 2023 20:00:50 -0300
+Subject: [PATCH] Optimize "ItemStack#isSimilar(...)" by removing the
+ unnecessary durability check
+
+
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index 0af73cc04edb93b9772136d4d808f657ea40e733..36e3fbc727cd748aa138f52976154ba32954cd87 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -295,7 +295,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+             return true;
+         }
+         Material comparisonType = (this.type.isLegacy()) ? Bukkit.getUnsafe().fromLegacy(this.getData(), true) : this.type; // This may be called from legacy item stacks, try to get the right material
+-        return comparisonType == stack.getType() && getDurability() == stack.getDurability() && hasItemMeta() == stack.hasItemMeta() && (hasItemMeta() ? Bukkit.getItemFactory().equals(getItemMeta(), stack.getItemMeta()) : true);
++        return comparisonType == stack.getType() && /* getDurability() == stack.getDurability() && */hasItemMeta() == stack.hasItemMeta() && (hasItemMeta() ? Bukkit.getItemFactory().equals(getItemMeta(), stack.getItemMeta()) : true); // Paper - remove redundant item durability check
+     }
+ 
+     @NotNull

--- a/patches/api/0449-Remove-unnecessary-durability-check-in-ItemStack-isS.patch
+++ b/patches/api/0449-Remove-unnecessary-durability-check-in-ItemStack-isS.patch
@@ -1,9 +1,12 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: MrPowerGamerBR <git@mrpowergamerbr.com>
 Date: Sun, 26 Nov 2023 20:00:50 -0300
-Subject: [PATCH] Optimize "ItemStack#isSimilar(...)" by removing the
- unnecessary durability check
+Subject: [PATCH] Remove unnecessary durability check in
+ "ItemStack#isSimilar(...)"
 
+By removing this check we avoid unnecessarily allocating useless `ItemMeta` objects if we are comparing two items, or one of the two items, that don't have any durability. Don't worry, the durability of the item is checked when it checks if both item metas are equal.
+
+This is a leftover from when checking for the item's durability was "free" because the durability was stored in the `ItemStack` itself, this [was changed in Minecraft 1.13](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/f8b2086d60942eb2cd7ac25a2a1408cb790c222c#src/main/java/org/bukkit/inventory/ItemStack.java).
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
 index 0af73cc04edb93b9772136d4d808f657ea40e733..36e3fbc727cd748aa138f52976154ba32954cd87 100644


### PR DESCRIPTION
I know that this looks like a stupid optimization that doesn't do anything, but hear me out: `getDurability()` ain't free, when you call `getDurability()`, it calls `getItemMeta()`, which then allocates a new `ItemMeta` or clones the current item's item meta.

However, this means that we are unnecessarily allocating useless `ItemMeta` objects if we are comparing one or more items that don't have any durability (if they had durability, they would have a non-null meta), and this impact can be noticed if one of your plugins has a `canHoldItem` function that checks if a inventory can hold an item by looping thru the player's inventory, especially if the plugin is checking this multiple times in a tick.

To avoid this, we can just... not check for the item's durability! Don't worry, the durability of the item is checked when it checks if both item metas are equal.

This is a leftover from when checking for the item's durability was "free" because the durability was stored in the `ItemStack` itself, this [was changed in Minecraft 1.13](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/f8b2086d60942eb2cd7ac25a2a1408cb790c222c#src/main/java/org/bukkit/inventory/ItemStack.java), however the `isSimilar(...)` method hasn't been changed since it was added in 2012.

Of course, maybe  this patch is a bit useless? There is a performance benefit if you remove that call since you avoid initializing/cloning a `ItemMeta` if one or both of the items have a null `ItemMeta` + removes a deprecated call + improves the code to match how items work in a post-1.13 world, but the benefit is so so so smol (really only helps plugins that are constantly checking if an item is similar to another, which is my case, where one of my plugins allows players to "quick harvest" their farms, and for each crop it needs to check if the drops fits on their inventory) that maybe it could just be ignored, after all, there's also the work of maintaining this diff to fix something that just boils down to "well now its correct and there is a super tiny perf improvement". (Maybe this should be upstreamed to Spigot since they are the ones who are maintaining Bukkit? but paper my beloved tho...)

(The reason I found out that this had a performance impact was because the `getDurability()` was using 0.08ms each tick in one of my plugins according to spark... yeah, sadly it ain't a super big crazy optimization, the performance impact would be bigger if you have more plugins using `isSimilar(...)` tho, something something pick a function and make it fast or something like that)

Keep in mind that `CraftItemStack` *does* override `isSimilar()`, and the overriden method also checks `getDurability()`. However, `CraftItemStack` `getDurability()` actually gets the damage directly from the NBT tags. *Maybe* both checks should be removed? "oh but if `CraftItemStack` overrides this method then your patch is USELESS!!!" actually not because you initialize the `ItemStack` class directly, and `CraftItemStack` delegates to ItemStack's `isSimilar()` if the stack being compared is not a `CraftItemStack`, see this debug log: `[org.bukkit.craftbukkit.v1_20_R2.inventory.CraftItemStack] CraftItemStack isSimilar comparing ItemStack{CRAFTING_TABLE x 1} (class org.bukkit.craftbukkit.v1_20_R2.inventory.CraftItemStack) to ItemStack{BEETROOT x 1} (class org.bukkit.inventory.ItemStack)`

**Example of a plugin code that uses `isSimilar(...)`:**
```kotlin
fun Inventory.canHoldItem(stack: ItemStack?): Boolean {
	if (stack == null) { return true }
	if (stack.type == Material.AIR) { return true }
	val storageContents = this.storageContents
	if (storageContents != null) {
		for (invItem in storageContents) {
			if (invItem == null) return true // Empty slot!
			if (invItem.isSimilar(stack)) { // 
				if (invItem.maxStackSize >= invItem.amount + stack.amount) {
					// Yes, we can add the items to this stack!
					return true
				}
			}
		}
	}
	return false
}
```