### PR TITLE
Fix long loading terrain screen when refreshing skins

### DIFF
--- a/patches/server/0180-Player.setPlayerProfile-API.patch
+++ b/patches/server/0180-Player.setPlayerProfile-API.patch
@@ -55,7 +55,7 @@ index 477d3245facb5ae59c786d4f696f64226cb540a6..e8490a58dd4d9bc39a5bb2f9fc109526
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9255edcd67e2cdd2fab31ae881ca88b6a5beb8e3..a343157512ca145b3e5ab1a0fcaeae0ae7aeb2e0 100644
+index 761704f3f15ab395d1c0c0d1734360d22cde05be..de2869e07928d02667b794bbc67d72b283cec746 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -275,11 +275,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -162,7 +162,7 @@ index 9255edcd67e2cdd2fab31ae881ca88b6a5beb8e3..a343157512ca145b3e5ab1a0fcaeae0a
  
      void resetAndShowEntity(org.bukkit.entity.Entity entity) {
          // SPIGOT-7312: Can't show/hide self
-@@ -1802,6 +1848,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1802,6 +1848,38 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              this.trackAndShowEntity(entity);
          }
      }
@@ -179,10 +179,12 @@ index 9255edcd67e2cdd2fab31ae881ca88b6a5beb8e3..a343157512ca145b3e5ab1a0fcaeae0a
 +
 +        //Respawn the player then update their position and selected slot
 +        ServerLevel worldserver = handle.serverLevel();
-+        connection.send(new net.minecraft.network.protocol.game.ClientboundRespawnPacket(new net.minecraft.network.protocol.game.CommonPlayerSpawnInfo(worldserver.dimensionTypeId(), worldserver.dimension(), net.minecraft.world.level.biome.BiomeManager.obfuscateSeed(worldserver.getSeed()), handle.gameMode.getGameModeForPlayer(), handle.gameMode.getPreviousGameModeForPlayer(), worldserver.isDebug(), worldserver.isFlat(), handle.getLastDeathLocation(), handle.getPortalCooldown()), net.minecraft.network.protocol.game.ClientboundRespawnPacket.KEEP_ALL_DATA));
++        connection.send(new net.minecraft.network.protocol.game.ClientboundRespawnPacket(handle.createCommonSpawnInfo(worldserver), net.minecraft.network.protocol.game.ClientboundRespawnPacket.KEEP_ALL_DATA));
 +        handle.onUpdateAbilities();
 +        connection.internalTeleport(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch(), java.util.Collections.emptySet());
-+        net.minecraft.server.MinecraftServer.getServer().getPlayerList().sendAllPlayerInfo(handle);
++        net.minecraft.server.players.PlayerList playerList = handle.server.getPlayerList();
++        playerList.sendLevelInfo(handle, worldserver);
++        playerList.sendAllPlayerInfo(handle);
 +
 +        // Resend their XP and effects because the respawn packet resets it
 +        connection.send(new net.minecraft.network.protocol.game.ClientboundSetExperiencePacket(handle.experienceProgress, handle.totalExperience, handle.experienceLevel));

--- a/patches/server/0185-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0185-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a343157512ca145b3e5ab1a0fcaeae0ae7aeb2e0..a5b82436d929c17007cf55d12686ecdd948bdee3 100644
+index de2869e07928d02667b794bbc67d72b283cec746..39b43dcfeb42591d01ac896b491116af17e394ee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -193,6 +193,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index a343157512ca145b3e5ab1a0fcaeae0ae7aeb2e0..a5b82436d929c17007cf55d12686ecdd
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -2128,7 +2129,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2130,7 +2131,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end - more resource pack API
  
      public void addChannel(String channel) {

--- a/patches/server/0250-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0250-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9e34575c8ffff57d692349a4a05db3d1f769c687..8417da1eb3a440adcd425ffbda9fdcb768857afd 100644
+index 85bb7fc6590b3a4aea17b6a51566f234291b4cc9..b175940b5edb3d82c9838d420f1c0a1294b28603 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2840,6 +2840,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2842,6 +2842,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0251-Improve-death-events.patch
+++ b/patches/server/0251-Improve-death-events.patch
@@ -392,10 +392,10 @@ index 948ba97e318506dad96e59121297b5bf8340d2e6..810bead2f19de70786027b190137f743
          this.gameEvent(GameEvent.ENTITY_DIE);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8417da1eb3a440adcd425ffbda9fdcb768857afd..e55d31783396e87ef18f5b6dfc27742c0b4e3465 100644
+index b175940b5edb3d82c9838d420f1c0a1294b28603..adc6c2f7c949722afd6a89aa603db31710bac6f3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2377,7 +2377,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2379,7 +2379,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void sendHealthUpdate() {
          FoodData foodData = this.getHandle().getFoodData();

--- a/patches/server/0287-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0287-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -106,7 +106,7 @@ index e8490a58dd4d9bc39a5bb2f9fc109526e031b971..5f590575f95eff8bf0cdcafde7dee0e3
      public Location getLastDeathLocation() {
          if (this.getData().contains("LastDeathLocation", 10)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e55d31783396e87ef18f5b6dfc27742c0b4e3465..6ec80e3a838f8f7479ee965561043586d64c649a 100644
+index adc6c2f7c949722afd6a89aa603db31710bac6f3..a0840db18062e670708cc2aa74792a68e28d1f62 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -194,6 +194,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index e55d31783396e87ef18f5b6dfc27742c0b4e3465..6ec80e3a838f8f7479ee965561043586
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -1958,6 +1959,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1960,6 +1961,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index e55d31783396e87ef18f5b6dfc27742c0b4e3465..6ec80e3a838f8f7479ee965561043586
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1980,6 +1993,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1982,6 +1995,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index e55d31783396e87ef18f5b6dfc27742c0b4e3465..6ec80e3a838f8f7479ee965561043586
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1994,6 +2009,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1996,6 +2011,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0441-Brand-support.patch
+++ b/patches/server/0441-Brand-support.patch
@@ -57,10 +57,10 @@ index 698fc66f8c232644f2d747c81f8ac2e39204fd7f..8cb7e9d67fc4713dc327ad0459518f06
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e10cad5e2b078ff6ff7cba84dfa105ea5704d019..630f98fc58579c0a900d8ff6712a463742f90338 100644
+index 0bc0f3d7f560f21267b3966fdbb399b9175acd3c..021c25a95683be11cddc5dfe3d3d6d192e96df43 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2999,6 +2999,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3001,6 +3001,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0487-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0487-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 630f98fc58579c0a900d8ff6712a463742f90338..32c51de77dcd278f895969c513e38075dad83ace 100644
+index 021c25a95683be11cddc5dfe3d3d6d192e96df43..51c192a3b681ce0841df5f73dd568339f84ee5df 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2562,7 +2562,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2564,7 +2564,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null) {
              Preconditions.checkArgument(particle.getDataType().isInstance(data), "data (%s) should be %s", data.getClass(), particle.getDataType());
          }

--- a/patches/server/0855-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0855-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 047b5a4b0d942726422f7025768dca5b00526d3c..e05b3033b64672a9afe316fca49674f38f2830d5 100644
+index dd21cebd00cdf30833471b37b3329b4337ae479b..8ee359aa25a317340055c3d4230862aa83a2c776 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3152,6 +3152,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3154,6 +3154,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0872-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0872-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e05b3033b64672a9afe316fca49674f38f2830d5..e15a9558e1525081025c1363e218f6b4bd312c59 100644
+index 8ee359aa25a317340055c3d4230862aa83a2c776..3c71e8336f8b84ab899b63e20046431866b16dfc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3157,6 +3157,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3159,6 +3159,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0896-Flying-Fall-Damage.patch
+++ b/patches/server/0896-Flying-Fall-Damage.patch
@@ -26,10 +26,10 @@ index 28fa46f29639a6b643b475912133d601028facb2..7f3466340891b4409d1399ebeb2ca865
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0911c5ca8f2ea1a0f99567b1621c80064ee81ce8..79105c8525b8087e4121814f99f3a8b8ae285bb5 100644
+index ca384ba2d1cb33a774160b5bc9c51f296c300b21..c96cadf685a23aa217810176977940e3c8fba910 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2434,6 +2434,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2436,6 +2436,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().onUpdateAbilities();
      }
  

--- a/patches/server/0988-Add-Listing-API-for-Player.patch
+++ b/patches/server/0988-Add-Listing-API-for-Player.patch
@@ -113,7 +113,7 @@ index 098bb36a66e022da30302936aba10d296587ac88..a35638a92479b90afa89cf201fc45b49
          // Paper end
          player.sentListPacket = true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1a0d57c849b059d781cda9617c163bf6830c063a..a86f389034825b200bec799c03464541a9f4df87 100644
+index 1cf76d71de9b831b5dd10e3401087e5fd2188e2f..b99b226e525f1121044e3958caa17feefa584cdf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -185,6 +185,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -133,7 +133,7 @@ index 1a0d57c849b059d781cda9617c163bf6830c063a..a86f389034825b200bec799c03464541
              if (original != null) otherPlayer.setUUID(original); // Paper - uuid override
          }
  
-@@ -2098,6 +2099,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2100,6 +2101,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (entity != null) ? this.canSee(entity) : false; // If we can't find it, we can't see it
      }
  

--- a/patches/server/1029-Add-player-idle-duration-API.patch
+++ b/patches/server/1029-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index abcde413e2fe22b14994b2f5b15fd7db1a257465..9073edd4c0baa82f2b340d1898a89cf285262484 100644
+index a855b1109ff1dae27dbe1fdae3e089527d00c476..54be80484ae12d41223f6e1c9273535a94b0e946 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3274,6 +3274,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3276,6 +3276,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/1052-Keep-previous-behavior-for-setResourcePack.patch
+++ b/patches/server/1052-Keep-previous-behavior-for-setResourcePack.patch
@@ -10,10 +10,10 @@ packs before sending the new pack. Other API exists
 for adding a new pack to the existing packs on a client.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2f65d85b35eec863dabf05eff2230ee513d341d3..036b31cbfda8bac02205d99c1eff8a08f4da1250 100644
+index a6a6cd37b8916677e335d675219175016cada79f..345be3737aeaf4bea62585957566bb46906d6217 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2350,8 +2350,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2352,8 +2352,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (hash != null) {
              Preconditions.checkArgument(hash.length == 20, "Resource pack hash should be 20 bytes long but was %s", hash.length);
  


### PR DESCRIPTION
The main necessary change was to send:
```java
new ClientboundGameEventPacket(ClientboundGameEventPacket.LEVEL_CHUNKS_LOAD_START, 0.0F)
```
to do this I call `sendLevelInfo`, which is called by respawn and dimenstion teleport and has also this side-effect.

I also made the respawn packet code smaller.