### PR TITLE
fix and cleanup loot table patches

### DIFF
--- a/patches/api/0041-LootTable-API.patch
+++ b/patches/api/0041-LootTable-API.patch
@@ -58,10 +58,10 @@ index 0000000000000000000000000000000000000000..b387894fe8001edb41ad2ad2b70ebabe
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/LootableInventory.java b/src/main/java/com/destroystokyo/paper/loottable/LootableInventory.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2b01a50b6e18856f4c9e28340a7a111cae646a0a
+index 0000000000000000000000000000000000000000..b18a0b50c12fe8d8c954e5c070f2ecd1854a2583
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/LootableInventory.java
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,124 @@
 +package com.destroystokyo.paper.loottable;
 +
 +import org.bukkit.entity.Player;
@@ -101,8 +101,8 @@ index 0000000000000000000000000000000000000000..2b01a50b6e18856f4c9e28340a7a111c
 +     * @param player The player to check
 +     * @return Whether or not this player has looted this block
 +     */
-+    default boolean hasPlayerLooted(@NotNull Player player) {
-+        return hasPlayerLooted(player.getUniqueId());
++    default boolean hasPlayerLooted(final @NotNull Player player) {
++        return this.hasPlayerLooted(player.getUniqueId());
 +    }
 +
 +    /**
@@ -127,9 +127,8 @@ index 0000000000000000000000000000000000000000..2b01a50b6e18856f4c9e28340a7a111c
 +     * @param player The player to check
 +     * @return Timestamp last looted, or null if player has not looted this object
 +     */
-+    @Nullable
-+    default Long getLastLooted(@NotNull Player player) {
-+        return getLastLooted(player.getUniqueId());
++    default @Nullable Long getLastLooted(final @NotNull Player player) {
++        return this.getLastLooted(player.getUniqueId());
 +    }
 +
 +    /**
@@ -147,8 +146,8 @@ index 0000000000000000000000000000000000000000..2b01a50b6e18856f4c9e28340a7a111c
 +     * @param looted true to add player to looted list, false to remove
 +     * @return The previous state of whether the player had looted this or not
 +     */
-+    default boolean setHasPlayerLooted(@NotNull Player player, boolean looted) {
-+        return setHasPlayerLooted(player.getUniqueId(), looted);
++    default boolean setHasPlayerLooted(final @NotNull Player player, final boolean looted) {
++        return this.setHasPlayerLooted(player.getUniqueId(), looted);
 +    }
 +
 +    /**
@@ -271,6 +270,19 @@ index b451191312e4fb19f2131c2d0a0c0337953f6c7c..db6affbc78106b2d93b41953b624a0bc
  
      /**
       * Gets the inventory of the chest block represented by this block state.
+diff --git a/src/main/java/org/bukkit/block/Crafter.java b/src/main/java/org/bukkit/block/Crafter.java
+index 05d6af1681351844a6673a6d0dfca2038dafa7b6..8b2a315ed5dd1c57ce60fc41fd5e83a6495028e6 100644
+--- a/src/main/java/org/bukkit/block/Crafter.java
++++ b/src/main/java/org/bukkit/block/Crafter.java
+@@ -10,7 +10,7 @@ import org.jetbrains.annotations.ApiStatus;
+  */
+ @ApiStatus.Experimental
+ @MinecraftExperimental(Requires.UPDATE_1_21)
+-public interface Crafter extends Container, Lootable {
++public interface Crafter extends Container, com.destroystokyo.paper.loottable.LootableBlockInventory { // Paper - LootTable API
+ 
+     /**
+      * Gets the number of ticks which this block will remain in the crafting
 diff --git a/src/main/java/org/bukkit/block/Dispenser.java b/src/main/java/org/bukkit/block/Dispenser.java
 index 74cd194c9a98245dc52e7e352d7d6c046e1e5cf3..07af1a3f011d4b96275f919d302ac367198e923e 100644
 --- a/src/main/java/org/bukkit/block/Dispenser.java
@@ -355,6 +367,23 @@ index 5b5c3be107fdaa6c55ceb1bca2c223ebc6ab7f43..4ebe1033c55dbd58d0794809435c9352
 -public interface ChestBoat extends Boat, InventoryHolder, Lootable {
 +public interface ChestBoat extends Boat, InventoryHolder, com.destroystokyo.paper.loottable.LootableEntityInventory { // Paper
  }
+diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java
+index 2926fa6071bc7640cc10280b5c3962b0ce7686f1..f3f62e13cc1b6172808c52f2d5f520f1f584e6db 100644
+--- a/src/main/java/org/bukkit/entity/Mob.java
++++ b/src/main/java/org/bukkit/entity/Mob.java
+@@ -61,4 +61,12 @@ public interface Mob extends LivingEntity, Lootable {
+      */
+     @Nullable
+     public Sound getAmbientSound();
++
++    // Paper start - LootTable API
++    @Override
++    default void setLootTable(final @Nullable org.bukkit.loot.LootTable table, final long seed) {
++        this.setLootTable(table);
++        this.setSeed(seed);
++    }
++    // Paper end - LootTable API
+ }
 diff --git a/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java b/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java
 index 937b99f8734d71b2ad33af142afbc251b81d9745..db69687a7ad4b18d17ab1677cae5d8dd4dcd3678 100644
 --- a/src/main/java/org/bukkit/entity/minecart/HopperMinecart.java
@@ -394,10 +423,10 @@ index 9ea403e6fd8e960d017660e0aec118abeda2c42b..238d118f7788b13cd86b7e9ea3a0fc38
 +public interface StorageMinecart extends Minecart, InventoryHolder, LootableEntityInventory { // Paper
  }
 diff --git a/src/main/java/org/bukkit/loot/Lootable.java b/src/main/java/org/bukkit/loot/Lootable.java
-index 24a3d989db3bc67e7afe8459a3d4bb132f448ea7..901db852498e0658c79a57582508dab29bf0a798 100644
+index 24a3d989db3bc67e7afe8459a3d4bb132f448ea7..ad4b0fb7f55ed44dc74fb5a4bd36be6004231116 100644
 --- a/src/main/java/org/bukkit/loot/Lootable.java
 +++ b/src/main/java/org/bukkit/loot/Lootable.java
-@@ -36,6 +36,34 @@ public interface Lootable {
+@@ -36,6 +36,31 @@ public interface Lootable {
      @Nullable
      LootTable getLootTable();
  
@@ -408,24 +437,21 @@ index 24a3d989db3bc67e7afe8459a3d4bb132f448ea7..901db852498e0658c79a57582508dab2
 +     * @param table the Loot Table this {@link org.bukkit.block.Container} or {@link org.bukkit.entity.Mob} will have.
 +     * @param seed the seed to used to generate loot. Default is 0.
 +     */
-+    default void setLootTable(@Nullable LootTable table, long seed) {
-+        setLootTable(table);
-+        setSeed(seed);
-+    }
++    void setLootTable(final @Nullable LootTable table, final long seed);
 +
 +    /**
 +     * Returns whether or not this object has a Loot Table
 +     * @return Has a loot table
 +     */
 +    default boolean hasLootTable() {
-+        return getLootTable() != null;
++        return this.getLootTable() != null;
 +    }
 +
 +    /**
 +     * Clears the associated Loot Table to this object
 +     */
 +    default void clearLootTable() {
-+        setLootTable(null);
++        this.setLootTable(null);
 +    }
 +    // Paper end
 +

--- a/patches/api/0056-Fix-upstream-javadocs.patch
+++ b/patches/api/0056-Fix-upstream-javadocs.patch
@@ -411,7 +411,7 @@ index b688b3856cb3068a539fcecfbfa113f8ab4160a9..c275b881cbd11307a6dcc7190d7a7d40
       * @return whether the item frame is visible or not
       */
 diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java
-index 2926fa6071bc7640cc10280b5c3962b0ce7686f1..4f63988848443aff55619bc12ef12c925642a3f9 100644
+index f3f62e13cc1b6172808c52f2d5f520f1f584e6db..ad5dbf310fe7b34c997bb339f09697222f862005 100644
 --- a/src/main/java/org/bukkit/entity/Mob.java
 +++ b/src/main/java/org/bukkit/entity/Mob.java
 @@ -9,6 +9,10 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0147-Mob-Pathfinding-API.patch
+++ b/patches/api/0147-Mob-Pathfinding-API.patch
@@ -238,7 +238,7 @@ index 0000000000000000000000000000000000000000..3c1e2c93d923a683cc0455af77c43784
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java
-index 4f63988848443aff55619bc12ef12c925642a3f9..6de4344931b2e3d570346b800186c44a0d5782cc 100644
+index ad5dbf310fe7b34c997bb339f09697222f862005..63a14bec00d0b23431d1d002139f48a7d0bc2a88 100644
 --- a/src/main/java/org/bukkit/entity/Mob.java
 +++ b/src/main/java/org/bukkit/entity/Mob.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;

--- a/patches/api/0155-Add-sun-related-API.patch
+++ b/patches/api/0155-Add-sun-related-API.patch
@@ -26,7 +26,7 @@ index 5efe33cef4d9c153d760fc71606721ff8abafbfc..b6ca63afb74b345e381d35646cc8faf5
       * Gets the full in-game time on this world since the world generation
       *
 diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java
-index 6de4344931b2e3d570346b800186c44a0d5782cc..7eee2e561346ac1d672f9652edb78e76c910fc9d 100644
+index 63a14bec00d0b23431d1d002139f48a7d0bc2a88..ef89a82669a6c5bf911827b90facf36a2ff26e91 100644
 --- a/src/main/java/org/bukkit/entity/Mob.java
 +++ b/src/main/java/org/bukkit/entity/Mob.java
 @@ -20,6 +20,13 @@ public interface Mob extends LivingEntity, Lootable {

--- a/patches/api/0279-Add-Mob-lookAt-API.patch
+++ b/patches/api/0279-Add-Mob-lookAt-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add Mob#lookAt API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java
-index 7eee2e561346ac1d672f9652edb78e76c910fc9d..11b6d1aba7d1f6ae1f3c822193486f5a1478e105 100644
+index ef89a82669a6c5bf911827b90facf36a2ff26e91..5fd723c9fdda81595db8b150d967ff3bd5cea608 100644
 --- a/src/main/java/org/bukkit/entity/Mob.java
 +++ b/src/main/java/org/bukkit/entity/Mob.java
 @@ -27,6 +27,88 @@ public interface Mob extends LivingEntity, Lootable {

--- a/patches/api/0292-Missing-Entity-API.patch
+++ b/patches/api/0292-Missing-Entity-API.patch
@@ -738,15 +738,15 @@ index d23226ccb0f6c25028f000ce31346cd0a8898e6a..bc84b892cae5fe7019a3ad481e9da799
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java
-index 11b6d1aba7d1f6ae1f3c822193486f5a1478e105..709c8fc3dde786f45ff13d6ee6c405ffdc765282 100644
+index 5fd723c9fdda81595db8b150d967ff3bd5cea608..91d31e5418a5ab7cefd7c02a41bbec8464fe7ab1 100644
 --- a/src/main/java/org/bukkit/entity/Mob.java
 +++ b/src/main/java/org/bukkit/entity/Mob.java
-@@ -162,4 +162,38 @@ public interface Mob extends LivingEntity, Lootable {
-      */
-     @Nullable
-     public Sound getAmbientSound();
+@@ -170,4 +170,38 @@ public interface Mob extends LivingEntity, Lootable {
+         this.setSeed(seed);
+     }
+     // Paper end - LootTable API
 +
-+    // Paper start
++    // Paper start - Missing Entity API
 +    /**
 +     * Some mobs will raise their arm(s) when aggressive:
 +     * <ul>
@@ -778,7 +778,7 @@ index 11b6d1aba7d1f6ae1f3c822193486f5a1478e105..709c8fc3dde786f45ff13d6ee6c405ff
 +     * @see #isAggressive()
 +     */
 +    void setAggressive(boolean aggressive);
-+    // Paper end
++    // Paper end - Missing Entity API
  }
 diff --git a/src/main/java/org/bukkit/entity/Panda.java b/src/main/java/org/bukkit/entity/Panda.java
 index 1f027927a1194f4f8e86c1375a2772e6e261c151..aa5686df134185334a74429576ff0709a604dbfd 100644

--- a/patches/api/0310-Left-handed-API.patch
+++ b/patches/api/0310-Left-handed-API.patch
@@ -5,15 +5,15 @@ Subject: [PATCH] Left handed API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java
-index 709c8fc3dde786f45ff13d6ee6c405ffdc765282..0c511b64672f9bafb92be3aea6bab8c1c12a7041 100644
+index 91d31e5418a5ab7cefd7c02a41bbec8464fe7ab1..d55250d820b02f3a23b99a59e68d3361698baddf 100644
 --- a/src/main/java/org/bukkit/entity/Mob.java
 +++ b/src/main/java/org/bukkit/entity/Mob.java
-@@ -196,4 +196,20 @@ public interface Mob extends LivingEntity, Lootable {
+@@ -204,4 +204,20 @@ public interface Mob extends LivingEntity, Lootable {
       */
      void setAggressive(boolean aggressive);
-     // Paper end
+     // Paper end - Missing Entity API
 +
-+    // Paper start
++    // Paper start - left-handed API
 +    /**
 +     * Check if Mob is left-handed
 +     *
@@ -27,5 +27,5 @@ index 709c8fc3dde786f45ff13d6ee6c405ffdc765282..0c511b64672f9bafb92be3aea6bab8c1
 +      * @param leftHanded True if left-handed
 +      */
 +    public void setLeftHanded(boolean leftHanded);
-+    // Paper end
++    // Paper end - left-handed API
  }

--- a/patches/api/0400-Add-Mob-Experience-reward-API.patch
+++ b/patches/api/0400-Add-Mob-Experience-reward-API.patch
@@ -5,20 +5,20 @@ Subject: [PATCH] Add Mob Experience reward API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java
-index 0c511b64672f9bafb92be3aea6bab8c1c12a7041..30ef0c20df8ff2ed56adb40fea103265dd3e886c 100644
+index d55250d820b02f3a23b99a59e68d3361698baddf..256e5645bcfa76e7ede58ae365e69b4a4bed6204 100644
 --- a/src/main/java/org/bukkit/entity/Mob.java
 +++ b/src/main/java/org/bukkit/entity/Mob.java
-@@ -212,4 +212,13 @@ public interface Mob extends LivingEntity, Lootable {
+@@ -220,4 +220,13 @@ public interface Mob extends LivingEntity, Lootable {
        */
      public void setLeftHanded(boolean leftHanded);
-     // Paper end
+     // Paper end - left-handed API
 +
-+    // Paper start
++    // Paper start - mob xp reward API
 +    /**
 +     * Gets the amount of experience the mob will possibly drop. This value is randomized and it can give different results
 +     *
 +     * @return the amount of experience the mob will possibly drop
 +     */
 +    public int getPossibleExperienceReward();
-+    // Paper end
++    // Paper end - mob xp reward API
  }

--- a/patches/server/0097-LootTable-API-and-replenishable-lootables.patch
+++ b/patches/server/0097-LootTable-API-and-replenishable-lootables.patch
@@ -15,222 +15,241 @@ public org.bukkit.craftbukkit.block.CraftBlockEntityState getTileEntity()Lnet/mi
 public org.bukkit.craftbukkit.block.CraftLootable setLootTable(Lorg/bukkit/loot/LootTable;J)V
 public org.bukkit.craftbukkit.entity.CraftMinecartContainer setLootTable(Lorg/bukkit/loot/LootTable;J)V
 
-diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperContainerEntityLootableInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperContainerEntityLootableInventory.java
+diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootable.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootable.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7f5283a8ee74253e326fe994f20ae00cf3c75e1b
+index 0000000000000000000000000000000000000000..a53d51be1da25b87f2bc0a29a196d8f9996dbd2b
 --- /dev/null
-+++ b/src/main/java/com/destroystokyo/paper/loottable/PaperContainerEntityLootableInventory.java
-@@ -0,0 +1,66 @@
++++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootable.java
+@@ -0,0 +1,21 @@
 +package com.destroystokyo.paper.loottable;
 +
-+import net.minecraft.Optionull;
-+import net.minecraft.core.registries.Registries;
-+import net.minecraft.resources.ResourceKey;
-+import net.minecraft.world.entity.Entity;
-+import net.minecraft.world.entity.vehicle.AbstractMinecartContainer;
-+import net.minecraft.world.entity.vehicle.ContainerEntity;
-+import net.minecraft.world.level.Level;
-+import org.bukkit.Bukkit;
-+import org.bukkit.craftbukkit.util.CraftNamespacedKey;
++import org.bukkit.loot.LootTable;
++import org.bukkit.loot.Lootable;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.checker.nullness.qual.Nullable;
++import org.checkerframework.framework.qual.DefaultQualifier;
 +
-+public class PaperContainerEntityLootableInventory implements PaperLootableEntityInventory {
++@DefaultQualifier(NonNull.class)
++public interface PaperLootable extends Lootable {
 +
-+    private final ContainerEntity entity;
-+
-+    public PaperContainerEntityLootableInventory(ContainerEntity entity) {
-+        this.entity = entity;
++    @Override
++    default void setLootTable(final @Nullable LootTable table) {
++        this.setLootTable(table, this.getSeed());
 +    }
 +
 +    @Override
-+    public org.bukkit.loot.LootTable getLootTable() {
-+        return entity.getLootTable() != null ? Optionull.map(entity.getLootTable(), rk -> Bukkit.getLootTable(CraftNamespacedKey.fromMinecraft(rk.location()))) : null;
++    default void setSeed(final long seed) {
++        this.setLootTable(this.getLootTable(), seed);
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlock.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlock.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9e9ea13234703d3e4a39eed2b007e8be69dfbd12
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlock.java
+@@ -0,0 +1,27 @@
++package com.destroystokyo.paper.loottable;
++
++import net.minecraft.world.RandomizableContainer;
++import org.bukkit.craftbukkit.CraftLootTable;
++import org.bukkit.loot.LootTable;
++import org.checkerframework.checker.nullness.qual.Nullable;
++
++public interface PaperLootableBlock extends PaperLootable {
++
++    RandomizableContainer getRandomizableContainer();
++
++    /* Lootable */
++    @Override
++    default @Nullable LootTable getLootTable() {
++        return CraftLootTable.minecraftToBukkit(this.getRandomizableContainer().getLootTable());
 +    }
 +
 +    @Override
-+    public void setLootTable(org.bukkit.loot.LootTable table, long seed) {
-+        setLootTable(table);
-+        setSeed(seed);
++    default void setLootTable(final @Nullable LootTable table, final long seed) {
++        this.getRandomizableContainer().setLootTable(CraftLootTable.bukkitToMinecraft(table), seed);
 +    }
 +
 +    @Override
-+    public void setSeed(long seed) {
-+        entity.setLootTableSeed(seed);
-+    }
-+
-+    @Override
-+    public long getSeed() {
-+        return entity.getLootTableSeed();
-+    }
-+
-+    @Override
-+    public void setLootTable(org.bukkit.loot.LootTable table) {
-+        entity.setLootTable((table == null) ? null : ResourceKey.create(Registries.LOOT_TABLE, CraftNamespacedKey.toMinecraft(table.getKey())));
-+    }
-+
-+    @Override
-+    public PaperLootableInventoryData getLootableData() {
-+        return entity.getLootableData();
-+    }
-+
-+    @Override
-+    public Entity getHandle() {
-+        return entity.getEntity();
-+    }
-+
-+    @Override
-+    public LootableInventory getAPILootableInventory() {
-+        return (LootableInventory) entity.getEntity().getBukkitEntity();
-+    }
-+
-+    @Override
-+    public Level getNMSWorld() {
-+        return entity.level();
++    default long getSeed() {
++        return this.getRandomizableContainer().getLootTableSeed();
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlockInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlockInventory.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..24c6ff57cd25533e71f8a1d0b3c0ece2fdbbf87e
+index 0000000000000000000000000000000000000000..50a10772f0ba4435dc165385f207866acd4e0e5f
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlockInventory.java
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,27 @@
 +package com.destroystokyo.paper.loottable;
 +
++import java.util.Objects;
 +import net.minecraft.core.BlockPos;
-+import net.minecraft.world.level.Level;
-+import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
 +import org.bukkit.Chunk;
 +import org.bukkit.block.Block;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
 +
-+public interface PaperLootableBlockInventory extends LootableBlockInventory, PaperLootableInventory {
++@DefaultQualifier(NonNull.class)
++public interface PaperLootableBlockInventory extends LootableBlockInventory, PaperLootableInventory, PaperLootableBlock {
 +
-+    RandomizableContainerBlockEntity getTileEntity();
-+
++    /* PaperLootableInventory */
 +    @Override
-+    default LootableInventory getAPILootableInventory() {
-+        return this;
++    default PaperLootableInventoryData lootableDataForAPI() {
++        return Objects.requireNonNull(this.getRandomizableContainer().lootableData(), "Can only manage loot tables on tile entities with lootableData");
 +    }
 +
++    /* LootableBlockInventory */
 +    @Override
-+    default Level getNMSWorld() {
-+        return this.getTileEntity().getLevel();
-+    }
-+
 +    default Block getBlock() {
-+        final BlockPos position = this.getTileEntity().getBlockPos();
++        final BlockPos position = this.getRandomizableContainer().getBlockPos();
 +        final Chunk bukkitChunk = this.getBukkitWorld().getChunkAt(org.bukkit.craftbukkit.block.CraftBlock.at(this.getNMSWorld(), position));
 +        return bukkitChunk.getBlock(position.getX(), position.getY(), position.getZ());
 +    }
 +
++}
+diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableEntity.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableEntity.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..de528b8bafd75b6f14b1384157f3a8a27e06b4a2
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableEntity.java
+@@ -0,0 +1,29 @@
++package com.destroystokyo.paper.loottable;
++
++import net.minecraft.world.entity.vehicle.ContainerEntity;
++import org.bukkit.craftbukkit.CraftLootTable;
++import org.bukkit.loot.LootTable;
++import org.bukkit.loot.Lootable;
++import org.checkerframework.checker.nullness.qual.Nullable;
++
++public interface PaperLootableEntity extends Lootable {
++
++    ContainerEntity getHandle();
++
++    /* Lootable */
 +    @Override
-+    default PaperLootableInventoryData getLootableData() {
-+        return this.getTileEntity().lootableData;
++    default @Nullable LootTable getLootTable() {
++        return CraftLootTable.minecraftToBukkit(this.getHandle().getLootTable());
++    }
++
++    @Override
++    default void setLootTable(final @Nullable LootTable table, final long seed) {
++        this.getHandle().setLootTable(CraftLootTable.bukkitToMinecraft(table));
++        this.getHandle().setLootTableSeed(seed);
++    }
++
++    @Override
++    default long getSeed() {
++        return this.getHandle().getLootTableSeed();
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableEntityInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableEntityInventory.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2fba5bc0f982e143ad5f5bda55d768edc5f847df
+index 0000000000000000000000000000000000000000..5c57acc95f638a8bcb351ae44e9434a056835470
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableEntityInventory.java
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,26 @@
 +package com.destroystokyo.paper.loottable;
 +
 +import net.minecraft.world.level.Level;
 +import org.bukkit.entity.Entity;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
 +
-+public interface PaperLootableEntityInventory extends LootableEntityInventory, PaperLootableInventory {
++@DefaultQualifier(NonNull.class)
++public interface PaperLootableEntityInventory extends LootableEntityInventory, PaperLootableInventory, PaperLootableEntity {
 +
-+    net.minecraft.world.entity.Entity getHandle();
-+
-+    @Override
-+    default LootableInventory getAPILootableInventory() {
-+        return this;
-+    }
-+
-+    default Entity getEntity() {
-+        return getHandle().getBukkitEntity();
-+    }
-+
++    /* PaperLootableInventory */
 +    @Override
 +    default Level getNMSWorld() {
-+        return getHandle().getCommandSenderWorld();
++        return this.getHandle().level();
 +    }
 +
 +    @Override
-+    default PaperLootableInventoryData getLootableData() {
-+        return getHandle().lootableData;
++    default PaperLootableInventoryData lootableDataForAPI() {
++        return this.getHandle().lootableData();
++    }
++
++    /* LootableEntityInventory */
++    default Entity getEntity() {
++        return ((net.minecraft.world.entity.Entity) this.getHandle()).getBukkitEntity();
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventory.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8e6dac2cef7af26ad74928eff631c1826c2980bb
+index 0000000000000000000000000000000000000000..9e7c22ef49f1699df298f7121d50d27b4cb0923f
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventory.java
-@@ -0,0 +1,75 @@
+@@ -0,0 +1,79 @@
 +package com.destroystokyo.paper.loottable;
 +
-+import org.bukkit.loot.Lootable;
 +import java.util.UUID;
 +import net.minecraft.world.level.Level;
++import org.bukkit.World;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
 +
-+public interface PaperLootableInventory extends LootableInventory, Lootable {
++@DefaultQualifier(NonNull.class)
++public interface PaperLootableInventory extends PaperLootable, LootableInventory {
 +
-+    PaperLootableInventoryData getLootableData();
-+    LootableInventory getAPILootableInventory();
++    /* impl */
++    PaperLootableInventoryData lootableDataForAPI();
 +
 +    Level getNMSWorld();
 +
-+    default org.bukkit.World getBukkitWorld() {
-+        return getNMSWorld().getWorld();
++    default World getBukkitWorld() {
++        return this.getNMSWorld().getWorld();
 +    }
 +
++    /* LootableInventory */
 +    @Override
 +    default boolean isRefillEnabled() {
-+        return getNMSWorld().paperConfig().lootables.autoReplenish;
++        return this.getNMSWorld().paperConfig().lootables.autoReplenish;
 +    }
 +
 +    @Override
 +    default boolean hasBeenFilled() {
-+        return getLastFilled() != -1;
++        return this.getLastFilled() != -1;
 +    }
 +
 +    @Override
-+    default boolean hasPlayerLooted(UUID player) {
-+        return getLootableData().hasPlayerLooted(player);
++    default boolean hasPlayerLooted(final UUID player) {
++        return this.lootableDataForAPI().hasPlayerLooted(player);
 +    }
 +
 +    @Override
 +    default boolean canPlayerLoot(final UUID player) {
-+        return getLootableData().canPlayerLoot(player, this.getNMSWorld().paperConfig());
++        return this.lootableDataForAPI().canPlayerLoot(player, this.getNMSWorld().paperConfig());
 +    }
 +
 +    @Override
-+    default Long getLastLooted(UUID player) {
-+        return getLootableData().getLastLooted(player);
++    default Long getLastLooted(final UUID player) {
++        return this.lootableDataForAPI().getLastLooted(player);
 +    }
 +
 +    @Override
-+    default boolean setHasPlayerLooted(UUID player, boolean looted) {
-+        final boolean hasLooted = hasPlayerLooted(player);
++    default boolean setHasPlayerLooted(final UUID player, final boolean looted) {
++        final boolean hasLooted = this.hasPlayerLooted(player);
 +        if (hasLooted != looted) {
-+            getLootableData().setPlayerLootedState(player, looted);
++            this.lootableDataForAPI().setPlayerLootedState(player, looted);
 +        }
 +        return hasLooted;
 +    }
 +
 +    @Override
 +    default boolean hasPendingRefill() {
-+        long nextRefill = getLootableData().getNextRefill();
-+        return nextRefill != -1 && nextRefill > getLootableData().getLastFill();
++        final long nextRefill = this.lootableDataForAPI().getNextRefill();
++        return nextRefill != -1 && nextRefill > this.lootableDataForAPI().getLastFill();
 +    }
 +
 +    @Override
 +    default long getLastFilled() {
-+        return getLootableData().getLastFill();
++        return this.lootableDataForAPI().getLastFill();
 +    }
 +
 +    @Override
 +    default long getNextRefill() {
-+        return getLootableData().getNextRefill();
++        return this.lootableDataForAPI().getNextRefill();
 +    }
 +
 +    @Override
@@ -238,31 +257,37 @@ index 0000000000000000000000000000000000000000..8e6dac2cef7af26ad74928eff631c182
 +        if (refillAt < -1) {
 +            refillAt = -1;
 +        }
-+        return getLootableData().setNextRefill(refillAt);
++        return this.lootableDataForAPI().setNextRefill(refillAt);
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6e72c43b9d3834eb91c02ce68e7d114ad907812d
+index 0000000000000000000000000000000000000000..fc6806aa3ca1537c6bd778d42e30dea330e72bbe
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
-@@ -0,0 +1,188 @@
+@@ -0,0 +1,262 @@
 +package com.destroystokyo.paper.loottable;
 +
 +import io.papermc.paper.configuration.WorldConfiguration;
 +import io.papermc.paper.configuration.type.DurationOrDisabled;
-+import java.time.temporal.ChronoUnit;
-+import java.util.concurrent.TimeUnit;
-+import org.bukkit.entity.Player;
-+import org.bukkit.loot.LootTable;
-+import javax.annotation.Nullable;
-+import net.minecraft.nbt.CompoundTag;
-+import net.minecraft.nbt.ListTag;
 +import java.util.HashMap;
 +import java.util.Map;
++import java.util.Objects;
 +import java.util.Random;
 +import java.util.UUID;
++import java.util.concurrent.TimeUnit;
++import net.minecraft.nbt.CompoundTag;
++import net.minecraft.nbt.ListTag;
++import net.minecraft.nbt.Tag;
++import net.minecraft.world.RandomizableContainer;
++import net.minecraft.world.entity.vehicle.ContainerEntity;
++import org.bukkit.entity.Player;
++import org.bukkit.loot.LootTable;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.checker.nullness.qual.Nullable;
++import org.checkerframework.framework.qual.DefaultQualifier;
 +
++@DefaultQualifier(NonNull.class)
 +public class PaperLootableInventoryData {
 +
 +    private static final Random RANDOM = new Random();
@@ -270,12 +295,7 @@ index 0000000000000000000000000000000000000000..6e72c43b9d3834eb91c02ce68e7d114a
 +    private long lastFill = -1;
 +    private long nextRefill = -1;
 +    private int numRefills = 0;
-+    private Map<UUID, Long> lootedPlayers;
-+    private final PaperLootableInventory lootable;
-+
-+    public PaperLootableInventoryData(PaperLootableInventory lootable) {
-+        this.lootable = lootable;
-+    }
++    private @Nullable Map<UUID, Long> lootedPlayers;
 +
 +    long getLastFill() {
 +        return this.lastFill;
@@ -285,22 +305,21 @@ index 0000000000000000000000000000000000000000..6e72c43b9d3834eb91c02ce68e7d114a
 +        return this.nextRefill;
 +    }
 +
-+    long setNextRefill(long nextRefill) {
-+        long prev = this.nextRefill;
++    long setNextRefill(final long nextRefill) {
++        final long prev = this.nextRefill;
 +        this.nextRefill = nextRefill;
 +        return prev;
 +    }
 +
-+    public boolean shouldReplenish(@Nullable net.minecraft.world.entity.player.Player player) {
-+        LootTable table = this.lootable.getLootTable();
++    public <T> boolean shouldReplenish(final T lootTableHolder, final LootTableInterface<T> holderInterface, final net.minecraft.world.entity.player.@Nullable Player player) {
 +
 +        // No Loot Table associated
-+        if (table == null) {
++        if (!holderInterface.hasLootTable(lootTableHolder)) {
 +            return false;
 +        }
 +
 +        // ALWAYS process the first fill or if the feature is disabled
-+        if (this.lastFill == -1 || !this.lootable.getNMSWorld().paperConfig().lootables.autoReplenish) {
++        if (this.lastFill == -1 || !holderInterface.paperConfig(lootTableHolder).lootables.autoReplenish) {
 +            return true;
 +        }
 +
@@ -314,7 +333,7 @@ index 0000000000000000000000000000000000000000..6e72c43b9d3834eb91c02ce68e7d114a
 +            return false;
 +        }
 +
-+        final WorldConfiguration paperConfig = this.lootable.getNMSWorld().paperConfig();
++        final WorldConfiguration paperConfig = holderInterface.paperConfig(lootTableHolder);
 +
 +        // Check if max refills has been hit
 +        if (paperConfig.lootables.maxRefills != -1 && this.numRefills >= paperConfig.lootables.maxRefills) {
@@ -328,85 +347,159 @@ index 0000000000000000000000000000000000000000..6e72c43b9d3834eb91c02ce68e7d114a
 +
 +
 +        final Player bukkitPlayer = (Player) player.getBukkitEntity();
-+        LootableInventoryReplenishEvent event = new LootableInventoryReplenishEvent(bukkitPlayer, lootable.getAPILootableInventory());
-+        event.setCancelled(!canPlayerLoot(player.getUUID(), paperConfig));
++        final LootableInventoryReplenishEvent event = new LootableInventoryReplenishEvent(bukkitPlayer, holderInterface.getInventoryForEvent(lootTableHolder));
++        event.setCancelled(!this.canPlayerLoot(player.getUUID(), paperConfig));
 +        return event.callEvent();
 +    }
-+    public void processRefill(@Nullable net.minecraft.world.entity.player.Player player) {
++
++    public interface LootTableInterface<T> {
++
++        WorldConfiguration paperConfig(T holder);
++
++        void setSeed(T holder, long seed);
++
++        boolean hasLootTable(T holder);
++
++        void clearLootTable(T holder);
++
++        LootableInventory getInventoryForEvent(T holder);
++    }
++
++    public static final LootTableInterface<RandomizableContainer> CONTAINER = new LootTableInterface<>() {
++        @Override
++        public WorldConfiguration paperConfig(final RandomizableContainer holder) {
++            return Objects.requireNonNull(holder.getLevel(), "Can only manager loot replenishment on block entities in a world").paperConfig();
++        }
++
++        @Override
++        public void setSeed(final RandomizableContainer holder, final long seed) {
++            holder.setLootTableSeed(seed);
++        }
++
++        @Override
++        public boolean hasLootTable(final RandomizableContainer holder) {
++            return holder.getLootTable() != null;
++        }
++
++        @Override
++        public void clearLootTable(final RandomizableContainer holder) {
++            holder.setLootTable(null);
++        }
++
++        @Override
++        public LootableInventory getInventoryForEvent(final RandomizableContainer holder) {
++            return holder.getLootableInventory();
++        }
++    };
++
++    public static final LootTableInterface<ContainerEntity> ENTITY = new LootTableInterface<>() {
++        @Override
++        public WorldConfiguration paperConfig(final ContainerEntity holder) {
++            return holder.level().paperConfig();
++        }
++
++        @Override
++        public void setSeed(final ContainerEntity holder, final long seed) {
++            holder.setLootTableSeed(seed);
++        }
++
++        @Override
++        public boolean hasLootTable(final ContainerEntity holder) {
++            return holder.getLootTable() != null;
++        }
++
++        @Override
++        public void clearLootTable(final ContainerEntity holder) {
++            holder.setLootTable(null);
++        }
++
++        @Override
++        public LootableInventory getInventoryForEvent(final ContainerEntity holder) {
++            return holder.getLootableInventory();
++        }
++    };
++
++    public <T> void processRefill(final T lootTableHolder, final LootTableInterface<T> holderInterface, final net.minecraft.world.entity.player.@Nullable Player player) {
 +        this.lastFill = System.currentTimeMillis();
-+        final WorldConfiguration paperConfig = this.lootable.getNMSWorld().paperConfig();
++        final WorldConfiguration paperConfig = holderInterface.paperConfig(lootTableHolder);
 +        if (paperConfig.lootables.autoReplenish) {
-+            long min = paperConfig.lootables.refreshMin.seconds();
-+            long max = paperConfig.lootables.refreshMax.seconds();
++            final long min = paperConfig.lootables.refreshMin.seconds();
++            final long max = paperConfig.lootables.refreshMax.seconds();
 +            this.nextRefill = this.lastFill + (min + RANDOM.nextLong(max - min + 1)) * 1000L;
 +            this.numRefills++;
 +            if (paperConfig.lootables.resetSeedOnFill) {
-+                this.lootable.setSeed(0);
++                holderInterface.setSeed(lootTableHolder, 0);
 +            }
 +            if (player != null) { // This means that numRefills can be incremented without a player being in the lootedPlayers list - Seems to be EntityMinecartChest specific
 +                this.setPlayerLootedState(player.getUUID(), true);
 +            }
 +        } else {
-+            this.lootable.clearLootTable();
++            holderInterface.clearLootTable(lootTableHolder);
 +        }
 +    }
 +
++    private static final String ROOT = "Paper.LootableData";
++    private static final String LAST_FILL = "lastFill";
++    private static final String NEXT_REFILL = "nextRefill";
++    private static final String NUM_REFILLS = "numRefills";
++    private static final String LOOTED_PLAYERS = "lootedPlayers";
 +
-+    public void loadNbt(CompoundTag base) {
-+        if (!base.contains("Paper.LootableData", 10)) { // 10 = compound
++    public void loadNbt(final CompoundTag base) {
++        if (!base.contains(ROOT, Tag.TAG_COMPOUND)) {
 +            return;
 +        }
-+        CompoundTag comp = base.getCompound("Paper.LootableData");
-+        if (comp.contains("lastFill")) {
-+            this.lastFill = comp.getLong("lastFill");
++        final CompoundTag comp = base.getCompound(ROOT);
++        if (comp.contains(LAST_FILL)) {
++            this.lastFill = comp.getLong(LAST_FILL);
 +        }
-+        if (comp.contains("nextRefill")) {
-+            this.nextRefill = comp.getLong("nextRefill");
++        if (comp.contains(NEXT_REFILL)) {
++            this.nextRefill = comp.getLong(NEXT_REFILL);
 +        }
 +
-+        if (comp.contains("numRefills")) {
-+            this.numRefills = comp.getInt("numRefills");
++        if (comp.contains(NUM_REFILLS)) {
++            this.numRefills = comp.getInt(NUM_REFILLS);
 +        }
-+        if (comp.contains("lootedPlayers", net.minecraft.nbt.Tag.TAG_LIST)) {
-+            ListTag list = comp.getList("lootedPlayers", net.minecraft.nbt.Tag.TAG_COMPOUND);
++        if (comp.contains(LOOTED_PLAYERS, Tag.TAG_LIST)) {
++            final ListTag list = comp.getList(LOOTED_PLAYERS, Tag.TAG_COMPOUND);
 +            final int size = list.size();
 +            if (size > 0) {
 +                this.lootedPlayers = new HashMap<>(list.size());
 +            }
 +            for (int i = 0; i < size; i++) {
 +                final CompoundTag cmp = list.getCompound(i);
-+                lootedPlayers.put(cmp.getUUID("UUID"), cmp.getLong("Time"));
++                this.lootedPlayers.put(cmp.getUUID("UUID"), cmp.getLong("Time"));
 +            }
 +        }
 +    }
-+    public void saveNbt(CompoundTag base) {
-+        CompoundTag comp = new CompoundTag();
++
++    public void saveNbt(final CompoundTag base) {
++        final CompoundTag comp = new CompoundTag();
 +        if (this.nextRefill != -1) {
-+            comp.putLong("nextRefill", this.nextRefill);
++            comp.putLong(NEXT_REFILL, this.nextRefill);
 +        }
 +        if (this.lastFill != -1) {
-+            comp.putLong("lastFill", this.lastFill);
++            comp.putLong(LAST_FILL, this.lastFill);
 +        }
 +        if (this.numRefills != 0) {
-+            comp.putInt("numRefills", this.numRefills);
++            comp.putInt(NUM_REFILLS, this.numRefills);
 +        }
 +        if (this.lootedPlayers != null && !this.lootedPlayers.isEmpty()) {
-+            ListTag list = new ListTag();
-+            for (Map.Entry<UUID, Long> entry : this.lootedPlayers.entrySet()) {
-+                CompoundTag cmp = new CompoundTag();
++            final ListTag list = new ListTag();
++            for (final Map.Entry<UUID, Long> entry : this.lootedPlayers.entrySet()) {
++                final CompoundTag cmp = new CompoundTag();
 +                cmp.putUUID("UUID", entry.getKey());
 +                cmp.putLong("Time", entry.getValue());
 +                list.add(cmp);
 +            }
-+            comp.put("lootedPlayers", list);
++            comp.put(LOOTED_PLAYERS, list);
 +        }
 +
 +        if (!comp.isEmpty()) {
-+            base.put("Paper.LootableData", comp);
++            base.put(ROOT, comp);
 +        }
 +    }
 +
-+    void setPlayerLootedState(UUID player, boolean looted) {
++    void setPlayerLootedState(final UUID player, final boolean looted) {
 +        if (looted && this.lootedPlayers == null) {
 +            this.lootedPlayers = new HashMap<>();
 +        }
@@ -418,7 +511,7 @@ index 0000000000000000000000000000000000000000..6e72c43b9d3834eb91c02ce68e7d114a
 +    }
 +
 +    boolean canPlayerLoot(final UUID player, final WorldConfiguration worldConfiguration) {
-+        final Long lastLooted = getLastLooted(player);
++        final @Nullable Long lastLooted = this.getLastLooted(player);
 +        if (!worldConfiguration.lootables.restrictPlayerReloot || lastLooted == null) return true;
 +
 +        final DurationOrDisabled restrictPlayerRelootTime = worldConfiguration.lootables.restrictPlayerRelootTime;
@@ -427,184 +520,157 @@ index 0000000000000000000000000000000000000000..6e72c43b9d3834eb91c02ce68e7d114a
 +        return TimeUnit.SECONDS.toMillis(restrictPlayerRelootTime.value().get().seconds()) + lastLooted < System.currentTimeMillis();
 +    }
 +
-+    boolean hasPlayerLooted(UUID player) {
++    boolean hasPlayerLooted(final UUID player) {
 +        return this.lootedPlayers != null && this.lootedPlayers.containsKey(player);
 +    }
 +
-+    Long getLastLooted(UUID player) {
-+        return lootedPlayers != null ? lootedPlayers.get(player) : null;
++    @Nullable Long getLastLooted(final UUID player) {
++        return this.lootedPlayers != null ? this.lootedPlayers.get(player) : null;
 +    }
 +}
-diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperTileEntityLootableInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperTileEntityLootableInventory.java
-new file mode 100644
-index 0000000000000000000000000000000000000000..fb72bdea520ccc0928cfbda0569e02a1917a7e86
---- /dev/null
-+++ b/src/main/java/com/destroystokyo/paper/loottable/PaperTileEntityLootableInventory.java
-@@ -0,0 +1,67 @@
-+package com.destroystokyo.paper.loottable;
-+
-+import io.papermc.paper.util.MCUtil;
-+import net.minecraft.core.registries.Registries;
-+import net.minecraft.resources.ResourceKey;
-+import net.minecraft.world.level.Level;
-+import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
-+import org.bukkit.Bukkit;
-+import org.bukkit.craftbukkit.util.CraftNamespacedKey;
-+
-+public class PaperTileEntityLootableInventory implements PaperLootableBlockInventory {
-+    private RandomizableContainerBlockEntity tileEntityLootable;
-+
-+    public PaperTileEntityLootableInventory(RandomizableContainerBlockEntity tileEntityLootable) {
-+        this.tileEntityLootable = tileEntityLootable;
-+    }
-+
-+    @Override
-+    public org.bukkit.loot.LootTable getLootTable() {
-+        return tileEntityLootable.lootTable != null ? Bukkit.getLootTable(CraftNamespacedKey.fromMinecraft(tileEntityLootable.lootTable.location())) : null;
-+    }
-+
-+    @Override
-+    public void setLootTable(org.bukkit.loot.LootTable table, long seed) {
-+        setLootTable(table);
-+        setSeed(seed);
-+    }
-+
-+    @Override
-+    public void setLootTable(org.bukkit.loot.LootTable table) {
-+        tileEntityLootable.lootTable = (table == null) ? null : ResourceKey.create(Registries.LOOT_TABLE, CraftNamespacedKey.toMinecraft(table.getKey()));
-+    }
-+
-+    @Override
-+    public void setSeed(long seed) {
-+        tileEntityLootable.lootTableSeed = seed;
-+    }
-+
-+    @Override
-+    public long getSeed() {
-+        return tileEntityLootable.lootTableSeed;
-+    }
-+
-+    @Override
-+    public PaperLootableInventoryData getLootableData() {
-+        return tileEntityLootable.lootableData;
-+    }
-+
-+    @Override
-+    public RandomizableContainerBlockEntity getTileEntity() {
-+        return tileEntityLootable;
-+    }
-+
-+    @Override
-+    public LootableInventory getAPILootableInventory() {
-+        Level world = tileEntityLootable.getLevel();
-+        if (world == null) {
-+            return null;
-+        }
-+        return (LootableInventory) getBukkitWorld().getBlockAt(MCUtil.toLocation(world, tileEntityLootable.getBlockPos())).getState();
-+    }
-+
-+    @Override
-+    public Level getNMSWorld() {
-+        return tileEntityLootable.getLevel();
-+    }
-+}
-diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2fcdd61e9669904756aa33b1ff8ab7160ea5e371..e04c0d333f8a425e4a1315b20f182b2206c22277 100644
---- a/src/main/java/net/minecraft/world/entity/Entity.java
-+++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -242,6 +242,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+diff --git a/src/main/java/net/minecraft/world/RandomizableContainer.java b/src/main/java/net/minecraft/world/RandomizableContainer.java
+index 155902bc2b99ba36003bceb37ba34958952900d3..00e732ccf5b03a2feb0a4af1c7bb5b735cb7e247 100644
+--- a/src/main/java/net/minecraft/world/RandomizableContainer.java
++++ b/src/main/java/net/minecraft/world/RandomizableContainer.java
+@@ -28,7 +28,7 @@ public interface RandomizableContainer extends Container {
+ 
+     void setLootTable(@Nullable ResourceKey<LootTable> lootTable);
+ 
+-    default void setLootTable(ResourceKey<LootTable> lootTableId, long lootTableSeed) {
++    default void setLootTable(@Nullable ResourceKey<LootTable> lootTableId, long lootTableSeed) { // Paper - add nullable
+         this.setLootTable(lootTableId);
+         this.setLootTableSeed(lootTableSeed);
      }
-     // Paper end - Share random for entities to make them more random
+@@ -49,6 +49,7 @@ public interface RandomizableContainer extends Container {
+     }
  
-+    public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
-     private CraftEntity bukkitEntity;
+     default boolean tryLoadLootTable(CompoundTag nbt) {
++        if (this.lootableData() != null) this.lootableData().loadNbt(nbt); // Paper - LootTable API
+         if (nbt.contains("LootTable", 8)) {
+             this.setLootTable(ResourceKey.create(Registries.LOOT_TABLE, new ResourceLocation(nbt.getString("LootTable"))));
+             if (nbt.contains("LootTableSeed", 4)) {
+@@ -57,13 +58,14 @@ public interface RandomizableContainer extends Container {
+                 this.setLootTableSeed(0L);
+             }
  
-     public CraftEntity getBukkitEntity() {
+-            return true;
++            return this.lootableData() == null; // Paper - only track the loot table if there is chance for replenish
+         } else {
+             return false;
+         }
+     }
+ 
+     default boolean trySaveLootTable(CompoundTag nbt) {
++        if (this.lootableData() != null) this.lootableData().saveNbt(nbt); // Paper - LootTable API
+         ResourceKey<LootTable> resourceKey = this.getLootTable();
+         if (resourceKey == null) {
+             return false;
+@@ -74,7 +76,7 @@ public interface RandomizableContainer extends Container {
+                 nbt.putLong("LootTableSeed", l);
+             }
+ 
+-            return true;
++            return this.lootableData() == null; // Paper - only track the loot table if there is chance for replenish
+         }
+     }
+ 
+@@ -82,13 +84,19 @@ public interface RandomizableContainer extends Container {
+         Level level = this.getLevel();
+         BlockPos blockPos = this.getBlockPos();
+         ResourceKey<LootTable> resourceKey = this.getLootTable();
+-        if (resourceKey != null && level != null && level.getServer() != null) {
++        if (resourceKey != null && level != null && level.getServer() != null && (this.lootableData() == null || this.lootableData().shouldReplenish(this, com.destroystokyo.paper.loottable.PaperLootableInventoryData.CONTAINER, player))) { // Paper - LootTable API
+             LootTable lootTable = level.getServer().reloadableRegistries().getLootTable(resourceKey);
+             if (player instanceof ServerPlayer) {
+                 CriteriaTriggers.GENERATE_LOOT.trigger((ServerPlayer)player, resourceKey);
+             }
+ 
+-            this.setLootTable(null);
++            // Paper start - LootTable API
++            if (this.lootableData() == null) {
++                this.setLootTable(null);
++            } else {
++                this.lootableData().processRefill(this, com.destroystokyo.paper.loottable.PaperLootableInventoryData.CONTAINER, player);
++            }
++            // Paper end - LootTable API
+             LootParams.Builder builder = new LootParams.Builder((ServerLevel)level).withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(blockPos));
+             if (player != null) {
+                 builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
+@@ -97,4 +105,16 @@ public interface RandomizableContainer extends Container {
+             lootTable.fill(this, builder.create(LootContextParamSets.CHEST), this.getLootTableSeed());
+         }
+     }
++
++    // Paper start - LootTable API
++    @Nullable @org.jetbrains.annotations.Contract(pure = true)
++    default com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData() {
++        return null; // some containers don't really have a "replenish" ability like decorated pots
++    }
++
++    default com.destroystokyo.paper.loottable.PaperLootableInventory getLootableInventory() {
++        final org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(java.util.Objects.requireNonNull(this.getLevel(), "Cannot manage loot tables on block entities not in world"), this.getBlockPos());
++        return (com.destroystokyo.paper.loottable.PaperLootableInventory) block.getState(false);
++    }
++    // Paper end - LootTable API
+ }
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java
-index 67840327e934b631a85cf2d64911f5cfab4402b1..2704389bc3ec6dbbf1b568a4380972f8c0d62d15 100644
+index 67840327e934b631a85cf2d64911f5cfab4402b1..9549eee0d92f322bd5232abd7e695213660c2e22 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java
-@@ -35,6 +35,20 @@ public abstract class AbstractMinecartContainer extends AbstractMinecart impleme
+@@ -35,6 +35,14 @@ public abstract class AbstractMinecartContainer extends AbstractMinecart impleme
      public ResourceKey<LootTable> lootTable;
      public long lootTableSeed;
  
-+    // Paper start
-+    {
-+        this.lootableData = new com.destroystokyo.paper.loottable.PaperLootableInventoryData(new com.destroystokyo.paper.loottable.PaperContainerEntityLootableInventory(this));
-+    }
-+    @Override
-+    public Entity getEntity() {
-+        return this;
-+    }
++    // Paper start - LootTable API
++    final com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData = new com.destroystokyo.paper.loottable.PaperLootableInventoryData();
 +
 +    @Override
-+    public com.destroystokyo.paper.loottable.PaperLootableInventoryData getLootableData() {
++    public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData() {
 +        return this.lootableData;
 +    }
-+    // Paper end
++    // Paper end - LootTable API
      // CraftBukkit start
      public List<HumanEntity> transaction = new java.util.ArrayList<HumanEntity>();
      private int maxStack = MAX_STACK;
-@@ -144,12 +158,14 @@ public abstract class AbstractMinecartContainer extends AbstractMinecart impleme
-     @Override
-     protected void addAdditionalSaveData(CompoundTag nbt) {
-         super.addAdditionalSaveData(nbt);
-+        this.lootableData.saveNbt(nbt); // Paper
-         this.addChestVehicleSaveData(nbt, this.registryAccess());
-     }
- 
-     @Override
-     protected void readAdditionalSaveData(CompoundTag nbt) {
-         super.readAdditionalSaveData(nbt);
-+        this.lootableData.loadNbt(nbt); // Paper
-         this.readChestVehicleSaveData(nbt, this.registryAccess());
-     }
- 
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java b/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java
-index 025e57993b85402c48db29d65ea3ceaf277ff27a..b04f7ce0805453f6c737fa9dc11c4129ca64e934 100644
+index 025e57993b85402c48db29d65ea3ceaf277ff27a..e0aec3b3e04d603dc208029554f981c6b9e6b43e 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/ChestBoat.java
-@@ -70,12 +70,14 @@ public class ChestBoat extends Boat implements HasCustomInventoryScreen, Contain
+@@ -209,7 +209,7 @@ public class ChestBoat extends Boat implements HasCustomInventoryScreen, Contain
+     @Nullable
      @Override
-     protected void addAdditionalSaveData(CompoundTag nbt) {
-         super.addAdditionalSaveData(nbt);
-+        this.lootableData.saveNbt(nbt); // Paper
-         this.addChestVehicleSaveData(nbt, this.registryAccess());
-     }
- 
-     @Override
-     protected void readAdditionalSaveData(CompoundTag nbt) {
-         super.readAdditionalSaveData(nbt);
-+        this.lootableData.loadNbt(nbt); // Paper
-         this.readChestVehicleSaveData(nbt, this.registryAccess());
-     }
- 
-@@ -257,6 +259,20 @@ public class ChestBoat extends Boat implements HasCustomInventoryScreen, Contain
+     public AbstractContainerMenu createMenu(int syncId, Inventory playerInventory, Player player) {
+-        if (this.lootTable != null && player.isSpectator()) {
++        if (this.lootTable != null && player.isSpectator()) { // Paper - LootTable API (TODO spectators can open chests that aren't ready to be re-generated but this doesn't support that)
+             return null;
+         } else {
+             this.unpackLootTable(playerInventory.player);
+@@ -257,6 +257,14 @@ public class ChestBoat extends Boat implements HasCustomInventoryScreen, Contain
          this.level().gameEvent((Holder) GameEvent.CONTAINER_CLOSE, this.position(), GameEvent.Context.of((Entity) player));
      }
  
-+    // Paper start
-+    {
-+        this.lootableData = new com.destroystokyo.paper.loottable.PaperLootableInventoryData(new com.destroystokyo.paper.loottable.PaperContainerEntityLootableInventory(this));
-+    }
-+    @Override
-+    public Entity getEntity() {
-+        return this;
-+    }
++    // Paper start - LootTable API
++    final com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData = new com.destroystokyo.paper.loottable.PaperLootableInventoryData();
 +
 +    @Override
-+    public com.destroystokyo.paper.loottable.PaperLootableInventoryData getLootableData() {
++    public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData() {
 +        return this.lootableData;
 +    }
-+    // Paper end
++    // Paper end - LootTable API
      // CraftBukkit start
      public List<HumanEntity> transaction = new java.util.ArrayList<HumanEntity>();
      private int maxStack = MAX_STACK;
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java b/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
-index dbde2402fd46b0d06e8efeb90be6fb98d7ae7798..f33e5cf6d456e615050047e924d9b24268a2c51e 100644
+index dbde2402fd46b0d06e8efeb90be6fb98d7ae7798..3a7d266d34740405681852b748a2ad9fd56d7f95 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
-@@ -65,9 +65,8 @@ public interface ContainerEntity extends Container, MenuProvider {
+@@ -60,24 +60,24 @@ public interface ContainerEntity extends Container, MenuProvider {
+     }
+ 
+     default void addChestVehicleSaveData(CompoundTag nbt, HolderLookup.Provider registriesLookup) {
++        this.lootableData().saveNbt(nbt); // Paper
+         if (this.getLootTable() != null) {
+             nbt.putString("LootTable", this.getLootTable().location().toString());
              if (this.getLootTableSeed() != 0L) {
                  nbt.putLong("LootTableSeed", this.getLootTableSeed());
              }
@@ -615,7 +681,8 @@ index dbde2402fd46b0d06e8efeb90be6fb98d7ae7798..f33e5cf6d456e615050047e924d9b242
      }
  
      default void readChestVehicleSaveData(CompoundTag nbt, HolderLookup.Provider registriesLookup) {
-@@ -75,9 +74,8 @@ public interface ContainerEntity extends Container, MenuProvider {
++        this.lootableData().loadNbt(nbt); // Paper
+         this.clearItemStacks();
          if (nbt.contains("LootTable", 8)) {
              this.setLootTable(ResourceKey.create(Registries.LOOT_TABLE, new ResourceLocation(nbt.getString("LootTable"))));
              this.setLootTableSeed(nbt.getLong("LootTableSeed"));
@@ -626,135 +693,71 @@ index dbde2402fd46b0d06e8efeb90be6fb98d7ae7798..f33e5cf6d456e615050047e924d9b242
      }
  
      default void chestVehicleDestroyed(DamageSource source, Level world, Entity vehicle) {
-@@ -99,13 +97,13 @@ public interface ContainerEntity extends Container, MenuProvider {
+@@ -99,13 +99,13 @@ public interface ContainerEntity extends Container, MenuProvider {
  
      default void unpackChestVehicleLootTable(@Nullable Player player) {
          MinecraftServer minecraftServer = this.level().getServer();
 -        if (this.getLootTable() != null && minecraftServer != null) {
-+        if (this.getLootableData().shouldReplenish(player) && minecraftServer != null) { // Paper
++        if (minecraftServer != null && this.lootableData().shouldReplenish(this, com.destroystokyo.paper.loottable.PaperLootableInventoryData.ENTITY, player)) { // Paper - LootTable API
              LootTable lootTable = minecraftServer.reloadableRegistries().getLootTable(this.getLootTable());
              if (player != null) {
                  CriteriaTriggers.GENERATE_LOOT.trigger((ServerPlayer)player, this.getLootTable());
              }
  
 -            this.setLootTable(null);
-+            this.getLootableData().processRefill(player); // Paper
++            this.lootableData().processRefill(this, com.destroystokyo.paper.loottable.PaperLootableInventoryData.ENTITY, player); // Paper - LootTable API
              LootParams.Builder builder = new LootParams.Builder((ServerLevel)this.level()).withParameter(LootContextParams.ORIGIN, this.position());
              if (player != null) {
                  builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
-@@ -175,4 +173,13 @@ public interface ContainerEntity extends Container, MenuProvider {
+@@ -175,4 +175,14 @@ public interface ContainerEntity extends Container, MenuProvider {
      default boolean isChestVehicleStillValid(Player player) {
          return !this.isRemoved() && player.canInteractWithEntity(this.getBoundingBox(), 4.0);
      }
-+    // Paper start
-+    default Entity getEntity() {
-+        throw new UnsupportedOperationException();
++
++    // Paper start - LootTable API
++    default com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData() {
++        throw new UnsupportedOperationException("Implement this method");
 +    }
 +
-+    default com.destroystokyo.paper.loottable.PaperLootableInventoryData getLootableData() {
-+        throw new UnsupportedOperationException();
++    default com.destroystokyo.paper.loottable.PaperLootableInventory getLootableInventory() {
++        return ((com.destroystokyo.paper.loottable.PaperLootableInventory) ((net.minecraft.world.entity.Entity) this).getBukkitEntity());
 +    }
-+    // Paper end
++    // Paper end - LootTable API
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java
-index c2493c15d8fe4587d6ee2db100cc13303b66b39b..5b183f12717008dd6c9863938c17b2e668ebded4 100644
+index c2493c15d8fe4587d6ee2db100cc13303b66b39b..13c9a68b604d4c7c6e09e72b3cea7ab2214b06ab 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java
-@@ -19,6 +19,7 @@ public abstract class RandomizableContainerBlockEntity extends BaseContainerBloc
-     @Nullable
-     public ResourceKey<LootTable> lootTable;
-     public long lootTableSeed = 0L;
-+    public final com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData = new com.destroystokyo.paper.loottable.PaperLootableInventoryData(new com.destroystokyo.paper.loottable.PaperTileEntityLootableInventory(this)); // Paper
- 
-     protected RandomizableContainerBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
-         super(type, pos, state);
-@@ -45,6 +46,56 @@ public abstract class RandomizableContainerBlockEntity extends BaseContainerBloc
-         this.lootTableSeed = lootTableSeed;
+@@ -115,4 +115,13 @@ public abstract class RandomizableContainerBlockEntity extends BaseContainerBloc
+         nbt.remove("LootTable");
+         nbt.remove("LootTableSeed");
      }
- 
-+    // Paper start
-+    @Override
-+    public boolean tryLoadLootTable(final net.minecraft.nbt.CompoundTag nbt) {
-+        // Copied from super with changes, always check the original method
-+        this.lootableData.loadNbt(nbt); // Paper
-+        if (nbt.contains("LootTable", 8)) {
-+            this.setLootTable(net.minecraft.Optionull.map(net.minecraft.resources.ResourceLocation.tryParse(nbt.getString("LootTable")), rl -> ResourceKey.create(net.minecraft.core.registries.Registries.LOOT_TABLE, rl)));
-+            try { if (this.lootTable != null) org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(this.lootTable.location()); } catch (IllegalArgumentException ex) { this.lootTable = null; } // Paper - validate
-+            if (nbt.contains("LootTableSeed", 4)) {
-+                this.setLootTableSeed(nbt.getLong("LootTableSeed"));
-+            } else {
-+                this.setLootTableSeed(0L);
-+            }
-+            return false; // Paper - always load the items, table may still remain
-+        } else {
-+            return false;
-+        }
-+    }
++
++    // Paper start - LootTable API
++    final com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData = new com.destroystokyo.paper.loottable.PaperLootableInventoryData(); // Paper
 +
 +    @Override
-+    public boolean trySaveLootTable(final net.minecraft.nbt.CompoundTag nbt) {
-+        this.lootableData.saveNbt(nbt);
-+        RandomizableContainer.super.trySaveLootTable(nbt);
-+        return false;
++    public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData() {
++        return this.lootableData;
 +    }
-+
-+    @Override
-+    public void unpackLootTable(@org.jetbrains.annotations.Nullable final Player player) {
-+        // Copied from super with changes, always check the original method
-+        net.minecraft.world.level.Level level = this.getLevel();
-+        BlockPos blockPos = this.getBlockPos();
-+        ResourceKey<LootTable> resourceKey = this.getLootTable();
-+        if (this.lootableData.shouldReplenish(player) && resourceKey != null && level != null && level.getServer() != null) { // Paper
-+            net.minecraft.world.level.storage.loot.LootTable lootTable = level.getServer().reloadableRegistries().getLootTable(resourceKey);
-+            if (player instanceof net.minecraft.server.level.ServerPlayer) {
-+                net.minecraft.advancements.CriteriaTriggers.GENERATE_LOOT.trigger((net.minecraft.server.level.ServerPlayer)player, resourceKey);
-+            }
-+
-+            this.lootableData.processRefill(player); // Paper
-+            net.minecraft.world.level.storage.loot.LootParams.Builder builder = (new net.minecraft.world.level.storage.loot.LootParams.Builder((net.minecraft.server.level.ServerLevel)level)).withParameter(net.minecraft.world.level.storage.loot.parameters.LootContextParams.ORIGIN, net.minecraft.world.phys.Vec3.atCenterOf(blockPos));
-+            if (player != null) {
-+                builder.withLuck(player.getLuck()).withParameter(net.minecraft.world.level.storage.loot.parameters.LootContextParams.THIS_ENTITY, player);
-+            }
-+
-+            lootTable.fill(this, builder.create(net.minecraft.world.level.storage.loot.parameters.LootContextParamSets.CHEST), this.getLootTableSeed());
-+        }
-+
-+    }
-+    // Paper end
-+
-     @Override
-     public boolean isEmpty() {
-         this.unpackLootTable(null);
++    // Paper end - LootTable API
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBrushableBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBrushableBlock.java
-index 949e074a32b6593bd8b7405499e686a074e283e5..398ffe274bddee2b01350b9490def3d2fe854917 100644
+index 949e074a32b6593bd8b7405499e686a074e283e5..1f084b73f2ec67dd2022feafc5ab5dac02c338f6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBrushableBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBrushableBlock.java
-@@ -58,7 +58,7 @@ public class CraftBrushableBlock extends CraftBlockEntityState<BrushableBlockEnt
+@@ -58,7 +58,8 @@ public class CraftBrushableBlock extends CraftBlockEntityState<BrushableBlockEnt
          this.setLootTable(this.getLootTable(), seed);
      }
  
 -    private void setLootTable(LootTable table, long seed) {
++    @Override // Paper - this is now an override
 +    public void setLootTable(LootTable table, long seed) { // Paper - make public since it overrides a public method
          this.getSnapshot().setLootTable(CraftLootTable.bukkitToMinecraft(table), seed);
      }
  
-diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-index 2b6a93a944b27290745278957a3577772b7b8212..29df470d6706a33dad4317a9aa599456d5c7f6ee 100644
---- a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-+++ b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-@@ -13,8 +13,9 @@ import org.bukkit.craftbukkit.CraftWorld;
- import org.bukkit.craftbukkit.inventory.CraftInventory;
- import org.bukkit.craftbukkit.inventory.CraftInventoryDoubleChest;
- import org.bukkit.inventory.Inventory;
-+import com.destroystokyo.paper.loottable.PaperLootableBlockInventory; // Paper
- 
--public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest {
-+public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest, PaperLootableBlockInventory { // Paper
- 
-     public CraftChest(World world, ChestBlockEntity tileEntity) {
-         super(world, tileEntity);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java b/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java
-index 74315a46f6101775321b1cf4944c124c69aed182..c3215f15b3088199dcf96f62b58d0ec7c2b4125c 100644
+index 74315a46f6101775321b1cf4944c124c69aed182..f23fbb8ed39a754b36d2eb162358877ef6dacb17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java
 @@ -8,7 +8,7 @@ import org.bukkit.craftbukkit.CraftLootTable;
@@ -766,8 +769,44 @@ index 74315a46f6101775321b1cf4944c124c69aed182..c3215f15b3088199dcf96f62b58d0ec7
  
      public CraftLootable(World world, T tileEntity) {
          super(world, tileEntity);
+@@ -27,29 +27,17 @@ public abstract class CraftLootable<T extends RandomizableContainerBlockEntity>
+         }
+     }
+ 
++    // Paper start - move to PaperLootableBlockInventory
+     @Override
+-    public LootTable getLootTable() {
+-        return CraftLootTable.minecraftToBukkit(this.getSnapshot().lootTable);
++    public net.minecraft.world.level.Level getNMSWorld() {
++        return ((org.bukkit.craftbukkit.CraftWorld) this.getWorld()).getHandle();
+     }
+ 
+     @Override
+-    public void setLootTable(LootTable table) {
+-        this.setLootTable(table, this.getSeed());
+-    }
+-
+-    @Override
+-    public long getSeed() {
+-        return this.getSnapshot().lootTableSeed;
+-    }
+-
+-    @Override
+-    public void setSeed(long seed) {
+-        this.setLootTable(this.getLootTable(), seed);
+-    }
+-
+-    public void setLootTable(LootTable table, long seed) {
+-        this.getSnapshot().setLootTable(CraftLootTable.bukkitToMinecraft(table), seed);
++    public net.minecraft.world.RandomizableContainer getRandomizableContainer() {
++        return this.getSnapshot();
+     }
++    // Paper end - move to PaperLootableBlockInventory
+ 
+     @Override
+     public abstract CraftLootable<T> copy();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftChestBoat.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftChestBoat.java
-index cfde210ea9d4b62fe514d3ab0dbab2f43eda0c7a..c0f6939ed782dd3151ebd7ee9d3d7e292154e76c 100644
+index cfde210ea9d4b62fe514d3ab0dbab2f43eda0c7a..e4f899a6a1d055b3ea17d1114ed0228fbba53352 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftChestBoat.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftChestBoat.java
 @@ -7,8 +7,7 @@ import org.bukkit.craftbukkit.inventory.CraftInventory;
@@ -780,15 +819,36 @@ index cfde210ea9d4b62fe514d3ab0dbab2f43eda0c7a..c0f6939ed782dd3151ebd7ee9d3d7e29
      private final Inventory inventory;
  
      public CraftChestBoat(CraftServer server, ChestBoat entity) {
-@@ -51,7 +50,7 @@ public class CraftChestBoat extends CraftBoat implements org.bukkit.entity.Chest
-         return this.getHandle().getLootTableSeed();
+@@ -31,28 +30,5 @@ public class CraftChestBoat extends CraftBoat implements org.bukkit.entity.Chest
+         return this.inventory;
      }
  
+-    @Override
+-    public void setLootTable(LootTable table) {
+-        this.setLootTable(table, this.getSeed());
+-    }
+-
+-    @Override
+-    public LootTable getLootTable() {
+-        return CraftLootTable.minecraftToBukkit(this.getHandle().getLootTable());
+-    }
+-
+-    @Override
+-    public void setSeed(long seed) {
+-        this.setLootTable(this.getLootTable(), seed);
+-    }
+-
+-    @Override
+-    public long getSeed() {
+-        return this.getHandle().getLootTableSeed();
+-    }
+-
 -    private void setLootTable(LootTable table, long seed) {
-+    public void setLootTable(LootTable table, long seed) { // Paper - change visibility since it overrides a public method
-         this.getHandle().setLootTable(CraftLootTable.bukkitToMinecraft(table));
-         this.getHandle().setLootTableSeed(seed);
-     }
+-        this.getHandle().setLootTable(CraftLootTable.bukkitToMinecraft(table));
+-        this.getHandle().setLootTableSeed(seed);
+-    }
++    // Paper - moved loot table logic to PaperLootableEntityInventory
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java
 index fd42f0b20132d08039ca7735d31a61806a6b07dc..b1a708de6790bbe336202b13ab862ced78de084f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java
@@ -802,6 +862,48 @@ index fd42f0b20132d08039ca7735d31a61806a6b07dc..b1a708de6790bbe336202b13ab862ced
      private final CraftInventory inventory;
  
      public CraftMinecartChest(CraftServer server, MinecartChest entity) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartContainer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartContainer.java
+index 4388cd0303b45faf21631e7644baebb63baaba10..451f3a6f0b47493da3af3f5d6baced6a8c97f350 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartContainer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartContainer.java
+@@ -7,7 +7,7 @@ import org.bukkit.craftbukkit.CraftServer;
+ import org.bukkit.loot.LootTable;
+ import org.bukkit.loot.Lootable;
+ 
+-public abstract class CraftMinecartContainer extends CraftMinecart implements Lootable {
++public abstract class CraftMinecartContainer extends CraftMinecart implements com.destroystokyo.paper.loottable.PaperLootableEntityInventory { // Paper
+ 
+     public CraftMinecartContainer(CraftServer server, AbstractMinecart entity) {
+         super(server, entity);
+@@ -18,27 +18,5 @@ public abstract class CraftMinecartContainer extends CraftMinecart implements Lo
+         return (AbstractMinecartContainer) this.entity;
+     }
+ 
+-    @Override
+-    public void setLootTable(LootTable table) {
+-        this.setLootTable(table, this.getSeed());
+-    }
+-
+-    @Override
+-    public LootTable getLootTable() {
+-        return CraftLootTable.minecraftToBukkit(this.getHandle().lootTable);
+-    }
+-
+-    @Override
+-    public void setSeed(long seed) {
+-        this.setLootTable(this.getLootTable(), seed);
+-    }
+-
+-    @Override
+-    public long getSeed() {
+-        return this.getHandle().lootTableSeed;
+-    }
+-
+-    public void setLootTable(LootTable table, long seed) {
+-        this.getHandle().setLootTable(CraftLootTable.bukkitToMinecraft(table), seed);
+-    }
++    // Paper - moved loot table logic to PaperLootableEntityInventory
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java
 index 39427b4f284e9402663be2b160ccb5f03f8b91da..17f5684cba9d3ed22d9925d1951520cc4751dfe2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java

--- a/patches/server/0097-LootTable-API-and-replenishable-lootables.patch
+++ b/patches/server/0097-LootTable-API-and-replenishable-lootables.patch
@@ -77,16 +77,16 @@ index 0000000000000000000000000000000000000000..9e9ea13234703d3e4a39eed2b007e8be
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlockInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlockInventory.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..50a10772f0ba4435dc165385f207866acd4e0e5f
+index 0000000000000000000000000000000000000000..0699c60920333ea1fec04e3c94d952244d2abeae
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlockInventory.java
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,26 @@
 +package com.destroystokyo.paper.loottable;
 +
 +import java.util.Objects;
 +import net.minecraft.core.BlockPos;
-+import org.bukkit.Chunk;
 +import org.bukkit.block.Block;
++import org.bukkit.craftbukkit.block.CraftBlock;
 +import org.checkerframework.checker.nullness.qual.NonNull;
 +import org.checkerframework.framework.qual.DefaultQualifier;
 +
@@ -103,8 +103,7 @@ index 0000000000000000000000000000000000000000..50a10772f0ba4435dc165385f207866a
 +    @Override
 +    default Block getBlock() {
 +        final BlockPos position = this.getRandomizableContainer().getBlockPos();
-+        final Chunk bukkitChunk = this.getBukkitWorld().getChunkAt(org.bukkit.craftbukkit.block.CraftBlock.at(this.getNMSWorld(), position));
-+        return bukkitChunk.getBlock(position.getX(), position.getY(), position.getZ());
++        return CraftBlock.at(this.getNMSWorld(), position);
 +    }
 +
 +}
@@ -262,10 +261,10 @@ index 0000000000000000000000000000000000000000..9e7c22ef49f1699df298f7121d50d27b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..fc6806aa3ca1537c6bd778d42e30dea330e72bbe
+index 0000000000000000000000000000000000000000..fea92d280c6817cee1f18379d5ed51a3a22ee344
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
-@@ -0,0 +1,262 @@
+@@ -0,0 +1,249 @@
 +package com.destroystokyo.paper.loottable;
 +
 +import io.papermc.paper.configuration.WorldConfiguration;
@@ -282,7 +281,6 @@ index 0000000000000000000000000000000000000000..fc6806aa3ca1537c6bd778d42e30dea3
 +import net.minecraft.world.RandomizableContainer;
 +import net.minecraft.world.entity.vehicle.ContainerEntity;
 +import org.bukkit.entity.Player;
-+import org.bukkit.loot.LootTable;
 +import org.checkerframework.checker.nullness.qual.NonNull;
 +import org.checkerframework.checker.nullness.qual.Nullable;
 +import org.checkerframework.framework.qual.DefaultQualifier;
@@ -360,8 +358,6 @@ index 0000000000000000000000000000000000000000..fc6806aa3ca1537c6bd778d42e30dea3
 +
 +        boolean hasLootTable(T holder);
 +
-+        void clearLootTable(T holder);
-+
 +        LootableInventory getInventoryForEvent(T holder);
 +    }
 +
@@ -379,11 +375,6 @@ index 0000000000000000000000000000000000000000..fc6806aa3ca1537c6bd778d42e30dea3
 +        @Override
 +        public boolean hasLootTable(final RandomizableContainer holder) {
 +            return holder.getLootTable() != null;
-+        }
-+
-+        @Override
-+        public void clearLootTable(final RandomizableContainer holder) {
-+            holder.setLootTable(null);
 +        }
 +
 +        @Override
@@ -409,17 +400,12 @@ index 0000000000000000000000000000000000000000..fc6806aa3ca1537c6bd778d42e30dea3
 +        }
 +
 +        @Override
-+        public void clearLootTable(final ContainerEntity holder) {
-+            holder.setLootTable(null);
-+        }
-+
-+        @Override
 +        public LootableInventory getInventoryForEvent(final ContainerEntity holder) {
 +            return holder.getLootableInventory();
 +        }
 +    };
 +
-+    public <T> void processRefill(final T lootTableHolder, final LootTableInterface<T> holderInterface, final net.minecraft.world.entity.player.@Nullable Player player) {
++    public <T> boolean shouldClearLootTable(final T lootTableHolder, final LootTableInterface<T> holderInterface, final net.minecraft.world.entity.player.@Nullable Player player) {
 +        this.lastFill = System.currentTimeMillis();
 +        final WorldConfiguration paperConfig = holderInterface.paperConfig(lootTableHolder);
 +        if (paperConfig.lootables.autoReplenish) {
@@ -433,9 +419,9 @@ index 0000000000000000000000000000000000000000..fc6806aa3ca1537c6bd778d42e30dea3
 +            if (player != null) { // This means that numRefills can be incremented without a player being in the lootedPlayers list - Seems to be EntityMinecartChest specific
 +                this.setPlayerLootedState(player.getUUID(), true);
 +            }
-+        } else {
-+            holderInterface.clearLootTable(lootTableHolder);
++            return false;
 +        }
++        return true;
 +    }
 +
 +    private static final String ROOT = "Paper.LootableData";
@@ -529,7 +515,7 @@ index 0000000000000000000000000000000000000000..fc6806aa3ca1537c6bd778d42e30dea3
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/RandomizableContainer.java b/src/main/java/net/minecraft/world/RandomizableContainer.java
-index 155902bc2b99ba36003bceb37ba34958952900d3..00e732ccf5b03a2feb0a4af1c7bb5b735cb7e247 100644
+index 155902bc2b99ba36003bceb37ba34958952900d3..68fadc351464dde459eb4cc86660cf9add40d04e 100644
 --- a/src/main/java/net/minecraft/world/RandomizableContainer.java
 +++ b/src/main/java/net/minecraft/world/RandomizableContainer.java
 @@ -28,7 +28,7 @@ public interface RandomizableContainer extends Container {
@@ -541,15 +527,14 @@ index 155902bc2b99ba36003bceb37ba34958952900d3..00e732ccf5b03a2feb0a4af1c7bb5b73
          this.setLootTable(lootTableId);
          this.setLootTableSeed(lootTableSeed);
      }
-@@ -49,6 +49,7 @@ public interface RandomizableContainer extends Container {
-     }
- 
+@@ -51,13 +51,14 @@ public interface RandomizableContainer extends Container {
      default boolean tryLoadLootTable(CompoundTag nbt) {
-+        if (this.lootableData() != null) this.lootableData().loadNbt(nbt); // Paper - LootTable API
          if (nbt.contains("LootTable", 8)) {
              this.setLootTable(ResourceKey.create(Registries.LOOT_TABLE, new ResourceLocation(nbt.getString("LootTable"))));
++            if (this.lootableData() != null && this.getLootTable() != null) this.lootableData().loadNbt(nbt); // Paper - LootTable API
              if (nbt.contains("LootTableSeed", 4)) {
-@@ -57,13 +58,14 @@ public interface RandomizableContainer extends Container {
+                 this.setLootTableSeed(nbt.getLong("LootTableSeed"));
+             } else {
                  this.setLootTableSeed(0L);
              }
  
@@ -558,14 +543,13 @@ index 155902bc2b99ba36003bceb37ba34958952900d3..00e732ccf5b03a2feb0a4af1c7bb5b73
          } else {
              return false;
          }
-     }
- 
-     default boolean trySaveLootTable(CompoundTag nbt) {
-+        if (this.lootableData() != null) this.lootableData().saveNbt(nbt); // Paper - LootTable API
-         ResourceKey<LootTable> resourceKey = this.getLootTable();
-         if (resourceKey == null) {
+@@ -69,12 +70,13 @@ public interface RandomizableContainer extends Container {
              return false;
-@@ -74,7 +76,7 @@ public interface RandomizableContainer extends Container {
+         } else {
+             nbt.putString("LootTable", resourceKey.location().toString());
++            if (this.lootableData() != null) this.lootableData().saveNbt(nbt); // Paper - LootTable API
+             long l = this.getLootTableSeed();
+             if (l != 0L) {
                  nbt.putLong("LootTableSeed", l);
              }
  
@@ -574,7 +558,7 @@ index 155902bc2b99ba36003bceb37ba34958952900d3..00e732ccf5b03a2feb0a4af1c7bb5b73
          }
      }
  
-@@ -82,13 +84,19 @@ public interface RandomizableContainer extends Container {
+@@ -82,13 +84,17 @@ public interface RandomizableContainer extends Container {
          Level level = this.getLevel();
          BlockPos blockPos = this.getBlockPos();
          ResourceKey<LootTable> resourceKey = this.getLootTable();
@@ -587,16 +571,14 @@ index 155902bc2b99ba36003bceb37ba34958952900d3..00e732ccf5b03a2feb0a4af1c7bb5b73
  
 -            this.setLootTable(null);
 +            // Paper start - LootTable API
-+            if (this.lootableData() == null) {
++            if (this.lootableData() == null || this.lootableData().shouldClearLootTable(this, com.destroystokyo.paper.loottable.PaperLootableInventoryData.CONTAINER, player)) {
 +                this.setLootTable(null);
-+            } else {
-+                this.lootableData().processRefill(this, com.destroystokyo.paper.loottable.PaperLootableInventoryData.CONTAINER, player);
 +            }
 +            // Paper end - LootTable API
              LootParams.Builder builder = new LootParams.Builder((ServerLevel)level).withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(blockPos));
              if (player != null) {
                  builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
-@@ -97,4 +105,16 @@ public interface RandomizableContainer extends Container {
+@@ -97,4 +103,16 @@ public interface RandomizableContainer extends Container {
              lootTable.fill(this, builder.create(LootContextParamSets.CHEST), this.getLootTableSeed());
          }
      }
@@ -661,16 +643,14 @@ index 025e57993b85402c48db29d65ea3ceaf277ff27a..e0aec3b3e04d603dc208029554f981c6
      public List<HumanEntity> transaction = new java.util.ArrayList<HumanEntity>();
      private int maxStack = MAX_STACK;
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java b/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
-index dbde2402fd46b0d06e8efeb90be6fb98d7ae7798..3a7d266d34740405681852b748a2ad9fd56d7f95 100644
+index dbde2402fd46b0d06e8efeb90be6fb98d7ae7798..d976a6e3a79a01392a5033b05864d82782a30916 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
-@@ -60,24 +60,24 @@ public interface ContainerEntity extends Container, MenuProvider {
-     }
- 
+@@ -62,22 +62,26 @@ public interface ContainerEntity extends Container, MenuProvider {
      default void addChestVehicleSaveData(CompoundTag nbt, HolderLookup.Provider registriesLookup) {
-+        this.lootableData().saveNbt(nbt); // Paper
          if (this.getLootTable() != null) {
              nbt.putString("LootTable", this.getLootTable().location().toString());
++            this.lootableData().saveNbt(nbt); // Paper
              if (this.getLootTableSeed() != 0L) {
                  nbt.putLong("LootTableSeed", this.getLootTableSeed());
              }
@@ -681,10 +661,14 @@ index dbde2402fd46b0d06e8efeb90be6fb98d7ae7798..3a7d266d34740405681852b748a2ad9f
      }
  
      default void readChestVehicleSaveData(CompoundTag nbt, HolderLookup.Provider registriesLookup) {
-+        this.lootableData().loadNbt(nbt); // Paper
          this.clearItemStacks();
          if (nbt.contains("LootTable", 8)) {
              this.setLootTable(ResourceKey.create(Registries.LOOT_TABLE, new ResourceLocation(nbt.getString("LootTable"))));
++            // Paper start - LootTable API
++            if (this.getLootTable() != null) {
++                this.lootableData().loadNbt(nbt);
++            }
++            // Paper end - LootTable API
              this.setLootTableSeed(nbt.getLong("LootTableSeed"));
 -        } else {
 -            ContainerHelper.loadAllItems(nbt, this.getItemStacks(), registriesLookup);
@@ -693,7 +677,7 @@ index dbde2402fd46b0d06e8efeb90be6fb98d7ae7798..3a7d266d34740405681852b748a2ad9f
      }
  
      default void chestVehicleDestroyed(DamageSource source, Level world, Entity vehicle) {
-@@ -99,13 +99,13 @@ public interface ContainerEntity extends Container, MenuProvider {
+@@ -99,13 +103,17 @@ public interface ContainerEntity extends Container, MenuProvider {
  
      default void unpackChestVehicleLootTable(@Nullable Player player) {
          MinecraftServer minecraftServer = this.level().getServer();
@@ -705,11 +689,15 @@ index dbde2402fd46b0d06e8efeb90be6fb98d7ae7798..3a7d266d34740405681852b748a2ad9f
              }
  
 -            this.setLootTable(null);
-+            this.lootableData().processRefill(this, com.destroystokyo.paper.loottable.PaperLootableInventoryData.ENTITY, player); // Paper - LootTable API
++            // Paper start - LootTable API
++            if (this.lootableData().shouldClearLootTable(this, com.destroystokyo.paper.loottable.PaperLootableInventoryData.ENTITY, player)) {
++                this.setLootTable(null);
++            }
++            // Paper end - LootTable API
              LootParams.Builder builder = new LootParams.Builder((ServerLevel)this.level()).withParameter(LootContextParams.ORIGIN, this.position());
              if (player != null) {
                  builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
-@@ -175,4 +175,14 @@ public interface ContainerEntity extends Container, MenuProvider {
+@@ -175,4 +183,14 @@ public interface ContainerEntity extends Container, MenuProvider {
      default boolean isChestVehicleStillValid(Player player) {
          return !this.isRemoved() && player.canInteractWithEntity(this.getBoundingBox(), 4.0);
      }

--- a/patches/server/0128-Cap-Entity-Collisions.patch
+++ b/patches/server/0128-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e04c0d333f8a425e4a1315b20f182b2206c22277..1bdf39894b4224d38fb3141e6445f6782b4e1920 100644
+index 2fcdd61e9669904756aa33b1ff8ab7160ea5e371..660a210c363fcb42145b273ea6b977ce4844505d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -396,6 +396,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -395,6 +395,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public long activatedTick = Integer.MIN_VALUE;
      public void inactiveTick() { }
      // Spigot end

--- a/patches/server/0143-Entity-fromMobSpawner.patch
+++ b/patches/server/0143-Entity-fromMobSpawner.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1bdf39894b4224d38fb3141e6445f6782b4e1920..9a8d70c1f92ecc8da6444ba5581a8d4b24af0672 100644
+index 660a210c363fcb42145b273ea6b977ce4844505d..655ce0b58cc327a8dac1b006bec7dcb34964da0a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -397,6 +397,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -396,6 +396,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public void inactiveTick() { }
      // Spigot end
      protected int numCollisions = 0; // Paper - Cap entity collisions
@@ -16,7 +16,7 @@ index 1bdf39894b4224d38fb3141e6445f6782b4e1920..9a8d70c1f92ecc8da6444ba5581a8d4b
      // Paper start - Entity origin API
      @javax.annotation.Nullable
      private org.bukkit.util.Vector origin;
-@@ -2190,6 +2191,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2189,6 +2190,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  }
                  nbttagcompound.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -27,7 +27,7 @@ index 1bdf39894b4224d38fb3141e6445f6782b4e1920..9a8d70c1f92ecc8da6444ba5581a8d4b
              // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
-@@ -2330,6 +2335,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2329,6 +2334,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  this.originWorld = originWorld;
                  origin = new org.bukkit.util.Vector(originTag.getDouble(0), originTag.getDouble(1), originTag.getDouble(2));
              }

--- a/patches/server/0204-Add-EntityKnockbackByEntityEvent-and-EntityPushedByE.patch
+++ b/patches/server/0204-Add-EntityKnockbackByEntityEvent-and-EntityPushedByE.patch
@@ -9,10 +9,10 @@ Co-authored-by: aerulion <aerulion@gmail.com>
 This event is called when an entity receives knockback by another entity.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9a8d70c1f92ecc8da6444ba5581a8d4b24af0672..6ade79a291f0443fbb8cb3bf7ef622b12b391b72 100644
+index 655ce0b58cc327a8dac1b006bec7dcb34964da0a..2777ed6f072af1733467c9f354bae0c5c967eea1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1892,9 +1892,23 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1891,9 +1891,23 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }
      }
  

--- a/patches/server/0213-add-more-information-to-Entity.toString.patch
+++ b/patches/server/0213-add-more-information-to-Entity.toString.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add more information to Entity.toString()
 UUID, ticks lived, valid, dead
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6ade79a291f0443fbb8cb3bf7ef622b12b391b72..ffc3cee1e19a039ef78634b9f94b045be8a2a3f8 100644
+index 2777ed6f072af1733467c9f354bae0c5c967eea1..9ff82d7e599b2c003f9677988b4ac5d79ea1223d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3182,7 +3182,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3181,7 +3181,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public String toString() {
          String s = this.level() == null ? "~NULL~" : this.level().toString();
  

--- a/patches/server/0228-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/patches/server/0228-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -43,11 +43,11 @@ index 6f2e316480c4cd1ffb32e8d01009a18c2234c731..42dd9ab70c07e92258da70ad29b51c77
              // WorldServer.LOGGER.warn("Tried to add entity {} but it was marked as removed already", EntityTypes.getKey(entity.getType())); // CraftBukkit
              return false;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ffc3cee1e19a039ef78634b9f94b045be8a2a3f8..50c5ad0eea45c1828b9a1c6c47727e4800940252 100644
+index 9ff82d7e599b2c003f9677988b4ac5d79ea1223d..4da4a0af7df25a913c48e9302ff47465c07e57af 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -245,6 +245,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
-     public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
+@@ -244,6 +244,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+ 
      private CraftEntity bukkitEntity;
  
 +    public @org.jetbrains.annotations.Nullable net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper

--- a/patches/server/0271-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0271-force-entity-dismount-during-teleportation.patch
@@ -41,10 +41,10 @@ index 665fcf8382fbcb214eda16dae9e40e33e257ec6f..2313c451dbcb28e79d8ff139696e2efb
              Iterator iterator = entityliving.getActiveEffects().iterator();
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 50c5ad0eea45c1828b9a1c6c47727e4800940252..932d9bb32c1473a31ea4da429c1f2dc3b3a73f60 100644
+index 4da4a0af7df25a913c48e9302ff47465c07e57af..82a54b40884d6c161f6f9935602ac107d7730338 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2601,17 +2601,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2600,17 +2600,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void removeVehicle() {
@@ -75,7 +75,7 @@ index 50c5ad0eea45c1828b9a1c6c47727e4800940252..932d9bb32c1473a31ea4da429c1f2dc3
      }
  
      protected void addPassenger(Entity passenger) {
-@@ -2636,7 +2647,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2635,7 +2646,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }
      }
  
@@ -87,7 +87,7 @@ index 50c5ad0eea45c1828b9a1c6c47727e4800940252..932d9bb32c1473a31ea4da429c1f2dc3
          if (entity.getVehicle() == this) {
              throw new IllegalStateException("Use x.stopRiding(y), not y.removePassenger(x)");
          } else {
-@@ -2646,7 +2660,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2645,7 +2659,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (this.getBukkitEntity() instanceof Vehicle && entity.getBukkitEntity() instanceof LivingEntity) {
                  VehicleExitEvent event = new VehicleExitEvent(
                          (Vehicle) this.getBukkitEntity(),
@@ -96,7 +96,7 @@ index 50c5ad0eea45c1828b9a1c6c47727e4800940252..932d9bb32c1473a31ea4da429c1f2dc3
                  );
                  // Suppress during worldgen
                  if (this.valid) {
-@@ -2659,7 +2673,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2658,7 +2672,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  }
              }
  

--- a/patches/server/0284-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0284-Entity-getEntitySpawnReason.patch
@@ -59,7 +59,7 @@ index f91e145a748dc524e1e95ee3afe00aa74a1aee9a..e3ce13685499e2adea5b776ec4abbdd9
  
              if (entity != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d372e2793948f532f473cd6eca578ebd3ff3fbfb..5bb379251c5af88d4350bd2715147e6442d695fd 100644
+index 4ab14e3ba7905179542082f0b93b7ea6bae8e505..a80041ccb308fa393498e72c1060f89ade440cb8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -241,6 +241,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -68,9 +68,9 @@ index d372e2793948f532f473cd6eca578ebd3ff3fbfb..5bb379251c5af88d4350bd2715147e64
      // Paper end - Share random for entities to make them more random
 +    public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
  
-     public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
      private CraftEntity bukkitEntity;
-@@ -2206,6 +2207,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+ 
+@@ -2205,6 +2206,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  }
                  nbttagcompound.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -80,7 +80,7 @@ index d372e2793948f532f473cd6eca578ebd3ff3fbfb..5bb379251c5af88d4350bd2715147e64
              // Save entity's from mob spawner status
              if (spawnedViaMobSpawner) {
                  nbttagcompound.putBoolean("Paper.FromMobSpawner", true);
-@@ -2352,6 +2356,26 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2351,6 +2355,26 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0323-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0323-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5bb379251c5af88d4350bd2715147e6442d695fd..f75457a5297fc041de5f2d7eabcc072201a42a09 100644
+index a80041ccb308fa393498e72c1060f89ade440cb8..70fdacb0aab225b89126d9c21e14cf42d69f00fa 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -399,6 +399,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -398,6 +398,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public void inactiveTick() { }
      // Spigot end
      protected int numCollisions = 0; // Paper - Cap entity collisions
@@ -16,7 +16,7 @@ index 5bb379251c5af88d4350bd2715147e6442d695fd..f75457a5297fc041de5f2d7eabcc0722
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      // Paper start - Entity origin API
      @javax.annotation.Nullable
-@@ -2214,6 +2215,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2213,6 +2214,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (spawnedViaMobSpawner) {
                  nbttagcompound.putBoolean("Paper.FromMobSpawner", true);
              }
@@ -26,7 +26,7 @@ index 5bb379251c5af88d4350bd2715147e6442d695fd..f75457a5297fc041de5f2d7eabcc0722
              // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
-@@ -2356,6 +2360,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2355,6 +2359,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0349-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/patches/server/0349-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -84,10 +84,10 @@ index a4db0bcefc92091ff26b146a2ce914c1d36a3c23..935061ed5c22b48e43d27fe0840cc69f
          }
          // Paper end - Entity#getEntitySpawnReason
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f75457a5297fc041de5f2d7eabcc072201a42a09..511208e323b26df24263b87eeb7d2645572d9ff8 100644
+index 70fdacb0aab225b89126d9c21e14cf42d69f00fa..06b52eefb16f7605021c2e2a5e3a300151fc5424 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2317,27 +2317,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2316,27 +2316,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
              // CraftBukkit end
  

--- a/patches/server/0353-Fix-item-duplication-and-teleport-issues.patch
+++ b/patches/server/0353-Fix-item-duplication-and-teleport-issues.patch
@@ -16,10 +16,10 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d45923ad2d82b3eb73a832c557eeea3c069b4dc9..6fcaa0e343b6f4e0e80eecdb7ea3e70d98272280 100644
+index b93185f50bd87d070ef08b9c6a714a065dd714d8..996ca6762fe45ee1c2fa2392ed6a050be9df5ac6 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2447,11 +2447,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2446,11 +2446,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          } else {
              // CraftBukkit start - Capture drops for death event
              if (this instanceof net.minecraft.world.entity.LivingEntity && !((net.minecraft.world.entity.LivingEntity) this).forceDrops) {
@@ -34,7 +34,7 @@ index d45923ad2d82b3eb73a832c557eeea3c069b4dc9..6fcaa0e343b6f4e0e80eecdb7ea3e70d
  
              entityitem.setDefaultPickUpDelay();
              // CraftBukkit start
-@@ -3244,6 +3245,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3243,6 +3244,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      @Nullable
      public Entity teleportTo(ServerLevel worldserver, Vec3 location) {
          // CraftBukkit end
@@ -47,7 +47,7 @@ index d45923ad2d82b3eb73a832c557eeea3c069b4dc9..6fcaa0e343b6f4e0e80eecdb7ea3e70d
          if (this.level() instanceof ServerLevel && !this.isRemoved()) {
              this.level().getProfiler().push("changeDimension");
              // CraftBukkit start
-@@ -3270,6 +3277,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3269,6 +3276,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  // CraftBukkit end
  
                  this.level().getProfiler().popPush("reloading");
@@ -59,7 +59,7 @@ index d45923ad2d82b3eb73a832c557eeea3c069b4dc9..6fcaa0e343b6f4e0e80eecdb7ea3e70d
                  Entity entity = this.getType().create(worldserver);
  
                  if (entity != null) {
-@@ -3287,10 +3299,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3286,10 +3298,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index d45923ad2d82b3eb73a832c557eeea3c069b4dc9..6fcaa0e343b6f4e0e80eecdb7ea3e70d
                      // CraftBukkit end
                  }
  
-@@ -3411,7 +3419,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3410,7 +3418,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean canChangeDimensions() {

--- a/patches/server/0380-Ensure-Entity-position-and-AABB-are-never-invalid.patch
+++ b/patches/server/0380-Ensure-Entity-position-and-AABB-are-never-invalid.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ensure Entity position and AABB are never invalid
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6fcaa0e343b6f4e0e80eecdb7ea3e70d98272280..d0e5769b7abf255ac5d64c499e872ecb9acf4829 100644
+index 996ca6762fe45ee1c2fa2392ed6a050be9df5ac6..184d8bdca8aa06b6a1f00bab03e8c2688a391663 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -665,8 +665,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -664,8 +664,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void setPos(double x, double y, double z) {
@@ -20,7 +20,7 @@ index 6fcaa0e343b6f4e0e80eecdb7ea3e70d98272280..d0e5769b7abf255ac5d64c499e872ecb
      }
  
      protected AABB makeBoundingBox() {
-@@ -4181,7 +4181,29 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4180,7 +4180,29 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.getZ((2.0D * this.random.nextDouble() - 1.0D) * widthScale);
      }
  
@@ -50,7 +50,7 @@ index 6fcaa0e343b6f4e0e80eecdb7ea3e70d98272280..d0e5769b7abf255ac5d64c499e872ecb
          if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
-@@ -4199,6 +4221,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4198,6 +4220,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.levelCallback.onMove();
          }
  

--- a/patches/server/0417-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0417-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -31,7 +31,7 @@ index bc9c68c4df11ece9a9cba9b8cff1182c1d21551f..5d8b1fb9ee96ca397b8f3a0629bc4273
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8576e7919dfaf6a17e6442a2047a7d6bef3b53cb..cde8925d0754c2428cf830ac58d83b9420947e30 100644
+index 9012d34db1768189ac68b9348e609d77948488d3..77e672f6146e4a9b32bead526b7dfcbe54c1829e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -165,6 +165,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -42,7 +42,7 @@ index 8576e7919dfaf6a17e6442a2047a7d6bef3b53cb..cde8925d0754c2428cf830ac58d83b94
      static boolean isLevelAtLeast(CompoundTag tag, int level) {
          return tag.contains("Bukkit.updateLevel") && tag.getInt("Bukkit.updateLevel") >= level;
      }
-@@ -1809,6 +1810,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1808,6 +1809,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void moveTo(double x, double y, double z, float yaw, float pitch) {

--- a/patches/server/0421-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0421-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f5078b093b61dfe58e6fac24f59af945dd2f3df4..81ff696c34afffe6b1ee76347984b0d8cb5723e7 100644
+index 0b98618cb0b0e9c4b13415ab0e535cdfbd55b224..240f322b1ae99a73f6b4720d2a03d1a1440cf930 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4445,4 +4445,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4444,4 +4444,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0423-Entity-isTicking.patch
+++ b/patches/server/0423-Entity-isTicking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 81ff696c34afffe6b1ee76347984b0d8cb5723e7..905d740814b7c911e8449fc53d6e5de7e77ecaf9 100644
+index 240f322b1ae99a73f6b4720d2a03d1a1440cf930..0a51ea55a6b768d71161c4492664a61ec1e5df15 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4450,5 +4450,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4449,5 +4449,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0449-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0449-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 81c9f06bdba9eb51c9ee3d1d969f8d8e6302a70f..3bc4b964d49d7de789506a482de9eb700051a2b8 100644
+index 33aaabed53362367a88b09d5c3f298101e699fa6..c57ad2c8fe0c0e2f4cbc55a00c895f510eb27bfd 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2011,6 +2011,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2010,6 +2010,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean isPushable() {

--- a/patches/server/0460-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0460-MC-4-Fix-item-position-desync.patch
@@ -28,10 +28,10 @@ index ffec3deb9bcd31d51974c1deda2e76bc8374e5c5..a3d247c93ac1a2d872ff0e3841efc3d7
  
      public Vec3 decode(long x, long y, long z) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index adfafb697eb7ba83b6c5305ce16e0b6fd191aae6..19da8864597b876dc302bed011ee38899b168da7 100644
+index 0328738d613358a9042b1d12de511f212db68244..da31287d60c60f01bf274f23c6bb23803f9658fb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4218,6 +4218,16 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4217,6 +4217,16 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              return;
          }
          // Paper end - Block invalid positions and bounding box

--- a/patches/server/0484-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0484-Collision-option-for-requiring-a-player-participant.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Collision option for requiring a player participant
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 67dd20b6fae2ee39eaae3286eba7b485a6dd41cc..eb5cc58e5b53407de5d2a0ddcbbfbc7cdd3bb072 100644
+index 77f24eb88af8fde66ef2198bb7673c71de42800f..d8658bca3964c931be9dbbfc25de03f0d2e4b6c5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1872,6 +1872,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1871,6 +1871,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public void push(Entity entity) {
          if (!this.isPassengerOfSameVehicle(entity)) {
              if (!entity.noPhysics && !this.noPhysics) {

--- a/patches/server/0553-More-Lidded-Block-API.patch
+++ b/patches/server/0553-More-Lidded-Block-API.patch
@@ -21,10 +21,10 @@ index f4b480e3041fc79060c5fa6ce517047104b280d5..6063f0e1fdc232d063105971359ae688
 +    // Paper end - More Lidded Block API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-index 29df470d6706a33dad4317a9aa599456d5c7f6ee..c7d19cef79dbe39edc8cddf0c60c7b59d656e581 100644
+index 2b6a93a944b27290745278957a3577772b7b8212..6e98a00d526b734992ce39b15768c5820dce4ca8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-@@ -93,4 +93,11 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
+@@ -92,4 +92,11 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
      public CraftChest copy(Location location) {
          return new CraftChest(this, location);
      }

--- a/patches/server/0563-Fix-dangerous-end-portal-logic.patch
+++ b/patches/server/0563-Fix-dangerous-end-portal-logic.patch
@@ -11,10 +11,10 @@ Move the tick logic into the post tick, where portaling was
 designed to happen in the first place.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 19f205560df2e35c2df05631de6e400c2f6a11f3..7e33e3ab3f14fccd85333b5192cd9c1119f0e5e4 100644
+index 715185c5f6ccb15bda34a2a4722609ac25421f90..318d0f557d50b74c44b2fd1ac84e12bf30e75c24 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -423,6 +423,36 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -422,6 +422,36 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.originWorld;
      }
      // Paper end - Entity origin API
@@ -51,7 +51,7 @@ index 19f205560df2e35c2df05631de6e400c2f6a11f3..7e33e3ab3f14fccd85333b5192cd9c11
      public float getBukkitYaw() {
          return this.yRot;
      }
-@@ -2834,6 +2864,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2833,6 +2863,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              }
  
              this.processPortalCooldown();

--- a/patches/server/0589-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0589-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7e33e3ab3f14fccd85333b5192cd9c1119f0e5e4..b92aba1a77bc8139f28232b96f1a126eef7852a4 100644
+index 318d0f557d50b74c44b2fd1ac84e12bf30e75c24..325d8551d4f6c1d24525fab607769a75320cf436 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3876,20 +3876,34 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3875,20 +3875,34 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      private Stream<Entity> getIndirectPassengersStream() {
@@ -43,7 +43,7 @@ index 7e33e3ab3f14fccd85333b5192cd9c1119f0e5e4..b92aba1a77bc8139f28232b96f1a126e
          return () -> {
              return this.getIndirectPassengersStream().iterator();
          };
-@@ -3902,6 +3916,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3901,6 +3915,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean hasExactlyOnePlayerPassenger() {

--- a/patches/server/0597-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0597-Add-back-EntityPortalExitEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b92aba1a77bc8139f28232b96f1a126eef7852a4..74c5f418ea6b5861d8e5d4ced17b5a8772d6dcde 100644
+index 325d8551d4f6c1d24525fab607769a75320cf436..2d98bdae7e8686d8a15e8938a16d8d63f0575bef 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3313,6 +3313,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3312,6 +3312,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              } else {
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
@@ -37,7 +37,7 @@ index b92aba1a77bc8139f28232b96f1a126eef7852a4..74c5f418ea6b5861d8e5d4ced17b5a87
                  if (worldserver == this.level) {
                      // SPIGOT-6782: Just move the entity if a plugin changed the world to the one the entity is already in
                      this.moveTo(shapedetectorshape.pos.x, shapedetectorshape.pos.y, shapedetectorshape.pos.z, shapedetectorshape.yRot, shapedetectorshape.xRot);
-@@ -3332,8 +3354,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3331,8 +3353,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
                  if (entity != null) {
                      entity.restoreFrom(this);

--- a/patches/server/0608-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0608-Add-Raw-Byte-Entity-Serialization.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 public net.minecraft.world.entity.Entity setLevel(Lnet/minecraft/world/level/Level;)V
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 74c5f418ea6b5861d8e5d4ced17b5a8772d6dcde..4abb1661e04278bf27a844cd0a957d4537aece37 100644
+index 2d98bdae7e8686d8a15e8938a16d8d63f0575bef..96c9feb545c02014c324852344a1d86156c32237 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2106,6 +2106,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2105,6 +2105,15 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }
      }
  

--- a/patches/server/0635-Update-head-rotation-in-missing-places.patch
+++ b/patches/server/0635-Update-head-rotation-in-missing-places.patch
@@ -8,10 +8,10 @@ This is because bukkit uses a separate head rotation field for yaw.
 This issue only applies to players.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6b66a9732f8e8b23b8d00beb9822fbb46ac76cab..f6419fe840836c3ff3c577b246d58f820b79fae2 100644
+index 3bf2b943797bed06f9424acfdc05107a59ce78d2..a9db8cf04403d0e23b8891346ff4007eecb9b3d2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1814,6 +1814,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1813,6 +1813,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.setXRot(Mth.clamp(pitch, -90.0F, 90.0F) % 360.0F);
          this.yRotO = this.getYRot();
          this.xRotO = this.getXRot();
@@ -19,7 +19,7 @@ index 6b66a9732f8e8b23b8d00beb9822fbb46ac76cab..f6419fe840836c3ff3c577b246d58f82
      }
  
      public void absMoveTo(double x, double y, double z) {
-@@ -1852,6 +1853,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1851,6 +1852,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.setXRot(pitch);
          this.setOldPosAndRot();
          this.reapplyPosition();

--- a/patches/server/0641-don-t-attempt-to-teleport-dead-entities.patch
+++ b/patches/server/0641-don-t-attempt-to-teleport-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] don't attempt to teleport dead entities
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f6419fe840836c3ff3c577b246d58f820b79fae2..e4885d1fd68955107e871dd4457df7e468348e15 100644
+index a9db8cf04403d0e23b8891346ff4007eecb9b3d2..17eff19ef7ce8ed51853d27c30643a727d7a942c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -731,7 +731,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -730,7 +730,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      // CraftBukkit start
      public void postTick() {
          // No clean way to break out of ticking once the entity has been copied to a new world, so instead we move the portalling later in the tick cycle

--- a/patches/server/0652-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0652-Forward-CraftEntity-in-teleport-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c5d652b24c5442e1f566e7f1fe71748f0d406f86..e3243ee624861771fb6b7c39a91ad33f827eebaa 100644
+index 50aca89516dea3f4c4d668b994f4afdea69b4cc9..af1b161e5e61fe244b316d352452038c9b4ea458 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3285,6 +3285,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3284,6 +3284,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void restoreFrom(Entity original) {
@@ -22,7 +22,7 @@ index c5d652b24c5442e1f566e7f1fe71748f0d406f86..e3243ee624861771fb6b7c39a91ad33f
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3375,10 +3382,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3374,10 +3381,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                          }
                      }
                      // CraftBukkit end

--- a/patches/server/0671-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0671-Freeze-Tick-Lock-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b488fe4ddc8a4fad42f45b2a7158766df3a85de4..ce21885281a2bca8f363ebc6423ca65df7c13c6d 100644
+index 11917a810a4d1a4f55ddb2afd81b9d15d011cbf8..c4d595ef91f43efe0f4f5ff27f311e8f9dcb7796 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -407,6 +407,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -406,6 +406,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
      private UUID originWorld;
@@ -16,7 +16,7 @@ index b488fe4ddc8a4fad42f45b2a7158766df3a85de4..ce21885281a2bca8f363ebc6423ca65d
  
      public void setOrigin(@javax.annotation.Nonnull Location location) {
          this.origin = location.toVector();
-@@ -777,7 +778,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -776,7 +777,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  this.setRemainingFireTicks(this.remainingFireTicks - 1);
              }
  
@@ -25,7 +25,7 @@ index b488fe4ddc8a4fad42f45b2a7158766df3a85de4..ce21885281a2bca8f363ebc6423ca65d
                  this.setTicksFrozen(0);
                  this.level().levelEvent((Player) null, 1009, this.blockPosition, 1);
              }
-@@ -2274,6 +2275,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2273,6 +2274,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (fromNetherPortal) {
                  nbttagcompound.putBoolean("Paper.FromNetherPortal", true);
              }
@@ -35,7 +35,7 @@ index b488fe4ddc8a4fad42f45b2a7158766df3a85de4..ce21885281a2bca8f363ebc6423ca65d
              // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
-@@ -2418,6 +2422,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2417,6 +2421,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (spawnReason == null) {
                  spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT;
              }

--- a/patches/server/0703-Ensure-entity-passenger-world-matches-ridden-entity.patch
+++ b/patches/server/0703-Ensure-entity-passenger-world-matches-ridden-entity.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ensure entity passenger world matches ridden entity
 Bad plugins doing this would cause some obvious problems...
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ce21885281a2bca8f363ebc6423ca65df7c13c6d..d689f02150fa55ffcfb03adb5955f190ffdcc0de 100644
+index c4d595ef91f43efe0f4f5ff27f311e8f9dcb7796..b3522e7d1c622ecb86668f5822da2d32922173e4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2611,7 +2611,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2610,7 +2610,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public boolean startRiding(Entity entity, boolean force) {

--- a/patches/server/0724-Prevent-entity-loading-causing-async-lookups.patch
+++ b/patches/server/0724-Prevent-entity-loading-causing-async-lookups.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent entity loading causing async lookups
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d689f02150fa55ffcfb03adb5955f190ffdcc0de..5a6041ca0a787a945629066477f94d48ea1f1f19 100644
+index b3522e7d1c622ecb86668f5822da2d32922173e4..c4f4aee317a15f9df5d249a8c86354b16ae9158a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -740,6 +740,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -739,6 +739,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      public void baseTick() {
          this.level().getProfiler().push("entityBaseTick");

--- a/patches/server/0736-Add-various-missing-EntityDropItemEvent-calls.patch
+++ b/patches/server/0736-Add-various-missing-EntityDropItemEvent-calls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add various missing EntityDropItemEvent calls
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5a6041ca0a787a945629066477f94d48ea1f1f19..e6c0dbe34790351f847a9a44aa6c733b71775318 100644
+index c4f4aee317a15f9df5d249a8c86354b16ae9158a..dcee9128fdd482653488d9fff1ad2a75860b0f8e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2519,6 +2519,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2518,6 +2518,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              stack.setCount(0); // Paper - destroy this item - if this ever leaks due to game bugs, ensure it doesn't dupe
  
              entityitem.setDefaultPickUpDelay();

--- a/patches/server/0740-Add-EntityPortalReadyEvent.patch
+++ b/patches/server/0740-Add-EntityPortalReadyEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add EntityPortalReadyEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 652dd9a4c1039b1f57844aa51041cb36b5c53568..0fae685f32cf370ae0023969d20ecd907a3be442 100644
+index ba6f680e9a851376960c6a3e29db5d6ca46c7e85..d6559c4dd5b6499903f8e5777710d48523104fa7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2868,6 +2868,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2867,6 +2867,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  if (true && !this.isPassenger() && this.portalTime++ >= i) { // CraftBukkit
                      this.level().getProfiler().push("portal");
                      this.portalTime = i;
@@ -22,7 +22,7 @@ index 652dd9a4c1039b1f57844aa51041cb36b5c53568..0fae685f32cf370ae0023969d20ecd90
                      this.setPortalCooldown();
                      // CraftBukkit start
                      if (this instanceof ServerPlayer) {
-@@ -2875,6 +2882,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2874,6 +2881,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                      } else {
                          this.changeDimension(worldserver1);
                      }

--- a/patches/server/0780-Fix-EntityCombustEvent-cancellation-cant-fully-preve.patch
+++ b/patches/server/0780-Fix-EntityCombustEvent-cancellation-cant-fully-preve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix EntityCombustEvent cancellation cant fully prevent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0fae685f32cf370ae0023969d20ecd907a3be442..0d1b6e05e2a8bc7cae3936e94033d9f936e61645 100644
+index d6559c4dd5b6499903f8e5777710d48523104fa7..bc44f69281472c4c5c1137ebf355f805dbfcafa8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3133,6 +3133,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3132,6 +3132,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              pluginManager.callEvent(entityCombustEvent);
              if (!entityCombustEvent.isCancelled()) {
                  this.igniteForSeconds(entityCombustEvent.getDuration(), false);

--- a/patches/server/0794-Player-Entity-Tracking-Events.patch
+++ b/patches/server/0794-Player-Entity-Tracking-Events.patch
@@ -21,10 +21,10 @@ index de19a5ea96fa38621513e970e04d153576f4f6ae..bff776f07bcc7841acc5757c1f53bde1
                  } else if (this.seenBy.remove(player.connection)) {
                      this.serverEntity.removePairing(player);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0d1b6e05e2a8bc7cae3936e94033d9f936e61645..12f165b3a8bc66f7836ce914b324509a48bf1b9f 100644
+index bc44f69281472c4c5c1137ebf355f805dbfcafa8..9163d565c63db3bffcbe1b002e315c31b726d6a3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3859,7 +3859,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3858,7 +3858,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      public void startSeenByPlayer(ServerPlayer player) {}
  

--- a/patches/server/0803-Improve-PortalEvents.patch
+++ b/patches/server/0803-Improve-PortalEvents.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Improve PortalEvents
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 12f165b3a8bc66f7836ce914b324509a48bf1b9f..cb426597c0ecf9469f87f8ea0dc29a87a8c098f2 100644
+index 9163d565c63db3bffcbe1b002e315c31b726d6a3..661f630b38dff4aa760e7939ff80b1361d426565 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3519,7 +3519,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3518,7 +3518,14 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          Location enter = bukkitEntity.getLocation();
          Location exit = CraftLocation.toBukkit(exitPosition, exitWorldServer.getWorld());
  

--- a/patches/server/0808-Expose-pre-collision-moving-velocity-to-VehicleBlock.patch
+++ b/patches/server/0808-Expose-pre-collision-moving-velocity-to-VehicleBlock.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose pre-collision moving velocity to
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f256bd908a9683085fa47d2a84cbdee78a7ba20b..d074b9f859f6ed9ce0137c8e238de188c290fa4d 100644
+index e6b61e4d5774532e67932b872bb84d7e91589fc6..1c370fd90427ea3ec9bcaece45775b1aa7ba9ee7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -968,6 +968,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -967,6 +967,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void move(MoverType movementType, Vec3 movement) {
@@ -17,7 +17,7 @@ index f256bd908a9683085fa47d2a84cbdee78a7ba20b..d074b9f859f6ed9ce0137c8e238de188
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -1052,7 +1053,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1051,7 +1052,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                      }
  
                      if (!bl.getType().isAir()) {

--- a/patches/server/0839-Refresh-ProjectileSource-for-projectiles.patch
+++ b/patches/server/0839-Refresh-ProjectileSource-for-projectiles.patch
@@ -14,10 +14,10 @@ clearing the owner.
 Co-authored-by: Warrior <50800980+Warriorrrr@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d074b9f859f6ed9ce0137c8e238de188c290fa4d..2323e8d69673d6291af6337f321f36ed9080bfd9 100644
+index 1c370fd90427ea3ec9bcaece45775b1aa7ba9ee7..cd9ec9d94594fc03b293728e442e20894ad6465b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -386,6 +386,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -385,6 +385,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public boolean inWorld = false;
      public boolean generation;
      public int maxAirTicks = this.getDefaultMaxAirSupply(); // CraftBukkit - SPIGOT-6907: re-implement LivingEntity#setMaximumAir()

--- a/patches/server/0854-Don-t-load-chunks-for-supporting-block-checks.patch
+++ b/patches/server/0854-Don-t-load-chunks-for-supporting-block-checks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't load chunks for supporting block checks
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2323e8d69673d6291af6337f321f36ed9080bfd9..51032754e62b9e5da3f1c1adffbae4168cfbb0d1 100644
+index cd9ec9d94594fc03b293728e442e20894ad6465b..6178ce2639b26c6dcd0033d0a99af0ddee10a7fe 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1211,7 +1211,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1210,7 +1210,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      protected BlockPos getOnPos(float offset) {

--- a/patches/server/0866-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/server/0866-Folia-scheduler-and-owned-region-API.patch
@@ -1185,10 +1185,10 @@ index 942af999a4a3aa03cb7ef5f0b9d377c78677fd0e..0246db4a1f6eb168fa88260282311fee
          this.players.remove(entityplayer);
          this.playersByName.remove(entityplayer.getScoreboardName().toLowerCase(java.util.Locale.ROOT)); // Spigot
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fbee7db6e9d8312e55cabfbc08decdb99dbd115b..897bc3c59f2c2cfdcdfcfe96804394dbb14457f7 100644
+index 9541fbd06bc000023d6119eff03787ef068178ce..3aeb24963ce0415e97168196cbf53e8f26334013 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -250,11 +250,23 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -249,11 +249,23 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public @org.jetbrains.annotations.Nullable net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper
      public CraftEntity getBukkitEntity() {
          if (this.bukkitEntity == null) {
@@ -1213,7 +1213,7 @@ index fbee7db6e9d8312e55cabfbc08decdb99dbd115b..897bc3c59f2c2cfdcdfcfe96804394db
      @Override
      public CommandSender getBukkitSender(CommandSourceStack wrapper) {
          return this.getBukkitEntity();
-@@ -4478,6 +4490,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4477,6 +4489,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public final void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
          CraftEventFactory.callEntityRemoveEvent(this, cause);
          // CraftBukkit end
@@ -1221,7 +1221,7 @@ index fbee7db6e9d8312e55cabfbc08decdb99dbd115b..897bc3c59f2c2cfdcdfcfe96804394db
          if (this.removalReason == null) {
              this.removalReason = entity_removalreason;
          }
-@@ -4488,12 +4501,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4487,12 +4500,28 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
          this.getPassengers().forEach(Entity::stopRiding);
          this.levelCallback.onRemove(entity_removalreason);
@@ -1251,7 +1251,7 @@ index fbee7db6e9d8312e55cabfbc08decdb99dbd115b..897bc3c59f2c2cfdcdfcfe96804394db
      public void setLevelCallback(EntityInLevelCallback changeListener) {
          this.levelCallback = changeListener;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 72b9b8f0e06ced33ac76af162fff52442decb2cf..dc2201ff1a1a95c30b050e58703d78098c8daea8 100644
+index 870cdb65854cb2cc204aca7c14ca867655e44512..2dc0473b2b4d905da5b4ba62db373feab9cb7763 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -306,6 +306,76 @@ public final class CraftServer implements Server {

--- a/patches/server/0889-Expand-Pose-API.patch
+++ b/patches/server/0889-Expand-Pose-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expand Pose API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b2c2d45bf390b9968dbb20c150b1fac2559a08a7..7f2ffffa270f493224ea97fcd0e862baf36ae40c 100644
+index 56f0648a7bb7eacc0a023c657be476b78774622d..bde80f721ea08f3f183d9cd60c944dcf8f798087 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -421,6 +421,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -420,6 +420,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      @javax.annotation.Nullable
      private UUID originWorld;
      public boolean freezeLocked = false; // Paper - Freeze Tick Lock API
@@ -16,7 +16,7 @@ index b2c2d45bf390b9968dbb20c150b1fac2559a08a7..7f2ffffa270f493224ea97fcd0e862ba
  
      public void setOrigin(@javax.annotation.Nonnull Location location) {
          this.origin = location.toVector();
-@@ -644,6 +645,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -643,6 +644,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      public void onClientRemoval() {}
  
      public void setPose(net.minecraft.world.entity.Pose pose) {

--- a/patches/server/0930-Don-t-fire-sync-events-during-worldgen.patch
+++ b/patches/server/0930-Don-t-fire-sync-events-during-worldgen.patch
@@ -31,10 +31,10 @@ index 2da315d288efa66f7bff96923ebd5eac5130ba39..39cf7ae086108d8077121829368b8160
          if (entity.valid) {
              MinecraftServer.LOGGER.error("Attempted Double World add on {}", entity, new Throwable());
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7f2ffffa270f493224ea97fcd0e862baf36ae40c..df82f696dc3a3ce388cfedbede22f503575a888a 100644
+index bde80f721ea08f3f183d9cd60c944dcf8f798087..7636b0ee46fd3f11ed7a4221dd29e6be8a4e5158 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -650,7 +650,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -649,7 +649,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          if (pose == this.getPose()) {
              return;
          }

--- a/patches/server/0933-Restore-vanilla-entity-drops-behavior.patch
+++ b/patches/server/0933-Restore-vanilla-entity-drops-behavior.patch
@@ -50,10 +50,10 @@ index e10c8309e184fe2c5c9682aa901ed7a320980431..3a3c17e62244a16cbad5558d55bcf8e3
          if (entityitem == null) {
              return null;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index df82f696dc3a3ce388cfedbede22f503575a888a..0782fd7bf29aa4d30ea5a9a303cc43620fe5b06e 100644
+index 7636b0ee46fd3f11ed7a4221dd29e6be8a4e5158..b7945199edd3151bd2300fc7a2718a0e5db86e6a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2524,6 +2524,25 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2523,6 +2523,25 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Nullable
      public ItemEntity spawnAtLocation(ItemStack stack, float yOffset) {
@@ -79,7 +79,7 @@ index df82f696dc3a3ce388cfedbede22f503575a888a..0782fd7bf29aa4d30ea5a9a303cc4362
          if (stack.isEmpty()) {
              return null;
          } else if (this.level().isClientSide) {
-@@ -2531,14 +2550,21 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2530,14 +2549,21 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          } else {
              // CraftBukkit start - Capture drops for death event
              if (this instanceof net.minecraft.world.entity.LivingEntity && !((net.minecraft.world.entity.LivingEntity) this).forceDrops) {

--- a/patches/server/0941-Validate-ResourceLocation-in-NBT-reading.patch
+++ b/patches/server/0941-Validate-ResourceLocation-in-NBT-reading.patch
@@ -98,11 +98,11 @@ index fc5913910f5614cd3e10cd9c1aa482a4b70ac260..31b8a8bf78d52b5f11b68e780ec09bf7
  
          this.setShotFromCrossbow(nbt.getBoolean("ShotFromCrossbow"));
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java b/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
-index f33e5cf6d456e615050047e924d9b24268a2c51e..c660e9b1e9635011b32fa19cf64118d64408f158 100644
+index 3a7d266d34740405681852b748a2ad9fd56d7f95..5ec48c0a3ba7b3c0fee5b54e17ad3448267ddbd8 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
-@@ -72,7 +72,7 @@ public interface ContainerEntity extends Container, MenuProvider {
-     default void readChestVehicleSaveData(CompoundTag nbt, HolderLookup.Provider registriesLookup) {
+@@ -74,7 +74,7 @@ public interface ContainerEntity extends Container, MenuProvider {
+         this.lootableData().loadNbt(nbt); // Paper
          this.clearItemStacks();
          if (nbt.contains("LootTable", 8)) {
 -            this.setLootTable(ResourceKey.create(Registries.LOOT_TABLE, new ResourceLocation(nbt.getString("LootTable"))));

--- a/patches/server/0941-Validate-ResourceLocation-in-NBT-reading.patch
+++ b/patches/server/0941-Validate-ResourceLocation-in-NBT-reading.patch
@@ -39,6 +39,19 @@ index d93b623ce973b63d4f3a77bfe459f51af7cb3c1c..2c4553312f2f37f8613ac813708b4b95
          this.namespace = namespace;
          this.path = path;
      }
+diff --git a/src/main/java/net/minecraft/world/RandomizableContainer.java b/src/main/java/net/minecraft/world/RandomizableContainer.java
+index 68fadc351464dde459eb4cc86660cf9add40d04e..feb35fba0c56445ee910dbe1af9b36f21b4ec480 100644
+--- a/src/main/java/net/minecraft/world/RandomizableContainer.java
++++ b/src/main/java/net/minecraft/world/RandomizableContainer.java
+@@ -50,7 +50,7 @@ public interface RandomizableContainer extends Container {
+ 
+     default boolean tryLoadLootTable(CompoundTag nbt) {
+         if (nbt.contains("LootTable", 8)) {
+-            this.setLootTable(ResourceKey.create(Registries.LOOT_TABLE, new ResourceLocation(nbt.getString("LootTable"))));
++            this.setLootTable(net.minecraft.Optionull.map(ResourceLocation.tryParse(nbt.getString("LootTable")), rl -> ResourceKey.create(Registries.LOOT_TABLE, rl))); // Paper - Validate ResourceLocation);
+             if (this.lootableData() != null && this.getLootTable() != null) this.lootableData().loadNbt(nbt); // Paper - LootTable API
+             if (nbt.contains("LootTableSeed", 4)) {
+                 this.setLootTableSeed(nbt.getLong("LootTableSeed"));
 diff --git a/src/main/java/net/minecraft/world/entity/EntityType.java b/src/main/java/net/minecraft/world/entity/EntityType.java
 index 8c7cc9c5af0b8d8bef9b6e2d3d3e723cd76f3212..56b51096ca4147363a843accf6ef2510f05e8f1a 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityType.java
@@ -53,7 +66,7 @@ index 8c7cc9c5af0b8d8bef9b6e2d3d3e723cd76f3212..56b51096ca4147363a843accf6ef2510
  
      @Nullable
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5a47752a1c7da9b9da692c34ef046988924b6266..480d7633016ac641d4318f7eb971e0c721c5397a 100644
+index c256b4307e896b3e9f0a399a93db761a8c5c593f..5eda2e858b309d2be704db1015c9c114ed9e63a9 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -911,12 +911,13 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -72,7 +85,7 @@ index 5a47752a1c7da9b9da692c34ef046988924b6266..480d7633016ac641d4318f7eb971e0c7
  
          if (nbt.contains("Brain", 10)) {
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index bca70fff39409617e9c2b8ea66c1de4b9376d261..b5fd4feb44e5aca2b37f0e6b3c5317d6caf4b3d4 100644
+index 7a2fefda293d72d665fee71ef29eea6bad3c0861..f6008004c00d45e5fb5b0b2133011e4d20d7a1ff 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -645,7 +645,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Targeti
@@ -98,18 +111,18 @@ index fc5913910f5614cd3e10cd9c1aa482a4b70ac260..31b8a8bf78d52b5f11b68e780ec09bf7
  
          this.setShotFromCrossbow(nbt.getBoolean("ShotFromCrossbow"));
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java b/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
-index 3a7d266d34740405681852b748a2ad9fd56d7f95..5ec48c0a3ba7b3c0fee5b54e17ad3448267ddbd8 100644
+index d976a6e3a79a01392a5033b05864d82782a30916..845eff7401b811c179dc9dee70eca0d724be5c80 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/ContainerEntity.java
-@@ -74,7 +74,7 @@ public interface ContainerEntity extends Container, MenuProvider {
-         this.lootableData().loadNbt(nbt); // Paper
+@@ -73,7 +73,7 @@ public interface ContainerEntity extends Container, MenuProvider {
+     default void readChestVehicleSaveData(CompoundTag nbt, HolderLookup.Provider registriesLookup) {
          this.clearItemStacks();
          if (nbt.contains("LootTable", 8)) {
 -            this.setLootTable(ResourceKey.create(Registries.LOOT_TABLE, new ResourceLocation(nbt.getString("LootTable"))));
 +            this.setLootTable(net.minecraft.Optionull.map(ResourceLocation.tryParse(nbt.getString("LootTable")), rl -> ResourceKey.create(Registries.LOOT_TABLE, rl))); // Paper - Validate ResourceLocation
-             this.setLootTableSeed(nbt.getLong("LootTableSeed"));
-         }
-         ContainerHelper.loadAllItems(nbt, this.getItemStacks(), registriesLookup); // Paper - always save the items, table may still remain
+             // Paper start - LootTable API
+             if (this.getLootTable() != null) {
+                 this.lootableData().loadNbt(nbt);
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 index f40b2582d9087f9dbb5cab950304698f33fdd879..a99fe191c429bb528209dd0f31b509acf9cccbb5 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java

--- a/patches/server/0943-Fixup-NamespacedKey-handling.patch
+++ b/patches/server/0943-Fixup-NamespacedKey-handling.patch
@@ -4,32 +4,6 @@ Date: Sat, 6 Jan 2024 14:31:00 +0100
 Subject: [PATCH] Fixup NamespacedKey handling
 
 
-diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperContainerEntityLootableInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperContainerEntityLootableInventory.java
-index 7f5283a8ee74253e326fe994f20ae00cf3c75e1b..183f31c81d9c0a966e6b20c2cff3d279dfc7e622 100644
---- a/src/main/java/com/destroystokyo/paper/loottable/PaperContainerEntityLootableInventory.java
-+++ b/src/main/java/com/destroystokyo/paper/loottable/PaperContainerEntityLootableInventory.java
-@@ -20,7 +20,7 @@ public class PaperContainerEntityLootableInventory implements PaperLootableEntit
- 
-     @Override
-     public org.bukkit.loot.LootTable getLootTable() {
--        return entity.getLootTable() != null ? Optionull.map(entity.getLootTable(), rk -> Bukkit.getLootTable(CraftNamespacedKey.fromMinecraft(rk.location()))) : null;
-+        return entity.getLootTable() != null && !entity.getLootTable().location().getPath().isEmpty() ? Optionull.map(entity.getLootTable(), rk -> Bukkit.getLootTable(CraftNamespacedKey.fromMinecraft(rk.location()))) : null;
-     }
- 
-     @Override
-diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperTileEntityLootableInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperTileEntityLootableInventory.java
-index fb72bdea520ccc0928cfbda0569e02a1917a7e86..6f6e19b7b57cb3070ef5b6810d8449344705af8c 100644
---- a/src/main/java/com/destroystokyo/paper/loottable/PaperTileEntityLootableInventory.java
-+++ b/src/main/java/com/destroystokyo/paper/loottable/PaperTileEntityLootableInventory.java
-@@ -17,7 +17,7 @@ public class PaperTileEntityLootableInventory implements PaperLootableBlockInven
- 
-     @Override
-     public org.bukkit.loot.LootTable getLootTable() {
--        return tileEntityLootable.lootTable != null ? Bukkit.getLootTable(CraftNamespacedKey.fromMinecraft(tileEntityLootable.lootTable.location())) : null;
-+        return tileEntityLootable.lootTable != null && !tileEntityLootable.lootTable.location().getPath().isEmpty() ? Bukkit.getLootTable(CraftNamespacedKey.fromMinecraft(tileEntityLootable.lootTable.location())) : null;
-     }
- 
-     @Override
 diff --git a/src/main/java/net/minecraft/world/inventory/LoomMenu.java b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
 index 4f3f6ea43030853bd9df067358a1f4d16c40e6d4..531336c44c46555fef8c001fe8ca00c93624ad42 100644
 --- a/src/main/java/net/minecraft/world/inventory/LoomMenu.java
@@ -64,6 +38,19 @@ index 4f3f6ea43030853bd9df067358a1f4d16c40e6d4..531336c44c46555fef8c001fe8ca00c9
              if (!event.callEvent()) {
                  player.containerMenu.sendAllDataToRemote();
                  return false;
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java b/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
+index 209c6b64e79c29ea3bb84ddbe89a8bff66f81d0f..1f90f4b3f310b8cf5750c3a581be178f19b979d2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
+@@ -38,7 +38,7 @@ public class CraftLootTable implements org.bukkit.loot.LootTable {
+     }
+ 
+     public static org.bukkit.loot.LootTable minecraftToBukkit(ResourceKey<LootTable> minecraft) {
+-        return (minecraft == null) ? null : Bukkit.getLootTable(CraftLootTable.minecraftToBukkitKey(minecraft));
++        return (minecraft == null || minecraft.location().getPath().isEmpty()) ? null : Bukkit.getLootTable(CraftLootTable.minecraftToBukkitKey(minecraft)); // Paper - fix some NamespacedKey parsing
+     }
+ 
+     public static NamespacedKey minecraftToBukkitKey(ResourceKey<LootTable> minecraft) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java b/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java
 index 5c725faae98a126ee0e34eea53cfa484d2315709..d41b502eb451ec11dade2b987aee621511312ac6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftRegistry.java

--- a/patches/server/0944-Expose-LootTable-of-DecoratedPot.patch
+++ b/patches/server/0944-Expose-LootTable-of-DecoratedPot.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose LootTable of DecoratedPot
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftDecoratedPot.java b/src/main/java/org/bukkit/craftbukkit/block/CraftDecoratedPot.java
-index 6e0258d4d6a07e0f471640a9edda0adf7ef6cd9e..6015565aeedc1b2cdddcdb488f8de71bc84b61f2 100644
+index 6e0258d4d6a07e0f471640a9edda0adf7ef6cd9e..47cc3ec5ccd3bb51a08b3f179cb29030948b8c11 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftDecoratedPot.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftDecoratedPot.java
-@@ -43,6 +43,39 @@ public class CraftDecoratedPot extends CraftBlockEntityState<DecoratedPotBlockEn
+@@ -43,6 +43,33 @@ public class CraftDecoratedPot extends CraftBlockEntityState<DecoratedPotBlockEn
          return new CraftInventoryDecoratedPot(this.getTileEntity());
      }
  
@@ -20,18 +20,12 @@ index 6e0258d4d6a07e0f471640a9edda0adf7ef6cd9e..6015565aeedc1b2cdddcdb488f8de71b
 +
 +    @Override
 +    public void setLootTable(org.bukkit.loot.LootTable table, long seed) {
-+        net.minecraft.resources.ResourceKey<net.minecraft.world.level.storage.loot.LootTable> key = (table == null) ? null : net.minecraft.resources.ResourceKey.create(net.minecraft.core.registries.Registries.LOOT_TABLE, org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(table.getKey()));
-+        this.getSnapshot().setLootTable(key, seed);
++        this.getSnapshot().setLootTable(org.bukkit.craftbukkit.CraftLootTable.bukkitToMinecraft(table), seed);
 +    }
 +
 +    @Override
 +    public org.bukkit.loot.LootTable getLootTable() {
-+        if (this.getSnapshot().getLootTable() == null) {
-+            return null;
-+        }
-+
-+        net.minecraft.resources.ResourceKey<net.minecraft.world.level.storage.loot.LootTable> key = this.getSnapshot().getLootTable();
-+        return org.bukkit.Bukkit.getLootTable(org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(key.location()));
++        return org.bukkit.craftbukkit.CraftLootTable.minecraftToBukkit(this.getSnapshot().getLootTable());
 +    }
 +
 +    @Override

--- a/patches/server/0965-Fix-DamageSource-API.patch
+++ b/patches/server/0965-Fix-DamageSource-API.patch
@@ -68,10 +68,10 @@ index abda6094e02ebd2589ba0e4760e574fcf44dc8e4..5ec8cbd07a1830876f58e1fd33de6df4
  
      public DamageSource sonicBoom(Entity attacker) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a28a26fd6b409471c14e5702b45f42b23e2bfbeb..d6c24ad4e32fba5416c7cdd898d72f6207ae278a 100644
+index 6342b9142ca6c3e17020911f95a81a4be3ca0401..370d00afe8384556ee92e28d253c44ed6989efab 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3201,7 +3201,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -3200,7 +3200,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              return;
          }
  

--- a/patches/server/0977-Rewrite-chunk-system.patch
+++ b/patches/server/0977-Rewrite-chunk-system.patch
@@ -19482,7 +19482,7 @@ index ea72dcb064a35bc6245bc5c94d592efedd8faf41..0793dfe47e68a2b48b010aad5b12dcfa
      public boolean remove(Object object) {
          int i = this.findIndex((T)object);
 diff --git a/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java b/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java
-index 7984f17cd9c4cef8100909b6c33b3144c8096fcf..639f72618a7c22fa94effa9d0406b97fffc64cb5 100644
+index 0382b6597a130d746f8954a93a756a9d1ac81d50..ffbb3bf9ff3fc968ef69d4f889b0baf7e8ab691b 100644
 --- a/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java
 +++ b/src/main/java/net/minecraft/util/worldupdate/WorldUpgrader.java
 @@ -227,7 +227,13 @@ public class WorldUpgrader {
@@ -19500,10 +19500,10 @@ index 7984f17cd9c4cef8100909b6c33b3144c8096fcf..639f72618a7c22fa94effa9d0406b97f
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d6c24ad4e32fba5416c7cdd898d72f6207ae278a..e4ae674d006821b254ffdd88c37c4a2dfec86bd9 100644
+index 370d00afe8384556ee92e28d253c44ed6989efab..6324b875472fc2dbc581157306ff255ef1bf5db2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -482,6 +482,58 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -481,6 +481,58 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
      // Paper end
  
@@ -19562,7 +19562,7 @@ index d6c24ad4e32fba5416c7cdd898d72f6207ae278a..e4ae674d006821b254ffdd88c37c4a2d
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
          this.passengers = ImmutableList.of();
-@@ -2608,11 +2660,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2607,11 +2659,11 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return InteractionResult.PASS;
      }
  
@@ -19576,7 +19576,7 @@ index d6c24ad4e32fba5416c7cdd898d72f6207ae278a..e4ae674d006821b254ffdd88c37c4a2d
          return false;
      }
  
-@@ -4043,6 +4095,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4042,6 +4094,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }).count();
      }
  
@@ -19590,7 +19590,7 @@ index d6c24ad4e32fba5416c7cdd898d72f6207ae278a..e4ae674d006821b254ffdd88c37c4a2d
      public boolean hasExactlyOnePlayerPassenger() {
          if (this.passengers.isEmpty()) { return false; } // Paper - Optimize indirect passenger iteration
          return this.countPlayerPassengers() == 1;
-@@ -4393,6 +4452,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4392,6 +4451,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              return;
          }
          // Paper end - Block invalid positions and bounding box
@@ -19603,7 +19603,7 @@ index d6c24ad4e32fba5416c7cdd898d72f6207ae278a..e4ae674d006821b254ffdd88c37c4a2d
          // Paper start - Fix MC-4
          if (this instanceof ItemEntity) {
              if (io.papermc.paper.configuration.GlobalConfiguration.get().misc.fixEntityPositionDesync) {
-@@ -4520,6 +4585,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4519,6 +4584,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public final void setRemoved(Entity.RemovalReason entity_removalreason, EntityRemoveEvent.Cause cause) {
@@ -19617,7 +19617,7 @@ index d6c24ad4e32fba5416c7cdd898d72f6207ae278a..e4ae674d006821b254ffdd88c37c4a2d
          CraftEventFactory.callEntityRemoveEvent(this, cause);
          // CraftBukkit end
          final boolean alreadyRemoved = this.removalReason != null; // Paper - Folia schedulers
-@@ -4531,7 +4603,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4530,7 +4602,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              this.stopRiding();
          }
  
@@ -19626,7 +19626,7 @@ index d6c24ad4e32fba5416c7cdd898d72f6207ae278a..e4ae674d006821b254ffdd88c37c4a2d
          this.levelCallback.onRemove(entity_removalreason);
          // Paper start - Folia schedulers
          if (!(this instanceof ServerPlayer) && entity_removalreason != RemovalReason.CHANGED_DIMENSION && !alreadyRemoved) {
-@@ -4562,7 +4634,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4561,7 +4633,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override
      public boolean shouldBeSaved() {
@@ -21607,7 +21607,7 @@ index 7dae8d91b74cc7df0745f0c121e3bea09b8d0b6d..1e2530c9e5212b6d2bdbc94817beddb4
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 927c3110a64cfab665137a6f0c8b72075168f2bf..52a8eaa84a22c5cfc30a4e8a4c15d41bd58caef6 100644
+index 522231b47036c98b1334dbe7756b07ed3481001a..13eb670b85a7ac77238b0a0ba9be13336765894e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1402,7 +1402,6 @@ public final class CraftServer implements Server {
@@ -21739,7 +21739,7 @@ index 4b6a04e47f5d4c071607516519098fab317dcf12..01fc74e6cc8ea8808b821583afb26309
  
      // Paper start - implement pointers
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b60db7df3cef33a4a6a9804104759ecaa3ae330a..6f8999df04e6ad4d4d52e87b05a187f586d60c74 100644
+index 8016976d226a421b3e16d281fa3c01be2f8d3eb0..2d373be107a610522db9b3ce8ae446b848d92580 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -3454,31 +3454,31 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0986-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0986-Entity-Activation-Range-2.0.patch
@@ -111,10 +111,10 @@ index 4934c59f0ac6bd6dea67b716e4db07d295757f46..12245d90ccb4bce09966ab6b3def1e7e
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 03840f520624662d4ce3ac9f3065a01c71b5f299..a13edd1165a5ba4dd3f5c323e454926e7fe75c07 100644
+index 920631eaa850f98eea92c9d78b6d94b922490c7c..b8030331085ea0fdb58e525693fc9e31d7b5929c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -414,6 +414,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -413,6 +413,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      // Spigot end
      protected int numCollisions = 0; // Paper - Cap entity collisions
      public boolean fromNetherPortal; // Paper - Add option to nerf pigmen from nether portals
@@ -123,7 +123,7 @@ index 03840f520624662d4ce3ac9f3065a01c71b5f299..a13edd1165a5ba4dd3f5c323e454926e
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      // Paper start - Entity origin API
      @javax.annotation.Nullable
-@@ -1045,6 +1047,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1044,6 +1046,8 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          } else {
              this.wasOnFire = this.isOnFire();
              if (movementType == MoverType.PISTON) {
@@ -132,7 +132,7 @@ index 03840f520624662d4ce3ac9f3065a01c71b5f299..a13edd1165a5ba4dd3f5c323e454926e
                  movement = this.limitPistonMovement(movement);
                  if (movement.equals(Vec3.ZERO)) {
                      return;
-@@ -1057,6 +1061,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1056,6 +1060,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }

--- a/patches/server/0990-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/0990-Optimize-Collision-to-not-load-chunks.patch
@@ -26,13 +26,13 @@ index 8f1a2de2a5542929f8a2fdd4d38de141eda985b2..29b35b8c0a6001d626e327a82eaff26d
              // CraftBukkit end
              entityplayer1.setPos(entityplayer1.getX(), entityplayer1.getY() + 1.0D, entityplayer1.getZ());
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a13edd1165a5ba4dd3f5c323e454926e7fe75c07..b57644317b5085d74d11ac6ba858c3747d703a47 100644
+index b8030331085ea0fdb58e525693fc9e31d7b5929c..5a15319fa9e3660369093c77ac6aedd8d906870f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -245,6 +245,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -244,6 +244,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+     // Paper end - Share random for entities to make them more random
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason; // Paper - Entity#getEntitySpawnReason
  
-     public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
 +    public boolean collisionLoadChunks = false; // Paper
      private CraftEntity bukkitEntity;
  

--- a/patches/server/0996-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/patches/server/0996-Use-distance-map-to-optimise-entity-tracker.patch
@@ -236,7 +236,7 @@ index 4621c33ed73b0db64e78e7b9be7013a2ba7393c8..48f7997e8a20f5a5a77516cbde990d0a
              return object instanceof ChunkMap.TrackedEntity ? ((ChunkMap.TrackedEntity) object).entity.getId() == this.entity.getId() : false;
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b57644317b5085d74d11ac6ba858c3747d703a47..257943b4c984d6faee29eca17c8f951e7f43168b 100644
+index 5a15319fa9e3660369093c77ac6aedd8d906870f..190a1e24c9b0109f8a881ecc017425fd3428b25e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -59,6 +59,7 @@ import net.minecraft.network.syncher.SyncedDataHolder;
@@ -247,7 +247,7 @@ index b57644317b5085d74d11ac6ba858c3747d703a47..257943b4c984d6faee29eca17c8f951e
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
-@@ -471,6 +472,38 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -470,6 +471,38 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          this.teleportTo(worldserver, null);
      }
      // Paper end - make end portalling safe

--- a/patches/server/1008-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/1008-Detail-more-information-in-watchdog-dumps.patch
@@ -122,10 +122,10 @@ index bdad61438e7fd89f5f0cac6632dd395fcf024361..019034eea40c1669ce3d774565ce71c0
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1b4659db5a90d0846b8904a6b8550d743ef38eb3..1a989abfb9ffe75e080e811647815a3e48de53df 100644
+index b0bd8be7f657cf0accd1d7b474298c281c174589..8485d30feb6844d9659d6364c576c0b3da5dea8f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1074,8 +1074,43 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1073,8 +1073,43 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          return this.onGround;
      }
  
@@ -169,7 +169,7 @@ index 1b4659db5a90d0846b8904a6b8550d743ef38eb3..1a989abfb9ffe75e080e811647815a3e
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -1245,6 +1280,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1244,6 +1279,13 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  this.level().getProfiler().pop();
              }
          }
@@ -183,7 +183,7 @@ index 1b4659db5a90d0846b8904a6b8550d743ef38eb3..1a989abfb9ffe75e080e811647815a3e
      }
  
      private boolean isStateClimbable(BlockState state) {
-@@ -4411,7 +4453,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4410,7 +4452,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -193,7 +193,7 @@ index 1b4659db5a90d0846b8904a6b8550d743ef38eb3..1a989abfb9ffe75e080e811647815a3e
      }
  
      public void addDeltaMovement(Vec3 velocity) {
-@@ -4514,7 +4558,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -4513,7 +4557,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
          }
          // Paper end - Fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {

--- a/patches/server/1009-Collision-optimisations.patch
+++ b/patches/server/1009-Collision-optimisations.patch
@@ -2214,10 +2214,10 @@ index 60ba289e724463129dfb27aa5e3b6daf3dd7386e..68446b7532dfbda303293aa9e756644c
              entityplayer1.setPos(entityplayer1.getX(), entityplayer1.getY() + 1.0D, entityplayer1.getZ());
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0fbcf60a994f67bdd81d40e4a8bf38f0cbb8993d..8ad2d17615ff489b2fbbb13480dd0b217a42d805 100644
+index 638ebf8d902d67fb90058fca4a17bd959426a7df..de655714c471143aa8c830d28c96b4fc17b4b588 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1261,9 +1261,44 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1260,9 +1260,44 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
                  float f = this.getBlockSpeedFactor();
  
                  this.setDeltaMovement(this.getDeltaMovement().multiply((double) f, 1.0D, (double) f));
@@ -2265,7 +2265,7 @@ index 0fbcf60a994f67bdd81d40e4a8bf38f0cbb8993d..8ad2d17615ff489b2fbbb13480dd0b21
                      if (this.remainingFireTicks <= 0) {
                          this.setRemainingFireTicks(-this.getFireImmuneTicks());
                      }
-@@ -1443,32 +1478,82 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -1442,32 +1477,82 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      private Vec3 collide(Vec3 movement) {
@@ -2364,7 +2364,7 @@ index 0fbcf60a994f67bdd81d40e4a8bf38f0cbb8993d..8ad2d17615ff489b2fbbb13480dd0b21
      }
  
      public static Vec3 collideBoundingBox(@Nullable Entity entity, Vec3 movement, AABB entityBoundingBox, Level world, List<VoxelShape> collisions) {
-@@ -2735,11 +2820,70 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2734,11 +2819,70 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              float f = this.dimensions.width() * 0.8F;
              AABB axisalignedbb = AABB.ofSize(this.getEyePosition(), (double) f, 1.0E-6D, (double) f);
  

--- a/patches/server/1015-Properly-resend-entities.patch
+++ b/patches/server/1015-Properly-resend-entities.patch
@@ -115,10 +115,10 @@ index 68446b7532dfbda303293aa9e756644c6fcdffca..a2142930b4d4b05987c90496fb9d733d
          this.sendLevelInfo(player, worldserver1);
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8ad2d17615ff489b2fbbb13480dd0b217a42d805..2bc85351e6e52f90da5fdb29d8d042a06132d742 100644
+index de655714c471143aa8c830d28c96b4fc17b4b588..4edf4da2e3ad010ab3d41aa5f66c776e7917cbf2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -704,13 +704,44 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -703,13 +703,44 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      // CraftBukkit start
      public void refreshEntityData(ServerPlayer to) {

--- a/patches/server/1016-Optimize-Hoppers.patch
+++ b/patches/server/1016-Optimize-Hoppers.patch
@@ -630,10 +630,10 @@ index 92086ca118d55ec49cefa5bf18977f8706e3e4b4..8310d132006043e93c612890514c4c7f
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java
-index 5b183f12717008dd6c9863938c17b2e668ebded4..17da915ffa638500a83b67db0940a7b9a9b333a1 100644
+index 13c9a68b604d4c7c6e09e72b3cea7ab2214b06ab..e2752752417c50b06f7c15b7d00bda0eaad3b0ae 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/RandomizableContainerBlockEntity.java
-@@ -104,7 +104,7 @@ public abstract class RandomizableContainerBlockEntity extends BaseContainerBloc
+@@ -53,7 +53,7 @@ public abstract class RandomizableContainerBlockEntity extends BaseContainerBloc
  
      @Override
      public ItemStack getItem(int slot) {

--- a/patches/server/1041-More-Chest-Block-API.patch
+++ b/patches/server/1041-More-Chest-Block-API.patch
@@ -20,10 +20,10 @@ index 5f9858ef8d0ec1a74d469ab4426eb1db068873fd..ca92d49ef2010ba00c623491671dcde8
              } else if (world.isClientSide) {
                  return InteractionResult.SUCCESS;
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-index c7d19cef79dbe39edc8cddf0c60c7b59d656e581..984bb158a5de646834031d06bfd0fb9c89a76dff 100644
+index 6e98a00d526b734992ce39b15768c5820dce4ca8..cc7bf4d39b834fba472bc163226a01a0cd4b6010 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-@@ -100,4 +100,29 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
+@@ -99,4 +99,29 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
          return getTileEntity().openersCounter.opened;
      }
      // Paper end - More Lidded Block API


### PR DESCRIPTION
Cleans up the loot table API and replenish patches to better support vanilla's new randomizable container and entity stuff.

Also adds such support to the Crafter. https://github.com/PaperMC/Paper/pull/10023 does so for Decorated Pot. That can be merged before or after this, doesn't matter.

Fixes https://github.com/PaperMC/Paper/issues/9917 (part of the issue started again)