### PR TITLE
fix more incorrect array nullability annotations

### DIFF
--- a/patches/api/0134-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/patches/api/0134-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index 766d643f0fe79660942fdad25e39e488e9379419..eca55d8d3464f0e13a3b7984f74559ccda87edba 100644
+index 766d643f0fe79660942fdad25e39e488e9379419..498d4d845484de53ff0ec34b08d9f03fd1745f18 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
 @@ -122,7 +122,30 @@ public interface Chunk extends PersistentDataHolder {
@@ -14,7 +14,7 @@ index 766d643f0fe79660942fdad25e39e488e9379419..eca55d8d3464f0e13a3b7984f74559cc
      @NotNull
 -    BlockState[] getTileEntities();
 +    // Paper start
-+    default BlockState[] getTileEntities() {
++    default BlockState @NotNull [] getTileEntities() {
 +        return getTileEntities(true);
 +    }
 +
@@ -25,7 +25,7 @@ index 766d643f0fe79660942fdad25e39e488e9379419..eca55d8d3464f0e13a3b7984f74559cc
 +     * @return The tile entities.
 +     */
 +    @NotNull
-+    BlockState[] getTileEntities(boolean useSnapshot);
++    BlockState @NotNull [] getTileEntities(boolean useSnapshot);
 +
 +    /**
 +     * Get a list of all tile entities that match a given predicate in the chunk.

--- a/patches/api/0187-Add-tick-times-API.patch
+++ b/patches/api/0187-Add-tick-times-API.patch
@@ -35,10 +35,10 @@ index f11c8e344694610b4a3f5ce945afb5ba876de33d..1a66d6314765840f529900a850265ed2
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 54400edeb6a2245bed7824db2a5c9b7a1ba76eda..88bb506880fa019881e95a2cc07915841c2028e7 100644
+index 54400edeb6a2245bed7824db2a5c9b7a1ba76eda..287a34f0d5a9e7b3ada97856ea6bf5849d06c468 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1787,6 +1787,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1787,6 +1787,20 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();
@@ -48,8 +48,7 @@ index 54400edeb6a2245bed7824db2a5c9b7a1ba76eda..88bb506880fa019881e95a2cc0791584
 +     *
 +     * @return A sample of the servers last tick times (in nanos)
 +     */
-+    @NotNull
-+    long[] getTickTimes();
++    long @NotNull [] getTickTimes();
 +
 +    /**
 +     * Get the average tick time (in millis)

--- a/patches/api/0188-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0188-Expose-MinecraftServer-isRunning.patch
@@ -26,10 +26,10 @@ index 1a66d6314765840f529900a850265ed20173fd9b..4e8383432a3a8a07dbc31f77986b0f47
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 88bb506880fa019881e95a2cc07915841c2028e7..37caeff1416cf0e3c63260ba7ad82a92e95a5399 100644
+index 287a34f0d5a9e7b3ada97856ea6bf5849d06c468..ea17fba537252d25fa9c49d41ebfe8918a37d466 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2147,5 +2147,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2146,5 +2146,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0189-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/api/0189-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -20,10 +20,10 @@ index 4604392831d19a789e4906cf1a5f0197105fd6f2..f063016f8a88dbff480ac3b4b3ef05c1
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 60a25898fb17c467ffae05039fcd4d3b154a99ff..3da071798b89e1dd1453f4339af87933cdf0105e 100644
+index 60a25898fb17c467ffae05039fcd4d3b154a99ff..e580ff68533435b3b75af63508057a0545b8a08c 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -639,6 +639,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -639,6 +639,28 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          return Bukkit.getServer().getItemFactory().ensureServerConversions(this);
      }
  
@@ -36,8 +36,7 @@ index 60a25898fb17c467ffae05039fcd4d3b154a99ff..3da071798b89e1dd1453f4339af87933
 +     * @param bytes bytes representing an item in NBT
 +     * @return ItemStack migrated to this version of Minecraft if needed.
 +     */
-+    @NotNull
-+    public static ItemStack deserializeBytes(@NotNull byte[] bytes) {
++    public static @NotNull ItemStack deserializeBytes(final byte @NotNull [] bytes) {
 +        return org.bukkit.Bukkit.getUnsafe().deserializeItem(bytes);
 +    }
 +
@@ -46,8 +45,7 @@ index 60a25898fb17c467ffae05039fcd4d3b154a99ff..3da071798b89e1dd1453f4339af87933
 +     * use the built in data converter instead of bukkits dangerous serialization system.
 +     * @return bytes representing this item in NBT.
 +     */
-+    @NotNull
-+    public byte[] serializeAsBytes() {
++    public byte @NotNull [] serializeAsBytes() {
 +        return org.bukkit.Bukkit.getUnsafe().serializeItem(this);
 +    }
 +

--- a/patches/api/0196-Add-Mob-Goal-API.patch
+++ b/patches/api/0196-Add-Mob-Goal-API.patch
@@ -556,10 +556,10 @@ index 29cf7359334144d6e718fed560771be35f580b16..5c508045a53d9f6efe6358648daa47c0
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d97200a8816dbbbce07734b5547a942f8f3f0fdc..aec7814485efb0b827ccfde92372a436d47ed2f5 100644
+index d14dcdd7efed4507e0f3e7f6c91f973038560ca9..7f75b3fabaddfb548737672230c903aa138df0ee 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2164,5 +2164,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2163,5 +2163,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0212-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0212-Add-methods-to-get-translation-keys.patch
@@ -478,7 +478,7 @@ index 5bd252c0ae3b09fe141d131360c67bb9bfbf5422..78587d9fabe6371a23a7963917b054db
 +
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 3da071798b89e1dd1453f4339af87933cdf0105e..e4ad3a550050c4bf9cc7a2a1082bfdf668050efe 100644
+index e580ff68533435b3b75af63508057a0545b8a08c..badb5d74a9d42ce468f80477ced7a51323d55085 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
@@ -498,7 +498,7 @@ index 3da071798b89e1dd1453f4339af87933cdf0105e..e4ad3a550050c4bf9cc7a2a1082bfdf6
      public String getTranslationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }
-@@ -865,5 +866,16 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -863,5 +864,16 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
          ItemMeta itemMeta = getItemMeta();
          return itemMeta != null && itemMeta.hasItemFlag(flag);
      }

--- a/patches/api/0266-Item-Rarity-API.patch
+++ b/patches/api/0266-Item-Rarity-API.patch
@@ -88,10 +88,10 @@ index 27d5f37a9b2da92307e5b505e3b31cca8a067018..26b0d5c0a62e516db6eef9dedc81216d
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index e4ad3a550050c4bf9cc7a2a1082bfdf668050efe..4f867ba2bc9b1a7c277e4a5f0ea8b452315f3272 100644
+index badb5d74a9d42ce468f80477ced7a51323d55085..4554fc6dcbfd456bbd35af494e11f83ef0131008 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -877,5 +877,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -875,5 +875,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public @NotNull String translationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }

--- a/patches/api/0283-Add-basic-Datapack-API.patch
+++ b/patches/api/0283-Add-basic-Datapack-API.patch
@@ -101,7 +101,7 @@ index 1e6307106391056af17add97080cd1f1908114e7..ff5c49c0a3a730ae6cf7a2547f63fcdb
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 91535f211ba7352c22c8cc30e340ed93b3ace21d..4a461c02b62ce782c69801b1b076e5383a79b7c6 100644
+index 4c19277644366b903dc15fa83d21b13ed403f5a0..4758dab9fd2b3527b3eed80d88b29cf7388ca9a4 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -256,9 +256,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -116,7 +116,7 @@ index 91535f211ba7352c22c8cc30e340ed93b3ace21d..4a461c02b62ce782c69801b1b076e538
      public DataPackManager getDataPackManager();
  
      /**
-@@ -2202,5 +2204,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2201,5 +2203,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/api/0285-ItemStack-repair-check-API.patch
+++ b/patches/api/0285-ItemStack-repair-check-API.patch
@@ -26,10 +26,10 @@ index 3ae23a15a2c8757d3003041425ced583187d3d21..6b8013b072c9ca0a6f5ba86f37de3744
       * Returns the server's protocol version.
       *
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 4f867ba2bc9b1a7c277e4a5f0ea8b452315f3272..2d945516ec65ffe103479aea218b3002cc572dc1 100644
+index 4554fc6dcbfd456bbd35af494e11f83ef0131008..423af51f272e4e99b622fe9133d6666e8bde205a 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -887,5 +887,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -885,5 +885,27 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public io.papermc.paper.inventory.ItemRarity getRarity() {
          return Bukkit.getUnsafe().getItemStackRarity(this);
      }

--- a/patches/api/0351-Custom-Potion-Mixes.patch
+++ b/patches/api/0351-Custom-Potion-Mixes.patch
@@ -175,10 +175,10 @@ index 5e8518372a30595f5f8f254e31a130645e75772e..011d4e3c6fe3ffb0636506f5447c0097
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 204e68a63cf32d3b58a9fadabde5780608f47421..5e5b5aedeaaca24aebe59ec2cfd0adde2ca4a7f5 100644
+index f42a28ea8f2045ae17df5f70126a1050cfb3c2ae..aa745c78b18a3da3b555e2b93b6175916518e1f7 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2238,5 +2238,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2237,5 +2237,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      io.papermc.paper.datapack.DatapackManager getDatapackManager();

--- a/patches/api/0391-ItemStack-damage-API.patch
+++ b/patches/api/0391-ItemStack-damage-API.patch
@@ -65,10 +65,10 @@ index eced9bfd35aa822b1ba141ea60e603bca5a137f8..088f42f294784e14f4478255193f4fd4
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index eac7adf622b91489711a2f8bcff77fb31292dd67..d15a74c38576c49df61cfab02c70fc5d8c0dd5f7 100644
+index 43c479f9070a7d39ddf5e75ff32236eb5dcb5b2e..e20dd1d8ba87b072b15e59b438fa9221bd0f0cef 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -971,5 +971,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -969,5 +969,19 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public boolean canRepair(@NotNull ItemStack toBeRepaired) {
          return Bukkit.getUnsafe().isValidRepairItemStack(toBeRepaired, this);
      }

--- a/patches/api/0416-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/api/0416-Folia-scheduler-and-owned-region-API.patch
@@ -645,10 +645,10 @@ index 458d98cc385718a86e0ef0eb90ff9ce64d77066a..2bafcb26c144a84d1b955c8cdf122cca
      public static Server.Spigot spigot() {
          return server.spigot();
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 383f1fcddaa50a8c94282c7a828912d73accfb62..cd1df326ef937863e427f47e1c8ac8720c01f75d 100644
+index e4db484170f541a9d21fad8937473d043df0e54b..46ad30e8e63eaaa986a682f1dea4cb3ade51ca8a 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -2267,4 +2267,119 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -2266,4 +2266,119 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull org.bukkit.potion.PotionBrewer getPotionBrewer();
      // Paper end

--- a/patches/api/0439-Allow-proper-checking-of-empty-item-stacks.patch
+++ b/patches/api/0439-Allow-proper-checking-of-empty-item-stacks.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow proper checking of empty item stacks
 This adds a method to check if an item stack is empty or not. This mirrors vanilla's implementation of the same method.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index d15a74c38576c49df61cfab02c70fc5d8c0dd5f7..0af73cc04edb93b9772136d4d808f657ea40e733 100644
+index e20dd1d8ba87b072b15e59b438fa9221bd0f0cef..5e03ea60f7eda81fd8e1370dee16298836992b0e 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -985,5 +985,24 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+@@ -983,5 +983,24 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
      public @NotNull ItemStack damage(int amount, @NotNull org.bukkit.entity.LivingEntity livingEntity) {
          return livingEntity.damageItemStack(this, amount);
      }

--- a/patches/api/0449-fix-more-incorrect-array-nullability-annotations.patch
+++ b/patches/api/0449-fix-more-incorrect-array-nullability-annotations.patch
@@ -1,0 +1,437 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 8 Dec 2023 23:03:42 -0800
+Subject: [PATCH] fix more incorrect array nullability annotations
+
+will be squashed into annotation fix patch
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 4863d9f21f0a0f11974be85360edc587ffd7eab3..f07e8ad69c2a896e83939cf55debdfec18a6bc03 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1134,7 +1134,7 @@ public final class Bukkit {
+      * @return the {@link Recipe} resulting from the given crafting matrix.
+      */
+     @Nullable
+-    public static Recipe getCraftingRecipe(@NotNull ItemStack[] craftingMatrix, @NotNull World world) {
++    public static Recipe getCraftingRecipe(@NotNull ItemStack @NotNull [] craftingMatrix, @NotNull World world) { // Paper - fix annotations
+         return server.getCraftingRecipe(craftingMatrix, world);
+     }
+ 
+@@ -1163,7 +1163,7 @@ public final class Bukkit {
+      * @return resulting {@link ItemCraftResult} containing the resulting item, matrix and any overflow items.
+      */
+     @NotNull
+-    public static ItemCraftResult craftItemResult(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player) {
++    public static ItemCraftResult craftItemResult(@NotNull ItemStack @NotNull [] craftingMatrix, @NotNull World world, @NotNull Player player) { // Paper - fix annotations
+         return server.craftItemResult(craftingMatrix, world, player);
+     }
+ 
+@@ -1185,7 +1185,7 @@ public final class Bukkit {
+      * @return resulting {@link ItemCraftResult} containing the resulting item, matrix and any overflow items.
+      */
+     @NotNull
+-    public static ItemCraftResult craftItemResult(@NotNull ItemStack[] craftingMatrix, @NotNull World world) {
++    public static ItemCraftResult craftItemResult(@NotNull ItemStack @NotNull [] craftingMatrix, @NotNull World world) { // Paper - fix annotations
+         return server.craftItemResult(craftingMatrix, world);
+     }
+ 
+@@ -1216,7 +1216,7 @@ public final class Bukkit {
+      * an ItemStack of {@link Material#AIR} is returned.
+      */
+     @NotNull
+-    public static ItemStack craftItem(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player) {
++    public static ItemStack craftItem(@NotNull ItemStack @NotNull [] craftingMatrix, @NotNull World world, @NotNull Player player) { // Paper - fix annotations
+         return server.craftItem(craftingMatrix, world, player);
+     }
+ 
+@@ -1239,7 +1239,7 @@ public final class Bukkit {
+      * an ItemStack of {@link Material#AIR} is returned.
+      */
+     @NotNull
+-    public static ItemStack craftItem(@NotNull ItemStack[] craftingMatrix, @NotNull World world) {
++    public static ItemStack craftItem(@NotNull ItemStack @NotNull [] craftingMatrix, @NotNull World world) { // Paper - fix annotations
+         return server.craftItem(craftingMatrix, world);
+     }
+ 
+diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
+index 498d4d845484de53ff0ec34b08d9f03fd1745f18..2f7656e227cc3c0c93071ab943e33bc05d7f2aab 100644
+--- a/src/main/java/org/bukkit/Chunk.java
++++ b/src/main/java/org/bukkit/Chunk.java
+@@ -113,8 +113,7 @@ public interface Chunk extends PersistentDataHolder {
+      *
+      * @return The entities.
+      */
+-    @NotNull
+-    Entity[] getEntities();
++    @NotNull Entity @NotNull [] getEntities(); // Paper - fix annotations
+ 
+     /**
+      * Get a list of all tile entities in the chunk.
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index bec728a9e4bf18bc6ac149f9e4bf3b857693671e..7650486d2aa9c8f1e969c810a0b3f20af33e13bc 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -971,7 +971,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @return the {@link Recipe} resulting from the given crafting matrix.
+      */
+     @Nullable
+-    public Recipe getCraftingRecipe(@NotNull ItemStack[] craftingMatrix, @NotNull World world);
++    public Recipe getCraftingRecipe(@NotNull ItemStack @NotNull [] craftingMatrix, @NotNull World world); // Paper - fix annotations
+ 
+     /**
+      * Get the crafted item using the list of {@link ItemStack} provided.
+@@ -999,7 +999,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * an ItemStack of {@link Material#AIR} is returned.
+      */
+     @NotNull
+-    public ItemStack craftItem(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player);
++    public ItemStack craftItem(@NotNull ItemStack @NotNull [] craftingMatrix, @NotNull World world, @NotNull Player player); // Paper - fix annotations
+ 
+     /**
+      * Get the crafted item using the list of {@link ItemStack} provided.
+@@ -1020,7 +1020,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * an ItemStack of {@link Material#AIR} is returned.
+      */
+     @NotNull
+-    public ItemStack craftItem(@NotNull ItemStack[] craftingMatrix, @NotNull World world);
++    public ItemStack craftItem(@NotNull ItemStack @NotNull [] craftingMatrix, @NotNull World world); // Paper - fix annotations
+ 
+     /**
+      * Get the crafted item using the list of {@link ItemStack} provided.
+@@ -1047,7 +1047,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @return resulting {@link ItemCraftResult} containing the resulting item, matrix and any overflow items.
+      */
+     @NotNull
+-    public ItemCraftResult craftItemResult(@NotNull ItemStack[] craftingMatrix, @NotNull World world, @NotNull Player player);
++    public ItemCraftResult craftItemResult(@NotNull ItemStack @NotNull [] craftingMatrix, @NotNull World world, @NotNull Player player); // Paper - fix annotations
+ 
+     /**
+      * Get the crafted item using the list of {@link ItemStack} provided.
+@@ -1067,7 +1067,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @return resulting {@link ItemCraftResult} containing the resulting item, matrix and any overflow items.
+      */
+     @NotNull
+-    public ItemCraftResult craftItemResult(@NotNull ItemStack[] craftingMatrix, @NotNull World world);
++    public ItemCraftResult craftItemResult(@NotNull ItemStack @NotNull [] craftingMatrix, @NotNull World world); // Paper - fix annotations
+ 
+     /**
+      * Get an iterator through the list of crafting recipes.
+diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
+index b791358f90fe92bc2264d9a26492245763813af3..8666940579e550ccbaa8ca279754f38927d23deb 100644
+--- a/src/main/java/org/bukkit/command/Command.java
++++ b/src/main/java/org/bukkit/command/Command.java
+@@ -58,7 +58,7 @@ public abstract class Command {
+      * @param args All arguments passed to the command, split via ' '
+      * @return true if the command was successful, otherwise false
+      */
+-    public abstract boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args);
++    public abstract boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String @NotNull [] args); // Paper - fix annotations
+ 
+     /**
+      * Executed on tab completion for this command, returning a list of
+@@ -72,7 +72,7 @@ public abstract class Command {
+      * @throws IllegalArgumentException if sender, alias, or args is null
+      */
+     @NotNull
+-    public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, @NotNull String[] args) throws IllegalArgumentException {
++    public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, @NotNull String @NotNull [] args) throws IllegalArgumentException { // Paper - fix annotations
+         return tabComplete0(sender, alias, args, null);
+     }
+ 
+@@ -89,7 +89,7 @@ public abstract class Command {
+      * @throws IllegalArgumentException if sender, alias, or args is null
+      */
+     @NotNull
+-    public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, @NotNull String[] args, @Nullable Location location) throws IllegalArgumentException {
++    public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, @NotNull String @NotNull [] args, @Nullable Location location) throws IllegalArgumentException { // Paper - fix annotations
+         return tabComplete(sender, alias, args);
+     }
+ 
+diff --git a/src/main/java/org/bukkit/command/CommandExecutor.java b/src/main/java/org/bukkit/command/CommandExecutor.java
+index 45cb8da120ac976fc1ccac7c54264d8d3c4f2072..cbfcd9689d1a7b769ec5a5479df8ff55f2c7e4a6 100644
+--- a/src/main/java/org/bukkit/command/CommandExecutor.java
++++ b/src/main/java/org/bukkit/command/CommandExecutor.java
+@@ -19,5 +19,5 @@ public interface CommandExecutor {
+      * @param args Passed command arguments
+      * @return true if a valid command, otherwise false
+      */
+-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args);
++    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args); // Paper - fix annotations
+ }
+diff --git a/src/main/java/org/bukkit/command/MessageCommandSender.java b/src/main/java/org/bukkit/command/MessageCommandSender.java
+index 9d263ab3afb938c215c0b64d9171345fca6ceb2c..3fccb724c58f2b55ed05707410221a58d662ac06 100644
+--- a/src/main/java/org/bukkit/command/MessageCommandSender.java
++++ b/src/main/java/org/bukkit/command/MessageCommandSender.java
+@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
+ public interface MessageCommandSender extends CommandSender {
+ 
+     @Override
+-    default void sendMessage(@NotNull String[] messages) {
++    default void sendMessage(@NotNull String @NotNull [] messages) { // Paper - fix annotations
+         for (String message : messages) {
+             sendMessage(message);
+         }
+@@ -31,7 +31,7 @@ public interface MessageCommandSender extends CommandSender {
+     }
+ 
+     @Override
+-    default void sendMessage(@Nullable UUID sender, @NotNull String[] messages) {
++    default void sendMessage(@Nullable UUID sender, @NotNull String @NotNull [] messages) { // Paper - fix annotations
+         for (String message : messages) {
+             sendMessage(message);
+         }
+diff --git a/src/main/java/org/bukkit/command/TabCompleter.java b/src/main/java/org/bukkit/command/TabCompleter.java
+index ed6f6525a627dcb4739c03a47d27c29417b1b35b..8e6cb12131f05c539ecdf289ca25c47b5e8bce60 100644
+--- a/src/main/java/org/bukkit/command/TabCompleter.java
++++ b/src/main/java/org/bukkit/command/TabCompleter.java
+@@ -23,5 +23,5 @@ public interface TabCompleter {
+      *     to default to the command executor
+      */
+     @Nullable
+-    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args);
++    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args); // Paper - fix annotations
+ }
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index a8d3451ccfcd21a9e80adc2feab8fc9c2926c753..24220b3177ca20ab5e8f7afc914bfa65a196b6b4 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -2082,7 +2082,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      *     long.
+      */
+     @Deprecated // Paper - adventure
+-    public void setResourcePack(@NotNull String url, @Nullable byte[] hash);
++    public void setResourcePack(@NotNull String url, byte @Nullable [] hash); // Paper - fix annotations
+ 
+     /**
+      * Request that the player's client download and switch resource packs.
+@@ -2125,7 +2125,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      *     long.
+      */
+     @Deprecated // Paper - adventure
+-    public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt);
++    public void setResourcePack(@NotNull String url, byte @Nullable [] hash, @Nullable String prompt); // Paper - fix annotations
+ 
+     // Paper start
+     /**
+@@ -2213,7 +2213,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @throws IllegalArgumentException Thrown if the hash is not 20 bytes
+      *     long.
+      */
+-    public void setResourcePack(@NotNull String url, @Nullable byte[] hash, boolean force);
++    public void setResourcePack(@NotNull String url, byte @Nullable [] hash, boolean force); // Paper - fix annotations
+ 
+     /**
+      * Request that the player's client download and switch resource packs.
+@@ -2257,7 +2257,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      *     long.
+      */
+     @Deprecated // Paper
+-    public void setResourcePack(@NotNull String url, @Nullable byte[] hash, @Nullable String prompt, boolean force);
++    public void setResourcePack(@NotNull String url, byte @Nullable [] hash, @Nullable String prompt, boolean force); // Paper - fix annotations
+ 
+     // Paper start
+     /**
+@@ -2350,7 +2350,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @deprecated use {@link #setResourcePack(UUID, String, byte[], net.kyori.adventure.text.Component, boolean)} )}
+      */
+     @Deprecated // Paper - adventure
+-    public void setResourcePack(@NotNull UUID id, @NotNull String url, @Nullable byte[] hash, @Nullable String prompt, boolean force);
++    public void setResourcePack(@NotNull UUID id, @NotNull String url, byte @Nullable [] hash, @Nullable String prompt, boolean force); // Paper - fix annotations
+ 
+     // Paper start
+     /**
+diff --git a/src/main/java/org/bukkit/inventory/EntityEquipment.java b/src/main/java/org/bukkit/inventory/EntityEquipment.java
+index bbc1aa3a317fd0a0a0060b30aae42567cda471ca..1d8e36c308eb879072dbbe93988623eb8d1b066f 100644
+--- a/src/main/java/org/bukkit/inventory/EntityEquipment.java
++++ b/src/main/java/org/bukkit/inventory/EntityEquipment.java
+@@ -321,7 +321,7 @@ public interface EntityEquipment {
+      *
+      * @param items The items to set the armor as. Individual items may be null.
+      */
+-    void setArmorContents(@NotNull ItemStack[] items);
++    void setArmorContents(@NotNull ItemStack @NotNull [] items); // Paper - fix annotations
+ 
+     /**
+      * Clears the entity of all armor and held items
+diff --git a/src/main/java/org/bukkit/inventory/PlayerInventory.java b/src/main/java/org/bukkit/inventory/PlayerInventory.java
+index c4d657727e508cb941320730a9d3aa5486712ef3..fca304310d87ca4906215d0fec71227228868c6f 100644
+--- a/src/main/java/org/bukkit/inventory/PlayerInventory.java
++++ b/src/main/java/org/bukkit/inventory/PlayerInventory.java
+@@ -112,7 +112,7 @@ public interface PlayerInventory extends Inventory {
+      *
+      * @param items The ItemStacks to use as armour
+      */
+-    public void setArmorContents(@Nullable ItemStack[] items);
++    public void setArmorContents(@Nullable ItemStack @NotNull [] items); // Paper - fix annotations
+ 
+     /**
+      * Put the given ItemStacks into the extra slots
+@@ -121,7 +121,7 @@ public interface PlayerInventory extends Inventory {
+      *
+      * @param items The ItemStacks to use as extra
+      */
+-    public void setExtraContents(@Nullable ItemStack[] items);
++    public void setExtraContents(@Nullable ItemStack @NotNull [] items); // Paper - fix annotations
+ 
+     /**
+      * Put the given ItemStack into the helmet slot. This does not check if
+diff --git a/src/main/java/org/bukkit/map/MapFont.java b/src/main/java/org/bukkit/map/MapFont.java
+index a45ce8198eafc57fd62c3ae86f68837cc90fd9e0..2d426da7468f728439ed79082b17c958074359d0 100644
+--- a/src/main/java/org/bukkit/map/MapFont.java
++++ b/src/main/java/org/bukkit/map/MapFont.java
+@@ -112,7 +112,7 @@ public class MapFont {
+         private final int height;
+         private final boolean[] data;
+ 
+-        public CharacterSprite(int width, int height, @NotNull boolean[] data) {
++        public CharacterSprite(int width, int height, boolean @NotNull [] data) { // Paper - fix annotations
+             this.width = width;
+             this.height = height;
+             this.data = data;
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+index 5cd236965de12392d8c7aa81307c0ff1cc8673b1..86cf110cca8481afbbf5d462e0504b81c595f243 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+@@ -311,7 +311,7 @@ public abstract class JavaPlugin extends PluginBase {
+      * {@inheritDoc}
+      */
+     @Override
+-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
++    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args) { // Paper - fix annotations
+         return false;
+     }
+ 
+@@ -320,7 +320,7 @@ public abstract class JavaPlugin extends PluginBase {
+      */
+     @Override
+     @Nullable
+-    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
++    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String @NotNull [] args) { // Paper - fix annotations
+         return null;
+     }
+ 
+diff --git a/src/main/java/org/bukkit/plugin/messaging/Messenger.java b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
+index 682c77188436d696d4dafbc70cf131d5c921e94d..bf371adad884b39fdc867c67c8eccf9d2abeff46 100644
+--- a/src/main/java/org/bukkit/plugin/messaging/Messenger.java
++++ b/src/main/java/org/bukkit/plugin/messaging/Messenger.java
+@@ -229,5 +229,5 @@ public interface Messenger {
+      * @param channel Channel that the message was sent by.
+      * @param message Raw payload of the message.
+      */
+-    public void dispatchIncomingMessage(@NotNull Player source, @NotNull String channel, @NotNull byte[] message);
++    public void dispatchIncomingMessage(@NotNull Player source, @NotNull String channel, byte @NotNull [] message); // Paper - fix annotations
+ }
+diff --git a/src/main/java/org/bukkit/plugin/messaging/PluginMessageListener.java b/src/main/java/org/bukkit/plugin/messaging/PluginMessageListener.java
+index eb962efd5086cb2682ee22977da0a2735e86892b..55a3c6e09cb3fd013fd6ad187ab866cab3622e4e 100644
+--- a/src/main/java/org/bukkit/plugin/messaging/PluginMessageListener.java
++++ b/src/main/java/org/bukkit/plugin/messaging/PluginMessageListener.java
+@@ -17,5 +17,5 @@ public interface PluginMessageListener {
+      * @param player Source of the message.
+      * @param message The raw message that was sent.
+      */
+-    public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, @NotNull byte[] message);
++    public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, byte @NotNull [] message); // Paper - fix annotations
+ }
+diff --git a/src/main/java/org/bukkit/plugin/messaging/PluginMessageRecipient.java b/src/main/java/org/bukkit/plugin/messaging/PluginMessageRecipient.java
+index b84b37fe27d84574dc5897285f1d9a1437bd322c..36d7adcbe4884d6e755e77f43fdb3a70bd0c770c 100644
+--- a/src/main/java/org/bukkit/plugin/messaging/PluginMessageRecipient.java
++++ b/src/main/java/org/bukkit/plugin/messaging/PluginMessageRecipient.java
+@@ -27,7 +27,7 @@ public interface PluginMessageRecipient {
+      * @throws ChannelNotRegisteredException Thrown if the channel is not
+      *     registered for this plugin.
+      */
+-    public void sendPluginMessage(@NotNull Plugin source, @NotNull String channel, @NotNull byte[] message);
++    public void sendPluginMessage(@NotNull Plugin source, @NotNull String channel, byte @NotNull [] message); // Paper - fix annotations
+ 
+     /**
+      * Gets a set containing all the Plugin Channels that this client is
+diff --git a/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java b/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java
+index 6fda7f3aa68e76af64362e9afed70fc6a5e92986..fed4a00bcc66c933c22f368620025feee038d2da 100644
+--- a/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java
++++ b/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java
+@@ -439,7 +439,7 @@ public class StandardMessenger implements Messenger {
+     }
+ 
+     @Override
+-    public void dispatchIncomingMessage(@NotNull Player source, @NotNull String channel, @NotNull byte[] message) {
++    public void dispatchIncomingMessage(@NotNull Player source, @NotNull String channel, byte @NotNull [] message) { // Paper - fix annotations
+         if (source == null) {
+             throw new IllegalArgumentException("Player source cannot be null");
+         }
+@@ -527,7 +527,7 @@ public class StandardMessenger implements Messenger {
+      * @throws ChannelNotRegisteredException Thrown if the channel is not
+      *     registered for this plugin.
+      */
+-    public static void validatePluginMessage(@NotNull Messenger messenger, @NotNull Plugin source, @NotNull String channel, @NotNull byte[] message) {
++    public static void validatePluginMessage(@NotNull Messenger messenger, @NotNull Plugin source, @NotNull String channel, byte @NotNull [] message) { // Paper - fix annotations
+         if (messenger == null) {
+             throw new IllegalArgumentException("Messenger cannot be null");
+         }
+diff --git a/src/main/java/org/bukkit/util/ChatPaginator.java b/src/main/java/org/bukkit/util/ChatPaginator.java
+index dea3b53c298128f93f2d71dbb488e69540dd8952..bbe2d304412694c73e2f2b3df22d2c085da8bb03 100644
+--- a/src/main/java/org/bukkit/util/ChatPaginator.java
++++ b/src/main/java/org/bukkit/util/ChatPaginator.java
+@@ -150,7 +150,7 @@ public class ChatPaginator {
+         private int pageNumber;
+         private int totalPages;
+ 
+-        public ChatPage(@NotNull String[] lines, int pageNumber, int totalPages) {
++        public ChatPage(@NotNull String @NotNull [] lines, int pageNumber, int totalPages) { // Paper - fix annotations
+             this.lines = lines;
+             this.pageNumber = pageNumber;
+             this.totalPages = totalPages;
+@@ -165,7 +165,7 @@ public class ChatPaginator {
+         }
+ 
+         @NotNull
+-        public String[] getLines() {
++        public String @NotNull [] getLines() { // Paper - fix annotations
+             return lines;
+         }
+     }
+diff --git a/src/main/java/org/bukkit/util/noise/OctaveGenerator.java b/src/main/java/org/bukkit/util/noise/OctaveGenerator.java
+index 618ed706e2fdc4855a9ce4fe55e092a052c911d0..931f49bb300497af4373a59fcb27854fce856b54 100644
+--- a/src/main/java/org/bukkit/util/noise/OctaveGenerator.java
++++ b/src/main/java/org/bukkit/util/noise/OctaveGenerator.java
+@@ -12,7 +12,7 @@ public abstract class OctaveGenerator {
+     protected double yScale = 1;
+     protected double zScale = 1;
+ 
+-    protected OctaveGenerator(@NotNull NoiseGenerator[] octaves) {
++    protected OctaveGenerator(@NotNull NoiseGenerator @NotNull [] octaves) { // Paper - fix annotations
+         this.octaves = octaves;
+     }
+ 
+@@ -90,7 +90,7 @@ public abstract class OctaveGenerator {
+      * @return Clone of the individual octaves
+      */
+     @NotNull
+-    public NoiseGenerator[] getOctaves() {
++    public NoiseGenerator @NotNull [] getOctaves() { // Paper - fix annotations
+         return octaves.clone();
+     }
+ 
+diff --git a/src/main/java/org/bukkit/util/noise/SimplexNoiseGenerator.java b/src/main/java/org/bukkit/util/noise/SimplexNoiseGenerator.java
+index 775d8f40322e9ed6702eb23bf50f35442d673c30..e1001a144e6d7c40c819a578fa3526186d92f783 100644
+--- a/src/main/java/org/bukkit/util/noise/SimplexNoiseGenerator.java
++++ b/src/main/java/org/bukkit/util/noise/SimplexNoiseGenerator.java
+@@ -78,15 +78,15 @@ public class SimplexNoiseGenerator extends PerlinNoiseGenerator {
+         offsetW = rand.nextDouble() * 256;
+     }
+ 
+-    protected static double dot(@NotNull int[] g, double x, double y) {
++    protected static double dot(int @NotNull[] g, double x, double y) { // Paper - fix annotations
+         return g[0] * x + g[1] * y;
+     }
+ 
+-    protected static double dot(@NotNull int[] g, double x, double y, double z) {
++    protected static double dot(int @NotNull [] g, double x, double y, double z) { // Paper - fix annotations
+         return g[0] * x + g[1] * y + g[2] * z;
+     }
+ 
+-    protected static double dot(@NotNull int[] g, double x, double y, double z, double w) {
++    protected static double dot(int @NotNull [] g, double x, double y, double z, double w) { // Paper - fix annotations
+         return g[0] * x + g[1] * y + g[2] * z + g[3] * w;
+     }
+ 


### PR DESCRIPTION
Fixes incorrect array nullability annotations. For reference for anyone not reading this, arrays require 2 annotations (1 if the element type is primitive). Like
```java
void someMethod(@NotNull String @Nullable [] array);
```
means that you can pass null or an array with no null elements.