### PR TITLE
Chunk serialization events

### DIFF
--- a/patches/api/0449-Adding-ChunkSerialization-and-Generation-events.patch
+++ b/patches/api/0449-Adding-ChunkSerialization-and-Generation-events.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: derverdox <lukasjonsson@outlook.de>
+From: derverdox <mail.ysp@web.de>
 Date: Thu, 30 Nov 2023 01:22:24 +0100
 Subject: [PATCH] Adding ChunkSerialization and Generation events.
 

--- a/patches/api/0449-Adding-ChunkSerialization-and-Generation-events.patch
+++ b/patches/api/0449-Adding-ChunkSerialization-and-Generation-events.patch
@@ -1,0 +1,204 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: derverdox <lukasjonsson@outlook.de>
+Date: Thu, 30 Nov 2023 01:22:24 +0100
+Subject: [PATCH] Adding ChunkSerialization and Generation events.
+
+This patch adds new Chunk events that are called during the serialization / generation process of chunks.
+A problem some developers may face while using the ChunkLoad or ChunkUnload events is the fact that they are called synchronously.
+These proposed events are called during the process.
+
+The use case of such events is that heavy saving / loading tasks from cache to the chunk nbt container or vice versa are executed asynchronously aswell but in the same thread
+that saves / loads / generates the chunk. 
+
+diff --git a/src/main/java/io/papermc/paper/event/chunk/ChunkDataEvent.java b/src/main/java/io/papermc/paper/event/chunk/ChunkDataEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..73c94926c975360f9b7c79f910dd09a0f3346058
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/chunk/ChunkDataEvent.java
+@@ -0,0 +1,61 @@
++package io.papermc.paper.event.chunk;
++
++import org.bukkit.Bukkit;
++import org.bukkit.Chunk;
++import org.bukkit.World;
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++import org.bukkit.persistence.PersistentDataContainer;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++public abstract class ChunkDataEvent extends Event {
++    private static final HandlerList handlers = new HandlerList();
++    private final World world;
++    private final Chunk chunk;
++    private final int chunkX;
++    private final int chunkZ;
++    private final PersistentDataContainer persistentDataContainer;
++
++    public ChunkDataEvent(@NotNull World world, @Nullable Chunk chunk, int chunkX, int chunkZ, @NotNull PersistentDataContainer chunkPersistentDataContainer) {
++        super(!Bukkit.isPrimaryThread());
++        this.world = world;
++        this.chunk = chunk;
++        this.chunkX = chunkX;
++        this.chunkZ = chunkZ;
++        this.persistentDataContainer = chunkPersistentDataContainer;
++    }
++
++    public int getChunkX() {
++        return chunkX;
++    }
++
++    public int getChunkZ() {
++        return chunkZ;
++    }
++
++    @Nullable
++    public Chunk getChunk() {
++        return this.chunk;
++    }
++
++    @NotNull
++    public World getWorld() {
++        return this.world;
++    }
++
++    @NotNull
++    public PersistentDataContainer getPersistentDataContainer() {
++        return this.persistentDataContainer;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/event/chunk/ChunkDeserializeEvent.java b/src/main/java/io/papermc/paper/event/chunk/ChunkDeserializeEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..e90357708c7d06150f446161d7761b6e22fb64d5
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/chunk/ChunkDeserializeEvent.java
+@@ -0,0 +1,32 @@
++package io.papermc.paper.event.chunk;
++
++import org.bukkit.Chunk;
++import org.bukkit.World;
++import org.bukkit.event.HandlerList;
++import org.bukkit.persistence.PersistentDataContainer;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when a chunk is loaded from disk.
++ * You can use this event to manipulate the persistent data container of the chunk after it is loaded.
++ * Since by default chunk loading is asynchronously on paper this might be an alternative to the ChunkLoadEvent in some cases.
++ * This event might get called asynchronously.
++ */
++public class ChunkDeserializeEvent extends ChunkDataEvent {
++    private static final HandlerList handlers = new HandlerList();
++    public ChunkDeserializeEvent(@NotNull final World world, @Nullable final Chunk chunk, final int chunkX, final int chunkZ, @NotNull final PersistentDataContainer chunkPersistentDataContainer) {
++        super(world, chunk, chunkX, chunkZ, chunkPersistentDataContainer);
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/event/chunk/ChunkGenerateEvent.java b/src/main/java/io/papermc/paper/event/chunk/ChunkGenerateEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..1f279d528ce2be534911686a4574596334ea944a
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/chunk/ChunkGenerateEvent.java
+@@ -0,0 +1,32 @@
++package io.papermc.paper.event.chunk;
++
++import org.bukkit.Chunk;
++import org.bukkit.World;
++import org.bukkit.event.HandlerList;
++import org.bukkit.persistence.PersistentDataContainer;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when a chunk is generated.
++ * You can use this event to manipulate the persistent data container of the chunk before it is generated.
++ * Since by default chunk generation is asynchronously on paper this might be an alternative to the ChunkLoadEvent in some cases.
++ * This event is might get called asynchronously.
++ */
++public class ChunkGenerateEvent extends ChunkDataEvent {
++    private static final HandlerList handlers = new HandlerList();
++    public ChunkGenerateEvent(@NotNull final World world, @Nullable final Chunk chunk, final int chunkX, final int chunkZ, @NotNull final PersistentDataContainer chunkPersistentDataContainer) {
++        super(world, chunk, chunkX, chunkZ, chunkPersistentDataContainer);
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/event/chunk/ChunkSerializeEvent.java b/src/main/java/io/papermc/paper/event/chunk/ChunkSerializeEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..77d7711f1c8513e4f1895a187cc758c376ab93e7
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/chunk/ChunkSerializeEvent.java
+@@ -0,0 +1,43 @@
++package io.papermc.paper.event.chunk;
++
++import org.bukkit.Chunk;
++import org.bukkit.World;
++import org.bukkit.event.HandlerList;
++import org.bukkit.persistence.PersistentDataContainer;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when a chunk is saved to disk.
++ * You can use this event to manipulate the persistent data container of the chunk after it is loaded.
++ * Since by default chunk saving is asynchronously on paper this might be an alternative to the ChunkUnloadEvent in some cases.
++ * This event might get called asynchronously.
++ */
++public class ChunkSerializeEvent extends ChunkDataEvent {
++    private static final HandlerList handlers = new HandlerList();
++    private final boolean unloaded;
++
++    public ChunkSerializeEvent(@NotNull final World world, @Nullable final Chunk chunk, final int chunkX, final int chunkZ, @NotNull final PersistentDataContainer chunkPersistentDataContainer, boolean unloaded) {
++        super(world, chunk, chunkX, chunkZ, chunkPersistentDataContainer);
++        this.unloaded = unloaded;
++    }
++
++    /**
++     * Gets if this chunk was unloaded after being saved
++     * @return true if the chunk is also unloaded
++     */
++    public boolean isUnloaded() {
++        return this.unloaded;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/patches/api/0449-Adding-CustomModelChoice.patch
+++ b/patches/api/0449-Adding-CustomModelChoice.patch
@@ -1,0 +1,185 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: derverdox <mail.ysp@web.de>
+Date: Thu, 30 Nov 2023 13:20:23 +0100
+Subject: [PATCH] Adding CustomModelChoice
+
+CustomModelChoice is used to create recipes that not only compare for materials but also CustomModelData.
+Using the ExactChoice alternative is not a good idea since items can have different lores or attributes.
+This is a great way to implement recipes with the new possibilities of Minecraft custom items.
+
+
+diff --git a/src/main/java/org/bukkit/inventory/CustomItemData.java b/src/main/java/org/bukkit/inventory/CustomItemData.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..3adbb5dbe9d53522b1ef528ba4c86d43f1dcef16
+--- /dev/null
++++ b/src/main/java/org/bukkit/inventory/CustomItemData.java
+@@ -0,0 +1,52 @@
++package org.bukkit.inventory;
++
++import org.bukkit.Material;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * CustomItemData representing a vanilla material and a customModelData value.
++ * Is used in {@link RecipeChoice.CustomModelChoice}
++ * @param material The vanilla material
++ * @param customModelData the customModelData value of the item.
++ */
++public record CustomItemData(@NotNull Material material, int customModelData) {
++    /**
++     * Creates an item stack with the material and the customModelData of the CustomItemDataObject
++     * @return the new item stack
++     */
++    public @NotNull ItemStack createStack() {
++        var stack = new ItemStack(material);
++        stack.editMeta(meta -> meta.setCustomModelData(customModelData));
++        return stack;
++    }
++
++    /**
++     * Checks if the provided item stack is equal based on its material and customModelData
++     * @param stackToCheck The item stack to check
++     * @return true if they are equal
++     */
++    public boolean isSame(@Nullable ItemStack stackToCheck) {
++        if(stackToCheck == null)
++            return false;
++        if (!stackToCheck.getType().equals(material))
++            return false;
++        return customModelData == ItemStack.getCustomModelData(stackToCheck);
++    }
++
++    /**
++     * Reads the CustomItemData from an item stack
++     * @param stack The item stack
++     * @return a new CustomItemData object
++     */
++    public static CustomItemData fromItemStack(@NotNull ItemStack stack){
++        return new CustomItemData(stack.getType(), ItemStack.getCustomModelData(stack));
++    }
++    @Override
++    public String toString() {
++        return "CustomItemData{" +
++            "material=" + material +
++            ", customModelData=" + customModelData +
++            '}';
++    }
++}
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index 0af73cc04edb93b9772136d4d808f657ea40e733..184cd662885f3ec96308315532631b9740f0a7f7 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
+ import java.util.LinkedHashMap;
+ import java.util.List; // Paper
+ import java.util.Map;
++import java.util.Objects;
+ import org.bukkit.Bukkit;
+ import org.bukkit.Material;
+ import org.bukkit.Translatable;
+@@ -1005,4 +1006,32 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+         return type.isAir() || amount <= 0;
+     }
+     // Paper end
++
++    // Paper start - Adding CustomModelChoice to bukkit recipes
++    /**
++     * Helper method to set customModelData of an ItemStack
++     * @param stack the ItemStack
++     * @param customModelData the new customModelData
++     */
++    public static void setCustomModelData(@NotNull ItemStack stack, int customModelData){
++        Objects.requireNonNull(stack);
++        stack.editMeta(meta -> meta.setCustomModelData(customModelData));
++    }
++
++    /**
++     * Helper method to get the customModelData of an ItemStack
++     * @param stack the ItemStack
++     * @return the customModelData
++     */
++
++    public static int getCustomModelData(ItemStack stack){
++        if(stack == null || stack.getType().isAir())
++            return 0;
++        if(!stack.hasItemMeta())
++            return 0;
++        if(!stack.getItemMeta().hasCustomModelData())
++            return 0;
++        return stack.getItemMeta().getCustomModelData();
++    }
++    // Paper end - Adding CustomModelChoice to bukkit recipes
+ }
+diff --git a/src/main/java/org/bukkit/inventory/RecipeChoice.java b/src/main/java/org/bukkit/inventory/RecipeChoice.java
+index 523818cbb0d6c90481ec97123e7fe0e2ff4eea14..f4cd027cb9adb23ae31dacba7d5205e431f2289e 100644
+--- a/src/main/java/org/bukkit/inventory/RecipeChoice.java
++++ b/src/main/java/org/bukkit/inventory/RecipeChoice.java
+@@ -233,4 +233,67 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+             return "ExactChoice{" + "choices=" + choices + '}';
+         }
+     }
++       // Paper start - Adding CustomModelChoice to bukkit recipes
++    /**
++     * Represents a choice of multiple matching materials and customModelData values.
++     */
++    public static class CustomModelChoice implements RecipeChoice {
++        private final List<CustomItemData> choices;
++
++        public CustomModelChoice(List<CustomItemData> customItemDataList) {
++            this.choices = Collections.unmodifiableList(customItemDataList);
++        }
++
++        public CustomModelChoice(CustomItemData customItemData) {
++            this.choices = Collections.unmodifiableList(List.of(customItemData));
++        }
++
++        public CustomModelChoice(Material material, int customModelData) {
++            this.choices = Collections.unmodifiableList(List.of(new CustomItemData(material, customModelData)));
++        }
++
++        @Override
++        public @NotNull ItemStack getItemStack() {
++            var choice = choices.get(0);
++            return choice.createStack();
++        }
++
++        @Override
++        public @NotNull RecipeChoice clone() {
++            return new CustomModelChoice(this.choices);
++        }
++
++        @Override
++        public boolean test(@NotNull ItemStack stackToCheck) {
++            for (CustomItemData choice : choices) {
++                if(choice.isSame(stackToCheck))
++                    return true;
++            }
++            return false;
++        }
++
++        @Override
++        public boolean equals(Object o) {
++            if (this == o) return true;
++            if (o == null || getClass() != o.getClass()) return false;
++            CustomModelChoice that = (CustomModelChoice) o;
++            return Objects.equals(choices, that.choices);
++        }
++
++        @Override
++        public int hashCode() {
++            return Objects.hash(choices);
++        }
++
++        @Override
++        public String toString() {
++            return "CustomModelChoice{" +
++                "choices=" + choices +
++                '}';
++        }
++
++        public List<CustomItemData> getChoices() {
++            return this.choices;
++        }
++    } // Paper end - Adding CustomModelChoice to bukkit recipes
+ }

--- a/patches/server/1055-Adding-ChunkSerialization-and-Generation-events.patch
+++ b/patches/server/1055-Adding-ChunkSerialization-and-Generation-events.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: derverdox <lukasjonsson@outlook.de>
+From: derverdox <mail.ysp@web.de>
 Date: Thu, 30 Nov 2023 01:22:23 +0100
 Subject: [PATCH] Adding ChunkSerialization and Generation events.
 

--- a/patches/server/1055-Adding-ChunkSerialization-and-Generation-events.patch
+++ b/patches/server/1055-Adding-ChunkSerialization-and-Generation-events.patch
@@ -1,0 +1,226 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: derverdox <lukasjonsson@outlook.de>
+Date: Thu, 30 Nov 2023 01:22:23 +0100
+Subject: [PATCH] Adding ChunkSerialization and Generation events.
+
+
+diff --git a/src/main/java/de/verdox/mccreativelab/worldgen/ChunkDataUtil.java b/src/main/java/de/verdox/mccreativelab/worldgen/ChunkDataUtil.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..682f4ac0708ba8bff474f8dedb14df03dd8e2189
+--- /dev/null
++++ b/src/main/java/de/verdox/mccreativelab/worldgen/ChunkDataUtil.java
+@@ -0,0 +1,37 @@
++package de.verdox.mccreativelab.worldgen;
++
++import io.papermc.paper.event.chunk.ChunkGenerateEvent;
++import io.papermc.paper.event.chunk.ChunkDeserializeEvent;
++import io.papermc.paper.event.chunk.ChunkSerializeEvent;
++import net.minecraft.server.level.ServerLevel;
++import net.minecraft.world.level.chunk.ChunkAccess;
++import net.minecraft.world.level.chunk.LevelChunk;
++import org.bukkit.Bukkit;
++import org.bukkit.craftbukkit.CraftChunk;
++import org.bukkit.craftbukkit.event.CraftEventFactory;
++import org.bukkit.persistence.PersistentDataContainer;
++
++public class ChunkDataUtil {
++
++    public static void callChunkDataCreateEvent(ServerLevel serverLevel, ChunkAccess chunkAccess, PersistentDataContainer persistentDataContainer) {
++        Bukkit.getPluginManager()
++              .callEvent(new ChunkGenerateEvent(serverLevel.getWorld(), getCraftChunk(chunkAccess), chunkAccess.locX, chunkAccess.locZ, persistentDataContainer));
++        chunkAccess.persistentDataContainer.dirty(true);
++    }
++
++    public static void callChunkDataLoadEvent(ServerLevel serverLevel, ChunkAccess chunkAccess, PersistentDataContainer persistentDataContainer) {
++        Bukkit.getPluginManager().
++              callEvent(new ChunkDeserializeEvent(serverLevel.getWorld(), getCraftChunk(chunkAccess), chunkAccess.locX, chunkAccess.locZ, persistentDataContainer));
++    }
++
++    public static void callChunkDataSaveEvent(ServerLevel serverLevel, ChunkAccess chunkAccess, PersistentDataContainer persistentDataContainer, boolean unloadingChunk) {
++        Bukkit.getPluginManager()
++              .callEvent(new ChunkSerializeEvent(serverLevel.getWorld(), getCraftChunk(chunkAccess), chunkAccess.locX, chunkAccess.locZ, persistentDataContainer, unloadingChunk));
++        chunkAccess.persistentDataContainer.dirty(true);
++    }
++
++    private static CraftChunk getCraftChunk(ChunkAccess chunkAccess) {
++        return chunkAccess instanceof LevelChunk chunk ? new CraftChunk(chunk) : null;
++    }
++
++}
+diff --git a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
+index b66a7d4aab887309579154815a0d4abf9de506b0..9c403423551db5280edaca5869e42e23ae6aa5c2 100644
+--- a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
++++ b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
+@@ -1817,7 +1817,9 @@ public final class NewChunkHolder {
+         public void run() {
+             final CompoundTag toSerialize;
+             try {
+-                toSerialize = ChunkSerializer.saveChunk(this.world, this.chunk, this.asyncSaveData);
++                // Paper start - add ChunkDataEvents
++                toSerialize = ChunkSerializer.saveChunk(this.world, this.chunk, this.asyncSaveData, false);
++                // Paper end - add ChunkDataEvents
+             } catch (final ThreadDeath death) {
+                 throw death;
+             } catch (final Throwable throwable) {
+@@ -1825,7 +1827,9 @@ public final class NewChunkHolder {
+                 this.world.chunkTaskScheduler.scheduleChunkTask(this.chunk.locX, this.chunk.locZ, () -> {
+                     final CompoundTag synchronousSave;
+                     try {
+-                        synchronousSave = ChunkSerializer.saveChunk(AsyncChunkSerializeTask.this.world, AsyncChunkSerializeTask.this.chunk, AsyncChunkSerializeTask.this.asyncSaveData);
++                        // Paper start - add ChunkDataEvents
++                        synchronousSave = ChunkSerializer.saveChunk(AsyncChunkSerializeTask.this.world, AsyncChunkSerializeTask.this.chunk, AsyncChunkSerializeTask.this.asyncSaveData, false);
++                        // Paper end - add ChunkDataEvents
+                     } catch (final ThreadDeath death) {
+                         throw death;
+                     } catch (final Throwable throwable2) {
+@@ -1881,7 +1885,9 @@ public final class NewChunkHolder {
+                 }
+             }
+ 
+-            final CompoundTag save = ChunkSerializer.saveChunk(this.world, chunk, null);
++            // Paper start - add ChunkDataEvents
++            final CompoundTag save = ChunkSerializer.saveChunk(this.world, chunk, null, unloading);
++            // Paper end - add ChunkDataEvents
+ 
+             if (unloading) {
+                 completing = true;
+diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkStatus.java b/src/main/java/net/minecraft/world/level/chunk/ChunkStatus.java
+index a907b79fd8291a0e92db138f37239d17424188a1..802735bf4f34ed225ab08252c0f10b4c5bb915a0 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/ChunkStatus.java
++++ b/src/main/java/net/minecraft/world/level/chunk/ChunkStatus.java
+@@ -27,6 +27,7 @@ import net.minecraft.world.level.levelgen.GenerationStep;
+ import net.minecraft.world.level.levelgen.Heightmap;
+ import net.minecraft.world.level.levelgen.blending.Blender;
+ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
++import org.bukkit.craftbukkit.event.CraftEventFactory;
+ 
+ public class ChunkStatus {
+ 
+@@ -68,6 +69,9 @@ public class ChunkStatus {
+         }
+ 
+         worldserver.onStructureStartsAvailable(ichunkaccess);
++        // Paper start - add ChunkDataEvents
++        CraftEventFactory.callChunkGenerateEvent(worldserver, ichunkaccess, ichunkaccess.persistentDataContainer);
++        // Paper end - add ChunkDataEvents
+         return CompletableFuture.completedFuture(Either.left(ichunkaccess));
+     }, (chunkstatus, worldserver, structuretemplatemanager, lightenginethreaded, function, ichunkaccess) -> {
+         worldserver.onStructureStartsAvailable(ichunkaccess);
+diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
+index 1379084a80ce25644f13736b4a5ee5fabbd9ec1f..fedfdcf893478d9df9e35851d0ab4edb9a30856f 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
++++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
+@@ -67,6 +67,7 @@ import net.minecraft.world.level.lighting.LevelLightEngine;
+ import net.minecraft.world.level.material.Fluid;
+ import net.minecraft.world.ticks.LevelChunkTicks;
+ import net.minecraft.world.ticks.ProtoChunkTicks;
++import org.bukkit.craftbukkit.event.CraftEventFactory;
+ import org.slf4j.Logger;
+ 
+ public class ChunkSerializer {
+@@ -366,6 +367,9 @@ public class ChunkSerializer {
+         }
+ 
+         if (chunkstatus_type == ChunkStatus.ChunkType.LEVELCHUNK) {
++            // Paper start - add ChunkDataEvents
++            CraftEventFactory.callChunkDeserializeEvent(world, (ChunkAccess) object1, ((ChunkAccess) object1).persistentDataContainer);
++            // Paper start - add ChunkDataEvents
+             return new InProgressChunkHolder(new ImposterProtoChunk((LevelChunk) object1, false)); // Paper - Async chunk loading
+         } else {
+             ProtoChunk protochunk1 = (ProtoChunk) object1;
+@@ -401,6 +405,9 @@ public class ChunkSerializer {
+                 protochunk1.setCarvingMask(worldgenstage_features, new CarvingMask(nbttagcompound5.getLongArray(s1), ((ChunkAccess) object1).getMinBuildHeight()));
+             }
+ 
++            // Paper start - add ChunkDataEvents
++            CraftEventFactory.callChunkDeserializeEvent(world, (ChunkAccess) object1, ((ChunkAccess) object1).persistentDataContainer);
++            // Paper end - add ChunkDataEvents
+             return new InProgressChunkHolder(protochunk1); // Paper - Async chunk loading
+         }
+     }
+@@ -452,11 +459,12 @@ public class ChunkSerializer {
+     // CraftBukkit end
+ 
+     public static CompoundTag write(ServerLevel world, ChunkAccess chunk) {
+-        // Paper start
+-        return saveChunk(world, chunk, null);
++        // Paper start - add ChunkDataEvents
++        return saveChunk(world, chunk, null, false);
++
+     }
+-    public static CompoundTag saveChunk(ServerLevel world, ChunkAccess chunk, @org.checkerframework.checker.nullness.qual.Nullable AsyncSaveData asyncsavedata) {
+-        // Paper end
++    public static CompoundTag saveChunk(ServerLevel world, ChunkAccess chunk, @org.checkerframework.checker.nullness.qual.Nullable AsyncSaveData asyncsavedata, boolean unloadingChunk) {
++        // Paper end - add ChunkDataEvents
+         // Paper start - rewrite light impl
+         final int minSection = io.papermc.paper.util.WorldUtil.getMinLightSection(world);
+         final int maxSection = io.papermc.paper.util.WorldUtil.getMaxLightSection(world);
+@@ -637,6 +645,9 @@ public class ChunkSerializer {
+ 
+         nbttagcompound.put("Heightmaps", nbttagcompound3);
+         nbttagcompound.put("structures", ChunkSerializer.packStructureData(StructurePieceSerializationContext.fromLevel(world), chunkcoordintpair, chunk.getAllStarts(), chunk.getAllReferences()));
++        // Paper start - add ChunkDataEvents
++        CraftEventFactory.callChunkSaveEvent(world, chunk, chunk.persistentDataContainer, unloadingChunk);
++        // Paper end - add ChunkDataEvents
+         // CraftBukkit start - store chunk persistent data in nbt
+         if (!chunk.persistentDataContainer.isEmpty()) { // SPIGOT-6814: Always save PDC to account for 1.17 to 1.18 chunk upgrading.
+             nbttagcompound.put("ChunkBukkitValues", chunk.persistentDataContainer.toTagCompound());
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 5dc160b743534665c6b3efb10b10f7c36e2da5ab..039383f4a17c7ace34a2cf93b75e89bf519c1612 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -16,6 +16,9 @@ import java.util.Map;
+ import java.util.stream.Collectors;
+ import java.util.stream.Stream;
+ import javax.annotation.Nullable;
++import io.papermc.paper.event.chunk.ChunkDeserializeEvent;
++import io.papermc.paper.event.chunk.ChunkGenerateEvent;
++import io.papermc.paper.event.chunk.ChunkSerializeEvent;
+ import net.minecraft.core.BlockPos;
+ import net.minecraft.core.Direction;
+ import net.minecraft.network.protocol.game.ServerboundContainerClosePacket;
+@@ -56,6 +59,8 @@ import net.minecraft.world.level.Level;
+ import net.minecraft.world.level.LevelAccessor;
+ import net.minecraft.world.level.block.entity.SignBlockEntity;
+ import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
++import net.minecraft.world.level.chunk.ChunkAccess;
++import net.minecraft.world.level.chunk.LevelChunk;
+ import net.minecraft.world.level.storage.loot.LootContext;
+ import net.minecraft.world.level.storage.loot.LootTable;
+ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+@@ -242,6 +247,7 @@ import org.bukkit.inventory.EquipmentSlot;
+ import org.bukkit.inventory.InventoryView;
+ import org.bukkit.inventory.Recipe;
+ import org.bukkit.inventory.meta.BookMeta;
++import org.bukkit.persistence.PersistentDataContainer;
+ import org.bukkit.potion.PotionEffect;
+ import org.bukkit.util.Vector;
+ 
+@@ -2166,4 +2172,27 @@ public class CraftEventFactory {
+         return event;
+     }
+     // Paper end - add EntityFertilizeEggEvent
++
++    // Paper start - add ChunkDataEvents
++    public static void callChunkGenerateEvent(ServerLevel serverLevel, ChunkAccess chunkAccess, PersistentDataContainer persistentDataContainer) {
++        Bukkit.getPluginManager()
++              .callEvent(new ChunkGenerateEvent(serverLevel.getWorld(), getCraftChunk(chunkAccess), chunkAccess.locX, chunkAccess.locZ, persistentDataContainer));
++        chunkAccess.persistentDataContainer.dirty(true);
++    }
++
++    public static void callChunkDeserializeEvent(ServerLevel serverLevel, ChunkAccess chunkAccess, PersistentDataContainer persistentDataContainer) {
++        Bukkit.getPluginManager().
++              callEvent(new ChunkDeserializeEvent(serverLevel.getWorld(), getCraftChunk(chunkAccess), chunkAccess.locX, chunkAccess.locZ, persistentDataContainer));
++    }
++
++    public static void callChunkSaveEvent(ServerLevel serverLevel, ChunkAccess chunkAccess, PersistentDataContainer persistentDataContainer, boolean unloadingChunk) {
++        Bukkit.getPluginManager()
++              .callEvent(new ChunkSerializeEvent(serverLevel.getWorld(), getCraftChunk(chunkAccess), chunkAccess.locX, chunkAccess.locZ, persistentDataContainer, unloadingChunk));
++        chunkAccess.persistentDataContainer.dirty(true);
++    }
++
++    private static CraftChunk getCraftChunk(ChunkAccess chunkAccess) {
++        return chunkAccess instanceof LevelChunk chunk ? new CraftChunk(chunk) : null;
++    }
++    // Paper end - add ChunkDataEvents
+ }

--- a/patches/server/1055-Adding-CustomModelChoice.patch
+++ b/patches/server/1055-Adding-CustomModelChoice.patch
@@ -1,0 +1,110 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: derverdox <mail.ysp@web.de>
+Date: Thu, 30 Nov 2023 13:20:22 +0100
+Subject: [PATCH] Adding CustomModelChoice
+
+
+diff --git a/src/main/java/net/minecraft/world/item/crafting/Ingredient.java b/src/main/java/net/minecraft/world/item/crafting/Ingredient.java
+index 06fe5b056d78d42cdf78437eeabe1786d596b7f8..4ffc47b8788176eb60412235e021e39a5f0afd2a 100644
+--- a/src/main/java/net/minecraft/world/item/crafting/Ingredient.java
++++ b/src/main/java/net/minecraft/world/item/crafting/Ingredient.java
+@@ -29,6 +29,7 @@ import net.minecraft.world.entity.player.StackedContents;
+ import net.minecraft.world.item.Item;
+ import net.minecraft.world.item.ItemStack;
+ import net.minecraft.world.level.ItemLike;
++import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ 
+ public final class Ingredient implements Predicate<ItemStack> {
+ 
+@@ -39,6 +40,7 @@ public final class Ingredient implements Predicate<ItemStack> {
+     @Nullable
+     private IntList stackingIds;
+     public boolean exact; // CraftBukkit
++    public boolean isCustomModelChoice = true; // Paper
+     public static final Codec<Ingredient> CODEC = Ingredient.codec(true);
+     public static final Codec<Ingredient> CODEC_NONEMPTY = Ingredient.codec(false);
+ 
+@@ -84,6 +86,13 @@ public final class Ingredient implements Predicate<ItemStack> {
+ 
+                     continue;
+                 }
++                else if(this.isCustomModelChoice){ // Paper start - Adding CustomModelChoice to bukkit recipes
++                    var material = itemstack.getBukkitStack().getType();
++                    var customModelData = CraftItemStack.getCustomModelData(itemstack);
++                    if(itemstack1.getBukkitStack().getType().equals(material) && CraftItemStack.getCustomModelData(itemstack1) == customModelData)
++                        return true;
++                    continue;
++                } // Paper end - Adding CustomModelChoice to bukkit recipes
+                 // CraftBukkit end
+                 if (itemstack1.is(itemstack.getItem())) {
+                     return true;
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+index 654694515b4b9257a41c8623675fa3abc51a1cb7..938371a98e128dfd8e4fb4fa9fa1e6e623bba75d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+@@ -23,6 +23,19 @@ import org.bukkit.material.MaterialData;
+ @DelegateDeserialization(ItemStack.class)
+ public final class CraftItemStack extends ItemStack {
+ 
++    // Paper start - Adding CustomModelChoice to bukkit recipes
++    public static void setCustomModelData(net.minecraft.world.item.ItemStack stack, int customModelData){
++        stack.getOrCreateTag().putInt("CustomModelData", customModelData);
++    }
++    public static int getCustomModelData(net.minecraft.world.item.ItemStack stack){
++        if(!stack.hasTag())
++            return 0;
++        if(!stack.getTag().contains("CustomModelData"))
++            return 0;
++        return stack.getTag().getInt("CustomModelData");
++    }
++    // Paper end - Adding CustomModelChoice to bukkit recipes
++
+     // Paper start - MC Utils
+     public static net.minecraft.world.item.ItemStack unwrap(ItemStack bukkit) {
+         if (bukkit instanceof CraftItemStack craftItemStack) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftRecipe.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftRecipe.java
+index 13d25d118eb4d3ef35a4cdfb9bbde9ed83f6c04b..dd639231955150736bd9776032374d682617c39b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftRecipe.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftRecipe.java
+@@ -3,6 +3,7 @@ package org.bukkit.craftbukkit.inventory;
+ import com.google.common.base.Preconditions;
+ import java.util.ArrayList;
+ import java.util.List;
++import org.bukkit.inventory.CustomItemData;
+ import net.minecraft.world.item.crafting.Ingredient;
+ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+ import org.bukkit.inventory.ItemStack;
+@@ -30,7 +31,15 @@ public interface CraftRecipe extends Recipe {
+         } else if (bukkit instanceof RecipeChoice.ExactChoice) {
+             stack = new Ingredient(((RecipeChoice.ExactChoice) bukkit).getChoices().stream().map((mat) -> new net.minecraft.world.item.crafting.Ingredient.ItemValue(CraftItemStack.asNMSCopy(mat))));
+             stack.exact = true;
+-        } else {
++        } // Paper start - Adding CustomModelChoice to bukkit recipes
++        else if (bukkit instanceof RecipeChoice.CustomModelChoice choice) {
++            stack = new Ingredient(choice.getChoices().stream()
++                                         .map(customItemData -> CraftItemStack.asNMSCopy(customItemData.createStack()))
++                                         .map(Ingredient.ItemValue::new)
++            );
++            stack.isCustomModelChoice = true;
++        }
++        else { // Paper end - Adding CustomModelChoice to bukkit recipes
+             throw new IllegalArgumentException("Unknown recipe stack instance " + bukkit);
+         }
+ 
+@@ -56,7 +65,15 @@ public interface CraftRecipe extends Recipe {
+             }
+ 
+             return new RecipeChoice.ExactChoice(choices);
+-        } else {
++        } // Paper start - Adding CustomModelChoice to bukkit recipes
++        else if(list.isCustomModelChoice){
++            List<CustomItemData> choices = new ArrayList<>(list.itemStacks.length);
++            for (net.minecraft.world.item.ItemStack i : list.itemStacks) {
++                choices.add(CustomItemData.fromItemStack(CraftItemStack.asBukkitCopy(i)));
++            }
++            return new RecipeChoice.CustomModelChoice(choices);
++        }
++        else { // Paper end - Adding CustomModelChoice to bukkit recipes
+ 
+             List<org.bukkit.Material> choices = new ArrayList<>(list.itemStacks.length);
+             for (net.minecraft.world.item.ItemStack i : list.itemStacks) {


### PR DESCRIPTION
This patch adds new Chunk events that are called during the serialization / generation process of chunks.

The use case of such events is that heavy saving/loading tasks from cache to the chunk nbt container or vice versa are executed asynchronously as well but in the same thread.