### PR TITLE
Skip Folia's EntityScheduler executeTick checks if the scheduler hasn't been used at least once

### DIFF
--- a/patches/server/0975-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/server/0975-Folia-scheduler-and-owned-region-API.patch
@@ -18,10 +18,10 @@ the schedulers depending on the result of the ownership check.
 
 diff --git a/src/main/java/io/papermc/paper/threadedregions/EntityScheduler.java b/src/main/java/io/papermc/paper/threadedregions/EntityScheduler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..62484ebf4550b05182f693a3180bbac5d5fd906d
+index 0000000000000000000000000000000000000000..f397d3a3dc1b8d8dd66982232e6e6a6542e9be96
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/threadedregions/EntityScheduler.java
-@@ -0,0 +1,181 @@
+@@ -0,0 +1,186 @@
 +package io.papermc.paper.threadedregions;
 +
 +import ca.spottedleaf.concurrentutil.util.Validate;
@@ -69,6 +69,7 @@ index 0000000000000000000000000000000000000000..62484ebf4550b05182f693a3180bbac5
 +    private final Long2ObjectOpenHashMap<List<ScheduledTask>> oneTimeDelayed = new Long2ObjectOpenHashMap<>();
 +
 +    private final ArrayDeque<ScheduledTask> currentlyExecuting = new ArrayDeque<>();
++    private boolean hasScheduledAtLeastOneTask = false;
 +
 +    public EntityScheduler(final CraftEntity entity) {
 +        this.entity = Validate.notNull(entity);
@@ -148,6 +149,7 @@ index 0000000000000000000000000000000000000000..62484ebf4550b05182f693a3180bbac5
 +            if (this.tickCount == RETIRED_TICK_COUNT) {
 +                return false;
 +            }
++            this.hasScheduledAtLeastOneTask = true;
 +            this.oneTimeDelayed.computeIfAbsent(this.tickCount + Math.max(1L, delay), (final long keyInMap) -> {
 +                return new ArrayList<>();
 +            }).add(task);
@@ -162,6 +164,9 @@ index 0000000000000000000000000000000000000000..62484ebf4550b05182f693a3180bbac5
 +     * @throws IllegalStateException If the scheduler is retired.
 +     */
 +    public void executeTick() {
++        if (!this.hasScheduledAtLeastOneTask)
++            return;
++
 +        final Entity thisEntity = this.entity.getHandleRaw();
 +
 +        TickThread.ensureTickThread(thisEntity, "May not tick entity scheduler asynchronously");
@@ -1224,7 +1229,7 @@ index bf77b0dae2ca25437df7386d2196da24d681e2ed..4516991a4d1299d7e93019a4b9bc227b
      public void setLevelCallback(EntityInLevelCallback changeListener) {
          this.levelCallback = changeListener;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9d86b54a9945d4644f7920e06e5d04faaaa2e8c8..16906e8ba7d05275561d465a08b792137d284c4e 100644
+index 33c1a46e7bd40784850745cc1a48b9f075da219e..db5f7a4e89aa963b640f2299ba3b08cf7c083506 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -310,6 +310,76 @@ public final class CraftServer implements Server {

--- a/patches/server/0975-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/server/0975-Folia-scheduler-and-owned-region-API.patch
@@ -18,10 +18,10 @@ the schedulers depending on the result of the ownership check.
 
 diff --git a/src/main/java/io/papermc/paper/threadedregions/EntityScheduler.java b/src/main/java/io/papermc/paper/threadedregions/EntityScheduler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f397d3a3dc1b8d8dd66982232e6e6a6542e9be96
+index 0000000000000000000000000000000000000000..a79a6e7da5cdcd2ab654791e8ed3fa63958257e0
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/threadedregions/EntityScheduler.java
-@@ -0,0 +1,186 @@
+@@ -0,0 +1,187 @@
 +package io.papermc.paper.threadedregions;
 +
 +import ca.spottedleaf.concurrentutil.util.Validate;
@@ -69,7 +69,7 @@ index 0000000000000000000000000000000000000000..f397d3a3dc1b8d8dd66982232e6e6a65
 +    private final Long2ObjectOpenHashMap<List<ScheduledTask>> oneTimeDelayed = new Long2ObjectOpenHashMap<>();
 +
 +    private final ArrayDeque<ScheduledTask> currentlyExecuting = new ArrayDeque<>();
-+    private boolean hasScheduledAtLeastOneTask = false;
++    private boolean awaitingFirstTask = false;
 +
 +    public EntityScheduler(final CraftEntity entity) {
 +        this.entity = Validate.notNull(entity);
@@ -149,7 +149,7 @@ index 0000000000000000000000000000000000000000..f397d3a3dc1b8d8dd66982232e6e6a65
 +            if (this.tickCount == RETIRED_TICK_COUNT) {
 +                return false;
 +            }
-+            this.hasScheduledAtLeastOneTask = true;
++            this.awaitingFirstTask = true;
 +            this.oneTimeDelayed.computeIfAbsent(this.tickCount + Math.max(1L, delay), (final long keyInMap) -> {
 +                return new ArrayList<>();
 +            }).add(task);
@@ -164,8 +164,9 @@ index 0000000000000000000000000000000000000000..f397d3a3dc1b8d8dd66982232e6e6a65
 +     * @throws IllegalStateException If the scheduler is retired.
 +     */
 +    public void executeTick() {
-+        if (!this.hasScheduledAtLeastOneTask)
++        if (!this.awaitingFirstTask) {
 +            return;
++        }
 +
 +        final Entity thisEntity = this.entity.getHandleRaw();
 +


### PR DESCRIPTION
This PR is mostly for "hey maybe there is a better solution for this", since I don't expect this PR to be accepted since it is mostly a hacky hack that probably has concurrency issues (accessing `hasScheduledAtLeastOneTask` outside of a synchronized block) and probably has a better solution.

Folia's EntityScheduler `executeTick` loop in `MinecraftServer`'s `tickChildren` is slooooow if you have a lot of entities (example: for a server with 15k entities, it uses ~1.7ms every tick, even if none of your plugins are using Folia's EntityScheduler)

To workaround this, we just don't attempt to do any of the checks if the scheduler hasn't been used at least once. Yes, I know, the scheduler increments the `tickCount`, but that doesn't matter since all the scheduled tasks are "relative" to the current tick count, not bound to the server's tick count.

The big performance boost comes from not needing to do all the checks `executeTick` does. Most server entities won't ever use a entity scheduler anyway, just think about it: Are plugins really going to add a scheduler to each item frame, each armor stand, each dropped item, each... you get my point.

Another way of doing this is changing the scheduler to store entities that have pending tasks into a global list to avoid getting all entities from all worlds, this is what I have done in my fork, and maybe this is a better less hacky solution, BUT that will probably make Folia explode, this needs to be tested further in a Folia environment instead of a Paper environment (on a Paper environment, I have been using this patch for one week+ without any issues): https://github.com/SparklyPower/SparklyPaper/blob/ver/1.20.2/patches/server/0010-Skip-EntityScheduler-s-executeTick-checks-if-there-i.patch (See PR #9985)

If anyone wants to reproduce the performance impact: Just spawn a bunch of entities, I used Armor Stands to test this.

(In the profiler, the loop is `net.minecraft.server.MinecraftServer.lambda$tickChildren$15()`)

**Profiler Before the Changes:** https://spark.lucko.me/eRvT1QqnI0
**Profiler After the Changes:** https://spark.lucko.me/DDAk1JQC0u