### PR TITLE
Log command execution exceptions if debug=true

### DIFF
--- a/patches/server/0384-misc-debugging-dumps.patch
+++ b/patches/server/0384-misc-debugging-dumps.patch
@@ -28,6 +28,19 @@ index 0000000000000000000000000000000000000000..2d5494d2813b773e60ddba6790b750a9
 +        new Throwable(reason).printStackTrace();
 +    }
 +}
+diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
+index b27256d251e5db5781197319f79f89cc7638c80b..337ff2b3e8ea6f106656cf4bef029d81998e0e58 100644
+--- a/src/main/java/net/minecraft/commands/Commands.java
++++ b/src/main/java/net/minecraft/commands/Commands.java
+@@ -341,7 +341,7 @@ public class Commands {
+         } catch (Exception exception) {
+             MutableComponent ichatmutablecomponent = Component.literal(exception.getMessage() == null ? exception.getClass().getName() : exception.getMessage());
+ 
+-            if (Commands.LOGGER.isDebugEnabled()) {
++            if (commandlistenerwrapper.getServer().isDebugging() || Commands.LOGGER.isDebugEnabled()) { // Paper
+                 Commands.LOGGER.error("Command exception: /{}", s, exception);
+                 StackTraceElement[] astacktraceelement = exception.getStackTrace();
+ 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index 08f7f287af32597d8a39f429013adec9266020bf..e230a6e3810929c2f9ac70a98c9fc41734ec06c2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -74,7 +87,7 @@ index 04a728a16bb629adbae1cd8586764a6dbc22b5dc..e48b287d6229f8043fba8a417f0b7558
              this.connection.disconnect(ServerConfigurationPacketListenerImpl.DISCONNECT_REASON_INVALID_DATA);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b805012214f1ff9526110e56b5ad9dde96c0468e..41bf17ccb60c3f66505539085de83017e2125afe 100644
+index 34016fdfe0357d817092c5932497701153326884..5895544e1c4d1b4c0ae862969d09aa0ed5ce42b8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1006,6 +1006,7 @@ public final class CraftServer implements Server {


### PR DESCRIPTION
By default, exceptions during command execution are not logged unless the Commands.java logger has debug logging enabled. This logs them if the server.properties `debug=true`. 

This also actually outputs the stacktrace in the error message sent to the player. We may want to not do that, only log the exception to the console log.