### PR TITLE
Fix some component bugs in login disconnect packet

### DIFF
--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -3227,10 +3227,21 @@ index 9c68c3f2d61500479f48b80264f625aaae2f3204..399afcd19fcb6acd24857ed6ab48cf0d
      private static final HandlerList handlers = new HandlerList();
      private boolean cancel = false;
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index 9866c07c999f46cb585709804aaad710c3031d5a..c7c45e2de8cca1bf8b8e12752e08db62403efa6a 100644
+index 9866c07c999f46cb585709804aaad710c3031d5a..3432872303aa0df97b5d9090fe98b269ef3cb9f4 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
+@@ -10,11 +10,18 @@ import org.jetbrains.annotations.NotNull;
+  * Stores details for players attempting to log in.
+  * <p>
+  * This event is asynchronous, and not run using main thread.
++ * <p>
++ * When this event is fired, the player's locale is not
++ * available. Therefore, any translatable component will be
++ * rendered with the default locale, {@link java.util.Locale#US}.
++ * <p>
++ * Consider rendering any translatable yourself with {@link net.kyori.adventure.translation.GlobalTranslator#render}
++ * if the client's language is known.
+  */
  public class AsyncPlayerPreLoginEvent extends Event {
      private static final HandlerList handlers = new HandlerList();
      private Result result;
@@ -3239,7 +3250,7 @@ index 9866c07c999f46cb585709804aaad710c3031d5a..c7c45e2de8cca1bf8b8e12752e08db62
      private final String name;
      private final InetAddress ipAddress;
      private final UUID uniqueId;
-@@ -27,7 +27,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -27,7 +34,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
      public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId) {
          super(true);
          this.result = Result.ALLOWED;
@@ -3248,7 +3259,7 @@ index 9866c07c999f46cb585709804aaad710c3031d5a..c7c45e2de8cca1bf8b8e12752e08db62
          this.name = name;
          this.ipAddress = ipAddress;
          this.uniqueId = uniqueId;
-@@ -79,6 +79,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -79,6 +86,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this.result = result == null ? null : Result.valueOf(result.name());
      }
  
@@ -3256,7 +3267,7 @@ index 9866c07c999f46cb585709804aaad710c3031d5a..c7c45e2de8cca1bf8b8e12752e08db62
      /**
       * Gets the current kick message that will be used if getResult() !=
       * Result.ALLOWED
-@@ -86,7 +87,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -86,7 +94,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
       * @return Current kick message
       */
      @NotNull
@@ -3265,7 +3276,7 @@ index 9866c07c999f46cb585709804aaad710c3031d5a..c7c45e2de8cca1bf8b8e12752e08db62
          return message;
      }
  
-@@ -95,16 +96,66 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -95,16 +103,66 @@ public class AsyncPlayerPreLoginEvent extends Event {
       *
       * @param message New kick message
       */
@@ -3334,7 +3345,7 @@ index 9866c07c999f46cb585709804aaad710c3031d5a..c7c45e2de8cca1bf8b8e12752e08db62
      }
  
      /**
-@@ -112,10 +163,12 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -112,10 +170,12 @@ public class AsyncPlayerPreLoginEvent extends Event {
       *
       * @param result New result for disallowing the player
       * @param message Kick message to display to the user
@@ -3348,7 +3359,7 @@ index 9866c07c999f46cb585709804aaad710c3031d5a..c7c45e2de8cca1bf8b8e12752e08db62
      }
  
      /**
-@@ -130,7 +183,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -130,7 +190,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
      @Deprecated
      public void disallow(@NotNull final PlayerPreLoginEvent.Result result, @NotNull final String message) {
          this.result = result == null ? null : Result.valueOf(result.name());
@@ -3735,10 +3746,24 @@ index 2bc81b0aa73f7f5b0352121f6bf18fa63acf7a83..eaa0548cf430bf5b58ff84e0a4403c45
          this.message = message;
      }
 diff --git a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
-index fb066251f793ec3b41bfc075b9478901b15ee549..6800132c6288b4588fd02b08d26f016c38f27129 100644
+index fb066251f793ec3b41bfc075b9478901b15ee549..175ed12dd1698f4d153c9acdac8340c15a427ea5 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerPreLoginEvent.java
-@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
+@@ -9,6 +9,13 @@ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+  * Stores details for players attempting to log in
++ * <p>
++ * When this event is fired, the player's locale is not
++ * available. Therefore, any translatable component will be
++ * rendered with the default locale, {@link java.util.Locale#US}.
++ * <p>
++ * Consider rendering any translatable yourself with {@link net.kyori.adventure.translation.GlobalTranslator#render}
++ * if the client's language is known.
+  *
+  * @deprecated This event causes synchronization from the login thread; {@link
+  *     AsyncPlayerPreLoginEvent} is preferred to keep the secondary threads
+@@ -19,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
  public class PlayerPreLoginEvent extends Event {
      private static final HandlerList handlers = new HandlerList();
      private Result result;
@@ -3747,7 +3772,7 @@ index fb066251f793ec3b41bfc075b9478901b15ee549..6800132c6288b4588fd02b08d26f016c
      private final String name;
      private final InetAddress ipAddress;
      private final UUID uniqueId;
-@@ -31,7 +31,7 @@ public class PlayerPreLoginEvent extends Event {
+@@ -31,7 +38,7 @@ public class PlayerPreLoginEvent extends Event {
  
      public PlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId) {
          this.result = Result.ALLOWED;
@@ -3756,7 +3781,7 @@ index fb066251f793ec3b41bfc075b9478901b15ee549..6800132c6288b4588fd02b08d26f016c
          this.name = name;
          this.ipAddress = ipAddress;
          this.uniqueId = uniqueId;
-@@ -56,6 +56,7 @@ public class PlayerPreLoginEvent extends Event {
+@@ -56,6 +63,7 @@ public class PlayerPreLoginEvent extends Event {
          this.result = result;
      }
  
@@ -3764,7 +3789,7 @@ index fb066251f793ec3b41bfc075b9478901b15ee549..6800132c6288b4588fd02b08d26f016c
      /**
       * Gets the current kick message that will be used if getResult() !=
       * Result.ALLOWED
-@@ -63,7 +64,7 @@ public class PlayerPreLoginEvent extends Event {
+@@ -63,7 +71,7 @@ public class PlayerPreLoginEvent extends Event {
       * @return Current kick message
       */
      @NotNull
@@ -3773,7 +3798,7 @@ index fb066251f793ec3b41bfc075b9478901b15ee549..6800132c6288b4588fd02b08d26f016c
          return message;
      }
  
-@@ -72,16 +73,51 @@ public class PlayerPreLoginEvent extends Event {
+@@ -72,16 +80,51 @@ public class PlayerPreLoginEvent extends Event {
       *
       * @param message New kick message
       */
@@ -3827,7 +3852,7 @@ index fb066251f793ec3b41bfc075b9478901b15ee549..6800132c6288b4588fd02b08d26f016c
      }
  
      /**
-@@ -89,10 +125,12 @@ public class PlayerPreLoginEvent extends Event {
+@@ -89,10 +132,12 @@ public class PlayerPreLoginEvent extends Event {
       *
       * @param result New result for disallowing the player
       * @param message Kick message to display to the user

--- a/patches/api/0090-Ability-to-change-PlayerProfile-in-AsyncPreLoginEven.patch
+++ b/patches/api/0090-Ability-to-change-PlayerProfile-in-AsyncPreLoginEven.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Ability to change PlayerProfile in AsyncPreLoginEvent
 This will allow you to change the players name or skin on login.
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index c7c45e2de8cca1bf8b8e12752e08db62403efa6a..c30b44ff26f8f253902754452a0816f07c7fd035 100644
+index 6aaeba3feb66462ce352dacabd845f8d8283f54b..e4afc428e9a8625bf6f5967cb659987c14f65ba6 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 @@ -2,6 +2,9 @@ package org.bukkit.event.player;
@@ -19,7 +19,7 @@ index c7c45e2de8cca1bf8b8e12752e08db62403efa6a..c30b44ff26f8f253902754452a0816f0
  import org.bukkit.event.Event;
  import org.bukkit.event.HandlerList;
  import org.jetbrains.annotations.NotNull;
-@@ -15,9 +18,9 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -22,9 +25,9 @@ public class AsyncPlayerPreLoginEvent extends Event {
      private static final HandlerList handlers = new HandlerList();
      private Result result;
      private net.kyori.adventure.text.Component message; // Paper
@@ -31,7 +31,7 @@ index c7c45e2de8cca1bf8b8e12752e08db62403efa6a..c30b44ff26f8f253902754452a0816f0
  
      @Deprecated
      public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress) {
-@@ -25,12 +28,37 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -32,12 +35,37 @@ public class AsyncPlayerPreLoginEvent extends Event {
      }
  
      public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId) {
@@ -71,7 +71,7 @@ index c7c45e2de8cca1bf8b8e12752e08db62403efa6a..c30b44ff26f8f253902754452a0816f0
      }
  
      /**
-@@ -193,7 +221,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -200,7 +228,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
       */
      @NotNull
      public String getName() {
@@ -80,7 +80,7 @@ index c7c45e2de8cca1bf8b8e12752e08db62403efa6a..c30b44ff26f8f253902754452a0816f0
      }
  
      /**
-@@ -213,7 +241,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -220,7 +248,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
       */
      @NotNull
      public UUID getUniqueId() {

--- a/patches/api/0280-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/api/0280-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add raw address to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index c30b44ff26f8f253902754452a0816f07c7fd035..34e4d666b6af58f64c6c001df80fadf818847e6a 100644
+index e4afc428e9a8625bf6f5967cb659987c14f65ba6..35176b16d208c9756bd00ac74b2a1dcc3fc9febb 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-@@ -20,6 +20,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -27,6 +27,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
      private net.kyori.adventure.text.Component message; // Paper
      //private String name; // Paper - Not used anymore
      private final InetAddress ipAddress;
@@ -16,7 +16,7 @@ index c30b44ff26f8f253902754452a0816f07c7fd035..34e4d666b6af58f64c6c001df80fadf8
      //private UUID uniqueId; // Paper - Not used anymore
  
      @Deprecated
-@@ -50,7 +51,23 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -57,7 +58,23 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this.profile = profile;
      }
  
@@ -40,7 +40,7 @@ index c30b44ff26f8f253902754452a0816f07c7fd035..34e4d666b6af58f64c6c001df80fadf8
          super(true);
          this.profile = profile;
          // Paper end
-@@ -58,6 +75,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -65,6 +82,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this.message = net.kyori.adventure.text.Component.empty(); // Paper
          //this.name = name; // Paper - Not used anymore
          this.ipAddress = ipAddress;

--- a/patches/api/0338-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/api/0338-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added getHostname to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index 34e4d666b6af58f64c6c001df80fadf818847e6a..fc2d9e85b65347b90bde3b0b13ccae759e33d466 100644
+index 35176b16d208c9756bd00ac74b2a1dcc3fc9febb..da07fc4ab0c299c1bb06ede36e7230626bbc28c9 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-@@ -22,6 +22,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -29,6 +29,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
      private final InetAddress ipAddress;
      private final InetAddress rawAddress; // Paper
      //private UUID uniqueId; // Paper - Not used anymore
@@ -16,7 +16,7 @@ index 34e4d666b6af58f64c6c001df80fadf818847e6a..fc2d9e85b65347b90bde3b0b13ccae75
  
      @Deprecated
      public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress) {
-@@ -67,7 +68,14 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -74,7 +75,14 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this(name, ipAddress, ipAddress, uniqueId, profile);
      }
  
@@ -31,7 +31,7 @@ index 34e4d666b6af58f64c6c001df80fadf818847e6a..fc2d9e85b65347b90bde3b0b13ccae75
          super(true);
          this.profile = profile;
          // Paper end
-@@ -77,6 +85,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -84,6 +92,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this.ipAddress = ipAddress;
          this.rawAddress = rawAddress; // Paper
          //this.uniqueId = uniqueId; // Paper - Not used anymore
@@ -39,7 +39,7 @@ index 34e4d666b6af58f64c6c001df80fadf818847e6a..fc2d9e85b65347b90bde3b0b13ccae75
      }
  
      /**
-@@ -262,6 +271,19 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -269,6 +278,19 @@ public class AsyncPlayerPreLoginEvent extends Event {
          return profile.getId(); // Paper
      }
  

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2624,10 +2624,16 @@ index 5a541e14caccaca97759879fd081becd0e8c6af2..13859822feebb65f14973aa688a54fcb
          buf.writeComponent(this.footer);
      }
 diff --git a/src/main/java/net/minecraft/network/protocol/login/ClientboundLoginDisconnectPacket.java b/src/main/java/net/minecraft/network/protocol/login/ClientboundLoginDisconnectPacket.java
-index a5578cbce2d1d39ba3315e53425d5323e6823a65..a4789caa63234ff1c257f9c205af4c1ba3e08506 100644
+index a5578cbce2d1d39ba3315e53425d5323e6823a65..7a036c08fa67504d06c8f72a32c22814fcfd5d1a 100644
 --- a/src/main/java/net/minecraft/network/protocol/login/ClientboundLoginDisconnectPacket.java
 +++ b/src/main/java/net/minecraft/network/protocol/login/ClientboundLoginDisconnectPacket.java
-@@ -17,7 +17,12 @@ public class ClientboundLoginDisconnectPacket implements Packet<ClientLoginPacke
+@@ -12,12 +12,17 @@ public class ClientboundLoginDisconnectPacket implements Packet<ClientLoginPacke
+     }
+ 
+     public ClientboundLoginDisconnectPacket(FriendlyByteBuf buf) {
+-        this.reason = Component.Serializer.fromJsonLenient(buf.readUtf(262144));
++        this.reason = Component.Serializer.fromJsonLenient(buf.readUtf(FriendlyByteBuf.MAX_COMPONENT_STRING_LENGTH)); // Paper - diff on change
+     }
  
      @Override
      public void write(FriendlyByteBuf buf) {

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2156,7 +2156,7 @@ index d120fff432d9c4fc7a35ddffdc4186459e45e950..73c15a0c56a103ba4e62f0a51af8d425
          }
      }
 diff --git a/src/main/java/net/minecraft/network/FriendlyByteBuf.java b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-index 9373502ede6c8a881af67db005cf12fd9313f37f..d9be3fada2e603684275a2094954e29039fb07c7 100644
+index 9373502ede6c8a881af67db005cf12fd9313f37f..39940edf4aef21842c8abd77bec0d0f1e7e9c762 100644
 --- a/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 +++ b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 @@ -87,6 +87,7 @@ public class FriendlyByteBuf extends ByteBuf {
@@ -2167,7 +2167,25 @@ index 9373502ede6c8a881af67db005cf12fd9313f37f..d9be3fada2e603684275a2094954e290
      public static final short MAX_STRING_LENGTH = 32767;
      public static final int MAX_COMPONENT_STRING_LENGTH = 262144;
      private static final int PUBLIC_KEY_SIZE = 256;
-@@ -526,8 +527,18 @@ public class FriendlyByteBuf extends ByteBuf {
+@@ -135,11 +136,16 @@ public class FriendlyByteBuf extends ByteBuf {
+     }
+ 
+     public <T> void writeJsonWithCodec(Codec<T> codec, T value) {
++        // Paper start - Adventure
++        this.writeJsonWithCodec(codec, value, MAX_STRING_LENGTH);
++    }
++    public <T> void writeJsonWithCodec(Codec<T> codec, T value, int maxLength) {
++        // Paper end - Adventure
+         DataResult<JsonElement> dataresult = codec.encodeStart(JsonOps.INSTANCE, value);
+ 
+         this.writeUtf(FriendlyByteBuf.GSON.toJson((JsonElement) Util.getOrThrow(dataresult, (s) -> {
+             return new EncoderException("Failed to encode: " + s + " " + value);
+-        })));
++        })), maxLength); // Paper - Adventure
+     }
+ 
+     public <T> void writeId(IdMap<T> registry, T value) {
+@@ -526,8 +532,18 @@ public class FriendlyByteBuf extends ByteBuf {
          return (Component) this.readWithCodecTrusted(NbtOps.INSTANCE, ComponentSerialization.CODEC);
      }
  
@@ -2605,6 +2623,24 @@ index 5a541e14caccaca97759879fd081becd0e8c6af2..13859822feebb65f14973aa688a54fcb
          buf.writeComponent(this.header);
          buf.writeComponent(this.footer);
      }
+diff --git a/src/main/java/net/minecraft/network/protocol/login/ClientboundLoginDisconnectPacket.java b/src/main/java/net/minecraft/network/protocol/login/ClientboundLoginDisconnectPacket.java
+index a5578cbce2d1d39ba3315e53425d5323e6823a65..a4789caa63234ff1c257f9c205af4c1ba3e08506 100644
+--- a/src/main/java/net/minecraft/network/protocol/login/ClientboundLoginDisconnectPacket.java
++++ b/src/main/java/net/minecraft/network/protocol/login/ClientboundLoginDisconnectPacket.java
+@@ -17,7 +17,12 @@ public class ClientboundLoginDisconnectPacket implements Packet<ClientLoginPacke
+ 
+     @Override
+     public void write(FriendlyByteBuf buf) {
+-        buf.writeUtf(Component.Serializer.toJson(this.reason));
++        // Paper start - Adventure
++        //buf.writeUtf(Component.Serializer.toJson(this.reason));
++
++        // In the login phase, buf.adventure$locale field is always null
++        buf.writeJsonWithCodec(net.minecraft.network.chat.ComponentSerialization.localizedCodec(java.util.Locale.US), this.reason, FriendlyByteBuf.MAX_COMPONENT_STRING_LENGTH);
++        // Paper end - Adventure
+     }
+ 
+     @Override
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index 729849caf3e3cb542d5c4097a568c5fadeff0f6d..1eb0809addfd77303b94bb594701ee7f38483909 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java

--- a/patches/server/0056-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/server/0056-Player-Tab-List-and-Title-APIs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player Tab List and Title APIs
 
 
 diff --git a/src/main/java/net/minecraft/network/FriendlyByteBuf.java b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-index d9be3fada2e603684275a2094954e29039fb07c7..95bd5958f55fc80d05ccb9cab4d37ff2ef6355e6 100644
+index 39940edf4aef21842c8abd77bec0d0f1e7e9c762..7dcd8d4e4886e1d35adbc604eafabccb5550f1b4 100644
 --- a/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 +++ b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-@@ -540,6 +540,12 @@ public class FriendlyByteBuf extends ByteBuf {
+@@ -545,6 +545,12 @@ public class FriendlyByteBuf extends ByteBuf {
          return this.writeWithCodec(NbtOps.INSTANCE, ComponentSerialization.localizedCodec(this.adventure$locale), text);
          // Paper end - adventure
      }
@@ -64,7 +64,7 @@ index 7bb08db97c324d13836303cc8a4623c71d6c8a2c..5e9045f7722481e1f83a3d36d7b3d86e
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4585c67495ffda7f149c4dbcf379839f40cf6bac..1cb9dbb01a320081188320048d36f61434efa109 100644
+index 054ada5455c6570f86d9a010fcb8eaf57bf7151d..6d8b46743473832b2c7c604b3023541a22e3abc9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@

--- a/patches/server/0232-Remove-unnecessary-itemmeta-handling.patch
+++ b/patches/server/0232-Remove-unnecessary-itemmeta-handling.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove unnecessary itemmeta handling
 
 
 diff --git a/src/main/java/net/minecraft/network/FriendlyByteBuf.java b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-index 95bd5958f55fc80d05ccb9cab4d37ff2ef6355e6..b13bc90b28b02f5e80d935bfcba727f92c5e4c4f 100644
+index 7dcd8d4e4886e1d35adbc604eafabccb5550f1b4..a5bcad412fb1ac3b6a3eee3f4618dc6c1ca66936 100644
 --- a/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 +++ b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-@@ -644,7 +644,7 @@ public class FriendlyByteBuf extends ByteBuf {
+@@ -649,7 +649,7 @@ public class FriendlyByteBuf extends ByteBuf {
              if (item.canBeDepleted() || item.shouldOverrideMultiplayerNbt()) {
                  // Spigot start - filter
                  stack = stack.copy();
@@ -17,7 +17,7 @@ index 95bd5958f55fc80d05ccb9cab4d37ff2ef6355e6..b13bc90b28b02f5e80d935bfcba727f9
                  // Spigot end
                  nbttagcompound = stack.getTag();
              }
-@@ -665,7 +665,7 @@ public class FriendlyByteBuf extends ByteBuf {
+@@ -670,7 +670,7 @@ public class FriendlyByteBuf extends ByteBuf {
  
              itemstack.setTag(this.readNbt());
              // CraftBukkit start


### PR DESCRIPTION
Fixes an issue in `ClientboundLoginDisconnectPacket` where Adventure translate components are not rendered
and Serialized components having a maximum length of 32767.

TestPlugin.java
```java
public final class TestPlugin extends JavaPlugin implements Listener {

    @Override
    public void onEnable() {
        final GlobalTranslator translator = GlobalTranslator.translator();
        final TranslationRegistry registry = TranslationRegistry.create(Key.key("paper", "test-plugin"));
        registry.register("paper.kittens", Locale.US, new MessageFormat("Kittens!!!!!!"));
        translator.addSource(registry);

        this.getServer().getPluginManager().registerEvents(this, this);
    }

    @EventHandler
    void onAsyncPlayerPreLogin(final AsyncPlayerPreLoginEvent event) {
        // 35096 lengths (Translated: 33596 lengths)
        event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER, MiniMessage.miniMessage().deserialize(
            "<rainbow>" + "<click:run_command:kittens><lang:paper.kittens> ".repeat(300)
        ));
    }
}
```