### PR TITLE
cleanup player death event adventure logic

### DIFF
--- a/patches/api/0006-Adventure.patch
+++ b/patches/api/0006-Adventure.patch
@@ -494,7 +494,7 @@ index 0000000000000000000000000000000000000000..667bfa6afc35f8a8f475431171ee474a
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/AsyncChatEvent.java b/src/main/java/io/papermc/paper/event/player/AsyncChatEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4eada40b8abb1833ce623ccee0789555e370d024
+index 0000000000000000000000000000000000000000..4d2eddba7dc88ba23b241ac7849114a30af968d3
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/AsyncChatEvent.java
 @@ -0,0 +1,47 @@
@@ -3061,37 +3061,40 @@ index f4ac033ff8794a61c82a49dc6c3f863f3291455d..d944d67f544494355f03c5bc9afd8ea7
  
      /**
 diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-index 3c2ea8fec3a748cab7f5ad9100d12bd8213ec6c9..a803bfea5400b3578bb4cf3261874e873b6467d9 100644
+index 3c2ea8fec3a748cab7f5ad9100d12bd8213ec6c9..03b4e0300d228e3f3a9f4f75c96e0cf9ed1a7d2d 100644
 --- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-@@ -12,25 +12,48 @@ import org.jetbrains.annotations.Nullable;
+@@ -11,26 +11,49 @@ import org.jetbrains.annotations.Nullable;
+  */
  public class PlayerDeathEvent extends EntityDeathEvent {
      private int newExp = 0;
-     private String deathMessage = "";
-+    private net.kyori.adventure.text.Component adventure$deathMessage; // Paper
+-    private String deathMessage = "";
++    private net.kyori.adventure.text.Component deathMessage; // Paper - adventure
      private int newLevel = 0;
      private int newTotalExp = 0;
      private boolean keepLevel = false;
      private boolean keepInventory = false;
-+    // Paper start
-+    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage) {
-+        this(player, drops, droppedExp, 0, adventure$deathMessage, null);
++    // Paper start - adventure
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final @Nullable net.kyori.adventure.text.Component deathMessage) {
++        this(player, drops, droppedExp, 0, deathMessage);
 +    }
 +
-+    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage, @Nullable String deathMessage) {
-+        this(player, drops, droppedExp, newExp, 0, 0, adventure$deathMessage, deathMessage);
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final int newExp, final @Nullable net.kyori.adventure.text.Component deathMessage) {
++        this(player, drops, droppedExp, newExp, 0, 0, deathMessage);
 +    }
- 
-+    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage, @Nullable String deathMessage) {
++
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final @Nullable net.kyori.adventure.text.Component deathMessage) {
 +        super(player, drops, droppedExp);
 +        this.newExp = newExp;
 +        this.newTotalExp = newTotalExp;
 +        this.newLevel = newLevel;
 +        this.deathMessage = deathMessage;
-+        this.adventure$deathMessage = adventure$deathMessage;
 +    }
-+    // Paper end
-+
++    // Paper end - adventure
+ 
 +    @Deprecated // Paper
      public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, @Nullable final String deathMessage) {
          this(player, drops, droppedExp, 0, deathMessage);
@@ -3108,35 +3111,34 @@ index 3c2ea8fec3a748cab7f5ad9100d12bd8213ec6c9..a803bfea5400b3578bb4cf3261874e87
          this.newExp = newExp;
          this.newTotalExp = newTotalExp;
          this.newLevel = newLevel;
-         this.deathMessage = deathMessage;
-+        this.adventure$deathMessage = deathMessage != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage) : null; // Paper
+-        this.deathMessage = deathMessage;
++        this.deathMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(deathMessage); // Paper
      }
  
      @NotNull
-@@ -39,25 +62,55 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -39,25 +62,49 @@ public class PlayerDeathEvent extends EntityDeathEvent {
          return (Player) entity;
      }
  
-+    // Paper start
++    // Paper start - adventure
 +    /**
 +     * Set the death message that will appear to everyone on the server.
 +     *
-+     * @param deathMessage Message to appear to other players on the server.
++     * @param deathMessage Component message to appear to other players on the server.
 +     */
-+    public void deathMessage(net.kyori.adventure.text.@Nullable Component deathMessage) {
-+        this.deathMessage = null;
-+        this.adventure$deathMessage = deathMessage;
++    public void deathMessage(final net.kyori.adventure.text.@Nullable Component deathMessage) {
++        this.deathMessage = deathMessage;
 +    }
 +
 +    /**
 +     * Get the death message that will appear to everyone on the server.
 +     *
-+     * @return Message to appear to other players on the server.
++     * @return Component message to appear to other players on the server.
 +     */
 +    public net.kyori.adventure.text.@Nullable Component deathMessage() {
-+        return this.adventure$deathMessage;
++        return this.deathMessage;
 +    }
-+    // Paper end
++    // Paper end - adventure
 +
      /**
       * Set the death message that will appear to everyone on the server.
@@ -3146,8 +3148,8 @@ index 3c2ea8fec3a748cab7f5ad9100d12bd8213ec6c9..a803bfea5400b3578bb4cf3261874e87
       */
 +    @Deprecated // Paper
      public void setDeathMessage(@Nullable String deathMessage) {
-         this.deathMessage = deathMessage;
-+        this.adventure$deathMessage = deathMessage != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage) : null; // Paper
+-        this.deathMessage = deathMessage;
++        this.deathMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(deathMessage); // Paper
      }
  
      /**
@@ -3160,13 +3162,9 @@ index 3c2ea8fec3a748cab7f5ad9100d12bd8213ec6c9..a803bfea5400b3578bb4cf3261874e87
 +    @Deprecated // Paper
      public String getDeathMessage() {
 -        return deathMessage;
-+        return this.deathMessage != null ? this.deathMessage : (this.adventure$deathMessage != null ? getDeathMessageString(this.adventure$deathMessage) : null); // Paper
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serializeOrNull(this.deathMessage); // Paper
      }
 -
-+    // Paper start //TODO: add translation API to drop String deathMessage in favor of just Adventure
-+    private static String getDeathMessageString(net.kyori.adventure.text.Component component) {
-+        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(component);
-+    }
 +    // Paper end
      /**
       * Gets how much EXP the Player should have at respawn.

--- a/patches/api/0146-Improve-death-events.patch
+++ b/patches/api/0146-Improve-death-events.patch
@@ -179,24 +179,26 @@ index a5984ab06cce95d30e70511e125f69339b574c04..130cf9e5981f701dff4fa72e71e0b5dc
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-index a803bfea5400b3578bb4cf3261874e873b6467d9..27909044c0c136acde18d64f14e84de932ba1045 100644
+index 03b4e0300d228e3f3a9f4f75c96e0cf9ed1a7d2d..38f81772edacb178e21c3f273e8c41ed46177d6d 100644
 --- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-@@ -63,6 +63,17 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -62,6 +62,19 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+         return (Player) entity;
      }
  
-     // Paper start
++    // Paper start - improve death events
 +    /**
 +     * Clarity method for getting the player. Not really needed except
 +     * for reasons of clarity.
-+     * 
++     *
 +     * @return Player who is involved in this event
 +     */
-+    @NotNull
-+    public Player getPlayer() {
-+        return getEntity();
++    public @NotNull Player getPlayer() {
++        return this.getEntity();
 +    }
 +
++    // Paper end - improve death events
++
+     // Paper start - adventure
      /**
       * Set the death message that will appear to everyone on the server.
-      *

--- a/patches/api/0175-PlayerDeathEvent-getItemsToKeep.patch
+++ b/patches/api/0175-PlayerDeathEvent-getItemsToKeep.patch
@@ -8,19 +8,19 @@ Exposes a mutable array on items a player should keep on death
 Example Usage: https://gist.github.com/aikar/5bb202de6057a051a950ce1f29feb0b4
 
 diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-index 27909044c0c136acde18d64f14e84de932ba1045..ed7ede83507c052e05afffea78600b16439590dd 100644
+index 59b84a0e07ddc214a419d5b59ab3a86c5ab63b78..3ce76cfb09f6f5eb55e950843bdd846b2b561116 100644
 --- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-@@ -36,7 +36,6 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -37,7 +37,6 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      }
-     // Paper end
+     // Paper end - adventure
  
 -    @Deprecated // Paper
      public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, @Nullable final String deathMessage) {
          this(player, drops, droppedExp, 0, deathMessage);
      }
 @@ -56,6 +55,41 @@ public class PlayerDeathEvent extends EntityDeathEvent {
-         this.adventure$deathMessage = deathMessage != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage) : null; // Paper
+         this.deathMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(deathMessage); // Paper
      }
  
 +    @Deprecated // Paper

--- a/patches/api/0183-PlayerDeathEvent-shouldDropExperience.patch
+++ b/patches/api/0183-PlayerDeathEvent-shouldDropExperience.patch
@@ -5,62 +5,61 @@ Subject: [PATCH] PlayerDeathEvent#shouldDropExperience
 
 
 diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-index ed7ede83507c052e05afffea78600b16439590dd..c7138d79a572a525c70b51b7c79d2c5dfb18f25c 100644
+index 3ce76cfb09f6f5eb55e950843bdd846b2b561116..dad291ad8cd16d24d587e771a8b60cfb5d0bce2a 100644
 --- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-@@ -1,6 +1,8 @@
- package org.bukkit.event.entity;
- 
- import java.util.List;
-+
-+import org.bukkit.GameMode;
- import org.bukkit.entity.Player;
- import org.bukkit.inventory.ItemStack;
- import org.jetbrains.annotations.NotNull;
-@@ -18,6 +20,8 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -16,6 +16,7 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+     private int newTotalExp = 0;
      private boolean keepLevel = false;
      private boolean keepInventory = false;
-     // Paper start
-+    private boolean doExpDrop;
-+
-     public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage) {
-         this(player, drops, droppedExp, 0, adventure$deathMessage, null);
-     }
-@@ -27,12 +31,17 @@ public class PlayerDeathEvent extends EntityDeathEvent {
-     }
++    private boolean doExpDrop; // Paper - shouldDropExperience API
+     // Paper start - adventure
+     @org.jetbrains.annotations.ApiStatus.Internal
+     public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final @Nullable net.kyori.adventure.text.Component deathMessage) {
+@@ -29,11 +30,18 @@ public class PlayerDeathEvent extends EntityDeathEvent {
  
-     public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage, @Nullable String deathMessage) {
-+        this(player, drops, droppedExp, newExp, newTotalExp, newLevel, adventure$deathMessage, deathMessage, true);
+     @org.jetbrains.annotations.ApiStatus.Internal
+     public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final @Nullable net.kyori.adventure.text.Component deathMessage) {
++        // Paper start - shouldDropExperience API
++        this(player, drops, droppedExp, newExp, newTotalExp, newLevel, deathMessage, true);
 +    }
-+
-+    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage, @Nullable String deathMessage, boolean doExpDrop) {
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public PlayerDeathEvent(final @NotNull Player player, final @NotNull List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, final @Nullable net.kyori.adventure.text.Component deathMessage, final boolean doExpDrop) {
++        // Paper end - shouldDropExperience API
          super(player, drops, droppedExp);
          this.newExp = newExp;
          this.newTotalExp = newTotalExp;
          this.newLevel = newLevel;
          this.deathMessage = deathMessage;
-         this.adventure$deathMessage = adventure$deathMessage;
-+        this.doExpDrop = doExpDrop;
++        this.doExpDrop = doExpDrop; // Paper - shouldDropExperience API
      }
-     // Paper end
+     // Paper end - adventure
  
-@@ -47,6 +56,11 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -48,11 +56,19 @@ public class PlayerDeathEvent extends EntityDeathEvent {
  
      @Deprecated // Paper
      public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final String deathMessage) {
++        // Paper start - shouldDropExperience API
 +        this(player, drops, droppedExp, newExp, newTotalExp, newLevel, deathMessage, true);
 +    }
 +
 +    @Deprecated // Paper
 +    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final String deathMessage, boolean doExpDrop) {
++        // Paper end - shouldDropExperience API
          super(player, drops, droppedExp);
          this.newExp = newExp;
          this.newTotalExp = newTotalExp;
-@@ -88,6 +102,20 @@ public class PlayerDeathEvent extends EntityDeathEvent {
-     public List<ItemStack> getItemsToKeep() {
-         return itemsToKeep;
+         this.newLevel = newLevel;
+         this.deathMessage = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserializeOrNull(deathMessage); // Paper
++        this.doExpDrop = doExpDrop; // Paper - shouldDropExperience API
      }
-+
+ 
+     @Deprecated // Paper
+@@ -90,6 +106,22 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+     }
+     // Paper end
+ 
++    // Paper start - shouldDropExperience API
 +    /**
 +     * @return should experience be dropped from this death
 +     */
@@ -74,6 +73,8 @@ index ed7ede83507c052e05afffea78600b16439590dd..c7138d79a572a525c70b51b7c79d2c5d
 +    public void setShouldDropExperience(boolean doExpDrop) {
 +        this.doExpDrop = doExpDrop;
 +    }
-     // Paper end
- 
++    // Paper end - shouldDropExperience API
++
      @NotNull
+     @Override
+     public Player getEntity() {

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2745,7 +2745,7 @@ index 729849caf3e3cb542d5c4097a568c5fadeff0f6d..1eb0809addfd77303b94bb594701ee7f
  
      public boolean logIPs() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index a721e9cd0958d7fceed1aba8ae55fefed4e6a887..d53c25ed96cfea839a5ad3531092d63478f6b869 100644
+index a721e9cd0958d7fceed1aba8ae55fefed4e6a887..61d4afb6b76fdffdda9f01af5005f005e21f4807 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -162,6 +162,7 @@ import net.minecraft.world.damagesource.CombatTracker;
@@ -2785,7 +2785,7 @@ index a721e9cd0958d7fceed1aba8ae55fefed4e6a887..d53c25ed96cfea839a5ad3531092d634
          String deathmessage = defaultMessage.getString();
          this.keepLevel = keepInventory; // SPIGOT-2222: pre-set keepLevel
 -        org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, deathmessage, keepInventory);
-+        org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), defaultMessage.getString(), keepInventory); // Paper - Adventure
++        org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), keepInventory); // Paper - Adventure
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.containerMenu != this.inventoryMenu) {
@@ -4670,21 +4670,18 @@ index 5725b0281ac53a2354b233223259d6784353bc6e..9ef939b76d06874b856e0c850addb364
      @Override
      public int getLineWidth() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 97cb754bcac8b1c511c59f9cd1c007749d8b7965..54c4a45d5f67c7ed6ce751b4985d9e920cf62008 100644
+index 97cb754bcac8b1c511c59f9cd1c007749d8b7965..756fc13c34cceeab054ee8e9678a16a56cc3f8ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -904,9 +904,9 @@ public class CraftEventFactory {
+@@ -904,7 +904,7 @@ public class CraftEventFactory {
          return event;
      }
  
 -    public static PlayerDeathEvent callPlayerDeathEvent(ServerPlayer victim, List<org.bukkit.inventory.ItemStack> drops, String deathMessage, boolean keepInventory) {
-+    public static PlayerDeathEvent callPlayerDeathEvent(ServerPlayer victim, List<org.bukkit.inventory.ItemStack> drops, net.kyori.adventure.text.Component deathMessage, String stringDeathMessage, boolean keepInventory) { // Paper - Adventure
++    public static PlayerDeathEvent callPlayerDeathEvent(ServerPlayer victim, List<org.bukkit.inventory.ItemStack> drops, net.kyori.adventure.text.Component deathMessage, boolean keepInventory) { // Paper - Adventure
          CraftPlayer entity = victim.getBukkitEntity();
--        PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
-+        PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
+         PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
          event.setKeepInventory(keepInventory);
-         event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
-         org.bukkit.World world = entity.getWorld();
 @@ -931,7 +931,7 @@ public class CraftEventFactory {
       * Server methods
       */

--- a/patches/server/0250-Improve-death-events.patch
+++ b/patches/server/0250-Improve-death-events.patch
@@ -45,7 +45,7 @@ index 0100aafc999cadcfa7a904a812355502379c418d..b2864db793e8d764cf06229d7868fcf8
 @@ -882,6 +886,16 @@ public class ServerPlayer extends Player {
          String deathmessage = defaultMessage.getString();
          this.keepLevel = keepInventory; // SPIGOT-2222: pre-set keepLevel
-         org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), defaultMessage.getString(), keepInventory); // Paper - Adventure
+         org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), keepInventory); // Paper - Adventure
 +        // Paper start - cancellable death event
 +        if (event.isCancelled()) {
 +            // make compatible with plugins that might have already set the health in an event listener
@@ -422,7 +422,7 @@ index bd6ac69d97ec1c12bf73e9ef07d39a484a39aad1..ce73a8c652cf95bae62808fc27db2ab8
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c5736eb070209d0ecad1007e4c4c633c4615be83..18074dab4529f92b164671543dd11d2628ea0982 100644
+index 5c81eb10e92142d8d4907751edc8c01659d2c62e..10c701eb269b02c763d32c6a0be8fe7b843805c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -890,9 +890,16 @@ public class CraftEventFactory {
@@ -443,7 +443,7 @@ index c5736eb070209d0ecad1007e4c4c633c4615be83..18074dab4529f92b164671543dd11d26
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
 @@ -909,8 +916,15 @@ public class CraftEventFactory {
-         PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
+         PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
 +        populateFields(victim, event); // Paper - make cancellable

--- a/patches/server/1043-Restore-vanilla-entity-drops-behavior.patch
+++ b/patches/server/1043-Restore-vanilla-entity-drops-behavior.patch
@@ -165,7 +165,7 @@ index ab708b256183fc54fe8e13f341d8a38acf611739..1e86e86b0a100a5d14aee10b60e70c32
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a7da88af0a41f16b3a54b28023a5afb6d9396262..f67ec3f5f4b7e2f678609f2387cc8afa2adce161 100644
+index e15e60b67c17a0ea4fedb4882ea839e1b9b1ae60..7d9fc84dd684093098fdefdcaf7c92a0fbc158de 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -939,17 +939,21 @@ public class CraftEventFactory {
@@ -214,11 +214,11 @@ index a7da88af0a41f16b3a54b28023a5afb6d9396262..f67ec3f5f4b7e2f678609f2387cc8afa
          return event;
      }
  
--    public static PlayerDeathEvent callPlayerDeathEvent(ServerPlayer victim, List<org.bukkit.inventory.ItemStack> drops, net.kyori.adventure.text.Component deathMessage, String stringDeathMessage, boolean keepInventory) { // Paper - Adventure
-+    public static PlayerDeathEvent callPlayerDeathEvent(ServerPlayer victim, List<Entity.DefaultDrop> drops, net.kyori.adventure.text.Component deathMessage, String stringDeathMessage, boolean keepInventory) { // Paper - Adventure & improve drops
+-    public static PlayerDeathEvent callPlayerDeathEvent(ServerPlayer victim, List<org.bukkit.inventory.ItemStack> drops, net.kyori.adventure.text.Component deathMessage, boolean keepInventory) { // Paper - Adventure
++    public static PlayerDeathEvent callPlayerDeathEvent(ServerPlayer victim, List<Entity.DefaultDrop> drops, net.kyori.adventure.text.Component deathMessage, boolean keepInventory) { // Paper - Adventure & improve drops
          CraftPlayer entity = victim.getBukkitEntity();
--        PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
-+        PlayerDeathEvent event = new PlayerDeathEvent(entity, new io.papermc.paper.util.TransformingRandomAccessList<>(drops, Entity.DefaultDrop::stack, FROM_FUNCTION), victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure & improve drops
+-        PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
++        PlayerDeathEvent event = new PlayerDeathEvent(entity, new io.papermc.paper.util.TransformingRandomAccessList<>(drops, Entity.DefaultDrop::stack, FROM_FUNCTION), victim.getExpReward(), 0, deathMessage); // Paper - improve drops
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          populateFields(victim, event); // Paper - make cancellable


### PR DESCRIPTION
There was a TODO left there regarding the translated death message being used by plugins to identify the cause of death. This should be mitigated now because the LegacyComponentSerializer default implemenation uses our custom flattener which renders vanilla translatable components to their English representation.