### PR TITLE
Add proper version check to startup

### DIFF
--- a/patches/server/1052-Add-proper-version-check-to-startup.patch
+++ b/patches/server/1052-Add-proper-version-check-to-startup.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tamion <70228790+notTamion@users.noreply.github.com>
+Date: Wed, 6 Dec 2023 21:44:55 +0100
+Subject: [PATCH] Add proper version check to startup
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 782bb8ca67517dde5dba8f0a133eb8699353dd01..a9ddd74af149f795cfa19885cd1a9181ee59f9b2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -403,6 +403,8 @@ public final class CraftServer implements Server {
+ 
+         Bukkit.setServer(this);
+ 
++        net.kyori.adventure.text.logger.slf4j.ComponentLogger.logger(this.getLogger().getName()).info(this.getUnsafe().getVersionFetcher().getVersionMessage(this.getVersion()).children().get(0)); // Paper
++
+         CraftRegistry.setMinecraftRegistry(console.registryAccess());
+ 
+         Potion.setPotionBrewer(potionBrewer); // Paper
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index 4b457cbfc56e55e0ae0fee5b69e2e75349702aab..418da2a10d99460e3ff9f49fb738472c5253b186 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -293,6 +293,8 @@ public class Main {
+                     System.setProperty(net.minecrell.terminalconsole.TerminalConsoleAppender.JLINE_OVERRIDE_PROPERTY, "false"); // Paper
+                 }
+ 
++                // Paper start
++                /*
+                 if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
+                     Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
+ 
+@@ -307,6 +309,8 @@ public class Main {
+                         // Paper End
+                     }
+                 }
++                */
++                // Paper end
+ 
+                 // Paper start - Log Java and OS versioning to help with debugging plugin issues
+                 java.lang.management.RuntimeMXBean runtimeMX = java.lang.management.ManagementFactory.getRuntimeMXBean();


### PR DESCRIPTION
removes the shitty "version check" which basically just checks if the build is more than 21 days old.
I put the new check right after the git information is printed, which is probably where it fits the nicest without having to change anything about how the PaperVersionFetcher and the methods it calls work.

Unsure if this should be merged into the Implement PaperVersionFetcher patch