### PR TITLE
fix NPE on EntityTeleportEvent getTo

### DIFF
--- a/patches/server/0199-Implement-EntityTeleportEndGatewayEvent.patch
+++ b/patches/server/0199-Implement-EntityTeleportEndGatewayEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement EntityTeleportEndGatewayEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index 8ae723c6500bb92f937a27730c2a5ec912247c0a..676c2a4c9423e37319b097b99a307dd0186061a0 100644
+index 8ae723c6500bb92f937a27730c2a5ec912247c0a..223550eccdf0a5596b8595a30f02ad891ffd91ea 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 @@ -224,8 +224,14 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
@@ -20,7 +20,7 @@ index 8ae723c6500bb92f937a27730c2a5ec912247c0a..676c2a4c9423e37319b097b99a307dd0
 +                location.setYaw(entity1.getBukkitYaw());
 +                org.bukkit.entity.Entity bukkitEntity = entity1.getBukkitEntity();
 +                org.bukkit.event.entity.EntityTeleportEvent teleEvent = new com.destroystokyo.paper.event.entity.EntityTeleportEndGatewayEvent(bukkitEntity, bukkitEntity.getLocation(), location, new org.bukkit.craftbukkit.block.CraftEndGateway(world.getWorld(), blockEntity));
-+                if (!teleEvent.callEvent()) {
++                if (!teleEvent.callEvent() || teleEvent.getTo() == null) {
 +                    // Paper end - EntityTeleportEndGatewayEvent
                      return;
                  }

--- a/patches/server/1039-Fix-missing-event-call-for-entity-teleport-API.patch
+++ b/patches/server/1039-Fix-missing-event-call-for-entity-teleport-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix missing event call for entity teleport API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index ed49b04d3918e46cd0769838b81cd0fae0d4e43a..17113544383fb4e6373d8f6151c536fecb00e0be 100644
+index 0349d9b6ad12e0a426cb1307be8633240b7426fe..2121bcf4517bf5b2aa595479720c8ed95d65b62b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -255,6 +255,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -17,7 +17,7 @@ index ed49b04d3918e46cd0769838b81cd0fae0d4e43a..17113544383fb4e6373d8f6151c536fe
 +            this, this.getLocation(), location);
 +        // cancelling the event is handled differently for players and entities,
 +        // entities just stop teleporting, players will still teleport to the "from" location of the event
-+        if (!event.callEvent()) {
++        if (!event.callEvent() || event.getTo() == null) {
 +            return false;
 +        }
 +        location = event.getTo();

--- a/patches/server/1052-Fix-NPE-on-null-loc-for-EntityTeleportEvent.patch
+++ b/patches/server/1052-Fix-NPE-on-null-loc-for-EntityTeleportEvent.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 9 Dec 2023 19:15:59 -0800
+Subject: [PATCH] Fix NPE on null loc for EntityTeleportEvent
+
+EntityTeleportEvent#setTo is marked as nullable and so is the
+getTo method. This fixes the handling of a null "to" location
+by treating it the same as the event being cancelled. This is
+already existing behavior for the EntityPortalEvent (which
+extends EntityTeleportEvent).
+
+diff --git a/src/main/java/net/minecraft/server/commands/TeleportCommand.java b/src/main/java/net/minecraft/server/commands/TeleportCommand.java
+index 3fec07b250a8f145e30c8c41888e47d2a3c902e1..2ddd033e1c3a2e5c8950b93c838491923803ccce 100644
+--- a/src/main/java/net/minecraft/server/commands/TeleportCommand.java
++++ b/src/main/java/net/minecraft/server/commands/TeleportCommand.java
+@@ -169,9 +169,10 @@ public class TeleportCommand {
+                 Location to = new Location(world.getWorld(), x, y, z, f2, f3);
+                 EntityTeleportEvent event = new EntityTeleportEvent(target.getBukkitEntity(), target.getBukkitEntity().getLocation(), to);
+                 world.getCraftServer().getPluginManager().callEvent(event);
+-                if (event.isCancelled()) {
++                if (event.isCancelled() || event.getTo() == null) { // Paper
+                     return;
+                 }
++                to = event.getTo(); // Paper - actually track new location
+ 
+                 x = to.getX();
+                 y = to.getY();
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 96885946be3b8e129984353f3dfe4330e73ad84a..bc908b75cb99536df658281ae7f8b4eeedbbedc9 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -4204,7 +4204,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+                     if (!(this instanceof ServerPlayer)) {
+                         EntityTeleportEvent teleport = new EntityTeleportEvent(this.getBukkitEntity(), new Location(this.level().getWorld(), d3, d4, d5), new Location(this.level().getWorld(), d0, d6, d2));
+                         this.level().getCraftServer().getPluginManager().callEvent(teleport);
+-                        if (!teleport.isCancelled()) {
++                        if (!teleport.isCancelled() && teleport.getTo() != null) { // Paper
+                             Location to = teleport.getTo();
+                             this.teleportTo(to.getX(), to.getY(), to.getZ());
+                         } else {
+diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java
+index 689bbc0feb700cfd6b10601d2c5a237ec40ed756..ca0a2191f5bfb3c44c1ddacab8b7a874c2f44cc1 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java
++++ b/src/main/java/net/minecraft/world/entity/ai/goal/FollowOwnerGoal.java
+@@ -129,7 +129,7 @@ public class FollowOwnerGoal extends Goal {
+         } else {
+             // CraftBukkit start
+             EntityTeleportEvent event = CraftEventFactory.callEntityTeleportEvent(this.tamable, (double) x + 0.5D, (double) y, (double) z + 0.5D);
+-            if (event.isCancelled()) {
++            if (event.isCancelled() || event.getTo() == null) { // Paper
+                 return false;
+             }
+             Location to = event.getTo();
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Shulker.java b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
+index 06ab07fb5d8d0e2f97325890218a11fef551a0ba..b73dac8f68041f8a2e0752d70cc9d08b5cfd1cde 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Shulker.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
+@@ -408,7 +408,7 @@ public class Shulker extends AbstractGolem implements VariantHolder<Optional<Dye
+                     if (enumdirection != null) {
+                         // CraftBukkit start
+                         EntityTeleportEvent teleportEvent = CraftEventFactory.callEntityTeleportEvent(this, blockposition1.getX(), blockposition1.getY(), blockposition1.getZ());
+-                        if (teleportEvent.isCancelled()) {
++                        if (teleportEvent.isCancelled() || teleportEvent.getTo() == null) { // Paper
+                             return false;
+                         } else {
+                             blockposition1 = CraftLocation.toBlockPosition(teleportEvent.getTo());


### PR DESCRIPTION
Almost everywhere EntityTeleportEvent (or a subclass) was used, the nullability of getTo was never checked despite it being marked as nullable (as well as setTo). This is really dumb, as what is null supposed to do? So I just made it act as being cancelled.

Also in one spot, the firing of the event for /teleport, the to location wasn't even respected if you called setTo.