### PR TITLE
Fix Mob Effect Visibility/Attributes syncing

### DIFF
--- a/patches/server/1062-Fix-Mob-Effect-Visibility-Attributes-syncing.patch
+++ b/patches/server/1062-Fix-Mob-Effect-Visibility-Attributes-syncing.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Fri, 5 Jan 2024 16:47:18 -0500
+Subject: [PATCH] Fix Mob Effect Visibility/Attributes syncing
+
+Currently, Minecraft waits a tick before syncing effect visiblity/glowing.
+This is noticeable when adding entities into the world with effects.
+So, this main logic moves the dirty effect logic into the actual updating logic.
+This causes effect visibility to be updated correctly.
+
+Additionally, mob effects are not correctly added when read from NBT due to their attributes not being applied.
+This is a problem for entities that have effects already added before being ticked for the first time.
+We also manually update effect visibility, causing glowing and invisibility to be correctly applied as well.
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index bc908b75cb99536df658281ae7f8b4eeedbbedc9..3a45051cde95fb0b76f2b57dea1d546b8fca8be8 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -831,9 +831,11 @@ public abstract class LivingEntity extends Entity implements Attackable {
+ 
+                 if (mobeffect != null) {
+                     this.activeEffects.put(mobeffect.getEffect(), mobeffect);
++                    mobeffect.getEffect().addAttributeModifiers(this.getAttributes(), mobeffect.getAmplifier()); // Paper
+                 }
+             }
+         }
++        this.updateEffectVisibility(); // Paper
+ 
+         // CraftBukkit start
+         if (nbt.contains("Bukkit.MaxHealth")) {
+@@ -947,14 +949,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+         this.effectsToProcess.clear();
+         // CraftBukkit end
+ 
+-        if (this.effectsDirty) {
+-            if (!this.level().isClientSide) {
+-                this.updateInvisibilityStatus();
+-                this.updateGlowingStatus();
+-            }
+-
+-            this.effectsDirty = false;
+-        }
++        this.updateEffectVisibilityIfDirty(); // Paper -- Move diff down
+ 
+         int i = (Integer) this.entityData.get(LivingEntity.DATA_EFFECT_COLOR_ID);
+         boolean flag = (Boolean) this.entityData.get(LivingEntity.DATA_EFFECT_AMBIENCE_ID);
+@@ -1255,7 +1250,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+     }
+ 
+     protected void onEffectAdded(MobEffectInstance effect, @Nullable Entity source) {
+-        this.effectsDirty = true;
++        this.updateEffectVisibility(); // Paper -- Resync effects right away
+         if (!this.level().isClientSide) {
+             effect.getEffect().addAttributeModifiers(this.getAttributes(), effect.getAmplifier());
+             this.sendEffectToPassengers(effect);
+@@ -1279,7 +1274,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+     }
+ 
+     protected void onEffectUpdated(MobEffectInstance effect, boolean reapplyEffect, @Nullable Entity source) {
+-        this.effectsDirty = true;
++        this.updateEffectVisibility(); // Paper
+         if (reapplyEffect && !this.level().isClientSide) {
+             MobEffect mobeffectlist = effect.getEffect();
+ 
+@@ -1295,7 +1290,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+     }
+ 
+     protected void onEffectRemoved(MobEffectInstance effect) {
+-        this.effectsDirty = true;
++        this.updateEffectVisibility(); // Paper
+         if (!this.level().isClientSide) {
+             effect.getEffect().removeAttributeModifiers(this.getAttributes());
+             this.refreshDirtyAttributes();
+@@ -3809,7 +3804,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
+ 
+     protected void updateEffectVisibility() {
+         this.effectsDirty = true;
++        this.updateEffectVisibilityIfDirty(); // Paper
+     }
++    // Paper start -- Move effect sync to separate method
++    protected void updateEffectVisibilityIfDirty() {
++        if (this.effectsDirty) {
++            if (!this.level().isClientSide) {
++                this.updateInvisibilityStatus();
++                this.updateGlowingStatus();
++            }
++
++            this.effectsDirty = false;
++        }
++    }
++    // Paper end
+ 
+     public abstract HumanoidArm getMainArm();
+ 


### PR DESCRIPTION
Currently, Minecraft waits a tick before syncing effect visiblity/glowing. This is noticeable when adding entities into the world with effects. So, this main logic moves the dirty effect logic into the actual updating logic. This causes effect visibility to be updated correctly.

Additionally, mob effects are not correctly added when read from NBT due to their attributes not being applied. This is a problem for entities that have effects already added before being ticked for the first time. We also manually update effect visibility, causing glowing and invisibility to be correctly applied as well.

To reproduce:
```
/give @s minecraft:squid_spawn_egg{EntityTag:{Glowing:1b,NoAI:1b,CustomName:'{"text":"Invisible","color":"dark_blue","bold":true,"italic":true,"underlined":true}',active_effects:[{id:invisibility,amplifier:1b,duration:1200,show_particles:1b}]}}
```
Vanilla: Blink occurs when spawning
After: Blink no longer occurs when spawning

```
/minecraft:give @s minecraft:zombie_spawn_egg{EntityTag:{Glowing:1b,NoAI:0b,active_effects:[{id:speed,amplifier:20b,duration:60,show_particles:1b}]}}
```
Vanilla: Speed attribute is not applied to the zombie.
After: Speed attribute correctly applied

Fixes:
https://bugs.mojang.com/browse/MC-72774
https://bugs.mojang.com/browse/MC-88181
https://bugs.mojang.com/browse/MC-257087 (technically)
https://bugs.mojang.com/browse/MC-171688


Best way to test this is with /tick freeze, place the entities, then /tick unfreeze.
<!-- bot: paperclip-pr-build -->
---
Download the paperclip jar for this pull request: [paper-10139.zip](https://nightly.link/PaperMC/Paper/actions/artifacts/2351989193.zip)