### PR TITLE
send sound and particle packets immediately even if off main

### DIFF
--- a/patches/server/0297-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
+++ b/patches/server/0297-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
@@ -28,7 +28,7 @@ and then catch exceptions and close if they fire.
 Part of this commit was authored by: Spottedleaf, sandtechnology
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 25881c890c643ce90bdcda6b094d912bafb0ed75..1931db6936773657bd43b9b16de950cb3e7a2303 100644
+index 25881c890c643ce90bdcda6b094d912bafb0ed75..93d3f29b08c79479c27d3f39e6c799c705e69902 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -84,7 +84,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -238,7 +238,7 @@ index 25881c890c643ce90bdcda6b094d912bafb0ed75..1931db6936773657bd43b9b16de950cb
                  // Paper start - Add PlayerConnectionCloseEvent
                  final PacketListener packetListener = this.getPacketListener();
                  if (packetListener instanceof net.minecraft.server.network.ServerCommonPacketListenerImpl commonPacketListener) {
-@@ -680,4 +764,89 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -680,4 +764,93 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
      public void setBandwidthLogger(SampleLogger log) {
          this.bandwidthDebugMonitor = new BandwidthDebugMonitor(log);
      }
@@ -292,6 +292,10 @@ index 25881c890c643ce90bdcda6b094d912bafb0ed75..1931db6936773657bd43b9b16de950cb
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundSetActionBarTextPacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundSetTitlesAnimationPacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundClearTitlesPacket ||
++                packet instanceof net.minecraft.network.protocol.game.ClientboundSoundPacket ||
++                packet instanceof net.minecraft.network.protocol.game.ClientboundSoundEntityPacket ||
++                packet instanceof net.minecraft.network.protocol.game.ClientboundStopSoundPacket ||
++                packet instanceof net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket ||
 +                packet instanceof net.minecraft.network.protocol.game.ClientboundBossEventPacket;
 +        }
 +    }


### PR DESCRIPTION
@bergerkiller reported that on Paper specifically, smooth sounds were getting messed up and I think this is the culprit. He'll test and confirm. Paper's network optimizations include a bit that makes packets dispatched async transfer to the main thread with the reasoning that 3rd party packet listeners like from protocollib mutate world state in those listeners and this makes that safer.

I'm curious if people think we should continue to do that? Packet listeners should understand that some packets are dispatched off the main thread and they may need to sync back to the main thread to read/write world state.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-10033.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/1120124594.zip)