### PR TITLE
fix block state meta when no id nbt key is present

### DIFF
--- a/patches/server/0704-Fix-upstreams-block-state-factories.patch
+++ b/patches/server/0704-Fix-upstreams-block-state-factories.patch
@@ -13,10 +13,27 @@ the material type of the block at that location.
 public net.minecraft.world.level.block.entity.BlockEntityType validBlocks
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index d156f7cc71050f13b2feca00c52ca6b64572b60e..e3557f4c8cee7c88b3e352cd246078da7762effc 100644
+index d156f7cc71050f13b2feca00c52ca6b64572b60e..e639a2507a73bed1662631c45e0aa55e6042d7de 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-@@ -247,7 +247,7 @@ public abstract class BlockEntity {
+@@ -137,7 +137,15 @@ public abstract class BlockEntity {
+             BlockEntity.LOGGER.error("Block entity has invalid type: {}", s);
+             return null;
+         } else {
+-            return (BlockEntity) BuiltInRegistries.BLOCK_ENTITY_TYPE.getOptional(minecraftkey).map((tileentitytypes) -> {
++            // Paper start
++            return loadStatic(pos, state, nbt, s, BuiltInRegistries.BLOCK_ENTITY_TYPE.getOptional(minecraftkey));
++        }
++    }
++    @Nullable
++    public static BlockEntity loadStatic(BlockPos pos, BlockState state, CompoundTag nbt, final String s, java.util.Optional<BlockEntityType<?>> type) {
++        {
++            return type.map((tileentitytypes) -> {
++            // Paper end
+                 try {
+                     return tileentitytypes.create(pos, state);
+                 } catch (Throwable throwable) {
+@@ -247,7 +255,7 @@ public abstract class BlockEntity {
          // Paper end
          if (this.level == null) return null;
          org.bukkit.block.Block block = this.level.getWorld().getBlockAt(this.worldPosition.getX(), this.worldPosition.getY(), this.worldPosition.getZ());
@@ -50,7 +67,7 @@ index f7f211b4f08a7f21a183078affd6f875aa30dd50..a8290624d8c5b19506f628d049984d2e
      // Paper start
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
-index 2fe8f7dfefd6e1f9b06f1d4821894091a8e6400e..000724a070f7f053c14cb53ecc45f0ee14454c53 100644
+index 2fe8f7dfefd6e1f9b06f1d4821894091a8e6400e..750dbd826e3c8995cdc263ab485a50e9d5341857 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
 @@ -19,6 +19,7 @@ import net.minecraft.world.level.block.entity.BeehiveBlockEntity;
@@ -61,7 +78,23 @@ index 2fe8f7dfefd6e1f9b06f1d4821894091a8e6400e..000724a070f7f053c14cb53ecc45f0ee
  import net.minecraft.world.level.block.entity.BrewingStandBlockEntity;
  import net.minecraft.world.level.block.entity.BrushableBlockEntity;
  import net.minecraft.world.level.block.entity.CalibratedSculkSensorBlockEntity;
-@@ -115,227 +116,64 @@ public final class CraftBlockStates {
+@@ -85,11 +86,13 @@ public final class CraftBlockStates {
+ 
+         private final BiFunction<World, T, B> blockStateConstructor;
+         private final BiFunction<BlockPos, net.minecraft.world.level.block.state.BlockState, T> tileEntityConstructor;
++        private final BlockEntityType<? extends T> blockEntityType; // Paper
+ 
+-        protected BlockEntityStateFactory(Class<B> blockStateType, BiFunction<World, T, B> blockStateConstructor, BiFunction<BlockPos, net.minecraft.world.level.block.state.BlockState, T> tileEntityConstructor) {
++        protected BlockEntityStateFactory(Class<B> blockStateType, BiFunction<World, T, B> blockStateConstructor, BlockEntityType<? extends T> blockEntityType) { // Paper
+             super(blockStateType);
+             this.blockStateConstructor = blockStateConstructor;
+-            this.tileEntityConstructor = tileEntityConstructor;
++            this.tileEntityConstructor = blockEntityType::create; // Paper
++            this.blockEntityType = blockEntityType; // Paper
+         }
+ 
+         @Override
+@@ -115,227 +118,64 @@ public final class CraftBlockStates {
      private static final BlockStateFactory<?> DEFAULT_FACTORY = new BlockStateFactory<CraftBlockState>(CraftBlockState.class) {
          @Override
          public CraftBlockState createBlockState(World world, BlockPos blockPosition, net.minecraft.world.level.block.state.BlockState blockData, BlockEntity tileEntity) {
@@ -341,31 +374,31 @@ index 2fe8f7dfefd6e1f9b06f1d4821894091a8e6400e..000724a070f7f053c14cb53ecc45f0ee
      }
  
      private static void register(Material blockType, BlockStateFactory<?> factory) {
-@@ -343,30 +181,33 @@ public final class CraftBlockStates {
+@@ -343,30 +183,38 @@ public final class CraftBlockStates {
      }
  
      private static <T extends BlockEntity, B extends CraftBlockEntityState<T>> void register(
 -            Material blockType,
--            Class<B> blockStateType,
--            BiFunction<World, T, B> blockStateConstructor,
--            BiFunction<BlockPos, net.minecraft.world.level.block.state.BlockState, T> tileEntityConstructor
--    ) {
--        CraftBlockStates.register(Collections.singletonList(blockType), blockStateType, blockStateConstructor, tileEntityConstructor);
--    }
--
--    private static <T extends BlockEntity, B extends CraftBlockEntityState<T>> void register(
--            List<Material> blockTypes,
-+            net.minecraft.world.level.block.entity.BlockEntityType<? extends T> blockEntityType, // Paper
++            BlockEntityType<? extends T> blockEntityType, // Paper
              Class<B> blockStateType,
 -            BiFunction<World, T, B> blockStateConstructor,
 -            BiFunction<BlockPos, net.minecraft.world.level.block.state.BlockState, T> tileEntityConstructor
 +            BiFunction<World, T, B> blockStateConstructor // Paper
      ) {
+-        CraftBlockStates.register(Collections.singletonList(blockType), blockStateType, blockStateConstructor, tileEntityConstructor);
+-    }
+-
+-    private static <T extends BlockEntity, B extends CraftBlockEntityState<T>> void register(
+-            List<Material> blockTypes,
+-            Class<B> blockStateType,
+-            BiFunction<World, T, B> blockStateConstructor,
+-            BiFunction<BlockPos, net.minecraft.world.level.block.state.BlockState, T> tileEntityConstructor
+-    ) {
 -        BlockStateFactory<B> factory = new BlockEntityStateFactory<>(blockStateType, blockStateConstructor, tileEntityConstructor);
 -        for (Material blockType : blockTypes) {
 -            CraftBlockStates.register(blockType, factory);
 +        // Paper start
-+        BlockStateFactory<B> factory = new BlockEntityStateFactory<>(blockStateType, blockStateConstructor, blockEntityType::create);
++        BlockStateFactory<B> factory = new BlockEntityStateFactory<>(blockStateType, blockStateConstructor, blockEntityType);
 +        for (net.minecraft.world.level.block.Block block : blockEntityType.validBlocks) {
 +            CraftBlockStates.register(CraftMagicNumbers.getMaterial(block), factory);
          }
@@ -385,12 +418,17 @@ index 2fe8f7dfefd6e1f9b06f1d4821894091a8e6400e..000724a070f7f053c14cb53ecc45f0ee
 +            return getFactory(material);
 +        }
 +    }
++    @Nullable
++    public static BlockEntityType<?> getBlockEntityType(final Material material) {
++        final BlockStateFactory<?> factory = org.bukkit.craftbukkit.block.CraftBlockStates.FACTORIES.get(material);
++        return factory instanceof final BlockEntityStateFactory<?,?> blockEntityStateFactory ? blockEntityStateFactory.blockEntityType : null;
++    }
 +    // Paper end
 +
      public static Class<? extends CraftBlockState> getBlockStateType(Material material) {
          Preconditions.checkNotNull(material, "material is null");
          return CraftBlockStates.getFactory(material).blockStateType;
-@@ -382,6 +223,13 @@ public final class CraftBlockStates {
+@@ -382,6 +230,13 @@ public final class CraftBlockStates {
          return null;
      }
  
@@ -404,7 +442,49 @@ index 2fe8f7dfefd6e1f9b06f1d4821894091a8e6400e..000724a070f7f053c14cb53ecc45f0ee
      public static BlockState getBlockState(Block block) {
          // Paper start
          return CraftBlockStates.getBlockState(block, true);
-@@ -439,7 +287,7 @@ public final class CraftBlockStates {
+@@ -410,13 +265,23 @@ public final class CraftBlockStates {
+     }
+ 
+     public static BlockState getBlockState(Material material, @Nullable CompoundTag blockEntityTag) {
+-        return CraftBlockStates.getBlockState(BlockPos.ZERO, material, blockEntityTag);
++        // Paper start
++        return CraftBlockStates.getBlockState(material, blockEntityTag, null);
++    }
++    public static BlockState getBlockState(Material material, @Nullable CompoundTag blockEntityTag, @Nullable BlockEntityType<?> blockEntityType) {
++        return CraftBlockStates.getBlockState(BlockPos.ZERO, material, blockEntityTag, blockEntityType);
++        // Paper end
+     }
+ 
+     public static BlockState getBlockState(BlockPos blockPosition, Material material, @Nullable CompoundTag blockEntityTag) {
++        // Paper start
++        return CraftBlockStates.getBlockState(blockPosition, material, blockEntityTag, null);
++    }
++    public static BlockState getBlockState(BlockPos blockPosition, Material material, @Nullable CompoundTag blockEntityTag, @Nullable BlockEntityType<?> blockEntityType) {
++        // Paper end
+         Preconditions.checkNotNull(material, "material is null");
+         net.minecraft.world.level.block.state.BlockState blockData = CraftMagicNumbers.getBlock(material).defaultBlockState();
+-        return CraftBlockStates.getBlockState(blockPosition, blockData, blockEntityTag);
++        return CraftBlockStates.getBlockState(blockPosition, blockData, blockEntityTag, blockEntityType); // Paper
+     }
+ 
+     public static BlockState getBlockState(net.minecraft.world.level.block.state.BlockState blockData, @Nullable CompoundTag blockEntityTag) {
+@@ -424,9 +289,14 @@ public final class CraftBlockStates {
+     }
+ 
+     public static BlockState getBlockState(BlockPos blockPosition, net.minecraft.world.level.block.state.BlockState blockData, @Nullable CompoundTag blockEntityTag) {
++        // Paper start
++        return CraftBlockStates.getBlockState(blockPosition, blockData, blockEntityTag, null);
++    }
++    public static BlockState getBlockState(BlockPos blockPosition, net.minecraft.world.level.block.state.BlockState blockData, @Nullable CompoundTag blockEntityTag, @Nullable BlockEntityType<?> blockEntityType) {
++        // Paper end
+         Preconditions.checkNotNull(blockPosition, "blockPosition is null");
+         Preconditions.checkNotNull(blockData, "blockData is null");
+-        BlockEntity tileEntity = (blockEntityTag == null) ? null : BlockEntity.loadStatic(blockPosition, blockData, blockEntityTag);
++        BlockEntity tileEntity = (blockEntityTag == null) ? null : blockEntityType == null ? BlockEntity.loadStatic(blockPosition, blockData, blockEntityTag) : BlockEntity.loadStatic(blockPosition, blockData, blockEntityTag, blockEntityTag.getString("id"), java.util.Optional.of(blockEntityType)); // Paper
+         return CraftBlockStates.getBlockState(null, blockPosition, blockData, tileEntity);
+     }
+ 
+@@ -439,7 +309,7 @@ public final class CraftBlockStates {
          if (world != null && tileEntity == null && CraftBlockStates.isTileEntityOptional(material)) {
              factory = CraftBlockStates.DEFAULT_FACTORY;
          } else {

--- a/patches/server/0804-Sanitize-Sent-BlockEntity-NBT.patch
+++ b/patches/server/0804-Sanitize-Sent-BlockEntity-NBT.patch
@@ -30,10 +30,10 @@ index bf6cdc08367fc26716e7904162a21e63fecab3ed..51e24105facfe71ce9f2757c6c881a21
          }
      }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index e3557f4c8cee7c88b3e352cd246078da7762effc..5bdad1866386908b9fef74d15862eb107fabe68f 100644
+index e639a2507a73bed1662631c45e0aa55e6042d7de..b96d52c09e260306c725539a2349b3ce7b6ee214 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-@@ -253,4 +253,12 @@ public abstract class BlockEntity {
+@@ -261,4 +261,12 @@ public abstract class BlockEntity {
          return null;
      }
      // CraftBukkit end

--- a/patches/server/0895-Add-exploded-block-state-to-BlockExplodeEvent-and-En.patch
+++ b/patches/server/0895-Add-exploded-block-state-to-BlockExplodeEvent-and-En.patch
@@ -113,11 +113,11 @@ index c83ffba568f33323b0f8b9a03fa0b7bbbfed4355..797ece59c10bdb60a86f71ca3b7bb95d
  
      public static boolean canSetSpawn(Level world) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
-index 000724a070f7f053c14cb53ecc45f0ee14454c53..9271ff2a9ea05569e3c81886399aa7ab47efb05d 100644
+index 750dbd826e3c8995cdc263ab485a50e9d5341857..d93e4ca1612e8e2f0961363e4c2c3ed8b30ea18f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
-@@ -277,6 +277,12 @@ public final class CraftBlockStates {
-         BlockEntity tileEntity = (blockEntityTag == null) ? null : BlockEntity.loadStatic(blockPosition, blockData, blockEntityTag);
+@@ -299,6 +299,12 @@ public final class CraftBlockStates {
+         BlockEntity tileEntity = (blockEntityTag == null) ? null : blockEntityType == null ? BlockEntity.loadStatic(blockPosition, blockData, blockEntityTag) : BlockEntity.loadStatic(blockPosition, blockData, blockEntityTag, blockEntityTag.getString("id"), java.util.Optional.of(blockEntityType)); // Paper
          return CraftBlockStates.getBlockState(null, blockPosition, blockData, tileEntity);
      }
 +    // Paper start

--- a/patches/server/0915-Optimize-Hoppers.patch
+++ b/patches/server/0915-Optimize-Hoppers.patch
@@ -85,7 +85,7 @@ index 3904c9d3ffde11320306f7c5c01ec2b8b0dfbaf9..26d00500831d07f2ef48da89770b3ece
              itemstack.setPopTime(this.getPopTime());
              if (this.tag != null) {
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index 5bdad1866386908b9fef74d15862eb107fabe68f..370a25d2deb54f10a35ee24d9e7e92fbfde60edf 100644
+index b96d52c09e260306c725539a2349b3ce7b6ee214..2af2a7fa9a0a543b023df933dfaf177916c7f43b 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 @@ -26,6 +26,7 @@ import co.aikar.timings.MinecraftTimings; // Paper
@@ -96,7 +96,7 @@ index 5bdad1866386908b9fef74d15862eb107fabe68f..370a25d2deb54f10a35ee24d9e7e92fb
  
      public Timing tickTimer = MinecraftTimings.getTileEntityTimings(this); // Paper
      // CraftBukkit start - data containers
-@@ -161,6 +162,7 @@ public abstract class BlockEntity {
+@@ -169,6 +170,7 @@ public abstract class BlockEntity {
  
      public void setChanged() {
          if (this.level != null) {

--- a/patches/server/1050-fix-block-state-meta-when-no-id-nbt-key-is-present.patch
+++ b/patches/server/1050-fix-block-state-meta-when-no-id-nbt-key-is-present.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 12 Dec 2023 20:57:54 -0800
+Subject: [PATCH] fix block state meta when no id nbt key is present
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+index 0cbca0c37b3e6a34157906d44357286126cfe112..bdb88e34f96f02373220dcca3c051baedeb5ef7c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+@@ -260,18 +260,17 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+     @Override
+     public BlockState getBlockState() {
+         Material stateMaterial = (this.material != Material.SHIELD) ? this.material : CraftMetaBlockState.shieldToBannerHack(this.blockEntityTag); // Only actually used for jigsaws
++        net.minecraft.world.level.block.entity.BlockEntityType<?> blockEntityType = null;
+         if (this.blockEntityTag != null) {
+-            if (this.material == Material.SHIELD) {
+-                this.blockEntityTag.putString("id", "minecraft:banner");
+-            } else if (this.material == Material.BEE_NEST || this.material == Material.BEEHIVE) {
+-                this.blockEntityTag.putString("id", "minecraft:beehive");
+-            } else if (CraftMetaBlockState.SHULKER_BOX_MATERIALS.contains(this.material)) {
+-                this.blockEntityTag.putString("id", "minecraft:shulker_box");
++            // Paper start - ensure block entity type is in compound tag (required for BlockEntity#loadStatic)
++            if (!this.blockEntityTag.contains("id")) {
++                blockEntityType = org.bukkit.craftbukkit.block.CraftBlockStates.getBlockEntityType(stateMaterial);
+             }
++            // Paper end
+         }
+ 
+         // This is expected to always return a CraftBlockEntityState for the passed material:
+-        return CraftBlockStates.getBlockState(stateMaterial, this.blockEntityTag);
++        return CraftBlockStates.getBlockState(stateMaterial, this.blockEntityTag, blockEntityType); // Paper
+     }
+ 
+     @Override


### PR DESCRIPTION
It is valid in vanilla to have a blockentitytag for an itemstack that does not have an `id` key specifying the type of block entity. This doesn't matter when placing the block because the block type determines the tile entity type, not the ID read from the nbt tag compound. Previously, CraftMetaBlockState expected the `id` tag except for 2 or 3 exceptions where it was manually added. Not sure why those were singled out, but now this adds a type override based on the specific material.

You can test this bug with an item like
`minecraft:chest{BlockEntityTag: {Items: [{Slot: 0b, Count: 1b, id: "minecraft:stone"}]}}` which is a chest that contains a stone block. It works when placed, but if you call getBlockState on the meta of the stack, you will get an empty chest.