### PR TITLE
MergedProperties POC for sharing properties between projects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     java
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "8.1.1" apply false
-    id("io.papermc.paperweight.core") version "1.5.10"
+    id("io.papermc.paperweight.core") version "1.5.11-SNAPSHOT"
 }
 
 allprojects {

--- a/patches/api/0449-MergedProperties-POC.patch
+++ b/patches/api/0449-MergedProperties-POC.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
+Date: Tue, 28 Nov 2023 19:28:45 -0700
+Subject: [PATCH] MergedProperties POC
+
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index e827ee211e3c65dc68ac5867fd8476639df63645..7456c41ccf126790ec11652d244710e2b797f237 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -1,3 +1,5 @@
++import io.papermc.paperweight.util.MergedProperties
++
+ plugins {
+     `java-library`
+     `maven-publish`
+@@ -9,11 +11,13 @@ java {
+     withJavadocJar()
+ }
+ 
+-val annotationsVersion = "24.0.1"
+-val bungeeCordChatVersion = "1.20-R0.1"
+-val adventureVersion = "4.14.0"
+-val slf4jVersion = "1.8.0-beta4"
+-val log4jVersion = "2.17.1"
++val versions = MergedProperties.fromAllProjects(project, "versions.properties")
++val annotationsVersion by versions
++val bungeeCordChatVersion by versions
++val adventureVersion by versions
++val slf4jVersion by versions
++val log4jVersion by versions
++val asmVersion by versions
+ val apiAndDocs: Configuration by configurations.creating {
+     attributes {
+         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+@@ -48,8 +52,8 @@ dependencies {
+     api("org.apache.logging.log4j:log4j-api:$log4jVersion")
+     api("org.slf4j:slf4j-api:$slf4jVersion")
+ 
+-    implementation("org.ow2.asm:asm:9.4")
+-    implementation("org.ow2.asm:asm-commons:9.4")
++    implementation("org.ow2.asm:asm:$asmVersion")
++    implementation("org.ow2.asm:asm-commons:$asmVersion")
+     // Paper end
+ 
+     api("org.apache.maven:maven-resolver-provider:3.8.5")
+@@ -71,7 +75,7 @@ dependencies {
+     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
+     testImplementation("org.hamcrest:hamcrest:2.2")
+     testImplementation("org.mockito:mockito-core:5.5.0")
+-    testImplementation("org.ow2.asm:asm-tree:9.5")
++    testImplementation("org.ow2.asm:asm-tree:$asmVersion")
+ }
+ 
+ // Paper start
+diff --git a/versions.properties b/versions.properties
+new file mode 100644
+index 0000000000000000000000000000000000000000..4e284ef8c083571a6655c9beeaaa20bd554b8395
+--- /dev/null
++++ b/versions.properties
+@@ -0,0 +1,6 @@
++annotationsVersion = 24.0.1
++bungeeCordChatVersion = 1.20-R0.1
++adventureVersion = 4.14.0
++slf4jVersion = 1.8.0-beta4
++log4jVersion = 2.17.1
++asmVersion = 9.6

--- a/patches/server/1055-MergedProperties-POC.patch
+++ b/patches/server/1055-MergedProperties-POC.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
+Date: Tue, 28 Nov 2023 19:28:37 -0700
+Subject: [PATCH] MergedProperties POC
+
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index 64479f0a892d6847f987d844efe282a6080d607b..655e72cc8500767043875884589423b33de96538 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -12,13 +12,19 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
+ }
+ val alsoShade: Configuration by configurations.creating
+ 
++val versions = MergedProperties.fromAllProjects(project, "versions.properties")
++val adventureVersion by versions
++val log4jVersion by versions
++val mappingIoVersion by versions
++val asmVersion by versions
++
+ dependencies {
+     implementation(project(":paper-api"))
+     implementation(project(":paper-mojangapi"))
+     // Paper start
+     implementation("org.jline:jline-terminal-jansi:3.21.0")
+     implementation("net.minecrell:terminalconsoleappender:1.3.0")
+-    implementation("net.kyori:adventure-text-serializer-ansi:4.14.0") // Keep in sync with adventureVersion from Paper-API build file
++    implementation("net.kyori:adventure-text-serializer-ansi:$adventureVersion")
+     implementation("net.kyori:ansi:1.0.3") // Manually bump beyond above transitive dep
+     /*
+           Required to add the missing Log4j2Plugins.dat file from log4j-core
+@@ -26,18 +32,18 @@ dependencies {
+           all its classes to check if they are plugins.
+           Scanning takes about 1-2 seconds so adding this speeds up the server start.
+      */
+-    implementation("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - implementation
+-    log4jPlugins.annotationProcessorConfigurationName("org.apache.logging.log4j:log4j-core:2.19.0") // Paper - Needed to generate meta for our Log4j plugins
++    implementation("org.apache.logging.log4j:log4j-core:$log4jVersion") // Paper - implementation
++    log4jPlugins.annotationProcessorConfigurationName("org.apache.logging.log4j:log4j-core:$log4jVersion") // Paper - Needed to generate meta for our Log4j plugins
+     runtimeOnly(log4jPlugins.output)
+     alsoShade(log4jPlugins.output)
+     implementation("io.netty:netty-codec-haproxy:4.1.97.Final") // Paper - Add support for proxy protocol
+     // Paper end
+-    implementation("org.apache.logging.log4j:log4j-iostreams:2.19.0") // Paper - remove exclusion
+-    implementation("org.ow2.asm:asm:9.5")
+-    implementation("org.ow2.asm:asm-commons:9.5") // Paper - ASM event executor generation
++    implementation("org.apache.logging.log4j:log4j-iostreams:$log4jVersion") // Paper - remove exclusion
++    implementation("org.ow2.asm:asm:$asmVersion")
++    implementation("org.ow2.asm:asm-commons:$asmVersion") // Paper - ASM event executor generation
+     implementation("org.spongepowered:configurate-yaml:4.2.0-SNAPSHOT") // Paper - config files
+     implementation("commons-lang:commons-lang:2.6")
+-    implementation("net.fabricmc:mapping-io:0.5.0") // Paper - needed to read mappings for stacktrace deobfuscation
++    implementation("net.fabricmc:mapping-io:$mappingIoVersion") // Paper - needed to read mappings for stacktrace deobfuscation
+     runtimeOnly("org.xerial:sqlite-jdbc:3.42.0.1")
+     runtimeOnly("com.mysql:mysql-connector-j:8.1.0")
+     runtimeOnly("com.lmax:disruptor:3.4.4") // Paper
+diff --git a/versions.properties b/versions.properties
+new file mode 100644
+index 0000000000000000000000000000000000000000..ecdcc6735c3f6e5205a57740bafdbf3c0fbfd36c
+--- /dev/null
++++ b/versions.properties
+@@ -0,0 +1,2 @@
++log4jVersion = 2.19.0
++mappingIoVersion = 0.5.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ import java.util.Locale
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        mavenLocal()
         maven("https://repo.papermc.io/repository/maven-public/")
     }
 }


### PR DESCRIPTION
This is an alternate way to share dependency versions between api & server to version catalogs (#9974), which have the problem where any catalog change that impacts the generated accessor ABI will cause the entire paperweight pipeline to run again (which makes it impractical for our use case)

If we decide to go forward with this, will need to merge https://github.com/PaperMC/paperweight/pull/226 and make a paperweight release first.