### PR TITLE
Add FallingBlockDropAsItemEvent

### DIFF
--- a/patches/api/0457-Add-FallingBlockDropAsItemEvent.patch
+++ b/patches/api/0457-Add-FallingBlockDropAsItemEvent.patch
@@ -1,0 +1,95 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Esophose <esophose@gmail.com>
+Date: Sat, 6 Jan 2024 20:44:16 -0700
+Subject: [PATCH] Add FallingBlockDropAsItemEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/FallingBlockDropAsItemEvent.java b/src/main/java/io/papermc/paper/event/entity/FallingBlockDropAsItemEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..240d4d7fab95c7408da317ec8452d9f033a1abad
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/FallingBlockDropAsItemEvent.java
+@@ -0,0 +1,83 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.FallingBlock;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when a {@link FallingBlock} is going to be dropped as an item.
++ * <p>
++ * Only called when {@link FallingBlock#getDropItem()} is <code>true</code> and {@link FallingBlock#getCancelDrop()} is <code>false</code>.
++ * <p>
++ * This can happen due to the following causes:
++ * <ul>
++ *     <li>The FallingBlock tried to land but broke due to no valid space</li>
++ *     <li>The EntityChangeBlockEvent for the FallingBlock was cancelled</li>
++ *     <li>The FallingBlock has expired</li>
++ * </ul>
++ */
++public class FallingBlockDropAsItemEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private ItemStack toDrop;
++    private boolean cancelled;
++
++    public FallingBlockDropAsItemEvent(@NotNull FallingBlock fallingBlock, @NotNull ItemStack toDrop) {
++        super(fallingBlock);
++        this.toDrop = toDrop;
++    }
++
++    /**
++     * Returns the {@link FallingBlock} that is being dropped as an item
++     *
++     * @return The falling block that is being dropped as an item
++     */
++    @Override
++    public @NotNull FallingBlock getEntity() {
++        return (FallingBlock) entity;
++    }
++
++    /**
++     * Gets the {@link ItemStack} to be dropped.
++     *
++     * @return The item to be dropped
++     */
++    public @NotNull ItemStack getItem() {
++        return toDrop;
++    }
++
++    /**
++     * Sets the {@link ItemStack} to be dropped.
++     *
++     * @param itemStack The item to be dropped
++     */
++    public void setItem(@NotNull ItemStack itemStack) {
++        toDrop = itemStack;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++}

--- a/patches/server/1062-Add-FallingBlockDropAsItemEvent.patch
+++ b/patches/server/1062-Add-FallingBlockDropAsItemEvent.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Esophose <esophose@gmail.com>
+Date: Sat, 6 Jan 2024 20:43:40 -0700
+Subject: [PATCH] Add FallingBlockDropAsItemEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
+index 45c07733f03b5c11f6d8e820f65dc950c70d9a67..ddc3a31a94f827221fd98bd8e0ece53f6ad877f4 100644
+--- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
++++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
+@@ -424,4 +424,16 @@ public class FallingBlockEntity extends Entity {
+         this.setPos(d0, d1, d2);
+         this.setStartPos(this.blockPosition());
+     }
++
++    // Paper start - call FallingBlockDropAsItemEvent
++    @Override
++    public ItemEntity spawnAtLocation(ItemLike item) {
++        org.bukkit.inventory.ItemStack toDrop = new ItemStack(item.asItem()).asBukkitCopy();
++        io.papermc.paper.event.entity.FallingBlockDropAsItemEvent event = new io.papermc.paper.event.entity.FallingBlockDropAsItemEvent((org.bukkit.entity.FallingBlock) this.getBukkitEntity(), toDrop);
++        if (event.callEvent()) {
++            return super.spawnAtLocation(org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getItem()));
++        }
++        return null;
++    }
++    // Paper end
+ }


### PR DESCRIPTION
Added a FallingBlockDropAsItemEvent to allow modifying or cancelling the item that is dropped when a falling block either expires or is unable to form a block.

As far as I can tell it isn't possible through any other means to associate the FallingBlock with the item that is being spawned, hence this event.