### PR TITLE
Fix untrack event not being called for all 'untracks'

### DIFF
--- a/patches/api/0394-Player-Entity-Tracking-Events.patch
+++ b/patches/api/0394-Player-Entity-Tracking-Events.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Player Entity Tracking Events
 
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerTrackEntityEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerTrackEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..db0a011815daf2690deb4ad2aff08227664fc6b8
+index 0000000000000000000000000000000000000000..40024c8d5fe81e23eae9b37a08fca34a91e40011
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerTrackEntityEvent.java
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,59 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Entity;
@@ -23,6 +23,9 @@ index 0000000000000000000000000000000000000000..db0a011815daf2690deb4ad2aff08227
 + * Is called when a {@link Player} tracks an {@link Entity}.
 + * <p>
 + * If cancelled entity is not shown to the player and interaction in both directions is not possible.
++ * <p>
++ * Adding or removing entities from the world at the point in time this event is called is completely
++ * unsupported and should be avoided.
 + */
 +public class PlayerTrackEntityEvent extends PlayerEvent implements Cancellable {
 +
@@ -68,10 +71,10 @@ index 0000000000000000000000000000000000000000..db0a011815daf2690deb4ad2aff08227
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/PlayerUntrackEntityEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerUntrackEntityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..683710d53e3802ca1cb1a448886a57df6b15dd44
+index 0000000000000000000000000000000000000000..82bb2d2b4bf05d7b4e8dd22280deb04433c2ad9e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/PlayerUntrackEntityEvent.java
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,44 @@
 +package io.papermc.paper.event.player;
 +
 +import org.bukkit.entity.Entity;
@@ -82,6 +85,9 @@ index 0000000000000000000000000000000000000000..683710d53e3802ca1cb1a448886a57df
 +
 +/**
 + * Is called when a {@link Player} untracks an {@link Entity}.
++ * <p>
++ * Adding or removing entities from the world at the point in time this event is called is completely
++ * unsupported and should be avoided.
 + */
 +public class PlayerUntrackEntityEvent extends PlayerEvent {
 +

--- a/patches/server/0878-Player-Entity-Tracking-Events.patch
+++ b/patches/server/0878-Player-Entity-Tracking-Events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player Entity Tracking Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 982750fd4f3f474514194df9b76388311c052b29..1e838661ced07b69e50e7ad3935ed0d676570860 100644
+index 982750fd4f3f474514194df9b76388311c052b29..526b52bbf7c5d82645d26710f05e62b781e3cb0e 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1409,9 +1409,18 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1409,7 +1409,11 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                  // CraftBukkit end
                  if (flag) {
                      if (this.seenBy.add(player.connection)) {
@@ -19,11 +19,24 @@ index 982750fd4f3f474514194df9b76388311c052b29..1e838661ced07b69e50e7ad3935ed0d6
 +                        // Paper end
                      }
                  } else if (this.seenBy.remove(player.connection)) {
-+                    // Paper start - entity tracking events
-+                    if (io.papermc.paper.event.player.PlayerUntrackEntityEvent.getHandlerList().getRegisteredListeners().length > 0) {
-+                        new io.papermc.paper.event.player.PlayerUntrackEntityEvent(player.getBukkitEntity(), this.entity.getBukkitEntity()).callEvent();
-+                    }
-+                    // Paper end
                      this.serverEntity.removePairing(player);
-                 }
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 89defc6e1e95fdd7d76ae3af0282066819831c9e..b5eb4a067cc3b4a2a6b0b6ba2c129c85c4aaa849 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -4107,7 +4107,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
  
+     public void startSeenByPlayer(ServerPlayer player) {}
+ 
+-    public void stopSeenByPlayer(ServerPlayer player) {}
++    // Paper start - entity tracking events
++    public void stopSeenByPlayer(ServerPlayer player) {
++        // Since this event cannot be cancelled, we should call it here to catch all "un-tracks"
++        if (io.papermc.paper.event.player.PlayerUntrackEntityEvent.getHandlerList().getRegisteredListeners().length > 0) {
++            new io.papermc.paper.event.player.PlayerUntrackEntityEvent(player.getBukkitEntity(), this.getBukkitEntity()).callEvent();
++        }
++    }
++    // Paper end
+ 
+     public float rotate(Rotation rotation) {
+         float f = Mth.wrapDegrees(this.getYRot());

--- a/patches/server/0963-Folia-scheduler-and-owned-region-API.patch
+++ b/patches/server/0963-Folia-scheduler-and-owned-region-API.patch
@@ -1185,7 +1185,7 @@ index a9cc3d7213f51a2a2cdc915fd9ab3cf97767b698..69e75aec30e8c25f621c8e7d024abe67
          this.players.remove(entityplayer);
          this.playersByName.remove(entityplayer.getScoreboardName().toLowerCase(java.util.Locale.ROOT)); // Spigot
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 903fa8c1489541e141bef59239ecd645955ffca4..a561da947df33d85a6bb6f61e88a2b5fe57b5c32 100644
+index 0b34913980a8def4af28bbc8d7308aa237bdadf0..c07eac5b7d3a5c21ea043ae56f036a5f396d92de 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -247,11 +247,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
@@ -1213,7 +1213,7 @@ index 903fa8c1489541e141bef59239ecd645955ffca4..a561da947df33d85a6bb6f61e88a2b5f
      @Override
      public CommandSender getBukkitSender(CommandSourceStack wrapper) {
          return this.getBukkitEntity();
-@@ -4734,6 +4746,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
+@@ -4741,6 +4753,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
              return;
          }
          // Paper end - rewrite chunk system
@@ -1221,7 +1221,7 @@ index 903fa8c1489541e141bef59239ecd645955ffca4..a561da947df33d85a6bb6f61e88a2b5f
          if (this.removalReason == null) {
              this.removalReason = reason;
          }
-@@ -4744,12 +4757,28 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
+@@ -4751,12 +4764,28 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, S
  
          if (reason != RemovalReason.UNLOADED_TO_CHUNK) this.getPassengers().forEach(Entity::stopRiding); // Paper - chunk system - don't adjust passenger state when unloading, it's just not safe (and messes with our logic in entity chunk unload)
          this.levelCallback.onRemove(reason);


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/10107

Moves the untrack event call back to the Entity#stopSeenByPlayer method. It was originally added there, then moved when the track event became cancellable. But the untrack event wasn't (and can't) be made cancellable so it should've been left.