### PR TITLE
Remove Keyed from Registry generic qualifier

### DIFF
--- a/patches/api/0487-Remove-Keyed-from-Registry-generic-qualifier.patch
+++ b/patches/api/0487-Remove-Keyed-from-Registry-generic-qualifier.patch
@@ -1,0 +1,150 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 20 Dec 2023 02:03:10 -0800
+Subject: [PATCH] Remove Keyed from Registry generic qualifier
+
+Keyed is no longer viable for future/current registry types.
+
+diff --git a/src/main/java/org/bukkit/Art.java b/src/main/java/org/bukkit/Art.java
+index dbbd997d4693f1d9f551bae2ed1d7906c9f39c12..808633907b21528d9d0af1f13cbd1fb4b783c2e1 100644
+--- a/src/main/java/org/bukkit/Art.java
++++ b/src/main/java/org/bukkit/Art.java
+@@ -105,7 +105,7 @@ public enum Art implements Keyed {
+ 
+     // Paper start - deprecate getKey
+     /**
+-     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#ART}. Painting variants
++     * @deprecated use {@link Registry#getKey(Object)} and {@link Registry#ART}. Painting variants
+      * can exist without a key.
+      */
+     @Deprecated(since = "1.21")
+diff --git a/src/main/java/org/bukkit/MusicInstrument.java b/src/main/java/org/bukkit/MusicInstrument.java
+index 98fdfc8978fea1937e31a7427433a1927d42ec7d..2a46d9d24afcffa26fa3ad398abddd0ed32351b8 100644
+--- a/src/main/java/org/bukkit/MusicInstrument.java
++++ b/src/main/java/org/bukkit/MusicInstrument.java
+@@ -55,7 +55,7 @@ public abstract class MusicInstrument implements Keyed, net.kyori.adventure.tran
+ 
+     // Paper start - deprecate getKey
+     /**
+-     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#INSTRUMENT}. MusicInstruments
++     * @deprecated use {@link Registry#getKey(Object)} and {@link Registry#INSTRUMENT}. MusicInstruments
+      * can exist without a key.
+      */
+     @Deprecated(forRemoval = true, since = "1.20.5")
+diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
+index 20015393f91af405c99db2635a471fb6ff19e4bf..3a222cad7310f19b02471b04f1f24c8ef283655f 100644
+--- a/src/main/java/org/bukkit/Registry.java
++++ b/src/main/java/org/bukkit/Registry.java
+@@ -43,7 +43,7 @@ import org.jetbrains.annotations.Nullable;
+  *
+  * @param <T> type of item in the registry
+  */
+-public interface Registry<T extends Keyed> extends Iterable<T> {
++public interface Registry<T> extends Iterable<T> { // Paper - improve Registry
+ 
+     /**
+      * Server advancements.
+@@ -421,7 +421,7 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      * @param value the value to get the key of in this registry
+      * @return the key for the value
+      * @throws java.util.NoSuchElementException if the value doesn't exist in this registry
+-     * @see #getKey(Keyed)
++     * @see #getKey(Object)
+      */
+     default @NotNull NamespacedKey getKeyOrThrow(final @NotNull T value) {
+         Preconditions.checkArgument(value != null, "value cannot be null");
+@@ -441,13 +441,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+      *
+      * @param value the value to get the key of in this registry
+      * @return the key for the value or null if not in the registry
+-     * @see #getKeyOrThrow(Keyed)
++     * @see #getKeyOrThrow(Object)
+      */
+     default @Nullable NamespacedKey getKey(final @NotNull T value) {
+         Preconditions.checkArgument(value != null, "value cannot be null");
+-        //noinspection ConstantValue (it might not be in the future...)
+-        if (value instanceof Keyed) {
+-            return value.getKey();
++        if (value instanceof final Keyed keyed) {
++            return keyed.getKey();
+         }
+         return null;
+     }
+diff --git a/src/main/java/org/bukkit/Sound.java b/src/main/java/org/bukkit/Sound.java
+index 7a35120c82b88774de777d3c3176ef553a8e9244..f67749a4e1072a3d604cfc9d0d9e84fd02796a64 100644
+--- a/src/main/java/org/bukkit/Sound.java
++++ b/src/main/java/org/bukkit/Sound.java
+@@ -1638,7 +1638,7 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
+ 
+     // Paper start - deprecate getKey
+     /**
+-     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#SOUNDS}. Sounds
++     * @deprecated use {@link Registry#getKey(Object)} and {@link Registry#SOUNDS}. Sounds
+      * can exist without a key.
+      */
+     @Deprecated(since = "1.20.5")
+diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
+index 8bfec649f7c6dda956bc388a21b489f3565ff384..0ab13cbf60bf07b6868b2cd11da6007e06474339 100644
+--- a/src/main/java/org/bukkit/Tag.java
++++ b/src/main/java/org/bukkit/Tag.java
+@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
+  *
+  * @param <T> the type of things grouped by this tag
+  */
+-public interface Tag<T extends Keyed> extends Keyed {
++public interface Tag<T> extends Keyed {
+ 
+     /**
+      * Key for the built in block registry.
+diff --git a/src/main/java/org/bukkit/block/banner/PatternType.java b/src/main/java/org/bukkit/block/banner/PatternType.java
+index e2afb2582a27b94a922754115dbb6b4ca35e0154..1ac45205c16fb0bdebea610bd88b48b757cceafc 100644
+--- a/src/main/java/org/bukkit/block/banner/PatternType.java
++++ b/src/main/java/org/bukkit/block/banner/PatternType.java
+@@ -58,7 +58,7 @@ public interface PatternType extends OldEnum<PatternType>, Keyed {
+ 
+     // Paper start - deprecate getKey
+     /**
+-     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#BANNER_PATTERN}. PatternTypes
++     * @deprecated use {@link Registry#getKey(Object)} and {@link Registry#BANNER_PATTERN}. PatternTypes
+      * can exist without a key.
+      */
+     @Deprecated(since = "1.20.5")
+diff --git a/src/main/java/org/bukkit/generator/structure/Structure.java b/src/main/java/org/bukkit/generator/structure/Structure.java
+index 978054ee364f9a3330525b9b50da5325ebb6ef57..0bb73cf7b1c2ef2e3cf0d1d9121e8b2c5a133c0d 100644
+--- a/src/main/java/org/bukkit/generator/structure/Structure.java
++++ b/src/main/java/org/bukkit/generator/structure/Structure.java
+@@ -62,7 +62,7 @@ public abstract class Structure implements Keyed {
+     public abstract StructureType getStructureType();
+     // Paper start - deprecate getKey
+     /**
+-     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#STRUCTURE}. Structures
++     * @deprecated use {@link Registry#getKey(Object)} and {@link Registry#STRUCTURE}. Structures
+      * can exist without a key.
+      */
+     @Override
+diff --git a/src/main/java/org/bukkit/inventory/meta/trim/TrimMaterial.java b/src/main/java/org/bukkit/inventory/meta/trim/TrimMaterial.java
+index 74816d6da4d7c8d2fa8a7b93fdc4bf29c8d12803..f3ce71ddf57c03c050f4832a36dff2c2714a94ac 100644
+--- a/src/main/java/org/bukkit/inventory/meta/trim/TrimMaterial.java
++++ b/src/main/java/org/bukkit/inventory/meta/trim/TrimMaterial.java
+@@ -71,7 +71,7 @@ public interface TrimMaterial extends Keyed, Translatable {
+ 
+     // Paper start - Registry#getKey
+     /**
+-     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#TRIM_MATERIAL}. TrimMaterials
++     * @deprecated use {@link Registry#getKey(Object)} and {@link Registry#TRIM_MATERIAL}. TrimMaterials
+      * can exist without a key.
+      */
+     @Deprecated(forRemoval = true, since = "1.20.4")
+diff --git a/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java b/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
+index 087e99ed281c0b282d91345067bfca80762faa0b..e0c89036e2da05e837a214f7b485ae5de6587729 100644
+--- a/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
++++ b/src/main/java/org/bukkit/inventory/meta/trim/TrimPattern.java
+@@ -103,7 +103,7 @@ public interface TrimPattern extends Keyed, Translatable {
+ 
+     // Paper start - Registry#getKey
+     /**
+-     * @deprecated use {@link Registry#getKey(Keyed)} and {@link Registry#TRIM_PATTERN}. TrimPatterns
++     * @deprecated use {@link Registry#getKey(Object)} and {@link Registry#TRIM_PATTERN}. TrimPatterns
+      * can exist without a key.
+      */
+     @Deprecated(forRemoval = true, since = "1.20.4")

--- a/patches/api/0488-remove-some-extends-Keyed-generic-qualifiers.patch
+++ b/patches/api/0488-remove-some-extends-Keyed-generic-qualifiers.patch
@@ -1,0 +1,125 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 27 Aug 2024 22:07:38 -0700
+Subject: [PATCH] remove some extends Keyed generic qualifiers
+
+
+diff --git a/src/main/java/io/papermc/paper/registry/RegistryAccess.java b/src/main/java/io/papermc/paper/registry/RegistryAccess.java
+index 86ab67ff5023bf6adea80b02648b6f67476e30e5..5cf423b1f54557ed497b2af2d6cd27b8cd1a7753 100644
+--- a/src/main/java/io/papermc/paper/registry/RegistryAccess.java
++++ b/src/main/java/io/papermc/paper/registry/RegistryAccess.java
+@@ -45,5 +45,5 @@ public interface RegistryAccess {
+      */
+     // Future note: We should have no trouble removing this generic qualifier when
+     // registry types no longer have to be "keyed" as it shouldn't break ABI or API.
+-    <T extends Keyed> @NotNull Registry<T> getRegistry(@NotNull RegistryKey<T> registryKey);
++    <T> @NotNull Registry<T> getRegistry(@NotNull RegistryKey<T> registryKey);
+ }
+diff --git a/src/main/java/io/papermc/paper/registry/event/RegistryEntryAddEvent.java b/src/main/java/io/papermc/paper/registry/event/RegistryEntryAddEvent.java
+index a5d7385eae9dfb88b52aed0e42c09a10ef807385..2f8741237a98e3d04ff47ddd312d22611a70522f 100644
+--- a/src/main/java/io/papermc/paper/registry/event/RegistryEntryAddEvent.java
++++ b/src/main/java/io/papermc/paper/registry/event/RegistryEntryAddEvent.java
+@@ -43,5 +43,5 @@ public interface RegistryEntryAddEvent<T, B extends RegistryBuilder<T>> extends
+      * @return the tag
+      * @param <V> the tag value type
+      */
+-    @NonNull <V extends Keyed> Tag<V> getOrCreateTag(@NonNull TagKey<V> tagKey);
++    @NonNull <V> Tag<V> getOrCreateTag(@NonNull TagKey<V> tagKey);
+ }
+diff --git a/src/main/java/io/papermc/paper/registry/event/RegistryFreezeEvent.java b/src/main/java/io/papermc/paper/registry/event/RegistryFreezeEvent.java
+index 12ec7e794a5047a30354a485acd40fa0f3438eea..5e67833850b160363566929a7a8bc6da7107e16e 100644
+--- a/src/main/java/io/papermc/paper/registry/event/RegistryFreezeEvent.java
++++ b/src/main/java/io/papermc/paper/registry/event/RegistryFreezeEvent.java
+@@ -35,5 +35,5 @@ public interface RegistryFreezeEvent<T, B extends RegistryBuilder<T>> extends Re
+      * @return the tag
+      * @param <V> the tag value type
+      */
+-    @NonNull <V extends Keyed> Tag<V> getOrCreateTag(@NonNull TagKey<V> tagKey);
++    @NonNull <V> Tag<V> getOrCreateTag(@NonNull TagKey<V> tagKey);
+ }
+diff --git a/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java b/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java
+index b891101b43148f63c96b7dd611914c85d7b29dbf..3683fd7222711a3c26022a291ce74fd733c1bbb1 100644
+--- a/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java
++++ b/src/main/java/io/papermc/paper/registry/set/RegistryKeySet.java
+@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Unmodifiable;
+ 
+ @ApiStatus.Experimental
+ @ApiStatus.NonExtendable
+-public non-sealed interface RegistryKeySet<T extends Keyed> extends Iterable<TypedKey<T>>, RegistrySet<T> { // TODO remove Keyed
++public non-sealed interface RegistryKeySet<T> extends Iterable<TypedKey<T>>, RegistrySet<T> {
+ 
+     @Override
+     default int size() {
+diff --git a/src/main/java/io/papermc/paper/registry/set/RegistryKeySetImpl.java b/src/main/java/io/papermc/paper/registry/set/RegistryKeySetImpl.java
+index c712181ad4c6a9d00bc04f8a48515a388c692f48..def9afa67af6c22ee8c71a30d73247e49505e485 100644
+--- a/src/main/java/io/papermc/paper/registry/set/RegistryKeySetImpl.java
++++ b/src/main/java/io/papermc/paper/registry/set/RegistryKeySetImpl.java
+@@ -18,9 +18,9 @@ import org.jetbrains.annotations.Nullable;
+ 
+ @ApiStatus.Internal
+ @DefaultQualifier(NonNull.class)
+-record RegistryKeySetImpl<T extends Keyed>(RegistryKey<T> registryKey, List<TypedKey<T>> values) implements RegistryKeySet<T> { // TODO remove Keyed
++record RegistryKeySetImpl<T>(RegistryKey<T> registryKey, List<TypedKey<T>> values) implements RegistryKeySet<T> {
+ 
+-    static <T extends Keyed> RegistryKeySet<T> create(final RegistryKey<T> registryKey, final Iterable<? extends T> values) { // TODO remove Keyed
++    static <T> RegistryKeySet<T> create(final RegistryKey<T> registryKey, final Iterable<? extends T> values) {
+         final Registry<T> registry = RegistryAccess.registryAccess().getRegistry(registryKey);
+         final ArrayList<TypedKey<T>> keys = new ArrayList<>();
+         for (final T value : values) {
+diff --git a/src/main/java/io/papermc/paper/registry/set/RegistrySet.java b/src/main/java/io/papermc/paper/registry/set/RegistrySet.java
+index 108df480e16131781a52c7bbba2ca6581e4c1ca1..f9ff65b9f556f157da562990890d3b0039b5a4d5 100644
+--- a/src/main/java/io/papermc/paper/registry/set/RegistrySet.java
++++ b/src/main/java/io/papermc/paper/registry/set/RegistrySet.java
+@@ -56,7 +56,7 @@ public sealed interface RegistrySet<T> permits RegistryKeySet, RegistryValueSet
+      * @throws IllegalArgumentException if the registry isn't available yet or if any value doesn't have a key in that registry
+      */
+     @Contract(value = "_, _ -> new", pure = true)
+-    static <T extends Keyed> @NonNull RegistryKeySet<T> keySetFromValues(final @NonNull RegistryKey<T> registryKey, final @NonNull Iterable<? extends T> values) { // TODO remove Keyed
++    static <T> @NonNull RegistryKeySet<T> keySetFromValues(final @NonNull RegistryKey<T> registryKey, final @NonNull Iterable<? extends T> values) {
+         return RegistryKeySetImpl.create(registryKey, values);
+     }
+ 
+@@ -69,7 +69,7 @@ public sealed interface RegistrySet<T> permits RegistryKeySet, RegistryValueSet
+      * @param <T> the type of the values
+      */
+     @SafeVarargs
+-    static <T extends Keyed> RegistryKeySet<T> keySet(final @NonNull RegistryKey<T> registryKey, final @NonNull TypedKey<T> @NonNull... keys) { // TODO remove Keyed
++    static <T> RegistryKeySet<T> keySet(final @NonNull RegistryKey<T> registryKey, final @NonNull TypedKey<T> @NonNull... keys) {
+         return keySet(registryKey, Lists.newArrayList(keys));
+     }
+ 
+@@ -83,7 +83,7 @@ public sealed interface RegistrySet<T> permits RegistryKeySet, RegistryValueSet
+      */
+     @SuppressWarnings("BoundedWildcard")
+     @Contract(value = "_, _ -> new", pure = true)
+-    static <T extends Keyed> @NonNull RegistryKeySet<T> keySet(final @NonNull RegistryKey<T> registryKey, final @NonNull Iterable<TypedKey<T>> keys) { // TODO remove Keyed
++    static <T> @NonNull RegistryKeySet<T> keySet(final @NonNull RegistryKey<T> registryKey, final @NonNull Iterable<TypedKey<T>> keys) {
+         return new RegistryKeySetImpl<>(registryKey, Lists.newArrayList(keys));
+     }
+ 
+diff --git a/src/main/java/io/papermc/paper/registry/tag/Tag.java b/src/main/java/io/papermc/paper/registry/tag/Tag.java
+index ae374f68ef9baa16ed90c371f1622de0c0159873..3a1f864bd9421ab38a021d272ff41e491f7cf76f 100644
+--- a/src/main/java/io/papermc/paper/registry/tag/Tag.java
++++ b/src/main/java/io/papermc/paper/registry/tag/Tag.java
+@@ -14,7 +14,7 @@ import org.jetbrains.annotations.ApiStatus;
+  * @see org.bukkit.Registry#getTag(TagKey)
+  */
+ @ApiStatus.Experimental
+-public interface Tag<T extends Keyed> extends RegistryKeySet<T> { // TODO remove Keyed
++public interface Tag<T> extends RegistryKeySet<T> {
+ 
+     /**
+      * Get the identifier for this named set.
+diff --git a/src/test/java/io/papermc/paper/registry/TestRegistryAccess.java b/src/test/java/io/papermc/paper/registry/TestRegistryAccess.java
+index f5ece852f97017f71bc129e194cb212979b2537b..b1ac725ef5ea408b2c7f884787446fd371fd7ea7 100644
+--- a/src/test/java/io/papermc/paper/registry/TestRegistryAccess.java
++++ b/src/test/java/io/papermc/paper/registry/TestRegistryAccess.java
+@@ -14,7 +14,7 @@ public class TestRegistryAccess implements RegistryAccess {
+     }
+ 
+     @Override
+-    public @NotNull <T extends Keyed> Registry<T> getRegistry(final @NotNull RegistryKey<T> registryKey) {
++    public <T> @NotNull Registry<T> getRegistry(final @NotNull RegistryKey<T> registryKey) {
+         throw new UnsupportedOperationException("Not supported");
+     }
+ }

--- a/patches/server/1057-Remove-Keyed-from-Registry-generic-qualifier.patch
+++ b/patches/server/1057-Remove-Keyed-from-Registry-generic-qualifier.patch
@@ -1,0 +1,149 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 20 Dec 2023 02:03:05 -0800
+Subject: [PATCH] Remove Keyed from Registry generic qualifier
+
+Keyed is no longer viable for future/current registry types.
+
+diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/bytecode/PaperClassloaderBytecodeModifier.java b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/bytecode/PaperClassloaderBytecodeModifier.java
+index d7a789af72e5a1ef5e42c7e855897b65fdeda805..f0383c6df4d8ce15f2e04bf589e0c9524e07befb 100644
+--- a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/bytecode/PaperClassloaderBytecodeModifier.java
++++ b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/bytecode/PaperClassloaderBytecodeModifier.java
+@@ -3,6 +3,7 @@ package io.papermc.paper.plugin.entrypoint.classloader.bytecode;
+ import com.google.common.collect.Iterators;
+ import io.papermc.paper.plugin.configuration.PluginMeta;
+ import io.papermc.paper.plugin.entrypoint.classloader.ClassloaderBytecodeModifier;
++import io.papermc.paper.plugin.entrypoint.classloader.bytecode.versions.API_1_21_1;
+ import java.util.Iterator;
+ import java.util.LinkedHashMap;
+ import java.util.List;
+@@ -15,6 +16,7 @@ import org.objectweb.asm.Opcodes;
+ public class PaperClassloaderBytecodeModifier implements ClassloaderBytecodeModifier {
+ 
+     private static final Map<ApiVersion, List<ModifierFactory>> MODIFIERS = Util.make(new LinkedHashMap<>(), map -> {
++        map.put(API_1_21_1.API_VERSION, List.of(API_1_21_1::new));
+     });
+ 
+     private final Map<ApiVersion, List<VersionedClassloaderBytecodeModifier>> constructedModifiers = MODIFIERS.entrySet().stream()
+diff --git a/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/bytecode/versions/API_1_21_1.java b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/bytecode/versions/API_1_21_1.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..e8175d837d611270e873693e88355512a3ec794d
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/plugin/entrypoint/classloader/bytecode/versions/API_1_21_1.java
+@@ -0,0 +1,72 @@
++package io.papermc.paper.plugin.entrypoint.classloader.bytecode.versions;
++
++import io.papermc.asm.rules.RewriteRule;
++import io.papermc.asm.rules.builder.matcher.method.MethodMatcher;
++import io.papermc.asm.rules.builder.matcher.method.targeted.TargetedMethodMatcher;
++import io.papermc.paper.plugin.entrypoint.classloader.bytecode.VersionedClassloaderBytecodeModifier;
++import java.lang.constant.ClassDesc;
++import java.lang.constant.ConstantDescs;
++import java.lang.reflect.Method;
++import org.bukkit.Keyed;
++import org.bukkit.NamespacedKey;
++import org.bukkit.Registry;
++import org.bukkit.Tag;
++import org.bukkit.craftbukkit.util.ApiVersion;
++import org.checkerframework.checker.nullness.qual.Nullable;
++
++import static io.papermc.asm.rules.RewriteRule.chain;
++import static io.papermc.asm.util.DescriptorUtils.desc;
++
++public class API_1_21_1 extends VersionedClassloaderBytecodeModifier {
++
++    public static final ApiVersion API_VERSION = ApiVersion.getOrCreateVersion("1.21.1");
++
++    private static final Method REGISTRY_KEYED_HANDLER;
++    static {
++        try {
++            REGISTRY_KEYED_HANDLER = API_1_21_1.class.getDeclaredMethod("tryCastKeyed", Object.class);
++        } catch (final ReflectiveOperationException exception) {
++            throw new RuntimeException(exception);
++        }
++    }
++
++    private static final ClassDesc KEYED = desc(Keyed.class);
++    private static final ClassDesc NAMESPACED_KEY = desc(NamespacedKey.class);
++
++    public API_1_21_1(final int api) {
++        super(api);
++    }
++
++    @Override
++    protected RewriteRule createRule() {
++        return chain(
++            this.forOwnerClass(Registry.class, rf -> {
++                rf.changeReturnTypeDirect(
++                    Object.class,
++                    REGISTRY_KEYED_HANDLER,
++                    TargetedMethodMatcher.builder()
++                        .match("get", b -> b.itf().hasParam(NAMESPACED_KEY, 0))
++                        .targetReturn(KEYED)
++                        .build()
++                    );
++            }),
++            this.forOwnerClass(Tag.class, rf -> {
++                rf.changeParamToSuper(
++                    KEYED,
++                    ConstantDescs.CD_Object,
++                    MethodMatcher.builder()
++                        .match("isTagged", b -> b.hasParam(KEYED, 0))
++                        .build()
++                );
++            })
++        );
++    }
++
++    public static @Nullable Keyed tryCastKeyed(final @Nullable Object maybeKeyed) {
++        if (maybeKeyed == null) return null;
++        if (maybeKeyed instanceof final Keyed keyed) {
++            return keyed;
++        }
++        throw new IllegalStateException(maybeKeyed + " does not implement Keyed");
++    }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+index cacbb35d365c66881f2a42d099bb88c494b584ee..711f0949444d24e7a354e96e05b90d69351dafe2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
+@@ -56,7 +56,7 @@ import org.bukkit.map.MapCursor;
+ import org.bukkit.potion.PotionEffectType;
+ import org.jetbrains.annotations.NotNull;
+ 
+-public class CraftRegistry<B extends Keyed, M> implements Registry<B> {
++public class CraftRegistry<B, M> implements Registry<B> { // Paper - improve Registry
+ 
+     private static RegistryAccess registry;
+ 
+diff --git a/src/test/java/org/bukkit/registry/PerRegistryTest.java b/src/test/java/org/bukkit/registry/PerRegistryTest.java
+index dad7935f9a4c7c8bb2a755cc0631330a59834233..05d8f3ed102a7e1399d234107d85a48832983efa 100644
+--- a/src/test/java/org/bukkit/registry/PerRegistryTest.java
++++ b/src/test/java/org/bukkit/registry/PerRegistryTest.java
+@@ -48,7 +48,7 @@ public class PerRegistryTest extends AbstractTestingBase {
+ 
+     @ParameterizedTest
+     @MethodSource("data")
+-    public <T extends Keyed> void testGet(Registry<T> registry) { // Paper - improve Registry
++    public <T> void testGet(Registry<T> registry) { // Paper - improve Registry
+         registry.forEach(element -> {
+             NamespacedKey key = registry.getKey(element); // Paper - improve Registry
+             assertNotNull(key); // Paper - improve Registry
+@@ -60,7 +60,7 @@ public class PerRegistryTest extends AbstractTestingBase {
+ 
+     @ParameterizedTest
+     @MethodSource("data")
+-    public <T extends Keyed> void testMatch(Registry<T> registry) { // Paper - improve Registry
++    public <T> void testMatch(Registry<T> registry) { // Paper - improve Registry
+         registry.forEach(element -> {
+             NamespacedKey key = registry.getKey(element); // Paper - improve Registry
+             assertNotNull(key); // Paper - improve Registry
+@@ -74,7 +74,7 @@ public class PerRegistryTest extends AbstractTestingBase {
+         });
+     }
+ 
+-    private <T extends Keyed> void assertSameMatchWithKeyMessage(Registry<T> registry, T element, String key) { // Paper - improve Registry
++    private <T> void assertSameMatchWithKeyMessage(Registry<T> registry, T element, String key) { // Paper - improve Registry
+         assertSame(element, registry.match(key), key);
+     }
+ 

--- a/patches/server/1058-remove-some-extends-Keyed-generic-qualifiers.patch
+++ b/patches/server/1058-remove-some-extends-Keyed-generic-qualifiers.patch
@@ -1,0 +1,437 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 27 Aug 2024 22:07:29 -0700
+Subject: [PATCH] remove some extends Keyed generic qualifiers
+
+
+diff --git a/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java b/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
+index 38fb7d13abfcb55fe4a132b9b27e0c91f8c3d891..ca713fbf5561ea1432c66119561874761a5c9373 100644
+--- a/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
++++ b/src/main/java/io/papermc/paper/command/brigadier/argument/VanillaArgumentProviderImpl.java
+@@ -304,13 +304,7 @@ public class VanillaArgumentProviderImpl implements VanillaArgumentProvider {
+ 
+     @Override
+     public <T> ArgumentType<T> resource(final RegistryKey<T> registryKey) {
+-        return this.resourceRaw(registryKey);
+-    }
+-
+-    @SuppressWarnings({"unchecked", "rawtypes", "UnnecessaryLocalVariable"})
+-    private <T, K extends Keyed> ArgumentType<T> resourceRaw(final RegistryKey registryKeyRaw) { // TODO remove Keyed
+-        final RegistryKey<K> registryKey = registryKeyRaw;
+-        return (ArgumentType<T>) this.wrap(
++        return this.wrap(
+             ResourceArgument.resource(PaperCommands.INSTANCE.getBuildContext(), PaperRegistries.registryToNms(registryKey)),
+             resource -> requireNonNull(
+                 RegistryAccess.registryAccess()
+diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistries.java b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
+index 6ec9d9b9acf557aa2ebf39d38a14225b0205fae1..1149ee93289ed4ae993972e8a68299f160eb1a60 100644
+--- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
++++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
+@@ -114,12 +114,12 @@ public final class PaperRegistries {
+     }
+ 
+     @SuppressWarnings("unchecked")
+-    public static <M, T extends Keyed> @Nullable RegistryEntry<M, T> getEntry(final ResourceKey<? extends Registry<M>> resourceKey) {
++    public static <M, T> @Nullable RegistryEntry<M, T> getEntry(final ResourceKey<? extends Registry<M>> resourceKey) {
+         return (RegistryEntry<M, T>) BY_RESOURCE_KEY.get(resourceKey);
+     }
+ 
+     @SuppressWarnings("unchecked")
+-    public static <M, T extends Keyed> @Nullable RegistryEntry<M, T> getEntry(final RegistryKey<? super T> registryKey) {
++    public static <M, T> @Nullable RegistryEntry<M, T> getEntry(final RegistryKey<? super T> registryKey) {
+         return (RegistryEntry<M, T>) BY_REGISTRY_KEY.get(registryKey);
+     }
+ 
+diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java b/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java
+index f05ebf453406a924da3de6fb250f4793a1b3c612..324cca4d7e276fe11c9d6f93a0a4fa3405419171 100644
+--- a/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java
++++ b/src/main/java/io/papermc/paper/registry/PaperRegistryAccess.java
+@@ -67,7 +67,7 @@ public class PaperRegistryAccess implements RegistryAccess {
+ 
+     @SuppressWarnings("unchecked")
+     @Override
+-    public <T extends Keyed> Registry<T> getRegistry(final RegistryKey<T> key) {
++    public <T> Registry<T> getRegistry(final RegistryKey<T> key) {
+         if (PaperRegistries.getEntry(key) == null) {
+             throw new NoSuchElementException(key + " is not a valid registry key");
+         }
+@@ -80,7 +80,7 @@ public class PaperRegistryAccess implements RegistryAccess {
+         return possiblyUnwrap(registryHolder.get());
+     }
+ 
+-    public <M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> WritableCraftRegistry<M, T, B> getWritableRegistry(final RegistryKey<T> key) {
++    public <M, T, B extends PaperRegistryBuilder<M, T>> WritableCraftRegistry<M, T, B> getWritableRegistry(final RegistryKey<T> key) {
+         final Registry<T> registry = this.getRegistry(key);
+         if (registry instanceof WritableCraftRegistry<?, T, ?>) {
+             return (WritableCraftRegistry<M, T, B>) registry;
+@@ -88,7 +88,7 @@ public class PaperRegistryAccess implements RegistryAccess {
+         throw new IllegalArgumentException(key + " does not point to a writable registry");
+     }
+ 
+-    private static <T extends Keyed> Registry<T> possiblyUnwrap(final Registry<T> registry) {
++    private static <T> Registry<T> possiblyUnwrap(final Registry<T> registry) {
+         if (registry instanceof final DelayedRegistry<T, ?> delayedRegistry) { // if not coming from legacy, unwrap the delayed registry
+             return delayedRegistry.delegate();
+         }
+@@ -104,7 +104,7 @@ public class PaperRegistryAccess implements RegistryAccess {
+     }
+ 
+     @SuppressWarnings("unchecked") // this method should be called right after any new MappedRegistry instances are created to later be used by the server.
+-    private <M, B extends Keyed, R extends Registry<B>> void registerRegistry(final ResourceKey<? extends net.minecraft.core.Registry<M>> resourceKey, final net.minecraft.core.Registry<M> registry, final boolean replace) {
++    private <M, B, R extends Registry<B>> void registerRegistry(final ResourceKey<? extends net.minecraft.core.Registry<M>> resourceKey, final net.minecraft.core.Registry<M> registry, final boolean replace) {
+         final @Nullable RegistryEntry<M, B> entry = PaperRegistries.getEntry(resourceKey);
+         if (entry == null) { // skip registries that don't have API entries
+             return;
+diff --git a/src/main/java/io/papermc/paper/registry/PaperRegistryListenerManager.java b/src/main/java/io/papermc/paper/registry/PaperRegistryListenerManager.java
+index a7f2b264d4f37f5293ae72195b4c78faf35351c9..8529fe4cb36f02f4d2459c03e183a2e8b5e2f859 100644
+--- a/src/main/java/io/papermc/paper/registry/PaperRegistryListenerManager.java
++++ b/src/main/java/io/papermc/paper/registry/PaperRegistryListenerManager.java
+@@ -86,8 +86,7 @@ public final class PaperRegistryListenerManager {
+         this.registerWithListeners(registry, key, nms, registrationInfo, WritableRegistry::register, conversions);
+     }
+ 
+-    // TODO remove Keyed
+-    public <M, T extends org.bukkit.Keyed, B extends PaperRegistryBuilder<M, T>, R> R registerWithListeners(
++    public <M, T, B extends PaperRegistryBuilder<M, T>, R> R registerWithListeners(
+         final Registry<M> registry,
+         final ResourceKey<M> key,
+         final M nms,
+@@ -106,7 +105,7 @@ public final class PaperRegistryListenerManager {
+         return this.registerWithListeners(registry, modifiableEntry, key, nms, builder, registrationInfo, registerMethod, conversions);
+     }
+ 
+-    <M, T extends org.bukkit.Keyed, B extends PaperRegistryBuilder<M, T>> void registerWithListeners( // TODO remove Keyed
++    <M, T, B extends PaperRegistryBuilder<M, T>> void registerWithListeners(
+         final WritableRegistry<M> registry,
+         final RegistryEntryInfo<M, T> entry,
+         final ResourceKey<M> key,
+@@ -121,7 +120,7 @@ public final class PaperRegistryListenerManager {
+         this.registerWithListeners(registry, RegistryEntry.Modifiable.asModifiable(entry), key, null, builder, registrationInfo, WritableRegistry::register, conversions);
+     }
+ 
+-    public <M, T extends org.bukkit.Keyed, B extends PaperRegistryBuilder<M, T>, R> R registerWithListeners( // TODO remove Keyed
++    public <M, T, B extends PaperRegistryBuilder<M, T>, R> R registerWithListeners(
+         final Registry<M> registry,
+         final RegistryEntry.Modifiable<M, T, B> entry,
+         final ResourceKey<M> key,
+@@ -156,7 +155,7 @@ public final class PaperRegistryListenerManager {
+         R register(WritableRegistry<M> writableRegistry, ResourceKey<M> key, M value, RegistrationInfo registrationInfo);
+     }
+ 
+-    public <M, T extends org.bukkit.Keyed, B extends PaperRegistryBuilder<M, T>> void runFreezeListeners(final ResourceKey<? extends Registry<M>> resourceKey, final Conversions conversions) {
++    public <M, T, B extends PaperRegistryBuilder<M, T>> void runFreezeListeners(final ResourceKey<? extends Registry<M>> resourceKey, final Conversions conversions) {
+         final @Nullable RegistryEntryInfo<M, T> entry = PaperRegistries.getEntry(resourceKey);
+         if (!RegistryEntry.Addable.isAddable(entry) || !this.freezeHooks.hasHooks(entry.apiKey())) {
+             return;
+diff --git a/src/main/java/io/papermc/paper/registry/RegistryHolder.java b/src/main/java/io/papermc/paper/registry/RegistryHolder.java
+index a31bdd9f02fe75a87fceb2ebe8c36b3232a561cc..8724eaf02a57452953f085e8b1becccddf7a2781 100644
+--- a/src/main/java/io/papermc/paper/registry/RegistryHolder.java
++++ b/src/main/java/io/papermc/paper/registry/RegistryHolder.java
+@@ -10,11 +10,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
+ import org.checkerframework.framework.qual.DefaultQualifier;
+ 
+ @DefaultQualifier(NonNull.class)
+-public interface RegistryHolder<B extends Keyed> {
++public interface RegistryHolder<B> {
+ 
+     Registry<B> get();
+ 
+-    final class Memoized<B extends Keyed, R extends Registry<B>> implements RegistryHolder<B> {
++    final class Memoized<B, R extends Registry<B>> implements RegistryHolder<B> {
+ 
+         private final Supplier<R> memoizedSupplier;
+ 
+@@ -27,7 +27,7 @@ public interface RegistryHolder<B extends Keyed> {
+         }
+     }
+ 
+-    final class Delayed<B extends Keyed, R extends Registry<B>> implements RegistryHolder<B> {
++    final class Delayed<B, R extends Registry<B>> implements RegistryHolder<B> {
+ 
+         private final DelayedRegistry<B, R> delayedRegistry = new DelayedRegistry<>();
+ 
+diff --git a/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java b/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java
+index 78317c7ab42a666f19634593a8f3b696700764c8..bb71763a5374c91e4dbcaa5e283aed2b73cf0eda 100644
+--- a/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java
++++ b/src/main/java/io/papermc/paper/registry/WritableCraftRegistry.java
+@@ -17,7 +17,7 @@ import org.bukkit.craftbukkit.CraftRegistry;
+ import org.bukkit.craftbukkit.util.ApiVersion;
+ import org.checkerframework.checker.nullness.qual.Nullable;
+ 
+-public class WritableCraftRegistry<M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> extends CraftRegistry<T, M> {
++public class WritableCraftRegistry<M, T, B extends PaperRegistryBuilder<M, T>> extends CraftRegistry<T, M> {
+ 
+     private static final RegistrationInfo FROM_PLUGIN = new RegistrationInfo(Optional.empty(), Lifecycle.experimental());
+ 
+diff --git a/src/main/java/io/papermc/paper/registry/entry/AddableRegistryEntry.java b/src/main/java/io/papermc/paper/registry/entry/AddableRegistryEntry.java
+index aeec9b3ae2911f041d000b3db72f37974020ba60..a982ae85d54f63c6ca3a14c885516d4090c52e75 100644
+--- a/src/main/java/io/papermc/paper/registry/entry/AddableRegistryEntry.java
++++ b/src/main/java/io/papermc/paper/registry/entry/AddableRegistryEntry.java
+@@ -13,7 +13,7 @@ import net.minecraft.resources.ResourceKey;
+ import org.bukkit.Keyed;
+ import org.bukkit.NamespacedKey;
+ 
+-public class AddableRegistryEntry<M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> extends CraftRegistryEntry<M, T> implements RegistryEntry.Addable<M, T, B> {
++public class AddableRegistryEntry<M, T, B extends PaperRegistryBuilder<M, T>> extends CraftRegistryEntry<M, T> implements RegistryEntry.Addable<M, T, B> {
+ 
+     private final PaperRegistryBuilder.Filler<M, T, B> builderFiller;
+ 
+diff --git a/src/main/java/io/papermc/paper/registry/entry/ApiRegistryEntry.java b/src/main/java/io/papermc/paper/registry/entry/ApiRegistryEntry.java
+index 2295b0d145cbaabef5d29482c817575dcbe2ba54..17617defef16f56a65a03c35b2e00d97f274baa0 100644
+--- a/src/main/java/io/papermc/paper/registry/entry/ApiRegistryEntry.java
++++ b/src/main/java/io/papermc/paper/registry/entry/ApiRegistryEntry.java
+@@ -7,7 +7,7 @@ import net.minecraft.core.Registry;
+ import net.minecraft.resources.ResourceKey;
+ import org.bukkit.Keyed;
+ 
+-public class ApiRegistryEntry<M, B extends Keyed> extends BaseRegistryEntry<M, B> {
++public class ApiRegistryEntry<M, B> extends BaseRegistryEntry<M, B> {
+ 
+     private final Supplier<org.bukkit.Registry<B>> registrySupplier;
+ 
+diff --git a/src/main/java/io/papermc/paper/registry/entry/BaseRegistryEntry.java b/src/main/java/io/papermc/paper/registry/entry/BaseRegistryEntry.java
+index ceb217dbbb84e8bd51365dd47bf91971e364d298..88a8e2170fa82213df8f52ec1b5f7d3821b92e96 100644
+--- a/src/main/java/io/papermc/paper/registry/entry/BaseRegistryEntry.java
++++ b/src/main/java/io/papermc/paper/registry/entry/BaseRegistryEntry.java
+@@ -5,7 +5,7 @@ import net.minecraft.core.Registry;
+ import net.minecraft.resources.ResourceKey;
+ import org.bukkit.Keyed;
+ 
+-public abstract class BaseRegistryEntry<M, B extends Keyed> implements RegistryEntry<M, B> { // TODO remove Keyed
++public abstract class BaseRegistryEntry<M, B> implements RegistryEntry<M, B> {
+ 
+     private final ResourceKey<? extends Registry<M>> minecraftRegistryKey;
+     private final RegistryKey<B> apiRegistryKey;
+diff --git a/src/main/java/io/papermc/paper/registry/entry/CraftRegistryEntry.java b/src/main/java/io/papermc/paper/registry/entry/CraftRegistryEntry.java
+index 568984894a5463ccfa68bb6944b409ab0a2d7ad7..93ea40ea78e6d00ef60844447ee25b6f3db83859 100644
+--- a/src/main/java/io/papermc/paper/registry/entry/CraftRegistryEntry.java
++++ b/src/main/java/io/papermc/paper/registry/entry/CraftRegistryEntry.java
+@@ -13,7 +13,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
+ import org.checkerframework.framework.qual.DefaultQualifier;
+ 
+ @DefaultQualifier(NonNull.class)
+-public class CraftRegistryEntry<M, B extends Keyed> extends BaseRegistryEntry<M, B> { // TODO remove Keyed
++public class CraftRegistryEntry<M, B> extends BaseRegistryEntry<M, B> {
+ 
+     private static final BiFunction<NamespacedKey, ApiVersion, NamespacedKey> EMPTY = (namespacedKey, apiVersion) -> namespacedKey;
+ 
+diff --git a/src/main/java/io/papermc/paper/registry/entry/ModifiableRegistryEntry.java b/src/main/java/io/papermc/paper/registry/entry/ModifiableRegistryEntry.java
+index 515a995e3862f8e7cb93d149315ea32e04a08716..e6ddd4b58908b112a1b2d4284dec17b0932522c3 100644
+--- a/src/main/java/io/papermc/paper/registry/entry/ModifiableRegistryEntry.java
++++ b/src/main/java/io/papermc/paper/registry/entry/ModifiableRegistryEntry.java
+@@ -10,7 +10,7 @@ import net.minecraft.resources.ResourceKey;
+ import org.bukkit.Keyed;
+ import org.bukkit.NamespacedKey;
+ 
+-public class ModifiableRegistryEntry<M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> extends CraftRegistryEntry<M, T> implements RegistryEntry.Modifiable<M, T, B> {
++public class ModifiableRegistryEntry<M, T, B extends PaperRegistryBuilder<M, T>> extends CraftRegistryEntry<M, T> implements RegistryEntry.Modifiable<M, T, B> {
+ 
+     protected final PaperRegistryBuilder.Filler<M, T, B> builderFiller;
+ 
+diff --git a/src/main/java/io/papermc/paper/registry/entry/RegistryEntry.java b/src/main/java/io/papermc/paper/registry/entry/RegistryEntry.java
+index f2e919705301cb23ed1938ca3c1976378249172c..93e1ca735e662c4a988b32229e39e654cfe31576 100644
+--- a/src/main/java/io/papermc/paper/registry/entry/RegistryEntry.java
++++ b/src/main/java/io/papermc/paper/registry/entry/RegistryEntry.java
+@@ -21,7 +21,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
+ import org.checkerframework.framework.qual.DefaultQualifier;
+ 
+ @DefaultQualifier(NonNull.class)
+-public interface RegistryEntry<M, B extends Keyed> extends RegistryEntryInfo<M, B> { // TODO remove Keyed
++public interface RegistryEntry<M, B> extends RegistryEntryInfo<M, B> {
+ 
+     RegistryHolder<B> createRegistryHolder(Registry<M> nmsRegistry);
+ 
+@@ -53,7 +53,7 @@ public interface RegistryEntry<M, B extends Keyed> extends RegistryEntryInfo<M,
+             return entry instanceof RegistryEntry.Modifiable<?, ?, ?> || (entry instanceof final DelayedRegistryEntry<?, ?> delayed && delayed.delegate() instanceof RegistryEntry.Modifiable<?, ?, ?>);
+         }
+ 
+-        static <M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> Modifiable<M, T, B> asModifiable(final RegistryEntryInfo<M, T> entry) { // TODO remove Keyed
++        static <M, T, B extends PaperRegistryBuilder<M, T>> Modifiable<M, T, B> asModifiable(final RegistryEntryInfo<M, T> entry) {
+             return (Modifiable<M, T, B>) possiblyUnwrap(entry);
+         }
+ 
+@@ -65,7 +65,7 @@ public interface RegistryEntry<M, B extends Keyed> extends RegistryEntryInfo<M,
+     /**
+      * Can only add new values to the registry, not modify any values.
+      */
+-    interface Addable<M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> extends BuilderHolder<M, T, B> { // TODO remove Keyed
++    interface Addable<M, T, B extends PaperRegistryBuilder<M, T>> extends BuilderHolder<M, T, B> {
+ 
+         default RegistryFreezeEventImpl<T, B> createFreezeEvent(final WritableCraftRegistry<M, T, B> writableRegistry, final Conversions conversions) {
+             return new RegistryFreezeEventImpl<>(this.apiKey(), writableRegistry.createApiWritableRegistry(conversions), conversions);
+@@ -75,7 +75,7 @@ public interface RegistryEntry<M, B extends Keyed> extends RegistryEntryInfo<M,
+             return entry instanceof RegistryEntry.Addable<?, ?, ?> || (entry instanceof final DelayedRegistryEntry<?, ?> delayed && delayed.delegate() instanceof RegistryEntry.Addable<?, ?, ?>);
+         }
+ 
+-        static <M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> Addable<M, T, B> asAddable(final RegistryEntryInfo<M, T> entry) {
++        static <M, T, B extends PaperRegistryBuilder<M, T>> Addable<M, T, B> asAddable(final RegistryEntryInfo<M, T> entry) {
+             return (Addable<M, T, B>) possiblyUnwrap(entry);
+         }
+     }
+@@ -83,22 +83,22 @@ public interface RegistryEntry<M, B extends Keyed> extends RegistryEntryInfo<M,
+     /**
+      * Can mutate values and add new values.
+      */
+-    interface Writable<M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> extends Modifiable<M, T, B>, Addable<M, T, B> { // TODO remove Keyed
++    interface Writable<M, T, B extends PaperRegistryBuilder<M, T>> extends Modifiable<M, T, B>, Addable<M, T, B> {
+ 
+         static boolean isWritable(final @Nullable RegistryEntryInfo<?, ?> entry) {
+             return entry instanceof RegistryEntry.Writable<?, ?, ?> || (entry instanceof final DelayedRegistryEntry<?, ?> delayed && delayed.delegate() instanceof RegistryEntry.Writable<?, ?, ?>);
+         }
+ 
+-        static <M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> Writable<M, T, B> asWritable(final RegistryEntryInfo<M, T> entry) { // TODO remove Keyed
++        static <M, T, B extends PaperRegistryBuilder<M, T>> Writable<M, T, B> asWritable(final RegistryEntryInfo<M, T> entry) {
+             return (Writable<M, T, B>) possiblyUnwrap(entry);
+         }
+     }
+ 
+-    private static <M, B extends Keyed> RegistryEntryInfo<M, B> possiblyUnwrap(final RegistryEntryInfo<M, B> entry) {
++    private static <M, B> RegistryEntryInfo<M, B> possiblyUnwrap(final RegistryEntryInfo<M, B> entry) {
+         return entry instanceof final DelayedRegistryEntry<M, B> delayed ? delayed.delegate() : entry;
+     }
+ 
+-    static <M, B extends Keyed> RegistryEntry<M, B> entry(
++    static <M, B> RegistryEntry<M, B> entry(
+         final ResourceKey<? extends Registry<M>> mcKey,
+         final RegistryKey<B> apiKey,
+         final Class<?> classToPreload,
+@@ -107,7 +107,7 @@ public interface RegistryEntry<M, B extends Keyed> extends RegistryEntryInfo<M,
+         return new CraftRegistryEntry<>(mcKey, apiKey, classToPreload, minecraftToBukkit);
+     }
+ 
+-    static <M, B extends Keyed> RegistryEntry<M, B> apiOnly(
++    static <M, B> RegistryEntry<M, B> apiOnly(
+         final ResourceKey<? extends Registry<M>> mcKey,
+         final RegistryKey<B> apiKey,
+         final Supplier<org.bukkit.Registry<B>> apiRegistrySupplier
+@@ -115,7 +115,7 @@ public interface RegistryEntry<M, B extends Keyed> extends RegistryEntryInfo<M,
+         return new ApiRegistryEntry<>(mcKey, apiKey, apiRegistrySupplier);
+     }
+ 
+-    static <M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> RegistryEntry<M, T> modifiable(
++    static <M, T, B extends PaperRegistryBuilder<M, T>> RegistryEntry<M, T> modifiable(
+         final ResourceKey<? extends Registry<M>> mcKey,
+         final RegistryKey<T> apiKey,
+         final Class<?> toPreload,
+@@ -125,7 +125,7 @@ public interface RegistryEntry<M, B extends Keyed> extends RegistryEntryInfo<M,
+         return new ModifiableRegistryEntry<>(mcKey, apiKey, toPreload, minecraftToBukkit, filler);
+     }
+ 
+-    static <M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> RegistryEntry<M, T> writable(
++    static <M, T, B extends PaperRegistryBuilder<M, T>> RegistryEntry<M, T> writable(
+         final ResourceKey<? extends Registry<M>> mcKey,
+         final RegistryKey<T> apiKey,
+         final Class<?> toPreload,
+diff --git a/src/main/java/io/papermc/paper/registry/entry/WritableRegistryEntry.java b/src/main/java/io/papermc/paper/registry/entry/WritableRegistryEntry.java
+index 562accce731630327d116afd1c9d559df7e386bd..ff2c1d8332dca8ea474eb0d1acc58c7aebfa9bce 100644
+--- a/src/main/java/io/papermc/paper/registry/entry/WritableRegistryEntry.java
++++ b/src/main/java/io/papermc/paper/registry/entry/WritableRegistryEntry.java
+@@ -8,7 +8,7 @@ import net.minecraft.resources.ResourceKey;
+ import org.bukkit.Keyed;
+ import org.bukkit.NamespacedKey;
+ 
+-public class WritableRegistryEntry<M, T extends Keyed, B extends PaperRegistryBuilder<M, T>> extends AddableRegistryEntry<M, T, B> implements RegistryEntry.Writable<M, T, B> { // TODO remove Keyed
++public class WritableRegistryEntry<M, T, B extends PaperRegistryBuilder<M, T>> extends AddableRegistryEntry<M, T, B> implements RegistryEntry.Writable<M, T, B> {
+ 
+     protected WritableRegistryEntry(
+         final ResourceKey<? extends Registry<M>> mcKey,
+diff --git a/src/main/java/io/papermc/paper/registry/event/RegistryEntryAddEventImpl.java b/src/main/java/io/papermc/paper/registry/event/RegistryEntryAddEventImpl.java
+index cc9c8fd313f530777af80ad79e03903f3f8f9829..613cfbc6cf2d33c8f2077b1c5ce17a3702678294 100644
+--- a/src/main/java/io/papermc/paper/registry/event/RegistryEntryAddEventImpl.java
++++ b/src/main/java/io/papermc/paper/registry/event/RegistryEntryAddEventImpl.java
+@@ -22,7 +22,7 @@ public record RegistryEntryAddEventImpl<T, B extends RegistryBuilder<T>>(
+ ) implements RegistryEntryAddEvent<T, B>, PaperLifecycleEvent {
+ 
+     @Override
+-    public @NonNull <V extends Keyed> Tag<V> getOrCreateTag(final TagKey<V> tagKey) {
++    public @NonNull <V> Tag<V> getOrCreateTag(final TagKey<V> tagKey) {
+         final RegistryOps.RegistryInfo<Object> registryInfo = this.conversions.lookup().lookup(PaperRegistries.registryToNms(tagKey.registryKey())).orElseThrow();
+         final HolderSet.Named<?> tagSet = registryInfo.getter().getOrThrow(PaperRegistries.toNms(tagKey));
+         return new NamedRegistryKeySetImpl<>(tagKey, tagSet);
+diff --git a/src/main/java/io/papermc/paper/registry/event/RegistryFreezeEventImpl.java b/src/main/java/io/papermc/paper/registry/event/RegistryFreezeEventImpl.java
+index 63957d2509e68ccc6eb2fd9ecaa35bfad7b71b81..aba718d563f53115aa64d445f9d61f9245ee0e9e 100644
+--- a/src/main/java/io/papermc/paper/registry/event/RegistryFreezeEventImpl.java
++++ b/src/main/java/io/papermc/paper/registry/event/RegistryFreezeEventImpl.java
+@@ -20,7 +20,7 @@ public record RegistryFreezeEventImpl<T, B extends RegistryBuilder<T>>(
+ ) implements RegistryFreezeEvent<T, B>, PaperLifecycleEvent {
+ 
+     @Override
+-    public @NonNull <V extends Keyed> Tag<V> getOrCreateTag(final TagKey<V> tagKey) {
++    public @NonNull <V> Tag<V> getOrCreateTag(final TagKey<V> tagKey) {
+         final RegistryOps.RegistryInfo<Object> registryInfo = this.conversions.lookup().lookup(PaperRegistries.registryToNms(tagKey.registryKey())).orElseThrow();
+         final HolderSet.Named<?> tagSet = registryInfo.getter().getOrThrow(PaperRegistries.toNms(tagKey));
+         return new NamedRegistryKeySetImpl<>(tagKey, tagSet);
+diff --git a/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistry.java b/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistry.java
+index e5880f76cdb8ebf01fcefdf77ba9b95674b997a8..b2f2aa25751b002d909fed3e911ffa95380ae9ca 100644
+--- a/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistry.java
++++ b/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistry.java
+@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
+  * This is to support the now-deprecated fields in {@link Registry} for
+  * data-driven registries.
+  */
+-public final class DelayedRegistry<T extends Keyed, R extends Registry<T>> implements Registry<T> {
++public final class DelayedRegistry<T, R extends Registry<T>> implements Registry<T> {
+ 
+     private @MonotonicNonNull Supplier<? extends R> delegate;
+ 
+diff --git a/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistryEntry.java b/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistryEntry.java
+index 110b8d559f49f9e4f181b47663962a139a273a72..dfae528518f25dab7825795d82f183fb07b3ba96 100644
+--- a/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistryEntry.java
++++ b/src/main/java/io/papermc/paper/registry/legacy/DelayedRegistryEntry.java
+@@ -7,7 +7,7 @@ import net.minecraft.core.Registry;
+ import net.minecraft.resources.ResourceKey;
+ import org.bukkit.Keyed;
+ 
+-public record DelayedRegistryEntry<M, T extends Keyed>(RegistryEntry<M, T> delegate) implements RegistryEntry<M, T> {
++public record DelayedRegistryEntry<M, T>(RegistryEntry<M, T> delegate) implements RegistryEntry<M, T> {
+ 
+     @Override
+     public ResourceKey<? extends Registry<M>> mcKey() {
+diff --git a/src/main/java/io/papermc/paper/registry/set/NamedRegistryKeySetImpl.java b/src/main/java/io/papermc/paper/registry/set/NamedRegistryKeySetImpl.java
+index e8c2c18a1ed5cd587266bd415170610781531a12..f48b45421eb4e6420a69a9eb048e29a3871963ab 100644
+--- a/src/main/java/io/papermc/paper/registry/set/NamedRegistryKeySetImpl.java
++++ b/src/main/java/io/papermc/paper/registry/set/NamedRegistryKeySetImpl.java
+@@ -23,7 +23,7 @@ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Unmodifiable;
+ 
+ @DefaultQualifier(NonNull.class)
+-public record NamedRegistryKeySetImpl<T extends Keyed, M>( // TODO remove Keyed
++public record NamedRegistryKeySetImpl<T, M>(
+     TagKey<T> tagKey,
+     HolderSet.Named<M> namedSet
+ ) implements Tag<T>, org.bukkit.Tag<T> {
+diff --git a/src/main/java/io/papermc/paper/registry/set/PaperRegistrySets.java b/src/main/java/io/papermc/paper/registry/set/PaperRegistrySets.java
+index f09ce9c8547ef05153847245746473dd9a8acbe6..0ecd651b32fc6c0d954f37999b67a9ea1128a957 100644
+--- a/src/main/java/io/papermc/paper/registry/set/PaperRegistrySets.java
++++ b/src/main/java/io/papermc/paper/registry/set/PaperRegistrySets.java
+@@ -17,7 +17,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
+ @DefaultQualifier(NonNull.class)
+ public final class PaperRegistrySets {
+ 
+-    public static <A extends Keyed, M> HolderSet<M> convertToNms(final ResourceKey<? extends Registry<M>> resourceKey, final RegistryOps.RegistryInfoLookup lookup, final RegistryKeySet<A> registryKeySet) { // TODO remove Keyed
++    public static <A, M> HolderSet<M> convertToNms(final ResourceKey<? extends Registry<M>> resourceKey, final RegistryOps.RegistryInfoLookup lookup, final RegistryKeySet<A> registryKeySet) {
+         if (registryKeySet instanceof NamedRegistryKeySetImpl<A, ?>) {
+             return ((NamedRegistryKeySetImpl<A, M>) registryKeySet).namedSet();
+         } else {
+@@ -28,7 +28,7 @@ public final class PaperRegistrySets {
+         }
+     }
+ 
+-    public static <A extends Keyed, M> RegistryKeySet<A> convertToApi(final RegistryKey<A> registryKey, final HolderSet<M> holders) { // TODO remove Keyed
++    public static <A, M> RegistryKeySet<A> convertToApi(final RegistryKey<A> registryKey, final HolderSet<M> holders) {
+         if (holders instanceof final HolderSet.Named<M> named) {
+             return new NamedRegistryKeySetImpl<>(PaperRegistries.fromNms(named.key()), named);
+         } else {
+diff --git a/src/main/java/org/bukkit/craftbukkit/legacy/MaterialRerouting.java b/src/main/java/org/bukkit/craftbukkit/legacy/MaterialRerouting.java
+index db8d8e2a07296d62c3097f02b03319e2e1ba9394..d050f41a75f5a79568e1bdab0ce685fe25bab57b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/legacy/MaterialRerouting.java
++++ b/src/main/java/org/bukkit/craftbukkit/legacy/MaterialRerouting.java
+@@ -551,7 +551,7 @@ public class MaterialRerouting {
+         return server.createBlockData(MaterialRerouting.transformToBlockType(material), data);
+     }
+ 
+-    public static <T extends Keyed> boolean isTagged(Tag<T> tag, T item) {
++    public static <T> boolean isTagged(Tag<T> tag, T item) {
+         if (tag instanceof CraftBlockTag) {
+             return tag.isTagged((T) MaterialRerouting.transformToBlockType((Material) item));
+         } else if (tag instanceof CraftItemTag) {

--- a/test-plugin/build.gradle.kts
+++ b/test-plugin/build.gradle.kts
@@ -1,7 +1,11 @@
 version = "1.0.0-SNAPSHOT"
+repositories {
+    maven("https://repo.papermc.io/repository/maven-public/")
+}
 
 dependencies {
-    compileOnly(project(":paper-api"))
+    // compileOnly(project(":paper-api"))
+    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
 }
 
 tasks.processResources {

--- a/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
+++ b/test-plugin/src/main/java/io/papermc/testplugin/TestPlugin.java
@@ -1,5 +1,17 @@
 package io.papermc.testplugin;
 
+import io.papermc.paper.event.player.ChatEvent;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.bukkit.GameEvent;
+import org.bukkit.Keyed;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.Tag;
+import org.bukkit.block.Biome;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -10,6 +22,31 @@ public final class TestPlugin extends JavaPlugin implements Listener {
         this.getServer().getPluginManager().registerEvents(this, this);
 
         // io.papermc.testplugin.brigtests.Registration.registerViaOnEnable(this);
+        this.test();
+    }
+
+    @EventHandler
+    public void onChat(ChatEvent event) {
+        this.test();
+    }
+
+    void test() {
+        final Function<NamespacedKey, Keyed> GET_KEYED = Registry.BIOME::get;
+        final BiFunction<Registry<?>, NamespacedKey, Keyed> GET_KEYED_2 = Registry::get;
+
+        final Keyed keyed = GET_KEYED.apply(Biome.PLAINS.getKey());
+        System.out.println(keyed.getKey() + " " + keyed.getClass().getSimpleName());
+        final Keyed keyed2 = GET_KEYED_2.apply(Registry.GAME_EVENT, GameEvent.EAT.getKey());
+        System.out.println(keyed2.getKey() + " " + keyed2.getClass().getSimpleName());
+
+        final Keyed keyed3 = Registry.BIOME.get(Biome.BEACH.getKey());
+        System.out.println(keyed3.getKey() + " " + keyed3.getClass().getSimpleName());
+
+        final Keyed keyed4 = Registry.ENCHANTMENT.get(Enchantment.FORTUNE.getKey());
+        System.out.println(keyed4.getKey() + " " + keyed4.getClass().getSimpleName());
+
+        System.out.println(Tag.ACACIA_LOGS.isTagged(Material.WRITTEN_BOOK));
+        System.out.println(Tag.ACACIA_LOGS.isTagged(Material.ACACIA_LOG));
     }
 
 }


### PR DESCRIPTION
This is a key step to improving Registries and enabling better and more accurate API in the future. We cannot require all type parameters for Registry to implement Keyed because we need to be able to create instances of things like `TrimMaterial` and `TrimPattern` without a key as they can exist like that in the server. 

----

Supersedes https://github.com/PaperMC/Paper/pull/9009

Closes https://github.com/PaperMC/Paper/issues/9063

Requires https://github.com/PaperMC/Paper/pull/10060