### PR TITLE
Fix long loading screen when refreshing skins

### DIFF
--- a/patches/server/0180-Player.setPlayerProfile-API.patch
+++ b/patches/server/0180-Player.setPlayerProfile-API.patch
@@ -183,6 +183,7 @@ index 7021921980b20a8c61016a021b281af58ed72b51..44b98fc01ce1879f08987c6544b77b44
 +        handle.onUpdateAbilities();
 +        connection.internalTeleport(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch(), java.util.Collections.emptySet());
 +        net.minecraft.server.players.PlayerList playerList = handle.server.getPlayerList();
++        playerList.sendPlayerPermissionLevel(handle);
 +        playerList.sendLevelInfo(handle, worldserver);
 +        playerList.sendAllPlayerInfo(handle);
 +
@@ -190,11 +191,6 @@ index 7021921980b20a8c61016a021b281af58ed72b51..44b98fc01ce1879f08987c6544b77b44
 +        connection.send(new net.minecraft.network.protocol.game.ClientboundSetExperiencePacket(handle.experienceProgress, handle.totalExperience, handle.experienceLevel));
 +        for (net.minecraft.world.effect.MobEffectInstance mobEffect : handle.getActiveEffects()) {
 +            connection.send(new net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket(handle.getId(), mobEffect));
-+        }
-+
-+        if (this.isOp()) {
-+            this.setOp(false);
-+            this.setOp(true);
 +        }
 +    }
 +    // Paper end

--- a/patches/server/0180-Player.setPlayerProfile-API.patch
+++ b/patches/server/0180-Player.setPlayerProfile-API.patch
@@ -39,6 +39,28 @@ index 827774b02136ec1862bc9ffabc76ba3a4eb87716..96ae1fd95956f5e5a1542dcce3fbd9d4
                          gameprofile = com.destroystokyo.paper.profile.CraftPlayerProfile.asAuthlibCopy(profile);
                          playerName = gameprofile.getName();
                          uniqueId = gameprofile.getId();
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index 6e0a21935f9d5f35cbce72b32e0a89bb636804e2..782cc6d910efe5bc5498d0083afab42fad6c4fa2 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -862,10 +862,16 @@ public abstract class PlayerList {
+     }
+ 
+     public void sendPlayerPermissionLevel(ServerPlayer player) {
++    // Paper start - avoid recalculating permissions if possible
++        this.sendPlayerPermissionLevel(player, true);
++    }
++
++    public void sendPlayerPermissionLevel(ServerPlayer player, boolean recalculatePermissions) {
++    // Paper end - avoid recalculating permissions if possible
+         GameProfile gameprofile = player.getGameProfile();
+         int i = this.server.getProfilePermissions(gameprofile);
+ 
+-        this.sendPlayerPermissionLevel(player, i);
++        this.sendPlayerPermissionLevel(player, i, recalculatePermissions); // Paper - avoid recalculating permissions if possible
+     }
+ 
+     public void tick() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
 index 477d3245facb5ae59c786d4f696f64226cb540a6..e8490a58dd4d9bc39a5bb2f9fc109526e031b971 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
@@ -55,7 +77,7 @@ index 477d3245facb5ae59c786d4f696f64226cb540a6..e8490a58dd4d9bc39a5bb2f9fc109526
  
      public Server getServer() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7021921980b20a8c61016a021b281af58ed72b51..44b98fc01ce1879f08987c6544b77b442e7bfad6 100644
+index 8dd7e875d0e2ac3c10cce9b7045b5dbc742e9fb7..d296e1687fd596d6674e18b316603d08cd9057df 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -272,11 +272,6 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -162,7 +184,7 @@ index 7021921980b20a8c61016a021b281af58ed72b51..44b98fc01ce1879f08987c6544b77b44
  
      void resetAndShowEntity(org.bukkit.entity.Entity entity) {
          // SPIGOT-7312: Can't show/hide self
-@@ -1799,6 +1845,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1799,6 +1845,34 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              this.trackAndShowEntity(entity);
          }
      }
@@ -183,7 +205,7 @@ index 7021921980b20a8c61016a021b281af58ed72b51..44b98fc01ce1879f08987c6544b77b44
 +        handle.onUpdateAbilities();
 +        connection.internalTeleport(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch(), java.util.Collections.emptySet());
 +        net.minecraft.server.players.PlayerList playerList = handle.server.getPlayerList();
-+        playerList.sendPlayerPermissionLevel(handle);
++        playerList.sendPlayerPermissionLevel(handle, false);
 +        playerList.sendLevelInfo(handle, worldserver);
 +        playerList.sendAllPlayerInfo(handle);
 +

--- a/patches/server/0180-Player.setPlayerProfile-API.patch
+++ b/patches/server/0180-Player.setPlayerProfile-API.patch
@@ -179,10 +179,12 @@ index 7021921980b20a8c61016a021b281af58ed72b51..44b98fc01ce1879f08987c6544b77b44
 +
 +        //Respawn the player then update their position and selected slot
 +        ServerLevel worldserver = handle.serverLevel();
-+        connection.send(new net.minecraft.network.protocol.game.ClientboundRespawnPacket(new net.minecraft.network.protocol.game.CommonPlayerSpawnInfo(worldserver.dimensionTypeId(), worldserver.dimension(), net.minecraft.world.level.biome.BiomeManager.obfuscateSeed(worldserver.getSeed()), handle.gameMode.getGameModeForPlayer(), handle.gameMode.getPreviousGameModeForPlayer(), worldserver.isDebug(), worldserver.isFlat(), handle.getLastDeathLocation(), handle.getPortalCooldown()), net.minecraft.network.protocol.game.ClientboundRespawnPacket.KEEP_ALL_DATA));
++        connection.send(new net.minecraft.network.protocol.game.ClientboundRespawnPacket(handle.createCommonSpawnInfo(worldserver), net.minecraft.network.protocol.game.ClientboundRespawnPacket.KEEP_ALL_DATA));
 +        handle.onUpdateAbilities();
 +        connection.internalTeleport(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch(), java.util.Collections.emptySet());
-+        net.minecraft.server.MinecraftServer.getServer().getPlayerList().sendAllPlayerInfo(handle);
++        net.minecraft.server.players.PlayerList playerList = handle.server.getPlayerList();
++        playerList.sendLevelInfo(handle, worldserver);
++        playerList.sendAllPlayerInfo(handle);
 +
 +        // Resend their XP and effects because the respawn packet resets it
 +        connection.send(new net.minecraft.network.protocol.game.ClientboundSetExperiencePacket(handle.experienceProgress, handle.totalExperience, handle.experienceLevel));

--- a/patches/server/0185-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0185-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index be7fce2bc261739232bc07468eeb0240f644e760..44334bafacd95304a5b657ea5be7acee3e64c7df 100644
+index 1094475d819f9d5fa866c33bcc1b2985c47c4f07..69f4147523c7cc75c91a0f6c0553cea66a6df151 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -190,6 +190,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index be7fce2bc261739232bc07468eeb0240f644e760..44334bafacd95304a5b657ea5be7acee
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -2162,7 +2163,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2160,7 +2161,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void addChannel(String channel) {

--- a/patches/server/0249-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0249-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2134b3f2267e42147cd740ce033888578e63af46..2221bbdf426ccc443f2530fa8857eec5e0013fda 100644
+index 17016f1ce89555ba10ea96368f5a1d195679a5d4..b6e4fbfdaa46a36e155870190252233eca99d456 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2873,6 +2873,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2871,6 +2871,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0250-Improve-death-events.patch
+++ b/patches/server/0250-Improve-death-events.patch
@@ -392,10 +392,10 @@ index 948ba97e318506dad96e59121297b5bf8340d2e6..810bead2f19de70786027b190137f743
          this.gameEvent(GameEvent.ENTITY_DIE);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2221bbdf426ccc443f2530fa8857eec5e0013fda..b3309656bd3d731a2fcbf0e26bfd63354ecc035c 100644
+index b6e4fbfdaa46a36e155870190252233eca99d456..baba4105ccd1fe769cbbbd222e9315277394f5c6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2410,7 +2410,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2408,7 +2408,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void sendHealthUpdate() {
          FoodData foodData = this.getHandle().getFoodData();

--- a/patches/server/0285-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0285-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,7 +16,7 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 6e025c8fdb14e6dcb178055d51efd11112247808..268567dab735619171c2cdfd566790527c07e64d 100644
+index 577035b401472d8b3c5966fe908ddf029ee54f46..ccde243c370ff670675b66b19d559461a0e9f111 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -248,6 +248,7 @@ public class ServerPlayer extends Player {
@@ -106,7 +106,7 @@ index e8490a58dd4d9bc39a5bb2f9fc109526e031b971..5f590575f95eff8bf0cdcafde7dee0e3
      public Location getLastDeathLocation() {
          if (this.getData().contains("LastDeathLocation", 10)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d03b9c8a0253b217666a745db18271336fcaab56..bfa59fc123af9189306d8482bac1ae478babab0a 100644
+index baba4105ccd1fe769cbbbd222e9315277394f5c6..108229bb7e6487e84607a918b3ede335a955b869 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -191,6 +191,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index d03b9c8a0253b217666a745db18271336fcaab56..bfa59fc123af9189306d8482bac1ae47
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -1955,6 +1956,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1953,6 +1954,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index d03b9c8a0253b217666a745db18271336fcaab56..bfa59fc123af9189306d8482bac1ae47
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1977,6 +1990,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1975,6 +1988,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index d03b9c8a0253b217666a745db18271336fcaab56..bfa59fc123af9189306d8482bac1ae47
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1991,6 +2006,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1989,6 +2004,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0293-Call-WhitelistToggleEvent-when-whitelist-is-toggled.patch
+++ b/patches/server/0293-Call-WhitelistToggleEvent-when-whitelist-is-toggled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Call WhitelistToggleEvent when whitelist is toggled
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4221a45fda5c3b40a1f6342aebe8d7b2e190fb9c..3d13d3a219d10cb12bcdfe31eff9b54136629492 100644
+index 1be04d937efaae86e6d0f65b4ec8475294091054..6ee2cdd2bda2aba32661bc93cef00adcd6a83be3 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1151,6 +1151,7 @@ public abstract class PlayerList {
+@@ -1157,6 +1157,7 @@ public abstract class PlayerList {
      }
  
      public void setUsingWhiteList(boolean whitelistEnabled) {

--- a/patches/server/0418-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0418-incremental-chunk-and-player-saving.patch
@@ -118,7 +118,7 @@ index c877aca6093435be9d349c07ea1b01d06bcbd416..17802108f41c98b77c89922451ee56b5
          // Paper start - rewrite chunk system - add close param
          this.save(progressListener, flush, savingDisabled, false);
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 898403dad5e9bac4b565e1c75871245fe5cd7908..25c5f23b859961c792b2ec08404171eea1aedba7 100644
+index 030d6c0d067dacf4f9603bdfb21acca8cafbeff0..14126f4f2f0c8d5ae06275fd735178a2c4d3efc0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -190,6 +190,7 @@ import org.bukkit.inventory.MainHand;
@@ -130,7 +130,7 @@ index 898403dad5e9bac4b565e1c75871245fe5cd7908..25c5f23b859961c792b2ec08404171ee
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      private static final int FLY_STAT_RECORDING_SPEED = 25;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6d61e70d1d5ad5bce6432f91d3b23c1734ad629c..ed686f82dfd264a6b5d0a89163786574525f043e 100644
+index a1a0177e4bce9623c606d6c0a40c6a3ce52afdb7..90c3146fae238e9c0300b97ca2eda48292b62213 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -552,6 +552,7 @@ public abstract class PlayerList {
@@ -141,7 +141,7 @@ index 6d61e70d1d5ad5bce6432f91d3b23c1734ad629c..ed686f82dfd264a6b5d0a89163786574
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -1149,10 +1150,22 @@ public abstract class PlayerList {
+@@ -1155,10 +1156,22 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {

--- a/patches/server/0438-Brand-support.patch
+++ b/patches/server/0438-Brand-support.patch
@@ -57,10 +57,10 @@ index 44aa178968c87fa72023a2c0f33c1a8123f3db72..f489b207cd3b62a33723f2e9ed0f4602
              } catch (Exception ex) {
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t dispatch custom payload", ex);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8f9072b19a7a8eeede0230e98b2e6dd0240d0244..cce9485ec1d98d3bc38ea37dc8610e2707f7d456 100644
+index 196ece23104bc67a2df4e528851c0a2df8baaf5b..ff8bef2a88f04e4a333f90de05faddd66c69be20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3032,6 +3032,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3030,6 +3030,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0470-Fix-item-locations-dropped-from-campfires.patch
+++ b/patches/server/0470-Fix-item-locations-dropped-from-campfires.patch
@@ -4,25 +4,21 @@ Date: Sat, 3 Oct 2020 20:32:25 -0500
 Subject: [PATCH] Fix item locations dropped from campfires
 
 Fixes #4259 by not flooring the blockposition among other weirdness
-Vanilla Issue: MC-267622
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
-index c4cf6abf0a962794ddbb4d7a691406054062ffee..f706c787f7608f7440a5f5e05e7e9c4cb582368c 100644
+index c4cf6abf0a962794ddbb4d7a691406054062ffee..24e2063db933bfbc8fc1f34edb8106ae4d7c633c 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
-@@ -82,7 +82,14 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
+@@ -82,7 +82,11 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
                          result = blockCookEvent.getResult();
                          itemstack1 = CraftItemStack.asNMSCopy(result);
                          // CraftBukkit end
 -                        Containers.dropItemStack(world, (double) pos.getX(), (double) pos.getY(), (double) pos.getZ(), itemstack1);
-+                        // Paper start
-+                        double deviation = 0.05F * RandomSource.GAUSSIAN_SPREAD_FACTOR;
-+                        while (!itemstack1.isEmpty()) {
-+                            net.minecraft.world.entity.item.ItemEntity droppedItem = new net.minecraft.world.entity.item.ItemEntity(world, pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, itemstack1.split(world.random.nextInt(21) + 10));
-+                            droppedItem.setDeltaMovement(world.random.triangle(0.0D, deviation), world.random.triangle(0.2D, deviation), world.random.triangle(0.0D, deviation));
-+                            world.addFreshEntity(droppedItem);
-+                        }
-+                        // Paper end
++                    // Paper start
++                    net.minecraft.world.entity.item.ItemEntity droppedItem = new net.minecraft.world.entity.item.ItemEntity(world, pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, itemstack1.split(world.random.nextInt(21) + 10));
++                    droppedItem.setDeltaMovement(world.random.nextGaussian() * 0.05D, world.random.nextGaussian() * 0.05D + 0.2D, world.random.nextGaussian() * 0.05D);
++                    world.addFreshEntity(droppedItem);
++                    // Paper end
                          campfire.items.set(i, ItemStack.EMPTY);
                          world.sendBlockUpdated(pos, state, state, 3);
                          world.gameEvent(GameEvent.BLOCK_CHANGE, pos, GameEvent.Context.of(state));

--- a/patches/server/0484-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0484-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cce9485ec1d98d3bc38ea37dc8610e2707f7d456..7b0c0c64f082cbf26ebce766c31835432ede7ad3 100644
+index ff8bef2a88f04e4a333f90de05faddd66c69be20..58731389c9b120395f4eb9e38c8e8584147fe9fd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2595,7 +2595,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2593,7 +2593,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null) {
              Preconditions.checkArgument(particle.getDataType().isInstance(data), "data (%s) should be %s", data.getClass(), particle.getDataType());
          }

--- a/patches/server/0523-Add-sendOpLevel-API.patch
+++ b/patches/server/0523-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 1131ee88f35c3898f0119c414c8376b0d9130169..bf361396bc2ec5d5c7b45d425af990c037ba0694 100644
+index 9ed8c8d90db1ae785b7f6b7e9ae7dc1147cb8a29..1e02dbbd1fbee57da79eade5a0c9cf70e38b2f13 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1099,6 +1099,11 @@ public abstract class PlayerList {
+@@ -1105,6 +1105,11 @@ public abstract class PlayerList {
      }
  
      private void sendPlayerPermissionLevel(ServerPlayer player, int permissionLevel) {
@@ -20,7 +20,7 @@ index 1131ee88f35c3898f0119c414c8376b0d9130169..bf361396bc2ec5d5c7b45d425af990c0
          if (player.connection != null) {
              byte b0;
  
-@@ -1113,8 +1118,10 @@ public abstract class PlayerList {
+@@ -1119,8 +1124,10 @@ public abstract class PlayerList {
              player.connection.send(new ClientboundEntityEventPacket(player, b0));
          }
  
@@ -32,7 +32,7 @@ index 1131ee88f35c3898f0119c414c8376b0d9130169..bf361396bc2ec5d5c7b45d425af990c0
  
      public boolean isWhiteListed(GameProfile profile) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cd8b40db82a42f55c8253dc91df3caa415aabed1..ece389c0f124c65b4adce1f8ce53e9139b46fd6f 100644
+index ba30c5e17a294cee9f408fdd4e31849c0e5d28ed..8a924ae677a93a177651aa1ec0728e3b8d5528a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -633,6 +633,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0602-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0602-Add-PlayerKickEvent-causes.patch
@@ -437,7 +437,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
  
              }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index bccb8400dd50654bae5cab23e1944fd5e6732648..a9cba92048b37135b048fd6fa7d00470c855053f 100644
+index b6e2069c2e817565dec961473a02454abf3b107d..8e5d5c2341ff723fff110229af470f55b85eb964 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -684,7 +684,7 @@ public abstract class PlayerList {
@@ -449,7 +449,7 @@ index bccb8400dd50654bae5cab23e1944fd5e6732648..a9cba92048b37135b048fd6fa7d00470
          }
  
          // Instead of kicking then returning, we need to store the kick reason
-@@ -1329,8 +1329,8 @@ public abstract class PlayerList {
+@@ -1335,8 +1335,8 @@ public abstract class PlayerList {
          // Paper end
          // CraftBukkit start - disconnect safely
          for (ServerPlayer player : this.players) {
@@ -491,7 +491,7 @@ index 6724d0a1af13e97bc1d3bd94fd43fef742a0deab..20ba0a0c9eae28658888a77dd2170f62
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6910cb1d02b07ec17f8ece922d40803c4eb659c4..bcd68b2e88f06e693d31a81b4eb79eeb381f7119 100644
+index 6cbb672bc76647e923ec1c16b6e56ee6a4982875..11507cbf0f213079b39b35d06f8fc675d437469b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -591,7 +591,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0720-Add-more-Campfire-API.patch
+++ b/patches/server/0720-Add-more-Campfire-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add more Campfire API
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
-index f776289eea00bd741ad55bb9bc338dd2c05c8b39..18d3cb828f85e17ec27dbb5b33c6f17fff178a1d 100644
+index 04b2697ee857e714b1202d02d093b0c60f079a6f..d80855b22dc10dbf697578d5f78664ed7b6ac572 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/CampfireBlockEntity.java
 @@ -42,6 +42,7 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
@@ -34,7 +34,7 @@ index f776289eea00bd741ad55bb9bc338dd2c05c8b39..18d3cb828f85e17ec27dbb5b33c6f17f
  
                  if (campfire.cookingProgress[i] >= campfire.cookingTime[i]) {
                      SimpleContainer inventorysubcontainer = new SimpleContainer(new ItemStack[]{itemstack});
-@@ -171,6 +175,16 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
+@@ -168,6 +172,16 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
              System.arraycopy(aint, 0, this.cookingTime, 0, Math.min(this.cookingTime.length, aint.length));
          }
  
@@ -51,7 +51,7 @@ index f776289eea00bd741ad55bb9bc338dd2c05c8b39..18d3cb828f85e17ec27dbb5b33c6f17f
      }
  
      @Override
-@@ -179,6 +193,13 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
+@@ -176,6 +190,13 @@ public class CampfireBlockEntity extends BlockEntity implements Clearable {
          ContainerHelper.saveAllItems(nbt, this.items, true);
          nbt.putIntArray("CookingTimes", this.cookingProgress);
          nbt.putIntArray("CookingTotalTimes", this.cookingTime);

--- a/patches/server/0786-Use-username-instead-of-display-name-in-PlayerList-g.patch
+++ b/patches/server/0786-Use-username-instead-of-display-name-in-PlayerList-g.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Use username instead of display name in
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index d728e637449ace459b3501fd6a4fb77657a5ca55..4bf3598f8d6f6f469a5a17e8067fd5035732da19 100644
+index 311dbc93e1f1aa9e4ea6786a3429f84e6ffa114c..f2e44904db90b43672367740e6e5f09da8db2797 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1445,7 +1445,7 @@ public abstract class PlayerList {
+@@ -1451,7 +1451,7 @@ public abstract class PlayerList {
      // CraftBukkit start
      public ServerStatsCounter getPlayerStats(ServerPlayer entityhuman) {
          ServerStatsCounter serverstatisticmanager = entityhuman.getStats();

--- a/patches/server/0793-Fire-CauldronLevelChange-on-initial-fill.patch
+++ b/patches/server/0793-Fire-CauldronLevelChange-on-initial-fill.patch
@@ -6,46 +6,6 @@ Subject: [PATCH] Fire CauldronLevelChange on initial fill
 Also don't fire level events or game events if stalactite
 drip is cancelled
 
-diff --git a/src/main/java/net/minecraft/core/cauldron/CauldronInteraction.java b/src/main/java/net/minecraft/core/cauldron/CauldronInteraction.java
-index 4c9334dde0734a3550a810845cee53f474e9c96b..ef7f1a871144f4a6897769f2459a4dd5eeffa5b4 100644
---- a/src/main/java/net/minecraft/core/cauldron/CauldronInteraction.java
-+++ b/src/main/java/net/minecraft/core/cauldron/CauldronInteraction.java
-@@ -80,7 +80,7 @@ public interface CauldronInteraction {
-             } else {
-                 if (!world.isClientSide) {
-                     // CraftBukkit start
--                    if (!LayeredCauldronBlock.changeLevel(iblockdata, world, blockposition, Blocks.WATER_CAULDRON.defaultBlockState(), entityhuman, CauldronLevelChangeEvent.ChangeReason.BOTTLE_EMPTY)) {
-+                    if (!LayeredCauldronBlock.changeLevel(iblockdata, world, blockposition, Blocks.WATER_CAULDRON.defaultBlockState(), entityhuman, CauldronLevelChangeEvent.ChangeReason.BOTTLE_EMPTY, false)) { // Paper
-                         return InteractionResult.SUCCESS;
-                     }
-                     // CraftBukkit end
-@@ -128,7 +128,7 @@ public interface CauldronInteraction {
-             if ((Integer) iblockdata.getValue(LayeredCauldronBlock.LEVEL) != 3 && PotionUtils.getPotion(itemstack) == Potions.WATER) {
-                 if (!world.isClientSide) {
-                     // CraftBukkit start
--                    if (!LayeredCauldronBlock.changeLevel(iblockdata, world, blockposition, iblockdata.cycle(LayeredCauldronBlock.LEVEL), entityhuman, CauldronLevelChangeEvent.ChangeReason.BOTTLE_EMPTY)) {
-+                    if (!LayeredCauldronBlock.changeLevel(iblockdata, world, blockposition, iblockdata.cycle(LayeredCauldronBlock.LEVEL), entityhuman, CauldronLevelChangeEvent.ChangeReason.BOTTLE_EMPTY, false)) { // Paper
-                         return InteractionResult.SUCCESS;
-                     }
-                     // CraftBukkit end
-@@ -212,7 +212,7 @@ public interface CauldronInteraction {
-         } else {
-             if (!world.isClientSide) {
-                 // CraftBukkit start
--                if (!LayeredCauldronBlock.changeLevel(state, world, pos, Blocks.CAULDRON.defaultBlockState(), player, CauldronLevelChangeEvent.ChangeReason.BUCKET_FILL)) {
-+                if (!LayeredCauldronBlock.changeLevel(state, world, pos, Blocks.CAULDRON.defaultBlockState(), player, CauldronLevelChangeEvent.ChangeReason.BUCKET_FILL, false)) { // Paper
-                     return InteractionResult.SUCCESS;
-                 }
-                 // CraftBukkit end
-@@ -233,7 +233,7 @@ public interface CauldronInteraction {
-     static InteractionResult emptyBucket(Level world, BlockPos pos, Player player, InteractionHand hand, ItemStack stack, BlockState state, SoundEvent soundEvent) {
-         if (!world.isClientSide) {
-             // CraftBukkit start
--            if (!LayeredCauldronBlock.changeLevel(state, world, pos, state, player, CauldronLevelChangeEvent.ChangeReason.BUCKET_EMPTY)) {
-+            if (!LayeredCauldronBlock.changeLevel(state, world, pos, state, player, CauldronLevelChangeEvent.ChangeReason.BUCKET_EMPTY, false)) { // Paper
-                 return InteractionResult.SUCCESS;
-             }
-             // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/level/block/CauldronBlock.java b/src/main/java/net/minecraft/world/level/block/CauldronBlock.java
 index 588b3e911d9b22dad2928ea9e32e8a8a3a8e9b96..a821a981adbebdcf22997731b9bbea3d033cd2b1 100644
 --- a/src/main/java/net/minecraft/world/level/block/CauldronBlock.java

--- a/patches/server/0851-Elder-Guardian-appearance-API.patch
+++ b/patches/server/0851-Elder-Guardian-appearance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Elder Guardian appearance API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 160b25a768969af347917aad00807381a6ba39d1..5e8b33d34da4489d32774c763216e7292e9b3408 100644
+index a31c1f1bcd54f070d3dd7f33c38e992999c2f383..10db4c791ce72563d6c84c39a68ce69b15b5aef6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3185,6 +3185,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3183,6 +3183,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0868-Add-Player-Warden-Warning-API.patch
+++ b/patches/server/0868-Add-Player-Warden-Warning-API.patch
@@ -10,10 +10,10 @@ public net.minecraft.world.entity.monster.warden.WardenSpawnTracker cooldownTick
 public net.minecraft.world.entity.monster.warden.WardenSpawnTracker increaseWarningLevel()V
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5e8b33d34da4489d32774c763216e7292e9b3408..fd01db8a45934cedd8d250a197c47a8e9d386fa7 100644
+index 10db4c791ce72563d6c84c39a68ce69b15b5aef6..fb0809ae3ceac3bd3e061305fe8404f0ff9d4449 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3190,6 +3190,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3188,6 +3188,41 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void showElderGuardian(boolean silent) {
          if (getHandle().connection != null) getHandle().connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.GUARDIAN_ELDER_EFFECT, silent ? 0F : 1F));
      }

--- a/patches/server/0892-Flying-Fall-Damage.patch
+++ b/patches/server/0892-Flying-Fall-Damage.patch
@@ -26,10 +26,10 @@ index 28fa46f29639a6b643b475912133d601028facb2..7f3466340891b4409d1399ebeb2ca865
          } else {
              if (fallDistance >= 2.0F) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7f90316c1f56f4829282d388233032bce97abbf5..ca9c49b1fc1c3e90b2b2aa7afa8a4ecb2dcc779d 100644
+index ba68feed47add99da1ea039acb47fd38239dcb65..09e2feda950fce9857b9c2f35941c93714130041 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2468,6 +2468,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2466,6 +2466,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().onUpdateAbilities();
      }
  

--- a/patches/server/0965-API-for-updating-recipes-on-clients.patch
+++ b/patches/server/0965-API-for-updating-recipes-on-clients.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] API for updating recipes on clients
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 895c4accbcf43baaa8a4d560e8b5c0d4dfae3ccc..098bb36a66e022da30302936aba10d296587ac88 100644
+index b54f1d7da0e6aa39172848871bd4b0073f43380d..09196224b9b5362918726265a8daad814118f83b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1539,6 +1539,13 @@ public abstract class PlayerList {
+@@ -1545,6 +1545,13 @@ public abstract class PlayerList {
      }
  
      public void reloadResources() {
@@ -22,7 +22,7 @@ index 895c4accbcf43baaa8a4d560e8b5c0d4dfae3ccc..098bb36a66e022da30302936aba10d29
          // CraftBukkit start
          /*Iterator iterator = this.advancements.values().iterator();
  
-@@ -1554,7 +1561,15 @@ public abstract class PlayerList {
+@@ -1560,7 +1567,15 @@ public abstract class PlayerList {
          }
          // CraftBukkit end
  
@@ -39,7 +39,7 @@ index 895c4accbcf43baaa8a4d560e8b5c0d4dfae3ccc..098bb36a66e022da30302936aba10d29
          Iterator iterator1 = this.players.iterator();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 79e342b5d28f445671191e3bf4d3b7f592cf2e9e..8a8cc2da46eac78c2871e4920eb78d04d4cbc0d6 100644
+index 81afb0d5349102025a96610098676e21647f85da..7155948d803bdea48602d10ca9f18b64c9fd1991 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1129,6 +1129,18 @@ public final class CraftServer implements Server {

--- a/patches/server/0983-Add-Listing-API-for-Player.patch
+++ b/patches/server/0983-Add-Listing-API-for-Player.patch
@@ -113,7 +113,7 @@ index 098bb36a66e022da30302936aba10d296587ac88..a35638a92479b90afa89cf201fc45b49
          // Paper end
          player.sentListPacket = true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1ed523128383e2f8b9090607af982645133338d5..af4b96c5b6b6cea3edf0eaca22d62288bda05ea4 100644
+index 96e2dab94c326e9ec863c47b1a55680cd321b1d5..32712c245804a98c8dba00eef916dfde89f09df2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -182,6 +182,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -133,7 +133,7 @@ index 1ed523128383e2f8b9090607af982645133338d5..af4b96c5b6b6cea3edf0eaca22d62288
              if (original != null) otherPlayer.setUUID(original); // Paper - uuid override
          }
  
-@@ -2095,6 +2096,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2093,6 +2094,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (entity != null) ? this.canSee(entity) : false; // If we can't find it, we can't see it
      }
  

--- a/patches/server/1024-Add-player-idle-duration-API.patch
+++ b/patches/server/1024-Add-player-idle-duration-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add player idle duration API
 Implements API for getting and resetting a player's idle duration.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ff3e42fe78b2ef7d6346d6b46a1fc664e1bf6352..d62678f58080d9c0514c9f2cfab7af597c07921a 100644
+index f6abddc962babce7a72bd30a0213c580d3fdad7f..e7a59e33333234cf548769c5318d3a59db5c78b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3307,6 +3307,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3305,6 +3305,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/1046-Keep-previous-behavior-for-setResourcePack.patch
+++ b/patches/server/1046-Keep-previous-behavior-for-setResourcePack.patch
@@ -10,10 +10,10 @@ packs before sending the new pack. Other API exists
 for adding a new pack to the existing packs on a client.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fe6e1e23b94d35ab5a2ba9c70bbc41820636c7df..c54df6e4aed9b7b46a41af4108a8e90d96c1fe1f 100644
+index 9e03fa9db5d4db2b6f5758d2287e37ae05f9ecfa..1520533c137ace61aa83067186adca349bff8039 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2347,8 +2347,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2345,8 +2345,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (hash != null) {
              Preconditions.checkArgument(hash.length == 20, "Resource pack hash should be 20 bytes long but was %s", hash.length);
  


### PR DESCRIPTION
The main necessary change was to send:
```java
new ClientboundGameEventPacket(ClientboundGameEventPacket.LEVEL_CHUNKS_LOAD_START, 0.0F)
```
to do this I call `sendLevelInfo`, which is called by respawn and dimension teleport and has also this packet as a side-effect.

I also made the respawn packet code smaller.