### PR TITLE
Fix MC-111729

### DIFF
--- a/patches/server/0002-Remap-fixes.patch
+++ b/patches/server/0002-Remap-fixes.patch
@@ -88,6 +88,21 @@ index 95a5ce711150c4c999a9d17f28a497f034638610..214215d203892b8009595539f25ce26e
          private LootContextParamSet paramSet;
          private Optional<ResourceLocation> randomSequence;
  
+diff --git a/src/main/java/net/minecraft/world/scores/Scoreboard.java b/src/main/java/net/minecraft/world/scores/Scoreboard.java
+index 8e310b674134fd9f9d73e3b8a9072ed7948ce18f..d184f9ffd42f05511b2919012273eb67661c1841 100644
+--- a/src/main/java/net/minecraft/world/scores/Scoreboard.java
++++ b/src/main/java/net/minecraft/world/scores/Scoreboard.java
+@@ -99,8 +99,8 @@ public class Scoreboard {
+                         }
+                     }
+ 
+-                    if (score != score.value()) {
+-                        score.value(score);
++                    if (scorex != score.value()) { // Paper - remap fixes
++                        score.value(scorex); // Paper - remap fixes
+                         bl = true;
+                     }
+ 
 diff --git a/src/test/java/org/bukkit/DyeColorsTest.java b/src/test/java/org/bukkit/DyeColorsTest.java
 index b70450722da13bc4d358a70d3d1d2f30a2cca2b9..86d86c292bdeeb7f42685691287c3b4bd476ea14 100644
 --- a/src/test/java/org/bukkit/DyeColorsTest.java

--- a/patches/server/1055-Fix-MC-111729.patch
+++ b/patches/server/1055-Fix-MC-111729.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: vicisacat <victor.branchu@gmail.com>
+Date: Sun, 24 Dec 2023 23:16:06 +0100
+Subject: [PATCH] Fix MC-111729
+
+
+diff --git a/src/main/java/net/minecraft/server/ServerScoreboard.java b/src/main/java/net/minecraft/server/ServerScoreboard.java
+index 5cc8173e845bf8d3414ac3347d25e1f6d0c65ce9..0d4660e4d64000fac3b5e4f2eeb03022de477c6b 100644
+--- a/src/main/java/net/minecraft/server/ServerScoreboard.java
++++ b/src/main/java/net/minecraft/server/ServerScoreboard.java
+@@ -144,6 +144,25 @@ public class ServerScoreboard extends Scoreboard {
+     @Override
+     public void onObjectiveAdded(Objective objective) {
+         super.onObjectiveAdded(objective);
++        // Paper start - fix MC-111729
++        if (objective.getCriteria().isReadOnly()) {
++            java.util.function.Function<ServerPlayer, Integer> function = null;
++            switch (objective.getCriteria().getName()) {
++                case "health" -> function = serverPlayer -> (int) serverPlayer.getHealth();
++                case "food" -> function = serverPlayer -> serverPlayer.getFoodData().foodLevel;
++                case "air" -> function = net.minecraft.world.entity.Entity::getAirSupply;
++                case "armor" -> function = net.minecraft.world.entity.LivingEntity::getArmorValue;
++                case "xp" -> function = serverPlayer -> serverPlayer.getScore();
++                case "level" -> function = serverPlayer -> serverPlayer.experienceLevel;
++            }
++
++            if (function != null) {
++                for (final ServerPlayer player : server.getPlayerList().players) {
++                    getOrCreatePlayerScore(player, objective, true).set(function.apply(player));
++                }
++            }
++        }
++        // Paper end - fix MC-111729
+         this.setDirty();
+     }
+ 


### PR DESCRIPTION
The more I worked on this, the sillier it became. So this is a draft for now.

The point of this PR is to fix [MC-111729](https://bugs.mojang.com/browse/MC-111729) (and a remap issue, doesn't affect the pr so is removable).
Did some testing, works when creating the objective with the scoreboard command and with a plugin.

The reason this is a draft is I really don't know how to deal with fake players created by plugins, or just big servers with a lot of players. I think having the command do it all the time is fine but maybe add a boolean to the methods that registers a new objective to enable or disable the init of scores? I dunno.

This bug isn't really a big issue but would still be nice to fix it!