### PR TITLE
Added API to expose the loot table of a decorated pot.

### DIFF
--- a/patches/api/0456-Expose-LootTable-of-DecoratedPot.patch
+++ b/patches/api/0456-Expose-LootTable-of-DecoratedPot.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: FireInstall <kettnerl@hu-berlin.de>
+Date: Sat, 20 Jan 2024 16:20:07 +0100
+Subject: [PATCH] Expose LootTable of DecoratedPot
+
+
+diff --git a/src/main/java/org/bukkit/block/DecoratedPot.java b/src/main/java/org/bukkit/block/DecoratedPot.java
+index f76230e0bba49639fc2e70ee32a53e3a9182f217..feae34e459523d17a10b673bbec28abcac9cdadd 100644
+--- a/src/main/java/org/bukkit/block/DecoratedPot.java
++++ b/src/main/java/org/bukkit/block/DecoratedPot.java
+@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
+ /**
+  * Represents a captured state of a decorated pot.
+  */
+-public interface DecoratedPot extends TileState, BlockInventoryHolder {
++public interface DecoratedPot extends TileState, BlockInventoryHolder , org.bukkit.loot.Lootable { // Paper - expose loot table
+ 
+     /**
+      * Set the sherd on the provided side.

--- a/patches/server/1042-Expose-LootTable-of-DecoratedPot.patch
+++ b/patches/server/1042-Expose-LootTable-of-DecoratedPot.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: FireInstall <kettnerl@hu-berlin.de>
+Date: Sat, 20 Jan 2024 16:20:06 +0100
+Subject: [PATCH] Expose LootTable of DecoratedPot
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftDecoratedPot.java b/src/main/java/org/bukkit/craftbukkit/block/CraftDecoratedPot.java
+index d595495943bd94a86aa32a6510e46a7ea5c8a723..e2fe5d8d7d8c00ed5d21cfe409933cdde8932e97 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftDecoratedPot.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftDecoratedPot.java
+@@ -40,6 +40,39 @@ public class CraftDecoratedPot extends CraftBlockEntityState<DecoratedPotBlockEn
+         return new CraftInventoryDecoratedPot(this.getTileEntity());
+     }
+ 
++    // Paper start - expose loot table
++    @Override
++    public void setLootTable(final org.bukkit.loot.LootTable table) {
++        this.setLootTable(table, this.getSeed());
++    }
++
++    @Override
++    public void setLootTable(org.bukkit.loot.LootTable table, long seed) {
++        net.minecraft.resources.ResourceLocation key = (table == null) ? null : org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(table.getKey());
++        this.getSnapshot().setLootTable(key, seed);
++    }
++
++    @Override
++    public org.bukkit.loot.LootTable getLootTable() {
++        if (this.getSnapshot().getLootTable() == null) {
++            return null;
++        }
++
++        net.minecraft.resources.ResourceLocation key = this.getSnapshot().getLootTable();
++        return org.bukkit.Bukkit.getLootTable(org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(key));
++    }
++
++    @Override
++    public void setSeed(final long seed) {
++        this.getSnapshot().setLootTableSeed(seed);
++    }
++
++    @Override
++    public long getSeed() {
++        return this.getSnapshot().getLootTableSeed();
++    }
++    // Paper end - expose loot table
++
+     @Override
+     public void setSherd(Side face, Material sherd) {
+         Preconditions.checkArgument(face != null, "face must not be null");


### PR DESCRIPTION
Extended the API around the decorated pot to encounter the new loot table in 1.20.3.

Outdated: ~~I wasn't sure where the best place was to add the DecoratedPotInventory interface / implementation. 
There is a case to be made, if it would be better to put them in a Bukkits folder since it would future proof if upstream implement the same API. However, in that case these two patches should removed anyway.~~