### PR TITLE
Update and clean up api dependencies

### DIFF
--- a/patches/api/0002-Build-system-changes.patch
+++ b/patches/api/0002-Build-system-changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 41e77b687df6480adf8f5e21daad105dab208df2..d86ee6acb78d249424c5df98a851178c0f62eec1 100644
+index 41e77b687df6480adf8f5e21daad105dab208df2..cc586ca58c9ef852d7154f29c2dc187047f2c64a 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -18,15 +18,27 @@ dependencies {
+@@ -18,15 +18,26 @@ dependencies {
      api("net.md-5:bungeecord-chat:$bungeeCordChatVersion")
      api("org.yaml:snakeyaml:2.2")
      api("org.joml:joml:1.10.5")
@@ -21,7 +21,6 @@ index 41e77b687df6480adf8f5e21daad105dab208df2..d86ee6acb78d249424c5df98a851178c
      compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")
      compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
      compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
-+    compileOnly("com.google.code.findbugs:jsr305:1.3.9") // Paper
  
 -    val annotations = "org.jetbrains:annotations-java5:$annotationsVersion"
 +    val annotations = "org.jetbrains:annotations:$annotationsVersion" // Paper - we don't want Java 5 annotations...
@@ -29,7 +28,7 @@ index 41e77b687df6480adf8f5e21daad105dab208df2..d86ee6acb78d249424c5df98a851178c
      testCompileOnly(annotations)
  
 +    // Paper start - add checker
-+    val checkerQual = "org.checkerframework:checker-qual:3.21.0"
++    val checkerQual = "org.checkerframework:checker-qual:3.33.0"
 +    compileOnlyApi(checkerQual)
 +    testCompileOnly(checkerQual)
 +    // Paper end
@@ -37,7 +36,7 @@ index 41e77b687df6480adf8f5e21daad105dab208df2..d86ee6acb78d249424c5df98a851178c
      testImplementation("org.apache.commons:commons-lang3:3.12.0")
      testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
      testImplementation("org.hamcrest:hamcrest:2.2")
-@@ -69,8 +81,12 @@ tasks.withType<Javadoc> {
+@@ -69,8 +80,12 @@ tasks.withType<Javadoc> {
      options.links(
          "https://guava.dev/releases/32.1.2-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/2.2/",
@@ -51,7 +50,7 @@ index 41e77b687df6480adf8f5e21daad105dab208df2..d86ee6acb78d249424c5df98a851178c
      )
      options.tags("apiNote:a:API Note:")
  
-@@ -89,3 +105,14 @@ tasks.withType<Javadoc> {
+@@ -89,3 +104,14 @@ tasks.withType<Javadoc> {
  tasks.test {
      useJUnitPlatform()
  }

--- a/patches/api/0003-Test-changes.patch
+++ b/patches/api/0003-Test-changes.patch
@@ -12,10 +12,10 @@ Co-authored-by: Riley Park <rileysebastianpark@gmail.com>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index d86ee6acb78d249424c5df98a851178c0f62eec1..75bfb0ab8049ebbb52240abf661d469de5526767 100644
+index cc586ca58c9ef852d7154f29c2dc187047f2c64a..948bd84db9923ef43cf753b7b72bf4d0081ab43a 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -106,6 +106,12 @@ tasks.test {
+@@ -105,6 +105,12 @@ tasks.test {
      useJUnitPlatform()
  }
  

--- a/patches/api/0004-Code-Generation.patch
+++ b/patches/api/0004-Code-Generation.patch
@@ -7,7 +7,7 @@ Currently includes generated key holder classes for types
 used in the Registry Modification API
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 75bfb0ab8049ebbb52240abf661d469de5526767..87e4ee95a8da287b02c13fac5f24f66902bc84c9 100644
+index 948bd84db9923ef43cf753b7b72bf4d0081ab43a..4ee1aed72727e911bff4ac91bcacfd8eee87ecfc 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,6 +1,7 @@
@@ -18,7 +18,7 @@ index 75bfb0ab8049ebbb52240abf661d469de5526767..87e4ee95a8da287b02c13fac5f24f669
  }
  
  java {
-@@ -46,6 +47,22 @@ dependencies {
+@@ -45,6 +46,22 @@ dependencies {
      testImplementation("org.ow2.asm:asm-tree:9.5")
  }
  
@@ -41,7 +41,7 @@ index 75bfb0ab8049ebbb52240abf661d469de5526767..87e4ee95a8da287b02c13fac5f24f669
  configure<PublishingExtension> {
      publications.create<MavenPublication>("maven") {
          from(components["java"])
-@@ -122,3 +139,14 @@ tasks.check {
+@@ -121,3 +138,14 @@ tasks.check {
      dependsOn(scanJar)
  }
  // Paper end

--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -7,10 +7,10 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 2b91ac7b5bc9fa7fb2ab64a80fd2707cb8d3f01d..acb27334da8245657a113a69faee6f6b19dd3110 100644
+index 41871b8a25798a98b856f1b0034016666216e28f..8324fa4b96ee6cf338e22d525f0d236df3a9addf 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -11,12 +11,24 @@ java {
+@@ -11,12 +11,28 @@ java {
  
  val annotationsVersion = "24.0.1"
  val bungeeCordChatVersion = "1.20-R0.1"
@@ -32,11 +32,15 @@ index 2b91ac7b5bc9fa7fb2ab64a80fd2707cb8d3f01d..acb27334da8245657a113a69faee6f6b
      api("com.google.guava:guava:32.1.2-jre")
      api("com.google.code.gson:gson:2.10.1")
 -    api("net.md-5:bungeecord-chat:$bungeeCordChatVersion")
-+    api("net.md-5:bungeecord-chat:$bungeeCordChatVersion-deprecated+build.14") // Paper
++    // Paper start - adventure
++    api("net.md-5:bungeecord-chat:$bungeeCordChatVersion-deprecated+build.14") {
++        exclude("com.google.guava", "guava")
++    }
++    // Paper - adventure
      api("org.yaml:snakeyaml:2.2")
      api("org.joml:joml:1.10.5")
      // Paper start
-@@ -24,6 +36,13 @@ dependencies {
+@@ -24,6 +40,13 @@ dependencies {
          isTransitive = false // includes junit
      }
      api("it.unimi.dsi:fastutil:8.5.6")
@@ -50,7 +54,7 @@ index 2b91ac7b5bc9fa7fb2ab64a80fd2707cb8d3f01d..acb27334da8245657a113a69faee6f6b
      // Paper end
  
      compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")
-@@ -100,14 +119,30 @@ tasks.withType<Javadoc> {
+@@ -99,14 +122,30 @@ tasks.withType<Javadoc> {
          "https://guava.dev/releases/32.1.2-jre/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/2.2/",
          "https://javadoc.io/doc/org.jetbrains/annotations/$annotationsVersion/", // Paper - we don't want Java 5 annotations

--- a/patches/api/0008-Use-ASM-for-event-executors.patch
+++ b/patches/api/0008-Use-ASM-for-event-executors.patch
@@ -6,16 +6,16 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index acb27334da8245657a113a69faee6f6b19dd3110..3a4d5cc766095cbb83868ccb99423f10e3a07289 100644
+index 8324fa4b96ee6cf338e22d525f0d236df3a9addf..801a31ca6812bd24aca1b7d2761b3f8cbc917b67 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -43,6 +43,9 @@ dependencies {
+@@ -47,6 +47,9 @@ dependencies {
      apiAndDocs("net.kyori:adventure-text-serializer-legacy")
      apiAndDocs("net.kyori:adventure-text-serializer-plain")
      apiAndDocs("net.kyori:adventure-text-logger-slf4j")
 +
-+    implementation("org.ow2.asm:asm:9.4")
-+    implementation("org.ow2.asm:asm-commons:9.4")
++    implementation("org.ow2.asm:asm:9.5")
++    implementation("org.ow2.asm:asm-commons:9.5")
      // Paper end
  
      compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")

--- a/patches/api/0009-Paper-Plugins.patch
+++ b/patches/api/0009-Paper-Plugins.patch
@@ -5,19 +5,19 @@ Subject: [PATCH] Paper Plugins
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 3a4d5cc766095cbb83868ccb99423f10e3a07289..37d894eaffbf31045b1ed349d70af6408348a1a6 100644
+index 801a31ca6812bd24aca1b7d2761b3f8cbc917b67..c8e4f4613cd2af0c650a079ec5ed520254ce5816 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -48,7 +48,7 @@ dependencies {
-     implementation("org.ow2.asm:asm-commons:9.4")
+@@ -52,7 +52,7 @@ dependencies {
+     implementation("org.ow2.asm:asm-commons:9.5")
      // Paper end
  
 -    compileOnly("org.apache.maven:maven-resolver-provider:3.8.5")
 +    api("org.apache.maven:maven-resolver-provider:3.8.5")
      compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
      compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
-     compileOnly("com.google.code.findbugs:jsr305:1.3.9") // Paper
-@@ -135,6 +135,7 @@ tasks.withType<Javadoc> {
+ 
+@@ -138,6 +138,7 @@ tasks.withType<Javadoc> {
          "https://jd.advntr.dev/text-serializer-plain/$adventureVersion/",
          "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/",
          // Paper end

--- a/patches/api/0070-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0070-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,28 +14,28 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 37d894eaffbf31045b1ed349d70af6408348a1a6..e827ee211e3c65dc68ac5867fd8476639df63645 100644
+index c8e4f4613cd2af0c650a079ec5ed520254ce5816..9d817bf3f26ffd484945a00a6538970eca22ee20 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -12,6 +12,8 @@ java {
  val annotationsVersion = "24.0.1"
  val bungeeCordChatVersion = "1.20-R0.1"
  val adventureVersion = "4.14.0"
-+val slf4jVersion = "1.8.0-beta4"
++val slf4jVersion = "2.0.9"
 +val log4jVersion = "2.17.1"
  val apiAndDocs: Configuration by configurations.creating {
      attributes {
          attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-@@ -43,6 +45,8 @@ dependencies {
+@@ -47,6 +49,8 @@ dependencies {
      apiAndDocs("net.kyori:adventure-text-serializer-legacy")
      apiAndDocs("net.kyori:adventure-text-serializer-plain")
      apiAndDocs("net.kyori:adventure-text-logger-slf4j")
 +    api("org.apache.logging.log4j:log4j-api:$log4jVersion")
 +    api("org.slf4j:slf4j-api:$slf4jVersion")
  
-     implementation("org.ow2.asm:asm:9.4")
-     implementation("org.ow2.asm:asm-commons:9.4")
-@@ -134,6 +138,8 @@ tasks.withType<Javadoc> {
+     implementation("org.ow2.asm:asm:9.5")
+     implementation("org.ow2.asm:asm-commons:9.5")
+@@ -137,6 +141,8 @@ tasks.withType<Javadoc> {
          "https://jd.advntr.dev/text-serializer-legacy/$adventureVersion/",
          "https://jd.advntr.dev/text-serializer-plain/$adventureVersion/",
          "https://jd.advntr.dev/text-logger-slf4j/$adventureVersion/",


### PR DESCRIPTION
I removed the compileOnly dep on `com.google.code.findbugs:jsr305:1.3.9`, not sure what it was used for. API compiles just fine without it.