### PR TITLE
Call entity_die game event after event cancel check

### DIFF
--- a/patches/server/0250-Improve-death-events.patch
+++ b/patches/server/0250-Improve-death-events.patch
@@ -19,7 +19,7 @@ public net.minecraft.world.entity.LivingEntity getDeathSound()Lnet/minecraft/sou
 public net.minecraft.world.entity.LivingEntity getSoundVolume()F
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 0100aafc999cadcfa7a904a812355502379c418d..6abd0b8c51138b9a46c0df3a34cfee98016964d3 100644
+index 0100aafc999cadcfa7a904a812355502379c418d..b2864db793e8d764cf06229d7868fcf80247f938 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -248,6 +248,10 @@ public class ServerPlayer extends Player {
@@ -33,7 +33,16 @@ index 0100aafc999cadcfa7a904a812355502379c418d..6abd0b8c51138b9a46c0df3a34cfee98
  
      // CraftBukkit start
      public String displayName;
-@@ -882,6 +886,15 @@ public class ServerPlayer extends Player {
+@@ -854,7 +858,7 @@ public class ServerPlayer extends Player {
+ 
+     @Override
+     public void die(DamageSource damageSource) {
+-        this.gameEvent(GameEvent.ENTITY_DIE);
++        // this.gameEvent(GameEvent.ENTITY_DIE); // Paper - move below event cancellation check
+         boolean flag = this.level().getGameRules().getBoolean(GameRules.RULE_SHOWDEATHMESSAGES);
+         // CraftBukkit start - fire PlayerDeathEvent
+         if (this.isRemoved()) {
+@@ -882,6 +886,16 @@ public class ServerPlayer extends Player {
          String deathmessage = defaultMessage.getString();
          this.keepLevel = keepInventory; // SPIGOT-2222: pre-set keepLevel
          org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), defaultMessage.getString(), keepInventory); // Paper - Adventure
@@ -45,11 +54,12 @@ index 0100aafc999cadcfa7a904a812355502379c418d..6abd0b8c51138b9a46c0df3a34cfee98
 +            }
 +            return;
 +        }
++        this.gameEvent(GameEvent.ENTITY_DIE); // moved from the top of this method
 +        // Paper end
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.containerMenu != this.inventoryMenu) {
-@@ -1030,8 +1043,17 @@ public class ServerPlayer extends Player {
+@@ -1030,8 +1044,17 @@ public class ServerPlayer extends Player {
                          }
                      }
                  }
@@ -392,7 +402,7 @@ index 948ba97e318506dad96e59121297b5bf8340d2e6..810bead2f19de70786027b190137f743
          this.gameEvent(GameEvent.ENTITY_DIE);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b6e4fbfdaa46a36e155870190252233eca99d456..baba4105ccd1fe769cbbbd222e9315277394f5c6 100644
+index bd6ac69d97ec1c12bf73e9ef07d39a484a39aad1..ce73a8c652cf95bae62808fc27db2ab852691fd8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2408,7 +2408,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0266-Call-player-spectator-target-events-and-improve-impl.patch
+++ b/patches/server/0266-Call-player-spectator-target-events-and-improve-impl.patch
@@ -19,10 +19,10 @@ spectate the target entity.
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 7dae09967ae47ae2ef01d1072ad98f125d0b67e9..859358b6bdffb836acbb653fefbafa592b5704e6 100644
+index b2864db793e8d764cf06229d7868fcf80247f938..aa4257a7d2e676cafeb85ceaeab364a83dead616 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2084,6 +2084,21 @@ public class ServerPlayer extends Player {
+@@ -2085,6 +2085,21 @@ public class ServerPlayer extends Player {
  
          this.camera = (Entity) (entity == null ? this : entity);
          if (entity1 != this.camera) {

--- a/patches/server/0270-Reset-players-airTicks-on-respawn.patch
+++ b/patches/server/0270-Reset-players-airTicks-on-respawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset players airTicks on respawn
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 859358b6bdffb836acbb653fefbafa592b5704e6..6e025c8fdb14e6dcb178055d51efd11112247808 100644
+index aa4257a7d2e676cafeb85ceaeab364a83dead616..471fd247659da0cc327e0695095bf8c0a517d087 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2559,6 +2559,7 @@ public class ServerPlayer extends Player {
+@@ -2560,6 +2560,7 @@ public class ServerPlayer extends Player {
  
          this.setHealth(this.getMaxHealth());
          this.stopUsingItem(); // CraftBukkit - SPIGOT-6682: Clear active item on reset

--- a/patches/server/0286-Workaround-for-vehicle-tracking-issue-on-disconnect.patch
+++ b/patches/server/0286-Workaround-for-vehicle-tracking-issue-on-disconnect.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Workaround for vehicle tracking issue on disconnect
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 268567dab735619171c2cdfd566790527c07e64d..c46326b7c761057f2d61542e088278553d694d7c 100644
+index cf1d636660e0e1e8bfec915e0c82525822beba49..a99e06b7507b3490ac8869dd626bdb1cee5b1690 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1748,6 +1748,13 @@ public class ServerPlayer extends Player {
+@@ -1749,6 +1749,13 @@ public class ServerPlayer extends Player {
      public void disconnect() {
          this.disconnected = true;
          this.ejectPassengers();

--- a/patches/server/0301-PlayerDeathEvent-getItemsToKeep.patch
+++ b/patches/server/0301-PlayerDeathEvent-getItemsToKeep.patch
@@ -11,7 +11,7 @@ Example Usage: https://gist.github.com/aikar/5bb202de6057a051a950ce1f29feb0b4
 public net.minecraft.world.entity.player.Inventory compartments
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index c46326b7c761057f2d61542e088278553d694d7c..c65b5054728418a62923eb4192d55ba30fd8f4fb 100644
+index a99e06b7507b3490ac8869dd626bdb1cee5b1690..602172f376edbecff94745f88d6a82aa8016c99d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -857,6 +857,46 @@ public class ServerPlayer extends Player {
@@ -60,8 +60,8 @@ index c46326b7c761057f2d61542e088278553d694d7c..c65b5054728418a62923eb4192d55ba3
 +
      @Override
      public void die(DamageSource damageSource) {
-         this.gameEvent(GameEvent.ENTITY_DIE);
-@@ -940,7 +980,12 @@ public class ServerPlayer extends Player {
+         // this.gameEvent(GameEvent.ENTITY_DIE); // Paper - move below event cancellation check
+@@ -941,7 +981,12 @@ public class ServerPlayer extends Player {
          this.dropExperience();
          // we clean the player's inventory after the EntityDeathEvent is called so plugins can get the exact state of the inventory.
          if (!event.getKeepInventory()) {

--- a/patches/server/0324-PlayerDeathEvent-shouldDropExperience.patch
+++ b/patches/server/0324-PlayerDeathEvent-shouldDropExperience.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerDeathEvent#shouldDropExperience
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index c65b5054728418a62923eb4192d55ba30fd8f4fb..05c658b988fd970eeba8117d06c5a5d93b8fd75d 100644
+index 602172f376edbecff94745f88d6a82aa8016c99d..d5b0fba5f38b099d84bb7952363cdc1455772684 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -977,7 +977,7 @@ public class ServerPlayer extends Player {
+@@ -978,7 +978,7 @@ public class ServerPlayer extends Player {
              this.tellNeutralMobsThatIDied();
          }
          // SPIGOT-5478 must be called manually now

--- a/patches/server/0369-Prevent-opening-inventories-when-frozen.patch
+++ b/patches/server/0369-Prevent-opening-inventories-when-frozen.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent opening inventories when frozen
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ff0191dd75b5014e224db8f1419dcec240cb1436..3a026f766e2d67e005ae8a06337d465f92c8d1f3 100644
+index 94360a83f72ba310da94f822d8aafd9d96e5121c..0caad3d6f66336cd0124b8b093af209b43ab9b25 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -701,7 +701,7 @@ public class ServerPlayer extends Player {
@@ -17,7 +17,7 @@ index ff0191dd75b5014e224db8f1419dcec240cb1436..3a026f766e2d67e005ae8a06337d465f
              this.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.CANT_USE); // Paper
              this.containerMenu = this.inventoryMenu;
          }
-@@ -1555,7 +1555,7 @@ public class ServerPlayer extends Player {
+@@ -1556,7 +1556,7 @@ public class ServerPlayer extends Player {
              } else {
                  // CraftBukkit start
                  this.containerMenu = container;

--- a/patches/server/0371-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0371-Implement-Player-Client-Options-API.patch
@@ -87,7 +87,7 @@ index 0000000000000000000000000000000000000000..b6f4400df3d8ec7e06a996de54f8cabb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3a026f766e2d67e005ae8a06337d465f92c8d1f3..352fbab070ccdb683e9a7558292c86cc443c018b 100644
+index 0caad3d6f66336cd0124b8b093af209b43ab9b25..efe768142bbf37d4ba07257e37fa71d576464a31 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -386,7 +386,7 @@ public class ServerPlayer extends Player {
@@ -99,7 +99,7 @@ index 3a026f766e2d67e005ae8a06337d465f92c8d1f3..352fbab070ccdb683e9a7558292c86cc
  
          this.cachedSingleHashSet = new com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<>(this); // Paper
  
-@@ -2051,7 +2051,23 @@ public class ServerPlayer extends Player {
+@@ -2052,7 +2052,23 @@ public class ServerPlayer extends Player {
          }
      }
  
@@ -123,7 +123,7 @@ index 3a026f766e2d67e005ae8a06337d465f92c8d1f3..352fbab070ccdb683e9a7558292c86cc
          // CraftBukkit start
          if (this.getMainArm() != clientOptions.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), this.getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
-@@ -2063,6 +2079,11 @@ public class ServerPlayer extends Player {
+@@ -2064,6 +2080,11 @@ public class ServerPlayer extends Player {
              this.server.server.getPluginManager().callEvent(new com.destroystokyo.paper.event.player.PlayerLocaleChangeEvent(this.getBukkitEntity(), this.language, clientOptions.language())); // Paper
          }
          // CraftBukkit end
@@ -136,7 +136,7 @@ index 3a026f766e2d67e005ae8a06337d465f92c8d1f3..352fbab070ccdb683e9a7558292c86cc
          this.adventure$locale = net.kyori.adventure.translation.Translator.parseLocale(this.language); // Paper
          this.requestedViewDistance = clientOptions.viewDistance();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 64380c3db88cf5a17a18d166d3869b9a75b1579f..5fdd1bc97b3e04b59a76cfbf190cc9cb504837cf 100644
+index 9cae7d8a77af303cb509c23efd5541a5e04f54a6..49862c0338b84924003df85883760317d1ca7aec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -609,6 +609,28 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0413-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0413-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -76,10 +76,10 @@ index 7f5ecea0ee78a534d7c56fa9e3ad2117b5192c0a..ac918da8234553e4d88664b240feddc1
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3dfbd1225b0c1ee6b6fb2e842efdb1a8ff2c26c6..030d6c0d067dacf4f9603bdfb21acca8cafbeff0 100644
+index fc8f8bc0762288b04d895a767f4af7b3aa61c078..a86a5475d2e6e68d893878de168aefb6b42e8248 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1208,7 +1208,7 @@ public class ServerPlayer extends Player {
+@@ -1209,7 +1209,7 @@ public class ServerPlayer extends Player {
                  this.isChangingDimension = true; // CraftBukkit - Set teleport invulnerability only if player changing worlds
  
                  this.connection.send(new ClientboundRespawnPacket(this.createCommonSpawnInfo(worldserver), (byte) 3));

--- a/patches/server/0536-Reset-shield-blocking-on-dimension-change.patch
+++ b/patches/server/0536-Reset-shield-blocking-on-dimension-change.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset shield blocking on dimension change
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 063742400f3065ace62b64b42d952517ae00ea1f..e460d3f66ef58e0788fd9dfb35a6ce0e3c171289 100644
+index 090ff649eeef45fe4c0403a171e5eddff12d2c7d..9db7bfe3782e96921e3a65ed60f4494770210d5a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1246,6 +1246,11 @@ public class ServerPlayer extends Player {
+@@ -1247,6 +1247,11 @@ public class ServerPlayer extends Player {
                  this.level().getCraftServer().getPluginManager().callEvent(changeEvent);
                  // CraftBukkit end
              }

--- a/patches/server/0590-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0590-additions-to-PlayerGameModeChangeEvent.patch
@@ -45,10 +45,10 @@ index aee8618e27b893b72931e925724dd683d2e6d2aa..5cb15e2209d7b315904a1fc6d650ce1e
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b4dc1b47a0f7298d202c7dff602d8e24e643a215..2118cb563a70596fe3690ad1bd326e72beba3cee 100644
+index 9db7bfe3782e96921e3a65ed60f4494770210d5a..48a5fda8d59e8a13bcca61e21c7cb1358c2d17a2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1988,8 +1988,16 @@ public class ServerPlayer extends Player {
+@@ -1989,8 +1989,16 @@ public class ServerPlayer extends Player {
      }
  
      public boolean setGameMode(GameType gameMode) {
@@ -67,7 +67,7 @@ index b4dc1b47a0f7298d202c7dff602d8e24e643a215..2118cb563a70596fe3690ad1bd326e72
          } else {
              this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.CHANGE_GAME_MODE, (float) gameMode.getId()));
              if (gameMode == GameType.SPECTATOR) {
-@@ -2001,7 +2009,7 @@ public class ServerPlayer extends Player {
+@@ -2002,7 +2010,7 @@ public class ServerPlayer extends Player {
  
              this.onUpdateAbilities();
              this.updateEffectVisibility();
@@ -76,7 +76,7 @@ index b4dc1b47a0f7298d202c7dff602d8e24e643a215..2118cb563a70596fe3690ad1bd326e72
          }
      }
  
-@@ -2413,6 +2421,16 @@ public class ServerPlayer extends Player {
+@@ -2414,6 +2422,16 @@ public class ServerPlayer extends Player {
      }
  
      public void loadGameTypes(@Nullable CompoundTag nbt) {

--- a/patches/server/0617-Fix-PlayerDropItemEvent-using-wrong-item.patch
+++ b/patches/server/0617-Fix-PlayerDropItemEvent-using-wrong-item.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix PlayerDropItemEvent using wrong item
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index c82f4f6f023ac8f416613db4fbfe2f4af61fd2de..814754a73a8d653adc159b313fa201565db59590 100644
+index 48a5fda8d59e8a13bcca61e21c7cb1358c2d17a2..bb44d07bdffcf077dae3c5c2aef2aa87a77bb264 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2390,7 +2390,7 @@ public class ServerPlayer extends Player {
+@@ -2391,7 +2391,7 @@ public class ServerPlayer extends Player {
  
              if (retainOwnership) {
                  if (!itemstack1.isEmpty()) {

--- a/patches/server/0626-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0626-Don-t-apply-cramming-damage-to-players.patch
@@ -11,7 +11,7 @@ It does not make a lot of sense to damage players if they get crammed,
 For those who really want it a config option is provided.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 83ba8472a5f3dc2c5d804e49310d8d0a2332a709..526daf9b8475db623ed3ae49a7fa3b48304c9bb4 100644
+index 6a21b06d07fd3ee8ea0fa567240ad6aec9e57096..064b7ccea1342a871caad96fc42db38720043c3b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -95,6 +95,7 @@ import net.minecraft.util.Mth;
@@ -22,7 +22,7 @@ index 83ba8472a5f3dc2c5d804e49310d8d0a2332a709..526daf9b8475db623ed3ae49a7fa3b48
  import net.minecraft.world.effect.MobEffectInstance;
  import net.minecraft.world.effect.MobEffects;
  import net.minecraft.world.entity.Entity;
-@@ -1478,7 +1479,7 @@ public class ServerPlayer extends Player {
+@@ -1479,7 +1480,7 @@ public class ServerPlayer extends Player {
  
      @Override
      public boolean isInvulnerableTo(DamageSource damageSource) {

--- a/patches/server/0636-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0636-Add-PlayerSetSpawnEvent.patch
@@ -49,10 +49,10 @@ index a2d0699e8427b2262a2396495111125eccafbb66..d797637f61bdf8a424f56fbb48e28b7c
      }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 526daf9b8475db623ed3ae49a7fa3b48304c9bb4..bbb394ca3b3b699f2c7d32ad5aff691375b4323e 100644
+index 064b7ccea1342a871caad96fc42db38720043c3b..b7cdc097e77cb133442191af6e46324a4d0310da 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1355,7 +1355,7 @@ public class ServerPlayer extends Player {
+@@ -1356,7 +1356,7 @@ public class ServerPlayer extends Player {
              } else if (this.bedBlocked(blockposition, enumdirection)) {
                  return Either.left(Player.BedSleepingProblem.OBSTRUCTED);
              } else {
@@ -61,7 +61,7 @@ index 526daf9b8475db623ed3ae49a7fa3b48304c9bb4..bbb394ca3b3b699f2c7d32ad5aff6913
                  if (this.level().isDay()) {
                      return Either.left(Player.BedSleepingProblem.NOT_POSSIBLE_NOW);
                  } else {
-@@ -2310,44 +2310,50 @@ public class ServerPlayer extends Player {
+@@ -2311,44 +2311,50 @@ public class ServerPlayer extends Player {
          return this.respawnForced;
      }
  
@@ -145,7 +145,7 @@ index 526daf9b8475db623ed3ae49a7fa3b48304c9bb4..bbb394ca3b3b699f2c7d32ad5aff6913
          } else {
              this.respawnPosition = null;
              this.respawnDimension = Level.OVERWORLD;
-@@ -2355,6 +2361,7 @@ public class ServerPlayer extends Player {
+@@ -2356,6 +2362,7 @@ public class ServerPlayer extends Player {
              this.respawnForced = false;
          }
  
@@ -154,7 +154,7 @@ index 526daf9b8475db623ed3ae49a7fa3b48304c9bb4..bbb394ca3b3b699f2c7d32ad5aff6913
  
      public SectionPos getLastSectionPos() {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 18205f003ca93cb9836b8b0bdb680ac88998880d..53dbfb828f4d6f47b87e7ff6829a8dbc3de2f0fd 100644
+index 6fdd1175f8d07fba7adf3a63d9c98dedd15e7774..159932e2807c8d51fbf141c2145a138a39ea8abe 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -874,7 +874,7 @@ public abstract class PlayerList {
@@ -187,7 +187,7 @@ index ecaa7f0b2bf795f16187f11fa27f6d5d435ccbfe..c83ffba568f33323b0f8b9a03fa0b7bb
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ab3787d4a6d8d0d5b557264f8eb76ff8b4d33db2..bf5c1e9a7742a327e1d35c3409d6623ae0f8ab48 100644
+index 11507cbf0f213079b39b35d06f8fc675d437469b..cb72755c1b1e04797dbe99612d7bdd0bfd4b540e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1318,9 +1318,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0663-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
+++ b/patches/server/0663-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
@@ -9,7 +9,7 @@ chunk through it. This should also be OK from a leak prevention/
 state desync POV because the TE is getting unloaded anyways.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 31d6fa97fcd1572fd291870082309469987676c6..e2b22b51a8c6d668eaa6572de16bb7a76351d0d3 100644
+index 00d37fc84d460cc5f2b897f66314d4e9ee2c9dd0..60563da7a11c394c5135c6cc630dabe871d48a05 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1574,9 +1574,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -28,10 +28,10 @@ index 31d6fa97fcd1572fd291870082309469987676c6..e2b22b51a8c6d668eaa6572de16bb7a7
          }
          // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index bbb394ca3b3b699f2c7d32ad5aff691375b4323e..a85b4223ab9eb97662f327f6179af6fc9970ab3c 100644
+index b7cdc097e77cb133442191af6e46324a4d0310da..7337d1e7e988889e9604433e8891750d8f172527 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1629,6 +1629,18 @@ public class ServerPlayer extends Player {
+@@ -1630,6 +1630,18 @@ public class ServerPlayer extends Player {
          this.connection.send(new ClientboundContainerClosePacket(this.containerMenu.containerId));
          this.doCloseContainer();
      }

--- a/patches/server/0809-Add-option-for-strict-advancement-dimension-checks.patch
+++ b/patches/server/0809-Add-option-for-strict-advancement-dimension-checks.patch
@@ -24,10 +24,10 @@ index 5f9cb2c7a2874e423087d04d3360af0364692b5c..f81aa5adf9a499cef6dc45bf3f9de2df
          } else {
              BlockPos blockPos = BlockPos.containing(x, y, z);
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index c9424effb591bbe96e803db9eb39640eec07148b..cd0fc31064ae5ec9a9422a7596372d94a6904186 100644
+index e8d527f67e84921a94a2196e86efec96039f06e4..a5893a5e3b22934db533967f515dd5e0eb7fbf2e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1320,6 +1320,12 @@ public class ServerPlayer extends Player {
+@@ -1321,6 +1321,12 @@ public class ServerPlayer extends Player {
          ResourceKey<Level> maindimensionkey = CraftDimensionUtil.getMainDimensionKey(origin);
          ResourceKey<Level> maindimensionkey1 = CraftDimensionUtil.getMainDimensionKey(this.level());
  

--- a/patches/server/0997-Add-titleOverride-to-InventoryOpenEvent.patch
+++ b/patches/server/0997-Add-titleOverride-to-InventoryOpenEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add titleOverride to InventoryOpenEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 222d41d9d730d245063bc93c1cd5c40b9163ef38..c993553383f3b417884bc161d58a9ab72455a55d 100644
+index 567f02ed8d48fcdc389e94c7cb422667a79e6b22..0becd123bf2211a8ccfb6469d9a824b3c948f68a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1572,12 +1572,17 @@ public class ServerPlayer extends Player {
+@@ -1573,12 +1573,17 @@ public class ServerPlayer extends Player {
              this.nextContainerCounter();
              AbstractContainerMenu container = factory.createMenu(this.containerCounter, this.getInventory(), this);
  
@@ -27,7 +27,7 @@ index 222d41d9d730d245063bc93c1cd5c40b9163ef38..c993553383f3b417884bc161d58a9ab7
                  if (container == null && !cancelled) { // Let pre-cancelled events fall through
                      // SPIGOT-5263 - close chest if cancelled
                      if (factory instanceof Container) {
-@@ -1599,7 +1604,7 @@ public class ServerPlayer extends Player {
+@@ -1600,7 +1605,7 @@ public class ServerPlayer extends Player {
              } else {
                  // CraftBukkit start
                  this.containerMenu = container;

--- a/patches/server/1043-Restore-vanilla-entity-drops-behavior.patch
+++ b/patches/server/1043-Restore-vanilla-entity-drops-behavior.patch
@@ -9,7 +9,7 @@ on dropping the item instead of generalizing it for all dropped
 items like CB does.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index bcdda70cb55113c37f5f1fbd511dc1ce973361e3..0eb3384df396508c3d26d1e155cd0e6d64251346 100644
+index a76470c86fcb40c032da43cbd1eb433ab8cff8ce..78c3477149e2b671af5d10cd7974b11554de5a1a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -944,22 +944,20 @@ public class ServerPlayer extends Player {
@@ -38,7 +38,7 @@ index bcdda70cb55113c37f5f1fbd511dc1ce973361e3..0eb3384df396508c3d26d1e155cd0e6d
          this.drops.clear(); // SPIGOT-5188: make sure to clear
          } // Paper
  
-@@ -2441,8 +2439,8 @@ public class ServerPlayer extends Player {
+@@ -2442,8 +2440,8 @@ public class ServerPlayer extends Player {
      }
  
      @Override
@@ -117,7 +117,7 @@ index bc45bd5816b1b62cdd6011f2372702451b83f22b..96885946be3b8e129984353f3dfe4330
      public boolean collides = true;
      public Set<UUID> collidableExemptions = new HashSet<>();
 diff --git a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
-index ad6df234b618235b4e08fb45952d4f0f0078fded..d65a6de8a0fc4859b7313c903201a41a7da830fa 100644
+index 71bcd55d9d71fbd5bf3014c7e36d1456d8d5c3fd..c59e44c45d9c8c719b34e85fb3b753ac3788842d 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 @@ -534,10 +534,10 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob


### PR DESCRIPTION
Delays the `entity_die` game event until after the PlayerDeathEvent has been fired and its cancel state checked.

The game event is already in the correct spot for `EntityDeathEvent`, so I believe just this is affected.