### PR TITLE
Set true custom payload channel size limit

### DIFF
--- a/patches/api/0180-Set-true-custom-payload-channel-size-limit.patch
+++ b/patches/api/0180-Set-true-custom-payload-channel-size-limit.patch
@@ -3,7 +3,7 @@ From: Shane Freeder <theboyetronic@gmail.com>
 Date: Fri, 18 Oct 2019 17:39:05 +0100
 Subject: [PATCH] Set true custom payload channel size limit
 
-This fixes compatibility with some mods that are sending very long channel names. Also gives developers the ability to send logner channel names.
+This fixes compatibility with some mods that are sending very long channel names. Also gives developers the ability to send longer channel names.
 
 diff --git a/src/main/java/org/bukkit/plugin/messaging/Messenger.java b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
 index 9d2c68c826f3b867d407e7f13c6394a899cc8ee8..ca6442ebe6a01a546e2f6d5c79583189ed0b0292 100644

--- a/patches/api/0180-Set-true-custom-payload-channel-size-limit.patch
+++ b/patches/api/0180-Set-true-custom-payload-channel-size-limit.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Set true custom payload channel size limit
 This fixes compatibility with some mods that are sending very long channel names. Also gives developers the ability to send longer channel names.
 
 diff --git a/src/main/java/org/bukkit/plugin/messaging/Messenger.java b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
-index 9d2c68c826f3b867d407e7f13c6394a899cc8ee8..d15190d927311b9cc511e0484316786a523ab9c5 100644
+index 9d2c68c826f3b867d407e7f13c6394a899cc8ee8..aec70aa740152c34297c42ad6e06c8b54523e78b 100644
 --- a/src/main/java/org/bukkit/plugin/messaging/Messenger.java
 +++ b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
 @@ -24,7 +24,7 @@ public interface Messenger {
@@ -14,7 +14,7 @@ index 9d2c68c826f3b867d407e7f13c6394a899cc8ee8..d15190d927311b9cc511e0484316786a
       * Represents the largest size that a Plugin Channel may be.
       */
 -    public static final int MAX_CHANNEL_SIZE = 64;
-+    public static final int MAX_CHANNEL_SIZE = Integer.getInteger("paper.maxCustomChannelName", 32767); // Paper - set true max channel size
++    public static final int MAX_CHANNEL_SIZE = Integer.getInteger("paper.maxCustomChannelName", java.lang.Short.MAX_VALUE); // Paper - set true max channel size
  
      /**
       * Checks if the specified channel is a reserved name.

--- a/patches/api/0180-Set-true-custom-payload-channel-size-limit.patch
+++ b/patches/api/0180-Set-true-custom-payload-channel-size-limit.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Set true custom payload channel size limit
 This fixes compatibility with some mods that are sending very long channel names. Also gives developers the ability to send longer channel names.
 
 diff --git a/src/main/java/org/bukkit/plugin/messaging/Messenger.java b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
-index 9d2c68c826f3b867d407e7f13c6394a899cc8ee8..ca6442ebe6a01a546e2f6d5c79583189ed0b0292 100644
+index 9d2c68c826f3b867d407e7f13c6394a899cc8ee8..d15190d927311b9cc511e0484316786a523ab9c5 100644
 --- a/src/main/java/org/bukkit/plugin/messaging/Messenger.java
 +++ b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
 @@ -24,7 +24,7 @@ public interface Messenger {
@@ -14,7 +14,7 @@ index 9d2c68c826f3b867d407e7f13c6394a899cc8ee8..ca6442ebe6a01a546e2f6d5c79583189
       * Represents the largest size that a Plugin Channel may be.
       */
 -    public static final int MAX_CHANNEL_SIZE = 64;
-+    public static final int MAX_CHANNEL_SIZE = 32767; // Paper - set true max channel size
++    public static final int MAX_CHANNEL_SIZE = Integer.getInteger("paper.maxCustomChannelName", 32767); // Paper - set true max channel size
  
      /**
       * Checks if the specified channel is a reserved name.

--- a/patches/api/0180-Set-true-custom-payload-channel-size-limit.patch
+++ b/patches/api/0180-Set-true-custom-payload-channel-size-limit.patch
@@ -1,13 +1,12 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Fri, 18 Oct 2019 17:39:05 +0100
-Subject: [PATCH] Increase custom payload channel message size
+Subject: [PATCH] Set true custom payload channel size limit
 
-Doubles the custom payload size limit imposed by bukkit, also creates a system
-property to allow customizing the size `paper.maxCustomChannelName`
+This fixes compatibility with some mods that are sending very long channel names. Also gives developers the ability to send logner channel names.
 
 diff --git a/src/main/java/org/bukkit/plugin/messaging/Messenger.java b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
-index 9d2c68c826f3b867d407e7f13c6394a899cc8ee8..682c77188436d696d4dafbc70cf131d5c921e94d 100644
+index 9d2c68c826f3b867d407e7f13c6394a899cc8ee8..ca6442ebe6a01a546e2f6d5c79583189ed0b0292 100644
 --- a/src/main/java/org/bukkit/plugin/messaging/Messenger.java
 +++ b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
 @@ -24,7 +24,7 @@ public interface Messenger {
@@ -15,7 +14,7 @@ index 9d2c68c826f3b867d407e7f13c6394a899cc8ee8..682c77188436d696d4dafbc70cf131d5
       * Represents the largest size that a Plugin Channel may be.
       */
 -    public static final int MAX_CHANNEL_SIZE = 64;
-+    public static final int MAX_CHANNEL_SIZE = Integer.getInteger("paper.maxCustomChannelName", 64); // Paper
++    public static final int MAX_CHANNEL_SIZE = 32767; // Paper - set true max channel size
  
      /**
       * Checks if the specified channel is a reserved name.


### PR DESCRIPTION
According to [Plugin Message packet](https://wiki.vg/Protocol#Serverbound_Plugin_Message_.28play.29) the channel itself does not have a limit, but `Identifier` has a limit. If we look up here we can see that `Identifier` can hold text of length `32767` bytes. So the max possible channel size is that `32767` bytes.

I wonder why spigot left there so small channel size limit. Maybe it's because minecraft used to have a limit set on the channel name but now it doesn't. 
EDIT: Yeah it would match: https://wiki.vg/index.php?title=Plugin_channels&diff=14556&oldid=14514

Related issue: #10003