### PR TITLE
fix `PlayerInteractEvent#getClickedBlock()` returns a wrong block in adventure mode.

### DIFF
--- a/patches/server/0009-MC-Utils.patch
+++ b/patches/server/0009-MC-Utils.patch
@@ -3480,10 +3480,10 @@ index 0000000000000000000000000000000000000000..cea9c098ade00ee87b8efc8164ab72f5
 +}
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..19708dee02491e74fb3db6e70911e20a57b09769
+index 0000000000000000000000000000000000000000..6d60bb9f77198de3f0692c24b3b0ae085f3a80d0
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
-@@ -0,0 +1,538 @@
+@@ -0,0 +1,533 @@
 +package io.papermc.paper.util;
 +
 +import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -3507,7 +3507,6 @@ index 0000000000000000000000000000000000000000..19708dee02491e74fb3db6e70911e20a
 +import org.bukkit.block.BlockFace;
 +import org.bukkit.craftbukkit.CraftWorld;
 +import org.bukkit.craftbukkit.util.Waitable;
-+import org.bukkit.util.Vector;
 +import org.spigotmc.AsyncCatcher;
 +
 +import javax.annotation.Nonnull;
@@ -3958,10 +3957,6 @@ index 0000000000000000000000000000000000000000..19708dee02491e74fb3db6e70911e20a
 +
 +    public static BlockPos toBlockPos(Position pos) {
 +        return new BlockPos(pos.blockX(), pos.blockY(), pos.blockZ());
-+    }
-+
-+    public static BlockPos toBlockPosition(Vector vec) {
-+        return new BlockPos(vec.getBlockX(), vec.getBlockY(), vec.getBlockZ());
 +    }
 +
 +    public static FinePosition toPosition(Vec3 vector) {
@@ -6987,7 +6982,7 @@ index 1d12a7934308aa48d7ea7fa10c7b6b5ccb27e707..7cacfceed5ef9276a19123a8a9079579
          ChunkHolder playerchunk = this.getVisibleChunkIfPresent(pos);
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2b94db53d9046299d1d4b39bce06002039a1800f..634869a2747c655a6705deeb5fcb27d2c4754e0c 100644
+index 9cf839be15126444d4d2ffdb7faa637859941d6b..3bd2bddb782d29e647a1f1b362a39d224151f8b1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -178,6 +178,7 @@ import org.bukkit.event.weather.LightningStrikeEvent;

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -15723,7 +15723,7 @@ index cea9c098ade00ee87b8efc8164ab72f5279758f0..197224e31175252d8438a8df585bbb65
 +    }
  }
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
-index 19708dee02491e74fb3db6e70911e20a57b09769..395873f89925b495978d151efe1d91da9ad11b0a 100644
+index 6d60bb9f77198de3f0692c24b3b0ae085f3a80d0..3a00e24d78acb99d226289ccb9ba419dfc607a45 100644
 --- a/src/main/java/io/papermc/paper/util/MCUtil.java
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
 @@ -4,17 +4,30 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -15757,7 +15757,7 @@ index 19708dee02491e74fb3db6e70911e20a57b09769..395873f89925b495978d151efe1d91da
  import net.minecraft.world.phys.Vec3;
  import org.apache.commons.lang.exception.ExceptionUtils;
  import org.bukkit.Location;
-@@ -26,8 +39,11 @@ import org.spigotmc.AsyncCatcher;
+@@ -25,8 +38,11 @@ import org.spigotmc.AsyncCatcher;
  
  import javax.annotation.Nonnull;
  import javax.annotation.Nullable;
@@ -15769,7 +15769,7 @@ index 19708dee02491e74fb3db6e70911e20a57b09769..395873f89925b495978d151efe1d91da
  import java.util.concurrent.CompletableFuture;
  import java.util.concurrent.ExecutionException;
  import java.util.concurrent.LinkedBlockingQueue;
-@@ -532,6 +548,100 @@ public final class MCUtil {
+@@ -527,6 +543,100 @@ public final class MCUtil {
          }
      }
  
@@ -22811,7 +22811,7 @@ index bb60804a77ecda3c86ccf54e028e634f8d7f141d..1f160036b433c5d1fb8ed1f94adefcca
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c74428dccd9db8c4d2809bbd23f3268a16d7e282..24c282c0727fa814c403716837b2d44b216c5b16 100644
+index 4a7199edc2c7597cba956b2427a17efa08eb8d82..41a4f6126f24848a26ff0f928a23b5be13783c90 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -198,6 +198,48 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0138-Basic-PlayerProfile-API.patch
+++ b/patches/server/0138-Basic-PlayerProfile-API.patch
@@ -546,7 +546,7 @@ index 0000000000000000000000000000000000000000..7ac27392a8647ef7d0dc78efe78703e9
 +    @NotNull GameProfile buildGameProfile();
 +}
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
-index 395873f89925b495978d151efe1d91da9ad11b0a..e969a0acf06d9265fa75fc07bb637752df468c11 100644
+index 3a00e24d78acb99d226289ccb9ba419dfc607a45..209594863c2aa965055412adb7db009cca4795a8 100644
 --- a/src/main/java/io/papermc/paper/util/MCUtil.java
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
 @@ -1,5 +1,7 @@
@@ -565,7 +565,7 @@ index 395873f89925b495978d151efe1d91da9ad11b0a..e969a0acf06d9265fa75fc07bb637752
  import org.bukkit.Location;
  import org.bukkit.block.BlockFace;
  import org.bukkit.craftbukkit.CraftWorld;
-@@ -378,6 +381,10 @@ public final class MCUtil {
+@@ -377,6 +380,10 @@ public final class MCUtil {
          return run.get();
      }
  

--- a/patches/server/0265-Catch-JsonParseException-in-Entity-and-TE-names.patch
+++ b/patches/server/0265-Catch-JsonParseException-in-Entity-and-TE-names.patch
@@ -13,10 +13,10 @@ Shulkers) may need to be changed in order for it to re-save properly
 No more crashing though.
 
 diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
-index e969a0acf06d9265fa75fc07bb637752df468c11..8240bb085b619f257f8c0a25775e0b15068e440f 100644
+index 209594863c2aa965055412adb7db009cca4795a8..200ed770b57e1a9240abf0473968d4b85cbefe3c 100644
 --- a/src/main/java/io/papermc/paper/util/MCUtil.java
 +++ b/src/main/java/io/papermc/paper/util/MCUtil.java
-@@ -652,4 +652,19 @@ public final class MCUtil {
+@@ -647,4 +647,19 @@ public final class MCUtil {
      public static int getTicketLevelFor(net.minecraft.world.level.chunk.ChunkStatus status) {
          return net.minecraft.server.level.ChunkMap.MAX_VIEW_DISTANCE + net.minecraft.world.level.chunk.ChunkStatus.getDistance(status);
      }

--- a/patches/server/0512-Fix-interact-event-not-being-called-sometimes.patch
+++ b/patches/server/0512-Fix-interact-event-not-being-called-sometimes.patch
@@ -11,7 +11,7 @@ Subject: [PATCH] Fix interact event not being called sometimes
 Co-authored-by: Moulberry <james.jenour@protonmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b13e19d7214cc8a84693df7f052ca0d4b8a34140..85660d2d5ba535f6d8ace6783314cfe278d34317 100644
+index b13e19d7214cc8a84693df7f052ca0d4b8a34140..30513a13c626d117e2de9ceef46621ef8cde6386 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1761,7 +1761,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -38,7 +38,7 @@ index b13e19d7214cc8a84693df7f052ca0d4b8a34140..85660d2d5ba535f6d8ace6783314cfe2
 +        } else { // Paper start - Fix interact event not being called sometimes
 +            GameType gameType = this.player.gameMode.getGameModeForPlayer();
 +            if (gameType == GameType.ADVENTURE && result.getHitBlock() != null) {
-+                CraftEventFactory.callPlayerInteractEvent(this.player, Action.LEFT_CLICK_BLOCK, io.papermc.paper.util.MCUtil.toBlockPosition(result.getHitPosition()), org.bukkit.craftbukkit.block.CraftBlock.blockFaceToNotch(result.getHitBlockFace()), this.player.getInventory().getSelected(), InteractionHand.MAIN_HAND);
++                CraftEventFactory.callPlayerInteractEvent(this.player, Action.LEFT_CLICK_BLOCK, ((org.bukkit.craftbukkit.block.CraftBlock) result.getHitBlock()).getPosition(), org.bukkit.craftbukkit.block.CraftBlock.blockFaceToNotch(result.getHitBlockFace()), this.player.getInventory().getSelected(), InteractionHand.MAIN_HAND);
 +            } else if (gameType != GameType.CREATIVE && result.getHitEntity() != null && origin.toVector().distanceSquared(result.getHitPosition()) > 3.0D * 3.0D) {
 +                CraftEventFactory.callPlayerInteractEvent(this.player, Action.LEFT_CLICK_AIR, this.player.getInventory().getSelected(), InteractionHand.MAIN_HAND);
 +            }


### PR DESCRIPTION
Fixes a bug where clicking on the SOUTH, EAST, or UP face of a block returns an incorrect block position.
This bug was introduced in #9211.