### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0453-Add-missing-InventoryType.patch
+++ b/patches/api/0453-Add-missing-InventoryType.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 27 Dec 2023 16:46:13 -0800
+Subject: [PATCH] Add missing InventoryType
+
+Upstream did not add a DECORATED_POT inventory type
+
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
+index 64e59fe706b0bb37fc2439fa88fd40c3167c9fb5..daa1306a7324d946d66ad5a674bbc84371d8d4d6 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
+@@ -144,6 +144,12 @@ public enum InventoryType {
+      * Pseudo jukebox inventory with 1 slot of undefined type.
+      */
+     JUKEBOX(1, "Jukebox", false),
++    // Paper start - add missing type
++    /**
++     * Pseudo decorated pot with 1 slot of undefined type.
++     */
++    DECORATED_POT(1, "Decorated Pot", false),
++    // Paper end - add missing type
+     /**
+      * A crafter inventory, with 9 CRAFTING slots.
+      */

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2891,7 +2891,7 @@ index a60fef571c94858998a91711b17d3670c28a81bd..04a728a16bb629adbae1cd8586764a6d
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index dfb7384e995662a9c2461b8b49533519b8e637a5..bc9ca925db912b637def658fd123105ac1c75412 100644
+index 04344fd06419ed849f4e49b89a34d48141410b4e..07161d7d2a16d75497ef4d15af12e0ac09163ad2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -44,6 +44,7 @@ import net.minecraft.nbt.ListTag;
@@ -2911,7 +2911,7 @@ index dfb7384e995662a9c2461b8b49533519b8e637a5..bc9ca925db912b637def658fd123105a
  import com.mojang.datafixers.util.Pair;
  import java.util.Arrays;
  import java.util.concurrent.ExecutionException;
-@@ -1714,9 +1717,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1717,9 +1720,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          */
  
          this.player.disconnect();
@@ -2926,7 +2926,7 @@ index dfb7384e995662a9c2461b8b49533519b8e637a5..bc9ca925db912b637def658fd123105a
          }
          // CraftBukkit end
          this.player.getTextFilter().leave();
-@@ -1780,10 +1785,10 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1783,10 +1788,10 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      }
  
                      CompletableFuture<FilteredText> completablefuture = this.filterTextPacket(playerchatmessage.signedContent()).thenApplyAsync(Function.identity(), this.server.chatExecutor); // CraftBukkit - async chat
@@ -2940,7 +2940,7 @@ index dfb7384e995662a9c2461b8b49533519b8e637a5..bc9ca925db912b637def658fd123105a
  
                          this.broadcastChatMessage(playerchatmessage1);
                      });
-@@ -1928,7 +1933,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1931,7 +1936,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.handleCommand(s);
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
@@ -2954,7 +2954,7 @@ index dfb7384e995662a9c2461b8b49533519b8e637a5..bc9ca925db912b637def658fd123105a
              Player player = this.getCraftPlayer();
              AsyncPlayerChatEvent event = new AsyncPlayerChatEvent(async, player, s, new LazyPlayerSet(this.server));
              String originalFormat = event.getFormat(), originalMessage = event.getMessage();
-@@ -2915,6 +2925,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2918,6 +2928,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleClientInformation(ServerboundClientInformationPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          this.player.updateOptions(packet.information());
@@ -5050,7 +5050,7 @@ index cc588fb207062829637adad79129ca91950496cb..8b27ca7606869798486c3afd03e86205
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 1f375990bae26abc744b3f110ecfc371ab3c3145..9e74a28d77c4c91ad46750d924a3e0789683a875 100644
+index adc67d73681ad5486c266e2a464ae2a1385ba7f4..fbde42a814f846ce8c9df6ea621f10610d9322b3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -750,6 +750,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {

--- a/patches/server/0014-Timings-v2.patch
+++ b/patches/server/0014-Timings-v2.patch
@@ -1242,10 +1242,10 @@ index 3bd2bddb782d29e647a1f1b362a39d224151f8b1..3851c1026b91b77a02dbb5df1a1eedb2
                  this.entityManager.saveAll();
              } else {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index bc9ca925db912b637def658fd123105ac1c75412..d6b9fee57d22da0eaf3dcc4abfd3995d69abef95 100644
+index 07161d7d2a16d75497ef4d15af12e0ac09163ad2..7c1154cd5fcc1f4c86067bb633218de682ef7bef 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -323,7 +323,6 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -322,7 +322,6 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void tick() {
@@ -1253,7 +1253,7 @@ index bc9ca925db912b637def658fd123105ac1c75412..d6b9fee57d22da0eaf3dcc4abfd3995d
          if (this.ackBlockChangesUpTo > -1) {
              this.send(new ClientboundBlockChangedAckPacket(this.ackBlockChangesUpTo));
              this.ackBlockChangesUpTo = -1;
-@@ -390,7 +389,6 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -389,7 +388,6 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.player.resetLastActionTime(); // CraftBukkit - SPIGOT-854
              this.disconnect(Component.translatable("multiplayer.disconnect.idling"));
          }
@@ -1261,7 +1261,7 @@ index bc9ca925db912b637def658fd123105ac1c75412..d6b9fee57d22da0eaf3dcc4abfd3995d
  
      }
  
-@@ -2014,7 +2012,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2017,7 +2015,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      }
  
      private void handleCommand(String s) {
@@ -1270,7 +1270,7 @@ index bc9ca925db912b637def658fd123105ac1c75412..d6b9fee57d22da0eaf3dcc4abfd3995d
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + s);
  
-@@ -2024,7 +2022,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2027,7 +2025,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          this.cserver.getPluginManager().callEvent(event);
  
          if (event.isCancelled()) {
@@ -1279,7 +1279,7 @@ index bc9ca925db912b637def658fd123105ac1c75412..d6b9fee57d22da0eaf3dcc4abfd3995d
              return;
          }
  
-@@ -2037,7 +2035,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2040,7 +2038,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              java.util.logging.Logger.getLogger(ServerGamePacketListenerImpl.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
              return;
          } finally {
@@ -1603,7 +1603,7 @@ index 0eb09ce5c850d85ffd7229d27cf06b3e0edda11b..cc1d7626a82881c4410d65c6a33dadae
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 04880123cde240f2d02936ecdefa9731db743b8f..836a388dbbc1987272aba6604a5b61acabe441b5 100644
+index a34037d03674ab64c1ef15a4c0cdb63dbad6d7af..491f59cdf41b686b7d03533c8d34cf367d6c658e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -368,7 +368,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0018-Rewrite-chunk-system.patch
+++ b/patches/server/0018-Rewrite-chunk-system.patch
@@ -20485,10 +20485,10 @@ index c509a1318bcef38fd4927e38b6ee9846853e2d15..5de5209e04d631bd6a50e28e8d3abebf
          this.desiredChunksPerTick = Double.isNaN((double)desiredBatchSize) ? 0.01F : Mth.clamp(desiredBatchSize, 0.01F, 64.0F);
          if (this.unacknowledgedBatches == 0) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d6b9fee57d22da0eaf3dcc4abfd3995d69abef95..b41351783ea9795afaddce453c82ab32cb8134a1 100644
+index 7c1154cd5fcc1f4c86067bb633218de682ef7bef..5248aaee63e87a339c6debdfbe09707c6849d84b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -699,6 +699,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -696,6 +696,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.disconnect(Component.translatable("disconnect.spam"));
              return;
          }
@@ -22663,7 +22663,7 @@ index b1aeb021e53a233bfb0439d38f1a889ed6fc301d..7687a81bfa420e8377308fea3d673814
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 836a388dbbc1987272aba6604a5b61acabe441b5..cf05dd46b17e69e09b97d955e9c2198e78ba7f1f 100644
+index 491f59cdf41b686b7d03533c8d34cf367d6c658e..611f3cb97e801e8ffff7a41cafc1d63d71ff841c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1195,7 +1195,7 @@ public final class CraftServer implements Server {
@@ -22694,7 +22694,7 @@ index 836a388dbbc1987272aba6604a5b61acabe441b5..cf05dd46b17e69e09b97d955e9c2198e
  
      // Paper start - Adventure
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1ae3d9fc4ed6bba1881079b86b965e2f51bcb5e2..6ca2e661381f546b424396922c62d9e4698dbf0e 100644
+index d98020ea7f56418fdab03c7e7772ce062672b728..814842871ea8e2104a0842919757cfbccabadc30 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -325,10 +325,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0052-Improve-Player-chat-API-handling.patch
+++ b/patches/server/0052-Improve-Player-chat-API-handling.patch
@@ -17,10 +17,10 @@ Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 Co-authored-by: SoSeDiK <mrsosedik@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b41351783ea9795afaddce453c82ab32cb8134a1..870a1d6679fa062d90bcfa1a21a8af0cf67f2950 100644
+index 5248aaee63e87a339c6debdfbe09707c6849d84b..17b4f7b76eda9735a4be1a60645d44e8f633dd52 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1934,7 +1934,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1937,7 +1937,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          OutgoingChatMessage outgoing = OutgoingChatMessage.create(original);
  
@@ -29,7 +29,7 @@ index b41351783ea9795afaddce453c82ab32cb8134a1..870a1d6679fa062d90bcfa1a21a8af0c
              this.handleCommand(s);
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
-@@ -2018,7 +2018,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2021,7 +2021,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
      }
  
@@ -40,7 +40,7 @@ index b41351783ea9795afaddce453c82ab32cb8134a1..870a1d6679fa062d90bcfa1a21a8af0c
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + s);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d491b3e7a6ec5ef2e2d7bf3fa014a4f501bff124..638d978d86ee324e2eddfebda02ae54572982935 100644
+index e2da717c11f48573babe27d0dac1d679e8eb6964..b80e4acbb67d6f2fbe31b1e518c20d7ec0ec4e49 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -885,7 +885,7 @@ public final class CraftServer implements Server {
@@ -53,7 +53,7 @@ index d491b3e7a6ec5ef2e2d7bf3fa014a4f501bff124..638d978d86ee324e2eddfebda02ae545
          if (this.commandMap.dispatch(sender, commandLine)) {
              return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fc6557ad318209a3f1f617cec162740a1d26b051..4585c67495ffda7f149c4dbcf379839f40cf6bac 100644
+index 49d0e2988d2267c4721d8ce37a96eb1d3944ea5a..054ada5455c6570f86d9a010fcb8eaf57bf7151d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -498,7 +498,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
+++ b/patches/server/0083-Add-PlayerUseUnknownEntityEvent.patch
@@ -28,10 +28,10 @@ index 644a0fdea6576647539b96528717dbaeab498d93..221e64a66ff12a8de5c75992fc26a54a
 +    // Paper end - PlayerUseUnknownEntityEvent
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 870a1d6679fa062d90bcfa1a21a8af0cf67f2950..d03d5629e3605626bba6ea806990443bfb151c61 100644
+index 17b4f7b76eda9735a4be1a60645d44e8f633dd52..fe6a995331ba489911886047130861496d75979a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2401,8 +2401,38 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2404,8 +2404,38 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  });
              }
          }

--- a/patches/server/0098-Async-GameProfileCache-saving.patch
+++ b/patches/server/0098-Async-GameProfileCache-saving.patch
@@ -31,10 +31,10 @@ index a267ab0b217573373d7b6a1f48cadab0f431da40..772d7c1e398538b8bbbd70aedaba0519
  
          if (!OldUsersConverter.serverReadyAfterUserconversion(this)) {
 diff --git a/src/main/java/net/minecraft/server/players/GameProfileCache.java b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-index d5e83f14bb7809c8bb3c2bffe436fd7284896aff..ee43e87fca2a8ac3f63bc2f8ffcf15be373195e9 100644
+index f5ac34923eb29a4d8df59d35f3381cdf08f74cf6..1924757cec5d7f2d13ef35f9bbe1554d786713d7 100644
 --- a/src/main/java/net/minecraft/server/players/GameProfileCache.java
 +++ b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-@@ -118,7 +118,7 @@ public class GameProfileCache {
+@@ -117,7 +117,7 @@ public class GameProfileCache {
          GameProfileCache.GameProfileInfo usercache_usercacheentry = new GameProfileCache.GameProfileInfo(profile, date);
  
          this.safeAdd(usercache_usercacheentry);
@@ -43,7 +43,7 @@ index d5e83f14bb7809c8bb3c2bffe436fd7284896aff..ee43e87fca2a8ac3f63bc2f8ffcf15be
      }
  
      private long getNextOperation() {
-@@ -151,7 +151,7 @@ public class GameProfileCache {
+@@ -150,7 +150,7 @@ public class GameProfileCache {
          }
  
          if (flag && !org.spigotmc.SpigotConfig.saveUserCacheOnStopOnly) { // Spigot - skip saving if disabled
@@ -52,7 +52,7 @@ index d5e83f14bb7809c8bb3c2bffe436fd7284896aff..ee43e87fca2a8ac3f63bc2f8ffcf15be
          }
  
          return optional;
-@@ -263,7 +263,7 @@ public class GameProfileCache {
+@@ -262,7 +262,7 @@ public class GameProfileCache {
          return arraylist;
      }
  
@@ -61,7 +61,7 @@ index d5e83f14bb7809c8bb3c2bffe436fd7284896aff..ee43e87fca2a8ac3f63bc2f8ffcf15be
          JsonArray jsonarray = new JsonArray();
          DateFormat dateformat = GameProfileCache.createDateFormat();
  
-@@ -271,6 +271,7 @@ public class GameProfileCache {
+@@ -270,6 +270,7 @@ public class GameProfileCache {
              jsonarray.add(GameProfileCache.writeGameProfile(usercache_usercacheentry, dateformat));
          });
          String s = this.gson.toJson(jsonarray);
@@ -69,7 +69,7 @@ index d5e83f14bb7809c8bb3c2bffe436fd7284896aff..ee43e87fca2a8ac3f63bc2f8ffcf15be
  
          try {
              BufferedWriter bufferedwriter = Files.newWriter(this.file, StandardCharsets.UTF_8);
-@@ -295,6 +296,14 @@ public class GameProfileCache {
+@@ -294,6 +295,14 @@ public class GameProfileCache {
          } catch (IOException ioexception) {
              ;
          }

--- a/patches/server/0104-Don-t-lookup-game-profiles-that-have-no-UUID-and-no-.patch
+++ b/patches/server/0104-Don-t-lookup-game-profiles-that-have-no-UUID-and-no-.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't lookup game profiles that have no UUID and no name
 
 
 diff --git a/src/main/java/net/minecraft/server/players/GameProfileCache.java b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-index ee43e87fca2a8ac3f63bc2f8ffcf15be373195e9..1a97dd1f9b9fcc5809aa3f103bc6efd5a548670f 100644
+index 1924757cec5d7f2d13ef35f9bbe1554d786713d7..0a2875f63523cc5eeec603e18eb62520587a8475 100644
 --- a/src/main/java/net/minecraft/server/players/GameProfileCache.java
 +++ b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-@@ -90,6 +90,7 @@ public class GameProfileCache {
+@@ -89,6 +89,7 @@ public class GameProfileCache {
                  }
              };
  

--- a/patches/server/0105-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0105-Add-setting-for-proxy-online-mode-status.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add setting for proxy online mode status
 TODO: Add isProxyOnlineMode check to Metrics
 
 diff --git a/src/main/java/net/minecraft/server/players/GameProfileCache.java b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-index 1a97dd1f9b9fcc5809aa3f103bc6efd5a548670f..68f95f4782c1effdee13543b702fdcc78ce14353 100644
+index 0a2875f63523cc5eeec603e18eb62520587a8475..09de1ca3802e97442bc090db0cc87fd833ad3a9f 100644
 --- a/src/main/java/net/minecraft/server/players/GameProfileCache.java
 +++ b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-@@ -90,7 +90,8 @@ public class GameProfileCache {
+@@ -89,7 +89,8 @@ public class GameProfileCache {
                  }
              };
  
@@ -19,7 +19,7 @@ index 1a97dd1f9b9fcc5809aa3f103bc6efd5a548670f..68f95f4782c1effdee13543b702fdcc7
              repository.findProfilesByNames(new String[]{name}, profilelookupcallback);
              GameProfile gameprofile = (GameProfile) atomicreference.get();
  
-@@ -107,7 +108,7 @@ public class GameProfileCache {
+@@ -106,7 +107,7 @@ public class GameProfileCache {
      }
  
      private static boolean usesAuthentication() {
@@ -43,7 +43,7 @@ index 78b11d6fd74fb0714a8013fdc78d096643c4f83c..6a64c58fff9bbed542bf29a029531996
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1d08a65fa782d8150bc6253d11f0a9ffa25ea325..a7c5f9b5c734243c81894e6b073e9ccef191f296 100644
+index b1cf58579bdb48d97b27f4295212cfb63a9eb98f..ee4d991c027b1390f3c995a82ebecc72e5622c9f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1822,7 +1822,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0107-Configurable-packet-in-spam-threshold.patch
+++ b/patches/server/0107-Configurable-packet-in-spam-threshold.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable packet in spam threshold
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d03d5629e3605626bba6ea806990443bfb151c61..3ec76a3073bb5ce95e56302eb16940b9efd23e47 100644
+index fe6a995331ba489911886047130861496d75979a..4300fd30f782a2fe32519f7e27edff292ca46ef6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1533,13 +1533,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1536,13 +1536,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      // Spigot start - limit place/interactions
      private int limitedPackets;
      private long lastLimitedPacket = -1;

--- a/patches/server/0108-Configurable-flying-kick-messages.patch
+++ b/patches/server/0108-Configurable-flying-kick-messages.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable flying kick messages
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3ec76a3073bb5ce95e56302eb16940b9efd23e47..d5aff46a9f4683fa6e175ecfd1702f7da8af21a8 100644
+index 4300fd30f782a2fe32519f7e27edff292ca46ef6..3e745e7adb36b9d5cb06754792c891266ec30722 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -339,7 +339,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -338,7 +338,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          if (this.clientIsFloating && !this.player.isSleeping() && !this.player.isPassenger() && !this.player.isDeadOrDying()) {
              if (++this.aboveGroundTickCount > 80) {
                  ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked for floating too long!", this.player.getName().getString());
@@ -17,7 +17,7 @@ index 3ec76a3073bb5ce95e56302eb16940b9efd23e47..d5aff46a9f4683fa6e175ecfd1702f7d
                  return;
              }
          } else {
-@@ -358,7 +358,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -357,7 +357,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              if (this.clientVehicleIsFloating && this.player.getRootVehicle().getControllingPassenger() == this.player) {
                  if (++this.aboveGroundVehicleTickCount > 80) {
                      ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked for floating a vehicle too long!", this.player.getName().getString());

--- a/patches/server/0130-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0130-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -14,10 +14,10 @@ To be converted into a Paper-API event at some point in the future?
 public net.minecraft.world.entity.player.Player removeEntitiesOnShoulder()V
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d5aff46a9f4683fa6e175ecfd1702f7da8af21a8..268ce65aa944295b0107daa2824fc93b55afeb89 100644
+index 3e745e7adb36b9d5cb06754792c891266ec30722..2f6591e5a0e450bfa68ab3e30f88afba68fbef29 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2178,6 +2178,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2181,6 +2181,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          switch (packet.getAction()) {
              case PRESS_SHIFT_KEY:
                  this.player.setShiftKeyDown(true);

--- a/patches/server/0137-Do-not-submit-profile-lookups-to-worldgen-threads.patch
+++ b/patches/server/0137-Do-not-submit-profile-lookups-to-worldgen-threads.patch
@@ -37,10 +37,10 @@ index 114f4017c4133042178c57d424f10079163835dd..aa52b271bd556a29f774fde375b713d0
      private static final int LINEAR_LOOKUP_THRESHOLD = 8;
      public static final long NANOS_PER_MILLI = 1000000L;
 diff --git a/src/main/java/net/minecraft/server/players/GameProfileCache.java b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-index 68f95f4782c1effdee13543b702fdcc78ce14353..fdf3194499512614355b02aa11e34574cdd89c59 100644
+index 09de1ca3802e97442bc090db0cc87fd833ad3a9f..9c500642eb2b59bf9aabd6b5d563e5fb15603056 100644
 --- a/src/main/java/net/minecraft/server/players/GameProfileCache.java
 +++ b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-@@ -170,7 +170,7 @@ public class GameProfileCache {
+@@ -169,7 +169,7 @@ public class GameProfileCache {
              } else {
                  CompletableFuture<Optional<GameProfile>> completablefuture1 = CompletableFuture.supplyAsync(() -> {
                      return this.get(username);

--- a/patches/server/0138-Basic-PlayerProfile-API.patch
+++ b/patches/server/0138-Basic-PlayerProfile-API.patch
@@ -590,10 +590,10 @@ index 360ecf561cde34b07929519a67485e0315e4676c..22f53d722f8e567554d2f7ed6c683e76
              String s = (String) Optional.ofNullable((String) optionset.valueOf("world")).orElse(dedicatedserversettings.getProperties().levelName);
              LevelStorageSource convertable = LevelStorageSource.createDefault(file.toPath());
 diff --git a/src/main/java/net/minecraft/server/players/GameProfileCache.java b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-index fdf3194499512614355b02aa11e34574cdd89c59..4dc08b0abf0a1edb51cc586d1a89444ba790ca7f 100644
+index 9c500642eb2b59bf9aabd6b5d563e5fb15603056..731a7c0363c8c91d25b35f7cbbb480879381bc8d 100644
 --- a/src/main/java/net/minecraft/server/players/GameProfileCache.java
 +++ b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-@@ -127,6 +127,17 @@ public class GameProfileCache {
+@@ -126,6 +126,17 @@ public class GameProfileCache {
          return this.operationCount.incrementAndGet();
      }
  
@@ -612,7 +612,7 @@ index fdf3194499512614355b02aa11e34574cdd89c59..4dc08b0abf0a1edb51cc586d1a89444b
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5096bc714c6b4731974da5d5cacafd46814f36f7..74fc348a64cfbb119f97e45dacc02512dbe150d5 100644
+index 22656e27aeb2b6de8bb2be2d7db402a4a81fec87..0cb507dde784443fea2a9ca2acb7a77e225cfbc5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -260,6 +260,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;

--- a/patches/server/0155-Add-PlayerJumpEvent.patch
+++ b/patches/server/0155-Add-PlayerJumpEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerJumpEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 268ce65aa944295b0107daa2824fc93b55afeb89..6b1885cd2dd03772e2a8f3ea2b58ce68e70e97e7 100644
+index 2f6591e5a0e450bfa68ab3e30f88afba68fbef29..61671ef718bd921ad0051f717a871d3db2ac5eab 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1227,7 +1227,34 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1225,7 +1225,34 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              boolean flag = d7 > 0.0D;
  
                              if (this.player.onGround() && !packet.isOnGround() && flag) {

--- a/patches/server/0165-AsyncTabCompleteEvent.patch
+++ b/patches/server/0165-AsyncTabCompleteEvent.patch
@@ -16,10 +16,10 @@ Also adds isCommand and getLocation to the sync TabCompleteEvent
 Co-authored-by: Aikar <aikar@aikar.co>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6b1885cd2dd03772e2a8f3ea2b58ce68e70e97e7..9aa8c643d0a338afefeb8ff6a1f016cc0ffdb00f 100644
+index 61671ef718bd921ad0051f717a871d3db2ac5eab..a128040002fd9f297b9ea501af357c598cbe7af2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -691,12 +691,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -688,12 +688,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      }
  
@@ -38,7 +38,7 @@ index 6b1885cd2dd03772e2a8f3ea2b58ce68e70e97e7..9aa8c643d0a338afefeb8ff6a1f016cc
              return;
          }
          // Paper start
-@@ -707,18 +711,45 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -704,18 +708,45 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          // Paper end
          // CraftBukkit end
@@ -91,7 +91,7 @@ index 6b1885cd2dd03772e2a8f3ea2b58ce68e70e97e7..9aa8c643d0a338afefeb8ff6a1f016cc
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a41b39a7b8f6011327584d5556ddb304a6e32e4b..dbbb697a91f137c32be663bb8c0a263158723a94 100644
+index 078e9bd8d93e6f6d6b68841566a6ee5f27deb402..93f6b1e469d5fe240ebdba98f969cf9b3b987da9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2228,7 +2228,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0180-Player.setPlayerProfile-API.patch
+++ b/patches/server/0180-Player.setPlayerProfile-API.patch
@@ -9,10 +9,10 @@ This can be useful for changing name or skins after a player has logged in.
 public-f net.minecraft.world.entity.player.Player gameProfile
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9aa8c643d0a338afefeb8ff6a1f016cc0ffdb00f..520de61cd21d71f8c77175977987091e3caa0be9 100644
+index a128040002fd9f297b9ea501af357c598cbe7af2..1e7d74df49712a3c3e107026406718c16bc3d166 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1465,7 +1465,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1468,7 +1468,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          this.internalTeleport(dest.getX(), dest.getY(), dest.getZ(), dest.getYaw(), dest.getPitch(), Collections.emptySet());
      }
  

--- a/patches/server/0213-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0213-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4190c31fae199e6b6481d2b840f15fe68615d720..2e1cabfc3131f43feadf8ce61d0027c18d7c78e6 100644
+index 243cba71dabd245ef5c0e196dadf3425424255b0..6d7bc8e979e608db9fca1bb881b7767f9f9fd89b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1470,7 +1470,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -29,7 +29,7 @@ index 4190c31fae199e6b6481d2b840f15fe68615d720..2e1cabfc3131f43feadf8ce61d0027c1
              }
              // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 1b56d6b05fee0aa430dab666f50c5b886c3910d0..2584e8eb867dca35e945ec7ab83bc2181d7bde26 100644
+index 8f826978564a1d144901f1ca2e46c5b083b68945..0100aafc999cadcfa7a904a812355502379c418d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -692,7 +692,7 @@ public class ServerPlayer extends Player {
@@ -75,7 +75,7 @@ index 1b56d6b05fee0aa430dab666f50c5b886c3910d0..2584e8eb867dca35e945ec7ab83bc218
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 520de61cd21d71f8c77175977987091e3caa0be9..9c8d5ccc82aafe455ec39e61af60d8a634278d1a 100644
+index 1e7d74df49712a3c3e107026406718c16bc3d166..b7ed2403dc0fd86f163b86af6e52aa9f10b607a0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -219,6 +219,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -86,7 +86,7 @@ index 520de61cd21d71f8c77175977987091e3caa0be9..9c8d5ccc82aafe455ec39e61af60d8a6
  import org.bukkit.event.inventory.InventoryCreativeEvent;
  import org.bukkit.event.inventory.InventoryType.SlotType;
  import org.bukkit.event.inventory.SmithItemEvent;
-@@ -2532,10 +2533,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2535,10 +2536,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handleContainerClose(ServerboundContainerClosePacket packet) {
@@ -104,7 +104,7 @@ index 520de61cd21d71f8c77175977987091e3caa0be9..9c8d5ccc82aafe455ec39e61af60d8a6
          this.player.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6e0a21935f9d5f35cbce72b32e0a89bb636804e2..5607616c933556de00bfb4218ba75ee477bb2201 100644
+index 782cc6d910efe5bc5498d0083afab42fad6c4fa2..49e3252d6af633d69bdf05ce71dc2a1b3d24f05a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -518,7 +518,7 @@ public abstract class PlayerList {
@@ -173,7 +173,7 @@ index f0194d4431821638e43a0f1b12b39f668ad147d1..21e3070a9aab9b4d8d352655d0145c99
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cb6cad55f02feaacfb1a194b63fa75c3b7e267be..d034c84a95f24233a8dd54b25c1ef670311c346a 100644
+index f929327522b98c12823ebbf94531c1c3681b1efa..701c8c8320f922c6227046d8275595279e5dba9a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1194,7 +1194,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0215-Refresh-player-inventory-when-cancelling-PlayerInter.patch
+++ b/patches/server/0215-Refresh-player-inventory-when-cancelling-PlayerInter.patch
@@ -16,10 +16,10 @@ Refresh the player inventory when PlayerInteractEntityEvent is
 cancelled to avoid this problem.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9c8d5ccc82aafe455ec39e61af60d8a634278d1a..9bc84ea2fbbc2f6f6e7358a5d595aafd20c10d74 100644
+index b7ed2403dc0fd86f163b86af6e52aa9f10b607a0..1e6c704279fe91530a23d17a151d28aa3fb9126e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2413,6 +2413,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2416,6 +2416,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              }
  
                              if (event.isCancelled()) {

--- a/patches/server/0230-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/patches/server/0230-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -22,7 +22,7 @@ to take the burden of this into their own hand without having to rely on
 plugins doing unsafe things.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9bc84ea2fbbc2f6f6e7358a5d595aafd20c10d74..01ae910d5997981ddbe400a057bb83932e89cbc0 100644
+index 1e6c704279fe91530a23d17a151d28aa3fb9126e..ea7eb7be6abfcfc3c70eba42cf31cc2030747428 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -257,6 +257,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -33,7 +33,7 @@ index 9bc84ea2fbbc2f6f6e7358a5d595aafd20c10d74..01ae910d5997981ddbe400a057bb8393
      // CraftBukkit end
      private int dropSpamTickCount;
      private double firstGoodX;
-@@ -375,6 +376,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -374,6 +375,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          this.keepConnectionAlive();
          // CraftBukkit start
          for (int spam; (spam = this.chatSpamTickCount.get()) > 0 && !this.chatSpamTickCount.compareAndSet(spam, spam - 1); ) ;
@@ -41,7 +41,7 @@ index 9bc84ea2fbbc2f6f6e7358a5d595aafd20c10d74..01ae910d5997981ddbe400a057bb8393
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -700,7 +702,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -697,7 +699,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleCustomCommandSuggestions(ServerboundCommandSuggestionPacket packet) {
          // PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel()); // Paper - run this async
          // CraftBukkit start

--- a/patches/server/0269-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/patches/server/0269-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 01ae910d5997981ddbe400a057bb83932e89cbc0..c4f6ea96f087edad74ca61acdb1908a9d3beb6aa 100644
+index ea7eb7be6abfcfc3c70eba42cf31cc2030747428..0a9a13404885e13061a8de88c25b01d3db039018 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -469,9 +469,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -475,9 +475,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  double d0 = entity.getX();
                  double d1 = entity.getY();
                  double d2 = entity.getZ();
@@ -22,7 +22,7 @@ index 01ae910d5997981ddbe400a057bb83932e89cbc0..c4f6ea96f087edad74ca61acdb1908a9
                  float f = Mth.wrapDegrees(packet.getYRot());
                  float f1 = Mth.wrapDegrees(packet.getXRot());
                  double d6 = d3 - this.vehicleFirstGoodX;
-@@ -506,6 +506,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -511,6 +511,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  }
                  speed *= 2f; // TODO: Get the speed of the vehicle instead of the player
  
@@ -39,8 +39,8 @@ index 01ae910d5997981ddbe400a057bb83932e89cbc0..c4f6ea96f087edad74ca61acdb1908a9
                  if (d10 - d9 > Math.max(100.0D, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
                  // CraftBukkit end
                      ServerGamePacketListenerImpl.LOGGER.warn("{} (vehicle of {}) moved too quickly! {},{},{}", new Object[]{entity.getName().getString(), this.player.getName().getString(), d6, d7, d8});
-@@ -1182,9 +1192,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
-                     this.allowedPlayerTicks = 20; // CraftBukkit
+@@ -1180,9 +1190,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+ 
                  } else {
                      this.awaitingTeleportTime = this.tickCount;
 -                    double d0 = ServerGamePacketListenerImpl.clampHorizontal(packet.getX(this.player.getX()));
@@ -52,7 +52,7 @@ index 01ae910d5997981ddbe400a057bb83932e89cbc0..c4f6ea96f087edad74ca61acdb1908a9
                      float f = Mth.wrapDegrees(packet.getYRot(this.player.getYRot()));
                      float f1 = Mth.wrapDegrees(packet.getXRot(this.player.getXRot()));
  
-@@ -1240,6 +1250,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1238,6 +1248,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  } else {
                                      speed = this.player.getAbilities().walkingSpeed * 10f;
                                  }

--- a/patches/server/0276-Don-t-allow-digging-into-unloaded-chunks.patch
+++ b/patches/server/0276-Don-t-allow-digging-into-unloaded-chunks.patch
@@ -59,10 +59,10 @@ index e3b7441d875b55ffce295c948f3dc867be09e042..79020edc9fac79e8b186d0f57f956d21
  
                  this.level.destroyBlockProgress(this.player.getId(), pos, -1);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c4f6ea96f087edad74ca61acdb1908a9d3beb6aa..e01c4b59686d0aa1726d793df0238b8a699e1bf4 100644
+index 0a9a13404885e13061a8de88c25b01d3db039018..20b8fe97ee0b73e3b1a71b8366267d7c5de5da2e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1589,6 +1589,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1592,6 +1592,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              case START_DESTROY_BLOCK:
              case ABORT_DESTROY_BLOCK:
              case STOP_DESTROY_BLOCK:

--- a/patches/server/0282-Book-Size-Limits.patch
+++ b/patches/server/0282-Book-Size-Limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Book Size Limits
 Puts some limits on the size of books.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e01c4b59686d0aa1726d793df0238b8a699e1bf4..efbc8236b148e3a194125d0ccfbd215a8cc8455a 100644
+index 20b8fe97ee0b73e3b1a71b8366267d7c5de5da2e..f4c58330cc1f65231fa48a7dd4a199fbfc696f26 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1029,6 +1029,45 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1026,6 +1026,45 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handleEditBook(ServerboundEditBookPacket packet) {

--- a/patches/server/0290-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0290-Implement-Brigadier-Mojang-API.patch
@@ -131,10 +131,10 @@ index 2a88cf008c98284954108f2362f46ac14c84200a..b27256d251e5db5781197319f79f89cc
  
              if (commandnode2.canUse(source)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index efbc8236b148e3a194125d0ccfbd215a8cc8455a..e4073e8287952e1528dd855c79987a1677f921dd 100644
+index f4c58330cc1f65231fa48a7dd4a199fbfc696f26..b0eb46e60fa51386999cda8ecc31ccf2d3e05b99 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -743,8 +743,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -740,8 +740,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          ParseResults<CommandSourceStack> parseresults = this.server.getCommands().getDispatcher().parse(stringreader, this.player.createCommandSourceStack());
  
                          this.server.getCommands().getDispatcher().getCompletionSuggestions(parseresults).thenAccept((suggestions) -> {
@@ -149,7 +149,7 @@ index efbc8236b148e3a194125d0ccfbd215a8cc8455a..e4073e8287952e1528dd855c79987a16
                          });
                      });
                  }
-@@ -759,7 +763,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -756,7 +760,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          builder.suggest(completion.suggestion(), PaperAdventure.asVanilla(completion.tooltip()));
                      }
                  });

--- a/patches/server/0292-Limit-Client-Sign-length-more.patch
+++ b/patches/server/0292-Limit-Client-Sign-length-more.patch
@@ -22,7 +22,7 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e4073e8287952e1528dd855c79987a1677f921dd..aca772397752b7f4c1b98c14c019f6fb9f71aba4 100644
+index b0eb46e60fa51386999cda8ecc31ccf2d3e05b99..d8285ff999cfea9a7b62e9914a7a7dfdae2ede76 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -291,6 +291,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -33,7 +33,7 @@ index e4073e8287952e1528dd855c79987a1677f921dd..aca772397752b7f4c1b98c14c019f6fb
  
      public ServerGamePacketListenerImpl(MinecraftServer server, Connection connection, ServerPlayer player, CommonListenerCookie clientData) {
          super(server, connection, clientData, player); // CraftBukkit
-@@ -3060,7 +3061,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3063,7 +3064,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handleSignUpdate(ServerboundSignUpdatePacket packet) {

--- a/patches/server/0380-Validate-PickItem-Packet-and-kick-for-invalid.patch
+++ b/patches/server/0380-Validate-PickItem-Packet-and-kick-for-invalid.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Validate PickItem Packet and kick for invalid
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index aca772397752b7f4c1b98c14c019f6fb9f71aba4..2197bd0d9b91c33d203b875d062483b9e57da6dc 100644
+index d8285ff999cfea9a7b62e9914a7a7dfdae2ede76..3b1127ac1e30c809d290192319f8bc5f9de30b46 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -870,7 +870,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -867,7 +867,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      @Override
      public void handlePickItem(ServerboundPickItemPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());

--- a/patches/server/0385-Prevent-teleporting-dead-entities.patch
+++ b/patches/server/0385-Prevent-teleporting-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent teleporting dead entities
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2197bd0d9b91c33d203b875d062483b9e57da6dc..bac6ab63b3efbd72b1e31372ed34113763b3d47f 100644
+index 3b1127ac1e30c809d290192319f8bc5f9de30b46..1776c839c651fe8491613fe606cfb8e8fe25b239 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1542,6 +1542,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1545,6 +1545,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      }
  
      public void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<RelativeMovement> set) { // Paper

--- a/patches/server/0405-Prevent-position-desync-in-playerconnection-causing-.patch
+++ b/patches/server/0405-Prevent-position-desync-in-playerconnection-causing-.patch
@@ -14,10 +14,10 @@ behaviour, we need to move all of this dangerous logic outside
 of the move call and into an appropriate place in the tick method.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index bac6ab63b3efbd72b1e31372ed34113763b3d47f..2740df2b89ff2f3ce7f52f7aef95bc5e0fd4d43c 100644
+index 1776c839c651fe8491613fe606cfb8e8fe25b239..33a9d4047d3a2bd57b12f3517592a333a574fa32 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1368,6 +1368,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1366,6 +1366,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              this.player.move(MoverType.PLAYER, new Vec3(d6, d7, d8));
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move

--- a/patches/server/0408-Add-and-implement-PlayerRecipeBookClickEvent.patch
+++ b/patches/server/0408-Add-and-implement-PlayerRecipeBookClickEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add and implement PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2740df2b89ff2f3ce7f52f7aef95bc5e0fd4d43c..10267257e012ebbeb714ce8aebe9b4a84dbb9750 100644
+index 33a9d4047d3a2bd57b12f3517592a333a574fa32..0bc8e06a2a7bc7858433e78fb0ad381d2fcb1f72 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2967,16 +2967,40 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2970,16 +2970,40 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              if (!this.player.containerMenu.stillValid(this.player)) {
                  ServerGamePacketListenerImpl.LOGGER.debug("Player {} interacted with invalid menu {}", this.player, this.player.containerMenu);
              } else {

--- a/patches/server/0411-Add-permission-for-command-blocks.patch
+++ b/patches/server/0411-Add-permission-for-command-blocks.patch
@@ -18,10 +18,10 @@ index b7e6d8441e8444c36919c126a8adeaeed02df08c..a9ede0d719e866655ab48fb5d0263c7d
                  return false;
              } else if (this.player.blockActionRestricted(this.level, pos, this.gameModeForPlayer)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 10267257e012ebbeb714ce8aebe9b4a84dbb9750..361ea663e6a2449855e0b7aa85c1b61a1bf211c2 100644
+index 0bc8e06a2a7bc7858433e78fb0ad381d2fcb1f72..85c8dd4f40eb5c71e8df52817167932e70e94c14 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -781,7 +781,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -778,7 +778,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (!this.server.isCommandBlockEnabled()) {
              this.player.sendSystemMessage(Component.translatable("advMode.notEnabled"));
@@ -30,7 +30,7 @@ index 10267257e012ebbeb714ce8aebe9b4a84dbb9750..361ea663e6a2449855e0b7aa85c1b61a
              this.player.sendSystemMessage(Component.translatable("advMode.notAllowed"));
          } else {
              BaseCommandBlock commandblocklistenerabstract = null;
-@@ -848,7 +848,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -845,7 +845,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (!this.server.isCommandBlockEnabled()) {
              this.player.sendSystemMessage(Component.translatable("advMode.notEnabled"));

--- a/patches/server/0413-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0413-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -89,10 +89,10 @@ index 3dfbd1225b0c1ee6b6fb2e842efdb1a8ff2c26c6..030d6c0d067dacf4f9603bdfb21acca8
  
                  playerlist.sendPlayerPermissionLevel(this);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 361ea663e6a2449855e0b7aa85c1b61a1bf211c2..dce7e232b4e2c2a7aa997da1c6aef955f8846e17 100644
+index 85c8dd4f40eb5c71e8df52817167932e70e94c14..9c0cc06f4ebbfbd7959f05cae12a9f9e7e622c04 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3170,7 +3170,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3173,7 +3173,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleChangeDifficulty(ServerboundChangeDifficultyPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (this.player.hasPermissions(2) || this.isSingleplayerOwner()) {
@@ -102,7 +102,7 @@ index 361ea663e6a2449855e0b7aa85c1b61a1bf211c2..dce7e232b4e2c2a7aa997da1c6aef955
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dfe8d6d8b592a7dc9b1f1d7fb68d0960dbeb387f..1b43d61f3464218bdf5221ffbf87a7280fa8028c 100644
+index 32482dc7bc10575ad43d668b4cac189e9a365911..2a05cb7f1e9304bb2ccd2bba3a46cfc02cc7f9a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -955,8 +955,8 @@ public final class CraftServer implements Server {
@@ -117,7 +117,7 @@ index dfe8d6d8b592a7dc9b1f1d7fb68d0960dbeb387f..1b43d61f3464218bdf5221ffbf87a728
              for (SpawnCategory spawnCategory : SpawnCategory.values()) {
                  if (CraftSpawnCategory.isValidForLimits(spawnCategory)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a834b763cf9190bf0effb02fe08b97861d5160cb..5a2f4712417ca48601674d6719590fab5ca336e7 100644
+index 9e755de8e278f5dd20c9a2d8c8057c16ffe0e118..bf8a645d310a307e5ea7e93a00eb336481100768 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1158,7 +1158,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {

--- a/patches/server/0455-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0455-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -9,10 +9,10 @@ as this is how Vanilla teleports entities.
 Cancel any pending motion when teleported.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index dce7e232b4e2c2a7aa997da1c6aef955f8846e17..45b8c7520c5a966fa0923dd8f616f30c5d80458c 100644
+index 9c0cc06f4ebbfbd7959f05cae12a9f9e7e622c04..0d4e641187b305c4b56782b4c70bca39efcaa69c 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -660,7 +660,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -657,7 +657,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  return;
              }
  
@@ -21,7 +21,7 @@ index dce7e232b4e2c2a7aa997da1c6aef955f8846e17..45b8c7520c5a966fa0923dd8f616f30c
              this.lastGoodX = this.awaitingPositionFromClient.x;
              this.lastGoodY = this.awaitingPositionFromClient.y;
              this.lastGoodZ = this.awaitingPositionFromClient.z;
-@@ -1584,7 +1584,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1587,7 +1587,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // CraftBukkit end
  
          this.awaitingTeleportTime = this.tickCount;
@@ -69,7 +69,7 @@ index 41f549f16f69f9bc50a004096e6c3c0f6e4d4eaf..9ec83d6eeff22c2ce25374a83f581a67
                          if (entity instanceof Mob) {
                              Mob entityinsentient = (Mob) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 3444051416632eb30ef2cb820767285718095497..fdf22cb358040738a1b7fabf1cef47a5d33af832 100644
+index c17bb16567ad2354dc80e710469730b1dbc55b08..d5e8c8ed7528cdac203a7594ccf9576db0e5f019 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -237,7 +237,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0465-Fix-for-large-move-vectors-crashing-server.patch
+++ b/patches/server/0465-Fix-for-large-move-vectors-crashing-server.patch
@@ -6,13 +6,13 @@ Subject: [PATCH] Fix for large move vectors crashing server
 Check movement distance also based on current position.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 45b8c7520c5a966fa0923dd8f616f30c5d80458c..052c86fb2c46d6d19ebdf3632f7d19d046d495ac 100644
+index 0d4e641187b305c4b56782b4c70bca39efcaa69c..5ee4d04f9770672f451b8a87b65075432203e310 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -467,9 +467,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
- 
-             if (entity != this.player && entity.getControllingPassenger() == this.player && entity == this.lastVehicle) {
-                 ServerLevel worldserver = this.player.serverLevel();
+@@ -473,9 +473,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+                 float prevYaw = this.player.getYRot();
+                 float prevPitch = this.player.getXRot();
+                 // CraftBukkit end
 -                double d0 = entity.getX();
 -                double d1 = entity.getY();
 -                double d2 = entity.getZ();
@@ -22,12 +22,11 @@ index 45b8c7520c5a966fa0923dd8f616f30c5d80458c..052c86fb2c46d6d19ebdf3632f7d19d0
                  double d3 = ServerGamePacketListenerImpl.clampHorizontal(packet.getX()); final double toX = d3; // Paper - OBFHELPER
                  double d4 = ServerGamePacketListenerImpl.clampVertical(packet.getY()); final double toY = d4; // Paper - OBFHELPER
                  double d5 = ServerGamePacketListenerImpl.clampHorizontal(packet.getZ()); final double toZ = d5; // Paper - OBFHELPER
-@@ -479,8 +479,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -485,7 +485,19 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  double d7 = d4 - this.vehicleFirstGoodY;
                  double d8 = d5 - this.vehicleFirstGoodZ;
                  double d9 = entity.getDeltaMovement().lengthSqr();
 -                double d10 = d6 * d6 + d7 * d7 + d8 * d8;
--
 +                // Paper start - fix large move vectors killing the server
 +                double currDeltaX = toX - fromX;
 +                double currDeltaY = toY - fromY;
@@ -44,7 +43,7 @@ index 45b8c7520c5a966fa0923dd8f616f30c5d80458c..052c86fb2c46d6d19ebdf3632f7d19d0
  
                  // CraftBukkit start - handle custom speeds and skipped ticks
                  this.allowedPlayerTicks += (System.currentTimeMillis() / 50) - this.lastTick;
-@@ -526,9 +537,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -531,9 +543,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                  boolean flag = worldserver.noCollision(entity, entity.getBoundingBox().deflate(0.0625D));
  
@@ -57,7 +56,7 @@ index 45b8c7520c5a966fa0923dd8f616f30c5d80458c..052c86fb2c46d6d19ebdf3632f7d19d0
                  boolean flag1 = entity.verticalCollisionBelow;
  
                  if (entity instanceof LivingEntity) {
-@@ -1274,7 +1285,18 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1272,7 +1284,18 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          double d7 = d1 - this.firstGoodY;
                          double d8 = d2 - this.firstGoodZ;
                          double d9 = this.player.getDeltaMovement().lengthSqr();
@@ -77,7 +76,7 @@ index 45b8c7520c5a966fa0923dd8f616f30c5d80458c..052c86fb2c46d6d19ebdf3632f7d19d0
  
                          if (this.player.isSleeping()) {
                              if (d10 > 1.0D) {
-@@ -1328,9 +1350,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1326,9 +1349,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              AABB axisalignedbb = this.player.getBoundingBox();
  

--- a/patches/server/0492-Limit-recipe-packets.patch
+++ b/patches/server/0492-Limit-recipe-packets.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Limit recipe packets
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 052c86fb2c46d6d19ebdf3632f7d19d046d495ac..b13e19d7214cc8a84693df7f052ca0d4b8a34140 100644
+index 5ee4d04f9770672f451b8a87b65075432203e310..498d38a016828384fe86129a7f0412c6aa981a9a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -258,6 +258,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -16,7 +16,7 @@ index 052c86fb2c46d6d19ebdf3632f7d19d046d495ac..b13e19d7214cc8a84693df7f052ca0d4
      // CraftBukkit end
      private int dropSpamTickCount;
      private double firstGoodX;
-@@ -378,6 +379,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -377,6 +378,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // CraftBukkit start
          for (int spam; (spam = this.chatSpamTickCount.get()) > 0 && !this.chatSpamTickCount.compareAndSet(spam, spam - 1); ) ;
          if (tabSpamLimiter.get() > 0) tabSpamLimiter.getAndDecrement(); // Paper - split to seperate variable
@@ -24,7 +24,7 @@ index 052c86fb2c46d6d19ebdf3632f7d19d046d495ac..b13e19d7214cc8a84693df7f052ca0d4
          /* Use thread-safe field access instead
          if (this.chatSpamTickCount > 0) {
              --this.chatSpamTickCount;
-@@ -2983,6 +2985,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2987,6 +2989,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handlePlaceRecipe(ServerboundPlaceRecipePacket packet) {

--- a/patches/server/0509-Fix-interact-event-not-being-called-sometimes.patch
+++ b/patches/server/0509-Fix-interact-event-not-being-called-sometimes.patch
@@ -11,10 +11,10 @@ Subject: [PATCH] Fix interact event not being called sometimes
 Co-authored-by: Moulberry <james.jenour@protonmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b13e19d7214cc8a84693df7f052ca0d4b8a34140..30513a13c626d117e2de9ceef46621ef8cde6386 100644
+index 498d38a016828384fe86129a7f0412c6aa981a9a..f066a3e2c21678f1019d223f97d181aa869ed9cc 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1761,7 +1761,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1765,7 +1765,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  MutableComponent ichatmutablecomponent = Component.translatable("build.tooHigh", i - 1).withStyle(ChatFormatting.RED);
  
                                  this.player.sendSystemMessage(ichatmutablecomponent, true);
@@ -23,7 +23,7 @@ index b13e19d7214cc8a84693df7f052ca0d4b8a34140..30513a13c626d117e2de9ceef46621ef
                                  this.player.swing(enumhand, true);
                              }
                          }
-@@ -2304,13 +2304,20 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2308,13 +2308,20 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          double d3 = this.player.gameMode.getGameModeForPlayer() == GameType.CREATIVE ? 5.0D : 4.5D;
          // SPIGOT-5607: Only call interact event if no block or entity is being clicked. Use bukkit ray trace method, because it handles blocks and entities at the same time
          // SPIGOT-7429: Make sure to call PlayerInteractEvent for spectators and non-pickable entities

--- a/patches/server/0555-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0555-Allow-using-signs-inside-spawn-protection.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow using signs inside spawn protection
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 30513a13c626d117e2de9ceef46621ef8cde6386..23e8bc131a6645d38b26eca3323eee7868c120ba 100644
+index f066a3e2c21678f1019d223f97d181aa869ed9cc..4ad617dcaf1af622f405a2c6cf08ad56de85cd9d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1753,7 +1753,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1757,7 +1757,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      int i = this.player.level().getMaxBuildHeight();
  
                      if (blockposition.getY() < i) {

--- a/patches/server/0561-Don-t-ignore-result-of-PlayerEditBookEvent.patch
+++ b/patches/server/0561-Don-t-ignore-result-of-PlayerEditBookEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't ignore result of PlayerEditBookEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 23e8bc131a6645d38b26eca3323eee7868c120ba..358a3ebd39bbbe9e4eba7197177bbf76e045b59c 100644
+index 4ad617dcaf1af622f405a2c6cf08ad56de85cd9d..2e41cf6f694549d9783884a2f1a9e6a54ad137c4 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1192,7 +1192,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1190,7 +1190,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
  
          itemstack.addTagElement("pages", nbttaglist);

--- a/patches/server/0571-fix-PlayerItemHeldEvent-firing-twice.patch
+++ b/patches/server/0571-fix-PlayerItemHeldEvent-firing-twice.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] fix PlayerItemHeldEvent firing twice
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 358a3ebd39bbbe9e4eba7197177bbf76e045b59c..dca8f977b13070a378ff4fd90fc61716da2636aa 100644
+index 2e41cf6f694549d9783884a2f1a9e6a54ad137c4..87e118594209d3f483588f5f59013da635f59a24 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1922,6 +1922,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1926,6 +1926,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (this.player.isImmobile()) return; // CraftBukkit
          if (packet.getSlot() >= 0 && packet.getSlot() < Inventory.getSelectionSize()) {

--- a/patches/server/0578-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/server/0578-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add RespawnFlags to PlayerRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index dca8f977b13070a378ff4fd90fc61716da2636aa..ba6f0c057f182b823d27d00e8c78349ca79c35ab 100644
+index 87e118594209d3f483588f5f59013da635f59a24..a4baca36aece8d6944453e87589d363213adee56 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2637,7 +2637,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2641,7 +2641,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              case PERFORM_RESPAWN:
                  if (this.player.wonGame) {
                      this.player.wonGame = false;
@@ -18,7 +18,7 @@ index dca8f977b13070a378ff4fd90fc61716da2636aa..ba6f0c057f182b823d27d00e8c78349c
                  } else {
                      if (this.player.getHealth() > 0.0F) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c2951a771456fc803dee0691cbe40f56a3010c70..bccb8400dd50654bae5cab23e1944fd5e6732648 100644
+index 43e8cb83ec6cd18706dcba7022dd0f56cf24f33b..cf39405eddcc9e5b19c2ffae571921494e1857eb 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -783,6 +783,12 @@ public abstract class PlayerList {

--- a/patches/server/0590-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0590-additions-to-PlayerGameModeChangeEvent.patch
@@ -45,7 +45,7 @@ index aee8618e27b893b72931e925724dd683d2e6d2aa..5cb15e2209d7b315904a1fc6d650ce1e
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e460d3f66ef58e0788fd9dfb35a6ce0e3c171289..c82f4f6f023ac8f416613db4fbfe2f4af61fd2de 100644
+index b4dc1b47a0f7298d202c7dff602d8e24e643a215..2118cb563a70596fe3690ad1bd326e72beba3cee 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1988,8 +1988,16 @@ public class ServerPlayer extends Player {
@@ -131,10 +131,10 @@ index c61754976fab6654f55b1403d769eb1721871dca..236dabc1d4ae9dc9a2a2c07a4a27fc0b
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ba6f0c057f182b823d27d00e8c78349ca79c35ab..353f85398aff20f15b78ff4334a242558876df19 100644
+index a4baca36aece8d6944453e87589d363213adee56..3a7592f022a5fdd90a525d84502b450c08409cf1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2646,7 +2646,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2650,7 +2650,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                      this.player = this.server.getPlayerList().respawn(this.player, false, RespawnReason.DEATH);
                      if (this.server.isHardcore()) {
@@ -144,7 +144,7 @@ index ba6f0c057f182b823d27d00e8c78349ca79c35ab..353f85398aff20f15b78ff4334a24255
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ece389c0f124c65b4adce1f8ce53e9139b46fd6f..ef707c71f3ba78a54c7bcaf74d4bc3a4b844dc9c 100644
+index 8a924ae677a93a177651aa1ec0728e3b8d5528a6..6cbb672bc76647e923ec1c16b6e56ee6a4982875 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1559,7 +1559,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0593-Move-range-check-for-block-placing-up.patch
+++ b/patches/server/0593-Move-range-check-for-block-placing-up.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Move range check for block placing up
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 353f85398aff20f15b78ff4334a242558876df19..598e3ae877f014ce979d8a578445f8a314f0ba82 100644
+index 3a7592f022a5fdd90a525d84502b450c08409cf1..808b000b43c6099bb4d1a0ea3041ec221ce3e6bb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1739,6 +1739,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1743,6 +1743,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          if (itemstack.isItemEnabled(worldserver.enabledFeatures())) {
              BlockHitResult movingobjectpositionblock = packet.getHitResult();
              Vec3 vec3d = movingobjectpositionblock.getLocation();

--- a/patches/server/0596-Add-Unix-domain-socket-support.patch
+++ b/patches/server/0596-Add-Unix-domain-socket-support.patch
@@ -93,10 +93,10 @@ index 6641fd04821240b1bbeff1bd8d996a8f2fff8385..5f625acf04ddb56e3596d086252f9bfc
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 598e3ae877f014ce979d8a578445f8a314f0ba82..b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46 100644
+index 808b000b43c6099bb4d1a0ea3041ec221ce3e6bb..063a4f1d85154e21efc1708feed9e9e33bbe32fb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2469,6 +2469,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2473,6 +2473,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      // Spigot Start
      public SocketAddress getRawAddress()
      {

--- a/patches/server/0602-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0602-Add-PlayerKickEvent-causes.patch
@@ -209,10 +209,10 @@ index 0616a8e89931680602da2dbc640906708aebd5ca..70458ff8c9bf6f3263868b0f5570840f
          if (this.cserver.getServer().isRunning()) {
              this.cserver.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f504571922f94c5ab 100644
+index 063a4f1d85154e21efc1708feed9e9e33bbe32fb..5382fc27e4f0147cae32c2ee2959428d28ab9265 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -343,7 +343,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -342,7 +342,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          if (this.clientIsFloating && !this.player.isSleeping() && !this.player.isPassenger() && !this.player.isDeadOrDying()) {
              if (++this.aboveGroundTickCount > 80) {
                  ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked for floating too long!", this.player.getName().getString());
@@ -221,7 +221,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
                  return;
              }
          } else {
-@@ -362,7 +362,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -361,7 +361,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              if (this.clientVehicleIsFloating && this.player.getRootVehicle().getControllingPassenger() == this.player) {
                  if (++this.aboveGroundVehicleTickCount > 80) {
                      ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked for floating a vehicle too long!", this.player.getName().getString());
@@ -230,7 +230,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
                      return;
                  }
              } else {
-@@ -393,7 +393,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -392,7 +392,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) this.server.getPlayerIdleTimeout() * 1000L * 60L) {
              this.player.resetLastActionTime(); // CraftBukkit - SPIGOT-854
@@ -239,7 +239,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
          }
  
      }
-@@ -463,7 +463,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -462,7 +462,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleMoveVehicle(ServerboundMoveVehiclePacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (ServerGamePacketListenerImpl.containsInvalidValues(packet.getX(), packet.getY(), packet.getZ(), packet.getYRot(), packet.getXRot())) {
@@ -248,7 +248,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
          } else {
              Entity entity = this.player.getRootVehicle();
  
-@@ -669,7 +669,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -667,7 +667,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (packet.getId() == this.awaitingTeleport) {
              if (this.awaitingPositionFromClient == null) {
@@ -257,7 +257,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
                  return;
              }
  
-@@ -727,7 +727,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -725,7 +725,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel()); // Paper - run this async
          // CraftBukkit start
          if (this.chatSpamTickCount.addAndGet(io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.tabSpamIncrement) > io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.tabSpamLimit && !this.server.getPlayerList().isOp(this.player.getGameProfile())) { // Paper start - split and make configurable
@@ -266,7 +266,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
              return;
          }
          // Paper start
-@@ -886,7 +886,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -884,7 +884,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Paper start - validate pick item position
          if (!(packet.getSlot() >= 0 && packet.getSlot() < this.player.getInventory().items.size())) {
              ServerGamePacketListenerImpl.LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
@@ -275,7 +275,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
              return;
          }
          this.player.getInventory().pickSlot(packet.getSlot()); // Paper - Diff above if changed
-@@ -1071,7 +1071,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1069,7 +1069,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  int byteLength = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
                  if (byteLength > 256 * 4) {
                      ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send a book with with a page too large!");
@@ -284,7 +284,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
                      return;
                  }
                  byteTotal += byteLength;
-@@ -1094,14 +1094,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1092,14 +1092,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
              if (byteTotal > byteAllowed) {
                  ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send too large of a book. Book Size: " + byteTotal + " - Allowed:  "+ byteAllowed + " - Pages: " + pageList.size());
@@ -301,7 +301,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
              return;
          }
          this.lastBookTick = MinecraftServer.currentTick;
-@@ -1245,7 +1245,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1243,7 +1243,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      public void handleMovePlayer(ServerboundMovePlayerPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
          if (ServerGamePacketListenerImpl.containsInvalidValues(packet.getX(0.0D), packet.getY(0.0D), packet.getZ(0.0D), packet.getYRot(0.0F), packet.getXRot(0.0F))) {
@@ -310,7 +310,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
          } else {
              ServerLevel worldserver = this.player.serverLevel();
  
-@@ -1661,7 +1661,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1665,7 +1665,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          this.dropCount++;
                          if (this.dropCount >= 20) {
                              ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " dropped their items too quickly!");
@@ -319,7 +319,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
                              return;
                          }
                      }
-@@ -1944,7 +1944,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1948,7 +1948,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.player.resetLastActionTime();
          } else {
              ServerGamePacketListenerImpl.LOGGER.warn("{} tried to set an invalid carried item", this.player.getName().getString());
@@ -328,7 +328,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
          }
      }
  
-@@ -1957,7 +1957,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1961,7 +1961,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          // CraftBukkit end
          if (ServerGamePacketListenerImpl.isChatMessageIllegal(packet.message())) {
@@ -337,7 +337,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
          } else {
              Optional<LastSeenMessages> optional = this.tryHandleChat(packet.lastSeenMessages());
  
-@@ -1989,7 +1989,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1993,7 +1993,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      @Override
      public void handleChatCommand(ServerboundChatCommandPacket packet) {
          if (ServerGamePacketListenerImpl.isChatMessageIllegal(packet.command())) {
@@ -346,7 +346,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
          } else {
              Optional<LastSeenMessages> optional = this.tryHandleChat(packet.lastSeenMessages());
  
-@@ -2045,7 +2045,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2049,7 +2049,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private void handleMessageDecodeFailure(SignedMessageChain.DecodeException exception) {
          ServerGamePacketListenerImpl.LOGGER.warn("Failed to update secure chat state for {}: '{}'", this.player.getGameProfile().getName(), exception.getComponent().getString());
          if (exception.shouldDisconnect()) {
@@ -355,7 +355,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
          } else {
              this.player.sendSystemMessage(exception.getComponent().copy().withStyle(ChatFormatting.RED));
          }
-@@ -2093,7 +2093,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2097,7 +2097,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
              if (optional.isEmpty()) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Failed to validate message acknowledgements from {}", this.player.getName().getString());
@@ -364,7 +364,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
              }
  
              return optional;
-@@ -2276,7 +2276,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2280,7 +2280,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // this.chatSpamTickCount += 20;
          if (this.chatSpamTickCount.addAndGet(20) > 200 && !this.server.getPlayerList().isOp(this.player.getGameProfile())) {
              // CraftBukkit end
@@ -373,7 +373,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
          }
  
      }
-@@ -2288,7 +2288,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2292,7 +2292,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          synchronized (this.lastSeenMessages) {
              if (!this.lastSeenMessages.applyOffset(packet.offset())) {
                  ServerGamePacketListenerImpl.LOGGER.warn("Failed to validate message acknowledgements from {}", this.player.getName().getString());
@@ -382,7 +382,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
              }
  
          }
-@@ -2441,7 +2441,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2445,7 +2445,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              }
  
              if (i > 4096) {
@@ -391,7 +391,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
              }
  
          }
-@@ -2498,7 +2498,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2502,7 +2502,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Spigot Start
          if ( entity == this.player && !this.player.isSpectator() )
          {
@@ -400,7 +400,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
              return;
          }
          // Spigot End
-@@ -2597,7 +2597,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2601,7 +2601,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  // CraftBukkit end
                              }
                          } else {
@@ -409,7 +409,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
                              ServerGamePacketListenerImpl.LOGGER.warn("Player {} tried to attack an invalid entity", ServerGamePacketListenerImpl.this.player.getName().getString());
                          }
                      }
-@@ -3006,7 +3006,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3010,7 +3010,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Paper start
          if (!org.bukkit.Bukkit.isPrimaryThread()) {
              if (this.recipeSpamPackets.addAndGet(io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamIncrement) > io.papermc.paper.configuration.GlobalConfiguration.get().spamLimiter.recipeSpamLimit) {
@@ -418,7 +418,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
                  return;
              }
          }
-@@ -3241,7 +3241,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3245,7 +3245,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          if (!Objects.equals(profilepublickey_a, profilepublickey_a1)) {
              if (profilepublickey_a != null && profilepublickey_a1.expiresAt().isBefore(profilepublickey_a.expiresAt())) {
@@ -427,7 +427,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
              } else {
                  try {
                      SignatureValidator signaturevalidator = this.server.getProfileKeySignatureValidator();
-@@ -3254,7 +3254,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3258,7 +3258,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      this.resetPlayerChatState(remotechatsession_a.validate(this.player.getGameProfile(), signaturevalidator));
                  } catch (ProfilePublicKey.ValidationException profilepublickey_b) {
                      ServerGamePacketListenerImpl.LOGGER.error("Failed to validate profile key: {}", profilepublickey_b.getMessage());
@@ -437,7 +437,7 @@ index b7e6c7fdccb91f3cef5e6d96fe5f0c2ee7eb4f46..8d666fb6b2d9ed90691d672f50457192
  
              }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b6e2069c2e817565dec961473a02454abf3b107d..8e5d5c2341ff723fff110229af470f55b85eb964 100644
+index cf39405eddcc9e5b19c2ffae571921494e1857eb..891fdeaba2b0f287a0da87a20bb850ffcc9d66bf 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -684,7 +684,7 @@ public abstract class PlayerList {

--- a/patches/server/0619-Ensure-disconnect-for-book-edit-is-called-on-main.patch
+++ b/patches/server/0619-Ensure-disconnect-for-book-edit-is-called-on-main.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure disconnect for book edit is called on main
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8d666fb6b2d9ed90691d672f504571922f94c5ab..a9a6bdccd55559614d933bf02b7d12432feb52dc 100644
+index 5382fc27e4f0147cae32c2ee2959428d28ab9265..4440c872aaf0a708de5c561f46ababadef95d900 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1101,7 +1101,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1099,7 +1099,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          // Paper end
          // CraftBukkit start
          if (this.lastBookTick + 20 > MinecraftServer.currentTick) {

--- a/patches/server/0623-Adds-PlayerArmSwingEvent.patch
+++ b/patches/server/0623-Adds-PlayerArmSwingEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Adds PlayerArmSwingEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a9a6bdccd55559614d933bf02b7d12432feb52dc..2b251bbfdb208e9482acf87c233dac90f8908018 100644
+index 4440c872aaf0a708de5c561f46ababadef95d900..2d7b88d0ea0acdd6e40d7c3e622af26de26bc0b7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2326,7 +2326,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2330,7 +2330,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          } // Paper end
  
          // Arm swing animation

--- a/patches/server/0624-Fixes-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0624-Fixes-kick-event-leave-message-not-being-sent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fixes kick event leave message not being sent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 814754a73a8d653adc159b313fa201565db59590..ebbf5f835d619c90eae4240dbd2eb665de1e601a 100644
+index 19ce7611ea1ebef24f246118839b57d9b6949c34..83ba8472a5f3dc2c5d804e49310d8d0a2332a709 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -273,7 +273,6 @@ public class ServerPlayer extends Player {
@@ -17,7 +17,7 @@ index 814754a73a8d653adc159b313fa201565db59590..ebbf5f835d619c90eae4240dbd2eb665
      public boolean isRealPlayer; // Paper
      public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<ServerPlayer> cachedSingleHashSet; // Paper
 diff --git a/src/main/java/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index 13e2129dd02706ad5eb3124efd2d8393201e1231..eee07d4c06380bfc797e83b36f880234170b03b7 100644
+index 70458ff8c9bf6f3263868b0f5570840fe3d89ed2..d28d0ef6105ddeb562ddf31ae9088739856941fc 100644
 --- a/src/main/java/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 @@ -77,6 +77,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
@@ -50,10 +50,10 @@ index 13e2129dd02706ad5eb3124efd2d8393201e1231..eee07d4c06380bfc797e83b36f880234
          MinecraftServer minecraftserver = this.server;
          Connection networkmanager = this.connection;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2b251bbfdb208e9482acf87c233dac90f8908018..f34049f0afa5f607e64d13c5325c3ca8ba13dc92 100644
+index 2d7b88d0ea0acdd6e40d7c3e622af26de26bc0b7..685f4bb5c0c6c7e546e44bf6d2e4bf1f4c6dce68 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1883,6 +1883,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1887,6 +1887,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void onDisconnect(Component reason) {
@@ -66,7 +66,7 @@ index 2b251bbfdb208e9482acf87c233dac90f8908018..f34049f0afa5f607e64d13c5325c3ca8
          // CraftBukkit start - Rarely it would send a disconnect line twice
          if (this.processedDisconnect) {
              return;
-@@ -1891,11 +1897,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1895,11 +1901,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          // CraftBukkit end
          ServerGamePacketListenerImpl.LOGGER.info("{} lost connection: {}", this.player.getName().getString(), reason.getString());
@@ -86,7 +86,7 @@ index 2b251bbfdb208e9482acf87c233dac90f8908018..f34049f0afa5f607e64d13c5325c3ca8
          this.chatMessageChain.close();
          // CraftBukkit start - Replace vanilla quit message handling with our own.
          /*
-@@ -1905,7 +1917,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1909,7 +1921,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
          this.player.disconnect();
          // Paper start - Adventure
@@ -96,7 +96,7 @@ index 2b251bbfdb208e9482acf87c233dac90f8908018..f34049f0afa5f607e64d13c5325c3ca8
              this.server.getPlayerList().broadcastSystemMessage(PaperAdventure.asVanilla(quitMessage), false);
              // Paper end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index a9cba92048b37135b048fd6fa7d00470c855053f..18205f003ca93cb9836b8b0bdb680ac88998880d 100644
+index 891fdeaba2b0f287a0da87a20bb850ffcc9d66bf..6fdd1175f8d07fba7adf3a63d9c98dedd15e7774 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -570,6 +570,11 @@ public abstract class PlayerList {

--- a/patches/server/0634-Prevent-AFK-kick-while-watching-end-credits.patch
+++ b/patches/server/0634-Prevent-AFK-kick-while-watching-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent AFK kick while watching end credits.
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f34049f0afa5f607e64d13c5325c3ca8ba13dc92..179a1a635b174f1a6b2080ceb394928848c2df43 100644
+index 685f4bb5c0c6c7e546e44bf6d2e4bf1f4c6dce68..80a31b422ecae9eb30a418034b6eb357076eded1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -391,7 +391,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -390,7 +390,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              --this.dropSpamTickCount;
          }
  

--- a/patches/server/0664-Fix-GameProfileCache-concurrency.patch
+++ b/patches/server/0664-Fix-GameProfileCache-concurrency.patch
@@ -7,10 +7,10 @@ Separate lookup and state access locks prevent lookups
 from stalling simple state access/write calls
 
 diff --git a/src/main/java/net/minecraft/server/players/GameProfileCache.java b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-index 4dc08b0abf0a1edb51cc586d1a89444ba790ca7f..13e05a9e42ba89d37c423d819da33f2f67fa9eac 100644
+index 731a7c0363c8c91d25b35f7cbbb480879381bc8d..452fbb0aa44157225d8a9064e3eae2db7771b27d 100644
 --- a/src/main/java/net/minecraft/server/players/GameProfileCache.java
 +++ b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-@@ -61,6 +61,11 @@ public class GameProfileCache {
+@@ -60,6 +60,11 @@ public class GameProfileCache {
      @Nullable
      private Executor executor;
  
@@ -22,7 +22,7 @@ index 4dc08b0abf0a1edb51cc586d1a89444ba790ca7f..13e05a9e42ba89d37c423d819da33f2f
      public GameProfileCache(GameProfileRepository profileRepository, File cacheFile) {
          this.profileRepository = profileRepository;
          this.file = cacheFile;
-@@ -68,11 +73,13 @@ public class GameProfileCache {
+@@ -67,11 +72,13 @@ public class GameProfileCache {
      }
  
      private void safeAdd(GameProfileCache.GameProfileInfo entry) {
@@ -36,7 +36,7 @@ index 4dc08b0abf0a1edb51cc586d1a89444ba790ca7f..13e05a9e42ba89d37c423d819da33f2f
      }
  
      private static Optional<GameProfile> lookupGameProfile(GameProfileRepository repository, String name) {
-@@ -129,17 +136,20 @@ public class GameProfileCache {
+@@ -128,17 +135,20 @@ public class GameProfileCache {
  
      // Paper start
      public @Nullable GameProfile getProfileIfCached(String name) {
@@ -57,7 +57,7 @@ index 4dc08b0abf0a1edb51cc586d1a89444ba790ca7f..13e05a9e42ba89d37c423d819da33f2f
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
          boolean flag = false;
  
-@@ -155,8 +165,12 @@ public class GameProfileCache {
+@@ -154,8 +164,12 @@ public class GameProfileCache {
          if (usercache_usercacheentry != null) {
              usercache_usercacheentry.setLastAccess(this.getNextOperation());
              optional = Optional.of(usercache_usercacheentry.getProfile());
@@ -65,12 +65,12 @@ index 4dc08b0abf0a1edb51cc586d1a89444ba790ca7f..13e05a9e42ba89d37c423d819da33f2f
          } else {
 +            stateLocked = false; this.stateLock.unlock(); // Paper - allow better concurrency
 +            try { this.lookupLock.lock(); // Paper - allow better concurrency
-             optional = GameProfileCache.lookupGameProfile(this.profileRepository, name); // Spigot - use correct case for offline players
+             optional = GameProfileCache.lookupGameProfile(this.profileRepository, name); // CraftBukkit - use correct case for offline players
 +            } finally { this.lookupLock.unlock(); } // Paper - allow better concurrency
              if (optional.isPresent()) {
                  this.add((GameProfile) optional.get());
                  flag = false;
-@@ -168,6 +182,7 @@ public class GameProfileCache {
+@@ -167,6 +181,7 @@ public class GameProfileCache {
          }
  
          return optional;
@@ -78,7 +78,7 @@ index 4dc08b0abf0a1edb51cc586d1a89444ba790ca7f..13e05a9e42ba89d37c423d819da33f2f
      }
  
      public CompletableFuture<Optional<GameProfile>> getAsync(String username) {
-@@ -192,6 +207,7 @@ public class GameProfileCache {
+@@ -191,6 +206,7 @@ public class GameProfileCache {
      }
  
      public Optional<GameProfile> get(UUID uuid) {
@@ -86,7 +86,7 @@ index 4dc08b0abf0a1edb51cc586d1a89444ba790ca7f..13e05a9e42ba89d37c423d819da33f2f
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByUUID.get(uuid);
  
          if (usercache_usercacheentry == null) {
-@@ -200,6 +216,7 @@ public class GameProfileCache {
+@@ -199,6 +215,7 @@ public class GameProfileCache {
              usercache_usercacheentry.setLastAccess(this.getNextOperation());
              return Optional.of(usercache_usercacheentry.getProfile());
          }
@@ -94,7 +94,7 @@ index 4dc08b0abf0a1edb51cc586d1a89444ba790ca7f..13e05a9e42ba89d37c423d819da33f2f
      }
  
      public void setExecutor(Executor executor) {
-@@ -280,7 +297,7 @@ public class GameProfileCache {
+@@ -279,7 +296,7 @@ public class GameProfileCache {
          JsonArray jsonarray = new JsonArray();
          DateFormat dateformat = GameProfileCache.createDateFormat();
  
@@ -103,7 +103,7 @@ index 4dc08b0abf0a1edb51cc586d1a89444ba790ca7f..13e05a9e42ba89d37c423d819da33f2f
              jsonarray.add(GameProfileCache.writeGameProfile(usercache_usercacheentry, dateformat));
          });
          String s = this.gson.toJson(jsonarray);
-@@ -321,8 +338,19 @@ public class GameProfileCache {
+@@ -320,8 +337,19 @@ public class GameProfileCache {
      }
  
      private Stream<GameProfileCache.GameProfileInfo> getTopMRUProfiles(int limit) {

--- a/patches/server/0665-Improve-and-expand-AsyncCatcher.patch
+++ b/patches/server/0665-Improve-and-expand-AsyncCatcher.patch
@@ -17,10 +17,10 @@ Async catch modifications to critical entity state
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 179a1a635b174f1a6b2080ceb394928848c2df43..711959d5c2889035f366b5e798c0310593158282 100644
+index 80a31b422ecae9eb30a418034b6eb357076eded1..93cb76c8e96488051b10ed4a634c681305628fcc 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1571,6 +1571,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1575,6 +1575,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      }
  
      public void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<RelativeMovement> set) { // Paper

--- a/patches/server/0690-Don-t-respond-to-ServerboundCommandSuggestionPacket-.patch
+++ b/patches/server/0690-Don-t-respond-to-ServerboundCommandSuggestionPacket-.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Don't respond to ServerboundCommandSuggestionPacket when
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 711959d5c2889035f366b5e798c0310593158282..2e80848841dcf6f4a693e3dc62af62e2a47cbf8f 100644
+index 93cb76c8e96488051b10ed4a634c681305628fcc..7d059605d2682672fd0cb89ae46c539c3f8f6021 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -738,6 +738,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -736,6 +736,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          // Paper end
          // CraftBukkit end

--- a/patches/server/0711-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0711-Hide-unnecessary-itemmeta-from-clients.patch
@@ -18,10 +18,10 @@ index 8d2870c780c4c253f6570c7ef73f6e7c2ccc46ad..0cbb5dd17c5b37ad90ce11a31b644707
                  }
              }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2e80848841dcf6f4a693e3dc62af62e2a47cbf8f..0b745f852976611a12834101adccae52453d7dce 100644
+index 7d059605d2682672fd0cb89ae46c539c3f8f6021..64269f1e6c8b5b9911cd36c5d0a11859cd8be599 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2559,8 +2559,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2563,8 +2563,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  // Refresh the current entity metadata
                                  entity.getEntityData().refresh(ServerGamePacketListenerImpl.this.player);
                                  // SPIGOT-7136 - Allays

--- a/patches/server/0718-Optimise-collision-checking-in-player-move-packet-ha.patch
+++ b/patches/server/0718-Optimise-collision-checking-in-player-move-packet-ha.patch
@@ -8,10 +8,10 @@ Move collision logic to just the hasNewCollision call instead of getCubes + hasN
 CHECK ME
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0b745f852976611a12834101adccae52453d7dce..adc87248cbd7af37aec299f1d7c9a10965c9de30 100644
+index 64269f1e6c8b5b9911cd36c5d0a11859cd8be599..e5b71a899884c3f26374051a60e026b7a01f6be3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -537,7 +537,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -543,7 +543,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      return;
                  }
  
@@ -20,7 +20,7 @@ index 0b745f852976611a12834101adccae52453d7dce..adc87248cbd7af37aec299f1d7c9a109
  
                  d6 = d3 - this.vehicleLastGoodX; // Paper - diff on change, used for checking large move vectors above
                  d7 = d4 - this.vehicleLastGoodY - 1.0E-6D; // Paper - diff on change, used for checking large move vectors above
-@@ -553,6 +553,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -559,6 +559,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  }
  
                  entity.move(MoverType.PLAYER, new Vec3(d6, d7, d8));
@@ -28,7 +28,7 @@ index 0b745f852976611a12834101adccae52453d7dce..adc87248cbd7af37aec299f1d7c9a109
                  double d11 = d7;
  
                  d6 = d3 - entity.getX();
-@@ -566,16 +567,24 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -572,15 +573,23 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  boolean flag2 = false;
  
                  if (d10 > org.spigotmc.SpigotConfig.movedWronglyThreshold) { // Spigot
@@ -36,7 +36,6 @@ index 0b745f852976611a12834101adccae52453d7dce..adc87248cbd7af37aec299f1d7c9a109
 +                    flag2 = true; // Paper - diff on change, this should be moved wrongly
                      ServerGamePacketListenerImpl.LOGGER.warn("{} (vehicle of {}) moved wrongly! {}", new Object[]{entity.getName().getString(), this.player.getName().getString(), Math.sqrt(d10)});
                  }
-                 Location curPos = this.getCraftPlayer().getLocation(); // Spigot
  
                  entity.absMoveTo(d3, d4, d5, f, f1);
                  this.player.absMoveTo(d3, d4, d5, this.player.getYRot(), this.player.getXRot()); // CraftBukkit
@@ -56,7 +55,7 @@ index 0b745f852976611a12834101adccae52453d7dce..adc87248cbd7af37aec299f1d7c9a109
                      entity.absMoveTo(d0, d1, d2, f, f1);
                      this.player.absMoveTo(d0, d1, d2, this.player.getYRot(), this.player.getXRot()); // CraftBukkit
                      this.send(new ClientboundMoveVehiclePacket(entity));
-@@ -661,7 +670,32 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -659,7 +668,32 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      }
  
      private boolean noBlocksAround(Entity entity) {
@@ -90,7 +89,7 @@ index 0b745f852976611a12834101adccae52453d7dce..adc87248cbd7af37aec299f1d7c9a109
      }
  
      @Override
-@@ -1260,7 +1294,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1258,7 +1292,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  }
  
                  if (this.awaitingPositionFromClient != null) {
@@ -99,7 +98,7 @@ index 0b745f852976611a12834101adccae52453d7dce..adc87248cbd7af37aec299f1d7c9a109
                          this.awaitingTeleportTime = this.tickCount;
                          this.teleport(this.awaitingPositionFromClient.x, this.awaitingPositionFromClient.y, this.awaitingPositionFromClient.z, this.player.getYRot(), this.player.getXRot());
                      }
-@@ -1355,7 +1389,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1354,7 +1388,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  }
                              }
  
@@ -108,7 +107,7 @@ index 0b745f852976611a12834101adccae52453d7dce..adc87248cbd7af37aec299f1d7c9a109
  
                              d6 = d0 - this.lastGoodX; // Paper - diff on change, used for checking large move vectors above
                              d7 = d1 - this.lastGoodY; // Paper - diff on change, used for checking large move vectors above
-@@ -1397,6 +1431,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1396,6 +1430,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              this.player.move(MoverType.PLAYER, new Vec3(d6, d7, d8));
                              this.player.onGround = packet.isOnGround(); // CraftBukkit - SPIGOT-5810, SPIGOT-5835, SPIGOT-6828: reset by this.player.move
@@ -116,7 +115,7 @@ index 0b745f852976611a12834101adccae52453d7dce..adc87248cbd7af37aec299f1d7c9a109
                              // Paper start - prevent position desync
                              if (this.awaitingPositionFromClient != null) {
                                  return; // ... thanks Mojang for letting move calls teleport across dimensions.
-@@ -1415,11 +1450,23 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1414,11 +1449,23 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              boolean flag2 = false;
  
                              if (!this.player.isChangingDimension() && d10 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
@@ -142,7 +141,7 @@ index 0b745f852976611a12834101adccae52453d7dce..adc87248cbd7af37aec299f1d7c9a109
                                  this.internalTeleport(d3, d4, d5, f, f1, Collections.emptySet()); // CraftBukkit - SPIGOT-1807: Don't call teleport event, when the client thinks the player is falling, because the chunks are not loaded on the client yet.
                                  this.player.doCheckFallDamage(this.player.getX() - d3, this.player.getY() - d4, this.player.getZ() - d5, packet.isOnGround());
                              } else {
-@@ -1505,6 +1552,33 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1509,6 +1556,33 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
      }
  

--- a/patches/server/0770-Don-t-allow-vehicle-movement-from-players-while-tele.patch
+++ b/patches/server/0770-Don-t-allow-vehicle-movement-from-players-while-tele.patch
@@ -7,10 +7,10 @@ Bring the vehicle move packet behavior in line with the
 regular player move packet.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index adc87248cbd7af37aec299f1d7c9a10965c9de30..8244cd81547b0ab95e4c5a322a05aa4a4d0bda7a 100644
+index e5b71a899884c3f26374051a60e026b7a01f6be3..74cc0b0044b8ad5fe9afc24b44e5e215ca8f8b4b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -466,6 +466,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -465,6 +465,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.disconnect(Component.translatable("multiplayer.disconnect.invalid_vehicle_movement"), org.bukkit.event.player.PlayerKickEvent.Cause.INVALID_VEHICLE_MOVEMENT); // Paper - kick event cause
          } else {
              Entity entity = this.player.getRootVehicle();

--- a/patches/server/0785-Prevent-tile-entity-copies-loading-chunks.patch
+++ b/patches/server/0785-Prevent-tile-entity-copies-loading-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent tile entity copies loading chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8244cd81547b0ab95e4c5a322a05aa4a4d0bda7a..f1e91dc5cc0fa3b1f028baf45118c79e630338af 100644
+index 74cc0b0044b8ad5fe9afc24b44e5e215ca8f8b4b..406432a6336543b9b537964bdfafd17bf9471859 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3190,7 +3190,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3194,7 +3194,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                  BlockPos blockposition = BlockEntity.getPosFromTag(nbttagcompound);
  
                  if (this.player.level().isLoaded(blockposition)) {

--- a/patches/server/0787-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0787-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -18,10 +18,10 @@ index a305557e97d8719f5f82e70794d15242364ce136..5264235c1547c78b8123e2efb07dcb77
  
              if (dedicatedserverproperties.enableQuery) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f1e91dc5cc0fa3b1f028baf45118c79e630338af..a3f85ab062a1eed25cdb75ec787ba2d7aa8c2e86 100644
+index 406432a6336543b9b537964bdfafd17bf9471859..faf16948a6336ba62a080ce0a28167cd57625502 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2754,7 +2754,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2758,7 +2758,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      this.player = this.server.getPlayerList().respawn(this.player, false, RespawnReason.DEATH);
                      if (this.server.isHardcore()) {
                          this.player.setGameMode(GameType.SPECTATOR, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.HARDCORE_DEATH, null); // Paper

--- a/patches/server/0798-Do-not-accept-invalid-client-settings.patch
+++ b/patches/server/0798-Do-not-accept-invalid-client-settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Do not accept invalid client settings
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a3f85ab062a1eed25cdb75ec787ba2d7aa8c2e86..417f1be1168df292988b707756fad78c7cd9391d 100644
+index faf16948a6336ba62a080ce0a28167cd57625502..d0895945970cf562dabe6adcc8f843fcef49ffda 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3314,6 +3314,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3318,6 +3318,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      @Override
      public void handleClientInformation(ServerboundClientInformationPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());

--- a/patches/server/0819-Fix-Spigot-Config-not-using-commands.spam-exclusions.patch
+++ b/patches/server/0819-Fix-Spigot-Config-not-using-commands.spam-exclusions.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Spigot Config not using commands.spam-exclusions
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 417f1be1168df292988b707756fad78c7cd9391d..65bc013e9dc603ef0d64a9340353869f06ce18c2 100644
+index d0895945970cf562dabe6adcc8f843fcef49ffda..009a14ad5de4bf98ec50cc4ba348445266c1c967 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2371,7 +2371,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2375,7 +2375,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
          // Spigot end
          // this.chatSpamTickCount += 20;

--- a/patches/server/0820-More-Teleport-API.patch
+++ b/patches/server/0820-More-Teleport-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More Teleport API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 65bc013e9dc603ef0d64a9340353869f06ce18c2..23522e52cd8da1208004a6982b718c2a30530314 100644
+index 009a14ad5de4bf98ec50cc4ba348445266c1c967..5af57f06717cb1fd891acfacfdd795e6f6426e7d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1633,11 +1633,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1637,11 +1637,17 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              return false; // CraftBukkit - Return event status
          }
  
@@ -72,7 +72,7 @@ index 1879ec9e275194cb83f30ec47930a3814fbe1da3..027fa02e855e14b1554ddd141d0a937a
          // Let the server handle cross world teleports
          if (location.getWorld() != null && !location.getWorld().equals(this.getWorld())) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 29a2e22bda0595e9b4bbd42e6b9a0515c5cc2f1c..10e5b244e3a55e4b26b05a7b117a868166abce43 100644
+index 9d12fab078c0625844b5f07b884b5f5978bf590c..c92ef0b4ab551e3538b11cec9256af25dddf8aa4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1207,13 +1207,101 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0823-Send-block-entities-after-destroy-prediction.patch
+++ b/patches/server/0823-Send-block-entities-after-destroy-prediction.patch
@@ -57,10 +57,10 @@ index bf9b185e3defb496022c20ec60a84a4f6f99d5be..4e1ed252bf400ec991f95b02984f01a9
              }
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 23522e52cd8da1208004a6982b718c2a30530314..a30523973711210e8c4b74d2f6cbce4314709338 100644
+index 5af57f06717cb1fd891acfacfdd795e6f6426e7d..bd5348f00249bf318bba308ef256ad42a69df7f0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1779,8 +1779,28 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1783,8 +1783,28 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      return;
                  }
                  // Paper end - Don't allow digging in unloaded chunks

--- a/patches/server/0880-Properly-resend-entities.patch
+++ b/patches/server/0880-Properly-resend-entities.patch
@@ -85,10 +85,10 @@ index d088479d160dbd2fc90b48a30553be141db8eef2..ccb7d92b6c36b6225a2e640f8cea6c0d
      public static class DataItem<T> {
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a30523973711210e8c4b74d2f6cbce4314709338..d4187f23bdebbab0cbee72009e0257de3e1c876c 100644
+index bd5348f00249bf318bba308ef256ad42a69df7f0..1c3452cd2212dabfb16bd5d2b15863ab562ed520 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2651,7 +2651,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2655,7 +2655,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                              // Entity in bucket - SPIGOT-4048 and SPIGOT-6859a
                              if ((entity instanceof Bucketable && entity instanceof LivingEntity && origItem != null && origItem.asItem() == Items.WATER_BUCKET) && (event.isCancelled() || ServerGamePacketListenerImpl.this.player.getInventory().getSelected() == null || ServerGamePacketListenerImpl.this.player.getInventory().getSelected().getItem() != origItem)) {
@@ -98,7 +98,7 @@ index a30523973711210e8c4b74d2f6cbce4314709338..d4187f23bdebbab0cbee72009e0257de
                              }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4bf3598f8d6f6f469a5a17e8067fd5035732da19..e1c0811c6dc8f3e268c60d23a25942a2c6d22475 100644
+index 6310d19a42f549fda7446569958019e8d75a0ca6..85ed7d2134902e2b3455efdb0defbbc8627933bf 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -376,7 +376,7 @@ public abstract class PlayerList {

--- a/patches/server/0887-Improve-logging-and-errors.patch
+++ b/patches/server/0887-Improve-logging-and-errors.patch
@@ -40,10 +40,10 @@ index 536f0c496ce36ca3248fc6eeac9bbd77214a36f9..5e24c1e712eb16d0d5343760a65310bd
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d4187f23bdebbab0cbee72009e0257de3e1c876c..8ff416bbb4743af7bb4f3a1b30e34bd288059fa9 100644
+index 1c3452cd2212dabfb16bd5d2b15863ab562ed520..a7f3a5c054a3f48ab37822585bbc268bd551a63d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3388,7 +3388,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3392,7 +3392,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                      this.resetPlayerChatState(remotechatsession_a.validate(this.player.getGameProfile(), signaturevalidator));
                  } catch (ProfilePublicKey.ValidationException profilepublickey_b) {

--- a/patches/server/0890-Add-missing-SpigotConfig-logCommands-check.patch
+++ b/patches/server/0890-Add-missing-SpigotConfig-logCommands-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add missing SpigotConfig logCommands check
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8ff416bbb4743af7bb4f3a1b30e34bd288059fa9..38f34e26dc515b66fe4bc38285b9813023c0ed97 100644
+index a7f3a5c054a3f48ab37822585bbc268bd551a63d..a1180623d885870bacb974d8128a61ab80403ab2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2135,7 +2135,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2139,7 +2139,9 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      private void performChatCommand(ServerboundChatCommandPacket packet, LastSeenMessages lastSeenMessages) {
          // CraftBukkit start
          String command = "/" + packet.command();

--- a/patches/server/0896-Use-single-player-info-update-packet-on-join.patch
+++ b/patches/server/0896-Use-single-player-info-update-packet-on-join.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use single player info update packet on join
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 38f34e26dc515b66fe4bc38285b9813023c0ed97..3aa38ad04f706de37406acbec7b9379a663bcc98 100644
+index a1180623d885870bacb974d8128a61ab80403ab2..2c5870846a3833da3da899a60dd6a69a2e7b195a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3418,7 +3418,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3422,7 +3422,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          this.signedMessageDecoder = session.createMessageDecoder(this.player.getUUID());
          this.chatMessageChain.append(() -> {
              this.player.setChatSession(session);
@@ -18,7 +18,7 @@ index 38f34e26dc515b66fe4bc38285b9813023c0ed97..3aa38ad04f706de37406acbec7b9379a
      }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index e1c0811c6dc8f3e268c60d23a25942a2c6d22475..3927558c62cf24af915d37eb8e983339bc0f2aa3 100644
+index 85ed7d2134902e2b3455efdb0defbbc8627933bf..a9cc3d7213f51a2a2cdc915fd9ab3cf97767b698 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -358,6 +358,7 @@ public abstract class PlayerList {

--- a/patches/server/0916-Treat-sequence-violations-like-they-should-be.patch
+++ b/patches/server/0916-Treat-sequence-violations-like-they-should-be.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Treat sequence violations like they should be
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3aa38ad04f706de37406acbec7b9379a663bcc98..40ba283c36436d2190f45592f2f96f645174978b 100644
+index 2c5870846a3833da3da899a60dd6a69a2e7b195a..d48ea4f9d2968a4d8af426058d01cc17a090a1fa 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2039,6 +2039,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2043,6 +2043,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      public void ackBlockChangesUpTo(int sequence) {
          if (sequence < 0) {

--- a/patches/server/0918-Prevent-causing-expired-keys-from-impacting-new-join.patch
+++ b/patches/server/0918-Prevent-causing-expired-keys-from-impacting-new-join.patch
@@ -24,7 +24,7 @@ index 0e54e8faa48751a651b953bec72543a94edf74bc..aa1c6de4d6cb7bbca33d25895c54707d
          UPDATE_GAME_MODE((serialized, buf) -> {
              serialized.gameMode = GameType.byId(buf.readVarInt());
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 40ba283c36436d2190f45592f2f96f645174978b..207576cbf4517d43a5159d7543db47782612c8c9 100644
+index d48ea4f9d2968a4d8af426058d01cc17a090a1fa..aa1c1418559265deaf755d65c9d57e9592ee0a6e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -287,6 +287,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
@@ -35,7 +35,7 @@ index 40ba283c36436d2190f45592f2f96f645174978b..207576cbf4517d43a5159d7543db4778
      private SignedMessageChain.Decoder signedMessageDecoder;
      private final LastSeenMessagesValidator lastSeenMessages = new LastSeenMessagesValidator(20);
      private final MessageSignatureCache messageSignatureCache = MessageSignatureCache.createDefault();
-@@ -396,6 +397,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -395,6 +396,13 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.disconnect(Component.translatable("multiplayer.disconnect.idling"), org.bukkit.event.player.PlayerKickEvent.Cause.IDLING); // Paper - kick event cause
          }
  
@@ -49,7 +49,7 @@ index 40ba283c36436d2190f45592f2f96f645174978b..207576cbf4517d43a5159d7543db4778
      }
  
      public void resetPosition() {
-@@ -3416,6 +3424,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -3420,6 +3428,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      private void resetPlayerChatState(RemoteChatSession session) {
          this.chatSession = session;

--- a/patches/server/0943-Properly-Cancel-Usable-Items.patch
+++ b/patches/server/0943-Properly-Cancel-Usable-Items.patch
@@ -34,10 +34,10 @@ index f58386e952d29a16d160b628a23efbe102791277..82f26186156a487f29ad3abff3f68852
          return enuminteractionresult;
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 207576cbf4517d43a5159d7543db47782612c8c9..ccd6b734534a9f2b4205ee857ac650b26be74d5e 100644
+index aa1c1418559265deaf755d65c9d57e9592ee0a6e..4a03a67194b963f45abc8febb48d0d7f9eaa6e4d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1951,6 +1951,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1955,6 +1955,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              }
  
              if (cancelled) {

--- a/patches/server/0962-Implement-PlayerFailMoveEvent.patch
+++ b/patches/server/0962-Implement-PlayerFailMoveEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement PlayerFailMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ccd6b734534a9f2b4205ee857ac650b26be74d5e..e58a86e70767707e144f45e9160f1b266ae07145 100644
+index 4a03a67194b963f45abc8febb48d0d7f9eaa6e4d..9cfc131d7c41e63f49baaca4d7e545f62fd7856e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1317,8 +1317,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1316,8 +1316,8 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                      double d0 = ServerGamePacketListenerImpl.clampHorizontal(packet.getX(this.player.getX())); final double toX = d0; // Paper - OBFHELPER
                      double d1 = ServerGamePacketListenerImpl.clampVertical(packet.getY(this.player.getY())); final double toY = d1;
                      double d2 = ServerGamePacketListenerImpl.clampHorizontal(packet.getZ(this.player.getZ())); final double toZ = d2; // Paper - OBFHELPER
@@ -19,7 +19,7 @@ index ccd6b734534a9f2b4205ee857ac650b26be74d5e..e58a86e70767707e144f45e9160f1b26
  
                      if (this.player.isPassenger()) {
                          this.player.absMoveTo(this.player.getX(), this.player.getY(), this.player.getZ(), f, f1);
-@@ -1385,8 +1385,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1384,8 +1384,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  }
                                  // Paper start - Prevent moving into unloaded chunks
                                  if (this.player.level().paperConfig().chunks.preventMovingIntoUnloadedChunks && (this.player.getX() != toX || this.player.getZ() != toZ) && !worldserver.areChunksLoadedForMove(this.player.getBoundingBox().expandTowards(new Vec3(toX, toY, toZ).subtract(this.player.position())))) {
@@ -36,7 +36,7 @@ index ccd6b734534a9f2b4205ee857ac650b26be74d5e..e58a86e70767707e144f45e9160f1b26
                                  }
                                  // Paper end
  
-@@ -1395,9 +1401,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1394,9 +1400,16 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
                                      if (d10 - d9 > Math.max(f2, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isSingleplayerOwner()) {
                                      // CraftBukkit end
@@ -56,7 +56,7 @@ index ccd6b734534a9f2b4205ee857ac650b26be74d5e..e58a86e70767707e144f45e9160f1b26
                                      }
                                  }
                              }
-@@ -1463,8 +1476,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1462,8 +1475,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              boolean flag2 = false;
  
                              if (!this.player.isChangingDimension() && d10 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
@@ -72,7 +72,7 @@ index ccd6b734534a9f2b4205ee857ac650b26be74d5e..e58a86e70767707e144f45e9160f1b26
                              }
  
                              // Paper start - optimise out extra getCubes
-@@ -1477,6 +1497,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1476,6 +1496,15 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                                  if (didCollide || !axisalignedbb.equals(newBox)) {
                                      // note: only call after setLocation, or else getBoundingBox is wrong
                                      teleportBack = this.hasNewCollision(worldserver, this.player, axisalignedbb, newBox);
@@ -88,7 +88,7 @@ index ccd6b734534a9f2b4205ee857ac650b26be74d5e..e58a86e70767707e144f45e9160f1b26
                                  } // else: no collision at all detected, why do we care?
                              }
                              if (!this.player.noPhysics && !this.player.isSleeping() && teleportBack) { // Paper end - optimise out extra getCubes
-@@ -1565,6 +1594,18 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1569,6 +1598,18 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
          }
      }
  

--- a/patches/server/0979-Don-t-tab-complete-namespaced-commands-if-send-names.patch
+++ b/patches/server/0979-Don-t-tab-complete-namespaced-commands-if-send-names.patch
@@ -11,10 +11,10 @@ This patch prevents server from sending namespaced commands when player
 requests tab-complete only commands.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e58a86e70767707e144f45e9160f1b266ae07145..38669b07813c41e6e7c2389507802d91fb697872 100644
+index 9cfc131d7c41e63f49baaca4d7e545f62fd7856e..971d4f3503f065dee0435249919aa8ed36f087d4 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -809,6 +809,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -807,6 +807,11 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                          ParseResults<CommandSourceStack> parseresults = this.server.getCommands().getDispatcher().parse(stringreader, this.player.createCommandSourceStack());
  
                          this.server.getCommands().getDispatcher().getCompletionSuggestions(parseresults).thenAccept((suggestions) -> {

--- a/patches/server/0990-Add-PlayerPickItemEvent.patch
+++ b/patches/server/0990-Add-PlayerPickItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerPickItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 38669b07813c41e6e7c2389507802d91fb697872..047af80d7becc0484f1d38a2c2b70fa394972161 100644
+index 971d4f3503f065dee0435249919aa8ed36f087d4..4510fbf86cc1b7b02f705ad9e304ace337604ffb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -946,7 +946,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -944,7 +944,14 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
              this.disconnect("Invalid hotbar selection (Hacking?)", org.bukkit.event.player.PlayerKickEvent.Cause.ILLEGAL_ACTION); // Paper - kick event cause
              return;
          }

--- a/patches/server/1001-Add-slot-sanity-checks-in-container-clicks.patch
+++ b/patches/server/1001-Add-slot-sanity-checks-in-container-clicks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add slot sanity checks in container clicks
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 047af80d7becc0484f1d38a2c2b70fa394972161..30ccbab1586a656e0ae41d7406525fb02d9e025b 100644
+index 4510fbf86cc1b7b02f705ad9e304ace337604ffb..9d310fffc240582df2cea085ee962e7ecd814853 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2983,6 +2983,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2987,6 +2987,12 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
                              break;
                          case SWAP:
                              if ((packet.getButtonNum() >= 0 && packet.getButtonNum() < 9) || packet.getButtonNum() == 40) {

--- a/patches/server/1054-Add-missing-InventoryType.patch
+++ b/patches/server/1054-Add-missing-InventoryType.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 27 Dec 2023 16:46:07 -0800
+Subject: [PATCH] Add missing InventoryType
+
+Upstream did not add a DECORATED_POT inventory type
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
+index 3b0d3e9a067fccb10122c273aaf658ba240aa716..af1ae3dacb628da23f7d2988c6e76d3fb2d64103 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
+@@ -541,6 +541,10 @@ public class CraftInventory implements Inventory {
+             return InventoryType.COMPOSTER;
+         } else if (this.inventory instanceof JukeboxBlockEntity) {
+             return InventoryType.JUKEBOX;
++            // Paper start
++        } else if (this.inventory instanceof net.minecraft.world.level.block.entity.DecoratedPotBlockEntity) {
++            return org.bukkit.event.inventory.InventoryType.DECORATED_POT;
++            // Paper end
+         } else {
+             return InventoryType.CHEST;
+         }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
0c7aedbc SPIGOT-7554, PR-954: Add DecoratedPotInventory

CraftBukkit Changes:
53ebb05e3 SPIGOT-7554, PR-1323: Add DecoratedPotInventory
33a2d8773 Ensure that PlayerMoveEvent is always fired where applicable
7df18510f SPIGOT-7555: Don't cast ItemFlags to byte
19aec59ea Use provided case for non-existent OfflinePlayers

Spigot Changes:
e7ce55a3 Remove obsolete PlayerMoveEvent improvements
3e5e22c0 Remove obsolete lowercasing of non existent OfflinePlayer names

----

Adds an inventory type for Decorated Pots preventing them from being identified as "CHEST".