### PR TITLE
Store entities with scheduled Folia EntityScheduler tasks in a set to avoid unnecessary checks and unnecessary iterations thru all entities

### DIFF
--- a/patches/server/0851-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/server/0851-Folia-scheduler-and-owned-region-API.patch
@@ -45,15 +45,16 @@ index d2dee700f2c5cc7d6a272e751a933901fe7a55b6..834b85f24df023642f8abf7213fe578a
          } catch (Throwable ex) {
 diff --git a/src/main/java/io/papermc/paper/threadedregions/EntityScheduler.java b/src/main/java/io/papermc/paper/threadedregions/EntityScheduler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..62484ebf4550b05182f693a3180bbac5d5fd906d
+index 0000000000000000000000000000000000000000..ba5ff3af4d3af6f8ec4a47262aafb50ff1348549
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/threadedregions/EntityScheduler.java
-@@ -0,0 +1,181 @@
+@@ -0,0 +1,191 @@
 +package io.papermc.paper.threadedregions;
 +
 +import ca.spottedleaf.concurrentutil.util.Validate;
 +import io.papermc.paper.util.TickThread;
 +import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
++import net.minecraft.server.MinecraftServer;
 +import net.minecraft.world.entity.Entity;
 +import org.bukkit.craftbukkit.entity.CraftEntity;
 +
@@ -87,6 +88,7 @@ index 0000000000000000000000000000000000000000..62484ebf4550b05182f693a3180bbac5
 +     * The Entity. Note that it is the CraftEntity, since only that class properly tracks world transfers.
 +     */
 +    public final CraftEntity entity;
++    public final MinecraftServer server;
 +
 +    private static final record ScheduledTask(Consumer<? extends Entity> run, Consumer<? extends Entity> retired) {}
 +
@@ -97,7 +99,8 @@ index 0000000000000000000000000000000000000000..62484ebf4550b05182f693a3180bbac5
 +
 +    private final ArrayDeque<ScheduledTask> currentlyExecuting = new ArrayDeque<>();
 +
-+    public EntityScheduler(final CraftEntity entity) {
++    public EntityScheduler(final MinecraftServer server, final CraftEntity entity) {
++        this.server = Validate.notNull(server);
 +        this.entity = Validate.notNull(entity);
 +    }
 +
@@ -112,14 +115,15 @@ index 0000000000000000000000000000000000000000..62484ebf4550b05182f693a3180bbac5
 +     * @throws IllegalStateException If the scheduler is already retired.
 +     */
 +    public void retire() {
++        final Entity thisEntity = this.entity.getHandleRaw();
++
 +        synchronized (this.stateLock) {
 +            if (this.tickCount == RETIRED_TICK_COUNT) {
 +                throw new IllegalStateException("Already retired");
 +            }
 +            this.tickCount = RETIRED_TICK_COUNT;
++            this.server.entitiesWithScheduledTasks.remove(thisEntity);
 +        }
-+
-+        final Entity thisEntity = this.entity.getHandleRaw();
 +
 +        // correctly handle and order retiring while running executeTick
 +        for (int i = 0, len = this.currentlyExecuting.size(); i < len; ++i) {
@@ -175,6 +179,7 @@ index 0000000000000000000000000000000000000000..62484ebf4550b05182f693a3180bbac5
 +            if (this.tickCount == RETIRED_TICK_COUNT) {
 +                return false;
 +            }
++            this.server.entitiesWithScheduledTasks.add(this.entity.getHandleRaw());
 +            this.oneTimeDelayed.computeIfAbsent(this.tickCount + Math.max(1L, delay), (final long keyInMap) -> {
 +                return new ArrayList<>();
 +            }).add(task);
@@ -196,6 +201,11 @@ index 0000000000000000000000000000000000000000..62484ebf4550b05182f693a3180bbac5
 +        synchronized (this.stateLock) {
 +            if (this.tickCount == RETIRED_TICK_COUNT) {
 +                throw new IllegalStateException("Ticking retired scheduler");
++            }
++            // Do we *really* have scheduled tasks tho?
++            if (this.currentlyExecuting.isEmpty() && this.oneTimeDelayed.isEmpty()) { // Check if we have any pending tasks and, if not, skip!
++                this.server.entitiesWithScheduledTasks.remove(thisEntity);
++                return;
 +            }
 +            ++this.tickCount;
 +            if (this.oneTimeDelayed.isEmpty()) {
@@ -1148,26 +1158,33 @@ index 0000000000000000000000000000000000000000..d306f911757a4d556c82c0070d4837db
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 374c20e530d2abd41674d80c711bd3737c6f6941..cbceb0ddea32781f89a19b1edb258bc23b96ee92 100644
+index 374c20e530d2abd41674d80c711bd3737c6f6941..dfdf64e24e46dc3866cb167962a9c8c9a8e0b6cc 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1579,6 +1579,20 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -319,6 +319,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+     public final io.papermc.paper.configuration.PaperConfigurations paperConfigurations; // Paper - add paper configuration files
+     public static long currentTickLong = 0L; // Paper - track current tick as a long
+     public boolean isIteratingOverLevels = false; // Paper - Throw exception on world create while being ticked
++    public final Set<Entity> entitiesWithScheduledTasks = java.util.concurrent.ConcurrentHashMap.newKeySet(); // Paper - Folia schedulers
+ 
+     public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
+         AtomicReference<S> atomicreference = new AtomicReference();
+@@ -1579,6 +1580,19 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          MinecraftTimings.bukkitSchedulerTimer.startTiming(); // Spigot // Paper
          this.server.getScheduler().mainThreadHeartbeat(this.tickCount); // CraftBukkit
          MinecraftTimings.bukkitSchedulerTimer.stopTiming(); // Spigot // Paper
 +        // Paper start - Folia scheduler API
 +        ((io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler) Bukkit.getGlobalRegionScheduler()).tick();
-+        getAllLevels().forEach(level -> {
-+            for (final Entity entity : level.getEntities().getAll()) {
-+                if (entity.isRemoved()) {
-+                    continue;
-+                }
-+                final org.bukkit.craftbukkit.entity.CraftEntity bukkit = entity.getBukkitEntityRaw();
-+                if (bukkit != null) {
-+                    bukkit.taskScheduler.executeTick();
-+                }
++        for (final Entity entity : entitiesWithScheduledTasks) {
++            if (entity.isRemoved()) {
++                continue;
 +            }
-+        });
++
++            final org.bukkit.craftbukkit.entity.CraftEntity bukkit = entity.getBukkitEntityRaw();
++            if (bukkit != null) {
++                bukkit.taskScheduler.executeTick();
++            }
++        }
 +        // Paper end - Folia scheduler API
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.CALLBACK_MANAGER.handleQueue(this.tickCount); // Paper
          this.profiler.push("commandFunctions");
@@ -1332,15 +1349,15 @@ index 7197cbf15ff9382cbc59c4a58e2f189c8cacbaaa..24097256203990a818aab2716fdb8a4a
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
          ConfigurationSerialization.registerClass(CraftPlayerProfile.class);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index d8b1cdc78eb234023a42d740599009737201e70e..bc37a3fc38e1966af3722ed16b3f940c2a8387a9 100644
+index d8b1cdc78eb234023a42d740599009737201e70e..1ba63d2ef3106e2f8e6a6f6dbd69efb3f17478cd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -70,6 +70,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -70,11 +70,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      private EntityDamageEvent lastDamageEvent;
      private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftEntity.DATA_TYPE_REGISTRY);
      protected net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
 +    // Paper start - Folia shedulers
-+    public final io.papermc.paper.threadedregions.EntityScheduler taskScheduler = new io.papermc.paper.threadedregions.EntityScheduler(this);
++    public final io.papermc.paper.threadedregions.EntityScheduler taskScheduler;
 +    private final io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler apiScheduler = new io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler(this);
 +
 +    @Override
@@ -1351,7 +1368,13 @@ index d8b1cdc78eb234023a42d740599009737201e70e..bc37a3fc38e1966af3722ed16b3f940c
  
      public CraftEntity(final CraftServer server, final Entity entity) {
          this.server = server;
-@@ -486,6 +495,12 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+         this.entity = entity;
+         this.entityType = CraftEntityType.minecraftToBukkit(entity.getType());
++        this.taskScheduler = new io.papermc.paper.threadedregions.EntityScheduler(this.entity.getServer(), this); // Paper - Folia schedulers
+     }
+ 
+     public static <T extends Entity> CraftEntity getEntity(CraftServer server, T entity) {
+@@ -486,6 +496,12 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.entity;
      }
  

--- a/patches/server/0864-API-for-an-entity-s-scoreboard-name.patch
+++ b/patches/server/0864-API-for-an-entity-s-scoreboard-name.patch
@@ -7,10 +7,10 @@ Was obtainable through different methods, but you had to use different
 methods depending on the implementation of Entity you were working with.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index bc37a3fc38e1966af3722ed16b3f940c2a8387a9..b5622c5bcc97ff9241d236a35018918db5b2103a 100644
+index 1ba63d2ef3106e2f8e6a6f6dbd69efb3f17478cd..0f1dfa6b9bc6bf48a4188b7c982df7e93b32c3d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1261,4 +1261,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1262,4 +1262,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return !this.getHandle().level().noCollision(this.getHandle(), aabb);
      }
      // Paper end - Collision API

--- a/patches/server/0874-Expand-Pose-API.patch
+++ b/patches/server/0874-Expand-Pose-API.patch
@@ -25,10 +25,10 @@ index 309dab6900543bf04ae371d7278bdf1b87a8a3c4..d56d1426a9be2f22fac458f8302bad04
          if (pose == this.getPose()) {
              return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index b5622c5bcc97ff9241d236a35018918db5b2103a..a8b9b50991361160880b9fc0a94cad30c319e62e 100644
+index 0f1dfa6b9bc6bf48a4188b7c982df7e93b32c3d6..1fe0c8cbf9cb079cdc89cbc2d5f1b97cd40ff9aa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -899,6 +899,20 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -900,6 +900,20 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean isSneaking() {
          return this.getHandle().isShiftKeyDown();
      }

--- a/patches/server/0913-Fix-missing-event-call-for-entity-teleport-API.patch
+++ b/patches/server/0913-Fix-missing-event-call-for-entity-teleport-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix missing event call for entity teleport API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index a8b9b50991361160880b9fc0a94cad30c319e62e..b8eb9166e44da8745a056bf68f2f9316ce25d7a7 100644
+index 1fe0c8cbf9cb079cdc89cbc2d5f1b97cd40ff9aa..fb19fe8ef70a3d23d3a09a1d0ee74637fc3d864a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -258,6 +258,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -259,6 +259,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return false;
          }
  

--- a/patches/server/0945-Add-onboarding-message-for-initial-server-start.patch
+++ b/patches/server/0945-Add-onboarding-message-for-initial-server-start.patch
@@ -29,10 +29,10 @@ index cc847dce0116b8260790b890b1d5452c280e186c..2a5453707bc172d8d0efe3f11959cb0b
          return instance;
      }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index cbceb0ddea32781f89a19b1edb258bc23b96ee92..fc0f17cd7ed4fcf10e0396aeeed115280318128d 100644
+index dfdf64e24e46dc3866cb167962a9c8c9a8e0b6cc..d4a1bd4d431fd69818822456be8abff6812324d7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1136,6 +1136,16 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1137,6 +1137,16 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              long tickSection = Util.getNanos();
              long currentTime;
              // Paper end - further improve server tick loop

--- a/patches/server/0975-Brigadier-based-command-API.patch
+++ b/patches/server/0975-Brigadier-based-command-API.patch
@@ -2213,7 +2213,7 @@ index 982b2bab27e3d55d0ba07060862c0c3183ad91b0..5fa8a3343ffc11e82c20b78a73205fd8
          Component component = message.resolveComponent(commandSourceStack);
          CommandSigningContext commandSigningContext = commandSourceStack.getSigningContext();
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index fc0f17cd7ed4fcf10e0396aeeed115280318128d..e14c0e1ccf526f81e28db5545d9e2351641e1bc8 100644
+index d4a1bd4d431fd69818822456be8abff6812324d7..cf3a6e12ac15bc1ffd074da0bcac7d23c94feb46 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -306,7 +306,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -2225,7 +2225,7 @@ index fc0f17cd7ed4fcf10e0396aeeed115280318128d..e14c0e1ccf526f81e28db5545d9e2351
      private boolean forceTicks;
      // CraftBukkit end
      // Spigot start
-@@ -393,7 +393,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -394,7 +394,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // CraftBukkit start
          this.options = options;
          this.worldLoader = worldLoader;
@@ -2233,7 +2233,7 @@ index fc0f17cd7ed4fcf10e0396aeeed115280318128d..e14c0e1ccf526f81e28db5545d9e2351
          // Paper start - Handled by TerminalConsoleAppender
          // Try to see if we're actually running in a terminal, disable jline if not
          /*
-@@ -678,6 +677,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -679,6 +678,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
          this.server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.POSTWORLD);
          if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.pluginsEnabled(); // Paper - Remap plugins

--- a/patches/server/0977-Fix-equipment-slot-and-group-API.patch
+++ b/patches/server/0977-Fix-equipment-slot-and-group-API.patch
@@ -10,10 +10,10 @@ Adds the following:
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index a1e715629313346f670bce92483996122b0f1d7b..a51b965cafa30e76cc8b4bca188b548c7837b098 100644
+index b3970222ed979dda5296ce472739c112b70d0e89..f7ef9f2e4f34398bab203d88c8793d57d925e1ff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -1181,4 +1181,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -1182,4 +1182,11 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().setYBodyRot(bodyYaw);
      }
      // Paper end - body yaw API

--- a/patches/server/0991-Chunk-System-Starlight-from-Moonrise.patch
+++ b/patches/server/0991-Chunk-System-Starlight-from-Moonrise.patch
@@ -23006,7 +23006,7 @@ index c33f85b570f159ab465b5a10a8044a81f2797f43..244a19ecd0234fa1d7a6ecfea2075159
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, worldLoader.get(), thread, convertable_conversionsession, resourcepackrepository, worldstem, dedicatedserversettings, DataFixers.getDataFixer(), services, LoggerChunkProgressListener::createFromGameruleRadius);
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a9df8c8ff 100644
+index cf3a6e12ac15bc1ffd074da0bcac7d23c94feb46..beff67feb12abfbdd93702bd67ed3798d086bc50 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -198,7 +198,7 @@ import org.bukkit.event.server.ServerLoadEvent;
@@ -23018,7 +23018,7 @@ index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a
  
      private static MinecraftServer SERVER; // Paper
      public static final Logger LOGGER = LogUtils.getLogger();
-@@ -322,7 +322,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -323,7 +323,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
          AtomicReference<S> atomicreference = new AtomicReference();
@@ -23027,7 +23027,7 @@ index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a
              ((MinecraftServer) atomicreference.get()).runServer();
          }, "Server thread");
  
-@@ -341,6 +341,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -342,6 +342,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          return s0;
      }
  
@@ -23043,7 +23043,7 @@ index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a
      public MinecraftServer(OptionSet options, WorldLoader.DataLoadContext worldLoader, Thread thread, LevelStorageSource.LevelStorageAccess convertable_conversionsession, PackRepository resourcepackrepository, WorldStem worldstem, Proxy proxy, DataFixer datafixer, Services services, ChunkProgressListenerFactory worldloadlistenerfactory) {
          super("Server");
          SERVER = this; // Paper - better singleton
-@@ -657,7 +666,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -658,7 +667,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          this.forceDifficulty();
          for (ServerLevel worldserver : this.getAllLevels()) {
              this.prepareLevels(worldserver.getChunkSource().chunkMap.progressListener, worldserver);
@@ -23052,7 +23052,7 @@ index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a
              this.server.getPluginManager().callEvent(new org.bukkit.event.world.WorldLoadEvent(worldserver.getWorld()));
          }
  
-@@ -870,6 +879,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -871,6 +880,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      public abstract boolean shouldRconBroadcast();
  
      public boolean saveAllChunks(boolean suppressLogs, boolean flush, boolean force) {
@@ -23064,7 +23064,7 @@ index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a
          boolean flag3 = false;
  
          for (Iterator iterator = this.getAllLevels().iterator(); iterator.hasNext(); flag3 = true) {
-@@ -879,7 +893,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -880,7 +894,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  MinecraftServer.LOGGER.info("Saving chunks for level '{}'/{}", worldserver, worldserver.dimension().location());
              }
  
@@ -23073,7 +23073,7 @@ index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a
          }
  
          // CraftBukkit start - moved to WorldServer.save
-@@ -980,7 +994,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -981,7 +995,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              }
          }
  
@@ -23082,7 +23082,7 @@ index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a
              return worldserver1.getChunkSource().chunkMap.hasWork();
          })) {
              this.nextTickTimeNanos = Util.getNanos() + TimeUtil.NANOSECONDS_PER_MILLISECOND;
-@@ -997,19 +1011,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -998,19 +1012,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.waitUntilNextTick();
          }
  
@@ -23103,7 +23103,7 @@ index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a
  
          this.isSaving = false;
          this.resources.close();
-@@ -1029,6 +1031,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1030,6 +1032,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
          // Spigot end
  
@@ -23111,7 +23111,7 @@ index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a
      }
  
      public String getLocalIp() {
-@@ -1203,6 +1206,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1204,6 +1207,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  this.tickServer(flag ? () -> {
                      return false;
                  } : this::haveTime);
@@ -23125,15 +23125,6 @@ index e14c0e1ccf526f81e28db5545d9e2351641e1bc8..3c230ae060998bfb79d5812fef21a80a
                  this.profiler.popPush("nextTickWait");
                  this.mayHaveDelayedTasks = true;
                  this.delayedTasksMaxNextTickTimeNanos = Math.max(Util.getNanos() + i, this.nextTickTimeNanos);
-@@ -1594,7 +1604,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
-         // Paper start - Folia scheduler API
-         ((io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler) Bukkit.getGlobalRegionScheduler()).tick();
-         getAllLevels().forEach(level -> {
--            for (final Entity entity : level.getEntities().getAll()) {
-+            for (final Entity entity : level.moonrise$getEntityLookup().getAllCopy()) { // Paper - rewrite chunk system
-                 if (entity.isRemoved()) {
-                     continue;
-                 }
 @@ -2656,6 +2666,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      }

--- a/patches/server/1008-Optimize-Hoppers.patch
+++ b/patches/server/1008-Optimize-Hoppers.patch
@@ -50,7 +50,7 @@ index 0000000000000000000000000000000000000000..5c42823726e70ce6c9d0121d07431548
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 3c230ae060998bfb79d5812fef21a80a9df8c8ff..64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1 100644
+index beff67feb12abfbdd93702bd67ed3798d086bc50..5689bffa94a567533c2698c0838d5b1e0878fcea 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1659,6 +1659,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/1020-Properly-resend-entities.patch
+++ b/patches/server/1020-Properly-resend-entities.patch
@@ -196,10 +196,10 @@ index b586116d8cca1585f9c9e618ed4d0cb2ef2747be..acf38ef6d8de8b15cf2b09eb7bda390c
              }
              entity.playSound(((Bucketable) entity).getPickupSound(), 1.0F, 1.0F);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index b8eb9166e44da8745a056bf68f2f9316ce25d7a7..2cde808bfa797256409879505ba205a71f381981 100644
+index fb19fe8ef70a3d23d3a09a1d0ee74637fc3d864a..9ba391d59735c9630d58da6bc0958fd1ac6cd984 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1012,7 +1012,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1013,7 +1013,11 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return;
          }
  

--- a/patches/server/1023-Improved-Watchdog-Support.patch
+++ b/patches/server/1023-Improved-Watchdog-Support.patch
@@ -71,7 +71,7 @@ index 589a8bf75be6ccc59f1e5dd5d8d9afed41c4772d..b24265573fdef5d9a964bcd76146f345
              cause = cause.getCause();
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1..68f60e77e0bfd42b6419491c1d59b6432974216b 100644
+index 5689bffa94a567533c2698c0838d5b1e0878fcea..7c1c59886eb2f9468dc4aee5f63342c2c2b0575b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -307,7 +307,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -83,9 +83,9 @@ index 64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1..68f60e77e0bfd42b6419491c1d59b643
      // CraftBukkit end
      // Spigot start
      public static final int TPS = 20;
-@@ -320,6 +320,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
-     public static long currentTickLong = 0L; // Paper - track current tick as a long
+@@ -321,6 +321,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      public boolean isIteratingOverLevels = false; // Paper - Throw exception on world create while being ticked
+     public final Set<Entity> entitiesWithScheduledTasks = java.util.concurrent.ConcurrentHashMap.newKeySet(); // Paper - Folia schedulers
  
 +    public volatile Thread shutdownThread; // Paper
 +    public volatile boolean abnormalExit = false; // Paper
@@ -93,7 +93,7 @@ index 64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1..68f60e77e0bfd42b6419491c1d59b643
      public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
          AtomicReference<S> atomicreference = new AtomicReference();
          Thread thread = new io.papermc.paper.util.TickThread(() -> { // Paper - rewrite chunk system
-@@ -943,6 +946,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -944,6 +947,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      // CraftBukkit start
      private boolean hasStopped = false;
      private boolean hasLoggedStop = false; // Paper - Debugging
@@ -101,7 +101,7 @@ index 64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1..68f60e77e0bfd42b6419491c1d59b643
      private final Object stopLock = new Object();
      public final boolean hasStopped() {
          synchronized (this.stopLock) {
-@@ -958,6 +962,19 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -959,6 +963,19 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.hasStopped = true;
          }
          if (!hasLoggedStop && isDebugging()) io.papermc.paper.util.TraceUtil.dumpTraceForThread("Server stopped"); // Paper - Debugging
@@ -121,7 +121,7 @@ index 64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1..68f60e77e0bfd42b6419491c1d59b643
          // CraftBukkit end
          if (this.metricsRecorder.isRecording()) {
              this.cancelRecordingMetrics();
-@@ -1031,7 +1048,17 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1032,7 +1049,17 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
          // Spigot end
  
@@ -139,7 +139,7 @@ index 64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1..68f60e77e0bfd42b6419491c1d59b643
      }
  
      public String getLocalIp() {
-@@ -1126,6 +1153,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1127,6 +1154,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      protected void runServer() {
          try {
@@ -147,7 +147,7 @@ index 64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1..68f60e77e0bfd42b6419491c1d59b643
              if (!this.initServer()) {
                  throw new IllegalStateException("Failed to initialize server");
              }
-@@ -1135,6 +1163,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1136,6 +1164,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.status = this.buildServerStatus();
  
              // Spigot start
@@ -166,7 +166,7 @@ index 64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1..68f60e77e0bfd42b6419491c1d59b643
              org.spigotmc.WatchdogThread.hasStarted = true; // Paper
              Arrays.fill( this.recentTps, 20 );
              // Paper start - further improve server tick loop
-@@ -1230,6 +1270,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1231,6 +1271,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  JvmProfiler.INSTANCE.onServerTick(this.smoothedTickTimeMillis);
              }
          } catch (Throwable throwable) {
@@ -179,7 +179,7 @@ index 64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1..68f60e77e0bfd42b6419491c1d59b643
              MinecraftServer.LOGGER.error("Encountered an unexpected exception", throwable);
              CrashReport crashreport = MinecraftServer.constructOrExtractCrashReport(throwable);
  
-@@ -1254,15 +1300,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1255,15 +1301,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                      this.services.profileCache().clearExecutor();
                  }
  
@@ -199,7 +199,7 @@ index 64d0e04b6f9c52d90d0bc185b16a8a4768af4ac1..68f60e77e0bfd42b6419491c1d59b643
              }
  
          }
-@@ -1385,6 +1431,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1386,6 +1432,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      @Override
      public TickTask wrapRunnable(Runnable runnable) {


### PR DESCRIPTION
This is an alternative implementation of #9984, based on the patch that I'm running on my server. https://github.com/SparklyPower/SparklyPaper/blob/ver/1.20.2/patches/server/0010-Skip-EntityScheduler-s-executeTick-checks-if-there-i.patch

In my opinion this PR is better than other PR because it is cleaner and better, but it is more complex than the other one. I haven't tested on Folia tho to see if there is any concurrency issues BUT I think there wouldn't be any, all checks are made within the `stateLock` synchronized block.

Folia's EntityScheduler `executeTick` loop in `MinecraftServer`'s `tickChildren` is slooooow if you have a lot of entities (example: for a server with 15k entities, [it uses ~1.7ms every tick](https://spark.lucko.me/eRvT1QqnI0), even if none of your plugins are using Folia's EntityScheduler)

To workaround this, we keep all entities with scheduled tasks into a concurrent set, and we loop that concurrent set instead of looping thru all world's entities. Yes, I know, the scheduler increments the `tickCount`, but that doesn't matter since all the scheduled tasks are "relative" to the current tick count, not bound to the server's tick count. As long as we keep ticking the tick count when there are pending tasks, it works fine.

The biggest performance boost comes from not needing to do all the checks `executeTick` does. Most server entities won't ever use a entity scheduler anyway, just think about it: Are plugins really going to add a scheduler to each item frame, each armor stand, each dropped item, each... you get my point. This also has a nice performance boost compared to #9984 because we don't need to iterate thru all entities that exist in all worlds, we only need to iterate the entities that we know that have pending tasks.

About set vs list: *Maybe* it would be better to use a list, I have used a set because it needed to be concurrent, but I could change to a list (it would require some synchronization checks tho)

If anyone wants to reproduce the performance impact: Just spawn a bunch of entities, I used Armor Stands to test this, but any entity should work.

**Profiler Before the Changes:** https://spark.lucko.me/eRvT1QqnI0
**Profiler After the Changes:** *haven't done it yet but just pretend it is the same profiler result but with 0% lag because we are iterating a set with 0 entries*