### PR TITLE
Fix world border edge collision

### DIFF
--- a/patches/server/0719-Collision-optimisations.patch
+++ b/patches/server/0719-Collision-optimisations.patch
@@ -105,10 +105,10 @@ index be668387f65a633c6ac497fca632a4767a1bf3a2..e08f4e39db4ee3fed62e37364d17dcc5
  }
 diff --git a/src/main/java/io/papermc/paper/util/CollisionUtil.java b/src/main/java/io/papermc/paper/util/CollisionUtil.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..acd8470b108432ac82e1d2f6efcaabd5540214c2
+index 0000000000000000000000000000000000000000..ee0331a6bc40cdde08d926fd8eb1dc642630c2e5
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/CollisionUtil.java
-@@ -0,0 +1,1850 @@
+@@ -0,0 +1,1851 @@
 +package io.papermc.paper.util;
 +
 +import io.papermc.paper.util.collisions.CachedShapeData;
@@ -1655,11 +1655,12 @@ index 0000000000000000000000000000000000000000..acd8470b108432ac82e1d2f6efcaabd5
 +
 +    public static boolean isCollidingWithBorder(final WorldBorder worldborder, final double boxMinX, final double boxMaxX,
 +                                                final double boxMinZ, final double boxMaxZ) {
-+        final double borderMinX = worldborder.getMinX(); // -X
-+        final double borderMaxX = worldborder.getMaxX(); // +X
++        // border size is rounded like the collide voxel shape of the border
++        final double borderMinX = Math.floor(worldborder.getMinX()); // -X
++        final double borderMaxX = Math.ceil(worldborder.getMaxX()); // +X
 +
-+        final double borderMinZ = worldborder.getMinZ(); // -Z
-+        final double borderMaxZ = worldborder.getMaxZ(); // +Z
++        final double borderMinZ = Math.floor(worldborder.getMinZ()); // -Z
++        final double borderMaxZ = Math.ceil(worldborder.getMaxZ()); // +Z
 +
 +        // inverted check for world border enclosing the specified box expanded by -EPSILON
 +        return (borderMinX - boxMinX) > CollisionUtil.COLLISION_EPSILON || (borderMaxX - boxMaxX) < -CollisionUtil.COLLISION_EPSILON ||


### PR DESCRIPTION
The collision at the edge is done using the voxelshape of the worldborder which is rounded. Since Paper doesn't use the voxelshape of the border some issues happens when the half size is not an integer.

Closes #9859 #9805