### PR TITLE
Add velocity forwarding secret env override

### DIFF
--- a/patches/server/0005-Paper-config-files.patch
+++ b/patches/server/0005-Paper-config-files.patch
@@ -487,10 +487,10 @@ index 0000000000000000000000000000000000000000..d9502ba028a96f9cc846f9ed428bd806
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..45ab7ff5497ceccb85944d2e8d354d9c860abf3b
+index 0000000000000000000000000000000000000000..b92bfd89e32becde2e7630c6116c16f8a4f6614a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -0,0 +1,324 @@
+@@ -0,0 +1,331 @@
 +package io.papermc.paper.configuration;
 +
 +import co.aikar.timings.MinecraftTimings;
@@ -594,7 +594,14 @@ index 0000000000000000000000000000000000000000..45ab7ff5497ceccb85944d2e8d354d9c
 +
 +            @PostProcess
 +            private void postProcess() {
-+                if (this.enabled && this.secret.isEmpty()) {
++                if (!this.enabled) return;
++
++                final String environmentSourcedVelocitySecret = System.getenv("PAPER_VELOCITY_SECRET");
++                if (environmentSourcedVelocitySecret != null && !environmentSourcedVelocitySecret.isEmpty()) {
++                    this.secret = environmentSourcedVelocitySecret;
++                }
++
++                if (this.secret.isEmpty()) {
 +                    LOGGER.error("Velocity is enabled, but no secret key was specified. A secret key is required. Disabling velocity...");
 +                    this.enabled = false;
 +                }
@@ -5216,7 +5223,7 @@ index e433037a03ffafabb952887ae3980e1d51411d4c..c061813d275fbc48d7629cc59d90dbb4
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3c0691ef65c8db1002b76984f4ddfe2072d793c9..b3c4cdd9cfff6857f3007fbd91a280bcc53ab072 100644
+index 10f07a6eff8f738cefef11829dd774874259b8f4..4c5b6f8d63e4c60a1dc81e68117fa049b956819a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -962,6 +962,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0740-Configurable-chat-thread-limit.patch
+++ b/patches/server/0740-Configurable-chat-thread-limit.patch
@@ -22,10 +22,10 @@ is actually processed, this is honestly really just exposed for the misnomers or
 who just wanna ensure that this won't grow over a specific size if chat gets stupidly active
 
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index 45ab7ff5497ceccb85944d2e8d354d9c860abf3b..917bd0c1dd8f356edc3741ee59d24e4d090af182 100644
+index b92bfd89e32becde2e7630c6116c16f8a4f6614a..73e8a524925ed6f2580d3bd01616646fabafda78 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-@@ -296,7 +296,18 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -303,7 +303,18 @@ public class GlobalConfiguration extends ConfigurationPart {
  
              @PostProcess
              private void postProcess() {

--- a/patches/server/0981-Moonrise-optimisation-patches.patch
+++ b/patches/server/0981-Moonrise-optimisation-patches.patch
@@ -22216,7 +22216,7 @@ index 0000000000000000000000000000000000000000..85950a1aa732ab8c01ad28bec9e0de14
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
-index f19b4a17a7e22969f7b51d3bea4056b41ab25484..690086adcb1f87adc0b3ab664fde735ad3e1093a 100644
+index 450a1cc8f1624dce2daf52210d017e0732b1bdf7..a9dd0e5216e95afd98fd2200d110e2cc0b1b0dca 100644
 --- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 +++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 @@ -31,6 +31,45 @@ public class GlobalConfiguration extends ConfigurationPart {
@@ -22265,7 +22265,7 @@ index f19b4a17a7e22969f7b51d3bea4056b41ab25484..690086adcb1f87adc0b3ab664fde735a
      static void set(GlobalConfiguration instance) {
          GlobalConfiguration.instance = instance;
      }
-@@ -139,21 +178,6 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -146,21 +185,6 @@ public class GlobalConfiguration extends ConfigurationPart {
          public int incomingPacketThreshold = 300;
      }
  
@@ -22287,7 +22287,7 @@ index f19b4a17a7e22969f7b51d3bea4056b41ab25484..690086adcb1f87adc0b3ab664fde735a
      public UnsupportedSettings unsupportedSettings;
  
      public class UnsupportedSettings extends ConfigurationPart {
-@@ -212,7 +236,7 @@ public class GlobalConfiguration extends ConfigurationPart {
+@@ -219,7 +243,7 @@ public class GlobalConfiguration extends ConfigurationPart {
  
          @PostProcess
          private void postProcess() {


### PR DESCRIPTION
Previously, the velocity forwarding secret could only be configured via
the configuration option in the global paper configuration.
This makes configuring/passing such a value rather difficult for
containerized/orchestrated servers as these configuration files are
usually part of the server data volume itself and hence cannot be
sourced from a secret.

This commit enables administrators to define the `PAPER_VELOCITY_SECRET`
environment variable, which will override any potentially configured
velocity secret.
