### PR TITLE
Add visual blockdata api for primed tnt

### DIFF
--- a/patches/api/0299-Missing-Entity-API.patch
+++ b/patches/api/0299-Missing-Entity-API.patch
@@ -1115,6 +1115,37 @@ index a52a7af219633d575dcbe8ac4b219834bfd4d4d2..1e839b247182af6873a4d74b236d6412
   */
 -public interface Salmon extends Fish { }
 +public interface Salmon extends io.papermc.paper.entity.SchoolableFish { } // Paper - Schooling Fish API
+diff --git a/src/main/java/org/bukkit/entity/TNTPrimed.java b/src/main/java/org/bukkit/entity/TNTPrimed.java
+index 0813bd913c8fdb2001963ce3e82c07c2af105418..87e717c9ea61b0cbf536bc62fa829ddcfae5ad8c 100644
+--- a/src/main/java/org/bukkit/entity/TNTPrimed.java
++++ b/src/main/java/org/bukkit/entity/TNTPrimed.java
+@@ -64,4 +64,26 @@ public interface TNTPrimed extends Explosive {
+     default org.bukkit.Location getSourceLoc() {
+         return this.getOrigin();
+     }
++
++    // Paper start
++    /**
++     * Sets the visual block data of this
++     * primed tnt.
++     * <br>
++     * The explosion of the tnt stays the
++     * same and is not affected by this change.
++     *
++     * @param data the visual block data
++     */
++    void setBlockData(@org.jetbrains.annotations.NotNull org.bukkit.block.data.BlockData data);
++
++    /**
++     * Gets the visual block data of this
++     * primed tnt.
++     *
++     * @return the visual block data
++     */
++    @org.jetbrains.annotations.NotNull
++    org.bukkit.block.data.BlockData getBlockData();
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/entity/Tadpole.java b/src/main/java/org/bukkit/entity/Tadpole.java
 index d64979ebdd018f0f63b6115809b48374ba454249..8e097ad55d208a6980c320e2a849efdcc504cff1 100644
 --- a/src/main/java/org/bukkit/entity/Tadpole.java

--- a/patches/server/0611-Missing-Entity-API.patch
+++ b/patches/server/0611-Missing-Entity-API.patch
@@ -1118,6 +1118,28 @@ index b8140aa25a25870259b5644091c6643da1e14b54..d4d8ce60098c74508e2de9541bf65349
  
      public CraftSalmon(CraftServer server, net.minecraft.world.entity.animal.Salmon entity) {
          super(server, entity);
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftTNTPrimed.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftTNTPrimed.java
+index 3f32c683ddc6999b89f2e4051eb6ae784b296b8f..dac3d34677688ac560bc1be2087a08479ef71b87 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftTNTPrimed.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftTNTPrimed.java
+@@ -67,4 +67,17 @@ public class CraftTNTPrimed extends CraftEntity implements TNTPrimed {
+             this.getHandle().owner = null;
+         }
+     }
++
++    // Paper start
++    @Override
++    public void setBlockData(org.bukkit.block.data.BlockData data) {
++        com.google.common.base.Preconditions.checkArgument(data != null, "The visual block data of this tnt cannot be null. To reset it just set to the TNT default block data");
++        this.getHandle().setBlockState(((org.bukkit.craftbukkit.block.data.CraftBlockData) data).getState());
++    }
++
++    @Override
++    public org.bukkit.block.data.BlockData getBlockData() {
++        return org.bukkit.craftbukkit.block.data.CraftBlockData.fromData(this.getHandle().getBlockState());
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftTadpole.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftTadpole.java
 index 451a9bfd9b9b6945e224f1bb05c7951ed934b4e3..d7c6a0bbc5671ea8f2488230c94df5146a1e98b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftTadpole.java


### PR DESCRIPTION
This adds a new way to define the rendered block state on a primed tnt since 1.20.3.