### PR TITLE
Scoreboard objective number format api

### DIFF
--- a/patches/api/0449-add-number-format-api.patch
+++ b/patches/api/0449-add-number-format-api.patch
@@ -1,0 +1,101 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Mayr <davidliebtkekse@gmail.com>
+Date: Sat, 16 Dec 2023 10:40:29 +0100
+Subject: [PATCH] add number format api
+
+
+diff --git a/src/main/java/io/papermc/paper/scoreboard/numbers/BlankFormat.java b/src/main/java/io/papermc/paper/scoreboard/numbers/BlankFormat.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..956f0e0e8c89713e354ae77656f731104b2a1a77
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/scoreboard/numbers/BlankFormat.java
+@@ -0,0 +1,17 @@
++package io.papermc.paper.scoreboard.numbers;
++
++/*
++ * A scoreboard number format that completely hides the score number.
++ */
++public final class BlankFormat implements NumberFormat {
++
++    private static final BlankFormat INSTANCE = new BlankFormat();
++
++    BlankFormat() {}
++
++    public static BlankFormat blank() {
++        return BlankFormat.INSTANCE;
++    }
++
++
++}
+diff --git a/src/main/java/io/papermc/paper/scoreboard/numbers/FixedFormat.java b/src/main/java/io/papermc/paper/scoreboard/numbers/FixedFormat.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..a205143227b44a19fe5ebaf4933c746353664813
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/scoreboard/numbers/FixedFormat.java
+@@ -0,0 +1,8 @@
++package io.papermc.paper.scoreboard.numbers;
++
++import net.kyori.adventure.text.Component;
++
++/*
++ * A scoreboard number format that replaces the score number with a chat component.
++ */
++public record FixedFormat(Component component) implements NumberFormat {}
+diff --git a/src/main/java/io/papermc/paper/scoreboard/numbers/NumberFormat.java b/src/main/java/io/papermc/paper/scoreboard/numbers/NumberFormat.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9fbc6e4fe2ba23d34fe0c85dbee2d5c63e5cdb1f
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/scoreboard/numbers/NumberFormat.java
+@@ -0,0 +1,6 @@
++package io.papermc.paper.scoreboard.numbers;
++
++/*
++ * Describes a scoreboard number format that applies custom formatting to scoreboard scores.
++ */
++public sealed interface NumberFormat permits BlankFormat, FixedFormat, StyledFormat {}
+diff --git a/src/main/java/io/papermc/paper/scoreboard/numbers/StyledFormat.java b/src/main/java/io/papermc/paper/scoreboard/numbers/StyledFormat.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..73c1e5990ca8af18dcdea4bdd275ee3c8f882f61
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/scoreboard/numbers/StyledFormat.java
+@@ -0,0 +1,17 @@
++package io.papermc.paper.scoreboard.numbers;
++
++import net.kyori.adventure.text.format.NamedTextColor;
++import net.kyori.adventure.text.format.Style;
++
++/*
++ * A scoreboard number format that applies a custom formatting to the score number.
++ */
++public record StyledFormat(Style style) implements NumberFormat {
++
++    public static final StyledFormat NO_STYLE = new StyledFormat(Style.empty());
++
++    public static final StyledFormat SIDEBAR_DEFAULT = new StyledFormat(Style.empty().color(NamedTextColor.RED));
++
++    public static final StyledFormat PLAYER_LIST_DEFAULT = new StyledFormat(Style.empty().color(NamedTextColor.YELLOW));
++
++}
+diff --git a/src/main/java/org/bukkit/scoreboard/Objective.java b/src/main/java/org/bukkit/scoreboard/Objective.java
+index a193ffabb05160b462dee1ba8f687fdbc84405b6..3aba9fc61378421ebc2d2ab46b555fe7cd99474a 100644
+--- a/src/main/java/org/bukkit/scoreboard/Objective.java
++++ b/src/main/java/org/bukkit/scoreboard/Objective.java
+@@ -175,4 +175,18 @@ public interface Objective {
+      */
+     @NotNull Score getScoreFor(@NotNull org.bukkit.entity.Entity entity) throws IllegalArgumentException, IllegalStateException;
+     // Paper end - improve scoreboard entries
++
++    //Paper start - number format
++    /*
++     * Gets the number format for this objective's entries (scores)
++     * @return this objective's number format
++     */
++    @Nullable io.papermc.paper.scoreboard.numbers.NumberFormat getNumberFormat();
++
++    /*
++     * Gets the number format for this objective's entries (scores)
++     * @param format the number format to set
++     */
++    void setNumberFormat(@Nullable io.papermc.paper.scoreboard.numbers.NumberFormat format);
++    //Paper end
+ }

--- a/patches/server/1052-add-number-format-api.patch
+++ b/patches/server/1052-add-number-format-api.patch
@@ -1,0 +1,111 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Mayr <davidliebtkekse@gmail.com>
+Date: Sat, 16 Dec 2023 10:40:29 +0100
+Subject: [PATCH] add number format api
+
+
+diff --git a/src/main/java/net/minecraft/network/chat/numbers/FixedFormat.java b/src/main/java/net/minecraft/network/chat/numbers/FixedFormat.java
+index 2b9f393062444a663dcd25c78f9471beda65ccf0..eb0c12016a5ef1221a3d312b71c160f03124acaf 100644
+--- a/src/main/java/net/minecraft/network/chat/numbers/FixedFormat.java
++++ b/src/main/java/net/minecraft/network/chat/numbers/FixedFormat.java
+@@ -5,6 +5,7 @@ import net.minecraft.network.FriendlyByteBuf;
+ import net.minecraft.network.chat.Component;
+ import net.minecraft.network.chat.ComponentSerialization;
+ import net.minecraft.network.chat.MutableComponent;
++import net.minecraft.network.chat.Style;
+ 
+ public class FixedFormat implements NumberFormat {
+     public static final NumberFormatType<FixedFormat> TYPE = new NumberFormatType<FixedFormat>() {
+@@ -38,6 +39,7 @@ public class FixedFormat implements NumberFormat {
+     public MutableComponent format(int number) {
+         return this.value.copy();
+     }
++    public Component getValue() { return this.value; } //Paper - make number formats accessible
+ 
+     @Override
+     public NumberFormatType<FixedFormat> type() {
+diff --git a/src/main/java/net/minecraft/network/chat/numbers/StyledFormat.java b/src/main/java/net/minecraft/network/chat/numbers/StyledFormat.java
+index 6a0700e2e88ebdd91a731084a3cf83b50f768730..6c1b586477ca6f86a05a53b2fc3ef6f345d8ab0d 100644
+--- a/src/main/java/net/minecraft/network/chat/numbers/StyledFormat.java
++++ b/src/main/java/net/minecraft/network/chat/numbers/StyledFormat.java
+@@ -43,7 +43,7 @@ public class StyledFormat implements NumberFormat {
+     public MutableComponent format(int number) {
+         return Component.literal(Integer.toString(number)).withStyle(this.style);
+     }
+-
++    public Style getStyle() { return this.style; } //Paper - make number formats accessible
+     @Override
+     public NumberFormatType<StyledFormat> type() {
+         return TYPE;
+diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
+index 3157f3d2f9ce7af4a763203672817a7f5c7bd4fb..03912118f9b7c15c73ee6cf0cd2da08bf05c3a8b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
++++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
+@@ -152,6 +152,67 @@ final class CraftObjective extends CraftScoreboardComponent implements Objective
+     }
+     // Paper end
+ 
++    //Paper start - add number format
++    @Override
++    public io.papermc.paper.scoreboard.numbers.NumberFormat getNumberFormat() {
++        net.minecraft.network.chat.numbers.NumberFormat vanilla = this.objective.numberFormat();
++        
++        if(vanilla == null) {
++            return null;
++        }
++
++        if (vanilla instanceof net.minecraft.network.chat.numbers.StyledFormat styled) {
++            com.google.gson.JsonElement json = net.minecraft.Util
++                .getOrThrow(
++                    net.minecraft.network.chat.Style.Serializer.CODEC
++                        .encodeStart(com.mojang.serialization.JsonOps.INSTANCE, styled.getStyle()),
++                    com.google.gson.JsonParseException::new
++                );
++
++            net.kyori.adventure.text.format.Style adventureStyle =
++                net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.gson()
++                    .serializer().fromJson(json, net.kyori.adventure.text.format.Style.class);
++
++            return new io.papermc.paper.scoreboard.numbers.StyledFormat(adventureStyle);
++        } else if (vanilla instanceof net.minecraft.network.chat.numbers.FixedFormat fixed) {
++            return new io.papermc.paper.scoreboard.numbers.FixedFormat(io.papermc.paper.adventure.PaperAdventure.asAdventure(fixed.getValue()));
++        } else if(vanilla instanceof net.minecraft.network.chat.numbers.BlankFormat) {
++            return io.papermc.paper.scoreboard.numbers.BlankFormat.blank();
++        }
++
++        throw new IllegalArgumentException("Unknown format type " + vanilla.getClass());
++    }
++
++
++    @Override
++    public void setNumberFormat(io.papermc.paper.scoreboard.numbers.NumberFormat format) {
++        if(format == null) {
++            this.objective.setNumberFormat(null);
++            return;
++        }
++
++        net.minecraft.network.chat.numbers.NumberFormat vanilla;
++        if (format instanceof io.papermc.paper.scoreboard.numbers.StyledFormat styled) {
++            com.google.gson.JsonElement json = net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.gson().serializer()
++                .toJsonTree(styled.style());
++            net.minecraft.network.chat.Style vanillaStyle = net.minecraft.Util
++                .getOrThrow(net.minecraft.network.chat.Style.Serializer.CODEC
++                .parse(com.mojang.serialization.JsonOps.INSTANCE, json), com.google.gson.JsonParseException::new);
++
++            vanilla = new net.minecraft.network.chat.numbers.StyledFormat(vanillaStyle);
++        } else if (format instanceof io.papermc.paper.scoreboard.numbers.FixedFormat fixed) {
++            vanilla = new net.minecraft.network.chat.numbers.FixedFormat(io.papermc.paper.adventure.PaperAdventure
++                .asVanilla(fixed.component()));
++        } else if(format instanceof io.papermc.paper.scoreboard.numbers.BlankFormat) {
++            vanilla = net.minecraft.network.chat.numbers.BlankFormat.INSTANCE;
++        } else {
++            throw new IllegalArgumentException("Unknown format type " + format.getClass());
++        }
++
++        this.objective.setNumberFormat(vanilla);
++    }
++    //Paper end - add number format
++
+     @Override
+     public void unregister() {
+         CraftScoreboard scoreboard = this.checkState();


### PR DESCRIPTION
This PR introduces an easily accessible number format API (using adventure styles and components) for scoreboard objectives for a feature introduced in 1.20.3. 

Setting a number format can be as easy as this:
```java
//Remove numbers
objective.setNumberFormat(BlankFormat.blank());

//Style numbers
objective.setNumberFormat(new StyledFormat(Style.style().color(NamedTextColor.GREEN).decorate(TextDecoration.BOLD).build()));

//Replace numbers
objective.setNumberFormat(new FixedFormat(Component.text("Lol")));
```

As for the implementation: The conversion between the Adventure style and Mojangs implementation is a bit messy.  The only other way I can think of to implement this is manually converting every style property. As paper doesn't even do that with chat components either, I have decided to just serialize and deserialize again. 